### PR TITLE
refactor(mocker): share live scheduler loop

### DIFF
--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -199,6 +199,11 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
     let mut deferred_commands = VecDeque::new();
 
     loop {
+        // Productive zero-duration passes may never enter one of the
+        // cancellation-aware waits below.
+        if cancel_token.is_cancelled() {
+            break;
+        }
         if !receive_until_live_schedulable(
             core,
             &mut request_rx,

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -1,16 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::protocols::{FpmPublisher, KvEventPublishers, OutputSignal};
+use std::collections::VecDeque;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::common::protocols::{
+    DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
+};
+use crate::common::utils::sleep_until_precise;
 use crate::scheduler::kv_event_sink::{
-    DeferredKvPublish, DeferredKvPublishBuffer, publish_deferred_fpm, publish_deferred_kv_events,
+    DeferredKvPublish, DeferredKvPublishBuffer, capture_deferred_kv_publish_sink,
+    publish_deferred_fpm, publish_deferred_kv_events,
 };
 use crate::scheduler::vllm::MockerMetrics;
 use crate::scheduler::{
     AdmissionEvent, EnginePassResult, RouterEventVisibility, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerLifecycleEvent,
+    SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent,
+    handoff_channel_capacity,
 };
 use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PublishedEffect {
@@ -25,6 +37,14 @@ enum PublishedEffect {
 }
 
 pub(crate) trait LiveBoundaryCore {
+    fn initialize_live(&mut self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn live_is_empty(&self) -> bool;
+
+    fn receive_live_request(&mut self, request: DirectRequest);
+
     fn apply_live_command(
         &mut self,
         command: SchedulerCommand,
@@ -38,6 +58,12 @@ pub(crate) trait LiveBoundaryCore {
 
     fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics;
 
+    fn live_internal_deadline_ms(&self) -> Option<f64> {
+        None
+    }
+
+    fn execute_live_pass(&mut self, scheduler_start: &Instant) -> LivePassExecution;
+
     fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {}
 
     #[cfg(feature = "kvbm-offload")]
@@ -49,6 +75,209 @@ pub(crate) trait LiveBoundaryCore {
         crate::scheduler::OffloadTickEffects {
             kv_events: Vec::new(),
             lifecycle_events: Vec::new(),
+        }
+    }
+}
+
+pub(crate) struct LivePassExecution {
+    pub(crate) pass: EnginePassResult,
+    pub(crate) duration: Duration,
+}
+
+struct LiveCancelGuard(CancellationToken);
+
+impl Drop for LiveCancelGuard {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct LiveSchedulerState {
+    request_tx: mpsc::UnboundedSender<DirectRequest>,
+    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
+    lifecycle_rx: Arc<Mutex<Option<mpsc::Receiver<SchedulerLifecycleEvent>>>>,
+    metrics_rx: watch::Receiver<MockerMetrics>,
+    _cancel_guard: Arc<LiveCancelGuard>,
+}
+
+impl SchedulerHandle for LiveSchedulerState {
+    fn receive(&self, request: DirectRequest) {
+        let _ = self.request_tx.send(request);
+    }
+
+    fn request_sender(&self) -> mpsc::UnboundedSender<DirectRequest> {
+        self.request_tx.clone()
+    }
+
+    fn metrics_receiver(&self) -> watch::Receiver<MockerMetrics> {
+        self.metrics_rx.clone()
+    }
+
+    fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope> {
+        self.command_tx.clone()
+    }
+
+    fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
+        self.lifecycle_rx
+            .lock()
+            .expect("scheduler lifecycle receiver mutex poisoned")
+            .take()
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_live_scheduler<C>(
+    args: MockEngineArgs,
+    dp_rank: u32,
+    output_tx: Option<mpsc::UnboundedSender<Vec<OutputSignal>>>,
+    kv_event_publishers: KvEventPublishers,
+    cancellation_token: Option<CancellationToken>,
+    admission_tx: Option<mpsc::UnboundedSender<AdmissionEvent>>,
+    fpm_publisher: FpmPublisher,
+    make_core: impl FnOnce(MockEngineArgs, u32, KvEventPublishers) -> C + Send + 'static,
+) -> LiveSchedulerState
+where
+    C: LiveBoundaryCore + Send + 'static,
+{
+    let controls_enabled = args.is_prefill() || args.is_decode();
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let control_capacity = handoff_channel_capacity(&args);
+    let (command_tx, command_rx) = mpsc::channel(control_capacity);
+    let (lifecycle_tx, lifecycle_rx) = mpsc::channel(control_capacity);
+    let initial_metrics = MockerMetrics::new(dp_rank, 0, args.num_gpu_blocks as u64);
+    let (metrics_tx, metrics_rx) = watch::channel(initial_metrics);
+    let cancel_token = cancellation_token.unwrap_or_default();
+    let actor_cancel_token = cancel_token.clone();
+    let cancel_guard = Arc::new(LiveCancelGuard(cancel_token));
+
+    tokio::spawn(async move {
+        let (deferred_kv_events, buffering_publishers) = capture_deferred_kv_publish_sink(
+            !kv_event_publishers.is_empty(),
+            kv_event_publishers.raw_enabled(),
+        );
+        let mut core = make_core(args, dp_rank, buffering_publishers);
+        let publisher = LiveEffectsPublisher::new(
+            output_tx,
+            admission_tx,
+            lifecycle_tx,
+            metrics_tx,
+            kv_event_publishers,
+            fpm_publisher,
+            deferred_kv_events,
+        );
+        core.initialize_live().await;
+        run_live_scheduler(
+            &mut core,
+            request_rx,
+            command_rx,
+            publisher,
+            actor_cancel_token,
+            controls_enabled,
+        )
+        .await;
+    });
+
+    LiveSchedulerState {
+        request_tx,
+        command_tx,
+        lifecycle_rx: Arc::new(Mutex::new(Some(lifecycle_rx))),
+        metrics_rx,
+        _cancel_guard: cancel_guard,
+    }
+}
+
+async fn run_live_scheduler<C: LiveBoundaryCore>(
+    core: &mut C,
+    mut request_rx: mpsc::UnboundedReceiver<DirectRequest>,
+    mut command_rx: mpsc::Receiver<SchedulerCommandEnvelope>,
+    publisher: LiveEffectsPublisher,
+    cancel_token: CancellationToken,
+    controls_enabled: bool,
+) {
+    let scheduler_start = Instant::now();
+    let mut deferred_commands = VecDeque::new();
+
+    loop {
+        if !receive_until_live_schedulable(
+            core,
+            &mut request_rx,
+            &mut command_rx,
+            &publisher,
+            &scheduler_start,
+            &cancel_token,
+            controls_enabled,
+        )
+        .await
+        {
+            break;
+        }
+
+        let iteration_start = Instant::now();
+        let metrics_before = core.live_metrics();
+        let execution = core.execute_live_pass(&scheduler_start);
+        let mut pending = publisher.capture_pass(execution.pass);
+        let zero_progress =
+            execution.duration.is_zero() && !pending.made_progress_since(&metrics_before);
+        publisher.publish_pass_start(&mut pending);
+        if execution.duration > Duration::ZERO {
+            let deadline = iteration_start + execution.duration;
+            if controls_enabled {
+                if !wait_for_live_pass_boundary(
+                    core,
+                    &mut command_rx,
+                    &mut deferred_commands,
+                    &publisher,
+                    &scheduler_start,
+                    &cancel_token,
+                    deadline,
+                )
+                .await
+                {
+                    break;
+                }
+            } else {
+                sleep_until_precise(deadline).await;
+            }
+        }
+        publisher.publish_pass(core, pending).await;
+        if controls_enabled {
+            let control_progress = apply_live_post_pass_controls(
+                core,
+                &mut command_rx,
+                &mut deferred_commands,
+                &publisher,
+                &scheduler_start,
+            )
+            .await;
+            if zero_progress
+                && !control_progress
+                && !wait_for_live_progress(
+                    core,
+                    &mut request_rx,
+                    &mut command_rx,
+                    &publisher,
+                    &scheduler_start,
+                    &cancel_token,
+                    true,
+                )
+                .await
+            {
+                break;
+            }
+        } else if zero_progress
+            && !wait_for_live_progress(
+                core,
+                &mut request_rx,
+                &mut command_rx,
+                &publisher,
+                &scheduler_start,
+                &cancel_token,
+                false,
+            )
+            .await
+        {
+            break;
         }
     }
 }
@@ -76,10 +305,6 @@ pub(crate) struct PendingLivePass {
 }
 
 impl PendingLivePass {
-    pub(crate) fn end_ms(&self) -> f64 {
-        self.pass.end_ms
-    }
-
     pub(crate) fn made_progress_since(&self, metrics_before: &MockerMetrics) -> bool {
         self.pass.completed_requests > 0
             || !self.pass.admissions.is_empty()
@@ -89,6 +314,239 @@ impl PendingLivePass {
             || !self.kv_events.is_empty()
             || self.pass.mocker_metrics != *metrics_before
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
+    core: &mut C,
+    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
+    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    publisher: &LiveEffectsPublisher,
+    scheduler_start: &Instant,
+    cancel_token: &CancellationToken,
+    controls_enabled: bool,
+) -> bool {
+    if !controls_enabled {
+        if cancel_token.is_cancelled() {
+            return false;
+        }
+        if core.live_is_empty() {
+            tokio::select! {
+                biased;
+                _ = cancel_token.cancelled() => return false,
+                request = request_rx.recv() => {
+                    let Some(request) = request else {
+                        return false;
+                    };
+                    core.receive_live_request(request);
+                }
+            }
+        }
+        while let Ok(request) = request_rx.try_recv() {
+            core.receive_live_request(request);
+        }
+        return true;
+    }
+
+    while core.live_is_empty() {
+        let internal_deadline_ms = core.live_internal_deadline_ms();
+        let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
+        tokio::pin!(internal_deadline);
+        tokio::select! {
+            biased;
+            _ = cancel_token.cancelled() => return false,
+            command = command_rx.recv() => {
+                let Some(command) = command else {
+                    return false;
+                };
+                publisher
+                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                    .await;
+            }
+            request = request_rx.recv() => {
+                let Some(request) = request else {
+                    return false;
+                };
+                core.receive_live_request(request);
+            }
+            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
+                #[cfg(feature = "kvbm-offload")]
+                {
+                    let now_ms = scheduler_elapsed_ms(scheduler_start)
+                        .max(internal_deadline_ms.expect("armed internal deadline"));
+                    publisher.advance_offload(core, now_ms, true).await;
+                }
+            }
+        }
+    }
+
+    while let Ok(command) = command_rx.try_recv() {
+        publisher
+            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+            .await;
+    }
+    while let Ok(request) = request_rx.try_recv() {
+        core.receive_live_request(request);
+    }
+
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
+    core: &mut C,
+    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
+    publisher: &LiveEffectsPublisher,
+    scheduler_start: &Instant,
+    cancel_token: &CancellationToken,
+    deadline: Instant,
+) -> bool {
+    let sleep = sleep_until_precise(deadline);
+    tokio::pin!(sleep);
+    let mut accept_commands = true;
+    loop {
+        let internal_deadline_ms = core.live_internal_deadline_ms();
+        let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
+        tokio::pin!(internal_deadline);
+        tokio::select! {
+            biased;
+            _ = cancel_token.cancelled() => return false,
+            _ = &mut sleep => return true,
+            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
+                #[cfg(feature = "kvbm-offload")]
+                {
+                    let now_ms = scheduler_elapsed_ms(scheduler_start)
+                        .max(internal_deadline_ms.expect("armed internal deadline"));
+                    publisher.advance_offload(core, now_ms, false).await;
+                    debug_assert!(
+                        core.live_internal_deadline_ms().is_none_or(|next| next > now_ms),
+                        "internal progress left an already-due deadline armed"
+                    );
+                }
+            }
+            command = command_rx.recv(), if accept_commands => {
+                let Some(command) = command else {
+                    return false;
+                };
+                if command_can_apply_during_pass(&command.command) {
+                    publisher
+                        .apply_command(
+                            core,
+                            command,
+                            false,
+                            scheduler_elapsed_ms(scheduler_start),
+                        )
+                        .await;
+                } else {
+                    deferred_commands.push_back(command);
+                    accept_commands = false;
+                }
+            }
+        }
+    }
+}
+
+async fn apply_live_post_pass_controls<C: LiveBoundaryCore>(
+    core: &mut C,
+    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
+    publisher: &LiveEffectsPublisher,
+    scheduler_start: &Instant,
+) -> bool {
+    let mut made_progress = false;
+    while let Some(command) = deferred_commands.pop_front() {
+        made_progress = true;
+        publisher
+            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+            .await;
+    }
+    while let Ok(command) = command_rx.try_recv() {
+        made_progress = true;
+        publisher
+            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+            .await;
+    }
+    publisher
+        .retry_destinations(core, scheduler_elapsed_ms(scheduler_start))
+        .await
+        || made_progress
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn wait_for_live_progress<C: LiveBoundaryCore>(
+    core: &mut C,
+    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
+    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    publisher: &LiveEffectsPublisher,
+    scheduler_start: &Instant,
+    cancel_token: &CancellationToken,
+    controls_enabled: bool,
+) -> bool {
+    let internal_deadline_ms = core.live_internal_deadline_ms();
+    let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
+    tokio::pin!(internal_deadline);
+    if controls_enabled {
+        tokio::select! {
+            biased;
+            _ = cancel_token.cancelled() => false,
+            command = command_rx.recv() => {
+                let Some(command) = command else {
+                    return false;
+                };
+                publisher
+                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                    .await;
+                true
+            }
+            request = request_rx.recv() => {
+                let Some(request) = request else {
+                    return false;
+                };
+                core.receive_live_request(request);
+                true
+            }
+            _ = &mut internal_deadline => true,
+        }
+    } else {
+        tokio::select! {
+            biased;
+            _ = cancel_token.cancelled() => false,
+            request = request_rx.recv() => {
+                let Some(request) = request else {
+                    return false;
+                };
+                core.receive_live_request(request);
+                true
+            }
+            _ = &mut internal_deadline => true,
+        }
+    }
+}
+
+async fn wait_for_internal_deadline(scheduler_start: &Instant, deadline_ms: Option<f64>) {
+    let Some(deadline_ms) = deadline_ms else {
+        std::future::pending::<()>().await;
+        return;
+    };
+    let deadline = *scheduler_start + Duration::from_secs_f64(deadline_ms.max(0.0) / 1000.0);
+    let wake_at = if deadline <= Instant::now() {
+        Instant::now() + Duration::from_millis(1)
+    } else {
+        deadline
+    };
+    sleep_until_precise(wake_at).await;
+}
+
+fn scheduler_elapsed_ms(scheduler_start: &Instant) -> f64 {
+    scheduler_start.elapsed().as_secs_f64() * 1000.0
+}
+
+fn command_can_apply_during_pass(command: &SchedulerCommand) -> bool {
+    matches!(
+        command,
+        SchedulerCommand::SubmitHandoffPrefill { .. } | SchedulerCommand::ReserveDestination { .. }
+    )
 }
 
 impl LiveEffectsPublisher {
@@ -338,282 +796,4 @@ impl LiveEffectsPublisher {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::common::handoff::HandoffId;
-    use crate::common::protocols::ForwardPassSnapshot;
-    use crate::scheduler::{SchedulerCommandResult, capture_deferred_kv_publish_sink};
-    use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
-    use std::sync::{Arc, Mutex};
-    use uuid::Uuid;
-
-    struct FakeCore {
-        publishers: KvEventPublishers,
-        command_effects: bool,
-        midpass_kv_effects: bool,
-    }
-
-    impl FakeCore {
-        fn publish_kv(&self, event_id: u64) {
-            self.publishers
-                .publish(
-                    KvCacheEvent {
-                        event_id,
-                        data: KvCacheEventData::Cleared,
-                        dp_rank: 0,
-                    },
-                    None,
-                )
-                .unwrap();
-        }
-    }
-
-    impl LiveBoundaryCore for FakeCore {
-        fn apply_live_command(
-            &mut self,
-            _command: SchedulerCommand,
-            _allow_destination_admission: bool,
-            _now_ms: f64,
-        ) -> anyhow::Result<SchedulerCommandEffects> {
-            let mut effects = SchedulerCommandEffects::new(SchedulerCommandResult::Applied);
-            if self.command_effects || self.midpass_kv_effects {
-                self.publish_kv(2);
-            }
-            if self.command_effects {
-                effects
-                    .lifecycle_events
-                    .push(SchedulerLifecycleEvent::DestinationReserved {
-                        handoff_id: HandoffId::from(Uuid::from_u128(2)),
-                        request_id: Uuid::from_u128(3),
-                        transferable_prompt_tokens: 4,
-                    });
-            }
-            Ok(effects)
-        }
-
-        fn retry_live_destinations(&mut self, _now_ms: f64) -> Vec<SchedulerLifecycleEvent> {
-            Vec::new()
-        }
-
-        fn live_metrics(&self) -> MockerMetrics {
-            MockerMetrics::default()
-        }
-
-        fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics {
-            pass_metrics
-        }
-
-        fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {
-            self.publish_kv(3);
-        }
-    }
-
-    fn pass() -> EnginePassResult {
-        let request_id = Uuid::from_u128(1);
-        EnginePassResult {
-            end_ms: 1.0,
-            completed_requests: 1,
-            output_signals: vec![OutputSignal {
-                uuid: request_id,
-                token_id: None,
-                completed: true,
-                rejected: false,
-                handoff_delay_ms: None,
-            }],
-            admissions: vec![AdmissionEvent {
-                uuid: request_id,
-                reused_input_tokens: 0,
-            }],
-            lifecycle_events: vec![SchedulerLifecycleEvent::DestinationReserved {
-                handoff_id: HandoffId::from(Uuid::from_u128(2)),
-                request_id,
-                transferable_prompt_tokens: 4,
-            }],
-            mocker_metrics: MockerMetrics::default(),
-            router_event_visibility: RouterEventVisibility::PassEnd,
-            kv_events: Vec::new(),
-            fpm: Some(ForwardPassSnapshot::default()),
-            accept_length_output_tokens: 1,
-            accept_length_decode_forwards: 1,
-        }
-    }
-
-    fn publisher(
-        output_tx: mpsc::UnboundedSender<Vec<OutputSignal>>,
-        captured: DeferredKvPublishBuffer,
-        log: Arc<Mutex<Vec<PublishedEffect>>>,
-    ) -> LiveEffectsPublisher {
-        let (admission_tx, _admission_rx) = mpsc::unbounded_channel();
-        let (lifecycle_tx, _lifecycle_rx) = mpsc::channel(4);
-        let (metrics_tx, _metrics_rx) = watch::channel(MockerMetrics::default());
-        LiveEffectsPublisher::new(
-            Some(output_tx),
-            Some(admission_tx),
-            lifecycle_tx,
-            metrics_tx,
-            KvEventPublishers::default(),
-            FpmPublisher::default(),
-            captured,
-        )
-        .with_publication_log(log)
-    }
-
-    #[tokio::test]
-    async fn pass_effects_publish_once_in_boundary_order_and_isolate_midpass_ack() {
-        let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
-        let mut core = FakeCore {
-            publishers: buffering_publishers,
-            command_effects: false,
-            midpass_kv_effects: false,
-        };
-        core.publish_kv(1);
-        let (output_tx, output_rx) = mpsc::unbounded_channel();
-        drop(output_rx);
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let publisher = publisher(output_tx, captured, log.clone());
-        let mut pending = publisher.capture_pass(pass());
-        publisher.publish_pass_start(&mut pending);
-
-        let (reply, reply_rx) = tokio::sync::oneshot::channel();
-        publisher
-            .apply_command(
-                &mut core,
-                SchedulerCommandEnvelope {
-                    command: SchedulerCommand::CancelSource {
-                        handoff_id: HandoffId::from(Uuid::from_u128(2)),
-                    },
-                    reply,
-                },
-                false,
-                1.0,
-            )
-            .await;
-        assert_eq!(
-            reply_rx.await.unwrap().unwrap().result,
-            SchedulerCommandResult::Applied
-        );
-        assert_eq!(
-            log.lock().unwrap().as_slice(),
-            &[PublishedEffect::Admissions, PublishedEffect::Ack]
-        );
-
-        publisher.publish_pass(&mut core, pending).await;
-        assert_eq!(
-            log.lock().unwrap().as_slice(),
-            &[
-                PublishedEffect::Admissions,
-                PublishedEffect::Ack,
-                PublishedEffect::Kv,
-                PublishedEffect::Fpm,
-                PublishedEffect::Outputs,
-                PublishedEffect::Accounting,
-                PublishedEffect::Kv,
-                PublishedEffect::Lifecycle,
-                PublishedEffect::Metrics,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn controlled_pass_start_router_effects_precede_midpass_ack_without_duplicates() {
-        let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
-        let mut core = FakeCore {
-            publishers: buffering_publishers,
-            command_effects: false,
-            midpass_kv_effects: true,
-        };
-        core.publish_kv(1);
-        let (output_tx, _output_rx) = mpsc::unbounded_channel();
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let publisher = publisher(output_tx, captured, log.clone());
-        let mut pass = pass();
-        pass.router_event_visibility = RouterEventVisibility::PassStart;
-        let mut pending = publisher.capture_pass(pass);
-
-        publisher.publish_pass_start(&mut pending);
-        let (reply, reply_rx) = tokio::sync::oneshot::channel();
-        publisher
-            .apply_command(
-                &mut core,
-                SchedulerCommandEnvelope {
-                    command: SchedulerCommand::CancelSource {
-                        handoff_id: HandoffId::from(Uuid::from_u128(2)),
-                    },
-                    reply,
-                },
-                false,
-                1.0,
-            )
-            .await;
-        assert_eq!(
-            reply_rx.await.unwrap().unwrap().result,
-            SchedulerCommandResult::Applied
-        );
-        assert_eq!(
-            log.lock().unwrap().as_slice(),
-            &[
-                PublishedEffect::Admissions,
-                PublishedEffect::Kv,
-                PublishedEffect::Ack,
-            ]
-        );
-
-        publisher.publish_pass(&mut core, pending).await;
-        assert_eq!(
-            log.lock().unwrap().as_slice(),
-            &[
-                PublishedEffect::Admissions,
-                PublishedEffect::Kv,
-                PublishedEffect::Ack,
-                PublishedEffect::Kv,
-                PublishedEffect::Fpm,
-                PublishedEffect::Outputs,
-                PublishedEffect::Accounting,
-                PublishedEffect::Lifecycle,
-                PublishedEffect::Metrics,
-            ]
-        );
-    }
-
-    #[tokio::test]
-    async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
-        let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
-        let mut core = FakeCore {
-            publishers: buffering_publishers,
-            command_effects: true,
-            midpass_kv_effects: false,
-        };
-        let (output_tx, _output_rx) = mpsc::unbounded_channel();
-        let log = Arc::new(Mutex::new(Vec::new()));
-        let publisher = publisher(output_tx, captured, log.clone());
-        let (reply, reply_rx) = tokio::sync::oneshot::channel();
-
-        publisher
-            .apply_command(
-                &mut core,
-                SchedulerCommandEnvelope {
-                    command: SchedulerCommand::ActivateDestination {
-                        handoff_id: HandoffId::from(Uuid::from_u128(2)),
-                    },
-                    reply,
-                },
-                true,
-                1.0,
-            )
-            .await;
-
-        assert_eq!(
-            reply_rx.await.unwrap().unwrap().result,
-            SchedulerCommandResult::Applied
-        );
-        assert_eq!(
-            log.lock().unwrap().as_slice(),
-            &[
-                PublishedEffect::Kv,
-                PublishedEffect::Ack,
-                PublishedEffect::Lifecycle,
-                PublishedEffect::Metrics,
-            ]
-        );
-    }
-}
+mod tests;

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -13,6 +13,8 @@ struct FakeCore {
     publishers: KvEventPublishers,
     command_effects: bool,
     midpass_kv_effects: bool,
+    execute_count: usize,
+    cancel_after_execute: Option<(usize, CancellationToken)>,
 }
 
 impl FakeCore {
@@ -32,13 +34,32 @@ impl FakeCore {
 
 impl LiveBoundaryCore for FakeCore {
     fn live_is_empty(&self) -> bool {
-        true
+        self.cancel_after_execute.is_none()
     }
 
     fn receive_live_request(&mut self, _request: DirectRequest) {}
 
     fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
-        panic!("boundary-only fake does not execute live passes")
+        let (cancel_after, cancel_token) = self
+            .cancel_after_execute
+            .as_ref()
+            .expect("boundary-only fake does not execute live passes");
+        self.execute_count += 1;
+        assert!(
+            self.execute_count <= *cancel_after,
+            "scheduler did not observe shutdown between productive zero-duration passes"
+        );
+        if self.execute_count == *cancel_after {
+            cancel_token.cancel();
+        }
+        let mut pass = pass();
+        pass.admissions.clear();
+        pass.lifecycle_events.clear();
+        pass.fpm = None;
+        LivePassExecution {
+            pass,
+            duration: Duration::ZERO,
+        }
     }
 
     fn apply_live_command(
@@ -137,6 +158,8 @@ async fn pass_effects_publish_once_in_boundary_order_and_isolate_midpass_ack() {
         publishers: buffering_publishers,
         command_effects: false,
         midpass_kv_effects: false,
+        execute_count: 0,
+        cancel_after_execute: None,
     };
     core.publish_kv(1);
     let (output_tx, output_rx) = mpsc::unbounded_channel();
@@ -193,6 +216,8 @@ async fn controlled_pass_start_router_effects_precede_midpass_ack_without_duplic
         publishers: buffering_publishers,
         command_effects: false,
         midpass_kv_effects: true,
+        execute_count: 0,
+        cancel_after_execute: None,
     };
     core.publish_kv(1);
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
@@ -254,6 +279,8 @@ async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
         publishers: buffering_publishers,
         command_effects: true,
         midpass_kv_effects: false,
+        execute_count: 0,
+        cancel_after_execute: None,
     };
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
     let log = Arc::new(Mutex::new(Vec::new()));
@@ -287,4 +314,35 @@ async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
             PublishedEffect::Metrics,
         ]
     );
+}
+
+// Regression: a productive zero-duration core could spin forever without
+// observing shutdown because it never entered a cancellation-aware wait.
+#[tokio::test]
+async fn shutdown_stops_a_nonempty_zero_duration_progress_loop() {
+    let cancel_token = CancellationToken::new();
+    let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(false, false);
+    let mut core = FakeCore {
+        publishers: buffering_publishers,
+        command_effects: false,
+        midpass_kv_effects: false,
+        execute_count: 0,
+        cancel_after_execute: Some((3, cancel_token.clone())),
+    };
+    let (output_tx, _output_rx) = mpsc::unbounded_channel();
+    let publisher = publisher(output_tx, captured, Arc::new(Mutex::new(Vec::new())));
+    let (_request_tx, request_rx) = mpsc::unbounded_channel();
+    let (_command_tx, command_rx) = mpsc::channel(1);
+
+    run_live_scheduler(
+        &mut core,
+        request_rx,
+        command_rx,
+        publisher,
+        cancel_token,
+        false,
+    )
+    .await;
+
+    assert_eq!(core.execute_count, 3);
 }

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -1,0 +1,290 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::common::handoff::HandoffId;
+use crate::common::protocols::ForwardPassSnapshot;
+use crate::scheduler::SchedulerCommandResult;
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+struct FakeCore {
+    publishers: KvEventPublishers,
+    command_effects: bool,
+    midpass_kv_effects: bool,
+}
+
+impl FakeCore {
+    fn publish_kv(&self, event_id: u64) {
+        self.publishers
+            .publish(
+                KvCacheEvent {
+                    event_id,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 0,
+                },
+                None,
+            )
+            .unwrap();
+    }
+}
+
+impl LiveBoundaryCore for FakeCore {
+    fn live_is_empty(&self) -> bool {
+        true
+    }
+
+    fn receive_live_request(&mut self, _request: DirectRequest) {}
+
+    fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
+        panic!("boundary-only fake does not execute live passes")
+    }
+
+    fn apply_live_command(
+        &mut self,
+        _command: SchedulerCommand,
+        _allow_destination_admission: bool,
+        _now_ms: f64,
+    ) -> anyhow::Result<SchedulerCommandEffects> {
+        let mut effects = SchedulerCommandEffects::new(SchedulerCommandResult::Applied);
+        if self.command_effects || self.midpass_kv_effects {
+            self.publish_kv(2);
+        }
+        if self.command_effects {
+            effects
+                .lifecycle_events
+                .push(SchedulerLifecycleEvent::DestinationReserved {
+                    handoff_id: HandoffId::from(Uuid::from_u128(2)),
+                    request_id: Uuid::from_u128(3),
+                    transferable_prompt_tokens: 4,
+                });
+        }
+        Ok(effects)
+    }
+
+    fn retry_live_destinations(&mut self, _now_ms: f64) -> Vec<SchedulerLifecycleEvent> {
+        Vec::new()
+    }
+
+    fn live_metrics(&self) -> MockerMetrics {
+        MockerMetrics::default()
+    }
+
+    fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics {
+        pass_metrics
+    }
+
+    fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {
+        self.publish_kv(3);
+    }
+}
+
+fn pass() -> EnginePassResult {
+    let request_id = Uuid::from_u128(1);
+    EnginePassResult {
+        end_ms: 1.0,
+        completed_requests: 1,
+        output_signals: vec![OutputSignal {
+            uuid: request_id,
+            token_id: None,
+            completed: true,
+            rejected: false,
+            handoff_delay_ms: None,
+        }],
+        admissions: vec![AdmissionEvent {
+            uuid: request_id,
+            reused_input_tokens: 0,
+        }],
+        lifecycle_events: vec![SchedulerLifecycleEvent::DestinationReserved {
+            handoff_id: HandoffId::from(Uuid::from_u128(2)),
+            request_id,
+            transferable_prompt_tokens: 4,
+        }],
+        mocker_metrics: MockerMetrics::default(),
+        router_event_visibility: RouterEventVisibility::PassEnd,
+        kv_events: Vec::new(),
+        fpm: Some(ForwardPassSnapshot::default()),
+        accept_length_output_tokens: 1,
+        accept_length_decode_forwards: 1,
+    }
+}
+
+fn publisher(
+    output_tx: mpsc::UnboundedSender<Vec<OutputSignal>>,
+    captured: DeferredKvPublishBuffer,
+    log: Arc<Mutex<Vec<PublishedEffect>>>,
+) -> LiveEffectsPublisher {
+    let (admission_tx, _admission_rx) = mpsc::unbounded_channel();
+    let (lifecycle_tx, _lifecycle_rx) = mpsc::channel(4);
+    let (metrics_tx, _metrics_rx) = watch::channel(MockerMetrics::default());
+    LiveEffectsPublisher::new(
+        Some(output_tx),
+        Some(admission_tx),
+        lifecycle_tx,
+        metrics_tx,
+        KvEventPublishers::default(),
+        FpmPublisher::default(),
+        captured,
+    )
+    .with_publication_log(log)
+}
+
+#[tokio::test]
+async fn pass_effects_publish_once_in_boundary_order_and_isolate_midpass_ack() {
+    let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
+    let mut core = FakeCore {
+        publishers: buffering_publishers,
+        command_effects: false,
+        midpass_kv_effects: false,
+    };
+    core.publish_kv(1);
+    let (output_tx, output_rx) = mpsc::unbounded_channel();
+    drop(output_rx);
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let publisher = publisher(output_tx, captured, log.clone());
+    let mut pending = publisher.capture_pass(pass());
+    publisher.publish_pass_start(&mut pending);
+
+    let (reply, reply_rx) = tokio::sync::oneshot::channel();
+    publisher
+        .apply_command(
+            &mut core,
+            SchedulerCommandEnvelope {
+                command: SchedulerCommand::CancelSource {
+                    handoff_id: HandoffId::from(Uuid::from_u128(2)),
+                },
+                reply,
+            },
+            false,
+            1.0,
+        )
+        .await;
+    assert_eq!(
+        reply_rx.await.unwrap().unwrap().result,
+        SchedulerCommandResult::Applied
+    );
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &[PublishedEffect::Admissions, PublishedEffect::Ack]
+    );
+
+    publisher.publish_pass(&mut core, pending).await;
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &[
+            PublishedEffect::Admissions,
+            PublishedEffect::Ack,
+            PublishedEffect::Kv,
+            PublishedEffect::Fpm,
+            PublishedEffect::Outputs,
+            PublishedEffect::Accounting,
+            PublishedEffect::Kv,
+            PublishedEffect::Lifecycle,
+            PublishedEffect::Metrics,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn controlled_pass_start_router_effects_precede_midpass_ack_without_duplicates() {
+    let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
+    let mut core = FakeCore {
+        publishers: buffering_publishers,
+        command_effects: false,
+        midpass_kv_effects: true,
+    };
+    core.publish_kv(1);
+    let (output_tx, _output_rx) = mpsc::unbounded_channel();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let publisher = publisher(output_tx, captured, log.clone());
+    let mut pass = pass();
+    pass.router_event_visibility = RouterEventVisibility::PassStart;
+    let mut pending = publisher.capture_pass(pass);
+
+    publisher.publish_pass_start(&mut pending);
+    let (reply, reply_rx) = tokio::sync::oneshot::channel();
+    publisher
+        .apply_command(
+            &mut core,
+            SchedulerCommandEnvelope {
+                command: SchedulerCommand::CancelSource {
+                    handoff_id: HandoffId::from(Uuid::from_u128(2)),
+                },
+                reply,
+            },
+            false,
+            1.0,
+        )
+        .await;
+    assert_eq!(
+        reply_rx.await.unwrap().unwrap().result,
+        SchedulerCommandResult::Applied
+    );
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &[
+            PublishedEffect::Admissions,
+            PublishedEffect::Kv,
+            PublishedEffect::Ack,
+        ]
+    );
+
+    publisher.publish_pass(&mut core, pending).await;
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &[
+            PublishedEffect::Admissions,
+            PublishedEffect::Kv,
+            PublishedEffect::Ack,
+            PublishedEffect::Kv,
+            PublishedEffect::Fpm,
+            PublishedEffect::Outputs,
+            PublishedEffect::Accounting,
+            PublishedEffect::Lifecycle,
+            PublishedEffect::Metrics,
+        ]
+    );
+}
+
+#[tokio::test]
+async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
+    let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
+    let mut core = FakeCore {
+        publishers: buffering_publishers,
+        command_effects: true,
+        midpass_kv_effects: false,
+    };
+    let (output_tx, _output_rx) = mpsc::unbounded_channel();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let publisher = publisher(output_tx, captured, log.clone());
+    let (reply, reply_rx) = tokio::sync::oneshot::channel();
+
+    publisher
+        .apply_command(
+            &mut core,
+            SchedulerCommandEnvelope {
+                command: SchedulerCommand::ActivateDestination {
+                    handoff_id: HandoffId::from(Uuid::from_u128(2)),
+                },
+                reply,
+            },
+            true,
+            1.0,
+        )
+        .await;
+
+    assert_eq!(
+        reply_rx.await.unwrap().unwrap().result,
+        SchedulerCommandResult::Applied
+    );
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &[
+            PublishedEffect::Kv,
+            PublishedEffect::Ack,
+            PublishedEffect::Lifecycle,
+            PublishedEffect::Metrics,
+        ]
+    );
+}

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -13,10 +13,10 @@ pub mod vllm;
 pub use crate::common::protocols::ForwardPassSnapshot;
 use crate::common::protocols::{DirectRequest, FpmPublisher, KvEventPublishers, OutputSignal};
 use dynamo_kv_router::protocols::RouterEvent;
-pub(crate) use kv_event_sink::{
-    CapturedRouterEventBuffer, capture_deferred_kv_publish_sink, capture_router_event_sink,
+pub(crate) use kv_event_sink::{CapturedRouterEventBuffer, capture_router_event_sink};
+pub(crate) use live_boundary::{
+    LiveBoundaryCore, LivePassExecution, LiveSchedulerState, spawn_live_scheduler,
 };
-pub(crate) use live_boundary::{LiveBoundaryCore, LiveEffectsPublisher};
 pub(crate) use source_holds::{
     ActiveHandoffRequests, DestinationHolds, PendingDestinations, RemovedSource, SourceCompletion,
     SourceHolds,

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
 use tokio::sync::mpsc;
@@ -11,32 +9,18 @@ use tokio_util::sync::CancellationToken;
 use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
-use crate::common::utils::sleep_until_precise;
 use crate::scheduler::{
-    AdmissionEvent, LiveBoundaryCore, LiveEffectsPublisher, MockerMetrics, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent,
-    capture_deferred_kv_publish_sink, handoff_channel_capacity,
+    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, MockerMetrics,
+    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle,
+    SchedulerLifecycleEvent, spawn_live_scheduler,
 };
 
 use super::core::SglangCore;
 
 #[derive(Clone)]
 pub struct SglangScheduler {
-    request_tx: mpsc::UnboundedSender<DirectRequest>,
-    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
-    lifecycle_rx: Arc<Mutex<Option<mpsc::Receiver<SchedulerLifecycleEvent>>>>,
-    metrics_rx: tokio::sync::watch::Receiver<MockerMetrics>,
-    _cancel_guard: Arc<CancelGuard>,
+    inner: LiveSchedulerState,
 }
-
-struct CancelGuard(CancellationToken);
-
-impl Drop for CancelGuard {
-    fn drop(&mut self) {
-        self.0.cancel();
-    }
-}
-
 impl SglangScheduler {
     pub fn new(
         args: MockEngineArgs,
@@ -86,345 +70,52 @@ impl SglangScheduler {
         admission_tx: Option<mpsc::UnboundedSender<AdmissionEvent>>,
         fpm_publisher: FpmPublisher,
     ) -> Self {
-        let (request_tx, mut request_rx) = mpsc::unbounded_channel::<DirectRequest>();
-        let control_capacity = handoff_channel_capacity(&args);
-        let (command_tx, mut command_rx) =
-            mpsc::channel::<SchedulerCommandEnvelope>(control_capacity);
-        let (lifecycle_tx, lifecycle_rx) =
-            mpsc::channel::<SchedulerLifecycleEvent>(control_capacity);
-        let total_blocks = args.num_gpu_blocks as u64;
-        let initial_metrics = MockerMetrics::new(dp_rank, 0, total_blocks);
-        let (metrics_tx, metrics_rx) =
-            tokio::sync::watch::channel::<MockerMetrics>(initial_metrics);
-
-        let cancel_token = cancellation_token.unwrap_or_default();
-        let cancel_token_clone = cancel_token.clone();
-        let cancel_guard = Arc::new(CancelGuard(cancel_token));
-        let controls_enabled = args.is_prefill() || args.is_decode();
-
-        tokio::spawn(async move {
-            let (deferred_kv_events, buffering_publishers) = capture_deferred_kv_publish_sink(
-                !kv_event_publishers.is_empty(),
-                kv_event_publishers.raw_enabled(),
-            );
-            let mut core = SglangCore::new_with_sink(args, dp_rank, buffering_publishers);
-            let publisher = LiveEffectsPublisher::new(
-                output_tx,
-                admission_tx,
-                lifecycle_tx,
-                metrics_tx,
-                kv_event_publishers,
-                fpm_publisher,
-                deferred_kv_events,
-            );
-            let scheduler_start = Instant::now();
-            let mut deferred_commands = VecDeque::new();
-
-            loop {
-                if !receive_until_schedulable(
-                    &mut core,
-                    &mut request_rx,
-                    &mut command_rx,
-                    &publisher,
-                    &scheduler_start,
-                    &cancel_token_clone,
-                    controls_enabled,
-                )
-                .await
-                {
-                    break;
-                }
-
-                let iteration_start = Instant::now();
-                let metrics_before = core.mocker_metrics();
-                let pass = core.execute_pass_internal(None, 0.0);
-                let mut pending = publisher.capture_pass(pass);
-                publisher.publish_pass_start(&mut pending);
-                let total_time = std::time::Duration::from_secs_f64(pending.end_ms() / 1000.0);
-                let zero_progress =
-                    total_time.is_zero() && !pending.made_progress_since(&metrics_before);
-                if total_time > std::time::Duration::ZERO {
-                    let deadline = iteration_start + total_time;
-                    if controls_enabled {
-                        if !wait_for_pass_boundary(
-                            &mut core,
-                            &mut command_rx,
-                            &mut deferred_commands,
-                            &publisher,
-                            &scheduler_start,
-                            &cancel_token_clone,
-                            deadline,
-                        )
-                        .await
-                        {
-                            break;
-                        }
-                    } else {
-                        sleep_until_precise(deadline).await;
-                    }
-                }
-                publisher.publish_pass(&mut core, pending).await;
-                if controls_enabled {
-                    let mut command_processed = false;
-                    while let Some(command) = deferred_commands.pop_front() {
-                        command_processed = true;
-                        publisher
-                            .apply_command(
-                                &mut core,
-                                command,
-                                true,
-                                scheduler_elapsed_ms(&scheduler_start),
-                            )
-                            .await;
-                    }
-                    while let Ok(command) = command_rx.try_recv() {
-                        command_processed = true;
-                        publisher
-                            .apply_command(
-                                &mut core,
-                                command,
-                                true,
-                                scheduler_elapsed_ms(&scheduler_start),
-                            )
-                            .await;
-                    }
-                    let retry_progress = publisher
-                        .retry_destinations(&mut core, scheduler_elapsed_ms(&scheduler_start))
-                        .await;
-                    if zero_progress
-                        && !command_processed
-                        && !retry_progress
-                        && !wait_for_progress_wake(
-                            &mut core,
-                            &mut request_rx,
-                            &mut command_rx,
-                            &publisher,
-                            &scheduler_start,
-                            &cancel_token_clone,
-                            true,
-                        )
-                        .await
-                    {
-                        break;
-                    }
-                } else if zero_progress
-                    && !wait_for_progress_wake(
-                        &mut core,
-                        &mut request_rx,
-                        &mut command_rx,
-                        &publisher,
-                        &scheduler_start,
-                        &cancel_token_clone,
-                        false,
-                    )
-                    .await
-                {
-                    break;
-                }
-            }
-        });
-
         Self {
-            request_tx,
-            command_tx,
-            lifecycle_rx: Arc::new(Mutex::new(Some(lifecycle_rx))),
-            metrics_rx,
-            _cancel_guard: cancel_guard,
+            inner: spawn_live_scheduler(
+                args,
+                dp_rank,
+                output_tx,
+                kv_event_publishers,
+                cancellation_token,
+                admission_tx,
+                fpm_publisher,
+                SglangCore::new_with_sink,
+            ),
         }
     }
 }
 
 impl SchedulerHandle for SglangScheduler {
     fn receive(&self, request: DirectRequest) {
-        let _ = self.request_tx.send(request);
+        self.inner.receive(request);
     }
 
     fn request_sender(&self) -> mpsc::UnboundedSender<DirectRequest> {
-        self.request_tx.clone()
+        self.inner.request_sender()
     }
 
     fn metrics_receiver(&self) -> tokio::sync::watch::Receiver<MockerMetrics> {
-        self.metrics_rx.clone()
+        self.inner.metrics_receiver()
     }
 
     fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope> {
-        self.command_tx.clone()
+        self.inner.command_sender()
     }
 
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
-        self.lifecycle_rx
-            .lock()
-            .expect("scheduler lifecycle receiver mutex poisoned")
-            .take()
+        self.inner.take_lifecycle_receiver()
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn receive_until_schedulable(
-    core: &mut SglangCore,
-    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    controls_enabled: bool,
-) -> bool {
-    if !controls_enabled {
-        if cancel_token.is_cancelled() {
-            return false;
-        }
-        if core.is_empty() {
-            tokio::select! {
-                biased;
-                _ = cancel_token.cancelled() => return false,
-                request = request_rx.recv() => {
-                    let Some(request) = request else {
-                        return false;
-                    };
-                    core.receive(request);
-                }
-            }
-        }
-        while let Ok(request) = request_rx.try_recv() {
-            core.receive(request);
-        }
-        return true;
-    }
-
-    while core.is_empty() {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => return false,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                publisher
-                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-                    .await;
-            }
-            result = request_rx.recv() => {
-                let Some(request) = result else {
-                    return false;
-                };
-                core.receive(request);
-            }
-        }
-    }
-
-    while let Ok(command) = command_rx.try_recv() {
-        publisher
-            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-            .await;
-    }
-    while let Ok(request) = request_rx.try_recv() {
-        core.receive(request);
-    }
-
-    true
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn wait_for_pass_boundary(
-    core: &mut SglangCore,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    deadline: Instant,
-) -> bool {
-    let sleep = sleep_until_precise(deadline);
-    tokio::pin!(sleep);
-    loop {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => return false,
-            _ = &mut sleep => return true,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                if command_can_apply_during_pass(&command.command) {
-                    publisher
-                        .apply_command(
-                            core,
-                            command,
-                            false,
-                            scheduler_elapsed_ms(scheduler_start),
-                        )
-                        .await;
-                } else {
-                    deferred_commands.push_back(command);
-                    return tokio::select! {
-                        biased;
-                        _ = cancel_token.cancelled() => false,
-                        _ = &mut sleep => true,
-                    };
-                }
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn wait_for_progress_wake(
-    core: &mut SglangCore,
-    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    controls_enabled: bool,
-) -> bool {
-    if controls_enabled {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                publisher
-                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-                    .await;
-                true
-            }
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive(request);
-                true
-            }
-        }
-    } else {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive(request);
-                true
-            }
-        }
-    }
-}
-
-fn scheduler_elapsed_ms(scheduler_start: &Instant) -> f64 {
-    scheduler_start.elapsed().as_secs_f64() * 1000.0
-}
-
-fn command_can_apply_during_pass(command: &SchedulerCommand) -> bool {
-    matches!(
-        command,
-        SchedulerCommand::SubmitHandoffPrefill { .. } | SchedulerCommand::ReserveDestination { .. }
-    )
 }
 
 impl LiveBoundaryCore for SglangCore {
+    fn live_is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn receive_live_request(&mut self, request: DirectRequest) {
+        self.receive(request);
+    }
+
     fn apply_live_command(
         &mut self,
         command: SchedulerCommand,
@@ -449,5 +140,11 @@ impl LiveBoundaryCore for SglangCore {
         pass_metrics.running_requests = current.running_requests;
         pass_metrics.waiting_requests = current.waiting_requests;
         pass_metrics
+    }
+
+    fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
+        let pass = self.execute_pass_internal(None, 0.0);
+        let duration = std::time::Duration::from_secs_f64(pass.end_ms / 1000.0);
+        LivePassExecution { pass, duration }
     }
 }

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
+use std::time::Instant;
+
+#[cfg(all(test, feature = "kvbm-offload"))]
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+#[cfg(all(test, feature = "kvbm-offload"))]
+use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -11,11 +14,10 @@ use tokio_util::sync::CancellationToken;
 use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
-use crate::common::utils::sleep_until_precise;
 use crate::scheduler::{
-    AdmissionEvent, LiveBoundaryCore, LiveEffectsPublisher, SchedulerCommand,
+    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, SchedulerCommand,
     SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent,
-    capture_deferred_kv_publish_sink, handoff_channel_capacity,
+    spawn_live_scheduler,
 };
 
 use super::core::VllmCore;
@@ -32,7 +34,6 @@ pub struct MockerMetrics {
     pub sglang_cache_hit_tokens: u64,
     pub sglang_cache_total_tokens: u64,
 }
-
 impl MockerMetrics {
     pub fn new(
         dp_rank: dynamo_kv_router::protocols::DpRank,
@@ -74,19 +75,7 @@ impl MockerMetrics {
 
 #[derive(Clone)]
 pub struct Scheduler {
-    request_tx: mpsc::UnboundedSender<DirectRequest>,
-    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
-    lifecycle_rx: Arc<Mutex<Option<mpsc::Receiver<SchedulerLifecycleEvent>>>>,
-    metrics_rx: tokio::sync::watch::Receiver<MockerMetrics>,
-    _cancel_guard: Arc<CancelGuard>,
-}
-
-struct CancelGuard(CancellationToken);
-
-impl Drop for CancelGuard {
-    fn drop(&mut self) {
-        self.0.cancel();
-    }
+    inner: LiveSchedulerState,
 }
 
 impl Scheduler {
@@ -138,407 +127,63 @@ impl Scheduler {
         admission_tx: Option<mpsc::UnboundedSender<AdmissionEvent>>,
         fpm_publisher: FpmPublisher,
     ) -> Self {
-        let (request_tx, mut request_rx) = mpsc::unbounded_channel::<DirectRequest>();
-        let control_capacity = handoff_channel_capacity(&args);
-        let (command_tx, mut command_rx) =
-            mpsc::channel::<SchedulerCommandEnvelope>(control_capacity);
-        let (lifecycle_tx, lifecycle_rx) =
-            mpsc::channel::<SchedulerLifecycleEvent>(control_capacity);
-        let total_blocks = args.num_gpu_blocks as u64;
-        let initial_metrics = MockerMetrics::new(dp_rank, 0, total_blocks);
-        let (metrics_tx, metrics_rx) = tokio::sync::watch::channel(initial_metrics);
-
-        let cancel_token = cancellation_token.unwrap_or_default();
-        let cancel_token_clone = cancel_token.clone();
-        let cancel_guard = Arc::new(CancelGuard(cancel_token));
-        let controls_enabled = args.is_prefill() || args.is_decode();
-
-        tokio::spawn(async move {
-            let (deferred_kv_events, buffering_publishers) = capture_deferred_kv_publish_sink(
-                !kv_event_publishers.is_empty(),
-                kv_event_publishers.raw_enabled(),
-            );
-            let mut core = VllmCore::new_with_sink(args, dp_rank, buffering_publishers);
-            let publisher = LiveEffectsPublisher::new(
-                output_tx,
-                admission_tx,
-                lifecycle_tx,
-                metrics_tx,
-                kv_event_publishers,
-                fpm_publisher,
-                deferred_kv_events,
-            );
-            #[cfg(feature = "kvbm-offload")]
-            if let Err(e) = core.init_offload_live().await {
-                tracing::error!("kvbm-offload live init failed: {e}");
-            }
-            // Wall-clock origin for this scheduler's simulated time. Drives
-            // `engine.tick(now_ms)` so the PS bandwidth models advance
-            // in real time across passes.
-            let scheduler_start = Instant::now();
-            let mut deferred_commands = VecDeque::new();
-
-            loop {
-                if !receive_until_schedulable(
-                    &mut core,
-                    &mut request_rx,
-                    &mut command_rx,
-                    &publisher,
-                    &scheduler_start,
-                    &cancel_token_clone,
-                    controls_enabled,
-                )
-                .await
-                {
-                    break;
-                }
-
-                let iteration_start = Instant::now();
-                let now_ms = scheduler_start.elapsed().as_secs_f64() * 1000.0;
-                let metrics_before = core.mocker_metrics();
-                let pass = core.execute_pass_internal(None, now_ms, None);
-                let mut pending = publisher.capture_pass(pass);
-                let total_time = std::time::Duration::from_secs_f64(
-                    (pending.end_ms() - now_ms).max(0.0) / 1000.0,
-                );
-                let zero_progress =
-                    total_time.is_zero() && !pending.made_progress_since(&metrics_before);
-                publisher.publish_pass_start(&mut pending);
-                if total_time > std::time::Duration::ZERO {
-                    let deadline = iteration_start + total_time;
-                    if controls_enabled {
-                        if !wait_for_pass_boundary(
-                            &mut core,
-                            &mut command_rx,
-                            &mut deferred_commands,
-                            &publisher,
-                            &scheduler_start,
-                            &cancel_token_clone,
-                            deadline,
-                        )
-                        .await
-                        {
-                            break;
-                        }
-                    } else {
-                        sleep_until_precise(deadline).await;
-                    }
-                }
-                publisher.publish_pass(&mut core, pending).await;
-                if controls_enabled {
-                    let mut command_processed = false;
-                    while let Some(command) = deferred_commands.pop_front() {
-                        command_processed = true;
-                        publisher
-                            .apply_command(
-                                &mut core,
-                                command,
-                                true,
-                                scheduler_elapsed_ms(&scheduler_start),
-                            )
-                            .await;
-                    }
-                    while let Ok(command) = command_rx.try_recv() {
-                        command_processed = true;
-                        publisher
-                            .apply_command(
-                                &mut core,
-                                command,
-                                true,
-                                scheduler_elapsed_ms(&scheduler_start),
-                            )
-                            .await;
-                    }
-                    let retry_progress = publisher
-                        .retry_destinations(&mut core, scheduler_elapsed_ms(&scheduler_start))
-                        .await;
-                    if zero_progress
-                        && !command_processed
-                        && !retry_progress
-                        && !wait_for_progress_wake(
-                            &mut core,
-                            &mut request_rx,
-                            &mut command_rx,
-                            &publisher,
-                            &scheduler_start,
-                            &cancel_token_clone,
-                            true,
-                        )
-                        .await
-                    {
-                        break;
-                    }
-                } else if zero_progress
-                    && !wait_for_progress_wake(
-                        &mut core,
-                        &mut request_rx,
-                        &mut command_rx,
-                        &publisher,
-                        &scheduler_start,
-                        &cancel_token_clone,
-                        false,
-                    )
-                    .await
-                {
-                    break;
-                }
-            }
-        });
-
         Self {
-            request_tx,
-            command_tx,
-            lifecycle_rx: Arc::new(Mutex::new(Some(lifecycle_rx))),
-            metrics_rx,
-            _cancel_guard: cancel_guard,
+            inner: spawn_live_scheduler(
+                args,
+                dp_rank,
+                output_tx,
+                kv_event_publishers,
+                cancellation_token,
+                admission_tx,
+                fpm_publisher,
+                VllmCore::new_with_sink,
+            ),
         }
     }
 }
 
 impl SchedulerHandle for Scheduler {
     fn receive(&self, request: DirectRequest) {
-        let _ = self.request_tx.send(request);
+        self.inner.receive(request);
     }
 
     fn request_sender(&self) -> mpsc::UnboundedSender<DirectRequest> {
-        self.request_tx.clone()
+        self.inner.request_sender()
     }
 
     fn metrics_receiver(&self) -> tokio::sync::watch::Receiver<MockerMetrics> {
-        self.metrics_rx.clone()
+        self.inner.metrics_receiver()
     }
 
     fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope> {
-        self.command_tx.clone()
+        self.inner.command_sender()
     }
 
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
-        self.lifecycle_rx
-            .lock()
-            .expect("scheduler lifecycle receiver mutex poisoned")
-            .take()
+        self.inner.take_lifecycle_receiver()
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn receive_until_schedulable(
-    core: &mut VllmCore,
-    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    controls_enabled: bool,
-) -> bool {
-    if !controls_enabled {
-        if cancel_token.is_cancelled() {
-            return false;
-        }
-        if core.is_empty() {
-            tokio::select! {
-                biased;
-                _ = cancel_token.cancelled() => return false,
-                request = request_rx.recv() => {
-                    let Some(request) = request else {
-                        return false;
-                    };
-                    core.receive(request);
-                }
-            }
-        }
-        while let Ok(request) = request_rx.try_recv() {
-            core.receive(request);
-        }
-        return true;
-    }
-
-    while core.is_empty() {
-        #[cfg(feature = "kvbm-offload")]
-        let internal_deadline_ms = core.earliest_offload_deadline();
-        #[cfg(not(feature = "kvbm-offload"))]
-        let internal_deadline_ms = None;
-        let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
-        tokio::pin!(internal_deadline);
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => return false,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                publisher
-                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-                    .await;
-            }
-            result = request_rx.recv() => {
-                let Some(request) = result else {
-                    return false;
-                };
-                core.receive(request);
-            }
-            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
-                #[cfg(feature = "kvbm-offload")]
-                {
-                    let now_ms = scheduler_elapsed_ms(scheduler_start)
-                        .max(internal_deadline_ms.expect("armed offload deadline"));
-                    publisher.advance_offload(core, now_ms, true).await;
-                }
-            }
-        }
-    }
-
-    while let Ok(command) = command_rx.try_recv() {
-        publisher
-            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-            .await;
-    }
-    while let Ok(request) = request_rx.try_recv() {
-        core.receive(request);
-    }
-
-    true
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn wait_for_pass_boundary(
-    core: &mut VllmCore,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    deadline: Instant,
-) -> bool {
-    let sleep = sleep_until_precise(deadline);
-    tokio::pin!(sleep);
-    let mut accept_commands = true;
-    loop {
-        #[cfg(feature = "kvbm-offload")]
-        let internal_deadline_ms = core.earliest_offload_deadline();
-        #[cfg(not(feature = "kvbm-offload"))]
-        let internal_deadline_ms = None;
-        let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
-        tokio::pin!(internal_deadline);
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => return false,
-            _ = &mut sleep => return true,
-            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
-                #[cfg(feature = "kvbm-offload")]
-                {
-                    let now_ms = scheduler_elapsed_ms(scheduler_start)
-                        .max(internal_deadline_ms.expect("armed offload deadline"));
-                    publisher.advance_offload(core, now_ms, false).await;
-                    debug_assert!(
-                        core.earliest_offload_deadline()
-                            .is_none_or(|next| next > now_ms),
-                        "offload tick left an already-due deadline armed"
-                    );
-                }
-            }
-            command = command_rx.recv(), if accept_commands => {
-                let Some(command) = command else {
-                    return false;
-                };
-                if command_can_apply_during_pass(&command.command) {
-                    publisher
-                        .apply_command(
-                            core,
-                            command,
-                            false,
-                            scheduler_elapsed_ms(scheduler_start),
-                        )
-                        .await;
-                } else {
-                    deferred_commands.push_back(command);
-                    accept_commands = false;
-                }
-            }
-        }
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn wait_for_progress_wake(
-    core: &mut VllmCore,
-    request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
-    command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
-    publisher: &LiveEffectsPublisher,
-    scheduler_start: &Instant,
-    cancel_token: &CancellationToken,
-    controls_enabled: bool,
-) -> bool {
-    #[cfg(feature = "kvbm-offload")]
-    let internal_deadline_ms = core.earliest_offload_deadline();
-    #[cfg(not(feature = "kvbm-offload"))]
-    let internal_deadline_ms = None;
-
-    let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
-    tokio::pin!(internal_deadline);
-    if controls_enabled {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                publisher
-                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-                    .await;
-                true
-            }
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive(request);
-                true
-            }
-            _ = &mut internal_deadline => true,
-        }
-    } else {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive(request);
-                true
-            }
-            _ = &mut internal_deadline => true,
-        }
-    }
-}
-
-async fn wait_for_internal_deadline(scheduler_start: &Instant, deadline_ms: Option<f64>) {
-    let Some(deadline_ms) = deadline_ms else {
-        std::future::pending::<()>().await;
-        return;
-    };
-    let deadline = *scheduler_start + Duration::from_secs_f64(deadline_ms.max(0.0) / 1000.0);
-    let wake_at = if deadline <= Instant::now() {
-        Instant::now() + Duration::from_millis(1)
-    } else {
-        deadline
-    };
-    sleep_until_precise(wake_at).await;
-}
-
-fn scheduler_elapsed_ms(scheduler_start: &Instant) -> f64 {
-    scheduler_start.elapsed().as_secs_f64() * 1000.0
-}
-
-fn command_can_apply_during_pass(command: &SchedulerCommand) -> bool {
-    matches!(
-        command,
-        SchedulerCommand::SubmitHandoffPrefill { .. } | SchedulerCommand::ReserveDestination { .. }
-    )
 }
 
 impl LiveBoundaryCore for VllmCore {
+    fn initialize_live(
+        &mut self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            #[cfg(feature = "kvbm-offload")]
+            if let Err(error) = self.init_offload_live().await {
+                tracing::error!("kvbm-offload live init failed: {error}");
+            }
+        })
+    }
+
+    fn live_is_empty(&self) -> bool {
+        self.is_empty()
+    }
+
+    fn receive_live_request(&mut self, request: DirectRequest) {
+        self.receive(request);
+    }
+
     fn apply_live_command(
         &mut self,
         command: SchedulerCommand,
@@ -558,6 +203,26 @@ impl LiveBoundaryCore for VllmCore {
 
     fn pass_boundary_metrics(&self, _pass_metrics: MockerMetrics) -> MockerMetrics {
         self.mocker_metrics()
+    }
+
+    fn live_internal_deadline_ms(&self) -> Option<f64> {
+        #[cfg(feature = "kvbm-offload")]
+        {
+            self.earliest_offload_deadline()
+        }
+        #[cfg(not(feature = "kvbm-offload"))]
+        {
+            None
+        }
+    }
+
+    fn execute_live_pass(&mut self, scheduler_start: &Instant) -> LivePassExecution {
+        // Wall-clock elapsed time drives the PS bandwidth models across
+        // vLLM passes; SGLang reports a duration directly from each pass.
+        let now_ms = scheduler_start.elapsed().as_secs_f64() * 1000.0;
+        let pass = self.execute_pass_internal(None, now_ms, None);
+        let duration = std::time::Duration::from_secs_f64((pass.end_ms - now_ms).max(0.0) / 1000.0);
+        LivePassExecution { pass, duration }
     }
 
     fn output_delivery_failed(&mut self, signals: Vec<OutputSignal>) {


### PR DESCRIPTION
## Overview:

Extract the duplicated Mocker vLLM and SGLang live scheduler actor loops into one shared implementation. This is the first prerequisite split from #11917; request cancellation and the public live request engine remain outside this PR.

## Details:

- Move request intake, pass timing, command handling, lifecycle publication, metrics, and progress waits into `scheduler/live_boundary.rs`.
- Keep the existing role-derived `controls_enabled` behavior and unbounded output channel semantics.
- Reduce the vLLM and SGLang live modules to scheduler wrappers and engine-specific hooks.
- Relocate the three existing boundary-publication tests without expanding their coverage.
- Fix shutdown observation between continuously productive zero-duration passes in a separate commit with one focused regression test.
- Do not add `CancelRequest`, a cancellation lane, bounded output plumbing, or `LiveEngine`.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/live_boundary.rs` for the shared actor loop.
- `lib/mocker/src/scheduler/vllm/live.rs` and `lib/mocker/src/scheduler/sglang/live.rs` for the engine-specific adapters.
- `lib/mocker/src/scheduler/live_boundary/tests.rs` for the relocated ordering tests and shutdown regression.

## Related Issues

- [DIS-2473: Expose Mocker as a live request engine for sidecar adapters](https://linear.app/nvidia/issue/DIS-2473/expose-mocker-as-a-live-request-engine-for-sidecar-adapters)
- Relates to #11873

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker --lib -- --skip services::bootstrap::tests` (512 passed, 1 pre-existing ignored)
- Focused live-boundary, vLLM live-scheduler, and SGLang lifecycle tests
- KVBM-offload test attempted locally but blocked during dependency build because the host has CUDA 11; KVBM requires CUDA 12+


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved live scheduling coordination across supported runtime backends.
  - Ensured outputs, lifecycle events, metrics, acknowledgements, and related updates are published in a consistent order.
  - Improved handling of deferred work and internal scheduling deadlines for smoother progress.
  - Added more reliable cancellation and shutdown behavior, including protection against endless zero-duration processing loops.

- **Tests**
  - Added coverage for publication ordering, command-driven effects, mid-pass acknowledgements, and clean shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->