### PR TITLE
perf(router): ingest active sequence updates concurrently [DYN-3849]

### DIFF
--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -2297,60 +2297,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn direct_batch_and_aggregated_replica_sync_reach_equivalent_state() {
-        let worker = WorkerWithDpRank::new(1, 0);
-        let events = vec![
-            replica_add("req-1", worker, vec![1, 2, 3]),
-            replica_add("req-2", worker, vec![4, 5, 6]),
-            replica_mark("req-2", worker),
-            replica_free("req-1", worker),
-        ];
-        let direct = ActiveSequencesMultiWorker::new(
-            NoopSequencePublisher,
-            4,
-            HashMap::from([(1, (0, 1))]),
-            true,
-            0,
-            "test",
-        );
-        let aggregated = ActiveSequencesMultiWorker::new(
-            NoopSequencePublisher,
-            4,
-            HashMap::from([(1, (0, 1))]),
-            true,
-            0,
-            "test",
-        );
-
-        direct.apply_replica_batch(events.clone());
-        aggregated
-            .run_replica_sync(
-                VecSubscriber {
-                    events: events.into_iter().map(Ok).collect(),
-                },
-                CancellationToken::new(),
-            )
-            .await
-            .unwrap();
-
-        let now = Instant::now();
-        assert_eq!(direct.active_blocks(), aggregated.active_blocks());
-        assert_eq!(direct.active_tokens(now), aggregated.active_tokens(now));
-        assert_eq!(
-            direct.active_request_counts(),
-            aggregated.active_request_counts()
-        );
-        assert_eq!(
-            direct.request_index.worker_for(&"req-1".to_string()),
-            aggregated.request_index.worker_for(&"req-1".to_string())
-        );
-        assert_eq!(
-            direct.request_index.worker_for(&"req-2".to_string()),
-            aggregated.request_index.worker_for(&"req-2".to_string())
-        );
-    }
-
-    #[tokio::test]
     async fn replica_sync_mark_only_batch_does_not_publish_load() {
         let worker = WorkerWithDpRank::new(1, 0);
         let (sequences, publisher) =

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -1172,7 +1172,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 mod tests {
     use std::collections::{HashMap, VecDeque};
     use std::future::{self, Future};
-    use std::sync::Mutex;
+    use std::sync::{Condvar, Mutex, mpsc as std_mpsc};
     use std::time::Duration;
 
     use rustc_hash::FxHashMap;
@@ -1472,6 +1472,48 @@ mod tests {
 
         fn observe_worker_removed(&self, worker: &WorkerWithDpRank, _worker_type: &str) {
             self.state.removed.lock().unwrap().push(*worker);
+        }
+    }
+
+    struct BlockingPublisher {
+        blocked_worker_id: u64,
+        entered: std_mpsc::Sender<()>,
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl SequencePublisher for BlockingPublisher {
+        fn publish_event(
+            &self,
+            _event: &ActiveSequenceEvent,
+        ) -> impl Future<Output = anyhow::Result<()>> + Send {
+            future::ready(Ok(()))
+        }
+
+        fn publish_load(&self, _load: ActiveLoad) {}
+
+        fn publish_load_batch(&self, loads: Vec<ActiveLoad>) {
+            if !loads
+                .iter()
+                .any(|load| load.worker_id == self.blocked_worker_id)
+            {
+                return;
+            }
+
+            self.entered.send(()).unwrap();
+            let (released, ready) = &*self.release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = ready.wait(released).unwrap();
+            }
+        }
+
+        fn observe_load(
+            &self,
+            _worker: &WorkerWithDpRank,
+            _worker_type: &str,
+            _blocks: usize,
+            _tokens: usize,
+        ) {
         }
     }
 
@@ -2152,6 +2194,159 @@ mod tests {
         assert_eq!(
             sequences.active_request_counts().get(&worker).copied(),
             Some(1)
+        );
+    }
+
+    #[test]
+    fn replica_batch_apply_uses_one_deferred_effect_flush() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+
+        sequences.apply_replica_batch(vec![
+            replica_add("req-1", worker, vec![1, 2, 3]),
+            replica_add("req-2", worker, vec![4, 5, 6]),
+            replica_mark("req-2", worker),
+            replica_free("req-1", worker),
+        ]);
+
+        let batches = publisher.load_batches();
+        assert_eq!(batches.len(), 1);
+        assert_eq!(batches[0].len(), 1);
+        assert_eq!(batches[0][0].active_decode_blocks, Some(3));
+        assert_eq!(batches[0][0].active_prefill_tokens, Some(0));
+        assert_eq!(sequences.remote_state_update_count(), 1);
+        assert_eq!(sequences.prompt_registry.cleanup_attempts(), 1);
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-2".to_string()),
+            Some(worker)
+        );
+        assert_eq!(
+            sequences.request_index.worker_for(&"req-1".to_string()),
+            None
+        );
+    }
+
+    #[test]
+    fn replica_batches_apply_concurrently_to_independent_workers() {
+        let worker_a = WorkerWithDpRank::new(1, 0);
+        let worker_b = WorkerWithDpRank::new(2, 0);
+        let (entered_tx, entered_rx) = std_mpsc::channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let sequences = Arc::new(ActiveSequencesMultiWorker::new(
+            BlockingPublisher {
+                blocked_worker_id: worker_a.worker_id,
+                entered: entered_tx,
+                release: Arc::clone(&release),
+            },
+            4,
+            HashMap::from([(1, (0, 1)), (2, (0, 1))]),
+            true,
+            0,
+            "test",
+        ));
+
+        let source_a = {
+            let sequences = Arc::clone(&sequences);
+            std::thread::spawn(move || {
+                sequences.apply_replica_batch(vec![replica_add(
+                    "source-a",
+                    worker_a,
+                    vec![1, 2, 3],
+                )]);
+            })
+        };
+        entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("source A should block inside tracker batch flush");
+
+        let (source_b_done_tx, source_b_done_rx) = std_mpsc::channel();
+        let source_b = {
+            let sequences = Arc::clone(&sequences);
+            std::thread::spawn(move || {
+                sequences.apply_replica_batch(vec![replica_add(
+                    "source-b",
+                    worker_b,
+                    vec![4, 5, 6],
+                )]);
+                source_b_done_tx.send(()).unwrap();
+            })
+        };
+        let source_b_completed = source_b_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .is_ok();
+
+        let (released, ready) = &*release;
+        *released.lock().unwrap() = true;
+        ready.notify_all();
+        source_a.join().unwrap();
+        source_b.join().unwrap();
+
+        assert!(
+            source_b_completed,
+            "source B should apply while source A remains blocked"
+        );
+        assert_eq!(
+            sequences.request_index.worker_for(&"source-a".to_string()),
+            Some(worker_a)
+        );
+        assert_eq!(
+            sequences.request_index.worker_for(&"source-b".to_string()),
+            Some(worker_b)
+        );
+    }
+
+    #[tokio::test]
+    async fn direct_batch_and_aggregated_replica_sync_reach_equivalent_state() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let events = vec![
+            replica_add("req-1", worker, vec![1, 2, 3]),
+            replica_add("req-2", worker, vec![4, 5, 6]),
+            replica_mark("req-2", worker),
+            replica_free("req-1", worker),
+        ];
+        let direct = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1, (0, 1))]),
+            true,
+            0,
+            "test",
+        );
+        let aggregated = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1, (0, 1))]),
+            true,
+            0,
+            "test",
+        );
+
+        direct.apply_replica_batch(events.clone());
+        aggregated
+            .run_replica_sync(
+                VecSubscriber {
+                    events: events.into_iter().map(Ok).collect(),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let now = Instant::now();
+        assert_eq!(direct.active_blocks(), aggregated.active_blocks());
+        assert_eq!(direct.active_tokens(now), aggregated.active_tokens(now));
+        assert_eq!(
+            direct.active_request_counts(),
+            aggregated.active_request_counts()
+        );
+        assert_eq!(
+            direct.request_index.worker_for(&"req-1".to_string()),
+            aggregated.request_index.worker_for(&"req-1".to_string())
+        );
+        assert_eq!(
+            direct.request_index.worker_for(&"req-2".to_string()),
+            aggregated.request_index.worker_for(&"req-2".to_string())
         );
     }
 

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -51,6 +51,15 @@ impl ReplicaBatchEffects {
 }
 
 impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
+    /// Apply one decoded replica-sync batch and flush its deferred effects once.
+    pub fn apply_replica_batch(&self, events: Vec<ActiveSequenceEvent>) {
+        let mut effects = ReplicaBatchEffects::default();
+        for event in events {
+            self.apply_replica_event(event, &mut effects);
+        }
+        self.flush_replica_batch_effects(&mut effects);
+    }
+
     /// Spawn a background task that subscribes to replica-sync events from peer routers
     /// and applies them to the local state.
     pub fn start_replica_sync<S: SequenceSubscriber + 'static>(

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -777,11 +777,13 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
-                let seen = last_sequences.lock().unwrap();
-                if seen.contains_key(&publisher_a_id) && seen.contains_key(&publisher_b_id) {
+                let both_seen = {
+                    let seen = last_sequences.lock().unwrap();
+                    seen.contains_key(&publisher_a_id) && seen.contains_key(&publisher_b_id)
+                };
+                if both_seen {
                     break;
                 }
-                drop(seen);
                 tokio::task::yield_now().await;
             }
         })

