### PR TITLE
fix(tokenizers): integrate Kimi Linear support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,9 +2859,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
+version = "1.5.3"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkimi-linear-tokenizer#d377887d657893525c094669441d004d5c13f4d0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
 dynamo-rl = { path = "lib/rl", version = "1.3.0" }
-dynamo-tokenizers = { version = "=1.5.0" }
+dynamo-tokenizers = { version = "=1.5.3" }
 dynamo-renderer = { version = "=1.3.8" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
 dynamo-truthy = { path = "lib/truthy", version = "1.3.0" }
@@ -199,3 +199,6 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
+
+[patch.crates-io]
+dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "rmccormick/kimi-linear-tokenizer" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1868,9 +1868,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
+version = "1.5.3"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkimi-linear-tokenizer#d377887d657893525c094669441d004d5c13f4d0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -60,3 +60,6 @@ dlpark = { version = "0.5", features = ["pyo3", "half"], optional = true }
 cudarc = { version = "=0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"], optional = true }
 
 [dev-dependencies]
+
+[patch.crates-io]
+dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "rmccormick/kimi-linear-tokenizer" }

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2544,9 +2544,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
+version = "1.5.3"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkimi-linear-tokenizer#d377887d657893525c094669441d004d5c13f4d0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -120,3 +120,6 @@ tracing-subscriber = { version = "0.3", features = ["registry"] }
 inherits = "release"
 debug = true
 strip = false
+
+[patch.crates-io]
+dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "rmccormick/kimi-linear-tokenizer" }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -87,9 +87,9 @@ fn instrumented_tokenizer_cache(
     cache_bytes: usize,
     cache_extend: bool,
     model: &str,
-) -> Arc<dyn crate::tokenizers::traits::Tokenizer> {
-    Arc::new(
-        crate::tokenizers::CachedTokenizer::new(raw, special_tokens, cache_bytes)
+) -> anyhow::Result<Arc<dyn crate::tokenizers::traits::Tokenizer>> {
+    Ok(Arc::new(
+        crate::tokenizers::CachedTokenizer::new(raw, special_tokens, cache_bytes)?
             .with_extend(cache_extend)
             .with_observer(
                 Arc::new(|| {
@@ -100,7 +100,7 @@ fn instrumented_tokenizer_cache(
                 }),
             )
             .with_token_observer(tokenizer_cache_token_observer(model)),
-    )
+    ))
 }
 
 /// Identify model deployment cards in the key-value store
@@ -1296,7 +1296,7 @@ impl ModelDeploymentCard {
                         cache_bytes,
                         cache_extend,
                         self.name(),
-                    )
+                    )?
                 } else {
                     raw
                 }
@@ -1328,7 +1328,7 @@ impl ModelDeploymentCard {
                         cache_bytes,
                         cache_extend,
                         self.name(),
-                    )
+                    )?
                 } else {
                     raw
                 }


### PR DESCRIPTION
## Summary

- Resolve `dynamo-tokenizers` 1.5.3 from the `rmccormick/kimi-linear-tokenizer` frontend-crates branch in the root, Python binding, and KVBM binding workspaces.
- Pin all three lockfiles to frontend-crates commit `d377887d`, which adds `model_type = "kimi_linear"` support.
- Propagate the fallible `CachedTokenizer::new` result introduced after Dynamo's existing 1.5.0 pin.

This is an integration/validation draft that depends on [frontend-crates PR #134](https://github.com/ai-dynamo/frontend-crates/pull/134). The Git branch overrides should be replaced with the released crate version before this PR is merged.

## Validation

- `cargo metadata --locked --format-version 1` in the root, Python binding, and KVBM binding workspaces
- Confirmed each workspace resolves one `dynamo-tokenizers` at frontend-crates `d377887d`
- `cargo build -p dynamo-llm --no-default-features --locked`
- `cargo build --manifest-path lib/bindings/python/Cargo.toml --no-default-features --locked --target-dir target`
- `cargo check --manifest-path lib/bindings/kvbm/Cargo.toml --locked --target-dir target`
- `cargo fmt --all -- --check`
- Targeted `pre-commit run --files ...`

The additional KVBM `--no-default-features` probe reaches a pre-existing unsupported configuration where KVBM imports optional `cudarc`; its normal default-feature check passes.

## Tracking

- [DIS-2465](https://linear.app/nvidia/issue/DIS-2465/support-kimi-linear-tokenizer-model-type)