### PR TITLE
refactor(router): unify routing partition identity [DYN-3849]

### DIFF
--- a/lib/kv-router/benches/tracking_hash.rs
+++ b/lib/kv-router/benches/tracking_hash.rs
@@ -6,7 +6,9 @@ use std::io::Write;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use dynamo_kv_router::config::KvRouterConfig;
 use dynamo_kv_router::protocols::{BlockHashOptions, compute_block_hash_for_seq};
-use dynamo_kv_router::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
+use dynamo_kv_router::{
+    RoutingPartitionRef, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+};
 use tempfile::NamedTempFile;
 
 const BENCHMARK_KEY: [u8; 32] = [0x5a; 32];
@@ -21,7 +23,11 @@ fn benchmark_blake3_sequence_hashes(
 ) -> Vec<u64> {
     let mut scope_hasher = blake3::Hasher::new_keyed(provider_key);
     scope_hasher.update(BLAKE3_SCOPE_DOMAIN);
-    for value in ["benchmark", scope.model_name, scope.routing_group] {
+    for value in [
+        "benchmark",
+        scope.partition.model_name,
+        scope.partition.routing_group,
+    ] {
         scope_hasher.update(&(value.len() as u64).to_le_bytes());
         scope_hasher.update(value.as_bytes());
     }
@@ -81,8 +87,7 @@ fn tracking_hash(c: &mut Criterion) {
     .unwrap();
     let block_size = 16;
     let scope = TrackingHashScope {
-        model_name: "benchmark-model",
-        routing_group: "default",
+        partition: RoutingPartitionRef::new("benchmark-model", "default"),
         block_size,
     };
 

--- a/lib/kv-router/src/identity.rs
+++ b/lib/kv-router/src/identity.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Compact identities for logical KV indexers and DC-local producer pools.
+//! Shared identities for routing partitions, logical KV indexers, and DC-local producer pools.
 //!
-//! Identity material is resolved on control paths. Mutation and query paths carry only these
-//! fixed-size values or physical lane indices.
+//! Hashed indexer identity material is resolved on control paths. Mutation and query paths carry
+//! only those fixed-size values or physical lane indices.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -17,10 +17,90 @@ pub const MAX_EXPLICIT_IDENTITY_ENTRIES: usize = 32;
 pub const MAX_EXPLICIT_IDENTITY_KEY_BYTES: usize = 128;
 pub const MAX_EXPLICIT_IDENTITY_VALUE_BYTES: usize = 1024;
 
+/// Routing group used when a request does not specify one.
+pub const DEFAULT_ROUTING_GROUP: &str = "default";
+
 const CACHE_SEMANTICS_DEFAULT_V1: &[u8] = b"dynamo/indexer-cache-semantics/default/v1";
 const CACHE_SEMANTICS_EXPLICIT_V1: &[u8] = b"dynamo/indexer-cache-semantics/explicit/v1";
 const ROUTING_SCOPE_DEFAULT_V1: &[u8] = b"dynamo/indexer-routing-scope/default/v1";
 const ROUTING_SCOPE_EXPLICIT_V1: &[u8] = b"dynamo/indexer-routing-scope/explicit/v1";
+
+#[cfg(any(
+    feature = "standalone-indexer",
+    feature = "standalone-selection",
+    feature = "standalone-slot-tracker"
+))]
+pub(crate) fn default_routing_group() -> String {
+    DEFAULT_ROUTING_GROUP.to_string()
+}
+
+/// Logical routing partition shared by selection, indexing, and active-sequence tracking.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingPartitionId {
+    pub model_name: String,
+    pub routing_group: String,
+}
+
+impl RoutingPartitionId {
+    pub fn new(model_name: impl Into<String>, routing_group: impl Into<String>) -> Self {
+        Self {
+            model_name: model_name.into(),
+            routing_group: routing_group.into(),
+        }
+    }
+
+    pub fn as_ref(&self) -> RoutingPartitionRef<'_> {
+        RoutingPartitionRef::new(&self.model_name, &self.routing_group)
+    }
+}
+
+impl fmt::Display for RoutingPartitionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(formatter)
+    }
+}
+
+/// Borrowed view of a [`RoutingPartitionId`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct RoutingPartitionRef<'a> {
+    pub model_name: &'a str,
+    pub routing_group: &'a str,
+}
+
+impl<'a> RoutingPartitionRef<'a> {
+    pub const fn new(model_name: &'a str, routing_group: &'a str) -> Self {
+        Self {
+            model_name,
+            routing_group,
+        }
+    }
+
+    pub fn into_owned(self) -> RoutingPartitionId {
+        RoutingPartitionId::new(self.model_name, self.routing_group)
+    }
+}
+
+impl fmt::Display for RoutingPartitionRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "model={} routing_group={}",
+            self.model_name, self.routing_group
+        )
+    }
+}
+
+impl<'a> From<&'a RoutingPartitionId> for RoutingPartitionRef<'a> {
+    fn from(partition: &'a RoutingPartitionId) -> Self {
+        partition.as_ref()
+    }
+}
+
+impl From<RoutingPartitionRef<'_>> for RoutingPartitionId {
+    fn from(partition: RoutingPartitionRef<'_>) -> Self {
+        partition.into_owned()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -390,7 +470,28 @@ fn write_digest(formatter: &mut fmt::Formatter<'_>, digest: &[u8; 16]) -> fmt::R
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+
+    #[test]
+    fn routing_partition_identity_matches_registry_key_semantics() {
+        let partition = RoutingPartitionId::new("model-a", "group-a");
+        let equivalent = RoutingPartitionId::new("model-a", "group-a");
+        let other_group = RoutingPartitionId::new("model-a", "group-b");
+        let other_model = RoutingPartitionId::new("model-b", "group-a");
+        let mut registry_keys = HashSet::new();
+
+        assert!(registry_keys.insert(partition.clone()));
+        assert!(!registry_keys.insert(equivalent));
+        assert!(registry_keys.insert(other_group));
+        assert!(registry_keys.insert(other_model));
+        assert_eq!(registry_keys.len(), 3);
+
+        let borrowed = partition.as_ref();
+        assert_eq!(borrowed, RoutingPartitionRef::new("model-a", "group-a"));
+        assert_eq!(borrowed.into_owned(), partition);
+    }
 
     #[test]
     fn explicit_identity_map_rejects_duplicate_json_keys() {

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -49,7 +49,7 @@ pub use config::{
     KvRouterConfig, RouterConfigOverride, RouterPrefillLoadModel, RouterQueuePolicy,
     SharedCacheType,
 };
-pub use identity::DcId;
+pub use identity::{DEFAULT_ROUTING_GROUP, DcId, RoutingPartitionId, RoutingPartitionRef};
 #[allow(deprecated)]
 pub use indexer::{
     AnchorAwareBranchShardedIndexer, AnchorRef, AnchorTask, BranchShardedIndexer,
@@ -68,6 +68,4 @@ pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse};
 pub use selector::{DefaultWorkerSelector, WorkerSelector};
-pub use tracking_hash::{
-    DEFAULT_TRACKING_ROUTING_GROUP, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
-};
+pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -950,13 +950,13 @@ fn random_sequence_hashes(num_blocks: usize) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::RoutingPartitionRef;
     use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo, compute_seq_hash_for_block};
     use std::collections::HashMap;
 
     fn test_tracking_scope(block_size: u32) -> TrackingHashScope<'static> {
         TrackingHashScope {
-            model_name: "model",
-            routing_group: "default",
+            partition: RoutingPartitionRef::new("model", "default"),
             block_size,
         }
     }

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -13,6 +13,7 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::{RoutingPartitionId, RoutingPartitionRef};
 use crate::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
 use crate::sequences::{SequencePublisher, SequenceSubscriber};
 use crate::services::common::zmq::{create_bound_pub_socket, create_sub_socket, validate_endpoint};
@@ -27,6 +28,20 @@ pub(crate) struct ScopedReplicaEvent {
     pub routing_group: String,
     pub block_size: u32,
     pub event: ActiveSequenceEvent,
+}
+
+impl ScopedReplicaEvent {
+    pub(crate) fn partition_ref(&self) -> RoutingPartitionRef<'_> {
+        RoutingPartitionRef::new(&self.model_name, &self.routing_group)
+    }
+
+    pub(crate) fn into_parts(self) -> (RoutingPartitionId, u32, ActiveSequenceEvent) {
+        (
+            RoutingPartitionId::new(self.model_name, self.routing_group),
+            self.block_size,
+            self.event,
+        )
+    }
 }
 
 pub(crate) type ReplicaEventSender = mpsc::Sender<ScopedReplicaEvent>;