--- a/lib/llm/src/direct_zmq_fan_in.rs
+++ b/lib/llm/src/direct_zmq_fan_in.rs
@@ -1,0 +1,888 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, time::Duration};
+
+use anyhow::Result;
+use dynamo_runtime::{
+    component::Endpoint,
+    discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
+        EventChannelInstanceId, EventChannelQuery, EventScope, EventTransport,
+    },
+    traits::DistributedRuntimeProvider,
+    transports::event_plane::{ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError},
+};
+use futures::StreamExt;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ContinuityMode {
+    Disabled,
+    TrackFromZero,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FanInEvent {
+    SourceStarted,
+    SourceStopped,
+    Reconnect,
+    Replacement,
+    EnvelopeDecodeError,
+    IdentityMismatch,
+    SequenceGap { missing: u64 },
+    OutOfOrder,
+    ForcedAbort,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FanInObservation {
+    pub publisher_id: u64,
+    pub generation: u64,
+    pub event: FanInEvent,
+}
+
+struct SourceTask {
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    cancel: CancellationToken,
+    handle: JoinHandle<Option<u64>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Continuity {
+    InOrder,
+    Gap(u64),
+    OutOfOrder,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SequenceCursor {
+    mode: ContinuityMode,
+    high_watermark: Option<u64>,
+}
+
+impl SequenceCursor {
+    fn new(mode: ContinuityMode, high_watermark: Option<u64>) -> Self {
+        Self {
+            mode,
+            high_watermark,
+        }
+    }
+
+    fn observe(&mut self, sequence: u64) -> Option<Continuity> {
+        if self.mode == ContinuityMode::Disabled {
+            return None;
+        }
+
+        let Some(high_watermark) = self.high_watermark else {
+            self.high_watermark = Some(sequence);
+            return Some(if sequence == 0 {
+                Continuity::InOrder
+            } else {
+                Continuity::Gap(sequence)
+            });
+        };
+
+        if sequence <= high_watermark {
+            return Some(Continuity::OutOfOrder);
+        }
+
+        self.high_watermark = Some(sequence);
+        let missing = sequence - high_watermark - 1;
+        Some(if missing == 0 {
+            Continuity::InOrder
+        } else {
+            Continuity::Gap(missing)
+        })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn start_direct_zmq_fan_in<H, O>(
+    endpoint: Endpoint,
+    topic: &'static str,
+    rcvhwm: i32,
+    excluded_publisher_id: Option<u64>,
+    continuity_mode: ContinuityMode,
+    cancellation_token: CancellationToken,
+    handler: H,
+    observer: O,
+) -> Result<JoinHandle<()>>
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
+    O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
+{
+    let query =
+        DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(endpoint.id(), topic));
+    let watch_cancel = cancellation_token.child_token();
+    let initial_watch = endpoint
+        .drt()
+        .discovery()
+        .list_and_watch(query.clone(), Some(watch_cancel.clone()))
+        .await?;
+
+    Ok(tokio::spawn(run_supervisor(
+        endpoint,
+        topic,
+        query,
+        rcvhwm,
+        excluded_publisher_id,
+        continuity_mode,
+        cancellation_token,
+        handler,
+        observer,
+        Some((initial_watch, watch_cancel)),
+    )))
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_supervisor<H, O>(
+    endpoint: Endpoint,
+    topic: &'static str,
+    query: DiscoveryQuery,
+    rcvhwm: i32,
+    excluded_publisher_id: Option<u64>,
+    continuity_mode: ContinuityMode,
+    cancellation_token: CancellationToken,
+    handler: H,
+    observer: O,
+    mut next_watch: Option<(
+        dynamo_runtime::discovery::DiscoveryStream,
+        CancellationToken,
+    )>,
+) where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
+    O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
+{
+    let expected_scope = EventScope::Endpoint {
+        endpoint: endpoint.id(),
+    };
+    let discovery = endpoint.drt().discovery();
+    let mut resume_cursors = HashMap::<u64, u64>::new();
+    let mut next_generation = 1_u64;
+    let mut retry_delay = INITIAL_BACKOFF;
+
+    loop {
+        let (mut watch, watch_cancel) = if let Some(watch) = next_watch.take() {
+            watch
+        } else {
+            let watch_cancel = cancellation_token.child_token();
+            let watch = tokio::select! {
+                _ = cancellation_token.cancelled() => break,
+                watch = discovery.list_and_watch(query.clone(), Some(watch_cancel.clone())) => watch,
+            };
+            let watch = match watch {
+                Ok(watch) => watch,
+                Err(error) => {
+                    tracing::warn!(%error, topic, "failed to watch direct-ZMQ publishers");
+                    if !sleep_or_cancel(retry_delay, &cancellation_token).await {
+                        break;
+                    }
+                    retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                    continue;
+                }
+            };
+            (watch, watch_cancel)
+        };
+        retry_delay = INITIAL_BACKOFF;
+        let mut sources = HashMap::<u64, SourceTask>::new();
+        let mut restart_watch = true;
+
+        loop {
+            let event = tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => {
+                    restart_watch = false;
+                    break;
+                }
+                event = watch.next() => event,
+            };
+            let Some(event) = event else {
+                tracing::warn!(topic, "direct-ZMQ discovery watch ended");
+                break;
+            };
+
+            match event {
+                Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
+                    scope,
+                    topic: discovered_topic,
+                    instance_id,
+                    transport,
+                })) if scope == expected_scope && discovered_topic == topic => {
+                    if excluded_publisher_id == Some(instance_id) {
+                        continue;
+                    }
+                    let EventTransport::Zmq { endpoint } = transport else {
+                        tracing::warn!(
+                            publisher_id = instance_id,
+                            topic,
+                            "ignoring non-ZMQ event channel in direct fan-in"
+                        );
+                        continue;
+                    };
+                    if let Some(source) = sources.get(&instance_id)
+                        && source.endpoint == endpoint
+                    {
+                        continue;
+                    }
+
+                    let high_watermark = if let Some(existing) = sources.remove(&instance_id) {
+                        observe(
+                            &observer,
+                            instance_id,
+                            existing.generation,
+                            FanInEvent::Replacement,
+                        );
+                        stop_source(existing, &observer).await
+                    } else {
+                        resume_cursors.remove(&instance_id)
+                    };
+                    let generation = next_generation;
+                    next_generation = next_generation.wrapping_add(1);
+                    sources.insert(
+                        instance_id,
+                        spawn_source(
+                            instance_id,
+                            endpoint,
+                            generation,
+                            high_watermark,
+                            topic,
+                            rcvhwm,
+                            continuity_mode,
+                            handler.clone(),
+                            observer.clone(),
+                            cancellation_token.child_token(),
+                        ),
+                    );
+                }
+                Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
+                    EventChannelInstanceId {
+                        scope,
+                        topic: discovered_topic,
+                        instance_id,
+                    },
+                ))) if scope == expected_scope && discovered_topic == topic => {
+                    resume_cursors.remove(&instance_id);
+                    if let Some(source) = sources.remove(&instance_id) {
+                        stop_source(source, &observer).await;
+                    }
+                }
+                Ok(DiscoveryEvent::Added(_)) | Ok(DiscoveryEvent::Removed(_)) => {}
+                Err(error) => {
+                    tracing::warn!(%error, topic, "direct-ZMQ discovery watch failed");
+                    break;
+                }
+            }
+        }
+
+        watch_cancel.cancel();
+        for (publisher_id, high_watermark) in stop_sources(sources, &observer).await {
+            resume_cursors.insert(publisher_id, high_watermark);
+        }
+        if !restart_watch {
+            break;
+        }
+        if !sleep_or_cancel(retry_delay, &cancellation_token).await {
+            break;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_source<H, O>(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    high_watermark: Option<u64>,
+    topic: &'static str,
+    rcvhwm: i32,
+    continuity_mode: ContinuityMode,
+    handler: H,
+    observer: O,
+    cancel: CancellationToken,
+) -> SourceTask
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
+    O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
+{
+    let task_endpoint = endpoint.clone();
+    let task_cancel = cancel.clone();
+    observe(
+        &observer,
+        publisher_id,
+        generation,
+        FanInEvent::SourceStarted,
+    );
+    let handle = tokio::spawn(async move {
+        run_source(
+            publisher_id,
+            task_endpoint,
+            generation,
+            high_watermark,
+            topic,
+            rcvhwm,
+            continuity_mode,
+            handler,
+            observer,
+            task_cancel,
+        )
+        .await
+    });
+    SourceTask {
+        publisher_id,
+        endpoint,
+        generation,
+        cancel,
+        handle,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_source<H, O>(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    high_watermark: Option<u64>,
+    topic: &'static str,
+    rcvhwm: i32,
+    continuity_mode: ContinuityMode,
+    handler: H,
+    observer: O,
+    cancel: CancellationToken,
+) -> Option<u64>
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Clone + Send + Sync + 'static,
+    O: Fn(FanInObservation) + Clone + Send + Sync + 'static,
+{
+    let mut cursor = SequenceCursor::new(continuity_mode, high_watermark);
+    let mut retry_delay = INITIAL_BACKOFF;
+    let mut connected_once = false;
+
+    loop {
+        let source = tokio::select! {
+            _ = cancel.cancelled() => break,
+            source = ValidatedZmqSource::connect(&endpoint, topic, publisher_id, rcvhwm) => source,
+        };
+        let mut source = match source {
+            Ok(source) => source,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, generation, %endpoint, topic, "failed to connect direct-ZMQ source");
+                observe(&observer, publisher_id, generation, FanInEvent::Reconnect);
+                if !sleep_or_cancel(retry_delay, &cancel).await {
+                    break;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+        if connected_once {
+            observe(&observer, publisher_id, generation, FanInEvent::Reconnect);
+        }
+        connected_once = true;
+        retry_delay = INITIAL_BACKOFF;
+
+        if !consume_connection(
+            publisher_id,
+            generation,
+            &mut source,
+            &mut cursor,
+            &handler,
+            &observer,
+            &cancel,
+        )
+        .await
+        {
+            break;
+        }
+        if !sleep_or_cancel(retry_delay, &cancel).await {
+            break;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+
+    cursor.high_watermark
+}
+
+async fn consume_connection<H, O>(
+    publisher_id: u64,
+    generation: u64,
+    source: &mut ValidatedZmqSource,
+    cursor: &mut SequenceCursor,
+    handler: &H,
+    observer: &O,
+    cancel: &CancellationToken,
+) -> bool
+where
+    H: Fn(ValidatedEnvelope) -> Result<()> + Send + Sync,
+    O: Fn(FanInObservation) + Send + Sync,
+{
+    loop {
+        let envelope = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return false,
+            envelope = source.next() => envelope,
+        };
+        let Some(envelope) = envelope else {
+            return true;
+        };
+        let envelope = match envelope {
+            Ok(envelope) => envelope,
+            Err(ValidatedZmqSourceError::Receive(error)) => {
+                tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source receive failed");
+                return true;
+            }
+            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
+                tracing::warn!(%error, publisher_id, generation, "dropping malformed direct-ZMQ envelope");
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::EnvelopeDecodeError,
+                );
+                continue;
+            }
+            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
+                tracing::warn!(%error, publisher_id, generation, "dropping misattributed direct-ZMQ envelope");
+                observe(
+                    observer,
+                    publisher_id,
+                    generation,
+                    FanInEvent::IdentityMismatch,
+                );
+                continue;
+            }
+        };
+
+        match cursor.observe(envelope.sequence) {
+            None | Some(Continuity::InOrder) => {}
+            Some(Continuity::Gap(missing)) => observe(
+                observer,
+                publisher_id,
+                generation,
+                FanInEvent::SequenceGap { missing },
+            ),
+            Some(Continuity::OutOfOrder) => {
+                observe(observer, publisher_id, generation, FanInEvent::OutOfOrder)
+            }
+        }
+        if let Err(error) = handler(envelope) {
+            tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source handler rejected an envelope");
+        }
+        tokio::task::consume_budget().await;
+    }
+}
+
+async fn stop_source<O>(source: SourceTask, observer: &O) -> Option<u64>
+where
+    O: Fn(FanInObservation) + Send + Sync,
+{
+    stop_source_with_timeout(source, observer, SOURCE_JOIN_TIMEOUT).await
+}
+
+async fn stop_source_with_timeout<O>(
+    source: SourceTask,
+    observer: &O,
+    join_timeout: Duration,
+) -> Option<u64>
+where
+    O: Fn(FanInObservation) + Send + Sync,
+{
+    source.cancel.cancel();
+    let publisher_id = source.publisher_id;
+    let generation = source.generation;
+    let mut handle = source.handle;
+    let high_watermark = match tokio::time::timeout(join_timeout, &mut handle).await {
+        Ok(Ok(high_watermark)) => high_watermark,
+        Ok(Err(error)) if error.is_cancelled() => None,
+        Ok(Err(error)) => {
+            tracing::warn!(%error, publisher_id, generation, "direct-ZMQ source task failed during shutdown");
+            None
+        }
+        Err(_) => {
+            handle.abort();
+            let _ = handle.await;
+            observe(observer, publisher_id, generation, FanInEvent::ForcedAbort);
+            None
+        }
+    };
+    observe(
+        observer,
+        publisher_id,
+        generation,
+        FanInEvent::SourceStopped,
+    );
+    high_watermark
+}
+
+async fn stop_sources<O>(sources: HashMap<u64, SourceTask>, observer: &O) -> HashMap<u64, u64>
+where
+    O: Fn(FanInObservation) + Clone + Send + Sync,
+{
+    for source in sources.values() {
+        source.cancel.cancel();
+    }
+    futures::future::join_all(sources.into_iter().map(|(publisher_id, source)| {
+        let observer = observer.clone();
+        async move { (publisher_id, stop_source(source, &observer).await) }
+    }))
+    .await
+    .into_iter()
+    .filter_map(|(publisher_id, high_watermark)| {
+        high_watermark.map(|high_watermark| (publisher_id, high_watermark))
+    })
+    .collect()
+}
+
+fn observe<O>(observer: &O, publisher_id: u64, generation: u64, event: FanInEvent)
+where
+    O: Fn(FanInObservation),
+{
+    observer(FanInObservation {
+        publisher_id,
+        generation,
+        event,
+    });
+}
+
+async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
+    tokio::select! {
+        _ = cancellation_token.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, HashSet},
+        sync::{
+            Arc, Condvar, Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
+
+    use dynamo_runtime::{
+        DistributedRuntime, Runtime,
+        distributed::DistributedConfig,
+        transports::event_plane::{EventPublisher, EventTransportKind},
+    };
+
+    use super::*;
+
+    struct BlockingGate(Arc<(Mutex<bool>, Condvar)>);
+
+    impl BlockingGate {
+        fn new() -> Self {
+            Self(Arc::new((Mutex::new(false), Condvar::new())))
+        }
+
+        fn open(&self) {
+            let (lock, ready) = &*self.0;
+            *lock.lock().unwrap() = true;
+            ready.notify_all();
+        }
+    }
+
+    impl Drop for BlockingGate {
+        fn drop(&mut self) {
+            self.open();
+        }
+    }
+
+    #[test]
+    fn continuity_tracks_initial_gaps_and_retains_high_watermark() {
+        let mut cursor = SequenceCursor::new(ContinuityMode::TrackFromZero, None);
+        assert_eq!(cursor.observe(3), Some(Continuity::Gap(3)));
+        assert_eq!(cursor.observe(4), Some(Continuity::InOrder));
+        assert_eq!(cursor.observe(7), Some(Continuity::Gap(2)));
+        assert_eq!(cursor.observe(6), Some(Continuity::OutOfOrder));
+
+        let mut resumed = SequenceCursor::new(ContinuityMode::TrackFromZero, cursor.high_watermark);
+        assert_eq!(resumed.observe(8), Some(Continuity::InOrder));
+        assert_eq!(
+            SequenceCursor::new(ContinuityMode::Disabled, None).observe(9),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial_test::serial]
+    async fn fan_in_tracks_source_recreation_and_excludes_local_publisher() -> Result<()> {
+        const TOPIC: &str = "direct-zmq-fan-in-lifecycle";
+
+        let runtime = Runtime::from_current()?;
+        let distributed =
+            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+        let endpoint = distributed
+            .namespace(format!("direct-zmq-fan-in-{}", uuid::Uuid::new_v4()))?
+            .component("frontend")?
+            .endpoint("generate");
+        let local =
+            EventPublisher::for_endpoint_with_transport(&endpoint, TOPIC, EventTransportKind::Zmq)
+                .await?;
+        let (observation_tx, mut observation_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cancel = CancellationToken::new();
+        let supervisor = start_direct_zmq_fan_in(
+            endpoint.clone(),
+            TOPIC,
+            32,
+            Some(local.publisher_id()),
+            ContinuityMode::Disabled,
+            cancel.clone(),
+            |_| Ok(()),
+            move |observation| {
+                let _ = observation_tx.send(observation);
+            },
+        )
+        .await?;
+        let mut active = HashSet::new();
+
+        for _ in 0..2 {
+            let mut publishers = Vec::with_capacity(32);
+            for _ in 0..32 {
+                publishers.push(
+                    EventPublisher::for_endpoint_with_transport(
+                        &endpoint,
+                        TOPIC,
+                        EventTransportKind::Zmq,
+                    )
+                    .await?,
+                );
+            }
+            wait_for_source_count(&mut observation_rx, &mut active, 32).await;
+            assert!(
+                !active
+                    .iter()
+                    .any(|(publisher_id, _)| { *publisher_id == local.publisher_id() })
+            );
+
+            drop(publishers);
+            wait_for_source_count(&mut observation_rx, &mut active, 0).await;
+        }
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), supervisor)
+            .await
+            .expect("fan-in supervisor should stop after cancellation")
+            .expect("fan-in supervisor should not panic");
+        assert!(active.is_empty());
+        drop(local);
+        distributed.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    #[serial_test::serial]
+    async fn one_blocked_source_does_not_stall_another_source() -> Result<()> {
+        const TOPIC: &str = "direct-zmq-fan-in-concurrency";
+
+        let runtime = Runtime::from_current()?;
+        let distributed =
+            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+        let endpoint = distributed
+            .namespace(format!("direct-zmq-concurrency-{}", uuid::Uuid::new_v4()))?
+            .component("frontend")?
+            .endpoint("generate");
+        let publisher_a =
+            EventPublisher::for_endpoint_with_transport(&endpoint, TOPIC, EventTransportKind::Zmq)
+                .await?;
+        let publisher_b =
+            EventPublisher::for_endpoint_with_transport(&endpoint, TOPIC, EventTransportKind::Zmq)
+                .await?;
+        let publisher_a_id = publisher_a.publisher_id();
+        let publisher_b_id = publisher_b.publisher_id();
+        let release = BlockingGate::new();
+        let block_enabled = Arc::new(AtomicBool::new(false));
+        let blocked_once = Arc::new(AtomicBool::new(false));
+        let order_violation = Arc::new(AtomicBool::new(false));
+        let last_sequences = Arc::new(Mutex::new(HashMap::<u64, u64>::new()));
+        let (a_seen_tx, mut a_seen_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (a_started_tx, mut a_started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (a_released_tx, mut a_released_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (b_seen_tx, mut b_seen_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let handler_release = release.0.clone();
+        let handler_block_enabled = block_enabled.clone();
+        let handler_blocked_once = blocked_once.clone();
+        let handler_order_violation = order_violation.clone();
+        let handler_last_sequences = last_sequences.clone();
+        let handler = move |envelope: ValidatedEnvelope| {
+            let mut last_sequences = handler_last_sequences.lock().unwrap();
+            if last_sequences
+                .insert(envelope.publisher_id, envelope.sequence)
+                .is_some_and(|previous| previous >= envelope.sequence)
+            {
+                handler_order_violation.store(true, Ordering::Relaxed);
+            }
+            drop(last_sequences);
+
+            if envelope.publisher_id == publisher_a_id {
+                let _ = a_seen_tx.send(());
+                if handler_block_enabled.load(Ordering::Relaxed)
+                    && !handler_blocked_once.swap(true, Ordering::Relaxed)
+                {
+                    let _ = a_started_tx.send(());
+                    tokio::task::block_in_place(|| {
+                        let (lock, ready) = &*handler_release;
+                        let released = lock.lock().unwrap();
+                        let _ = ready
+                            .wait_timeout_while(released, Duration::from_secs(5), |released| {
+                                !*released
+                            })
+                            .unwrap();
+                    });
+                    let _ = a_released_tx.send(());
+                }
+            }
+            if envelope.publisher_id == publisher_b_id {
+                let _ = b_seen_tx.send(());
+            }
+            Ok(())
+        };
+        let cancel = CancellationToken::new();
+        let supervisor = start_direct_zmq_fan_in(
+            endpoint,
+            TOPIC,
+            32,
+            None,
+            ContinuityMode::Disabled,
+            cancel.clone(),
+            handler,
+            |_| {},
+        )
+        .await?;
+
+        publish_until_observed(&publisher_a, &mut a_seen_rx, Duration::from_secs(5)).await;
+        publish_until_observed(&publisher_b, &mut b_seen_rx, Duration::from_secs(5)).await;
+        block_enabled.store(true, Ordering::Relaxed);
+        publish_until_observed(&publisher_a, &mut a_started_rx, Duration::from_secs(5)).await;
+        publish_until_observed(&publisher_b, &mut b_seen_rx, Duration::from_secs(1)).await;
+        assert!(
+            a_released_rx.try_recv().is_err(),
+            "source B must progress while source A remains blocked"
+        );
+        release.open();
+        tokio::time::timeout(Duration::from_secs(1), a_released_rx.recv())
+            .await
+            .expect("source A handler should resume after release")
+            .expect("source A release observer should stay open");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let seen = last_sequences.lock().unwrap();
+                if seen.contains_key(&publisher_a_id) && seen.contains_key(&publisher_b_id) {
+                    break;
+                }
+                drop(seen);
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("both sources should make progress");
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), supervisor)
+            .await
+            .expect("fan-in supervisor should stop after cancellation")
+            .expect("fan-in supervisor should not panic");
+        assert!(!order_violation.load(Ordering::Relaxed));
+        drop(publisher_a);
+        drop(publisher_b);
+        distributed.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn source_shutdown_joins_and_forces_abort_after_timeout() {
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let observer = {
+            let observations = observations.clone();
+            move |observation| observations.lock().unwrap().push(observation)
+        };
+
+        let cooperative_cancel = CancellationToken::new();
+        let task_cancel = cooperative_cancel.clone();
+        let cooperative = SourceTask {
+            publisher_id: 1,
+            endpoint: "cooperative".to_string(),
+            generation: 1,
+            cancel: cooperative_cancel,
+            handle: tokio::spawn(async move {
+                task_cancel.cancelled().await;
+                Some(17)
+            }),
+        };
+        assert_eq!(
+            stop_source_with_timeout(cooperative, &observer, Duration::from_secs(1)).await,
+            Some(17)
+        );
+
+        let stuck_handle = tokio::spawn(std::future::pending::<Option<u64>>());
+        let abort_handle = stuck_handle.abort_handle();
+        let stuck = SourceTask {
+            publisher_id: 2,
+            endpoint: "stuck".to_string(),
+            generation: 2,
+            cancel: CancellationToken::new(),
+            handle: stuck_handle,
+        };
+        assert_eq!(
+            stop_source_with_timeout(stuck, &observer, Duration::from_millis(10)).await,
+            None
+        );
+        assert!(abort_handle.is_finished());
+        assert!(observations.lock().unwrap().iter().any(|observation| {
+            observation.publisher_id == 2 && observation.event == FanInEvent::ForcedAbort
+        }));
+    }
+
+    async fn wait_for_source_count(
+        observations: &mut tokio::sync::mpsc::UnboundedReceiver<FanInObservation>,
+        active: &mut HashSet<(u64, u64)>,
+        expected: usize,
+    ) {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while active.len() != expected {
+                let observation = observations
+                    .recv()
+                    .await
+                    .expect("fan-in observation channel closed");
+                let key = (observation.publisher_id, observation.generation);
+                match observation.event {
+                    FanInEvent::SourceStarted => assert!(active.insert(key)),
+                    FanInEvent::SourceStopped => assert!(active.remove(&key)),
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .unwrap_or_else(|_| panic!("source count did not reach {expected}"));
+    }
+
+    async fn publish_until_observed(
+        publisher: &EventPublisher,
+        observed: &mut tokio::sync::mpsc::UnboundedReceiver<()>,
+        timeout: Duration,
+    ) {
+        tokio::time::timeout(timeout, async {
+            loop {
+                publisher.publish(&()).await.unwrap();
+                if tokio::time::timeout(Duration::from_millis(20), observed.recv())
+                    .await
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("source should receive a warmed-up message");
+    }
+}

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -17,8 +17,7 @@ use dynamo_runtime::{
     },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::zmq_transport::ZmqWireStream,
-    transports::event_plane::{Codec, EventScope, ZmqSubTransport},
+    transports::event_plane::{Codec, EventScope, ValidatedZmqSource, ValidatedZmqSourceError},
 };
 use futures::StreamExt;
 use tokio::{
@@ -645,7 +644,11 @@ async fn run_source(
     loop {
         let stream = tokio::select! {
             _ = cancel.cancelled() => return,
-            stream = ZmqSubTransport::connect_single_consumer(&endpoint, KV_EVENT_SUBJECT) => stream,
+            stream = ValidatedZmqSource::connect_default(
+                &endpoint,
+                KV_EVENT_SUBJECT,
+                publisher_id,
+            ) => stream,
         };
         let mut stream = match stream {
             Ok(stream) => stream,
@@ -715,7 +718,7 @@ async fn run_source(
 
 async fn consume_connection(
     publisher_id: u64,
-    stream: &mut ZmqWireStream,
+    stream: &mut ValidatedZmqSource,
     client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
     metrics: &KvZmqIngressMetrics,
 ) {
@@ -725,39 +728,23 @@ async fn consume_connection(
         let Some(result) = result else {
             return;
         };
-        let message = match result {
-            Ok(message) => message,
-            Err(error) => {
+        let envelope = match result {
+            Ok(envelope) => envelope,
+            Err(ValidatedZmqSourceError::Receive(error)) => {
                 tracing::warn!(%error, publisher_id, "Direct-ZMQ KV source stream failed");
                 return;
             }
-        };
-
-        let envelope = match codec.decode_envelope(&message.payload) {
-            Ok(envelope) => envelope,
-            Err(error) => {
+            Err(ValidatedZmqSourceError::EnvelopeDecode(error)) => {
                 tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV envelope");
                 metrics.increment_lifecycle("envelope_decode_error");
                 continue;
             }
+            Err(error @ ValidatedZmqSourceError::IdentityMismatch { .. }) => {
+                tracing::warn!(%error, publisher_id, "Dropping direct-ZMQ KV envelope with inconsistent attribution");
+                metrics.increment_lifecycle("identity_mismatch");
+                continue;
+            }
         };
-        if envelope.publisher_id != publisher_id
-            || envelope.publisher_id != message.publisher_id
-            || envelope.sequence != message.sequence
-            || envelope.topic != KV_EVENT_SUBJECT
-        {
-            tracing::warn!(
-                publisher_id,
-                frame_publisher_id = message.publisher_id,
-                frame_sequence = message.sequence,
-                envelope_publisher_id = envelope.publisher_id,
-                envelope_sequence = envelope.sequence,
-                envelope_topic = %envelope.topic,
-                "Dropping direct-ZMQ KV envelope with inconsistent attribution"
-            );
-            metrics.increment_lifecycle("identity_mismatch");
-            continue;
-        }
         let events = match codec.decode_payload::<Vec<RouterEvent>>(&envelope.payload) {
             Ok(events) => events,
             Err(error) => {

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -259,6 +259,151 @@ impl KvZmqIngressMetrics {
 }
 
 // ---------------------------------------------------------------------------
+// Direct-ZMQ active-sequence ingress metrics
+// ---------------------------------------------------------------------------
+
+pub(crate) struct ActiveSequenceZmqIngressMetrics {
+    tracked_sources: IntGauge,
+    received_batches_total: IntCounter,
+    received_events_total: IntCounter,
+    handled_batches_total: IntCounter,
+    handled_events_total: IntCounter,
+    sequence_gaps_total: IntCounter,
+    out_of_order_total: IntCounter,
+    reconnects_total: IntCounter,
+    replacements_total: IntCounter,
+    envelope_decode_errors_total: IntCounter,
+    payload_decode_errors_total: IntCounter,
+    identity_errors_total: IntCounter,
+    forced_aborts_total: IntCounter,
+}
+
+static ACTIVE_SEQUENCE_ZMQ_INGRESS_METRICS: OnceLock<Arc<ActiveSequenceZmqIngressMetrics>> =
+    OnceLock::new();
+
+impl ActiveSequenceZmqIngressMetrics {
+    pub(crate) fn from_component(component: &Component) -> Arc<Self> {
+        ACTIVE_SEQUENCE_ZMQ_INGRESS_METRICS
+            .get_or_init(|| {
+                let metrics = component.metrics();
+                let counter = |name, help| {
+                    metrics
+                        .create_intcounter(name, help, &[])
+                        .unwrap_or_else(|error| panic!("failed to create {name}: {error}"))
+                };
+                Arc::new(Self {
+                    tracked_sources: metrics
+                        .create_intgauge(
+                            "router_active_sequence_zmq_ingress_sources",
+                            "Number of tracked direct-ZMQ active-sequence sources",
+                            &[],
+                        )
+                        .expect("failed to create router_active_sequence_zmq_ingress_sources"),
+                    received_batches_total: counter(
+                        "router_active_sequence_zmq_ingress_received_batches_total",
+                        "Direct-ZMQ active-sequence batches decoded from the wire",
+                    ),
+                    received_events_total: counter(
+                        "router_active_sequence_zmq_ingress_received_events_total",
+                        "Active-sequence events decoded from direct-ZMQ batches",
+                    ),
+                    handled_batches_total: counter(
+                        "router_active_sequence_zmq_ingress_handled_batches_total",
+                        "Direct-ZMQ active-sequence batches handed to the tracker",
+                    ),
+                    handled_events_total: counter(
+                        "router_active_sequence_zmq_ingress_handled_events_total",
+                        "Active-sequence events handed to the tracker",
+                    ),
+                    sequence_gaps_total: counter(
+                        "router_active_sequence_zmq_ingress_sequence_gaps_total",
+                        "Missing direct-ZMQ active-sequence envelopes inferred from sequence gaps",
+                    ),
+                    out_of_order_total: counter(
+                        "router_active_sequence_zmq_ingress_out_of_order_total",
+                        "Non-increasing direct-ZMQ active-sequence envelope sequences",
+                    ),
+                    reconnects_total: counter(
+                        "router_active_sequence_zmq_ingress_reconnects_total",
+                        "Direct-ZMQ active-sequence source reconnect attempts",
+                    ),
+                    replacements_total: counter(
+                        "router_active_sequence_zmq_ingress_replacements_total",
+                        "Direct-ZMQ active-sequence source task replacements",
+                    ),
+                    envelope_decode_errors_total: counter(
+                        "router_active_sequence_zmq_ingress_envelope_decode_errors_total",
+                        "Direct-ZMQ active-sequence envelope decode errors",
+                    ),
+                    payload_decode_errors_total: counter(
+                        "router_active_sequence_zmq_ingress_payload_decode_errors_total",
+                        "Direct-ZMQ active-sequence payload decode errors",
+                    ),
+                    identity_errors_total: counter(
+                        "router_active_sequence_zmq_ingress_identity_errors_total",
+                        "Direct-ZMQ active-sequence frame and envelope identity mismatches",
+                    ),
+                    forced_aborts_total: counter(
+                        "router_active_sequence_zmq_ingress_forced_aborts_total",
+                        "Direct-ZMQ active-sequence source tasks aborted after join timeout",
+                    ),
+                })
+            })
+            .clone()
+    }
+
+    pub(crate) fn source_started(&self) {
+        self.tracked_sources.inc();
+    }
+
+    pub(crate) fn source_stopped(&self) {
+        self.tracked_sources.dec();
+    }
+
+    pub(crate) fn record_received(&self, events: usize) {
+        self.received_batches_total.inc();
+        self.received_events_total.inc_by(events as u64);
+    }
+
+    pub(crate) fn record_handled(&self, events: usize) {
+        self.handled_batches_total.inc();
+        self.handled_events_total.inc_by(events as u64);
+    }
+
+    pub(crate) fn record_gap(&self, missing: u64) {
+        self.sequence_gaps_total.inc_by(missing);
+    }
+
+    pub(crate) fn record_out_of_order(&self) {
+        self.out_of_order_total.inc();
+    }
+
+    pub(crate) fn record_reconnect(&self) {
+        self.reconnects_total.inc();
+    }
+
+    pub(crate) fn record_replacement(&self) {
+        self.replacements_total.inc();
+    }
+
+    pub(crate) fn record_envelope_decode_error(&self) {
+        self.envelope_decode_errors_total.inc();
+    }
+
+    pub(crate) fn record_payload_decode_error(&self) {
+        self.payload_decode_errors_total.inc();
+    }
+
+    pub(crate) fn record_identity_error(&self) {
+        self.identity_errors_total.inc();
+    }
+
+    pub(crate) fn record_forced_abort(&self) {
+        self.forced_aborts_total.inc();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Router worker status metrics (component-scoped gauges)
 // ---------------------------------------------------------------------------
 

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -264,10 +264,6 @@ impl KvZmqIngressMetrics {
 
 pub(crate) struct ActiveSequenceZmqIngressMetrics {
     tracked_sources: IntGauge,
-    received_batches_total: IntCounter,
-    received_events_total: IntCounter,
-    handled_batches_total: IntCounter,
-    handled_events_total: IntCounter,
     sequence_gaps_total: IntCounter,
     out_of_order_total: IntCounter,
     reconnects_total: IntCounter,
@@ -299,22 +295,6 @@ impl ActiveSequenceZmqIngressMetrics {
                             &[],
                         )
                         .expect("failed to create router_active_sequence_zmq_ingress_sources"),
-                    received_batches_total: counter(
-                        "router_active_sequence_zmq_ingress_received_batches_total",
-                        "Direct-ZMQ active-sequence batches decoded from the wire",
-                    ),
-                    received_events_total: counter(
-                        "router_active_sequence_zmq_ingress_received_events_total",
-                        "Active-sequence events decoded from direct-ZMQ batches",
-                    ),
-                    handled_batches_total: counter(
-                        "router_active_sequence_zmq_ingress_handled_batches_total",
-                        "Direct-ZMQ active-sequence batches handed to the tracker",
-                    ),
-                    handled_events_total: counter(
-                        "router_active_sequence_zmq_ingress_handled_events_total",
-                        "Active-sequence events handed to the tracker",
-                    ),
                     sequence_gaps_total: counter(
                         "router_active_sequence_zmq_ingress_sequence_gaps_total",
                         "Missing direct-ZMQ active-sequence envelopes inferred from sequence gaps",
@@ -358,16 +338,6 @@ impl ActiveSequenceZmqIngressMetrics {
 
     pub(crate) fn source_stopped(&self) {
         self.tracked_sources.dec();
-    }
-
-    pub(crate) fn record_received(&self, events: usize) {
-        self.received_batches_total.inc();
-        self.received_events_total.inc_by(events as u64);
-    }
-
-    pub(crate) fn record_handled(&self, events: usize) {
-        self.handled_batches_total.inc();
-        self.handled_events_total.inc_by(events as u64);
     }
 
     pub(crate) fn record_gap(&self, missing: u64) {

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -378,12 +378,13 @@ pub async fn create_multi_worker_sequences(
     if replica_sync {
         let direct_config = direct_zmq::DirectZmqSequenceConfig::from_env();
         if direct_config.should_use_direct(transport_kind) {
-            direct_zmq::start(
+            let _direct_zmq_task = direct_zmq::start(
                 endpoint,
                 arc.clone(),
                 direct_config.rcvhwm,
                 cancellation_token.child_token(),
-            );
+            )
+            .await?;
         } else {
             let subscriber = RuntimeSequenceSubscriber::for_endpoint(&endpoint).await?;
             arc.start_replica_sync(subscriber, cancellation_token.child_token());

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -7,6 +7,8 @@
 //! implementations that wire the runtime-agnostic business logic (in `dynamo_kv_router`)
 //! to the configured event transport and Prometheus metrics.
 
+mod direct_zmq;
+
 pub use dynamo_kv_router::multi_worker_sequence::{
     ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
     SequenceSubscriber,
@@ -317,8 +319,8 @@ pub async fn create_multi_worker_sequences(
     worker_type: &'static str,
     cancellation_token: CancellationToken,
 ) -> Result<Arc<ActiveSequencesMulti>> {
+    let transport_kind = endpoint.drt().default_event_transport_kind();
     let event_publisher = if replica_sync {
-        let transport_kind = endpoint.drt().default_event_transport_kind();
         let event_publisher = EventPublisher::for_endpoint_with_transport(
             &endpoint,
             ACTIVE_SEQUENCES_SUBJECT,
@@ -374,8 +376,18 @@ pub async fn create_multi_worker_sequences(
     let arc = Arc::new(multi_worker);
 
     if replica_sync {
-        let subscriber = RuntimeSequenceSubscriber::for_endpoint(&endpoint).await?;
-        arc.start_replica_sync(subscriber, cancellation_token.child_token());
+        let direct_config = direct_zmq::DirectZmqSequenceConfig::from_env();
+        if direct_config.should_use_direct(transport_kind) {
+            direct_zmq::start(
+                endpoint,
+                arc.clone(),
+                direct_config.rcvhwm,
+                cancellation_token.child_token(),
+            );
+        } else {
+            let subscriber = RuntimeSequenceSubscriber::for_endpoint(&endpoint).await?;
+            arc.start_replica_sync(subscriber, cancellation_token.child_token());
+        }
     }
 
     arc.start_periodic_force_expiry_across_all_workers(cancellation_token.child_token());

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -516,10 +516,7 @@ where
             metrics.record_payload_decode_error();
             continue;
         }
-        let event_count = batch.events.len();
-        metrics.record_received(event_count);
         tracker.apply_replica_batch(batch.events);
-        metrics.record_handled(event_count);
         tokio::task::consume_budget().await;
     }
 }
@@ -708,6 +705,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn real_zmq_batch_ingress_validates_identity_and_survives_rebind() -> anyhow::Result<()> {
         let runtime = Runtime::from_current()?;
         let distributed =
@@ -991,33 +989,6 @@ mod tests {
             None
         );
         assert!(stuck_abort.is_finished());
-
-        for generation_base in [100_u64, 200] {
-            let mut sources = HashMap::new();
-            for publisher_id in 0..32 {
-                let cancel = CancellationToken::new();
-                let task_cancel = cancel.clone();
-                let generation = generation_base + publisher_id;
-                metrics.source_started();
-                sources.insert(
-                    publisher_id,
-                    SourceTask {
-                        endpoint: format!("source-{publisher_id}"),
-                        generation,
-                        cancel,
-                        handle: tokio::spawn(async move {
-                            task_cancel.cancelled().await;
-                            Some(generation)
-                        }),
-                    },
-                );
-            }
-            assert_eq!(sources.len(), 32);
-            let cursors = stop_sources(sources, &metrics).await;
-            assert_eq!(cursors.len(), 32);
-            assert_eq!(cursors[&0], generation_base);
-            assert_eq!(cursors[&31], generation_base + 31);
-        }
 
         distributed.shutdown();
         Ok(())

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -10,6 +10,7 @@ use dynamo_kv_router::{
 };
 use dynamo_runtime::{
     component::Endpoint,
+    config::parse_bool_opt,
     discovery::EventTransportKind,
     transports::event_plane::{Codec, uses_direct_zmq},
 };
@@ -39,18 +40,20 @@ impl DirectZmqSequenceConfig {
     fn from_lookup(mut get_env: impl FnMut(&str) -> Option<OsString>) -> Self {
         let enabled = match get_env(DIRECT_ZMQ_ENV) {
             None => true,
-            Some(raw) => match raw.to_string_lossy().trim().to_ascii_lowercase().as_str() {
-                "0" | "false" => false,
-                "1" | "true" => true,
-                value => {
-                    tracing::warn!(
-                        env = DIRECT_ZMQ_ENV,
-                        %value,
-                        "invalid direct-ZMQ active-sequence setting; using enabled default"
-                    );
-                    true
+            Some(raw) => {
+                let value = raw.to_string_lossy();
+                match parse_bool_opt(&value) {
+                    Some(enabled) => enabled,
+                    None => {
+                        tracing::warn!(
+                            env = DIRECT_ZMQ_ENV,
+                            %value,
+                            "invalid direct-ZMQ active-sequence setting; using enabled default"
+                        );
+                        true
+                    }
                 }
-            },
+            }
         };
 
         let rcvhwm = match get_env(RCVHWM_ENV) {

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -1,0 +1,1025 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashMap, ffi::OsString, sync::Arc, time::Duration};
+
+use dynamo_kv_router::{
+    ActiveSequencesMultiWorker, SequencePublisher,
+    protocols::{ActiveSequenceEventBatch, MAX_REPLICA_BATCH_EVENTS},
+};
+use dynamo_runtime::{
+    component::Endpoint,
+    discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
+        EventChannelInstanceId, EventChannelQuery, EventScope, EventTransport, EventTransportKind,
+    },
+    traits::DistributedRuntimeProvider,
+    transports::event_plane::{Codec, ZmqSubTransport, uses_direct_zmq},
+};
+use futures::StreamExt;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use super::ActiveSequencesMulti;
+use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, metrics::ActiveSequenceZmqIngressMetrics};
+
+const DIRECT_ZMQ_ENV: &str = "DYN_ROUTER_ACTIVE_SEQUENCE_DIRECT_ZMQ";
+const RCVHWM_ENV: &str = "DYN_ROUTER_ACTIVE_SEQUENCE_ZMQ_RCVHWM";
+const DEFAULT_RCVHWM: i32 = 1024;
+const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DirectZmqSequenceConfig {
+    enabled: bool,
+    pub(super) rcvhwm: i32,
+}
+
+impl DirectZmqSequenceConfig {
+    pub(super) fn from_env() -> Self {
+        Self::from_lookup(|key| std::env::var_os(key))
+    }
+
+    fn from_lookup(mut get_env: impl FnMut(&str) -> Option<OsString>) -> Self {
+        let enabled = match get_env(DIRECT_ZMQ_ENV) {
+            None => true,
+            Some(raw) => match raw.to_string_lossy().trim().to_ascii_lowercase().as_str() {
+                "0" | "false" => false,
+                "1" | "true" => true,
+                value => {
+                    tracing::warn!(
+                        env = DIRECT_ZMQ_ENV,
+                        %value,
+                        "invalid direct-ZMQ active-sequence setting; using enabled default"
+                    );
+                    true
+                }
+            },
+        };
+
+        let rcvhwm = match get_env(RCVHWM_ENV) {
+            None => DEFAULT_RCVHWM,
+            Some(raw) => match raw.to_string_lossy().trim().parse::<i32>() {
+                Ok(value) if value > 0 => value,
+                _ => {
+                    tracing::warn!(
+                        env = RCVHWM_ENV,
+                        value = %raw.to_string_lossy(),
+                        default = DEFAULT_RCVHWM,
+                        "invalid direct-ZMQ active-sequence receive HWM; using default"
+                    );
+                    DEFAULT_RCVHWM
+                }
+            },
+        };
+
+        Self { enabled, rcvhwm }
+    }
+
+    pub(super) fn should_use_direct(self, transport_kind: EventTransportKind) -> bool {
+        self.should_use_direct_for_topology(transport_kind, uses_direct_zmq(transport_kind))
+    }
+
+    fn should_use_direct_for_topology(
+        self,
+        transport_kind: EventTransportKind,
+        direct_zmq_topology: bool,
+    ) -> bool {
+        self.enabled && transport_kind == EventTransportKind::Zmq && direct_zmq_topology
+    }
+}
+
+struct SourceTask {
+    endpoint: String,
+    generation: u64,
+    cancel: CancellationToken,
+    handle: JoinHandle<Option<u64>>,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct SequenceCursor {
+    high_watermark: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Continuity {
+    InOrder,
+    Gap(u64),
+    OutOfOrder,
+}
+
+impl SequenceCursor {
+    fn from_high_watermark(high_watermark: Option<u64>) -> Self {
+        Self { high_watermark }
+    }
+
+    fn observe(&mut self, sequence: u64) -> Continuity {
+        let Some(high_watermark) = self.high_watermark else {
+            self.high_watermark = Some(sequence);
+            return if sequence == 0 {
+                Continuity::InOrder
+            } else {
+                Continuity::Gap(sequence)
+            };
+        };
+
+        if sequence <= high_watermark {
+            return Continuity::OutOfOrder;
+        }
+
+        self.high_watermark = Some(sequence);
+        let missing = sequence - high_watermark - 1;
+        if missing == 0 {
+            Continuity::InOrder
+        } else {
+            Continuity::Gap(missing)
+        }
+    }
+}
+
+pub(super) fn start(
+    endpoint: Endpoint,
+    tracker: Arc<ActiveSequencesMulti>,
+    rcvhwm: i32,
+    cancellation_token: CancellationToken,
+) {
+    tokio::spawn(run_supervisor(
+        endpoint,
+        tracker,
+        rcvhwm,
+        cancellation_token,
+    ));
+}
+
+async fn run_supervisor<P>(
+    endpoint: Endpoint,
+    tracker: Arc<ActiveSequencesMultiWorker<P>>,
+    rcvhwm: i32,
+    cancellation_token: CancellationToken,
+) where
+    P: SequencePublisher + 'static,
+{
+    run_supervisor_inner(endpoint, tracker, rcvhwm, cancellation_token, |_| {}).await;
+}
+
+async fn run_supervisor_inner<P, F>(
+    endpoint: Endpoint,
+    tracker: Arc<ActiveSequencesMultiWorker<P>>,
+    rcvhwm: i32,
+    cancellation_token: CancellationToken,
+    mut observe_source_count: F,
+) where
+    P: SequencePublisher + 'static,
+    F: FnMut(usize),
+{
+    let expected_scope = EventScope::Endpoint {
+        endpoint: endpoint.id(),
+    };
+    let query = DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(
+        endpoint.id(),
+        ACTIVE_SEQUENCES_SUBJECT,
+    ));
+    let discovery = endpoint.drt().discovery();
+    let metrics = ActiveSequenceZmqIngressMetrics::from_component(endpoint.component());
+    let mut resume_cursors = HashMap::<u64, u64>::new();
+    let mut next_generation = 1_u64;
+    let mut retry_delay = INITIAL_BACKOFF;
+
+    loop {
+        let watch_cancel = cancellation_token.child_token();
+        let watch = tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            watch = discovery.list_and_watch(query.clone(), Some(watch_cancel.clone())) => watch,
+        };
+        let mut watch = match watch {
+            Ok(watch) => watch,
+            Err(error) => {
+                tracing::warn!(%error, "failed to watch active-sequence ZMQ publishers");
+                if !sleep_or_cancel(retry_delay, &cancellation_token).await {
+                    break;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+        retry_delay = INITIAL_BACKOFF;
+        let mut sources = HashMap::<u64, SourceTask>::new();
+        let mut restart_watch = true;
+
+        loop {
+            let event = tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => {
+                    restart_watch = false;
+                    break;
+                }
+                event = watch.next() => event,
+            };
+            let Some(event) = event else {
+                tracing::warn!("active-sequence ZMQ discovery watch ended");
+                break;
+            };
+
+            match event {
+                Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
+                    scope,
+                    topic,
+                    instance_id,
+                    transport,
+                })) if scope == expected_scope && topic == ACTIVE_SEQUENCES_SUBJECT => {
+                    let EventTransport::Zmq { endpoint } = transport else {
+                        tracing::warn!(
+                            publisher_id = instance_id,
+                            "ignoring non-ZMQ active-sequence event channel"
+                        );
+                        continue;
+                    };
+
+                    if let Some(existing) = sources.get(&instance_id) {
+                        if existing.endpoint == endpoint {
+                            continue;
+                        }
+                    }
+
+                    let high_watermark = if let Some(existing) = sources.remove(&instance_id) {
+                        tracing::warn!(
+                            publisher_id = instance_id,
+                            old_endpoint = %existing.endpoint,
+                            new_endpoint = %endpoint,
+                            "replacing active-sequence ZMQ source endpoint"
+                        );
+                        metrics.record_replacement();
+                        stop_source(existing, &metrics).await
+                    } else {
+                        resume_cursors.remove(&instance_id)
+                    };
+
+                    let generation = next_generation;
+                    next_generation = next_generation.wrapping_add(1);
+                    sources.insert(
+                        instance_id,
+                        spawn_source(
+                            instance_id,
+                            endpoint,
+                            generation,
+                            high_watermark,
+                            rcvhwm,
+                            tracker.clone(),
+                            metrics.clone(),
+                            cancellation_token.child_token(),
+                        ),
+                    );
+                    observe_source_count(sources.len());
+                }
+                Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
+                    EventChannelInstanceId {
+                        scope,
+                        topic,
+                        instance_id,
+                    },
+                ))) if scope == expected_scope && topic == ACTIVE_SEQUENCES_SUBJECT => {
+                    resume_cursors.remove(&instance_id);
+                    if let Some(source) = sources.remove(&instance_id) {
+                        stop_source(source, &metrics).await;
+                        observe_source_count(sources.len());
+                    }
+                }
+                Ok(DiscoveryEvent::Added(_)) | Ok(DiscoveryEvent::Removed(_)) => {}
+                Err(error) => {
+                    tracing::warn!(%error, "active-sequence ZMQ discovery watch failed");
+                    break;
+                }
+            }
+        }
+
+        watch_cancel.cancel();
+        for (publisher_id, high_watermark) in stop_sources(sources, &metrics).await {
+            resume_cursors.insert(publisher_id, high_watermark);
+        }
+        observe_source_count(0);
+        if !restart_watch {
+            break;
+        }
+        if !sleep_or_cancel(retry_delay, &cancellation_token).await {
+            break;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_source<P>(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    high_watermark: Option<u64>,
+    rcvhwm: i32,
+    tracker: Arc<ActiveSequencesMultiWorker<P>>,
+    metrics: Arc<ActiveSequenceZmqIngressMetrics>,
+    cancel: CancellationToken,
+) -> SourceTask
+where
+    P: SequencePublisher + 'static,
+{
+    let task_endpoint = endpoint.clone();
+    let task_cancel = cancel.clone();
+    metrics.source_started();
+    let handle = tokio::spawn(async move {
+        run_source(
+            publisher_id,
+            task_endpoint,
+            generation,
+            high_watermark,
+            rcvhwm,
+            tracker,
+            metrics,
+            task_cancel,
+        )
+        .await
+    });
+    SourceTask {
+        endpoint,
+        generation,
+        cancel,
+        handle,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_source<P>(
+    publisher_id: u64,
+    endpoint: String,
+    generation: u64,
+    high_watermark: Option<u64>,
+    rcvhwm: i32,
+    tracker: Arc<ActiveSequencesMultiWorker<P>>,
+    metrics: Arc<ActiveSequenceZmqIngressMetrics>,
+    cancel: CancellationToken,
+) -> Option<u64>
+where
+    P: SequencePublisher + 'static,
+{
+    let mut cursor = SequenceCursor::from_high_watermark(high_watermark);
+    let mut retry_delay = INITIAL_BACKOFF;
+    let mut connected_once = false;
+
+    loop {
+        let stream = tokio::select! {
+            _ = cancel.cancelled() => break,
+            stream = ZmqSubTransport::connect_single_consumer_with_rcvhwm(
+                &endpoint,
+                ACTIVE_SEQUENCES_SUBJECT,
+                rcvhwm,
+            ) => stream,
+        };
+        let mut stream = match stream {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    publisher_id,
+                    generation,
+                    %endpoint,
+                    "failed to connect direct-ZMQ active-sequence source"
+                );
+                metrics.record_reconnect();
+                if !sleep_or_cancel(retry_delay, &cancel).await {
+                    break;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+        if connected_once {
+            metrics.record_reconnect();
+        }
+        connected_once = true;
+        retry_delay = INITIAL_BACKOFF;
+
+        if !consume_connection(
+            publisher_id,
+            generation,
+            &mut stream,
+            &tracker,
+            &metrics,
+            &cancel,
+            &mut cursor,
+        )
+        .await
+        {
+            break;
+        }
+        if !sleep_or_cancel(retry_delay, &cancel).await {
+            break;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+
+    cursor.high_watermark
+}
+
+async fn consume_connection<P>(
+    publisher_id: u64,
+    generation: u64,
+    stream: &mut dynamo_runtime::transports::event_plane::zmq_transport::ZmqWireStream,
+    tracker: &ActiveSequencesMultiWorker<P>,
+    metrics: &ActiveSequenceZmqIngressMetrics,
+    cancel: &CancellationToken,
+    cursor: &mut SequenceCursor,
+) -> bool
+where
+    P: SequencePublisher + 'static,
+{
+    let codec = Codec::default();
+    loop {
+        let message = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return false,
+            message = stream.next() => message,
+        };
+        let Some(message) = message else {
+            return true;
+        };
+        let message = match message {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    publisher_id,
+                    generation,
+                    "direct-ZMQ active-sequence source stream failed"
+                );
+                return true;
+            }
+        };
+
+        let envelope = match codec.decode_envelope(&message.payload) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    publisher_id,
+                    generation,
+                    "failed to decode direct-ZMQ active-sequence envelope"
+                );
+                metrics.record_envelope_decode_error();
+                continue;
+            }
+        };
+        if envelope.publisher_id != publisher_id
+            || envelope.publisher_id != message.publisher_id
+            || envelope.sequence != message.sequence
+            || envelope.topic != ACTIVE_SEQUENCES_SUBJECT
+        {
+            tracing::warn!(
+                publisher_id,
+                generation,
+                frame_publisher_id = message.publisher_id,
+                frame_sequence = message.sequence,
+                envelope_publisher_id = envelope.publisher_id,
+                envelope_sequence = envelope.sequence,
+                envelope_topic = %envelope.topic,
+                "dropping direct-ZMQ active-sequence envelope with inconsistent attribution"
+            );
+            metrics.record_identity_error();
+            continue;
+        }
+
+        match cursor.observe(envelope.sequence) {
+            Continuity::InOrder => {}
+            Continuity::Gap(missing) => metrics.record_gap(missing),
+            Continuity::OutOfOrder => metrics.record_out_of_order(),
+        }
+
+        let batch = match codec.decode_payload::<ActiveSequenceEventBatch>(&envelope.payload) {
+            Ok(batch) => batch,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    publisher_id,
+                    generation,
+                    "failed to decode direct-ZMQ active-sequence batch"
+                );
+                metrics.record_payload_decode_error();
+                continue;
+            }
+        };
+        if batch.events.len() > MAX_REPLICA_BATCH_EVENTS {
+            tracing::warn!(
+                publisher_id,
+                generation,
+                event_count = batch.events.len(),
+                max_event_count = MAX_REPLICA_BATCH_EVENTS,
+                "dropping oversized direct-ZMQ active-sequence batch"
+            );
+            metrics.record_payload_decode_error();
+            continue;
+        }
+        let event_count = batch.events.len();
+        metrics.record_received(event_count);
+        tracker.apply_replica_batch(batch.events);
+        metrics.record_handled(event_count);
+        tokio::task::consume_budget().await;
+    }
+}
+
+async fn stop_source(source: SourceTask, metrics: &ActiveSequenceZmqIngressMetrics) -> Option<u64> {
+    stop_source_with_timeout(source, metrics, SOURCE_JOIN_TIMEOUT).await
+}
+
+async fn stop_sources(
+    sources: HashMap<u64, SourceTask>,
+    metrics: &ActiveSequenceZmqIngressMetrics,
+) -> HashMap<u64, u64> {
+    for source in sources.values() {
+        source.cancel.cancel();
+    }
+    futures::future::join_all(
+        sources
+            .into_iter()
+            .map(|(publisher_id, source)| async move {
+                (publisher_id, stop_source(source, metrics).await)
+            }),
+    )
+    .await
+    .into_iter()
+    .filter_map(|(publisher_id, high_watermark)| {
+        high_watermark.map(|high_watermark| (publisher_id, high_watermark))
+    })
+    .collect()
+}
+
+async fn stop_source_with_timeout(
+    source: SourceTask,
+    metrics: &ActiveSequenceZmqIngressMetrics,
+    join_timeout: Duration,
+) -> Option<u64> {
+    tracing::debug!(
+        generation = source.generation,
+        endpoint = %source.endpoint,
+        "stopping direct-ZMQ active-sequence source"
+    );
+    source.cancel.cancel();
+    let mut handle = source.handle;
+    let high_watermark = match tokio::time::timeout(join_timeout, &mut handle).await {
+        Ok(Ok(high_watermark)) => high_watermark,
+        Ok(Err(error)) if error.is_cancelled() => None,
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "direct-ZMQ active-sequence source task failed during shutdown");
+            None
+        }
+        Err(_) => {
+            handle.abort();
+            let _ = handle.await;
+            metrics.record_forced_abort();
+            None
+        }
+    };
+    metrics.source_stopped();
+    high_watermark
+}
+
+async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
+    tokio::select! {
+        _ = cancellation_token.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use dynamo_kv_router::{
+        NoopSequencePublisher,
+        protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank},
+    };
+    use dynamo_runtime::{
+        DistributedRuntime, Runtime,
+        distributed::DistributedConfig,
+        transports::event_plane::{EventPublisher, EventTransportTx, ZmqPubTransport},
+    };
+
+    use super::*;
+
+    fn lookup(direct: Option<&str>, rcvhwm: Option<&str>) -> impl FnMut(&str) -> Option<OsString> {
+        let direct = direct.map(OsString::from);
+        let rcvhwm = rcvhwm.map(OsString::from);
+        move |key| match key {
+            DIRECT_ZMQ_ENV => direct.clone(),
+            RCVHWM_ENV => rcvhwm.clone(),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn parses_direct_zmq_configuration() {
+        assert_eq!(
+            DirectZmqSequenceConfig::from_lookup(lookup(None, None)),
+            DirectZmqSequenceConfig {
+                enabled: true,
+                rcvhwm: DEFAULT_RCVHWM,
+            }
+        );
+        assert_eq!(
+            DirectZmqSequenceConfig::from_lookup(lookup(Some("false"), Some("37"))),
+            DirectZmqSequenceConfig {
+                enabled: false,
+                rcvhwm: 37,
+            }
+        );
+        for invalid in ["0", "-1", "not-a-number", "2147483648"] {
+            assert_eq!(
+                DirectZmqSequenceConfig::from_lookup(lookup(None, Some(invalid))).rcvhwm,
+                DEFAULT_RCVHWM
+            );
+        }
+        assert!(DirectZmqSequenceConfig::from_lookup(lookup(Some("invalid"), None)).enabled);
+    }
+
+    #[test]
+    fn selects_only_direct_zmq_and_honors_rollback() {
+        let enabled = DirectZmqSequenceConfig::from_lookup(lookup(None, None));
+        let rollback = DirectZmqSequenceConfig::from_lookup(lookup(Some("0"), None));
+
+        assert!(enabled.should_use_direct_for_topology(EventTransportKind::Zmq, true));
+        assert!(!enabled.should_use_direct_for_topology(EventTransportKind::Zmq, false));
+        assert!(!enabled.should_use_direct_for_topology(EventTransportKind::Nats, false));
+        assert!(!rollback.should_use_direct_for_topology(EventTransportKind::Zmq, true));
+        assert!(!rollback.should_use_direct_for_topology(EventTransportKind::Zmq, false));
+        assert!(!rollback.should_use_direct_for_topology(EventTransportKind::Nats, false));
+    }
+
+    #[test]
+    fn observes_initial_forward_and_out_of_order_sequences() {
+        let mut cursor = SequenceCursor::default();
+        assert_eq!(cursor.observe(3), Continuity::Gap(3));
+        assert_eq!(cursor.observe(4), Continuity::InOrder);
+        assert_eq!(cursor.observe(7), Continuity::Gap(2));
+        assert_eq!(cursor.observe(6), Continuity::OutOfOrder);
+        assert_eq!(cursor.high_watermark, Some(7));
+
+        let mut resumed = SequenceCursor::from_high_watermark(cursor.high_watermark);
+        assert_eq!(resumed.observe(8), Continuity::InOrder);
+    }
+
+    fn add_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(0, 0),
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(vec![1]),
+                track_prefill_tokens: false,
+                expected_output_tokens: None,
+                prefill_load_hint: None,
+            },
+            router_id: 99,
+            lora_name: None,
+        }
+    }
+
+    fn free_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(0, 0),
+            data: ActiveSequenceEventData::Free,
+            router_id: 99,
+            lora_name: None,
+        }
+    }
+
+    async fn publish_batch(
+        publisher: &ZmqPubTransport,
+        publisher_id: u64,
+        sequence: u64,
+        events: Vec<ActiveSequenceEvent>,
+    ) -> anyhow::Result<()> {
+        let codec = Codec::default();
+        let payload = codec.encode_payload(&ActiveSequenceEventBatch { events })?;
+        let envelope = codec.encode_envelope_parts(
+            publisher_id,
+            sequence,
+            0,
+            ACTIVE_SEQUENCES_SUBJECT,
+            &payload,
+        )?;
+        publisher.publish(ACTIVE_SEQUENCES_SUBJECT, envelope).await
+    }
+
+    #[tokio::test]
+    async fn real_zmq_batch_ingress_validates_identity_and_survives_rebind() -> anyhow::Result<()> {
+        let runtime = Runtime::from_current()?;
+        let distributed =
+            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+        let component = distributed
+            .namespace(format!(
+                "active-sequence-direct-zmq-{}",
+                uuid::Uuid::new_v4()
+            ))?
+            .component("frontend")?;
+        let metrics = ActiveSequenceZmqIngressMetrics::from_component(&component);
+        let tracker = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(0, (0, 1))]),
+            true,
+            1,
+            "test",
+        ));
+        let worker = WorkerWithDpRank::new(0, 0);
+        let publisher_id = 42;
+        let (publisher, bind_endpoint) =
+            ZmqPubTransport::bind("tcp://127.0.0.1:0", ACTIVE_SEQUENCES_SUBJECT).await?;
+        let connect_endpoint = bind_endpoint.replace("0.0.0.0", "127.0.0.1");
+        let cancel = CancellationToken::new();
+        let source = tokio::spawn(run_source(
+            publisher_id,
+            connect_endpoint,
+            1,
+            None,
+            DEFAULT_RCVHWM,
+            tracker.clone(),
+            metrics,
+            cancel.clone(),
+        ));
+
+        let mut sequence = 0;
+        let mut sent_requests = Vec::new();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let request_id = format!("warmup-{sequence}");
+                publish_batch(
+                    &publisher,
+                    publisher_id,
+                    sequence,
+                    vec![add_event(request_id.clone())],
+                )
+                .await
+                .unwrap();
+                sequence += 1;
+                sent_requests.push(request_id);
+                if tracker.active_blocks()[&worker] > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("warmed direct-ZMQ source should apply a batch");
+
+        let requests_before_out_of_order = tracker.active_request_counts()[&worker];
+        let out_of_order_request = "out-of-order".to_string();
+        publish_batch(
+            &publisher,
+            publisher_id,
+            0,
+            vec![add_event(out_of_order_request.clone())],
+        )
+        .await?;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while tracker.active_request_counts()[&worker] == requests_before_out_of_order {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("out-of-order envelopes should remain observational and be applied");
+        sent_requests.push(out_of_order_request);
+
+        let requests_before_mismatch = tracker.active_request_counts()[&worker];
+        publish_batch(
+            &publisher,
+            publisher_id + 1,
+            sequence,
+            vec![add_event("identity-mismatch")],
+        )
+        .await?;
+        sequence += 1;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert_eq!(
+            tracker.active_request_counts()[&worker],
+            requests_before_mismatch
+        );
+
+        let free_events = sent_requests
+            .iter()
+            .cloned()
+            .map(free_event)
+            .collect::<Vec<_>>();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                publish_batch(&publisher, publisher_id, sequence, free_events.clone())
+                    .await
+                    .unwrap();
+                sequence += 1;
+                if tracker.active_blocks()[&worker] == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("warmed source should drain before rebind");
+
+        drop(publisher);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let publisher = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match ZmqPubTransport::bind(&bind_endpoint, ACTIVE_SEQUENCES_SUBJECT).await {
+                    Ok((publisher, _)) => break publisher,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+                }
+            }
+        })
+        .await
+        .expect("publisher should rebind to its original endpoint");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                publish_batch(
+                    &publisher,
+                    publisher_id,
+                    sequence,
+                    vec![add_event("after-rebind")],
+                )
+                .await
+                .unwrap();
+                sequence += 1;
+                if tracker.active_blocks()[&worker] > 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("direct-ZMQ source should receive after publisher rebind");
+
+        cancel.cancel();
+        let final_cursor = tokio::time::timeout(Duration::from_secs(1), source)
+            .await
+            .expect("source should stop after cancellation")
+            .expect("source task should not panic");
+        assert!(final_cursor.is_some());
+        distributed.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn supervisor_tracks_recreation_and_drains_every_source() -> anyhow::Result<()> {
+        let runtime = Runtime::from_current()?;
+        let distributed =
+            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+        let endpoint = distributed
+            .namespace(format!(
+                "active-sequence-supervisor-lifecycle-{}",
+                uuid::Uuid::new_v4()
+            ))?
+            .component("frontend")?
+            .endpoint("generate");
+        let tracker = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(0, (0, 1))]),
+            true,
+            1,
+            "test",
+        ));
+        let cancel = CancellationToken::new();
+        let (source_count_tx, mut source_count_rx) = tokio::sync::mpsc::unbounded_channel();
+        let supervisor = tokio::spawn(run_supervisor_inner(
+            endpoint.clone(),
+            tracker,
+            DEFAULT_RCVHWM,
+            cancel.clone(),
+            move |count| {
+                let _ = source_count_tx.send(count);
+            },
+        ));
+
+        for _ in 0..2 {
+            let mut publishers = Vec::with_capacity(32);
+            for _ in 0..32 {
+                publishers.push(
+                    EventPublisher::for_endpoint_with_transport(
+                        &endpoint,
+                        ACTIVE_SEQUENCES_SUBJECT,
+                        EventTransportKind::Zmq,
+                    )
+                    .await?,
+                );
+            }
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    match source_count_rx.recv().await {
+                        Some(32) => break,
+                        Some(_) => {}
+                        None => panic!("source-count observer closed before reaching 32"),
+                    }
+                }
+            })
+            .await
+            .expect("supervisor should track all 32 publishers");
+
+            drop(publishers);
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    match source_count_rx.recv().await {
+                        Some(0) => break,
+                        Some(_) => {}
+                        None => panic!("source-count observer closed before reaching zero"),
+                    }
+                }
+            })
+            .await
+            .expect("supervisor should drain all removed publishers");
+        }
+
+        cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(5), supervisor)
+            .await
+            .expect("supervisor should join after cancellation")
+            .expect("supervisor task should not panic");
+        distributed.shutdown();
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn source_shutdown_joins_cooperative_tasks_and_aborts_stuck_tasks() -> anyhow::Result<()>
+    {
+        let runtime = Runtime::from_current()?;
+        let distributed =
+            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+        let component = distributed
+            .namespace(format!(
+                "active-sequence-source-shutdown-{}",
+                uuid::Uuid::new_v4()
+            ))?
+            .component("frontend")?;
+        let metrics = ActiveSequenceZmqIngressMetrics::from_component(&component);
+
+        let cooperative_cancel = CancellationToken::new();
+        let task_cancel = cooperative_cancel.clone();
+        let cooperative = SourceTask {
+            endpoint: "cooperative".to_string(),
+            generation: 1,
+            cancel: cooperative_cancel,
+            handle: tokio::spawn(async move {
+                task_cancel.cancelled().await;
+                Some(17)
+            }),
+        };
+        metrics.source_started();
+        assert_eq!(
+            stop_source_with_timeout(cooperative, &metrics, Duration::from_secs(1)).await,
+            Some(17)
+        );
+
+        let stuck_cancel = CancellationToken::new();
+        let stuck_handle = tokio::spawn(std::future::pending::<Option<u64>>());
+        let stuck_abort = stuck_handle.abort_handle();
+        let stuck = SourceTask {
+            endpoint: "stuck".to_string(),
+            generation: 2,
+            cancel: stuck_cancel,
+            handle: stuck_handle,
+        };
+        metrics.source_started();
+        assert_eq!(
+            stop_source_with_timeout(stuck, &metrics, Duration::from_millis(10)).await,
+            None
+        );
+        assert!(stuck_abort.is_finished());
+
+        for generation_base in [100_u64, 200] {
+            let mut sources = HashMap::new();
+            for publisher_id in 0..32 {
+                let cancel = CancellationToken::new();
+                let task_cancel = cancel.clone();
+                let generation = generation_base + publisher_id;
+                metrics.source_started();
+                sources.insert(
+                    publisher_id,
+                    SourceTask {
+                        endpoint: format!("source-{publisher_id}"),
+                        generation,
+                        cancel,
+                        handle: tokio::spawn(async move {
+                            task_cancel.cancelled().await;
+                            Some(generation)
+                        }),
+                    },
+                );
+            }
+            assert_eq!(sources.len(), 32);
+            let cursors = stop_sources(sources, &metrics).await;
+            assert_eq!(cursors.len(), 32);
+            assert_eq!(cursors[&0], generation_base);
+            assert_eq!(cursors[&31], generation_base + 31);
+        }
+
+        distributed.shutdown();
+        Ok(())
+    }
+}

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -1,34 +1,29 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, ffi::OsString, sync::Arc, time::Duration};
+use std::{ffi::OsString, sync::Arc};
 
+use anyhow::Result;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, SequencePublisher,
     protocols::{ActiveSequenceEventBatch, MAX_REPLICA_BATCH_EVENTS},
 };
 use dynamo_runtime::{
     component::Endpoint,
-    discovery::{
-        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
-        EventChannelInstanceId, EventChannelQuery, EventScope, EventTransport, EventTransportKind,
-    },
-    traits::DistributedRuntimeProvider,
-    transports::event_plane::{Codec, ZmqSubTransport, uses_direct_zmq},
+    discovery::EventTransportKind,
+    transports::event_plane::{Codec, uses_direct_zmq},
 };
-use futures::StreamExt;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use super::ActiveSequencesMulti;
-use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, metrics::ActiveSequenceZmqIngressMetrics};
+use crate::{
+    direct_zmq_fan_in::{ContinuityMode, FanInEvent, start_direct_zmq_fan_in},
+    kv_router::{ACTIVE_SEQUENCES_SUBJECT, metrics::ActiveSequenceZmqIngressMetrics},
+};
 
 const DIRECT_ZMQ_ENV: &str = "DYN_ROUTER_ACTIVE_SEQUENCE_DIRECT_ZMQ";
 const RCVHWM_ENV: &str = "DYN_ROUTER_ACTIVE_SEQUENCE_ZMQ_RCVHWM";
 const DEFAULT_RCVHWM: i32 = 1024;
-const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
-const MAX_BACKOFF: Duration = Duration::from_secs(5);
-const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct DirectZmqSequenceConfig {
@@ -90,512 +85,69 @@ impl DirectZmqSequenceConfig {
     }
 }
 
-struct SourceTask {
-    endpoint: String,
-    generation: u64,
-    cancel: CancellationToken,
-    handle: JoinHandle<Option<u64>>,
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-struct SequenceCursor {
-    high_watermark: Option<u64>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Continuity {
-    InOrder,
-    Gap(u64),
-    OutOfOrder,
-}
-
-impl SequenceCursor {
-    fn from_high_watermark(high_watermark: Option<u64>) -> Self {
-        Self { high_watermark }
-    }
-
-    fn observe(&mut self, sequence: u64) -> Continuity {
-        let Some(high_watermark) = self.high_watermark else {
-            self.high_watermark = Some(sequence);
-            return if sequence == 0 {
-                Continuity::InOrder
-            } else {
-                Continuity::Gap(sequence)
-            };
-        };
-
-        if sequence <= high_watermark {
-            return Continuity::OutOfOrder;
-        }
-
-        self.high_watermark = Some(sequence);
-        let missing = sequence - high_watermark - 1;
-        if missing == 0 {
-            Continuity::InOrder
-        } else {
-            Continuity::Gap(missing)
-        }
-    }
-}
-
-pub(super) fn start(
-    endpoint: Endpoint,
-    tracker: Arc<ActiveSequencesMulti>,
-    rcvhwm: i32,
-    cancellation_token: CancellationToken,
-) {
-    tokio::spawn(run_supervisor(
-        endpoint,
-        tracker,
-        rcvhwm,
-        cancellation_token,
-    ));
-}
-
-async fn run_supervisor<P>(
+pub(super) async fn start<P: SequencePublisher + 'static>(
     endpoint: Endpoint,
     tracker: Arc<ActiveSequencesMultiWorker<P>>,
     rcvhwm: i32,
     cancellation_token: CancellationToken,
-) where
-    P: SequencePublisher + 'static,
-{
-    run_supervisor_inner(endpoint, tracker, rcvhwm, cancellation_token, |_| {}).await;
-}
-
-async fn run_supervisor_inner<P, F>(
-    endpoint: Endpoint,
-    tracker: Arc<ActiveSequencesMultiWorker<P>>,
-    rcvhwm: i32,
-    cancellation_token: CancellationToken,
-    mut observe_source_count: F,
-) where
-    P: SequencePublisher + 'static,
-    F: FnMut(usize),
-{
-    let expected_scope = EventScope::Endpoint {
-        endpoint: endpoint.id(),
-    };
-    let query = DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(
-        endpoint.id(),
-        ACTIVE_SEQUENCES_SUBJECT,
-    ));
-    let discovery = endpoint.drt().discovery();
+) -> Result<JoinHandle<()>> {
     let metrics = ActiveSequenceZmqIngressMetrics::from_component(endpoint.component());
-    let mut resume_cursors = HashMap::<u64, u64>::new();
-    let mut next_generation = 1_u64;
-    let mut retry_delay = INITIAL_BACKOFF;
-
-    loop {
-        let watch_cancel = cancellation_token.child_token();
-        let watch = tokio::select! {
-            _ = cancellation_token.cancelled() => break,
-            watch = discovery.list_and_watch(query.clone(), Some(watch_cancel.clone())) => watch,
-        };
-        let mut watch = match watch {
-            Ok(watch) => watch,
-            Err(error) => {
-                tracing::warn!(%error, "failed to watch active-sequence ZMQ publishers");
-                if !sleep_or_cancel(retry_delay, &cancellation_token).await {
-                    break;
-                }
-                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-                continue;
-            }
-        };
-        retry_delay = INITIAL_BACKOFF;
-        let mut sources = HashMap::<u64, SourceTask>::new();
-        let mut restart_watch = true;
-
-        loop {
-            let event = tokio::select! {
-                biased;
-                _ = cancellation_token.cancelled() => {
-                    restart_watch = false;
-                    break;
-                }
-                event = watch.next() => event,
-            };
-            let Some(event) = event else {
-                tracing::warn!("active-sequence ZMQ discovery watch ended");
-                break;
-            };
-
-            match event {
-                Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
-                    scope,
-                    topic,
-                    instance_id,
-                    transport,
-                })) if scope == expected_scope && topic == ACTIVE_SEQUENCES_SUBJECT => {
-                    let EventTransport::Zmq { endpoint } = transport else {
-                        tracing::warn!(
-                            publisher_id = instance_id,
-                            "ignoring non-ZMQ active-sequence event channel"
-                        );
-                        continue;
-                    };
-
-                    if let Some(existing) = sources.get(&instance_id) {
-                        if existing.endpoint == endpoint {
-                            continue;
-                        }
-                    }
-
-                    let high_watermark = if let Some(existing) = sources.remove(&instance_id) {
-                        tracing::warn!(
-                            publisher_id = instance_id,
-                            old_endpoint = %existing.endpoint,
-                            new_endpoint = %endpoint,
-                            "replacing active-sequence ZMQ source endpoint"
-                        );
-                        metrics.record_replacement();
-                        stop_source(existing, &metrics).await
-                    } else {
-                        resume_cursors.remove(&instance_id)
-                    };
-
-                    let generation = next_generation;
-                    next_generation = next_generation.wrapping_add(1);
-                    sources.insert(
-                        instance_id,
-                        spawn_source(
-                            instance_id,
-                            endpoint,
-                            generation,
-                            high_watermark,
-                            rcvhwm,
-                            tracker.clone(),
-                            metrics.clone(),
-                            cancellation_token.child_token(),
-                        ),
-                    );
-                    observe_source_count(sources.len());
-                }
-                Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
-                    EventChannelInstanceId {
-                        scope,
-                        topic,
-                        instance_id,
-                    },
-                ))) if scope == expected_scope && topic == ACTIVE_SEQUENCES_SUBJECT => {
-                    resume_cursors.remove(&instance_id);
-                    if let Some(source) = sources.remove(&instance_id) {
-                        stop_source(source, &metrics).await;
-                        observe_source_count(sources.len());
-                    }
-                }
-                Ok(DiscoveryEvent::Added(_)) | Ok(DiscoveryEvent::Removed(_)) => {}
-                Err(error) => {
-                    tracing::warn!(%error, "active-sequence ZMQ discovery watch failed");
-                    break;
-                }
-            }
-        }
-
-        watch_cancel.cancel();
-        for (publisher_id, high_watermark) in stop_sources(sources, &metrics).await {
-            resume_cursors.insert(publisher_id, high_watermark);
-        }
-        observe_source_count(0);
-        if !restart_watch {
-            break;
-        }
-        if !sleep_or_cancel(retry_delay, &cancellation_token).await {
-            break;
-        }
-        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn spawn_source<P>(
-    publisher_id: u64,
-    endpoint: String,
-    generation: u64,
-    high_watermark: Option<u64>,
-    rcvhwm: i32,
-    tracker: Arc<ActiveSequencesMultiWorker<P>>,
-    metrics: Arc<ActiveSequenceZmqIngressMetrics>,
-    cancel: CancellationToken,
-) -> SourceTask
-where
-    P: SequencePublisher + 'static,
-{
-    let task_endpoint = endpoint.clone();
-    let task_cancel = cancel.clone();
-    metrics.source_started();
-    let handle = tokio::spawn(async move {
-        run_source(
-            publisher_id,
-            task_endpoint,
-            generation,
-            high_watermark,
-            rcvhwm,
-            tracker,
-            metrics,
-            task_cancel,
-        )
-        .await
-    });
-    SourceTask {
-        endpoint,
-        generation,
-        cancel,
-        handle,
-    }
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn run_source<P>(
-    publisher_id: u64,
-    endpoint: String,
-    generation: u64,
-    high_watermark: Option<u64>,
-    rcvhwm: i32,
-    tracker: Arc<ActiveSequencesMultiWorker<P>>,
-    metrics: Arc<ActiveSequenceZmqIngressMetrics>,
-    cancel: CancellationToken,
-) -> Option<u64>
-where
-    P: SequencePublisher + 'static,
-{
-    let mut cursor = SequenceCursor::from_high_watermark(high_watermark);
-    let mut retry_delay = INITIAL_BACKOFF;
-    let mut connected_once = false;
-
-    loop {
-        let stream = tokio::select! {
-            _ = cancel.cancelled() => break,
-            stream = ZmqSubTransport::connect_single_consumer_with_rcvhwm(
-                &endpoint,
-                ACTIVE_SEQUENCES_SUBJECT,
-                rcvhwm,
-            ) => stream,
-        };
-        let mut stream = match stream {
-            Ok(stream) => stream,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    publisher_id,
-                    generation,
-                    %endpoint,
-                    "failed to connect direct-ZMQ active-sequence source"
-                );
-                metrics.record_reconnect();
-                if !sleep_or_cancel(retry_delay, &cancel).await {
-                    break;
-                }
-                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-                continue;
-            }
-        };
-        if connected_once {
-            metrics.record_reconnect();
-        }
-        connected_once = true;
-        retry_delay = INITIAL_BACKOFF;
-
-        if !consume_connection(
-            publisher_id,
-            generation,
-            &mut stream,
-            &tracker,
-            &metrics,
-            &cancel,
-            &mut cursor,
-        )
-        .await
-        {
-            break;
-        }
-        if !sleep_or_cancel(retry_delay, &cancel).await {
-            break;
-        }
-        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
-    }
-
-    cursor.high_watermark
-}
-
-async fn consume_connection<P>(
-    publisher_id: u64,
-    generation: u64,
-    stream: &mut dynamo_runtime::transports::event_plane::zmq_transport::ZmqWireStream,
-    tracker: &ActiveSequencesMultiWorker<P>,
-    metrics: &ActiveSequenceZmqIngressMetrics,
-    cancel: &CancellationToken,
-    cursor: &mut SequenceCursor,
-) -> bool
-where
-    P: SequencePublisher + 'static,
-{
-    let codec = Codec::default();
-    loop {
-        let message = tokio::select! {
-            biased;
-            _ = cancel.cancelled() => return false,
-            message = stream.next() => message,
-        };
-        let Some(message) = message else {
-            return true;
-        };
-        let message = match message {
-            Ok(message) => message,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    publisher_id,
-                    generation,
-                    "direct-ZMQ active-sequence source stream failed"
-                );
-                return true;
-            }
-        };
-
-        let envelope = match codec.decode_envelope(&message.payload) {
-            Ok(envelope) => envelope,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    publisher_id,
-                    generation,
-                    "failed to decode direct-ZMQ active-sequence envelope"
-                );
-                metrics.record_envelope_decode_error();
-                continue;
-            }
-        };
-        if envelope.publisher_id != publisher_id
-            || envelope.publisher_id != message.publisher_id
-            || envelope.sequence != message.sequence
-            || envelope.topic != ACTIVE_SEQUENCES_SUBJECT
-        {
-            tracing::warn!(
-                publisher_id,
-                generation,
-                frame_publisher_id = message.publisher_id,
-                frame_sequence = message.sequence,
-                envelope_publisher_id = envelope.publisher_id,
-                envelope_sequence = envelope.sequence,
-                envelope_topic = %envelope.topic,
-                "dropping direct-ZMQ active-sequence envelope with inconsistent attribution"
-            );
-            metrics.record_identity_error();
-            continue;
-        }
-
-        match cursor.observe(envelope.sequence) {
-            Continuity::InOrder => {}
-            Continuity::Gap(missing) => metrics.record_gap(missing),
-            Continuity::OutOfOrder => metrics.record_out_of_order(),
-        }
-
-        let batch = match codec.decode_payload::<ActiveSequenceEventBatch>(&envelope.payload) {
-            Ok(batch) => batch,
-            Err(error) => {
-                tracing::warn!(
-                    %error,
-                    publisher_id,
-                    generation,
-                    "failed to decode direct-ZMQ active-sequence batch"
-                );
-                metrics.record_payload_decode_error();
-                continue;
-            }
-        };
+    let handler_metrics = metrics.clone();
+    let handler = move |envelope: dynamo_runtime::transports::event_plane::ValidatedEnvelope| {
+        let codec = Codec::default();
+        let batch = codec
+            .decode_payload::<ActiveSequenceEventBatch>(&envelope.payload)
+            .inspect_err(|_| {
+                handler_metrics.record_payload_decode_error();
+            })?;
         if batch.events.len() > MAX_REPLICA_BATCH_EVENTS {
-            tracing::warn!(
-                publisher_id,
-                generation,
-                event_count = batch.events.len(),
-                max_event_count = MAX_REPLICA_BATCH_EVENTS,
-                "dropping oversized direct-ZMQ active-sequence batch"
+            handler_metrics.record_payload_decode_error();
+            anyhow::bail!(
+                "active-sequence batch contains {} events; maximum is {}",
+                batch.events.len(),
+                MAX_REPLICA_BATCH_EVENTS
             );
-            metrics.record_payload_decode_error();
-            continue;
         }
         tracker.apply_replica_batch(batch.events);
-        tokio::task::consume_budget().await;
-    }
-}
+        Ok(())
+    };
+    let observer =
+        move |observation: crate::direct_zmq_fan_in::FanInObservation| match observation.event {
+            FanInEvent::SourceStarted => metrics.source_started(),
+            FanInEvent::SourceStopped => metrics.source_stopped(),
+            FanInEvent::Reconnect => metrics.record_reconnect(),
+            FanInEvent::Replacement => metrics.record_replacement(),
+            FanInEvent::EnvelopeDecodeError => metrics.record_envelope_decode_error(),
+            FanInEvent::IdentityMismatch => metrics.record_identity_error(),
+            FanInEvent::SequenceGap { missing } => metrics.record_gap(missing),
+            FanInEvent::OutOfOrder => metrics.record_out_of_order(),
+            FanInEvent::ForcedAbort => metrics.record_forced_abort(),
+        };
 
-async fn stop_source(source: SourceTask, metrics: &ActiveSequenceZmqIngressMetrics) -> Option<u64> {
-    stop_source_with_timeout(source, metrics, SOURCE_JOIN_TIMEOUT).await
-}
-
-async fn stop_sources(
-    sources: HashMap<u64, SourceTask>,
-    metrics: &ActiveSequenceZmqIngressMetrics,
-) -> HashMap<u64, u64> {
-    for source in sources.values() {
-        source.cancel.cancel();
-    }
-    futures::future::join_all(
-        sources
-            .into_iter()
-            .map(|(publisher_id, source)| async move {
-                (publisher_id, stop_source(source, metrics).await)
-            }),
+    start_direct_zmq_fan_in(
+        endpoint,
+        ACTIVE_SEQUENCES_SUBJECT,
+        rcvhwm,
+        None,
+        ContinuityMode::TrackFromZero,
+        cancellation_token,
+        handler,
+        observer,
     )
     .await
-    .into_iter()
-    .filter_map(|(publisher_id, high_watermark)| {
-        high_watermark.map(|high_watermark| (publisher_id, high_watermark))
-    })
-    .collect()
-}
-
-async fn stop_source_with_timeout(
-    source: SourceTask,
-    metrics: &ActiveSequenceZmqIngressMetrics,
-    join_timeout: Duration,
-) -> Option<u64> {
-    tracing::debug!(
-        generation = source.generation,
-        endpoint = %source.endpoint,
-        "stopping direct-ZMQ active-sequence source"
-    );
-    source.cancel.cancel();
-    let mut handle = source.handle;
-    let high_watermark = match tokio::time::timeout(join_timeout, &mut handle).await {
-        Ok(Ok(high_watermark)) => high_watermark,
-        Ok(Err(error)) if error.is_cancelled() => None,
-        Ok(Err(error)) => {
-            tracing::warn!(%error, "direct-ZMQ active-sequence source task failed during shutdown");
-            None
-        }
-        Err(_) => {
-            handle.abort();
-            let _ = handle.await;
-            metrics.record_forced_abort();
-            None
-        }
-    };
-    metrics.source_stopped();
-    high_watermark
-}
-
-async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
-    tokio::select! {
-        _ = cancellation_token.cancelled() => false,
-        _ = tokio::time::sleep(delay) => true,
-    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, time::Duration};
 
     use dynamo_kv_router::{
         NoopSequencePublisher,
         protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank},
     };
     use dynamo_runtime::{
-        DistributedRuntime, Runtime,
-        distributed::DistributedConfig,
-        transports::event_plane::{EventPublisher, EventTransportTx, ZmqPubTransport},
+        DistributedRuntime, Runtime, distributed::DistributedConfig,
+        transports::event_plane::EventPublisher,
     };
 
     use super::*;
@@ -648,19 +200,6 @@ mod tests {
         assert!(!rollback.should_use_direct_for_topology(EventTransportKind::Nats, false));
     }
 
-    #[test]
-    fn observes_initial_forward_and_out_of_order_sequences() {
-        let mut cursor = SequenceCursor::default();
-        assert_eq!(cursor.observe(3), Continuity::Gap(3));
-        assert_eq!(cursor.observe(4), Continuity::InOrder);
-        assert_eq!(cursor.observe(7), Continuity::Gap(2));
-        assert_eq!(cursor.observe(6), Continuity::OutOfOrder);
-        assert_eq!(cursor.high_watermark, Some(7));
-
-        let mut resumed = SequenceCursor::from_high_watermark(cursor.high_watermark);
-        assert_eq!(resumed.observe(8), Continuity::InOrder);
-    }
-
     fn add_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
         ActiveSequenceEvent {
             request_id: request_id.into(),
@@ -676,201 +215,15 @@ mod tests {
         }
     }
 
-    fn free_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
-        ActiveSequenceEvent {
-            request_id: request_id.into(),
-            worker: WorkerWithDpRank::new(0, 0),
-            data: ActiveSequenceEventData::Free,
-            router_id: 99,
-            lora_name: None,
-        }
-    }
-
-    async fn publish_batch(
-        publisher: &ZmqPubTransport,
-        publisher_id: u64,
-        sequence: u64,
-        events: Vec<ActiveSequenceEvent>,
-    ) -> anyhow::Result<()> {
-        let codec = Codec::default();
-        let payload = codec.encode_payload(&ActiveSequenceEventBatch { events })?;
-        let envelope = codec.encode_envelope_parts(
-            publisher_id,
-            sequence,
-            0,
-            ACTIVE_SEQUENCES_SUBJECT,
-            &payload,
-        )?;
-        publisher.publish(ACTIVE_SEQUENCES_SUBJECT, envelope).await
-    }
-
     #[tokio::test]
     #[serial_test::serial]
-    async fn real_zmq_batch_ingress_validates_identity_and_survives_rebind() -> anyhow::Result<()> {
-        let runtime = Runtime::from_current()?;
-        let distributed =
-            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
-        let component = distributed
-            .namespace(format!(
-                "active-sequence-direct-zmq-{}",
-                uuid::Uuid::new_v4()
-            ))?
-            .component("frontend")?;
-        let metrics = ActiveSequenceZmqIngressMetrics::from_component(&component);
-        let tracker = Arc::new(ActiveSequencesMultiWorker::new(
-            NoopSequencePublisher,
-            4,
-            HashMap::from([(0, (0, 1))]),
-            true,
-            1,
-            "test",
-        ));
-        let worker = WorkerWithDpRank::new(0, 0);
-        let publisher_id = 42;
-        let (publisher, bind_endpoint) =
-            ZmqPubTransport::bind("tcp://127.0.0.1:0", ACTIVE_SEQUENCES_SUBJECT).await?;
-        let connect_endpoint = bind_endpoint.replace("0.0.0.0", "127.0.0.1");
-        let cancel = CancellationToken::new();
-        let source = tokio::spawn(run_source(
-            publisher_id,
-            connect_endpoint,
-            1,
-            None,
-            DEFAULT_RCVHWM,
-            tracker.clone(),
-            metrics,
-            cancel.clone(),
-        ));
-
-        let mut sequence = 0;
-        let mut sent_requests = Vec::new();
-        tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                let request_id = format!("warmup-{sequence}");
-                publish_batch(
-                    &publisher,
-                    publisher_id,
-                    sequence,
-                    vec![add_event(request_id.clone())],
-                )
-                .await
-                .unwrap();
-                sequence += 1;
-                sent_requests.push(request_id);
-                if tracker.active_blocks()[&worker] > 0 {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-        })
-        .await
-        .expect("warmed direct-ZMQ source should apply a batch");
-
-        let requests_before_out_of_order = tracker.active_request_counts()[&worker];
-        let out_of_order_request = "out-of-order".to_string();
-        publish_batch(
-            &publisher,
-            publisher_id,
-            0,
-            vec![add_event(out_of_order_request.clone())],
-        )
-        .await?;
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while tracker.active_request_counts()[&worker] == requests_before_out_of_order {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("out-of-order envelopes should remain observational and be applied");
-        sent_requests.push(out_of_order_request);
-
-        let requests_before_mismatch = tracker.active_request_counts()[&worker];
-        publish_batch(
-            &publisher,
-            publisher_id + 1,
-            sequence,
-            vec![add_event("identity-mismatch")],
-        )
-        .await?;
-        sequence += 1;
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        assert_eq!(
-            tracker.active_request_counts()[&worker],
-            requests_before_mismatch
-        );
-
-        let free_events = sent_requests
-            .iter()
-            .cloned()
-            .map(free_event)
-            .collect::<Vec<_>>();
-        tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                publish_batch(&publisher, publisher_id, sequence, free_events.clone())
-                    .await
-                    .unwrap();
-                sequence += 1;
-                if tracker.active_blocks()[&worker] == 0 {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-        })
-        .await
-        .expect("warmed source should drain before rebind");
-
-        drop(publisher);
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let publisher = tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                match ZmqPubTransport::bind(&bind_endpoint, ACTIVE_SEQUENCES_SUBJECT).await {
-                    Ok((publisher, _)) => break publisher,
-                    Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
-                }
-            }
-        })
-        .await
-        .expect("publisher should rebind to its original endpoint");
-
-        tokio::time::timeout(Duration::from_secs(5), async {
-            loop {
-                publish_batch(
-                    &publisher,
-                    publisher_id,
-                    sequence,
-                    vec![add_event("after-rebind")],
-                )
-                .await
-                .unwrap();
-                sequence += 1;
-                if tracker.active_blocks()[&worker] > 0 {
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(20)).await;
-            }
-        })
-        .await
-        .expect("direct-ZMQ source should receive after publisher rebind");
-
-        cancel.cancel();
-        let final_cursor = tokio::time::timeout(Duration::from_secs(1), source)
-            .await
-            .expect("source should stop after cancellation")
-            .expect("source task should not panic");
-        assert!(final_cursor.is_some());
-        distributed.shutdown();
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn supervisor_tracks_recreation_and_drains_every_source() -> anyhow::Result<()> {
+    async fn direct_zmq_batch_ingress_applies_after_publisher_recreation() -> Result<()> {
         let runtime = Runtime::from_current()?;
         let distributed =
             DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
         let endpoint = distributed
             .namespace(format!(
-                "active-sequence-supervisor-lifecycle-{}",
+                "active-sequence-direct-zmq-{}",
                 uuid::Uuid::new_v4()
             ))?
             .component("frontend")?
@@ -883,113 +236,50 @@ mod tests {
             1,
             "test",
         ));
+        let worker = WorkerWithDpRank::new(0, 0);
         let cancel = CancellationToken::new();
-        let (source_count_tx, mut source_count_rx) = tokio::sync::mpsc::unbounded_channel();
-        let supervisor = tokio::spawn(run_supervisor_inner(
+        let supervisor = start(
             endpoint.clone(),
-            tracker,
+            tracker.clone(),
             DEFAULT_RCVHWM,
             cancel.clone(),
-            move |count| {
-                let _ = source_count_tx.send(count);
-            },
-        ));
+        )
+        .await?;
 
-        for _ in 0..2 {
-            let mut publishers = Vec::with_capacity(32);
-            for _ in 0..32 {
-                publishers.push(
-                    EventPublisher::for_endpoint_with_transport(
-                        &endpoint,
-                        ACTIVE_SEQUENCES_SUBJECT,
-                        EventTransportKind::Zmq,
-                    )
-                    .await?,
-                );
-            }
+        for (index, request_id) in ["before-recreation", "after-recreation"]
+            .into_iter()
+            .enumerate()
+        {
+            let publisher = EventPublisher::for_endpoint_with_transport(
+                &endpoint,
+                ACTIVE_SEQUENCES_SUBJECT,
+                EventTransportKind::Zmq,
+            )
+            .await?;
             tokio::time::timeout(Duration::from_secs(5), async {
                 loop {
-                    match source_count_rx.recv().await {
-                        Some(32) => break,
-                        Some(_) => {}
-                        None => panic!("source-count observer closed before reaching 32"),
+                    publisher
+                        .publish(&ActiveSequenceEventBatch {
+                            events: vec![add_event(request_id)],
+                        })
+                        .await
+                        .unwrap();
+                    if tracker.active_request_counts()[&worker] == index + 1 {
+                        break;
                     }
+                    tokio::time::sleep(Duration::from_millis(20)).await;
                 }
             })
             .await
-            .expect("supervisor should track all 32 publishers");
-
-            drop(publishers);
-            tokio::time::timeout(Duration::from_secs(5), async {
-                loop {
-                    match source_count_rx.recv().await {
-                        Some(0) => break,
-                        Some(_) => {}
-                        None => panic!("source-count observer closed before reaching zero"),
-                    }
-                }
-            })
-            .await
-            .expect("supervisor should drain all removed publishers");
+            .expect("direct-ZMQ source should apply a warmed publisher batch");
+            drop(publisher);
         }
 
         cancel.cancel();
         tokio::time::timeout(Duration::from_secs(5), supervisor)
             .await
-            .expect("supervisor should join after cancellation")
-            .expect("supervisor task should not panic");
-        distributed.shutdown();
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn source_shutdown_joins_cooperative_tasks_and_aborts_stuck_tasks() -> anyhow::Result<()>
-    {
-        let runtime = Runtime::from_current()?;
-        let distributed =
-            DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
-        let component = distributed
-            .namespace(format!(
-                "active-sequence-source-shutdown-{}",
-                uuid::Uuid::new_v4()
-            ))?
-            .component("frontend")?;
-        let metrics = ActiveSequenceZmqIngressMetrics::from_component(&component);
-
-        let cooperative_cancel = CancellationToken::new();
-        let task_cancel = cooperative_cancel.clone();
-        let cooperative = SourceTask {
-            endpoint: "cooperative".to_string(),
-            generation: 1,
-            cancel: cooperative_cancel,
-            handle: tokio::spawn(async move {
-                task_cancel.cancelled().await;
-                Some(17)
-            }),
-        };
-        metrics.source_started();
-        assert_eq!(
-            stop_source_with_timeout(cooperative, &metrics, Duration::from_secs(1)).await,
-            Some(17)
-        );
-
-        let stuck_cancel = CancellationToken::new();
-        let stuck_handle = tokio::spawn(std::future::pending::<Option<u64>>());
-        let stuck_abort = stuck_handle.abort_handle();
-        let stuck = SourceTask {
-            endpoint: "stuck".to_string(),
-            generation: 2,
-            cancel: stuck_cancel,
-            handle: stuck_handle,
-        };
-        metrics.source_started();
-        assert_eq!(
-            stop_source_with_timeout(stuck, &metrics, Duration::from_millis(10)).await,
-            None
-        );
-        assert!(stuck_abort.is_finished());
-
+            .expect("fan-in supervisor should stop after cancellation")
+            .expect("fan-in supervisor should not panic");
         distributed.shutdown();
         Ok(())
     }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod backend;
 pub mod common;
+mod direct_zmq_fan_in;
 pub mod discovery;
 pub mod endpoint_type;
 pub mod engines;

--- a/lib/llm/src/session_affinity/replica_sync.rs
+++ b/lib/llm/src/session_affinity/replica_sync.rs
@@ -6,17 +6,27 @@ use std::sync::Weak;
 use anyhow::{Context, Result};
 use dynamo_runtime::{
     component::Client,
+    discovery::EventTransportKind,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{EventPublisher, EventSubscriber},
+    transports::event_plane::{
+        Codec, EventPublisher, EventSubscriber, ValidatedEnvelope, uses_direct_zmq,
+    },
 };
 use serde::{Deserialize, Serialize};
-use tokio::{sync::mpsc, task::JoinHandle};
+use tokio::{
+    sync::{mpsc, watch},
+    task::JoinHandle,
+};
 use tokio_util::sync::CancellationToken;
 
 use super::coordinator::{AffinityCoordinatorInner, AffinityTarget};
+use crate::direct_zmq_fan_in::{
+    ContinuityMode, FanInEvent, FanInObservation, start_direct_zmq_fan_in,
+};
 
 pub(super) const SESSION_AFFINITY_SUBJECT: &str = "session_affinity_events";
 const OUTBOUND_CHANNEL_CAPACITY: usize = 4_096;
+const DIRECT_ZMQ_RCVHWM: i32 = 1_024;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(super) struct SessionAffinityUpdate {
@@ -51,6 +61,40 @@ impl ReplicaUpdateSender {
     }
 }
 
+#[derive(Clone)]
+struct ReplicaUpdateApplier {
+    router_id: u64,
+    local_worker_ids: watch::Receiver<Vec<u64>>,
+    coordinator: Weak<AffinityCoordinatorInner>,
+}
+
+impl ReplicaUpdateApplier {
+    fn apply(&self, update: SessionAffinityUpdate) -> bool {
+        let worker_ids = self.local_worker_ids.borrow();
+        if !should_apply_update(self.router_id, worker_ids.as_slice(), &update) {
+            return true;
+        }
+        drop(worker_ids);
+
+        let Some(coordinator) = self.coordinator.upgrade() else {
+            return false;
+        };
+        let target = AffinityTarget {
+            worker_id: update.worker_id,
+            dp_rank: update.dp_rank,
+        };
+        let outcome = coordinator.apply_replica_update(update.session_id, target);
+        drop(coordinator);
+        tracing::trace!(
+            worker_id = target.worker_id,
+            dp_rank = ?target.dp_rank,
+            ?outcome,
+            "processed best-effort session affinity update"
+        );
+        true
+    }
+}
+
 pub(super) struct ReplicaSyncRuntime {
     sender: ReplicaUpdateSender,
     cancel: CancellationToken,
@@ -66,16 +110,95 @@ impl ReplicaSyncRuntime {
     ) -> Result<Self> {
         let endpoint = &client.endpoint;
         let router_id = endpoint.drt().discovery().instance_id();
-        let publisher = EventPublisher::for_endpoint(endpoint, SESSION_AFFINITY_SUBJECT)
-            .await
-            .context("create session affinity event publisher")?;
-        let mut subscriber = EventSubscriber::for_endpoint(endpoint, SESSION_AFFINITY_SUBJECT)
-            .await
-            .context("create session affinity event subscriber")?
-            .typed::<SessionAffinityUpdate>();
-        let local_worker_ids = client.instance_avail_watcher();
+        let transport_kind = endpoint.drt().default_event_transport_kind();
+        let publisher = EventPublisher::for_endpoint_with_transport(
+            endpoint,
+            SESSION_AFFINITY_SUBJECT,
+            transport_kind,
+        )
+        .await
+        .context("create session affinity event publisher")?;
+        let publisher_id = publisher.publisher_id();
+        let applier = ReplicaUpdateApplier {
+            router_id,
+            local_worker_ids: client.instance_avail_watcher(),
+            coordinator,
+        };
 
         let cancel = parent_cancel.child_token();
+        let subscriber_task =
+            if should_use_direct_sync(transport_kind, uses_direct_zmq(transport_kind)) {
+                let codec = Codec::default();
+                let handler_applier = applier.clone();
+                let handler = move |envelope: ValidatedEnvelope| {
+                    let update = codec
+                        .decode_payload::<SessionAffinityUpdate>(&envelope.payload)
+                        .context("decode session affinity update")?;
+                    handler_applier.apply(update);
+                    Ok(())
+                };
+                let observer = |observation: FanInObservation| match observation.event {
+                    FanInEvent::SequenceGap { missing } => tracing::warn!(
+                        publisher_id = observation.publisher_id,
+                        generation = observation.generation,
+                        missing,
+                        "session affinity direct-ZMQ source skipped envelopes"
+                    ),
+                    FanInEvent::OutOfOrder => tracing::warn!(
+                        publisher_id = observation.publisher_id,
+                        generation = observation.generation,
+                        "session affinity direct-ZMQ source received a non-increasing sequence"
+                    ),
+                    _ => {}
+                };
+                start_direct_zmq_fan_in(
+                    endpoint.clone(),
+                    SESSION_AFFINITY_SUBJECT,
+                    DIRECT_ZMQ_RCVHWM,
+                    Some(publisher_id),
+                    ContinuityMode::TrackFromZero,
+                    cancel.clone(),
+                    handler,
+                    observer,
+                )
+                .await
+                .context("start direct-ZMQ session affinity subscriber")?
+            } else {
+                let mut subscriber = EventSubscriber::for_endpoint_with_transport(
+                    endpoint,
+                    SESSION_AFFINITY_SUBJECT,
+                    transport_kind,
+                )
+                .await
+                .context("create session affinity event subscriber")?
+                .typed::<SessionAffinityUpdate>();
+                let subscriber_cancel = cancel.clone();
+                tokio::spawn(async move {
+                    loop {
+                        let event = tokio::select! {
+                            _ = subscriber_cancel.cancelled() => return,
+                            event = subscriber.next() => event,
+                        };
+                        let Some(event) = event else {
+                            return;
+                        };
+                        let update = match event {
+                            Ok((_envelope, update)) => update,
+                            Err(error) => {
+                                tracing::trace!(
+                                    %error,
+                                    "failed to receive best-effort session affinity update"
+                                );
+                                continue;
+                            }
+                        };
+                        if !applier.apply(update) {
+                            return;
+                        }
+                    }
+                })
+            };
+
         let (tx, mut rx) = mpsc::channel(OUTBOUND_CHANNEL_CAPACITY);
         let sender = ReplicaUpdateSender { router_id, tx };
 
@@ -100,52 +223,6 @@ impl ReplicaSyncRuntime {
             }
         });
 
-        let subscriber_cancel = cancel.clone();
-        let subscriber_task = tokio::spawn(async move {
-            loop {
-                let event = tokio::select! {
-                    _ = subscriber_cancel.cancelled() => return,
-                    event = subscriber.next() => event,
-                };
-                let Some(event) = event else {
-                    return;
-                };
-                let update = match event {
-                    Ok((_envelope, update)) => update,
-                    Err(error) => {
-                        tracing::trace!(
-                            %error,
-                            "failed to receive best-effort session affinity update"
-                        );
-                        continue;
-                    }
-                };
-                if update.router_id == router_id {
-                    continue;
-                }
-                let worker_ids = local_worker_ids.borrow();
-                if !should_apply_update(router_id, worker_ids.as_slice(), &update) {
-                    continue;
-                }
-                drop(worker_ids);
-                let Some(coordinator) = coordinator.upgrade() else {
-                    return;
-                };
-                let target = AffinityTarget {
-                    worker_id: update.worker_id,
-                    dp_rank: update.dp_rank,
-                };
-                let outcome = coordinator.apply_replica_update(update.session_id, target);
-                drop(coordinator);
-                tracing::trace!(
-                    worker_id = target.worker_id,
-                    dp_rank = ?target.dp_rank,
-                    ?outcome,
-                    "processed best-effort session affinity update"
-                );
-            }
-        });
-
         Ok(Self {
             sender,
             cancel,
@@ -163,9 +240,7 @@ impl ReplicaSyncRuntime {
         if let Some(task) = self.publisher_task.take() {
             task.abort();
         }
-        if let Some(task) = self.subscriber_task.take() {
-            task.abort();
-        }
+        drop(self.subscriber_task.take());
     }
 
     #[cfg(test)]
@@ -200,6 +275,10 @@ fn should_apply_update(
     update.router_id != local_router_id && local_worker_ids.contains(&update.worker_id)
 }
 
+fn should_use_direct_sync(transport_kind: EventTransportKind, direct_zmq_topology: bool) -> bool {
+    transport_kind == EventTransportKind::Zmq && direct_zmq_topology
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,6 +304,13 @@ mod tests {
         assert!(!should_apply_update(7, &[10, 11], &update(7, 10)));
         assert!(!should_apply_update(7, &[10, 11], &update(8, 12)));
         assert!(should_apply_update(7, &[10, 11], &update(8, 10)));
+    }
+
+    #[test]
+    fn direct_sync_is_selected_only_for_unbrokered_zmq() {
+        assert!(should_use_direct_sync(EventTransportKind::Zmq, true));
+        assert!(!should_use_direct_sync(EventTransportKind::Zmq, false));
+        assert!(!should_use_direct_sync(EventTransportKind::Nats, false));
     }
 
     #[tokio::test]

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -16,7 +16,10 @@ pub use dynamic_subscriber::DynamicSubscriber;
 pub use frame::{FRAME_HEADER_SIZE, FRAME_VERSION, Frame, FrameError, FrameHeader};
 pub use traits::{EventEnvelope, EventStream, TypedEventStream};
 pub use transport::{EventTransportRx, EventTransportTx, WireStream};
-pub use zmq_transport::{ZmqPubTransport, ZmqSubTransport};
+pub use zmq_transport::{
+    ValidatedEnvelope, ValidatedZmqSource, ValidatedZmqSourceError, ZmqPubTransport,
+    ZmqSubTransport,
+};
 
 // Re-export transport kind from discovery for convenience
 pub use crate::discovery::{EventScope, EventTransportKind};

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use std::sync::{Arc, OnceLock};
+use thiserror::Error;
 use tmq::{
     AsZmqSocket, Context, Message, Multipart, SocketBuilder,
     publish::{Publish, publish},
@@ -45,7 +46,7 @@ const ZMQ_RCVHWM: i32 = 100_000; // Receive buffer: 100K messages
 const ZMQ_SNDTIMEOUT_MS: i32 = 0; // Send timeout: fail fast under pressure
 const ZMQ_RCVTIMEOUT_MS: i32 = 100; // Receive timeout: 100ms (avoids blocking forever)
 
-use super::codec::MsgpackCodec;
+use super::codec::{Codec, MsgpackCodec};
 use super::frame::Frame;
 use super::transport::{EventTransportRx, EventTransportTx, WireStream};
 use crate::discovery::EventTransportKind;
@@ -228,6 +229,107 @@ pub struct ZmqWireMessage {
 
 pub type ZmqWireStream =
     std::pin::Pin<Box<dyn futures::Stream<Item = Result<ZmqWireMessage>> + Send>>;
+
+/// One event envelope whose ZMQ frames and envelope attribution agree.
+#[derive(Debug)]
+pub struct ValidatedEnvelope {
+    pub publisher_id: u64,
+    pub sequence: u64,
+    pub published_at: u64,
+    pub payload: Bytes,
+}
+
+/// Failure returned while reading a [`ValidatedZmqSource`].
+#[derive(Debug, Error)]
+pub enum ValidatedZmqSourceError {
+    #[error("direct ZMQ receive failed: {0}")]
+    Receive(#[source] anyhow::Error),
+    #[error("direct ZMQ envelope decode failed: {0}")]
+    EnvelopeDecode(#[source] anyhow::Error),
+    #[error(
+        "direct ZMQ identity mismatch: expected publisher {expected_publisher_id} topic {expected_topic}, frame publisher {frame_publisher_id} sequence {frame_sequence}, envelope publisher {envelope_publisher_id} sequence {envelope_sequence} topic {envelope_topic}"
+    )]
+    IdentityMismatch {
+        expected_publisher_id: u64,
+        expected_topic: String,
+        frame_publisher_id: u64,
+        frame_sequence: u64,
+        envelope_publisher_id: u64,
+        envelope_sequence: u64,
+        envelope_topic: String,
+    },
+}
+
+/// A direct ZMQ source that validates frame and envelope attribution once.
+pub struct ValidatedZmqSource {
+    stream: ZmqWireStream,
+    expected_topic: String,
+    expected_publisher_id: u64,
+    codec: Codec,
+}
+
+impl ValidatedZmqSource {
+    pub async fn connect_default(
+        endpoint: &str,
+        topic: &str,
+        expected_publisher_id: u64,
+    ) -> Result<Self> {
+        Self::connect(endpoint, topic, expected_publisher_id, ZMQ_RCVHWM).await
+    }
+
+    pub async fn connect(
+        endpoint: &str,
+        topic: &str,
+        expected_publisher_id: u64,
+        rcvhwm: i32,
+    ) -> Result<Self> {
+        Ok(Self {
+            stream: ZmqSubTransport::connect_single_consumer_with_rcvhwm(endpoint, topic, rcvhwm)
+                .await?,
+            expected_topic: topic.to_string(),
+            expected_publisher_id,
+            codec: Codec::default(),
+        })
+    }
+
+    pub async fn next(
+        &mut self,
+    ) -> Option<std::result::Result<ValidatedEnvelope, ValidatedZmqSourceError>> {
+        let message = match self.stream.next().await? {
+            Ok(message) => message,
+            Err(error) => return Some(Err(ValidatedZmqSourceError::Receive(error))),
+        };
+        let envelope = match self.codec.decode_envelope(&message.payload) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                return Some(Err(ValidatedZmqSourceError::EnvelopeDecode(error)));
+            }
+        };
+
+        if envelope.publisher_id != self.expected_publisher_id
+            || envelope.publisher_id != message.publisher_id
+            || envelope.sequence != message.sequence
+            || envelope.topic != self.expected_topic
+        {
+            return Some(Err(ValidatedZmqSourceError::IdentityMismatch {
+                expected_publisher_id: self.expected_publisher_id,
+                expected_topic: self.expected_topic.clone(),
+                frame_publisher_id: message.publisher_id,
+                frame_sequence: message.sequence,
+                envelope_publisher_id: envelope.publisher_id,
+                envelope_sequence: envelope.sequence,
+                envelope_topic: envelope.topic,
+            }));
+        }
+
+        Some(Ok(ValidatedEnvelope {
+            publisher_id: envelope.publisher_id,
+            sequence: envelope.sequence,
+            published_at: envelope.published_at,
+            payload: envelope.payload,
+        }))
+    }
+}
 
 impl ZmqSubTransport {
     fn connect_socket(endpoint: &str, topic: &str) -> Result<Subscribe> {
@@ -592,6 +694,63 @@ mod tests {
                 .await
                 .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn validated_source_rejects_bad_envelopes_and_continues_zero_copy() {
+        let codec = Codec::default();
+        let topic = "validated-source";
+        let publisher_id = 7;
+        let invalid = ZmqWireMessage {
+            publisher_id,
+            sequence: 0,
+            payload: Bytes::from_static(&[0xc1]),
+        };
+        let mismatched_payload = codec
+            .encode_envelope_parts(8, 1, 11, topic, b"mismatch")
+            .unwrap();
+        let mismatch = ZmqWireMessage {
+            publisher_id,
+            sequence: 1,
+            payload: mismatched_payload,
+        };
+        let encoded = codec
+            .encode_envelope_parts(publisher_id, 2, 12, topic, b"payload")
+            .unwrap();
+        let encoded_start = encoded.as_ptr() as usize;
+        let encoded_end = encoded_start + encoded.len();
+        let valid = ZmqWireMessage {
+            publisher_id,
+            sequence: 2,
+            payload: encoded,
+        };
+        let mut source = ValidatedZmqSource {
+            stream: Box::pin(futures::stream::iter(vec![
+                Ok(invalid),
+                Ok(mismatch),
+                Ok(valid),
+            ])),
+            expected_topic: topic.to_string(),
+            expected_publisher_id: publisher_id,
+            codec,
+        };
+
+        assert!(matches!(
+            source.next().await.unwrap(),
+            Err(ValidatedZmqSourceError::EnvelopeDecode(_))
+        ));
+        assert!(matches!(
+            source.next().await.unwrap(),
+            Err(ValidatedZmqSourceError::IdentityMismatch { .. })
+        ));
+        let envelope = source.next().await.unwrap().unwrap();
+        assert_eq!(envelope.publisher_id, publisher_id);
+        assert_eq!(envelope.sequence, 2);
+        assert_eq!(envelope.published_at, 12);
+        assert_eq!(envelope.payload, Bytes::from_static(b"payload"));
+        let payload_ptr = envelope.payload.as_ptr() as usize;
+        assert!((encoded_start..encoded_end).contains(&payload_ptr));
+        assert!(source.next().await.is_none());
     }
 
     #[tokio::test]

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -63,9 +63,17 @@ fn configure_subscribe_builder<T>(builder: SocketBuilder<T>) -> SocketBuilder<T>
 where
     T: tmq::FromZmqSocket<T>,
 {
-    builder
-        .set_rcvhwm(ZMQ_RCVHWM)
-        .set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)
+    configure_subscribe_builder_with_hwm(builder, ZMQ_RCVHWM)
+}
+
+fn configure_subscribe_builder_with_hwm<T>(
+    builder: SocketBuilder<T>,
+    rcvhwm: i32,
+) -> SocketBuilder<T>
+where
+    T: tmq::FromZmqSocket<T>,
+{
+    builder.set_rcvhwm(rcvhwm).set_rcvtimeo(ZMQ_RCVTIMEOUT_MS)
 }
 
 /// Keeps a received ZMQ message alive for as long as any derived `Bytes` exists.
@@ -223,10 +231,17 @@ pub type ZmqWireStream =
 
 impl ZmqSubTransport {
     fn connect_socket(endpoint: &str, topic: &str) -> Result<Subscribe> {
+        Self::connect_socket_with_rcvhwm(endpoint, topic, ZMQ_RCVHWM)
+    }
+
+    fn connect_socket_with_rcvhwm(endpoint: &str, topic: &str, rcvhwm: i32) -> Result<Subscribe> {
+        anyhow::ensure!(rcvhwm > 0, "ZMQ receive HWM must be greater than zero");
         let ctx = shared_zmq_context();
-        Ok(configure_subscribe_builder(subscribe(&ctx))
-            .connect(endpoint)?
-            .subscribe(topic.as_bytes())?)
+        Ok(
+            configure_subscribe_builder_with_hwm(subscribe(&ctx), rcvhwm)
+                .connect(endpoint)?
+                .subscribe(topic.as_bytes())?,
+        )
     }
 
     /// Create a new ZMQ subscriber by connecting to a single endpoint.
@@ -255,13 +270,22 @@ impl ZmqSubTransport {
     /// therefore has no background pump or lossy broadcast hop and naturally
     /// applies backpressure at the configured ZMQ receive HWM.
     pub async fn connect_single_consumer(endpoint: &str, topic: &str) -> Result<ZmqWireStream> {
-        let mut socket = Self::connect_socket(endpoint, topic)?;
+        Self::connect_single_consumer_with_rcvhwm(endpoint, topic, ZMQ_RCVHWM).await
+    }
+
+    /// Connect one consumer directly to one ZMQ publisher with an explicit receive HWM.
+    pub async fn connect_single_consumer_with_rcvhwm(
+        endpoint: &str,
+        topic: &str,
+        rcvhwm: i32,
+    ) -> Result<ZmqWireStream> {
+        let mut socket = Self::connect_socket_with_rcvhwm(endpoint, topic, rcvhwm)?;
         let expected_topic = topic.as_bytes().to_vec();
 
         tracing::info!(
             endpoint,
             topic,
-            rcvhwm = ZMQ_RCVHWM,
+            rcvhwm,
             "Direct ZMQ single-consumer stream connected"
         );
 
@@ -547,6 +571,27 @@ mod tests {
         assert_eq!(decoded.publisher_id, 12345);
         assert_eq!(decoded.sequence, 1);
         assert_eq!(decoded.topic, topic);
+    }
+
+    #[tokio::test]
+    async fn single_consumer_applies_explicit_receive_hwm() {
+        let endpoint = format!("inproc://dynamo-zmq-explicit-hwm-{}", std::process::id());
+        let topic = "explicit-hwm";
+        let (_publisher, _) = ZmqPubTransport::bind(&endpoint, topic).await.unwrap();
+
+        let socket = ZmqSubTransport::connect_socket_with_rcvhwm(&endpoint, topic, 37).unwrap();
+        assert_eq!(socket.get_socket().get_rcvhwm().unwrap(), 37);
+
+        let default_socket = ZmqSubTransport::connect_socket(&endpoint, topic).unwrap();
+        assert_eq!(
+            default_socket.get_socket().get_rcvhwm().unwrap(),
+            ZMQ_RCVHWM
+        );
+        assert!(
+            ZmqSubTransport::connect_single_consumer_with_rcvhwm(&endpoint, topic, 0)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a validated single-consumer ZMQ source while retaining the existing 100k-default connector API
- share a lifecycle-owned direct-ZMQ fan-in between active-sequence and session-affinity replica synchronization; KV ingress reuses only validated intake and retains its specialized recovery lifecycle
- make unbrokered direct-ZMQ replica synchronization consume one socket/task per publisher, preserve per-source FIFO, and synchronously invoke existing domain apply semantics
- retain Rust-only active-sequence rollback/HWM controls, bounded lifecycle supervision, sparse continuity/error observability, and deterministic concurrency, recreation, reconnect, and shutdown coverage
- leave NATS, brokered ZMQ, generic subscribers, LoRA, sticky-session wire format, and sender queues/HWM unchanged

This PR is ready for architectural and code review, but the default-on active-sequence rollout remains blocked by the overload result below. `DYN_ROUTER_ACTIVE_SEQUENCE_DIRECT_ZMQ=0` restores aggregated ingestion without reverting the batched wire format.

## Performance

- Prior prototype campaigns measured 51% aggregate loss versus zero direct loss at 2.4M logical events/s, and 42.26% versus zero over short 3.2M/s runs. A prior 40GB overload result motivated the 1,024-envelope per-socket receive cap.
- On the final production patch, 32 publishers at 2.0M/s delivered 120.13M/120.13M directly with 10ms drain and 0.92GiB receiver MaxRSS. Aggregated ingestion delivered 66.96M/120.13M, missed 44.26%, drained for 19.2s, left 7.22M residual requests, and reached 6.33GiB.
- A 4.0M/s sink-light control delivered 240.13M/240.13M with 1.97ms p99 issue lag, confirming the generator was not the bottleneck.
- The rollout gate did not pass: direct ingestion at 2.4M/s was lossless over 30s but drained for 14.2s, and the longer run reached 20.1GiB after 131s before it was stopped. Zero receiver sequence gaps while RSS grew indicates the bounded receiver moved backlog into the unchanged 100k sender-side queues. The true 32-process mesh and expiry soak are deferred pending a sender/service-wide backlog design.

### CPU-limited follow-up

The follow-up used the production-shaped receive/decode/`apply_replica_batch` loop with 32 publishers and one sink over real loopback TCP ZMQ. `taskset` hard-limited the entire process—including identical publisher work—to 1, 2, 4, or 8 CPUs; `perf stat` measured whole-process task-clock. All accepted runs had exact published/decoded accounting, zero sequence gaps and residual state, and 11–34ms drain. An 8-CPU sink-light control sustained 2.8M/s with 1.9ms p99 issue lag.

- At the same sustainable rate, direct versus aggregate CPU-seconds was 59.52 vs 60.13 at 1 CPU/500k/s (-1.0%), 104.73 vs 96.84 at 2 CPUs/700k/s (+8.1%), 147.65 vs 120.99 at 4 CPUs/800k/s (+22.0%), and 220.22 vs 148.55 at 8 CPUs/1.0M/s (+48.3%). The direct path therefore does not consume >2x CPU at the same throughput, but it is not iso-CPU once parallelism widens.
- Five-minute 8-CPU knees: aggregate sustained 1.0M/s (300.03M exact, 744.01 CPU-seconds / 2.48 average cores, 33ms drain); direct sustained 2.3M/s (690.03M exact, 2,230.75 CPU-seconds / 7.44 average cores, 11ms drain, 4.86ms p99 issue lag). That is 2.3x throughput for 3.0x CPU-seconds, or about 30% more CPU per logical event.
- The nominal 2.4M/s five-minute point was rejected: it remained lossless and drained in 385ms, but p99 issue lag grew to 16.4s and the sender queue reached about 100k events.
- A same-rate `perf record` profile attributes the added wide-concurrency cost primarily to concurrent tracker state: prompt-registry load updates (12.9%), replica-event application (9.4%), DashMap removal (4.2%), and atomic/lock paths. Decode/serialization was not duplicated; the evidence points to lower IPC/shared-state contention after exposing parallel apply.

## Validation

- `cargo test -p dynamo-runtime single_consumer` (2 passed)
- `cargo test -p dynamo-kv-router` (834 passed, 2 ignored)
- `cargo test -p dynamo-llm --no-default-features` (1,540 library tests passed, 3 ignored; integration and doc-test binaries also passed)
- final production head exercised on an exclusive 144-core Arm CPU node; lifecycle regression independently completed two exact `32 -> 0 -> 32` source cycles and joined supervisor shutdown

## Reviewer guide

- validated transport primitive: `lib/runtime/src/transports/event_plane/zmq_transport.rs`
- shared fan-in lifecycle: `lib/llm/src/direct_zmq_fan_in.rs`
- tracker batch semantics: `lib/kv-router/src/sequences/replica_sync.rs` and `lib/kv-router/src/sequences/multi_worker.rs`
- active-sequence integration: `lib/llm/src/kv_router/sequence.rs`, `lib/llm/src/kv_router/sequence/direct_zmq.rs`, and `lib/llm/src/kv_router/metrics.rs`
- session-affinity integration: `lib/llm/src/session_affinity/replica_sync.rs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional direct messaging path for active-sequence synchronization.
  - Added configurable receive-buffer settings for direct event streams.
  - Added monitoring for received and processed events, sequence gaps, reconnects, replacements, and errors.

- **Bug Fixes**
  - Improved resilience when event sources reconnect or are replaced.
  - Independent worker updates can now proceed without being blocked by stalled work.
  - Replica batches apply updates consistently with a single deferred flush.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
