### PR TITLE
feat(mocker): add targeted request cancellation

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -226,7 +226,7 @@ pub struct MockEngine {
     active_requests: Arc<DashMap<Uuid, mpsc::UnboundedSender<OutputSignal>>>,
     request_senders: OnceCell<Vec<mpsc::UnboundedSender<DirectRequest>>>,
     command_senders: OnceCell<Vec<mpsc::Sender<SchedulerCommandEnvelope>>>,
-    // TODO(DIS-2473): Store the scheduler cancellation senders and connect the AsyncEngine
+    // TODO(DIS-2478): Store the scheduler cancellation senders and connect the AsyncEngine
     // context stop/response-stream drop path to targeted cancellation. Until then, lib/mocker
     // cancellation is not wired end to end through MockEngine.
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -226,6 +226,9 @@ pub struct MockEngine {
     active_requests: Arc<DashMap<Uuid, mpsc::UnboundedSender<OutputSignal>>>,
     request_senders: OnceCell<Vec<mpsc::UnboundedSender<DirectRequest>>>,
     command_senders: OnceCell<Vec<mpsc::Sender<SchedulerCommandEnvelope>>>,
+    // TODO(DIS-2473): Store the scheduler cancellation senders and connect the AsyncEngine
+    // context stop/response-stream drop path to targeted cancellation. Until then, lib/mocker
+    // cancellation is not wired end to end through MockEngine.
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,
     senders_ready: Notify,
     engine_args: MockEngineArgs,

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -307,6 +307,7 @@ impl OfflineWorkerState {
         enum Accounting {
             Submit,
             ReserveDestination,
+            CancelRequest,
             CancelSource,
             CancelDestination,
             None,
@@ -317,6 +318,7 @@ impl OfflineWorkerState {
                 Accounting::Submit
             }
             SchedulerCommand::ReserveDestination { .. } => Accounting::ReserveDestination,
+            SchedulerCommand::CancelRequest { .. } => Accounting::CancelRequest,
             SchedulerCommand::CancelSource { .. } => Accounting::CancelSource,
             SchedulerCommand::CancelDestination { .. } => Accounting::CancelDestination,
             SchedulerCommand::ReleaseSource { .. }
@@ -332,6 +334,9 @@ impl OfflineWorkerState {
                 SchedulerCommandResult::DestinationAccepted { .. },
             ) => self.increment_in_flight(),
             (Accounting::CancelDestination, SchedulerCommandResult::Applied) => {
+                self.decrement_in_flight(1)
+            }
+            (Accounting::CancelRequest, SchedulerCommandResult::Applied) => {
                 self.decrement_in_flight(1)
             }
             (Accounting::CancelSource, SchedulerCommandResult::Applied) => {

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -490,6 +490,33 @@ mod tests {
     }
 
     #[test]
+    fn request_cancellation_releases_offline_in_flight_slot() {
+        let mut worker = worker(EngineType::Vllm, WorkerType::Aggregated, 8);
+        let request_id = Uuid::from_u128(850);
+        worker.receive_request(request(request_id.as_u128(), 8));
+        assert_eq!(worker.in_flight(), 1);
+
+        assert_eq!(
+            worker
+                .apply_command(SchedulerCommand::CancelRequest { request_id })
+                .unwrap()
+                .result,
+            SchedulerCommandResult::Applied
+        );
+        assert_eq!(worker.in_flight(), 0);
+        assert!(worker.is_drained());
+
+        assert_eq!(
+            worker
+                .apply_command(SchedulerCommand::CancelRequest { request_id })
+                .unwrap()
+                .result,
+            SchedulerCommandResult::Noop
+        );
+        assert_eq!(worker.in_flight(), 0);
+    }
+
+    #[test]
     fn ranked_worker_preserves_router_worker_and_dp_rank_identity() {
         for engine_type in [EngineType::Vllm, EngineType::Sglang] {
             let mut builder = MockEngineArgs::builder()

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::VecDeque;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -24,12 +24,6 @@ use crate::scheduler::{
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum RequestResidency {
-    Running,
-    Waiting,
-}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PublishedEffect {
@@ -64,8 +58,6 @@ pub(crate) trait LiveBoundaryCore {
     fn live_metrics(&self) -> MockerMetrics;
 
     fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics;
-
-    fn visit_live_request_residencies(&self, visitor: &mut dyn FnMut(Uuid, RequestResidency));
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {
         None
@@ -307,7 +299,6 @@ pub(crate) struct LiveEffectsPublisher {
     kv_event_publishers: KvEventPublishers,
     fpm_publisher: FpmPublisher,
     captured_kv_events: DeferredKvPublishBuffer,
-    visible_residencies: Mutex<HashMap<Uuid, RequestResidency>>,
     #[cfg(test)]
     publication_log: Option<std::sync::Arc<std::sync::Mutex<Vec<PublishedEffect>>>>,
 }
@@ -641,7 +632,6 @@ impl LiveEffectsPublisher {
             kv_event_publishers,
             fpm_publisher,
             captured_kv_events,
-            visible_residencies: Mutex::new(HashMap::new()),
             #[cfg(test)]
             publication_log: None,
         }
@@ -654,11 +644,6 @@ impl LiveEffectsPublisher {
     ) -> Self {
         self.publication_log = Some(log);
         self
-    }
-
-    #[cfg(test)]
-    fn published_metrics(&self) -> MockerMetrics {
-        self.metrics_tx.borrow().clone()
     }
 
     pub(crate) fn capture_pass(&self, pass: EnginePassResult) -> PendingLivePass {
@@ -731,7 +716,6 @@ impl LiveEffectsPublisher {
         // disappeared. Those cleanup events belong to this same boundary.
         self.publish_router_effects(self.captured_kv_events.drain(), None);
         self.publish_lifecycle(pending.pass.lifecycle_events).await;
-        self.refresh_visible_residencies(core);
         let metrics = core.pass_boundary_metrics(pending.pass.mocker_metrics);
         self.record(PublishedEffect::Metrics);
         let _ = self.metrics_tx.send(metrics);
@@ -772,10 +756,6 @@ impl LiveEffectsPublisher {
         now_ms: f64,
     ) -> Option<SchedulerCommandResult> {
         let SchedulerCommandEnvelope { command, reply } = envelope;
-        let cancellation_id = match &command {
-            SchedulerCommand::CancelRequest { request_id } => Some(*request_id),
-            _ => None,
-        };
         let result = core.apply_live_command(command, allow_destination_admission, now_ms);
         match result {
             Ok(mut effects) => {
@@ -791,33 +771,10 @@ impl LiveEffectsPublisher {
                 }
                 self.record(PublishedEffect::Ack);
                 let _ = reply.send(Ok(effects));
-                let cancelled_residency = if command_result == SchedulerCommandResult::Applied {
-                    cancellation_id.and_then(|request_id| {
-                        self.visible_residencies.lock().unwrap().remove(&request_id)
-                    })
-                } else {
-                    None
-                };
                 if allow_destination_admission {
                     self.publish_lifecycle(lifecycle_events).await;
-                    self.refresh_visible_residencies(core);
                     self.record(PublishedEffect::Metrics);
                     let _ = self.metrics_tx.send(core.live_metrics());
-                } else if let Some(residency) = cancelled_residency {
-                    // The core has already executed the pending pass. Update
-                    // only the queue where this request lived at the last
-                    // published boundary; aggregate post-pass metrics cannot
-                    // identify which visible request was cancelled.
-                    let mut published = self.metrics_tx.borrow().clone();
-                    let visible_count = match residency {
-                        RequestResidency::Running => &mut published.running_requests,
-                        RequestResidency::Waiting => &mut published.waiting_requests,
-                    };
-                    if *visible_count > 0 {
-                        *visible_count -= 1;
-                        self.record(PublishedEffect::Metrics);
-                        self.metrics_tx.send_replace(published);
-                    }
                 }
                 Some(command_result)
             }
@@ -827,14 +784,6 @@ impl LiveEffectsPublisher {
                 None
             }
         }
-    }
-
-    fn refresh_visible_residencies<C: LiveBoundaryCore>(&self, core: &C) {
-        let mut visible_residencies = self.visible_residencies.lock().unwrap();
-        visible_residencies.clear();
-        core.visit_live_request_residencies(&mut |request_id, residency| {
-            visible_residencies.insert(request_id, residency);
-        });
     }
 
     pub(crate) async fn retry_destinations<C: LiveBoundaryCore>(

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -17,12 +17,19 @@ use crate::scheduler::kv_event_sink::{
 };
 use crate::scheduler::vllm::MockerMetrics;
 use crate::scheduler::{
-    AdmissionEvent, EnginePassResult, RouterEventVisibility, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent,
-    handoff_channel_capacity,
+    AdmissionEvent, EnginePassResult, RouterEventVisibility, SchedulerCancellationEnvelope,
+    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerCommandResult,
+    SchedulerHandle, SchedulerLifecycleEvent, handoff_channel_capacity,
 };
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RequestResidency {
+    Running,
+    Waiting,
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PublishedEffect {
@@ -57,6 +64,8 @@ pub(crate) trait LiveBoundaryCore {
     fn live_metrics(&self) -> MockerMetrics;
 
     fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics;
+
+    fn live_request_residency(&self, request_id: Uuid) -> Option<RequestResidency>;
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {
         None
@@ -96,6 +105,7 @@ impl Drop for LiveCancelGuard {
 pub(crate) struct LiveSchedulerState {
     request_tx: mpsc::UnboundedSender<DirectRequest>,
     command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
+    cancellation_tx: mpsc::Sender<SchedulerCancellationEnvelope>,
     lifecycle_rx: Arc<Mutex<Option<mpsc::Receiver<SchedulerLifecycleEvent>>>>,
     metrics_rx: watch::Receiver<MockerMetrics>,
     _cancel_guard: Arc<LiveCancelGuard>,
@@ -116,6 +126,10 @@ impl SchedulerHandle for LiveSchedulerState {
 
     fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope> {
         self.command_tx.clone()
+    }
+
+    fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope> {
+        self.cancellation_tx.clone()
     }
 
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
@@ -144,6 +158,7 @@ where
     let (request_tx, request_rx) = mpsc::unbounded_channel();
     let control_capacity = handoff_channel_capacity(&args);
     let (command_tx, command_rx) = mpsc::channel(control_capacity);
+    let (cancellation_tx, cancellation_rx) = mpsc::channel(control_capacity);
     let (lifecycle_tx, lifecycle_rx) = mpsc::channel(control_capacity);
     let initial_metrics = MockerMetrics::new(dp_rank, 0, args.num_gpu_blocks as u64);
     let (metrics_tx, metrics_rx) = watch::channel(initial_metrics);
@@ -171,6 +186,7 @@ where
             &mut core,
             request_rx,
             command_rx,
+            cancellation_rx,
             publisher,
             actor_cancel_token,
             controls_enabled,
@@ -181,6 +197,7 @@ where
     LiveSchedulerState {
         request_tx,
         command_tx,
+        cancellation_tx,
         lifecycle_rx: Arc::new(Mutex::new(Some(lifecycle_rx))),
         metrics_rx,
         _cancel_guard: cancel_guard,
@@ -191,6 +208,7 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
     core: &mut C,
     mut request_rx: mpsc::UnboundedReceiver<DirectRequest>,
     mut command_rx: mpsc::Receiver<SchedulerCommandEnvelope>,
+    mut cancellation_rx: mpsc::Receiver<SchedulerCancellationEnvelope>,
     publisher: LiveEffectsPublisher,
     cancel_token: CancellationToken,
     controls_enabled: bool,
@@ -208,6 +226,7 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
             core,
             &mut request_rx,
             &mut command_rx,
+            &mut cancellation_rx,
             &publisher,
             &scheduler_start,
             &cancel_token,
@@ -227,58 +246,45 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
         publisher.publish_pass_start(&mut pending);
         if execution.duration > Duration::ZERO {
             let deadline = iteration_start + execution.duration;
-            if controls_enabled {
-                if !wait_for_live_pass_boundary(
-                    core,
-                    &mut command_rx,
-                    &mut deferred_commands,
-                    &publisher,
-                    &scheduler_start,
-                    &cancel_token,
-                    deadline,
-                )
-                .await
-                {
-                    break;
-                }
-            } else {
-                sleep_until_precise(deadline).await;
-            }
-        }
-        publisher.publish_pass(core, pending).await;
-        if controls_enabled {
-            let control_progress = apply_live_post_pass_controls(
+            if !wait_for_live_pass_boundary(
                 core,
                 &mut command_rx,
+                &mut cancellation_rx,
                 &mut deferred_commands,
+                &mut pending,
                 &publisher,
                 &scheduler_start,
+                &cancel_token,
+                deadline,
+                controls_enabled,
             )
-            .await;
-            if zero_progress
-                && !control_progress
-                && !wait_for_live_progress(
-                    core,
-                    &mut request_rx,
-                    &mut command_rx,
-                    &publisher,
-                    &scheduler_start,
-                    &cancel_token,
-                    true,
-                )
-                .await
+            .await
             {
                 break;
             }
-        } else if zero_progress
+        }
+        publisher.publish_pass(core, pending).await;
+        let control_progress = apply_live_post_pass_controls(
+            core,
+            &mut command_rx,
+            &mut cancellation_rx,
+            &mut deferred_commands,
+            &publisher,
+            &scheduler_start,
+            controls_enabled,
+        )
+        .await;
+        if zero_progress
+            && !control_progress
             && !wait_for_live_progress(
                 core,
                 &mut request_rx,
                 &mut command_rx,
+                &mut cancellation_rx,
                 &publisher,
                 &scheduler_start,
                 &cancel_token,
-                false,
+                controls_enabled,
             )
             .await
         {
@@ -298,6 +304,7 @@ pub(crate) struct LiveEffectsPublisher {
     kv_event_publishers: KvEventPublishers,
     fpm_publisher: FpmPublisher,
     captured_kv_events: DeferredKvPublishBuffer,
+    visible_residencies: Mutex<HashMap<Uuid, RequestResidency>>,
     #[cfg(test)]
     publication_log: Option<std::sync::Arc<std::sync::Mutex<Vec<PublishedEffect>>>>,
 }
@@ -319,6 +326,22 @@ impl PendingLivePass {
             || !self.kv_events.is_empty()
             || self.pass.mocker_metrics != *metrics_before
     }
+
+    pub(crate) fn suppress_request_outputs(&mut self, request_id: Uuid) {
+        self.pass
+            .output_signals
+            .retain(|signal| signal.uuid != request_id);
+        self.pass.completed_requests = self
+            .pass
+            .output_signals
+            .iter()
+            .filter(|signal| signal.completed)
+            .count();
+        let (output_tokens, decode_forwards) =
+            crate::scheduler::accept_length_sample(&self.pass.output_signals);
+        self.pass.accept_length_output_tokens = output_tokens;
+        self.pass.accept_length_decode_forwards = decode_forwards;
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -326,33 +349,12 @@ async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
     core: &mut C,
     request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
     command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    cancellation_rx: &mut mpsc::Receiver<SchedulerCancellationEnvelope>,
     publisher: &LiveEffectsPublisher,
     scheduler_start: &Instant,
     cancel_token: &CancellationToken,
     controls_enabled: bool,
 ) -> bool {
-    if !controls_enabled {
-        if cancel_token.is_cancelled() {
-            return false;
-        }
-        if core.live_is_empty() {
-            tokio::select! {
-                biased;
-                _ = cancel_token.cancelled() => return false,
-                request = request_rx.recv() => {
-                    let Some(request) = request else {
-                        return false;
-                    };
-                    core.receive_live_request(request);
-                }
-            }
-        }
-        while let Ok(request) = request_rx.try_recv() {
-            core.receive_live_request(request);
-        }
-        return true;
-    }
-
     while core.live_is_empty() {
         let internal_deadline_ms = core.live_internal_deadline_ms();
         let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
@@ -360,7 +362,20 @@ async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
         tokio::select! {
             biased;
             _ = cancel_token.cancelled() => return false,
-            command = command_rx.recv() => {
+            cancellation = cancellation_rx.recv() => {
+                let Some(cancellation) = cancellation else {
+                    return false;
+                };
+                let _ = publisher
+                    .apply_cancellation(
+                        core,
+                        cancellation,
+                        true,
+                        scheduler_elapsed_ms(scheduler_start),
+                    )
+                    .await;
+            }
+            command = command_rx.recv(), if controls_enabled => {
                 let Some(command) = command else {
                     return false;
                 };
@@ -374,7 +389,7 @@ async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
                 };
                 core.receive_live_request(request);
             }
-            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
+            _ = &mut internal_deadline, if controls_enabled && internal_deadline_ms.is_some() => {
                 #[cfg(feature = "kvbm-offload")]
                 {
                     let now_ms = scheduler_elapsed_ms(scheduler_start)
@@ -385,10 +400,22 @@ async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
         }
     }
 
-    while let Ok(command) = command_rx.try_recv() {
-        publisher
-            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+    while let Ok(cancellation) = cancellation_rx.try_recv() {
+        let _ = publisher
+            .apply_cancellation(
+                core,
+                cancellation,
+                true,
+                scheduler_elapsed_ms(scheduler_start),
+            )
             .await;
+    }
+    if controls_enabled {
+        while let Ok(command) = command_rx.try_recv() {
+            publisher
+                .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                .await;
+        }
     }
     while let Ok(request) = request_rx.try_recv() {
         core.receive_live_request(request);
@@ -401,11 +428,14 @@ async fn receive_until_live_schedulable<C: LiveBoundaryCore>(
 async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
     core: &mut C,
     command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    cancellation_rx: &mut mpsc::Receiver<SchedulerCancellationEnvelope>,
     deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
+    pending: &mut PendingLivePass,
     publisher: &LiveEffectsPublisher,
     scheduler_start: &Instant,
     cancel_token: &CancellationToken,
     deadline: Instant,
+    controls_enabled: bool,
 ) -> bool {
     let sleep = sleep_until_precise(deadline);
     tokio::pin!(sleep);
@@ -418,7 +448,25 @@ async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
             biased;
             _ = cancel_token.cancelled() => return false,
             _ = &mut sleep => return true,
-            _ = &mut internal_deadline, if internal_deadline_ms.is_some() => {
+            cancellation = cancellation_rx.recv() => {
+                let Some(cancellation) = cancellation else {
+                    return false;
+                };
+                let request_id = cancellation.request_id;
+                let discard_pending_output = cancellation.discard_pending_output;
+                let outcome = publisher
+                    .apply_cancellation(
+                        core,
+                        cancellation,
+                        false,
+                        scheduler_elapsed_ms(scheduler_start),
+                    )
+                    .await;
+                if discard_pending_output || outcome != Some(SchedulerCommandResult::Noop) {
+                    pending.suppress_request_outputs(request_id);
+                }
+            }
+            _ = &mut internal_deadline, if controls_enabled && internal_deadline_ms.is_some() => {
                 #[cfg(feature = "kvbm-offload")]
                 {
                     let now_ms = scheduler_elapsed_ms(scheduler_start)
@@ -430,7 +478,7 @@ async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
                     );
                 }
             }
-            command = command_rx.recv(), if accept_commands => {
+            command = command_rx.recv(), if controls_enabled && accept_commands => {
                 let Some(command) = command else {
                     return false;
                 };
@@ -455,27 +503,44 @@ async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
 async fn apply_live_post_pass_controls<C: LiveBoundaryCore>(
     core: &mut C,
     command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    cancellation_rx: &mut mpsc::Receiver<SchedulerCancellationEnvelope>,
     deferred_commands: &mut VecDeque<SchedulerCommandEnvelope>,
     publisher: &LiveEffectsPublisher,
     scheduler_start: &Instant,
+    controls_enabled: bool,
 ) -> bool {
     let mut made_progress = false;
-    while let Some(command) = deferred_commands.pop_front() {
+    while let Ok(cancellation) = cancellation_rx.try_recv() {
         made_progress = true;
-        publisher
-            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+        let _ = publisher
+            .apply_cancellation(
+                core,
+                cancellation,
+                true,
+                scheduler_elapsed_ms(scheduler_start),
+            )
             .await;
     }
-    while let Ok(command) = command_rx.try_recv() {
-        made_progress = true;
+    if controls_enabled {
+        while let Some(command) = deferred_commands.pop_front() {
+            made_progress = true;
+            publisher
+                .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                .await;
+        }
+        while let Ok(command) = command_rx.try_recv() {
+            made_progress = true;
+            publisher
+                .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                .await;
+        }
         publisher
-            .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-            .await;
+            .retry_destinations(core, scheduler_elapsed_ms(scheduler_start))
+            .await
+            || made_progress
+    } else {
+        made_progress
     }
-    publisher
-        .retry_destinations(core, scheduler_elapsed_ms(scheduler_start))
-        .await
-        || made_progress
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -483,6 +548,7 @@ async fn wait_for_live_progress<C: LiveBoundaryCore>(
     core: &mut C,
     request_rx: &mut mpsc::UnboundedReceiver<DirectRequest>,
     command_rx: &mut mpsc::Receiver<SchedulerCommandEnvelope>,
+    cancellation_rx: &mut mpsc::Receiver<SchedulerCancellationEnvelope>,
     publisher: &LiveEffectsPublisher,
     scheduler_start: &Instant,
     cancel_token: &CancellationToken,
@@ -491,41 +557,40 @@ async fn wait_for_live_progress<C: LiveBoundaryCore>(
     let internal_deadline_ms = core.live_internal_deadline_ms();
     let internal_deadline = wait_for_internal_deadline(scheduler_start, internal_deadline_ms);
     tokio::pin!(internal_deadline);
-    if controls_enabled {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            command = command_rx.recv() => {
-                let Some(command) = command else {
-                    return false;
-                };
-                publisher
-                    .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
-                    .await;
-                true
-            }
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive_live_request(request);
-                true
-            }
-            _ = &mut internal_deadline => true,
+    tokio::select! {
+        biased;
+        _ = cancel_token.cancelled() => false,
+        cancellation = cancellation_rx.recv() => {
+            let Some(cancellation) = cancellation else {
+                return false;
+            };
+            let _ = publisher
+                .apply_cancellation(
+                    core,
+                    cancellation,
+                    true,
+                    scheduler_elapsed_ms(scheduler_start),
+                )
+                .await;
+            true
         }
-    } else {
-        tokio::select! {
-            biased;
-            _ = cancel_token.cancelled() => false,
-            request = request_rx.recv() => {
-                let Some(request) = request else {
-                    return false;
-                };
-                core.receive_live_request(request);
-                true
-            }
-            _ = &mut internal_deadline => true,
+        command = command_rx.recv(), if controls_enabled => {
+            let Some(command) = command else {
+                return false;
+            };
+            publisher
+                .apply_command(core, command, true, scheduler_elapsed_ms(scheduler_start))
+                .await;
+            true
         }
+        request = request_rx.recv() => {
+            let Some(request) = request else {
+                return false;
+            };
+            core.receive_live_request(request);
+            true
+        }
+        _ = &mut internal_deadline => true,
     }
 }
 
@@ -573,6 +638,7 @@ impl LiveEffectsPublisher {
             kv_event_publishers,
             fpm_publisher,
             captured_kv_events,
+            visible_residencies: Mutex::new(HashMap::new()),
             #[cfg(test)]
             publication_log: None,
         }
@@ -585,6 +651,19 @@ impl LiveEffectsPublisher {
     ) -> Self {
         self.publication_log = Some(log);
         self
+    }
+
+    #[cfg(test)]
+    fn published_metrics(&self) -> MockerMetrics {
+        self.metrics_tx.borrow().clone()
+    }
+
+    #[cfg(test)]
+    fn set_visible_request_residency(&self, request_id: Uuid, residency: RequestResidency) {
+        self.visible_residencies
+            .lock()
+            .unwrap()
+            .insert(request_id, residency);
     }
 
     pub(crate) fn capture_pass(&self, pass: EnginePassResult) -> PendingLivePass {
@@ -657,6 +736,7 @@ impl LiveEffectsPublisher {
         // disappeared. Those cleanup events belong to this same boundary.
         self.publish_router_effects(self.captured_kv_events.drain(), None);
         self.publish_lifecycle(pending.pass.lifecycle_events).await;
+        self.refresh_visible_residencies(core);
         let metrics = core.pass_boundary_metrics(pending.pass.mocker_metrics);
         self.record(PublishedEffect::Metrics);
         let _ = self.metrics_tx.send(metrics);
@@ -669,11 +749,43 @@ impl LiveEffectsPublisher {
         allow_destination_admission: bool,
         now_ms: f64,
     ) {
+        self.apply_command_inner(core, envelope, allow_destination_admission, now_ms)
+            .await;
+    }
+
+    pub(crate) async fn apply_cancellation<C: LiveBoundaryCore>(
+        &self,
+        core: &mut C,
+        cancellation: SchedulerCancellationEnvelope,
+        allow_destination_admission: bool,
+        now_ms: f64,
+    ) -> Option<SchedulerCommandResult> {
+        self.apply_command_inner(
+            core,
+            cancellation.into(),
+            allow_destination_admission,
+            now_ms,
+        )
+        .await
+    }
+
+    async fn apply_command_inner<C: LiveBoundaryCore>(
+        &self,
+        core: &mut C,
+        envelope: SchedulerCommandEnvelope,
+        allow_destination_admission: bool,
+        now_ms: f64,
+    ) -> Option<SchedulerCommandResult> {
         let SchedulerCommandEnvelope { command, reply } = envelope;
+        let cancellation_id = match &command {
+            SchedulerCommand::CancelRequest { request_id } => Some(*request_id),
+            _ => None,
+        };
         let result = core.apply_live_command(command, allow_destination_admission, now_ms);
         match result {
             Ok(mut effects) => {
                 let lifecycle_events = std::mem::take(&mut effects.lifecycle_events);
+                let command_result = effects.result;
                 if allow_destination_admission {
                     self.publish_router_effects(self.captured_kv_events.drain(), None);
                 } else {
@@ -684,17 +796,62 @@ impl LiveEffectsPublisher {
                 }
                 self.record(PublishedEffect::Ack);
                 let _ = reply.send(Ok(effects));
+                if let SchedulerCommandResult::Submitted(request_id) = command_result
+                    && let Some(residency) = core.live_request_residency(request_id)
+                {
+                    self.visible_residencies
+                        .lock()
+                        .unwrap()
+                        .insert(request_id, residency);
+                }
+                let cancelled_residency = if command_result == SchedulerCommandResult::Applied {
+                    cancellation_id.and_then(|request_id| {
+                        self.visible_residencies.lock().unwrap().remove(&request_id)
+                    })
+                } else {
+                    None
+                };
                 if allow_destination_admission {
                     self.publish_lifecycle(lifecycle_events).await;
                     self.record(PublishedEffect::Metrics);
                     let _ = self.metrics_tx.send(core.live_metrics());
+                } else if let Some(residency) = cancelled_residency {
+                    // The core has already executed the pending pass. Update
+                    // only the queue where this request lived at the last
+                    // published boundary; aggregate post-pass metrics cannot
+                    // identify which visible request was cancelled.
+                    let mut published = self.metrics_tx.borrow().clone();
+                    let visible_count = match residency {
+                        RequestResidency::Running => &mut published.running_requests,
+                        RequestResidency::Waiting => &mut published.waiting_requests,
+                    };
+                    if *visible_count > 0 {
+                        *visible_count -= 1;
+                        self.record(PublishedEffect::Metrics);
+                        self.metrics_tx.send_replace(published);
+                    }
                 }
+                Some(command_result)
             }
             Err(error) => {
                 self.record(PublishedEffect::Ack);
                 let _ = reply.send(Err(error));
+                None
             }
         }
+    }
+
+    fn refresh_visible_residencies<C: LiveBoundaryCore>(&self, core: &C) {
+        self.visible_residencies
+            .lock()
+            .unwrap()
+            .retain(|request_id, residency| {
+                let Some(current) = core.live_request_residency(*request_id) else {
+                    return false;
+                };
+                *residency = current;
+                true
+            });
     }
 
     pub(crate) async fn retry_destinations<C: LiveBoundaryCore>(

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -65,7 +65,7 @@ pub(crate) trait LiveBoundaryCore {
 
     fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics;
 
-    fn live_request_residency(&self, request_id: Uuid) -> Option<RequestResidency>;
+    fn visit_live_request_residencies(&self, visitor: &mut dyn FnMut(Uuid, RequestResidency));
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {
         None
@@ -661,14 +661,6 @@ impl LiveEffectsPublisher {
         self.metrics_tx.borrow().clone()
     }
 
-    #[cfg(test)]
-    fn set_visible_request_residency(&self, request_id: Uuid, residency: RequestResidency) {
-        self.visible_residencies
-            .lock()
-            .unwrap()
-            .insert(request_id, residency);
-    }
-
     pub(crate) fn capture_pass(&self, pass: EnginePassResult) -> PendingLivePass {
         PendingLivePass {
             pass,
@@ -799,14 +791,6 @@ impl LiveEffectsPublisher {
                 }
                 self.record(PublishedEffect::Ack);
                 let _ = reply.send(Ok(effects));
-                if let SchedulerCommandResult::Submitted(request_id) = command_result
-                    && let Some(residency) = core.live_request_residency(request_id)
-                {
-                    self.visible_residencies
-                        .lock()
-                        .unwrap()
-                        .insert(request_id, residency);
-                }
                 let cancelled_residency = if command_result == SchedulerCommandResult::Applied {
                     cancellation_id.and_then(|request_id| {
                         self.visible_residencies.lock().unwrap().remove(&request_id)
@@ -816,6 +800,7 @@ impl LiveEffectsPublisher {
                 };
                 if allow_destination_admission {
                     self.publish_lifecycle(lifecycle_events).await;
+                    self.refresh_visible_residencies(core);
                     self.record(PublishedEffect::Metrics);
                     let _ = self.metrics_tx.send(core.live_metrics());
                 } else if let Some(residency) = cancelled_residency {
@@ -845,16 +830,11 @@ impl LiveEffectsPublisher {
     }
 
     fn refresh_visible_residencies<C: LiveBoundaryCore>(&self, core: &C) {
-        self.visible_residencies
-            .lock()
-            .unwrap()
-            .retain(|request_id, residency| {
-                let Some(current) = core.live_request_residency(*request_id) else {
-                    return false;
-                };
-                *residency = current;
-                true
-            });
+        let mut visible_residencies = self.visible_residencies.lock().unwrap();
+        visible_residencies.clear();
+        core.visit_live_request_residencies(&mut |request_id, residency| {
+            visible_residencies.insert(request_id, residency);
+        });
     }
 
     pub(crate) async fn retry_destinations<C: LiveBoundaryCore>(

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -290,6 +290,9 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
         {
             break;
         }
+        if execution.duration.is_zero() && !zero_progress {
+            tokio::task::coop::consume_budget().await;
+        }
     }
 }
 

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -96,6 +96,10 @@ impl LiveBoundaryCore for FakeCore {
         pass_metrics
     }
 
+    fn live_request_residency(&self, _request_id: Uuid) -> Option<RequestResidency> {
+        None
+    }
+
     fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {
         self.publish_kv(3);
     }
@@ -136,9 +140,18 @@ fn publisher(
     captured: DeferredKvPublishBuffer,
     log: Arc<Mutex<Vec<PublishedEffect>>>,
 ) -> LiveEffectsPublisher {
+    publisher_with_metrics(output_tx, captured, log, MockerMetrics::default())
+}
+
+fn publisher_with_metrics(
+    output_tx: mpsc::UnboundedSender<Vec<OutputSignal>>,
+    captured: DeferredKvPublishBuffer,
+    log: Arc<Mutex<Vec<PublishedEffect>>>,
+    metrics: MockerMetrics,
+) -> LiveEffectsPublisher {
     let (admission_tx, _admission_rx) = mpsc::unbounded_channel();
     let (lifecycle_tx, _lifecycle_rx) = mpsc::channel(4);
-    let (metrics_tx, _metrics_rx) = watch::channel(MockerMetrics::default());
+    let (metrics_tx, _metrics_rx) = watch::channel(metrics);
     LiveEffectsPublisher::new(
         Some(output_tx),
         Some(admission_tx),
@@ -149,6 +162,63 @@ fn publisher(
         captured,
     )
     .with_publication_log(log)
+}
+
+#[tokio::test]
+async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pending_output() {
+    let request_id = Uuid::from_u128(1);
+    let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(false, false);
+    let mut core = FakeCore {
+        publishers: buffering_publishers,
+        command_effects: false,
+        midpass_kv_effects: false,
+        execute_count: 0,
+        cancel_after_execute: None,
+    };
+    let (output_tx, _output_rx) = mpsc::unbounded_channel();
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let metrics = MockerMetrics {
+        running_requests: 1,
+        ..Default::default()
+    };
+    let publisher = publisher_with_metrics(output_tx, captured, log, metrics);
+    publisher.set_visible_request_residency(request_id, RequestResidency::Running);
+    let mut pending = publisher.capture_pass(pass());
+    let (_command_tx, mut command_rx) = mpsc::channel(1);
+    let (cancellation_tx, mut cancellation_rx) = mpsc::channel(1);
+    let (reply, reply_rx) = tokio::sync::oneshot::channel();
+    cancellation_tx
+        .send(SchedulerCancellationEnvelope {
+            request_id,
+            discard_pending_output: false,
+            reply,
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        wait_for_live_pass_boundary(
+            &mut core,
+            &mut command_rx,
+            &mut cancellation_rx,
+            &mut VecDeque::new(),
+            &mut pending,
+            &publisher,
+            &Instant::now(),
+            &CancellationToken::new(),
+            Instant::now() + Duration::from_millis(1),
+            false,
+        )
+        .await
+    );
+    assert_eq!(
+        reply_rx.await.unwrap().unwrap().result,
+        SchedulerCommandResult::Applied
+    );
+    assert!(pending.pass.output_signals.is_empty());
+    assert_eq!(pending.pass.completed_requests, 0);
+    assert_eq!(pending.pass.accept_length_output_tokens, 0);
+    assert_eq!(publisher.published_metrics().running_requests, 0);
 }
 
 #[tokio::test]
@@ -333,11 +403,13 @@ async fn shutdown_stops_a_nonempty_zero_duration_progress_loop() {
     let publisher = publisher(output_tx, captured, Arc::new(Mutex::new(Vec::new())));
     let (_request_tx, request_rx) = mpsc::unbounded_channel();
     let (_command_tx, command_rx) = mpsc::channel(1);
+    let (_cancellation_tx, cancellation_rx) = mpsc::channel(1);
 
     run_live_scheduler(
         &mut core,
         request_rx,
         command_rx,
+        cancellation_rx,
         publisher,
         cancel_token,
         false,

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -93,8 +93,8 @@ impl LiveBoundaryCore for FakeCore {
         pass_metrics
     }
 
-    fn live_request_residency(&self, _request_id: Uuid) -> Option<RequestResidency> {
-        None
+    fn visit_live_request_residencies(&self, visitor: &mut dyn FnMut(Uuid, RequestResidency)) {
+        visitor(Uuid::from_u128(1), RequestResidency::Running);
     }
 
     fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {
@@ -179,7 +179,7 @@ async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pendin
         ..Default::default()
     };
     let publisher = publisher_with_metrics(output_tx, captured, log, metrics);
-    publisher.set_visible_request_residency(request_id, RequestResidency::Running);
+    publisher.refresh_visible_residencies(&core);
     let mut pending = publisher.capture_pass(pass());
     let (_command_tx, mut command_rx) = mpsc::channel(1);
     let (cancellation_tx, mut cancellation_rx) = mpsc::channel(1);

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -14,7 +14,7 @@ struct FakeCore {
     command_effects: bool,
     midpass_kv_effects: bool,
     execute_count: usize,
-    cancel_after_execute: Option<(usize, CancellationToken)>,
+    live_pass_limit: Option<usize>,
 }
 
 impl FakeCore {
@@ -34,24 +34,21 @@ impl FakeCore {
 
 impl LiveBoundaryCore for FakeCore {
     fn live_is_empty(&self) -> bool {
-        self.cancel_after_execute.is_none()
+        self.live_pass_limit.is_none()
     }
 
     fn receive_live_request(&mut self, _request: DirectRequest) {}
 
     fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
-        let (cancel_after, cancel_token) = self
-            .cancel_after_execute
+        let live_pass_limit = self
+            .live_pass_limit
             .as_ref()
             .expect("boundary-only fake does not execute live passes");
         self.execute_count += 1;
         assert!(
-            self.execute_count <= *cancel_after,
-            "scheduler did not observe shutdown between productive zero-duration passes"
+            self.execute_count <= *live_pass_limit,
+            "scheduler did not yield to externally triggered shutdown"
         );
-        if self.execute_count == *cancel_after {
-            cancel_token.cancel();
-        }
         let mut pass = pass();
         pass.admissions.clear();
         pass.lifecycle_events.clear();
@@ -173,7 +170,7 @@ async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pendin
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,
-        cancel_after_execute: None,
+        live_pass_limit: None,
     };
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
     let log = Arc::new(Mutex::new(Vec::new()));
@@ -229,7 +226,7 @@ async fn pass_effects_publish_once_in_boundary_order_and_isolate_midpass_ack() {
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,
-        cancel_after_execute: None,
+        live_pass_limit: None,
     };
     core.publish_kv(1);
     let (output_tx, output_rx) = mpsc::unbounded_channel();
@@ -287,7 +284,7 @@ async fn controlled_pass_start_router_effects_precede_midpass_ack_without_duplic
         command_effects: false,
         midpass_kv_effects: true,
         execute_count: 0,
-        cancel_after_execute: None,
+        live_pass_limit: None,
     };
     core.publish_kv(1);
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
@@ -350,7 +347,7 @@ async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
         command_effects: true,
         midpass_kv_effects: false,
         execute_count: 0,
-        cancel_after_execute: None,
+        live_pass_limit: None,
     };
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
     let log = Arc::new(Mutex::new(Vec::new()));
@@ -386,10 +383,10 @@ async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
     );
 }
 
-// Regression: a productive zero-duration core could spin forever without
-// observing shutdown because it never entered a cancellation-aware wait.
-#[tokio::test]
-async fn shutdown_stops_a_nonempty_zero_duration_progress_loop() {
+// Regression: a productive zero-duration core could monopolize a current-thread
+// runtime, preventing an external task from triggering shutdown.
+#[tokio::test(flavor = "current_thread")]
+async fn external_shutdown_stops_a_nonempty_zero_duration_progress_loop() {
     let cancel_token = CancellationToken::new();
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(false, false);
     let mut core = FakeCore {
@@ -397,13 +394,17 @@ async fn shutdown_stops_a_nonempty_zero_duration_progress_loop() {
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,
-        cancel_after_execute: Some((3, cancel_token.clone())),
+        live_pass_limit: Some(10_000),
     };
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
     let publisher = publisher(output_tx, captured, Arc::new(Mutex::new(Vec::new())));
     let (_request_tx, request_rx) = mpsc::unbounded_channel();
     let (_command_tx, command_rx) = mpsc::channel(1);
     let (_cancellation_tx, cancellation_rx) = mpsc::channel(1);
+    let external_cancel_token = cancel_token.clone();
+    let cancel_task = tokio::spawn(async move {
+        external_cancel_token.cancel();
+    });
 
     run_live_scheduler(
         &mut core,
@@ -416,5 +417,6 @@ async fn shutdown_stops_a_nonempty_zero_duration_progress_loop() {
     )
     .await;
 
-    assert_eq!(core.execute_count, 3);
+    cancel_task.await.unwrap();
+    assert!(core.execute_count > 0);
 }

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 struct FakeCore {
     publishers: KvEventPublishers,
+    command_result: SchedulerCommandResult,
     command_effects: bool,
     midpass_kv_effects: bool,
     execute_count: usize,
@@ -65,7 +66,7 @@ impl LiveBoundaryCore for FakeCore {
         _allow_destination_admission: bool,
         _now_ms: f64,
     ) -> anyhow::Result<SchedulerCommandEffects> {
-        let mut effects = SchedulerCommandEffects::new(SchedulerCommandResult::Applied);
+        let mut effects = SchedulerCommandEffects::new(self.command_result);
         if self.command_effects || self.midpass_kv_effects {
             self.publish_kv(2);
         }
@@ -91,10 +92,6 @@ impl LiveBoundaryCore for FakeCore {
 
     fn pass_boundary_metrics(&self, pass_metrics: MockerMetrics) -> MockerMetrics {
         pass_metrics
-    }
-
-    fn visit_live_request_residencies(&self, visitor: &mut dyn FnMut(Uuid, RequestResidency)) {
-        visitor(Uuid::from_u128(1), RequestResidency::Running);
     }
 
     fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {
@@ -137,18 +134,9 @@ fn publisher(
     captured: DeferredKvPublishBuffer,
     log: Arc<Mutex<Vec<PublishedEffect>>>,
 ) -> LiveEffectsPublisher {
-    publisher_with_metrics(output_tx, captured, log, MockerMetrics::default())
-}
-
-fn publisher_with_metrics(
-    output_tx: mpsc::UnboundedSender<Vec<OutputSignal>>,
-    captured: DeferredKvPublishBuffer,
-    log: Arc<Mutex<Vec<PublishedEffect>>>,
-    metrics: MockerMetrics,
-) -> LiveEffectsPublisher {
     let (admission_tx, _admission_rx) = mpsc::unbounded_channel();
     let (lifecycle_tx, _lifecycle_rx) = mpsc::channel(4);
-    let (metrics_tx, _metrics_rx) = watch::channel(metrics);
+    let (metrics_tx, _metrics_rx) = watch::channel(MockerMetrics::default());
     LiveEffectsPublisher::new(
         Some(output_tx),
         Some(admission_tx),
@@ -161,12 +149,15 @@ fn publisher_with_metrics(
     .with_publication_log(log)
 }
 
-#[tokio::test]
-async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pending_output() {
+async fn cancel_pending_pass(
+    command_result: SchedulerCommandResult,
+    discard_pending_output: bool,
+) -> (SchedulerCommandResult, PendingLivePass) {
     let request_id = Uuid::from_u128(1);
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(false, false);
     let mut core = FakeCore {
         publishers: buffering_publishers,
+        command_result,
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,
@@ -174,12 +165,7 @@ async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pendin
     };
     let (output_tx, _output_rx) = mpsc::unbounded_channel();
     let log = Arc::new(Mutex::new(Vec::new()));
-    let metrics = MockerMetrics {
-        running_requests: 1,
-        ..Default::default()
-    };
-    let publisher = publisher_with_metrics(output_tx, captured, log, metrics);
-    publisher.refresh_visible_residencies(&core);
+    let publisher = publisher(output_tx, captured, log);
     let mut pending = publisher.capture_pass(pass());
     let (_command_tx, mut command_rx) = mpsc::channel(1);
     let (cancellation_tx, mut cancellation_rx) = mpsc::channel(1);
@@ -187,35 +173,60 @@ async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pendin
     cancellation_tx
         .send(SchedulerCancellationEnvelope {
             request_id,
-            discard_pending_output: false,
+            discard_pending_output,
             reply,
         })
         .await
         .unwrap();
 
-    assert!(
-        wait_for_live_pass_boundary(
+    let result = {
+        let cancel_token = CancellationToken::new();
+        let scheduler_start = Instant::now();
+        let mut deferred_commands = VecDeque::new();
+        let boundary = wait_for_live_pass_boundary(
             &mut core,
             &mut command_rx,
             &mut cancellation_rx,
-            &mut VecDeque::new(),
+            &mut deferred_commands,
             &mut pending,
             &publisher,
-            &Instant::now(),
-            &CancellationToken::new(),
-            Instant::now() + Duration::from_millis(1),
+            &scheduler_start,
+            &cancel_token,
+            Instant::now() + Duration::from_secs(5),
             false,
-        )
-        .await
-    );
-    assert_eq!(
-        reply_rx.await.unwrap().unwrap().result,
-        SchedulerCommandResult::Applied
-    );
+        );
+        tokio::pin!(boundary);
+        let result = tokio::select! {
+            reply = reply_rx => reply.unwrap().unwrap().result,
+            boundary_result = &mut boundary => {
+                panic!("pass boundary completed before cancellation was acknowledged: {boundary_result}")
+            }
+        };
+        cancel_token.cancel();
+        assert!(!boundary.await);
+        result
+    };
+    (result, pending)
+}
+
+#[tokio::test]
+async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pending_output() {
+    let (result, pending) = cancel_pending_pass(SchedulerCommandResult::Applied, false).await;
+
+    assert_eq!(result, SchedulerCommandResult::Applied);
     assert!(pending.pass.output_signals.is_empty());
     assert_eq!(pending.pass.completed_requests, 0);
     assert_eq!(pending.pass.accept_length_output_tokens, 0);
-    assert_eq!(publisher.published_metrics().running_requests, 0);
+}
+
+#[tokio::test]
+async fn explicit_discard_suppresses_pending_output_after_noop_cancellation() {
+    let (result, pending) = cancel_pending_pass(SchedulerCommandResult::Noop, true).await;
+
+    assert_eq!(result, SchedulerCommandResult::Noop);
+    assert!(pending.pass.output_signals.is_empty());
+    assert_eq!(pending.pass.completed_requests, 0);
+    assert_eq!(pending.pass.accept_length_output_tokens, 0);
 }
 
 #[tokio::test]
@@ -223,6 +234,7 @@ async fn pass_effects_publish_once_in_boundary_order_and_isolate_midpass_ack() {
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
     let mut core = FakeCore {
         publishers: buffering_publishers,
+        command_result: SchedulerCommandResult::Applied,
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,
@@ -281,6 +293,7 @@ async fn controlled_pass_start_router_effects_precede_midpass_ack_without_duplic
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
     let mut core = FakeCore {
         publishers: buffering_publishers,
+        command_result: SchedulerCommandResult::Applied,
         command_effects: false,
         midpass_kv_effects: true,
         execute_count: 0,
@@ -344,6 +357,7 @@ async fn command_effects_publish_kv_before_ack_then_lifecycle_and_metrics() {
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(true, false);
     let mut core = FakeCore {
         publishers: buffering_publishers,
+        command_result: SchedulerCommandResult::Applied,
         command_effects: true,
         midpass_kv_effects: false,
         execute_count: 0,
@@ -391,6 +405,7 @@ async fn external_shutdown_stops_a_nonempty_zero_duration_progress_loop() {
     let (captured, buffering_publishers) = capture_deferred_kv_publish_sink(false, false);
     let mut core = FakeCore {
         publishers: buffering_publishers,
+        command_result: SchedulerCommandResult::Applied,
         command_effects: false,
         midpass_kv_effects: false,
         execute_count: 0,

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -15,7 +15,7 @@ use crate::common::protocols::{DirectRequest, FpmPublisher, KvEventPublishers, O
 use dynamo_kv_router::protocols::RouterEvent;
 pub(crate) use kv_event_sink::{CapturedRouterEventBuffer, capture_router_event_sink};
 pub(crate) use live_boundary::{
-    LiveBoundaryCore, LivePassExecution, LiveSchedulerState, RequestResidency, spawn_live_scheduler,
+    LiveBoundaryCore, LivePassExecution, LiveSchedulerState, spawn_live_scheduler,
 };
 pub(crate) use source_holds::{
     ActiveHandoffRequests, DestinationHolds, PendingDestinations, RemovedSource, SourceCompletion,
@@ -466,6 +466,10 @@ pub trait SchedulerHandle: Send + Sync {
     fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope>;
 
     /// Bounded cancellation channel observed even while a modeled pass is running.
+    ///
+    /// Cancellation removes scheduler state and can suppress pending output immediately. During a
+    /// modeled pass, published running/waiting metrics refresh at the next pass boundary; exact
+    /// mid-pass metrics would require incremental per-request residency accounting.
     fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope>;
 
     /// Take the single lifecycle-event stream owned by this DP-rank scheduler.
@@ -592,10 +596,10 @@ mod tests {
         }
     }
 
-    fn request_residency(core: &EngineCore, request_id: Uuid) -> Option<RequestResidency> {
+    fn request_metrics(core: &EngineCore) -> MockerMetrics {
         match core {
-            EngineCore::Vllm(core) => core.request_residency(request_id),
-            EngineCore::Sglang(core) => core.request_residency(request_id),
+            EngineCore::Vllm(core) => core.mocker_metrics(),
+            EngineCore::Sglang(core) => core.mocker_metrics(),
         }
     }
 
@@ -608,10 +612,7 @@ mod tests {
             let mut core = core(engine_type, WorkerType::Aggregated, 16);
             let waiting_id = Uuid::from_u128(20_000 + case as u128);
             core.receive(request(waiting_id, (0..4).collect()));
-            assert_eq!(
-                request_residency(&core, waiting_id),
-                Some(RequestResidency::Waiting)
-            );
+            assert_eq!(request_metrics(&core).waiting_requests, 1);
             assert_eq!(
                 core.apply_command(SchedulerCommand::CancelRequest {
                     request_id: waiting_id,
@@ -626,16 +627,14 @@ mod tests {
                 .unwrap(),
                 SchedulerCommandResult::Noop
             );
+            assert_eq!(core.num_requests(), 0);
 
             let running_id = Uuid::from_u128(20_100 + case as u128);
             let mut running_request = request(running_id, (100..108).collect());
             running_request.max_output_tokens = 32;
             core.receive(running_request);
             core.execute_hidden_pass(0.0);
-            assert_eq!(
-                request_residency(&core, running_id),
-                Some(RequestResidency::Running)
-            );
+            assert_eq!(request_metrics(&core).running_requests, 1);
             assert_eq!(
                 core.apply_command(SchedulerCommand::CancelRequest {
                     request_id: running_id,
@@ -643,7 +642,6 @@ mod tests {
                 .unwrap(),
                 SchedulerCommandResult::Applied
             );
-            assert_eq!(request_residency(&core, running_id), None);
             assert_eq!(core.num_requests(), 0);
         }
     }

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -635,6 +635,11 @@ mod tests {
             core.receive(running_request);
             core.execute_hidden_pass(0.0);
             assert_eq!(request_metrics(&core).running_requests, 1);
+            let active_blocks_before_cancel = request_metrics(&core).active_decode_blocks;
+            assert!(
+                active_blocks_before_cancel > 0,
+                "{engine_type:?} running request should own KV blocks"
+            );
             assert_eq!(
                 core.apply_command(SchedulerCommand::CancelRequest {
                     request_id: running_id,
@@ -643,6 +648,14 @@ mod tests {
                 SchedulerCommandResult::Applied
             );
             assert_eq!(core.num_requests(), 0);
+            let active_blocks_after_cancel = request_metrics(&core).active_decode_blocks;
+            assert!(
+                active_blocks_after_cancel < active_blocks_before_cancel,
+                "{engine_type:?} cancellation should release request-owned KV blocks"
+            );
+            if engine_type == EngineType::Vllm {
+                assert_eq!(active_blocks_after_cancel, 0);
+            }
         }
     }
 

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -15,7 +15,7 @@ use crate::common::protocols::{DirectRequest, FpmPublisher, KvEventPublishers, O
 use dynamo_kv_router::protocols::RouterEvent;
 pub(crate) use kv_event_sink::{CapturedRouterEventBuffer, capture_router_event_sink};
 pub(crate) use live_boundary::{
-    LiveBoundaryCore, LivePassExecution, LiveSchedulerState, spawn_live_scheduler,
+    LiveBoundaryCore, LivePassExecution, LiveSchedulerState, RequestResidency, spawn_live_scheduler,
 };
 pub(crate) use source_holds::{
     ActiveHandoffRequests, DestinationHolds, PendingDestinations, RemovedSource, SourceCompletion,
@@ -411,6 +411,13 @@ impl SchedulerHandle for EngineScheduler {
         }
     }
 
+    fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope> {
+        match self {
+            Self::Vllm(scheduler) => scheduler.cancellation_sender(),
+            Self::Sglang(scheduler) => scheduler.cancellation_sender(),
+        }
+    }
+
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
         match self {
             Self::Vllm(scheduler) => scheduler.take_lifecycle_receiver(),
@@ -422,6 +429,23 @@ impl SchedulerHandle for EngineScheduler {
 pub struct SchedulerCommandEnvelope {
     pub command: SchedulerCommand,
     pub reply: oneshot::Sender<anyhow::Result<SchedulerCommandEffects>>,
+}
+
+pub struct SchedulerCancellationEnvelope {
+    pub request_id: Uuid,
+    pub discard_pending_output: bool,
+    pub reply: oneshot::Sender<anyhow::Result<SchedulerCommandEffects>>,
+}
+
+impl From<SchedulerCancellationEnvelope> for SchedulerCommandEnvelope {
+    fn from(cancellation: SchedulerCancellationEnvelope) -> Self {
+        Self {
+            command: SchedulerCommand::CancelRequest {
+                request_id: cancellation.request_id,
+            },
+            reply: cancellation.reply,
+        }
+    }
 }
 
 /// Engine-agnostic scheduler interface.
@@ -440,6 +464,9 @@ pub trait SchedulerHandle: Send + Sync {
 
     /// Bounded lifecycle-control channel for disaggregated handoff sessions.
     fn command_sender(&self) -> mpsc::Sender<SchedulerCommandEnvelope>;
+
+    /// Bounded cancellation channel observed even while a modeled pass is running.
+    fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope>;
 
     /// Take the single lifecycle-event stream owned by this DP-rank scheduler.
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>>;
@@ -562,6 +589,62 @@ mod tests {
         match core {
             EngineCore::Vllm(core) => core.destination_reservation_attempts(),
             EngineCore::Sglang(core) => core.destination_reservation_attempts(),
+        }
+    }
+
+    fn request_residency(core: &EngineCore, request_id: Uuid) -> Option<RequestResidency> {
+        match core {
+            EngineCore::Vllm(core) => core.request_residency(request_id),
+            EngineCore::Sglang(core) => core.request_residency(request_id),
+        }
+    }
+
+    #[test]
+    fn request_cancellation_removes_waiting_and_running_requests_for_each_engine() {
+        for (case, engine_type) in [EngineType::Vllm, EngineType::Sglang]
+            .into_iter()
+            .enumerate()
+        {
+            let mut core = core(engine_type, WorkerType::Aggregated, 16);
+            let waiting_id = Uuid::from_u128(20_000 + case as u128);
+            core.receive(request(waiting_id, (0..4).collect()));
+            assert_eq!(
+                request_residency(&core, waiting_id),
+                Some(RequestResidency::Waiting)
+            );
+            assert_eq!(
+                core.apply_command(SchedulerCommand::CancelRequest {
+                    request_id: waiting_id,
+                })
+                .unwrap(),
+                SchedulerCommandResult::Applied
+            );
+            assert_eq!(
+                core.apply_command(SchedulerCommand::CancelRequest {
+                    request_id: waiting_id,
+                })
+                .unwrap(),
+                SchedulerCommandResult::Noop
+            );
+
+            let running_id = Uuid::from_u128(20_100 + case as u128);
+            let mut running_request = request(running_id, (100..108).collect());
+            running_request.max_output_tokens = 32;
+            core.receive(running_request);
+            core.execute_hidden_pass(0.0);
+            assert_eq!(
+                request_residency(&core, running_id),
+                Some(RequestResidency::Running)
+            );
+            assert_eq!(
+                core.apply_command(SchedulerCommand::CancelRequest {
+                    request_id: running_id,
+                })
+                .unwrap(),
+                SchedulerCommandResult::Applied
+            );
+            assert_eq!(request_residency(&core, running_id), None);
+            assert_eq!(core.num_requests(), 0);
         }
     }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -25,9 +25,9 @@ use super::request::SglangRequest;
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionInvariant, AdmissionStage, CapturedRouterEventBuffer,
     DestinationHolds, EnginePassResult, MockerMetrics, PendingDestinations, RemovedSource,
-    RequestResidency, RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects,
-    SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion, SourceHolds,
-    accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
+    RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult,
+    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, accept_length_sample,
+    build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
@@ -511,38 +511,6 @@ impl SglangCore {
 
     pub(crate) fn mocker_metrics(&self) -> MockerMetrics {
         self.mocker_metrics_with_cache(0, 0)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
-        if self
-            .running
-            .iter()
-            .any(|request| request.uuid == request_id)
-        {
-            Some(RequestResidency::Running)
-        } else if self
-            .waiting
-            .iter()
-            .chain(self.prebuilt_ready.iter())
-            .any(|request| request.uuid == request_id)
-        {
-            Some(RequestResidency::Waiting)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn visit_request_residencies(
-        &self,
-        visitor: &mut dyn FnMut(Uuid, RequestResidency),
-    ) {
-        for request in &self.running {
-            visitor(request.uuid, RequestResidency::Running);
-        }
-        for request in self.waiting.iter().chain(self.prebuilt_ready.iter()) {
-            visitor(request.uuid, RequestResidency::Waiting);
-        }
     }
 
     fn mocker_metrics_with_cache(

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -25,9 +25,9 @@ use super::request::SglangRequest;
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionInvariant, AdmissionStage, CapturedRouterEventBuffer,
     DestinationHolds, EnginePassResult, MockerMetrics, PendingDestinations, RemovedSource,
-    RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult,
-    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, accept_length_sample,
-    build_fpm_snapshot, capture_router_event_sink,
+    RequestResidency, RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects,
+    SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion, SourceHolds,
+    accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
@@ -186,6 +186,18 @@ impl SglangCore {
                 Ok(SchedulerCommandEffects::new(
                     SchedulerCommandResult::Submitted(self.submit(request)?),
                 ))
+            }
+            SchedulerCommand::CancelRequest { request_id } => {
+                let result = if self.cancel_active_request(request_id) {
+                    SchedulerCommandResult::Applied
+                } else {
+                    SchedulerCommandResult::Noop
+                };
+                if allow_destination_admission {
+                    Ok(self.effects_after_capacity_change(result))
+                } else {
+                    Ok(SchedulerCommandEffects::new(result))
+                }
             }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
@@ -499,6 +511,25 @@ impl SglangCore {
 
     pub(crate) fn mocker_metrics(&self) -> MockerMetrics {
         self.mocker_metrics_with_cache(0, 0)
+    }
+
+    pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
+        if self
+            .running
+            .iter()
+            .any(|request| request.uuid == request_id)
+        {
+            Some(RequestResidency::Running)
+        } else if self
+            .waiting
+            .iter()
+            .chain(self.prebuilt_ready.iter())
+            .any(|request| request.uuid == request_id)
+        {
+            Some(RequestResidency::Waiting)
+        } else {
+            None
+        }
     }
 
     fn mocker_metrics_with_cache(

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -513,6 +513,7 @@ impl SglangCore {
         self.mocker_metrics_with_cache(0, 0)
     }
 
+    #[cfg(test)]
     pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
         if self
             .running
@@ -529,6 +530,18 @@ impl SglangCore {
             Some(RequestResidency::Waiting)
         } else {
             None
+        }
+    }
+
+    pub(crate) fn visit_request_residencies(
+        &self,
+        visitor: &mut dyn FnMut(Uuid, RequestResidency),
+    ) {
+        for request in &self.running {
+            visitor(request.uuid, RequestResidency::Running);
+        }
+        for request in self.waiting.iter().chain(self.prebuilt_ready.iter()) {
+            visitor(request.uuid, RequestResidency::Waiting);
         }
     }
 

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -11,8 +11,8 @@ use crate::common::protocols::{
 };
 use crate::scheduler::{
     AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, MockerMetrics,
-    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle,
-    SchedulerLifecycleEvent, spawn_live_scheduler,
+    RequestResidency, SchedulerCancellationEnvelope, SchedulerCommand, SchedulerCommandEffects,
+    SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent, spawn_live_scheduler,
 };
 
 use super::core::SglangCore;
@@ -102,6 +102,10 @@ impl SchedulerHandle for SglangScheduler {
         self.inner.command_sender()
     }
 
+    fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope> {
+        self.inner.cancellation_sender()
+    }
+
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
         self.inner.take_lifecycle_receiver()
     }
@@ -140,6 +144,10 @@ impl LiveBoundaryCore for SglangCore {
         pass_metrics.running_requests = current.running_requests;
         pass_metrics.waiting_requests = current.waiting_requests;
         pass_metrics
+    }
+
+    fn live_request_residency(&self, request_id: uuid::Uuid) -> Option<RequestResidency> {
+        self.request_residency(request_id)
     }
 
     fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -146,8 +146,11 @@ impl LiveBoundaryCore for SglangCore {
         pass_metrics
     }
 
-    fn live_request_residency(&self, request_id: uuid::Uuid) -> Option<RequestResidency> {
-        self.request_residency(request_id)
+    fn visit_live_request_residencies(
+        &self,
+        visitor: &mut dyn FnMut(uuid::Uuid, RequestResidency),
+    ) {
+        self.visit_request_residencies(visitor);
     }
 
     fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -11,7 +11,7 @@ use crate::common::protocols::{
 };
 use crate::scheduler::{
     AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, MockerMetrics,
-    RequestResidency, SchedulerCancellationEnvelope, SchedulerCommand, SchedulerCommandEffects,
+    SchedulerCancellationEnvelope, SchedulerCommand, SchedulerCommandEffects,
     SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent, spawn_live_scheduler,
 };
 
@@ -144,13 +144,6 @@ impl LiveBoundaryCore for SglangCore {
         pass_metrics.running_requests = current.running_requests;
         pass_metrics.waiting_requests = current.waiting_requests;
         pass_metrics
-    }
-
-    fn visit_live_request_residencies(
-        &self,
-        visitor: &mut dyn FnMut(uuid::Uuid, RequestResidency),
-    ) {
-        self.visit_request_residencies(visitor);
     }
 
     fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {

--- a/lib/mocker/src/scheduler/source_holds.rs
+++ b/lib/mocker/src/scheduler/source_holds.rs
@@ -13,6 +13,14 @@ use crate::common::protocols::DirectRequest;
 #[allow(dead_code)]
 pub enum SchedulerCommand {
     Submit(DirectRequest),
+    /// Remove an ordinary request from the live scheduler by its stable ID.
+    ///
+    /// Live requests use a dedicated cancellation lane. Their owned submit
+    /// task must acknowledge admission before cancellation is enqueued, so a
+    /// dropped network stream cannot race ahead of its own request admission.
+    CancelRequest {
+        request_id: Uuid,
+    },
     SubmitHandoffPrefill {
         handoff_id: HandoffId,
         request: DirectRequest,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -29,10 +29,9 @@ use crate::scheduler::vllm::policy::{self, AdmissionDecision};
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
     CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, ForwardPassSnapshot,
-    MockerMetrics, PendingDestinations, RemovedSource, RequestResidency, RouterEventVisibility,
-    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent,
-    SourceCompletion, SourceHolds, accept_length_sample, build_fpm_snapshot,
-    capture_router_event_sink,
+    MockerMetrics, PendingDestinations, RemovedSource, RouterEventVisibility, SchedulerCommand,
+    SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion,
+    SourceHolds, accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1044,29 +1043,6 @@ impl VllmCore {
             0,
             0,
         )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
-        if self.state.running_members.contains(&request_id) {
-            Some(RequestResidency::Running)
-        } else if self.state.waiting_members.contains(&request_id) {
-            Some(RequestResidency::Waiting)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn visit_request_residencies(
-        &self,
-        visitor: &mut dyn FnMut(Uuid, RequestResidency),
-    ) {
-        for request_id in &self.state.running_members {
-            visitor(*request_id, RequestResidency::Running);
-        }
-        for request_id in &self.state.waiting_members {
-            visitor(*request_id, RequestResidency::Waiting);
-        }
     }
 
     pub(crate) fn execute_pass(

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -29,9 +29,10 @@ use crate::scheduler::vllm::policy::{self, AdmissionDecision};
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
     CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, ForwardPassSnapshot,
-    MockerMetrics, PendingDestinations, RemovedSource, RouterEventVisibility, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion,
-    SourceHolds, accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
+    MockerMetrics, PendingDestinations, RemovedSource, RequestResidency, RouterEventVisibility,
+    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent,
+    SourceCompletion, SourceHolds, accept_length_sample, build_fpm_snapshot,
+    capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -573,6 +574,19 @@ impl VllmCore {
                     SchedulerCommandResult::Submitted(self.submit(request)?),
                 ))
             }
+            SchedulerCommand::CancelRequest { request_id } => {
+                let result = if self.state.requests.contains_key(&request_id) {
+                    self.drop_request(request_id);
+                    SchedulerCommandResult::Applied
+                } else {
+                    SchedulerCommandResult::Noop
+                };
+                if allow_destination_admission {
+                    Ok(self.effects_after_capacity_change(result, reservation_now_ms))
+                } else {
+                    Ok(SchedulerCommandEffects::new(result))
+                }
+            }
             SchedulerCommand::SubmitHandoffPrefill {
                 handoff_id,
                 mut request,
@@ -1030,6 +1044,16 @@ impl VllmCore {
             0,
             0,
         )
+    }
+
+    pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
+        if self.state.running_members.contains(&request_id) {
+            Some(RequestResidency::Running)
+        } else if self.state.waiting_members.contains(&request_id) {
+            Some(RequestResidency::Waiting)
+        } else {
+            None
+        }
     }
 
     pub(crate) fn execute_pass(

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1046,6 +1046,7 @@ impl VllmCore {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn request_residency(&self, request_id: Uuid) -> Option<RequestResidency> {
         if self.state.running_members.contains(&request_id) {
             Some(RequestResidency::Running)
@@ -1053,6 +1054,18 @@ impl VllmCore {
             Some(RequestResidency::Waiting)
         } else {
             None
+        }
+    }
+
+    pub(crate) fn visit_request_residencies(
+        &self,
+        visitor: &mut dyn FnMut(Uuid, RequestResidency),
+    ) {
+        for request_id in &self.state.running_members {
+            visitor(*request_id, RequestResidency::Running);
+        }
+        for request_id in &self.state.waiting_members {
+            visitor(*request_id, RequestResidency::Waiting);
         }
     }
 

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -209,8 +209,11 @@ impl LiveBoundaryCore for VllmCore {
         self.mocker_metrics()
     }
 
-    fn live_request_residency(&self, request_id: uuid::Uuid) -> Option<RequestResidency> {
-        self.request_residency(request_id)
+    fn visit_live_request_residencies(
+        &self,
+        visitor: &mut dyn FnMut(uuid::Uuid, RequestResidency),
+    ) {
+        self.visit_request_residencies(visitor);
     }
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -15,7 +15,7 @@ use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
 use crate::scheduler::{
-    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, RequestResidency,
+    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState,
     SchedulerCancellationEnvelope, SchedulerCommand, SchedulerCommandEffects,
     SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent, spawn_live_scheduler,
 };
@@ -207,13 +207,6 @@ impl LiveBoundaryCore for VllmCore {
 
     fn pass_boundary_metrics(&self, _pass_metrics: MockerMetrics) -> MockerMetrics {
         self.mocker_metrics()
-    }
-
-    fn visit_live_request_residencies(
-        &self,
-        visitor: &mut dyn FnMut(uuid::Uuid, RequestResidency),
-    ) {
-        self.visit_request_residencies(visitor);
     }
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -15,9 +15,9 @@ use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
 use crate::scheduler::{
-    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent,
-    spawn_live_scheduler,
+    AdmissionEvent, LiveBoundaryCore, LivePassExecution, LiveSchedulerState, RequestResidency,
+    SchedulerCancellationEnvelope, SchedulerCommand, SchedulerCommandEffects,
+    SchedulerCommandEnvelope, SchedulerHandle, SchedulerLifecycleEvent, spawn_live_scheduler,
 };
 
 use super::core::VllmCore;
@@ -159,6 +159,10 @@ impl SchedulerHandle for Scheduler {
         self.inner.command_sender()
     }
 
+    fn cancellation_sender(&self) -> mpsc::Sender<SchedulerCancellationEnvelope> {
+        self.inner.cancellation_sender()
+    }
+
     fn take_lifecycle_receiver(&mut self) -> Option<mpsc::Receiver<SchedulerLifecycleEvent>> {
         self.inner.take_lifecycle_receiver()
     }
@@ -203,6 +207,10 @@ impl LiveBoundaryCore for VllmCore {
 
     fn pass_boundary_metrics(&self, _pass_metrics: MockerMetrics) -> MockerMetrics {
         self.mocker_metrics()
+    }
+
+    fn live_request_residency(&self, request_id: uuid::Uuid) -> Option<RequestResidency> {
+        self.request_residency(request_id)
     }
 
     fn live_internal_deadline_ms(&self) -> Option<f64> {


### PR DESCRIPTION
## Overview:

Add targeted request cancellation to the shared live Mocker scheduler as a follow-up to #11960.

This is the cancellation-only prerequisite for sidecar-facing Mocker adapters. It intentionally excludes the `LiveEngine`, bounded output channels, and protocol-specific adapters.

Scope note: this PR stops at the `lib/mocker` live-scheduler boundary. The existing `lib/llm::MockEngine` context-stop and response-stream-drop paths do not yet call the new cancellation lane. That end-to-end integration is tracked by [DIS-2478](https://linear.app/nvidia/issue/DIS-2478/wire-mockengine-lifecycle-cancellation-into-the-mocker-scheduler), including disaggregated cancellation coverage.

## Details:

- Add an idempotent `CancelRequest` scheduler command for vLLM and SGLang requests.
- Add a dedicated cancellation lane that remains responsive during modeled passes and in aggregated workers without enabling general lifecycle controls there.
- Cooperatively yield during productive zero-duration passes so external cancellation and shutdown tasks can run on current-thread Tokio runtimes.
- Remove cancelled scheduler state and suppress pending output immediately. During a modeled pass, published running/waiting metrics refresh at the next pass boundary; exact mid-pass metrics are deferred rather than adding an O(all resident requests) snapshot to every pass.
- Update offline replay accounting for applied request cancellations.
- Cover waiting/running cancellation for both engines, mid-pass cancellation at the shared live boundary, explicit pending-output discard after an idempotent `Noop`, and offline in-flight cleanup.
- Replace the inherited self-triggered shutdown test with current-thread external-canceller regression coverage.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/live_boundary.rs`
- `lib/mocker/src/scheduler/vllm/core.rs`
- `lib/mocker/src/scheduler/sglang/core.rs`

## Related Issues

- [DIS-2478: Wire MockEngine lifecycle cancellation into the Mocker scheduler](https://linear.app/nvidia/issue/DIS-2478/wire-mockengine-lifecycle-cancellation-into-the-mocker-scheduler)
- [DIS-2473: Expose Mocker as a live request engine for sidecar adapters](https://linear.app/nvidia/issue/DIS-2473/expose-mocker-as-a-live-request-engine-for-sidecar-adapters)
- Depends on #11960
- Relates to #11873

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo test -p dynamo-mocker` (525 passed, 1 ignored)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request cancellation support across live scheduling workflows.
  * Cancellations now work for requests that are waiting or actively running.
  * Pending output can be discarded when a request is cancelled.

* **Bug Fixes**
  * Corrected in-flight request accounting after successful cancellation.
  * Prevented cancelled requests from delivering pending output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
