### PR TITLE
feat(operator): pause annotated DGD reconciliation

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -58,6 +58,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller/paused"
 	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
@@ -2750,7 +2751,10 @@ func (r *DynamoGraphDeploymentReconciler) FinalizeResource(ctx context.Context, 
 func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&nvidiacomv1beta1.DynamoGraphDeployment{}, builder.WithPredicates(
-			predicate.GenerationChangedPredicate{},
+			predicate.Or(
+				predicate.GenerationChangedPredicate{},
+				paused.AnnotationChangedPredicate(),
+			),
 		)).
 		Named(consts.ResourceTypeDynamoGraphDeployment).
 		Watches(
@@ -2844,9 +2848,14 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			)
 
 	}
+	pausedReconciler := paused.Wrap(
+		mgr.GetClient(),
+		&nvidiacomv1beta1.DynamoGraphDeployment{},
+		r,
+	)
+
 	// Wrap with metrics collection
-	observedReconciler := observability.NewObservedReconciler(r, consts.ResourceTypeDynamoGraphDeployment)
-	return ctrlBuilder.Complete(observedReconciler)
+	return ctrlBuilder.Complete(observability.NewObservedReconciler(pausedReconciler, consts.ResourceTypeDynamoGraphDeployment))
 }
 
 func (r *DynamoGraphDeploymentReconciler) GetRecorder() record.EventRecorder {

--- a/deploy/operator/internal/controller/paused/reconciler.go
+++ b/deploy/operator/internal/controller/paused/reconciler.go
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Package paused provides the opt-in pause boundary used by the DGD controller.
+package paused
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// Annotation marks an object for paused reconciliation.
+	Annotation = "nvidia.com/paused"
+	// Value is the only annotation value that pauses reconciliation.
+	Value = "true"
+)
+
+type reconciler struct {
+	reader    client.Reader
+	prototype client.Object
+	delegate  reconcile.Reconciler
+}
+
+// Wrap returns a reconciler that does not call delegate while the requested
+// object has the pause annotation set to exactly "true".
+func Wrap(reader client.Reader, prototype client.Object, delegate reconcile.Reconciler) reconcile.Reconciler {
+	return &reconciler{reader: reader, prototype: prototype, delegate: delegate}
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	object := r.prototype.DeepCopyObject().(client.Object)
+	if err := r.reader.Get(ctx, request.NamespacedName, object); err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.delegate.Reconcile(ctx, request)
+		}
+		return reconcile.Result{}, err
+	}
+	if object.GetAnnotations()[Annotation] == Value {
+		return reconcile.Result{}, nil
+	}
+	return r.delegate.Reconcile(ctx, request)
+}
+
+// AnnotationChangedPredicate triggers reconciliation when the pause value changes.
+func AnnotationChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(event.CreateEvent) bool { return false },
+		DeleteFunc: func(event.DeleteEvent) bool { return false },
+		UpdateFunc: func(update event.UpdateEvent) bool {
+			return update.ObjectOld.GetAnnotations()[Annotation] != update.ObjectNew.GetAnnotations()[Annotation]
+		},
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}

--- a/deploy/operator/internal/controller/paused/reconciler_test.go
+++ b/deploy/operator/internal/controller/paused/reconciler_test.go
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package paused
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcilerPausesExactTrue(t *testing.T) {
+	ctx := t.Context()
+	object := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:        "paused",
+		Namespace:   "default",
+		Annotations: map[string]string{Annotation: Value},
+		Finalizers:  []string{"test-finalizer"},
+	}}
+	delegateCalled := false
+	wrapped := Wrap(
+		pausedTestClient(t, object),
+		&corev1.ConfigMap{},
+		reconcile.Func(func(context.Context, reconcile.Request) (reconcile.Result, error) {
+			delegateCalled = true
+			return reconcile.Result{}, nil
+		}),
+	)
+
+	t.Log("Reconcile an object paused with the exact accepted value")
+	if _, err := wrapped.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+		Name: object.Name, Namespace: object.Namespace,
+	}}); err != nil {
+		t.Fatalf("reconcile paused object: %v", err)
+	}
+
+	t.Log("Verify the delegate did not run, leaving finalization untouched")
+	if delegateCalled {
+		t.Fatal("paused reconciler called its delegate")
+	}
+}
+
+func TestReconcilerDelegatesOtherValues(t *testing.T) {
+	values := []string{"", "false", "TRUE", "1"}
+	for _, value := range values {
+		object := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:        "not-paused",
+			Namespace:   "default",
+			Annotations: map[string]string{Annotation: value},
+		}}
+		delegateCalled := false
+		wrapped := Wrap(
+			pausedTestClient(t, object),
+			&corev1.ConfigMap{},
+			reconcile.Func(func(context.Context, reconcile.Request) (reconcile.Result, error) {
+				delegateCalled = true
+				return reconcile.Result{}, nil
+			}),
+		)
+
+		t.Logf("Reconcile pause annotation value %q", value)
+		if _, err := wrapped.Reconcile(t.Context(), reconcile.Request{NamespacedName: types.NamespacedName{
+			Name: object.Name, Namespace: object.Namespace,
+		}}); err != nil {
+			t.Fatalf("reconcile pause value %q: %v", value, err)
+		}
+		if !delegateCalled {
+			t.Fatalf("pause value %q did not call delegate", value)
+		}
+	}
+}
+
+func TestAnnotationChangedPredicate(t *testing.T) {
+	pauseChanged := AnnotationChangedPredicate()
+	oldObject := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{Annotation: Value, "other": "old"},
+	}}
+	unpausedObject := oldObject.DeepCopy()
+	unpausedObject.Annotations[Annotation] = "false"
+	otherChanged := oldObject.DeepCopy()
+	otherChanged.Annotations["other"] = "new"
+
+	t.Log("Wake reconciliation when the pause value changes")
+	if !pauseChanged.Update(event.UpdateEvent{ObjectOld: oldObject, ObjectNew: unpausedObject}) {
+		t.Fatal("pause annotation change was ignored")
+	}
+
+	t.Log("Ignore metadata changes unrelated to the pause value")
+	if pauseChanged.Update(event.UpdateEvent{ObjectOld: oldObject, ObjectNew: otherChanged}) {
+		t.Fatal("unrelated annotation change triggered pause predicate")
+	}
+}
+
+func pausedTestClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}


### PR DESCRIPTION
## Summary

- skip DGD reconciliation when `nvidia.com/paused` is exactly `true`
- retrigger reconciliation when the pause annotation changes
- leave finalizers and all other state untouched while paused

## Validation

- `go test ./internal/controller/paused ./internal/controller -run '^(TestReconcilerPausesExactTrue|TestReconcilerDelegatesOtherValues|TestAnnotationChangedPredicate)$'`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pausing DynamoGraphDeployment reconciliation with the `nvidia.com/paused: "true"` annotation.
  * Reconciliation automatically resumes when the annotation is removed or changed.
  * Changes to the pause annotation trigger reconciliation.

* **Tests**
  * Added coverage for paused, resumed, and annotation-change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->