### PR TITLE
ci(deploy): dump cluster state on failure

### DIFF
--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -133,6 +133,23 @@ runs:
           --alluredir=test-results/allure-results \
           --log-cli-level=INFO
 
+    - name: Dump cluster state on failure
+      if: failure()
+      shell: bash
+      env:
+        NAMESPACE: ${{ inputs.namespace }}
+        DYN_TEST_OUTPUT_PATH: ${{ github.workspace }}/test-output
+      run: |
+        namespaces="${NAMESPACE}"
+        if [ "${NAMESPACE}" != default ]; then
+          namespaces="${NAMESPACE},default"
+        fi
+
+        mkdir -p "${DYN_TEST_OUTPUT_PATH}"
+        kubectl cluster-info dump \
+          --namespaces="${namespaces}" \
+          --output-directory="${DYN_TEST_OUTPUT_PATH}/cluster-info" || true
+
     - name: Cleanup Deployment
       if: always()
       shell: bash


### PR DESCRIPTION
## Summary
- Use `kubectl cluster-info dump` for the shared deploy-test failure fallback.
- Dump the test namespace plus `default` before cleanup into the existing pod-logs artifact.
- Keep resource-specific diagnostics in the existing Python test managers.

Prerequisite for #11946.

## Validation
- pre-commit
- YAML validation