@@ -104,8 +119,7 @@ pub(crate) struct ScopedSequencePublisher {
 
 #[derive(Clone)]
 struct ScopedReplicaPublisher {
-    model_name: Arc<str>,
-    routing_group: Arc<str>,
+    partition: Arc<RoutingPartitionId>,
     block_size: u32,
     tx: ReplicaEventSender,
 }
@@ -116,15 +130,13 @@ impl ScopedSequencePublisher {
     }
 
     pub(crate) fn enabled(
-        model_name: Arc<str>,
-        routing_group: Arc<str>,
+        partition: Arc<RoutingPartitionId>,
         block_size: u32,
         tx: ReplicaEventSender,
     ) -> Self {
         Self {
             replica: Some(ScopedReplicaPublisher {
-                model_name,
-                routing_group,
+                partition,
                 block_size,
                 tx,
             }),
@@ -141,8 +153,8 @@ impl SequencePublisher for ScopedSequencePublisher {
             return future::ready(Ok(()));
         };
         let envelope = ScopedReplicaEvent {
-            model_name: replica.model_name.to_string(),
-            routing_group: replica.routing_group.to_string(),
+            model_name: replica.partition.model_name.clone(),
+            routing_group: replica.partition.routing_group.clone(),
             block_size: replica.block_size,
             event: event.clone(),
         };
@@ -240,8 +252,7 @@ pub(crate) fn setup_replica_sync(
 
 pub(crate) fn setup_scoped_replica_sync(
     config: Option<&ReplicaSyncConfig>,
-    model_name: &str,
-    routing_group: &str,
+    partition: &RoutingPartitionId,
     block_size: u32,
 ) -> ScopedReplicaSync {
     let Some(config) = config else {
@@ -256,8 +267,7 @@ pub(crate) fn setup_scoped_replica_sync(
     let (replica_tx, replica_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
     ScopedReplicaSync {
         publisher: ScopedSequencePublisher::enabled(
-            Arc::from(model_name),
-            Arc::from(routing_group),
+            Arc::new(partition.clone()),
             block_size,
             config.outbound_tx.clone(),
         ),
@@ -289,10 +299,13 @@ pub(crate) fn start_replica_publisher(
             };
 
             let request_id = event.event.request_id.clone();
+            let partition = event.partition_ref();
             let payload = match rmp_serde::to_vec_named(&event) {
                 Ok(payload) => payload,
                 Err(error) => {
                     tracing::error!(
+                        model_name = %partition.model_name,
+                        routing_group = %partition.routing_group,
                         request_id = %request_id,
                         "Failed to encode active-sequence replica event: {error}"
                     );
@@ -304,6 +317,8 @@ pub(crate) fn start_replica_publisher(
                 .await
             {
                 tracing::error!(
+                    model_name = %partition.model_name,
+                    routing_group = %partition.routing_group,
                     request_id = %request_id,
                     "Failed to publish active-sequence replica event: {error}"
                 );
@@ -530,7 +545,7 @@ mod tests {
     use super::*;
     use crate::protocols::{ActiveSequenceEventData, WorkerWithDpRank};
     #[cfg(feature = "standalone-slot-tracker")]
-    use crate::services::slot_tracker::registry::{SlotTrackerRegistry, TrackerKey};
+    use crate::services::slot_tracker::registry::SlotTrackerRegistry;
 
     fn event() -> ScopedReplicaEvent {
         ScopedReplicaEvent {
@@ -573,12 +588,39 @@ mod tests {
     fn replica_event_wire_schema_uses_routing_group() {
         let payload = rmp_serde::to_vec_named(&event()).unwrap();
         let value: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
+        let fields = value.as_object().unwrap();
 
+        assert_eq!(fields.len(), 4);
+        assert!(fields.contains_key("model_name"));
         assert_eq!(value["routing_group"], "group");
+        assert!(fields.contains_key("block_size"));
+        assert!(fields.contains_key("event"));
+        assert!(value.get("partition").is_none());
         assert!(value.get("tenant_id").is_none());
 
         let decoded: ScopedReplicaEvent = rmp_serde::from_slice(&payload).unwrap();
-        assert_eq!(decoded.routing_group, "group");
+        assert_eq!(
+            decoded.partition_ref(),
+            RoutingPartitionRef::new("model", "group")
+        );
+    }
+
+    #[test]
+    fn previous_flat_replica_event_wire_schema_is_accepted() {
+        let previous = serde_json::json!({
+            "model_name": "model",
+            "routing_group": "group",
+            "block_size": 16,
+            "event": event().event,
+        });
+        let payload = rmp_serde::to_vec_named(&previous).unwrap();
+
+        let decoded: ScopedReplicaEvent = rmp_serde::from_slice(&payload).unwrap();
+        assert_eq!(
+            decoded.partition_ref(),
+            RoutingPartitionRef::new("model", "group")
+        );
+        assert_eq!(decoded.block_size, 16);
     }
 
     #[test]
@@ -597,8 +639,11 @@ mod tests {
     #[tokio::test]
     async fn scoped_publisher_drops_when_outbound_channel_is_full() {
         let (tx, mut rx) = mpsc::channel(1);
-        let publisher =
-            ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("group"), 16, tx);
+        let publisher = ScopedSequencePublisher::enabled(
+            Arc::new(RoutingPartitionId::new("model", "group")),
+            16,
+            tx,
+        );
         let event = event().event;
 
         publisher.publish_event(&event).await.unwrap();
@@ -678,7 +723,7 @@ mod tests {
                 dispatch_registry_b.dispatch_replica_event(event)
             })
             .unwrap();
-        let key = TrackerKey::new("model".to_string(), Some("group".to_string()));
+        let key = RoutingPartitionId::new("model", "group");
         registry_a.register(key.clone(), 1, 16, 0, 1).unwrap();
         registry_b.register(key.clone(), 1, 16, 0, 1).unwrap();
         let worker = WorkerWithDpRank::new(1, 0);

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -9,7 +9,8 @@
 //! a ZMQ listener that ingests its KV events into a per-(model, routing group)
 //! [`backend::Indexer`].
 //!
-//! `IndexerKey { model_name, routing_group }` remains this service's sole registry authority.
+//! [`RoutingPartitionId`](crate::identity::RoutingPartitionId) remains this service's sole registry
+//! authority for `(model_name, routing_group)`.
 //! Resolving it to `IndexerDomainId` is intentionally deferred until registration can carry
 //! authoritative explicit identity material; hashing local defaults here would create a second
 //! authority without enabling safe cross-service identity.

--- a/lib/kv-router/src/services/indexer/recovery.rs
+++ b/lib/kv-router/src/services/indexer/recovery.rs
@@ -6,9 +6,10 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::RouterEvent;
 
-use super::registry::{IndexerKey, WorkerRegistry};
+use super::registry::WorkerRegistry;
 
 #[derive(Deserialize)]
 struct DumpEntry {
@@ -65,10 +66,7 @@ async fn try_recover_from_peer(
             .split_once(':')
             .ok_or_else(|| anyhow::anyhow!("invalid dump key format: {map_key}"))?;
 
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         let indexer = registry.get_or_create_indexer(key, entry.block_size);
 

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -14,17 +14,12 @@ use serde::Serialize;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::indexer::KvIndexerMetrics;
 use crate::protocols::WorkerId;
 
 use super::backend::{Indexer, create_indexer_with_metrics};
 use super::listener::spawn_zmq_listener;
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct IndexerKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
 
 pub struct IndexerEntry {
     pub indexer: Indexer,
@@ -309,13 +304,13 @@ impl ListenerRecord {
 }
 
 pub struct WorkerEntry {
-    key: IndexerKey,
+    key: RoutingPartitionId,
     listeners: HashMap<u32, Arc<ListenerRecord>>,
 }
 
 pub struct WorkerRegistry {
     workers: DashMap<WorkerId, WorkerEntry>,
-    indexers: DashMap<IndexerKey, IndexerEntry>,
+    indexers: DashMap<RoutingPartitionId, IndexerEntry>,
     peers: DashMap<String, ()>,
     watermarks: DashMap<(WorkerId, u32), Arc<AtomicU64>>,
     num_threads: usize,
@@ -418,10 +413,7 @@ impl WorkerRegistry {
         block_size: u32,
         replay_endpoint: Option<String>,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name,
-            routing_group,
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
@@ -504,10 +496,7 @@ impl WorkerRegistry {
         model_name: &str,
         routing_group: &str,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
@@ -546,10 +535,7 @@ impl WorkerRegistry {
         model_name: &str,
         routing_group: &str,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         let (record, remove_worker) = {
             let mut entry = self
@@ -741,11 +727,14 @@ impl WorkerRegistry {
             .collect()
     }
 
-    pub fn get_indexer(&self, key: &IndexerKey) -> Option<Ref<'_, IndexerKey, IndexerEntry>> {
+    pub fn get_indexer(
+        &self,
+        key: &RoutingPartitionId,
+    ) -> Option<Ref<'_, RoutingPartitionId, IndexerEntry>> {
         self.indexers.get(key)
     }
 
-    pub fn get_or_create_indexer(&self, key: IndexerKey, block_size: u32) -> Indexer {
+    pub fn get_or_create_indexer(&self, key: RoutingPartitionId, block_size: u32) -> Indexer {
         let entry = self.indexers.entry(key.clone()).or_insert_with(|| {
             tracing::info!(
                 model_name = %key.model_name,
@@ -774,7 +763,7 @@ impl WorkerRegistry {
         entry.indexer.clone()
     }
 
-    pub fn all_indexers_with_block_size(&self) -> Vec<(IndexerKey, Indexer, u32)> {
+    pub fn all_indexers_with_block_size(&self) -> Vec<(RoutingPartitionId, Indexer, u32)> {
         self.indexers
             .iter()
             .map(|entry| {
@@ -818,7 +807,7 @@ impl WorkerRegistry {
         );
     }
 
-    fn maybe_remove_indexer(&self, key: &IndexerKey) {
+    fn maybe_remove_indexer(&self, key: &RoutingPartitionId) {
         if self.workers.iter().any(|entry| entry.value().key == *key) {
             return;
         }
@@ -1123,10 +1112,7 @@ mod tests {
         // trivially without exercising the filter.
         let registry = test_registry();
 
-        let key = IndexerKey {
-            model_name: "llama3".to_string(),
-            routing_group: "acme".to_string(),
-        };
+        let key = RoutingPartitionId::new("llama3", "acme");
 
         // Inject the empty-listener WorkerEntry directly.
         registry.workers.insert(

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -14,6 +14,7 @@ use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 #[cfg(feature = "metrics")]
 use crate::indexer::KvIndexerMetrics;
 use crate::indexer::TieredMatchDetails;
@@ -21,7 +22,7 @@ use crate::protocols::{BlockHashOptions, LocalBlockHash, WorkerId, compute_block
 use crate::services::overlap::{MooncakeOverlapSummary, build_mooncake_overlap_summaries};
 
 use super::backend::Indexer;
-use super::registry::{IndexerKey, ListenerControlError, WorkerRegistry};
+use super::registry::{ListenerControlError, WorkerRegistry};
 
 /// We need to fit one million tokens as JSON text, this should do it.
 const QUERY_REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
@@ -77,10 +78,6 @@ impl AppState {
             access_log_sink: None,
         })
     }
-}
-
-fn default_routing_group() -> String {
-    "default".to_string()
 }
 
 #[derive(Deserialize)]
@@ -316,10 +313,7 @@ async fn run_tiered_query(
 
 async fn query(State(state): State<Arc<AppState>>, Json(req): Json<QueryRequest>) -> Response {
     let model = req.model_name.clone();
-    let key = IndexerKey {
-        model_name: req.model_name,
-        routing_group: req.routing_group,
-    };
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,
@@ -370,10 +364,7 @@ async fn query_by_hash(
         return resp;
     }
 
-    let key = IndexerKey {
-        model_name: req.model_name,
-        routing_group: req.routing_group,
-    };
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,

--- a/lib/kv-router/src/services/selection/catalog.rs
+++ b/lib/kv-router/src/services/selection/catalog.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 
 use parking_lot::RwLock;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::{WorkerId, WorkerWithDpRank};
 
 use super::error::SelectionError;
 use super::types::{
-    SelectionKey, SelectionWorkerConfig, WorkerCatalogRecord, WorkerLifecycle, WorkerPatchRequest,
-    WorkerRequest,
+    SelectionWorkerConfig, WorkerCatalogRecord, WorkerLifecycle, WorkerPatchRequest, WorkerRequest,
 };
 
 #[derive(Debug, Default)]
@@ -91,7 +91,7 @@ impl WorkerCatalog {
         records
     }
 
-    pub(super) fn has_schedulable_for_key(&self, key: &SelectionKey) -> bool {
+    pub(super) fn has_schedulable_for_key(&self, key: &RoutingPartitionId) -> bool {
         self.workers.read().values().any(|record| {
             record.lifecycle == WorkerLifecycle::Schedulable
                 && record.model_name == key.model_name
@@ -101,7 +101,7 @@ impl WorkerCatalog {
 
     pub(super) fn scheduler_configs_for_key(
         &self,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> HashMap<WorkerId, SelectionWorkerConfig> {
         self.workers
             .read()
@@ -130,7 +130,7 @@ impl WorkerCatalog {
     pub(super) fn schedulable_endpoint(
         &self,
         worker_id: WorkerId,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Option<String> {
         let workers = self.workers.read();
         let record = workers.get(&worker_id)?;
@@ -146,7 +146,7 @@ impl WorkerCatalog {
     pub(super) fn schedulable_worker_endpoint(
         &self,
         worker: WorkerWithDpRank,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Option<String> {
         let workers = self.workers.read();
         let record = workers.get(&worker.worker_id)?;

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -10,6 +10,7 @@ use parking_lot::RwLock;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::indexer::TieredMatchDetails;
 use crate::protocols::{
     ActiveSequenceEvent, LocalBlockHash, PrefillLoadHint, RoutingConstraints, WorkerId,
@@ -41,8 +42,8 @@ use super::pending::{PendingSelection, SelectionCache, SelectionCacheConfig};
 use super::types::{
     ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
     ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
-    SelectResponse, SelectionKey, SelectionWorkerConfig, WORKER_TYPE, WorkerCatalogRecord,
-    WorkerLifecycle, WorkerPatchRequest, WorkerRequest,
+    SelectResponse, SelectionWorkerConfig, WORKER_TYPE, WorkerCatalogRecord, WorkerLifecycle,
+    WorkerPatchRequest, WorkerRequest,
 };
 
 type SelectionScheduler = LocalScheduler<
@@ -53,7 +54,7 @@ type SelectionScheduler = LocalScheduler<
 >;
 
 struct SelectionEntry {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     block_size: u32,
     is_eagle: bool,
     indexer: Indexer,
@@ -70,7 +71,7 @@ struct PreparedSelectionInputs {
 }
 
 struct SelectionOperation {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     selection_id: Option<String>,
     prompt: PromptRequest,
     router_config_override: Option<RouterConfigOverride>,
@@ -87,7 +88,7 @@ struct SelectionOperation {
 /// Resolved inputs for booking a reservation, shared by the cached and explicit
 /// `create_reservation` paths.
 struct ReservationBooking {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     selection_id: String,
     worker: WorkerWithDpRank,
     sequence_hashes: Vec<SequenceHash>,
@@ -110,7 +111,7 @@ pub struct SelectionServiceConfig {
 
 pub struct SelectionCore {
     catalog: WorkerCatalog,
-    entries: RwLock<HashMap<SelectionKey, Arc<SelectionEntry>>>,
+    entries: RwLock<HashMap<RoutingPartitionId, Arc<SelectionEntry>>>,
     indexer_registry: Arc<WorkerRegistry>,
     kv_router_config: crate::config::KvRouterConfig,
     cancel_token: CancellationToken,
@@ -249,24 +250,24 @@ impl SelectionCore {
     }
 
     pub(crate) fn dispatch_replica_event(&self, envelope: ScopedReplicaEvent) {
+        let (key, block_size, event) = envelope.into_parts();
         if self
             .replica_config
             .as_ref()
-            .is_some_and(|config| config.is_self_event(&envelope.event))
+            .is_some_and(|config| config.is_self_event(&event))
         {
             return;
         }
 
-        let key = SelectionKey::new(envelope.model_name, envelope.routing_group);
         let Some(entry) = self.entries.read().get(&key).cloned() else {
             tracing::trace!(%key, "Dropping replica event for unknown selector entry");
             return;
         };
-        if entry.block_size != envelope.block_size {
+        if entry.block_size != block_size {
             tracing::debug!(
                 %key,
                 expected_block_size = entry.block_size,
-                received_block_size = envelope.block_size,
+                received_block_size = block_size,
                 "Dropping selector replica event with mismatched block size"
             );
             return;
@@ -274,7 +275,7 @@ impl SelectionCore {
         let Some(replica_tx) = &entry.replica_tx else {
             return;
         };
-        match replica_tx.try_send(envelope.event) {
+        match replica_tx.try_send(event) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
@@ -410,7 +411,7 @@ impl SelectionCore {
     fn mark_incomplete_after_reconcile_error(
         &self,
         worker_id: WorkerId,
-        key: SelectionKey,
+        key: RoutingPartitionId,
         error: SelectionError,
     ) -> Result<WorkerCatalogRecord, SelectionError> {
         let updated = self
@@ -469,12 +470,8 @@ impl SelectionCore {
         }
 
         let (workers_tx, workers_rx) = watch::channel(HashMap::new());
-        let scoped_replica_sync = setup_scoped_replica_sync(
-            self.replica_config.as_ref(),
-            &key.model_name,
-            &key.routing_group,
-            block_size,
-        );
+        let scoped_replica_sync =
+            setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
         let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -492,7 +489,7 @@ impl SelectionCore {
 
         let indexer = self
             .indexer_registry
-            .get_or_create_indexer(key.indexer_key(), block_size);
+            .get_or_create_indexer(key.clone(), block_size);
         let overlap_refresh = Arc::new(TieredOverlapRefresher::new(
             indexer.clone(),
             self.kv_router_config.clone(),
@@ -590,7 +587,7 @@ impl SelectionCore {
             return;
         }
 
-        let key = record.key().indexer_key();
+        let key = record.key();
         let indexer = self
             .indexer_registry
             .get_indexer(&key)
@@ -600,7 +597,7 @@ impl SelectionCore {
         }
     }
 
-    fn publish_scheduler_config(&self, key: &SelectionKey) -> Result<(), SelectionError> {
+    fn publish_scheduler_config(&self, key: &RoutingPartitionId) -> Result<(), SelectionError> {
         let Some(entry) = self.entries.read().get(key).cloned() else {
             return Ok(());
         };
@@ -610,7 +607,7 @@ impl SelectionCore {
         })
     }
 
-    fn ready_entry(&self, key: &SelectionKey) -> Result<Arc<SelectionEntry>, SelectionError> {
+    fn ready_entry(&self, key: &RoutingPartitionId) -> Result<Arc<SelectionEntry>, SelectionError> {
         if self.catalog.schedulable_count() == 0 {
             return Err(SelectionError::NotReady(
                 "no schedulable workers are available".to_string(),
@@ -641,7 +638,7 @@ impl SelectionCore {
     ) -> Result<SelectResponse, SelectionError> {
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.routing_group),
+                key: RoutingPartitionId::new(req.model_name, req.routing_group),
                 selection_id: req.selection_id,
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
@@ -676,7 +673,7 @@ impl SelectionCore {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.routing_group),
+                key: RoutingPartitionId::new(req.model_name, req.routing_group),
                 selection_id: Some(selection_id),
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
@@ -833,7 +830,7 @@ impl SelectionCore {
     ) -> Result<ReservationResponse, SelectionError> {
         self.ensure_running()?;
 
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
 
         // Explicit form: book on the given worker under selection_id, discarding
         // any cached selection for the id so a later replay can't book stale state.
@@ -917,7 +914,7 @@ impl SelectionCore {
     fn schedulable_endpoint(
         &self,
         worker_id: WorkerId,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Result<String, SelectionError> {
         self.catalog
             .schedulable_endpoint(worker_id, key)
@@ -931,7 +928,7 @@ impl SelectionCore {
     /// Book a reservation from a self-contained request (explicit worker_id and prompt).
     async fn reserve_explicit(
         &self,
-        key: SelectionKey,
+        key: RoutingPartitionId,
         worker_id: WorkerId,
         req: ReservationRequest,
     ) -> Result<ReservationResponse, SelectionError> {
@@ -1115,7 +1112,7 @@ impl SelectionCore {
         &self,
         req: PotentialLoadsRequest,
     ) -> Result<Vec<PotentialLoad>, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let prepared = self
             .prepare_selection_inputs(
@@ -1142,7 +1139,7 @@ impl SelectionCore {
         &self,
         req: OverlapScoresRequest,
     ) -> Result<OverlapScoresResponse, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let block_hashes = req
             .prompt
@@ -1201,7 +1198,7 @@ impl SelectionCore {
         })
     }
 
-    fn schedulable_worker_ranks(&self, key: &SelectionKey) -> Vec<WorkerWithDpRank> {
+    fn schedulable_worker_ranks(&self, key: &RoutingPartitionId) -> Vec<WorkerWithDpRank> {
         let configs = self.catalog.scheduler_configs_for_key(key);
         let mut workers = Vec::new();
         for (worker_id, config) in configs {
@@ -1217,8 +1214,7 @@ impl SelectionCore {
 
 fn tracking_scope(entry: &SelectionEntry) -> TrackingHashScope<'_> {
     TrackingHashScope {
-        model_name: &entry.key.model_name,
-        routing_group: &entry.key.routing_group,
+        partition: entry.key.as_ref(),
         block_size: entry.block_size,
     }
 }
@@ -1564,7 +1560,7 @@ mod tests {
             request.max_num_batched_tokens = Some(8);
             core.upsert_worker(request).await.expect("worker upsert");
         }
-        let key = SelectionKey::new("model".to_string(), "default".to_string());
+        let key = RoutingPartitionId::new("model", "default");
         let entry = core.entries.read().get(&key).cloned().expect("entry");
         entry
             .indexer

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -27,7 +27,7 @@ pub use service::{SelectionService, SelectionServiceBuilder};
 pub use types::{
     ModelLoadResponse, OutputBlockRequest, OverlapScoresRequest, OverlapScoresResponse,
     PotentialLoadsRequest, ReadyResponse, ReservationRequest, ReservationResponse,
-    SelectAndReserveRequest, SelectRequest, SelectResponse, SelectionKey, SelectionWorkerConfig,
+    SelectAndReserveRequest, SelectRequest, SelectResponse, SelectionWorkerConfig,
     SharedCacheOverlapScore, WorkerCatalogRecord, WorkerLifecycle, WorkerOverlapScore,
     WorkerPatchRequest, WorkerRequest,
 };

--- a/lib/kv-router/src/services/selection/pending.rs
+++ b/lib/kv-router/src/services/selection/pending.rs
@@ -12,9 +12,8 @@ use std::time::{Duration, Instant};
 use dynamo_tokens::SequenceHash;
 use parking_lot::Mutex;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::WorkerWithDpRank;
-
-use super::types::SelectionKey;
 
 /// How long a pending selection lives before it is evicted.
 const SELECTION_CACHE_TTL: Duration = Duration::from_secs(120);
@@ -49,7 +48,7 @@ impl Default for SelectionCacheConfig {
 
 /// Booking inputs captured by `select`, replayed by a later `create_reservation`.
 pub(super) struct PendingSelection {
-    pub key: SelectionKey,
+    pub key: RoutingPartitionId,
     pub worker: WorkerWithDpRank,
     pub sequence_hashes: Vec<SequenceHash>,
     pub isl_tokens: usize,
@@ -66,8 +65,8 @@ struct Entry {
     bytes: usize,
 }
 
-/// Scoped by `(SelectionKey, selection_id)`; `SelectionKey` is (model, routing_group).
-type CacheKey = (SelectionKey, String);
+/// Scoped by `(RoutingPartitionId, selection_id)`.
+type CacheKey = (RoutingPartitionId, String);
 
 /// Approximate resident bytes: sequence hashes plus id and scope strings.
 fn entry_bytes(key: &CacheKey, selection: &PendingSelection) -> usize {
@@ -87,7 +86,7 @@ struct State {
     total_bytes: usize,
 }
 
-/// Maps `(SelectionKey, selection_id)` -> the booking inputs computed during `select`.
+/// Maps `(RoutingPartitionId, selection_id)` to the booking inputs computed during `select`.
 pub(super) struct SelectionCache {
     ttl: Duration,
     max_entries: usize,
@@ -183,7 +182,7 @@ impl SelectionCache {
     /// once the booking lands.
     pub(super) fn peek(
         &self,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
         selection_id: &str,
         now: Instant,
     ) -> Option<(Arc<PendingSelection>, u64)> {
@@ -198,7 +197,7 @@ impl SelectionCache {
 
     /// Consume the entry after a booking lands, only if its `generation` still
     /// matches the peek; a newer `select` for the id survives.
-    pub(super) fn remove(&self, key: &SelectionKey, selection_id: &str, generation: u64) {
+    pub(super) fn remove(&self, key: &RoutingPartitionId, selection_id: &str, generation: u64) {
         let cache_key = (key.clone(), selection_id.to_string());
         let mut state = self.state.lock();
         if state
@@ -211,7 +210,7 @@ impl SelectionCache {
     }
 
     /// Drop any cached selection for the id (an explicit booking supersedes it).
-    pub(super) fn discard(&self, key: &SelectionKey, selection_id: &str) {
+    pub(super) fn discard(&self, key: &RoutingPartitionId, selection_id: &str) {
         let cache_key = (key.clone(), selection_id.to_string());
         let mut state = self.state.lock();
         self.remove_locked(&mut state, &cache_key);
@@ -254,8 +253,8 @@ mod tests {
         cache_with(CAP, usize::MAX)
     }
 
-    fn key() -> SelectionKey {
-        SelectionKey::new("model", "default")
+    fn key() -> RoutingPartitionId {
+        RoutingPartitionId::new("model", "default")
     }
 
     fn pending(worker_id: u64) -> PendingSelection {

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -14,6 +14,7 @@ use tower::ServiceExt;
 use super::input::{MmRoutingInfoRequest, PromptRequest, TrackingHashInput};
 use super::server::create_router;
 use super::*;
+use crate::identity::RoutingPartitionRef;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier,
@@ -46,8 +47,7 @@ fn normalize_prompt(request: &PromptRequest) -> super::input::NormalizedPrompt {
             TrackingHashInput {
                 context: &context,
                 scope: TrackingHashScope {
-                    model_name: "model",
-                    routing_group: "default",
+                    partition: RoutingPartitionRef::new("model", "default"),
                     block_size: 4,
                 },
                 assume_kv_reuse: true,
@@ -214,8 +214,7 @@ fn keyed_prompt_tracking_leaves_indexer_hashes_public() {
             TrackingHashInput {
                 context: &context,
                 scope: TrackingHashScope {
-                    model_name: "model",
-                    routing_group: "default",
+                    partition: RoutingPartitionRef::new("model", "default"),
                     block_size: 4,
                 },
                 assume_kv_reuse: true,
@@ -253,8 +252,7 @@ fn disabled_kv_reuse_keeps_public_indexer_hashes_and_randomizes_tracking() {
                 TrackingHashInput {
                     context: &context,
                     scope: TrackingHashScope {
-                        model_name: "model",
-                        routing_group: "default",
+                        partition: RoutingPartitionRef::new("model", "default"),
                         block_size: 4,
                     },
                     assume_kv_reuse: false,
@@ -290,8 +288,7 @@ fn keyed_reservation_hashes_directly_from_tokens() {
     }))
     .unwrap();
     let scope = TrackingHashScope {
-        model_name: "model",
-        routing_group: "default",
+        partition: RoutingPartitionRef::new("model", "default"),
         block_size: 4,
     };
 
@@ -346,8 +343,7 @@ fn randomized_reservation_uses_canonical_complete_block_count() {
                 TrackingHashInput {
                     context: &context,
                     scope: TrackingHashScope {
-                        model_name: "model",
-                        routing_group: "default",
+                        partition: RoutingPartitionRef::new("model", "default"),
                         block_size: 4,
                     },
                     assume_kv_reuse: false,

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 use crate::protocols::{
     DpRank, KvTransferEnforcement, RoutingConstraints, WorkerConfigLike, WorkerId, WorkerWithDpRank,
 };
 use crate::scheduling::PotentialLoad;
 use crate::scheduling::config::RouterConfigOverride;
 pub use crate::scheduling::{OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore};
-use crate::services::indexer::registry::IndexerKey;
 use crate::services::overlap::MooncakeOverlapSummary;
-use crate::tracking_hash::DEFAULT_TRACKING_ROUTING_GROUP;
 
 use super::input::PromptRequest;
 
@@ -24,42 +22,6 @@ pub(super) const REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
 fn default_model_name() -> String {
     DEFAULT_MODEL_NAME.to_string()
-}
-
-fn default_routing_group() -> String {
-    DEFAULT_TRACKING_ROUTING_GROUP.to_string()
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
-pub struct SelectionKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
-
-impl SelectionKey {
-    pub(super) fn new(model_name: impl Into<String>, routing_group: impl Into<String>) -> Self {
-        Self {
-            model_name: model_name.into(),
-            routing_group: routing_group.into(),
-        }
-    }
-
-    pub(super) fn indexer_key(&self) -> IndexerKey {
-        IndexerKey {
-            model_name: self.model_name.clone(),
-            routing_group: self.routing_group.clone(),
-        }
-    }
-}
-
-impl fmt::Display for SelectionKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "model={} routing_group={}",
-            self.model_name, self.routing_group
-        )
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -187,8 +149,8 @@ impl WorkerCatalogRecord {
         }
     }
 
-    pub(super) fn key(&self) -> SelectionKey {
-        SelectionKey::new(self.model_name.clone(), self.routing_group.clone())
+    pub(super) fn key(&self) -> RoutingPartitionId {
+        RoutingPartitionId::new(self.model_name.clone(), self.routing_group.clone())
     }
 
     pub(super) fn dp_start(&self) -> u32 {

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::{PrefillLoadHint, WorkerId, WorkerWithDpRank};
 use crate::scheduling::PotentialLoad;
 use crate::sequences::topology::{WorkerDpRange, WorkerTopologyError};
@@ -23,25 +24,6 @@ use crate::sequences::{
 use crate::services::common::replica_sync::{
     ReplicaSyncConfig, ScopedReplicaEvent, ScopedSequencePublisher, setup_scoped_replica_sync,
 };
-
-fn default_routing_group() -> String {
-    "default".to_string()
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct TrackerKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
-
-impl TrackerKey {
-    pub fn new(model_name: String, routing_group: Option<String>) -> Self {
-        Self {
-            model_name,
-            routing_group: routing_group.unwrap_or_else(default_routing_group),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WorkerInfo {
@@ -117,18 +99,13 @@ struct TrackerEntry {
 
 impl TrackerEntry {
     fn new(
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         block_size: u32,
         root_cancel_token: &CancellationToken,
         replica_config: Option<&ReplicaSyncConfig>,
     ) -> Arc<Self> {
         let cancel_token = root_cancel_token.child_token();
-        let scoped_replica_sync = setup_scoped_replica_sync(
-            replica_config,
-            &key.model_name,
-            &key.routing_group,
-            block_size,
-        );
+        let scoped_replica_sync = setup_scoped_replica_sync(replica_config, key, block_size);
         let tracker = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -154,7 +131,7 @@ impl TrackerEntry {
 }
 
 pub struct SlotTrackerRegistry {
-    trackers: DashMap<TrackerKey, Arc<TrackerEntry>>,
+    trackers: DashMap<RoutingPartitionId, Arc<TrackerEntry>>,
     root_cancel_token: CancellationToken,
     replica_config: Option<ReplicaSyncConfig>,
 }
@@ -181,7 +158,7 @@ impl SlotTrackerRegistry {
 
     pub fn register(
         &self,
-        key: TrackerKey,
+        key: RoutingPartitionId,
         worker_id: WorkerId,
         block_size: u32,
         dp_start: u32,
@@ -227,7 +204,11 @@ impl SlotTrackerRegistry {
         }
     }
 
-    pub fn unregister(&self, key: &TrackerKey, worker_id: WorkerId) -> Result<(), RegistryError> {
+    pub fn unregister(
+        &self,
+        key: &RoutingPartitionId,
+        worker_id: WorkerId,
+    ) -> Result<(), RegistryError> {
         loop {
             let Some(entry) = self
                 .trackers
@@ -296,7 +277,7 @@ impl SlotTrackerRegistry {
 
     pub fn add_request(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         request_id: String,
         worker: WorkerWithDpRank,
         sequence_hashes: Vec<SequenceHash>,
@@ -324,7 +305,7 @@ impl SlotTrackerRegistry {
 
     pub fn mark_prefill_completed(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         request_id: &str,
     ) -> Result<(), ServiceError> {
         let entry = self.entry(key)?;
@@ -334,7 +315,7 @@ impl SlotTrackerRegistry {
         Ok(())
     }
 
-    pub fn free(&self, key: &TrackerKey, request_id: &str) -> Result<(), ServiceError> {
+    pub fn free(&self, key: &RoutingPartitionId, request_id: &str) -> Result<(), ServiceError> {
         let entry = self.entry(key)?;
         entry
             .tracker
@@ -383,7 +364,7 @@ impl SlotTrackerRegistry {
 
     pub fn potential_loads(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         sequence_hashes: &[SequenceHash],
         new_isl_tokens: usize,
     ) -> Result<Vec<PotentialLoad>, RegistryError> {
@@ -407,15 +388,15 @@ impl SlotTrackerRegistry {
     }
 
     pub(crate) fn dispatch_replica_event(&self, envelope: ScopedReplicaEvent) {
+        let (key, block_size, event) = envelope.into_parts();
         if self
             .replica_config
             .as_ref()
-            .is_some_and(|config| config.is_self_event(&envelope.event))
+            .is_some_and(|config| config.is_self_event(&event))
         {
             return;
         }
 
-        let key = TrackerKey::new(envelope.model_name, Some(envelope.routing_group));
         let Some(entry) = self
             .trackers
             .get(&key)
@@ -428,12 +409,12 @@ impl SlotTrackerRegistry {
             );
             return;
         };
-        if entry.block_size != envelope.block_size {
+        if entry.block_size != block_size {
             tracing::debug!(
                 model_name = %key.model_name,
                 routing_group = %key.routing_group,
                 expected_block_size = entry.block_size,
-                received_block_size = envelope.block_size,
+                received_block_size = block_size,
                 "Dropping replica event with mismatched block size"
             );
             return;
@@ -441,7 +422,7 @@ impl SlotTrackerRegistry {
         let Some(replica_tx) = &entry.replica_tx else {
             return;
         };
-        match replica_tx.try_send(envelope.event) {
+        match replica_tx.try_send(event) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
@@ -461,7 +442,7 @@ impl SlotTrackerRegistry {
         }
     }
 
-    fn entry(&self, key: &TrackerKey) -> Result<Arc<TrackerEntry>, RegistryError> {
+    fn entry(&self, key: &RoutingPartitionId) -> Result<Arc<TrackerEntry>, RegistryError> {
         self.trackers
             .get(key)
             .map(|entry| Arc::clone(entry.value()))
@@ -471,7 +452,7 @@ impl SlotTrackerRegistry {
             })
     }
 
-    fn is_attached(&self, key: &TrackerKey, entry: &Arc<TrackerEntry>) -> bool {
+    fn is_attached(&self, key: &RoutingPartitionId, entry: &Arc<TrackerEntry>) -> bool {
         self.trackers
             .get(key)
             .is_some_and(|current| Arc::ptr_eq(current.value(), entry))
@@ -494,7 +475,7 @@ fn validate_block_size(block_size: u32) -> Result<(), RegistryError> {
     Ok(())
 }
 
-fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError {
+fn topology_error(key: &RoutingPartitionId, error: WorkerTopologyError) -> RegistryError {
     match error {
         WorkerTopologyError::InvalidDpSize { .. } => RegistryError::InvalidDpSize,
         WorkerTopologyError::InvalidDpRange {
@@ -514,7 +495,7 @@ fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError
 }
 
 fn matches_filters(
-    key: &TrackerKey,
+    key: &RoutingPartitionId,
     model_name: Option<&str>,
     routing_group: Option<&str>,
 ) -> bool {
@@ -531,8 +512,8 @@ mod tests {
         SlotTrackerRegistry::new(CancellationToken::new())
     }
 
-    fn key(routing_group: &str) -> TrackerKey {
-        TrackerKey::new("model".to_string(), Some(routing_group.to_string()))
+    fn key(routing_group: &str) -> RoutingPartitionId {
+        RoutingPartitionId::new("model", routing_group)
     }
 
     fn replica_event(

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -14,19 +14,16 @@ use dynamo_tokens::SequenceHash;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 use crate::protocols::WorkerWithDpRank;
 use crate::sequences::SequenceError;
 use crate::services::common::replica_sync::PeerManager;
 use crate::services::common::replica_sync_http;
 
-use super::registry::{RegistryError, ServiceError, SlotTrackerRegistry, TrackerKey};
+use super::registry::{RegistryError, ServiceError, SlotTrackerRegistry};
 
 pub struct AppState {
     pub registry: Arc<SlotTrackerRegistry>,
-}
-
-fn default_routing_group() -> String {
-    "default".to_string()
 }
 
 #[derive(Deserialize)]
@@ -123,7 +120,7 @@ async fn register(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.register(
         key,
         req.worker_id,
@@ -144,7 +141,7 @@ async fn unregister(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.unregister(&key, req.worker_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => registry_error(error),
@@ -170,7 +167,7 @@ async fn add(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
 
     // Lifecycle delivery is intentionally arrival-ordered. Consumers should
     // normally await /add before sending /prefill_complete or /free.
@@ -194,7 +191,7 @@ async fn prefill_complete(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.mark_prefill_completed(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -209,7 +206,7 @@ async fn free(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.free(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -235,7 +232,7 @@ async fn potential_loads(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state
         .registry
         .potential_loads(&key, &req.sequence_hashes, req.new_isl_tokens)

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use crate::config::KvRouterConfig;
+use crate::identity::RoutingPartitionRef;
 use crate::protocols::{
     BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
     compute_block_hash_for_seq_with_seed, compute_seq_hash_for_block,
@@ -21,9 +22,6 @@ use crate::protocols::{
 
 const KEY_SIZE: usize = 32;
 const KEYED_XXH3_V1_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/keyed-xxh3-v1\0";
-
-/// Default routing group used when a router request does not specify one.
-pub const DEFAULT_TRACKING_ROUTING_GROUP: &str = "default";
 
 /// Hash algorithm used only for router-derived active-sequence tracking state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,8 +82,7 @@ pub(crate) fn validate_tracking_hash_options(
 /// same derived tracking identities.
 #[derive(Clone, Copy, Debug)]
 pub struct TrackingHashScope<'a> {
-    pub model_name: &'a str,
-    pub routing_group: &'a str,
+    pub partition: RoutingPartitionRef<'a>,
     pub block_size: u32,
 }
 
@@ -240,8 +237,8 @@ impl TrackingHashContext {
         let mut hasher = blake3::Hasher::new_keyed(key);
         hasher.update(KEYED_XXH3_V1_DOMAIN);
         frame_string(&mut hasher, 1, self.key_id.as_deref().unwrap_or_default());
-        frame_string(&mut hasher, 2, scope.model_name);
-        frame_string(&mut hasher, 3, scope.routing_group);
+        frame_string(&mut hasher, 2, scope.partition.model_name);
+        frame_string(&mut hasher, 3, scope.partition.routing_group);
         frame_fixed(&mut hasher, 4, &scope.block_size.to_le_bytes());
         frame_optional_string(&mut hasher, 5, normalize_optional(options.cache_namespace));
         frame_optional_string(&mut hasher, 6, normalize_optional(options.lora_name));
@@ -305,8 +302,7 @@ mod tests {
 
     fn scope<'a>(model_name: &'a str, routing_group: &'a str) -> TrackingHashScope<'a> {
         TrackingHashScope {
-            model_name,
-            routing_group,
+            partition: RoutingPartitionRef::new(model_name, routing_group),
             block_size: 4,
         }
     }
@@ -395,8 +391,7 @@ mod tests {
             base,
             first.compute_sequence_hashes(
                 TrackingHashScope {
-                    model_name: "model-a",
-                    routing_group: "group-a",
+                    partition: RoutingPartitionRef::new("model-a", "group-a"),
                     block_size: 3,
                 },
                 &tokens,

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -15,12 +15,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use dynamo_kv_router::RoutingPartitionId;
 use dynamo_kv_router::protocols::{
     BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
     KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, compute_block_hash_for_seq,
     compute_seq_hash_for_block,
 };
-use dynamo_kv_router::services::indexer::registry::{IndexerKey, WorkerRegistry};
+use dynamo_kv_router::services::indexer::registry::WorkerRegistry;
 use dynamo_kv_router::services::indexer::server::{AppState, create_router};
 use dynamo_kv_router::zmq_wire::{BlockHashValue, RawKvEvent};
 use serde_json::json;
@@ -127,22 +128,14 @@ async fn add_group_events(
     block_size: u32,
     events: Vec<RouterEvent>,
 ) {
-    let indexer = registry.get_or_create_indexer(
-        IndexerKey {
-            model_name: model.to_string(),
-            routing_group: routing_group.to_string(),
-        },
-        block_size,
-    );
+    let indexer =
+        registry.get_or_create_indexer(RoutingPartitionId::new(model, routing_group), block_size);
     for event in events {
         indexer.apply_event_routed(event).await;
     }
     // Force the in-flight events through KvIndexer's mpsc channel before the
     // first query lands; otherwise the test races the indexer worker.
-    if let Some(entry) = registry.get_indexer(&IndexerKey {
-        model_name: model.to_string(),
-        routing_group: routing_group.to_string(),
-    }) {
+    if let Some(entry) = registry.get_indexer(&RoutingPartitionId::new(model, routing_group)) {
         let dump = entry.indexer.dump_events().await.expect("dump events");
         // dump_events provides the FIFO barrier we need; we don't care about
         // its contents here.
@@ -492,10 +485,7 @@ async fn duplicate_store_warning_is_exported() {
     let state = Arc::new(AppState::new(4).expect("create app state"));
     state.registry.signal_ready();
 
-    let key = IndexerKey {
-        model_name: MODEL.to_string(),
-        routing_group: ROUTING_GROUP.to_string(),
-    };
+    let key = RoutingPartitionId::new(MODEL, ROUTING_GROUP);
     let indexer = state
         .registry
         .get_or_create_indexer(key.clone(), BLOCK_SIZE);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -5,8 +5,8 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use dynamo_kv_router::{
-    DEFAULT_TRACKING_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
-    TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+    DEFAULT_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, RoutingPartitionRef,
+    SharedKvCache, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
@@ -414,8 +414,7 @@ where
 
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
         TrackingHashScope {
-            model_name: &self.tracking_model_name,
-            routing_group: DEFAULT_TRACKING_ROUTING_GROUP,
+            partition: RoutingPartitionRef::new(&self.tracking_model_name, DEFAULT_ROUTING_GROUP),
             block_size: self.block_size,
         }
     }

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -19,9 +19,9 @@ use dynamo_kv_router::scheduling::{
 };
 use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
-    ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, SchedulingRequest,
-    SequenceRequest, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
-    WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
+    ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, RoutingPartitionRef,
+    SchedulingRequest, SequenceRequest, TrackingHashAlgorithm, TrackingHashContext,
+    TrackingHashScope, WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
 };
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
@@ -552,8 +552,7 @@ impl OfflineReplayRouter {
 
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
         TrackingHashScope {
-            model_name: "replay",
-            routing_group: "default",
+            partition: RoutingPartitionRef::new("replay", "default"),
             block_size: self.block_size,
         }
     }

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -14,7 +14,9 @@ use dynamo_kv_router::protocols::{
     BlockHashOptions, OverlapScores, RouterEvent, RoutingConstraints, StorageTier, WorkerId,
 };
 use dynamo_kv_router::scheduling::TierOverlapBlocks;
-use dynamo_kv_router::{ConcurrentRadixTree, TrackingHashContext, TrackingHashScope};
+use dynamo_kv_router::{
+    ConcurrentRadixTree, RoutingPartitionRef, TrackingHashContext, TrackingHashScope,
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -235,8 +237,7 @@ impl KvReplayRouter {
         let token_seq = self.config.compute_seq_hashes_for_tracking_with_context(
             &self.tracking_hash,
             TrackingHashScope {
-                model_name: "replay",
-                routing_group: "default",
+                partition: RoutingPartitionRef::new("replay", "default"),
                 block_size: self.block_size,
             },
             &request.tokens,


### PR DESCRIPTION
## Summary

- Introduce shared `RoutingPartitionId` / borrowed `RoutingPartitionRef` for `(model_name, routing_group)` and replace selection, indexer, and tracker-specific keys.
- Keep `block_size` outside the logical partition while composing it into `TrackingHashScope`; keyed tracking vectors and scope framing remain unchanged.
- Reuse the identity in replica synchronization while retaining the existing flat `model_name`, `routing_group`, `block_size`, and `event` wire fields.

Stacked on #11548. This is the first focused consolidation from #11971; broader `IndexerDomainId`, `PoolId`, endpoint, and cache-hash identity integration remains deferred. Preserving the replica wire is scope control, not a new rolling-upgrade guarantee.

## Validation

- `cargo test -p dynamo-kv-router --features "standalone-selection standalone-slot-tracker"` — 915 passed, 2 ignored; 6 standalone indexer integration tests passed.
- `cargo test -p dynamo-llm --no-default-features --lib` — 1,533 passed, 3 ignored.
- `cargo test -p dynamo-mocker --lib` — 521 passed, 1 ignored.
- `cargo fmt --all -- --check`
- `git diff --check`
