### PR TITLE
build(container): bump in-tree ffmpeg to 8.1.2 (OPS-7769)

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -81,7 +81,7 @@ packages:
   # and copied into vllm/sglang runtime (container/templates/vllm_runtime.Dockerfile
   # + sglang_runtime.Dockerfile). Replaces the purged GPL apt ffmpeg.
   - name: ffmpeg
-    version: "8.1"
+    version: "8.1.2"
     license: LGPL-2.1-or-later
     source: https://ffmpeg.org/
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -46,7 +46,7 @@ dynamo:
   enable_kvbm: "true"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
-  ffmpeg_version: "8.1"
+  ffmpeg_version: "8.1.2"
   # ffmpeg build inputs (only consumed when ENABLE_MEDIA_FFMPEG=true).
   nv_codec_headers_ref: "n13.0.19.0"
   libvpx_ref: "v1.14.1"


### PR DESCRIPTION
## Summary

Bump the in-tree, source-built ffmpeg from 8.1 to **8.1.2** (latest patch release on the 8.1 stable branch). Version-only change:

- `container/context.yaml` — `ffmpeg_version` 8.1 → 8.1.2. This single knob feeds `FFMPEG_VERSION` into `wheel_builder`, which builds ffmpeg once and copies it into the vLLM / SGLang / TRT-LLM runtime images, so all three move in place together.
- `container/compliance/native_packages.yaml` — mirror `version` 8.1 → 8.1.2, keeping the generated SBOM attribution in lockstep with the built binaries.

Configure flags and the encoder set are unchanged (`h264_nvenc` + `libvpx_vp9` preserved). 8.1.2 is a same-branch patch release, so configure options are frozen and the `libav*` soname is unchanged — ABI-stable with the Rust `ffmpeg-next` 8.1 binding (no `Cargo.toml` change needed).

## Validation

Built ffmpeg 8.1.2 in a clean container using the **exact** `wheel_builder` configure flags:

- `ffmpeg-8.1.2.tar.xz` downloads from ffmpeg.org
- `./configure` accepts every flag, incl. `--enable-encoder=h264_nvenc,libvpx_vp9` (configure aborts on an unknown encoder name, so this confirms both exist in 8.1.2)
- `make` compiles the tree
- resulting binary reports `ffmpeg version 8.1.2` and exposes exactly `h264_nvenc` + `libvpx-vp9` — no software H.264/H.265/AAC encoders

CI container-build lanes perform the authoritative image build.

## Notes

Follow-up (tracked separately): TRT-LLM runtime ships the identical in-tree ffmpeg but is currently missing from the `ffmpeg` / `libvpx` `images:` lists in `native_packages.yaml`.

Linear: OPS-7769

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->