### PR TITLE
feat(observability): Add embedding cache metrics

### DIFF
--- a/components/src/dynamo/common/utils/prometheus.py
+++ b/components/src/dynamo/common/utils/prometheus.py
@@ -38,15 +38,18 @@ if TYPE_CHECKING:
 
 
 # Single source of truth for embedding cache metric names.
+EMBEDDING_CACHE_METRIC_PREFIX = f"{name_prefix.COMPONENT}_embedding_cache"
+
+
 class EmbeddingCacheMetrics(str, enum.Enum):
     """Prometheus metric names for the multimodal embedding cache."""
 
-    HITS_TOTAL = f"{name_prefix.COMPONENT}_embedding_cache_hits_total"
-    MISSES_TOTAL = f"{name_prefix.COMPONENT}_embedding_cache_misses_total"
-    EVICTIONS_TOTAL = f"{name_prefix.COMPONENT}_embedding_cache_evictions_total"
-    UTILIZATION = f"{name_prefix.COMPONENT}_embedding_cache_utilization"
-    CURRENT_BYTES = f"{name_prefix.COMPONENT}_embedding_cache_current_bytes"
-    ENTRIES = f"{name_prefix.COMPONENT}_embedding_cache_entries"
+    HITS_TOTAL = f"{EMBEDDING_CACHE_METRIC_PREFIX}_hits_total"
+    MISSES_TOTAL = f"{EMBEDDING_CACHE_METRIC_PREFIX}_misses_total"
+    EVICTIONS_TOTAL = f"{EMBEDDING_CACHE_METRIC_PREFIX}_evictions_total"
+    UTILIZATION = f"{EMBEDDING_CACHE_METRIC_PREFIX}_utilization"
+    CURRENT_BYTES = f"{EMBEDDING_CACHE_METRIC_PREFIX}_current_bytes"
+    ENTRIES = f"{EMBEDDING_CACHE_METRIC_PREFIX}_entries"
 
 
 def register_engine_metrics_callback(

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -31,6 +31,7 @@ from dynamo.common.snapshot.restore_context import (
 )
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers
 from dynamo.common.utils.prometheus import (
+    EMBEDDING_CACHE_METRIC_PREFIX,
     LLMBackendMetrics,
     register_engine_metrics_callback,
 )
@@ -213,6 +214,20 @@ def setup_metrics_collection(
         Additional labels can be provided via inject_labels parameter.
     """
     metrics_model_name = get_metrics_model_name(config)
+
+    # The DynamoMultimodalEmbeddingCacheConnector (scheduler side, EngineCore
+    # process) publishes its cache metrics through the multiprocess .db files.
+    # Forward that family only when the connector is configured — the
+    # encode-routing path exposes the same metric names in-process via
+    # register_embedding_cache_metrics instead.
+    engine_metric_prefixes = ["vllm:", "lmcache:"]
+    ec_config = getattr(config.engine_args, "ec_transfer_config", None)
+    if (
+        getattr(ec_config, "ec_connector", None)
+        == "DynamoMultimodalEmbeddingCacheConnector"
+    ):
+        engine_metric_prefixes.append(EMBEDDING_CACHE_METRIC_PREFIX)
+
     if config.engine_args.disable_log_stats is False:
         # Register the dedicated dynamo_component registry callback
         # IMPORTANT: We do NOT use MultiProcessCollector for DYNAMO_COMPONENT_REGISTRY
@@ -242,7 +257,7 @@ def setup_metrics_collection(
                 register_engine_metrics_callback(
                     endpoint=generate_endpoint,
                     registry=REGISTRY,
-                    metric_prefix_filters=["vllm:", "lmcache:"],
+                    metric_prefix_filters=engine_metric_prefixes,
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
@@ -272,7 +287,7 @@ def setup_metrics_collection(
                 register_engine_metrics_callback(
                     endpoint=generate_endpoint,
                     registry=multiproc_registry,
-                    metric_prefix_filters=["vllm:", "lmcache:"],
+                    metric_prefix_filters=engine_metric_prefixes,
                     namespace_name=config.namespace,
                     component_name=config.component,
                     endpoint_name=config.endpoint,
@@ -554,6 +569,7 @@ def setup_vllm_engine(
         capacity_gb=config.multimodal_embedding_cache_capacity_gb,
         namespace=config.namespace,
         component=config.component,
+        model_name=get_metrics_model_name(config),
     )
 
     # Taken from build_async_engine_client_from_engine_args()

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -303,7 +303,7 @@ def setup_metrics_collection(
             register_engine_metrics_callback(
                 endpoint=generate_endpoint,
                 registry=REGISTRY,
-                metric_prefix_filters=["vllm:", "lmcache:"],
+                metric_prefix_filters=engine_metric_prefixes,
                 namespace_name=config.namespace,
                 component_name=config.component,
                 endpoint_name=config.endpoint,

--- a/components/src/dynamo/vllm/multimodal_utils/cache_config.py
+++ b/components/src/dynamo/vllm/multimodal_utils/cache_config.py
@@ -15,6 +15,7 @@ def configure_multimodal_embedding_cache(
     capacity_gb: float,
     namespace: str,
     component: str,
+    model_name: str = "",
 ) -> None:
     """Configure vLLM's CPU embedding cache before engine creation.
 
@@ -40,6 +41,11 @@ def configure_multimodal_embedding_cache(
             ),
             ec_connector_extra_config={
                 "multimodal_embedding_cache_capacity_gb": capacity_gb,
+                # Prometheus label values for the connector's cache metrics —
+                # the scheduler-side connector has no other channel to learn
+                # its Dynamo identity.
+                "component": component,
+                "model_name": model_name,
             },
         ),
     )

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -75,7 +75,7 @@ class _SchedulerCacheMetrics:
     """
 
     def __init__(
-        self, model_name: str, component_name: str, capacity_bytes: int
+        self, model_name: str, component_name: str, capacity_bytes: int, dp_rank: int
     ) -> None:
         # Deferred imports: prometheus_client must be imported after
         # PROMETHEUS_MULTIPROC_DIR is set (inherited from the parent process).
@@ -86,10 +86,16 @@ class _SchedulerCacheMetrics:
 
         self._capacity_bytes = capacity_bytes
         self.registry = CollectorRegistry()
-        labelnames = [labels.MODEL, labels.COMPONENT]
+        # dp_rank partitions series per data-parallel EngineCore (each rank has
+        # its own scheduler-side cache), so gauges never collide across ranks
+        # and "mostrecent" only arbitrates between a dead pre-restart pid and
+        # its live replacement within one rank. Same pattern as the kvstats
+        # gauges in LLMBackendMetrics.
+        labelnames = [labels.MODEL, labels.COMPONENT, labels.DP_RANK]
         labelvalues = {
             labels.MODEL: model_name,
             labels.COMPONENT: component_name,
+            labels.DP_RANK: str(dp_rank),
         }
 
         def _counter(name: str, doc: str):
@@ -203,6 +209,7 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
                 model_name=extra_config.get("model_name", ""),
                 component_name=extra_config.get("component", ""),
                 capacity_bytes=self._capacity_bytes,
+                dp_rank=getattr(vllm_config.parallel_config, "data_parallel_rank", 0),
             )
             if role == ECConnectorRole.SCHEDULER
             else None

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -72,6 +72,15 @@ class _SchedulerCacheMetrics:
     private CollectorRegistry keeps these metrics out of this process's global
     REGISTRY so they are never exported twice when the engine core runs
     in-process.
+
+    This filesystem transport only covers EngineCore processes that inherit
+    PROMETHEUS_MULTIPROC_DIR and share a filesystem with the metrics-serving
+    process — the default local-subprocess topology. Remote EngineCore actors
+    (Ray data-parallel placement) don't inherit the env var and write to their
+    own node's filesystem, so their cache metrics are never exported; covering
+    them would need EC-connector stats plumbed through EngineCoreOutputs, as
+    KV connectors do. The connector logs a warning for these topologies at
+    init instead of failing.
     """
 
     def __init__(
@@ -203,17 +212,34 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
 
         # Only the scheduler role does cache accounting, so only it emits
         # metrics; worker-role instances would just publish idle zeros.
-        extra_config = transfer_config.ec_connector_extra_config
-        self._metrics: _SchedulerCacheMetrics | None = (
-            _SchedulerCacheMetrics(
+        self._metrics: _SchedulerCacheMetrics | None = None
+        if role == ECConnectorRole.SCHEDULER:
+            extra_config = transfer_config.ec_connector_extra_config
+            self._metrics = _SchedulerCacheMetrics(
                 model_name=extra_config.get("model_name", ""),
                 component_name=extra_config.get("component", ""),
                 capacity_bytes=self._capacity_bytes,
                 dp_rank=getattr(vllm_config.parallel_config, "data_parallel_rank", 0),
             )
-            if role == ECConnectorRole.SCHEDULER
-            else None
-        )
+            # The mmap transport (see _SchedulerCacheMetrics) needs the env
+            # var inherited from the metrics-serving process; without it the
+            # values stay in this process's memory.
+            if "PROMETHEUS_MULTIPROC_DIR" not in os.environ:
+                logger.warning(
+                    "Embedding cache metrics: PROMETHEUS_MULTIPROC_DIR is not "
+                    "set; cache metrics stay local to this process and will "
+                    "not be exported (expected under offline LLM() usage or "
+                    "remote Ray DP actors)."
+                )
+            if (
+                getattr(vllm_config.parallel_config, "data_parallel_backend", "")
+                == "ray"
+            ):
+                logger.warning(
+                    "Embedding cache metrics: data_parallel_backend=ray — "
+                    "remote DP ranks do not share the multiprocess Prometheus "
+                    "directory and will not contribute cache metrics."
+                )
 
         # --- Worker-side: dumb CPU tensor store ---
         self._cpu_store: dict[str, torch.Tensor] = {}

--- a/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py
@@ -55,6 +55,90 @@ class MultimodalEmbeddingCacheConnectorMetadata(ECConnectorMetadata):
     evicts: list[str] = field(default_factory=list)
 
 
+class _SchedulerCacheMetrics:
+    """Prometheus metrics for the scheduler-side logical CPU cache.
+
+    Emits the same EmbeddingCacheMetrics family as
+    register_embedding_cache_metrics (the worker-layer
+    MultimodalEmbeddingCacheManager used by encode-routing deployments), so
+    dashboards see one embedding-cache family regardless of which
+    implementation serves the model.
+
+    The scheduler-side connector runs in vLLM's EngineCore process, not the
+    process serving /metrics. Values reach the frontend through Dynamo's
+    multiprocess Prometheus setup: PROMETHEUS_MULTIPROC_DIR is set before the
+    engine starts (see setup_vllm_engine), so prometheus_client mmap-persists
+    values that setup_metrics_collection's MultiProcessCollector exposes. The
+    private CollectorRegistry keeps these metrics out of this process's global
+    REGISTRY so they are never exported twice when the engine core runs
+    in-process.
+    """
+
+    def __init__(
+        self, model_name: str, component_name: str, capacity_bytes: int
+    ) -> None:
+        # Deferred imports: prometheus_client must be imported after
+        # PROMETHEUS_MULTIPROC_DIR is set (inherited from the parent process).
+        from prometheus_client import CollectorRegistry, Counter, Gauge
+
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+        from dynamo.prometheus_names import labels
+
+        self._capacity_bytes = capacity_bytes
+        self.registry = CollectorRegistry()
+        labelnames = [labels.MODEL, labels.COMPONENT]
+        labelvalues = {
+            labels.MODEL: model_name,
+            labels.COMPONENT: component_name,
+        }
+
+        def _counter(name: str, doc: str):
+            return Counter(name, doc, labelnames, registry=self.registry).labels(
+                **labelvalues
+            )
+
+        def _gauge(name: str, doc: str):
+            # "mostrecent" so MultiProcessCollector reports this process's
+            # latest snapshot instead of aggregating across dead pids.
+            return Gauge(
+                name,
+                doc,
+                labelnames,
+                registry=self.registry,
+                multiprocess_mode="mostrecent",
+            ).labels(**labelvalues)
+
+        self._hits = _counter(ECM.HITS_TOTAL, "Total embedding cache hits.")
+        self._misses = _counter(ECM.MISSES_TOTAL, "Total embedding cache misses.")
+        self._evictions = _counter(
+            ECM.EVICTIONS_TOTAL, "Total embedding cache evictions."
+        )
+        self._utilization = _gauge(
+            ECM.UTILIZATION, "Cache memory utilization ratio (0.0-1.0)."
+        )
+        self._current_bytes = _gauge(
+            ECM.CURRENT_BYTES, "Current cache memory usage in bytes."
+        )
+        self._entries = _gauge(ECM.ENTRIES, "Number of entries in the cache.")
+        self.update_usage(0, 0)
+
+    def record_hit(self) -> None:
+        self._hits.inc()
+
+    def record_miss(self) -> None:
+        self._misses.inc()
+
+    def record_evictions(self, count: int) -> None:
+        self._evictions.inc(count)
+
+    def update_usage(self, used_bytes: int, entries: int) -> None:
+        self._current_bytes.set(used_bytes)
+        self._entries.set(entries)
+        self._utilization.set(
+            used_bytes / self._capacity_bytes if self._capacity_bytes else 0.0
+        )
+
+
 class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
     """EC connector with scheduler-authoritative CPU embedding cache.
 
@@ -110,6 +194,19 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         self._loads_this_step: set[str] = set()
         self._saves_this_step: set[str] = set()
         self._evicts_this_step: set[str] = set()
+
+        # Only the scheduler role does cache accounting, so only it emits
+        # metrics; worker-role instances would just publish idle zeros.
+        extra_config = transfer_config.ec_connector_extra_config
+        self._metrics: _SchedulerCacheMetrics | None = (
+            _SchedulerCacheMetrics(
+                model_name=extra_config.get("model_name", ""),
+                component_name=extra_config.get("component", ""),
+                capacity_bytes=self._capacity_bytes,
+            )
+            if role == ECConnectorRole.SCHEDULER
+            else None
+        )
 
         # --- Worker-side: dumb CPU tensor store ---
         self._cpu_store: dict[str, torch.Tensor] = {}
@@ -172,13 +269,19 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
         if mm_hash in self._cache_order:
             self._cache_order.move_to_end(mm_hash)
             self._loads_this_step.add(mm_hash)
+            if self._metrics is not None:
+                self._metrics.record_hit()
             return
+
+        if self._metrics is not None:
+            self._metrics.record_miss()
 
         if size_bytes > self._capacity_bytes:
             return
 
         self._saves_this_step.add(mm_hash)
 
+        num_evicted = 0
         while (
             self._num_used_bytes + size_bytes > self._capacity_bytes
             and self._cache_order
@@ -186,9 +289,15 @@ class DynamoMultimodalEmbeddingCacheConnector(ECConnectorBase):
             evicted_hash, evicted_bytes = self._cache_order.popitem(last=False)
             self._num_used_bytes -= evicted_bytes
             self._evicts_this_step.add(evicted_hash)
+            num_evicted += 1
 
         self._cache_order[mm_hash] = size_bytes
         self._num_used_bytes += size_bytes
+
+        if self._metrics is not None:
+            if num_evicted:
+                self._metrics.record_evictions(num_evicted)
+            self._metrics.update_usage(self._num_used_bytes, len(self._cache_order))
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
@@ -27,6 +27,7 @@ def _make_vllm_config(capacity_gb: float = 1.0) -> MagicMock:
     }
     config.model_config.get_hidden_size.return_value = 4096
     config.model_config.dtype = torch.float16
+    config.parallel_config.data_parallel_rank = 0
     return config
 
 
@@ -213,7 +214,7 @@ class TestSchedulerSideLRU:
 class TestSchedulerMetrics:
     """Prometheus metrics emitted by the scheduler-role connector."""
 
-    LABELS = {"model": "test-model", "dynamo_component": "backend"}
+    LABELS = {"model": "test-model", "dynamo_component": "backend", "dp_rank": "0"}
 
     def _make_connector(
         self, capacity_gb: float = 1.0, role=None
@@ -234,6 +235,32 @@ class TestSchedulerMetrics:
     def test_worker_role_has_no_metrics(self):
         conn = self._make_connector(role=mod.ECConnectorRole.WORKER)
         assert conn._metrics is None
+
+    def test_dp_rank_label_partitions_series(self):
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+
+        config = _make_vllm_config()
+        config.parallel_config.data_parallel_rank = 3
+        config.ec_transfer_config.ec_connector_extra_config.update(
+            {"model_name": "test-model", "component": "backend"}
+        )
+        with patch.object(mod.ECConnectorBase, "__init__", return_value=None):
+            conn = mod.DynamoMultimodalEmbeddingCacheConnector(
+                vllm_config=config,
+                role=mod.ECConnectorRole.SCHEDULER,
+            )
+
+        rank3_labels = {**self.LABELS, "dp_rank": "3"}
+        assert (
+            conn._metrics.registry.get_sample_value(
+                ECM.MISSES_TOTAL.value, rank3_labels
+            )
+            == 0.0
+        )
+        assert (
+            conn._metrics.registry.get_sample_value(ECM.MISSES_TOTAL.value, self.LABELS)
+            is None
+        )
 
     def test_series_present_before_activity(self):
         from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
@@ -30,6 +30,22 @@ def _make_vllm_config(capacity_gb: float = 1.0) -> MagicMock:
     return config
 
 
+def _make_request(hashes_and_embeds: list[tuple[str, int]]) -> MagicMock:
+    request = MagicMock()
+    features = []
+    for h, _ in hashes_and_embeds:
+        f = MagicMock()
+        f.identifier = h
+        features.append(f)
+    request.mm_features = features
+
+    def get_num_encoder_embeds(idx):
+        return hashes_and_embeds[idx][1]
+
+    request.get_num_encoder_embeds = get_num_encoder_embeds
+    return request
+
+
 class TestCacheConfiguration:
     def test_disabled_capacity_leaves_engine_args_unchanged(self):
         engine_args = SimpleNamespace()
@@ -68,6 +84,7 @@ class TestCacheConfiguration:
                 capacity_gb=2.5,
                 namespace="deployment",
                 component="prefill",
+                model_name="test-model",
             )
 
         assert engine_args.ec_transfer_config is transfer_config
@@ -80,6 +97,8 @@ class TestCacheConfiguration:
             ),
             ec_connector_extra_config={
                 "multimodal_embedding_cache_capacity_gb": 2.5,
+                "component": "prefill",
+                "model_name": "test-model",
             },
         )
 
@@ -111,27 +130,12 @@ class TestSchedulerSideLRU:
                 role=MagicMock(),
             )
 
-    def _make_request(self, hashes_and_embeds: list[tuple[str, int]]) -> MagicMock:
-        request = MagicMock()
-        features = []
-        for h, _ in hashes_and_embeds:
-            f = MagicMock()
-            f.identifier = h
-            features.append(f)
-        request.mm_features = features
-
-        def get_num_encoder_embeds(idx):
-            return hashes_and_embeds[idx][1]
-
-        request.get_num_encoder_embeds = get_num_encoder_embeds
-        return request
-
     def test_has_cache_item_miss_then_hit(self):
         conn = self._make_connector()
         opaque_uuid = "catalog/image:v2"
         assert not conn.has_cache_item(opaque_uuid)
 
-        request = self._make_request([(opaque_uuid, 100)])
+        request = _make_request([(opaque_uuid, 100)])
         conn.update_state_after_alloc(request, 0)
 
         with patch.object(mod.logger, "debug") as log_debug:
@@ -143,7 +147,7 @@ class TestSchedulerSideLRU:
 
     def test_update_state_plans_save(self):
         conn = self._make_connector()
-        request = self._make_request([("hash_a", 100)])
+        request = _make_request([("hash_a", 100)])
         conn.update_state_after_alloc(request, 0)
 
         scheduler_output = MagicMock()
@@ -155,7 +159,7 @@ class TestSchedulerSideLRU:
 
     def test_update_state_plans_load_for_cached(self):
         conn = self._make_connector()
-        request = self._make_request([("hash_a", 100)])
+        request = _make_request([("hash_a", 100)])
 
         conn.update_state_after_alloc(request, 0)
         conn.build_connector_meta(MagicMock())
@@ -172,18 +176,18 @@ class TestSchedulerSideLRU:
         # Set capacity to hold exactly 200 embeds worth of bytes
         conn._capacity_bytes = 200 * bpe
 
-        req_a = self._make_request([("hash_a", 100)])
+        req_a = _make_request([("hash_a", 100)])
         conn.update_state_after_alloc(req_a, 0)
         conn.build_connector_meta(MagicMock())
 
-        req_b = self._make_request([("hash_b", 100)])
+        req_b = _make_request([("hash_b", 100)])
         conn.update_state_after_alloc(req_b, 0)
         conn.build_connector_meta(MagicMock())
 
         assert conn._num_used_bytes == 200 * bpe
 
         # Adding hash_c (100 embeds) should evict hash_a (LRU)
-        req_c = self._make_request([("hash_c", 100)])
+        req_c = _make_request([("hash_c", 100)])
         conn.update_state_after_alloc(req_c, 0)
         meta = conn.build_connector_meta(MagicMock())
 
@@ -197,10 +201,95 @@ class TestSchedulerSideLRU:
         bpe = conn._bytes_per_embed
         conn._capacity_bytes = 50 * bpe
 
-        request = self._make_request([("huge_hash", 100)])
+        request = _make_request([("huge_hash", 100)])
         conn.update_state_after_alloc(request, 0)
         meta = conn.build_connector_meta(MagicMock())
 
         assert meta.saves == []
         assert meta.loads == []
         assert "huge_hash" not in conn._cache_order
+
+
+class TestSchedulerMetrics:
+    """Prometheus metrics emitted by the scheduler-role connector."""
+
+    LABELS = {"model": "test-model", "dynamo_component": "backend"}
+
+    def _make_connector(
+        self, capacity_gb: float = 1.0, role=None
+    ) -> "mod.DynamoMultimodalEmbeddingCacheConnector":
+        config = _make_vllm_config(capacity_gb)
+        config.ec_transfer_config.ec_connector_extra_config.update(
+            {"model_name": "test-model", "component": "backend"}
+        )
+        with patch.object(mod.ECConnectorBase, "__init__", return_value=None):
+            return mod.DynamoMultimodalEmbeddingCacheConnector(
+                vllm_config=config,
+                role=mod.ECConnectorRole.SCHEDULER if role is None else role,
+            )
+
+    def _value(self, conn, metric) -> float | None:
+        return conn._metrics.registry.get_sample_value(metric.value, self.LABELS)
+
+    def test_worker_role_has_no_metrics(self):
+        conn = self._make_connector(role=mod.ECConnectorRole.WORKER)
+        assert conn._metrics is None
+
+    def test_series_present_before_activity(self):
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+
+        conn = self._make_connector()
+        assert self._value(conn, ECM.HITS_TOTAL) == 0.0
+        assert self._value(conn, ECM.MISSES_TOTAL) == 0.0
+        assert self._value(conn, ECM.EVICTIONS_TOTAL) == 0.0
+        assert self._value(conn, ECM.UTILIZATION) == 0.0
+        assert self._value(conn, ECM.CURRENT_BYTES) == 0.0
+        assert self._value(conn, ECM.ENTRIES) == 0.0
+
+    def test_hit_miss_and_usage_accounting(self):
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+
+        conn = self._make_connector()
+        request = _make_request([("hash_a", 100)])
+
+        # First alloc: miss + save, usage gauges reflect the insert.
+        conn.update_state_after_alloc(request, 0)
+        conn.build_connector_meta(MagicMock())
+        assert self._value(conn, ECM.MISSES_TOTAL) == 1.0
+        assert self._value(conn, ECM.HITS_TOTAL) == 0.0
+        assert self._value(conn, ECM.CURRENT_BYTES) == 100 * conn._bytes_per_embed
+        assert self._value(conn, ECM.ENTRIES) == 1.0
+
+        # Second alloc of the same hash: hit, usage unchanged.
+        conn.update_state_after_alloc(request, 0)
+        assert self._value(conn, ECM.HITS_TOTAL) == 1.0
+        assert self._value(conn, ECM.MISSES_TOTAL) == 1.0
+        assert self._value(conn, ECM.ENTRIES) == 1.0
+
+    def test_eviction_counted(self):
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+
+        # 4096 hidden * 2 bytes (fp16) = 8192 bytes/embed; room for 200 embeds.
+        conn = self._make_connector(capacity_gb=200 * 8192 / 1024**3)
+        assert conn._capacity_bytes == 200 * conn._bytes_per_embed
+
+        conn.update_state_after_alloc(_make_request([("hash_a", 100)]), 0)
+        conn.update_state_after_alloc(_make_request([("hash_b", 100)]), 0)
+        conn.update_state_after_alloc(_make_request([("hash_c", 100)]), 0)
+
+        assert self._value(conn, ECM.EVICTIONS_TOTAL) == 1.0
+        assert self._value(conn, ECM.MISSES_TOTAL) == 3.0
+        assert self._value(conn, ECM.CURRENT_BYTES) == 200 * conn._bytes_per_embed
+        assert self._value(conn, ECM.ENTRIES) == 2.0
+        assert self._value(conn, ECM.UTILIZATION) == pytest.approx(1.0)
+
+    def test_oversized_item_counts_miss_without_usage_change(self):
+        from dynamo.common.utils.prometheus import EmbeddingCacheMetrics as ECM
+
+        conn = self._make_connector(capacity_gb=50 * 8192 / 1024**3)
+
+        conn.update_state_after_alloc(_make_request([("huge_hash", 100)]), 0)
+
+        assert self._value(conn, ECM.MISSES_TOTAL) == 1.0
+        assert self._value(conn, ECM.CURRENT_BYTES) == 0.0
+        assert self._value(conn, ECM.ENTRIES) == 0.0


### PR DESCRIPTION

## Overview:

Add Prometheus metrics to `DynamoMultimodalEmbeddingCacheConnector`, the vLLM EC connector implementing the CPU tier of the multimodal embedding cache. Cache effectiveness (hit rate, occupancy, eviction pressure) was previously invisible in production.

## Details:

- The scheduler-role connector now emits the existing `EmbeddingCacheMetrics` family (`dynamo_component_embedding_cache_{hits,misses,evictions}_total`, `_utilization`, `_current_bytes`, `_entries`) — the same names `register_embedding_cache_metrics` uses for the worker-layer `MultimodalEmbeddingCacheManager`, so dashboards see one metric family regardless of which cache implementation serves the model. Worker-role instances emit nothing (they do no cache accounting).
- The scheduler-side connector lives in vLLM's EngineCore process, not the process serving `/metrics`. Transport rides on the existing multiprocess Prometheus setup: `PROMETHEUS_MULTIPROC_DIR` is set before engine start, so `prometheus_client` mmap-persists values that the frontend's `MultiProcessCollector` picks up. Metrics live in a private `CollectorRegistry` (never double-exported through the global `REGISTRY`); gauges use `multiprocess_mode="mostrecent"` so dead-pid values don't pollute aggregation.
- `setup_metrics_collection` forwards the family from the multiproc registry only when this connector is configured — encode-routing deployments expose the same names in-process via `register_embedding_cache_metrics`, so unconditional forwarding would double-expose.
- `configure_multimodal_embedding_cache` gains a `model_name` parameter and passes `model_name`/`component` through `ec_connector_extra_config` — the scheduler-side connector has no other channel to learn its Dynamo identity for label values.
- Accounting lives in `update_state_after_alloc`: hits on the load path, misses on the save path (oversized items count as misses), evictions per LRU pop, gauges after each insert. Note a repeat image only reaches this connector after a GPU `EncoderCacheManager` miss — GPU-cache and prefix-cache hits bypass the CPU tier by design.
- Verified end-to-end on a live `ec_both` deployment (122B multimodal model): 26 unique images → 26 misses/entries with byte-exact `current_bytes`/`utilization`, and a confirmed CPU-tier hit after overflowing the GPU encoder-cache budget. Also works under plain `vllm serve` (no Dynamo frontend): vLLM's `/metrics` collects the multiproc dir unfiltered, so the family appears there with no extra wiring.

## Where should the reviewer start?

- `components/src/dynamo/vllm/multimodal_utils/multimodal_embedding_cache_connector.py` — `_SchedulerCacheMetrics` and the accounting call sites; the class docstring explains the cross-process transport.
- `components/src/dynamo/vllm/main.py` — conditional `engine_metric_prefixes` in `setup_metrics_collection` (the double-exposure guard).
- `components/src/dynamo/vllm/multimodal_utils/cache_config.py` — label-value plumbing via `ec_connector_extra_config`.
- `components/src/dynamo/common/utils/prometheus.py` — just extracts `EMBEDDING_CACHE_METRIC_PREFIX` from the existing enum.
- `components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py` — `TestSchedulerMetrics`: worker-role silence, zero-valued series at init, hit/miss/usage accounting, evictions, oversized items.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus monitoring for multimodal embedding cache activity.
  * Metrics now report cache hits, misses, evictions, utilization, current storage, and entry counts.
  * Embedding cache metrics can be associated with the configured model name for clearer monitoring.

* **Bug Fixes**
  * Improved metric collection so embedding cache statistics are included when the feature is enabled.
  * Added coverage for cache hits, misses, evictions, capacity limits, and oversized items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->