### PR TITLE
refactor(trtllm): report max_num_seqs per attention DP rank

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.trtllm.utils.trtllm_utils import get_spec_decode_runtime_data
+from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.utils.trtllm_utils import (
+    get_spec_decode_runtime_data,
+    per_dp_rank_max_num_seqs,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -13,6 +17,53 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.mark.parametrize(
+    ("max_batch_size", "data_parallel_size", "expected"),
+    [
+        (37, 1, 37),
+        (36, 4, 9),
+        (37, 4, 9),
+        (None, 1, None),
+        (0, 1, None),
+        (-1, 1, None),
+        (True, 1, None),
+        ("37", 1, None),
+        (37, None, None),
+        (37, 0, None),
+        (37, -1, None),
+        (37, True, None),
+        (37, "4", None),
+        (3, 4, None),
+    ],
+)
+def test_max_num_seqs_is_reported_per_dp_rank(
+    max_batch_size, data_parallel_size, expected
+):
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=max_batch_size))
+    )
+
+    result = per_dp_rank_max_num_seqs(engine, data_parallel_size)
+
+    assert result == expected
+    if result is not None:
+        assert result * data_parallel_size <= max_batch_size
+
+
+def test_encode_registration_without_local_scheduler_reports_no_max_num_seqs():
+    engine = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        encoder_available=False,
+    )
+
+    assert per_dp_rank_max_num_seqs(engine, 1) is None
+
+
+def test_per_dp_rank_max_num_seqs_fails_if_engine_contract_changes():
+    with pytest.raises(AttributeError):
+        per_dp_rank_max_num_seqs(SimpleNamespace(), 1)
 
 
 def test_spec_decode_runtime_data_uses_max_draft_len():

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -7,6 +7,8 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from dynamo.trtllm.constants import DisaggregationMode
+
 
 def deep_update(target: dict[str, Any], source: Mapping[str, Any]) -> None:
     """Recursively update nested dictionaries.
@@ -77,3 +79,35 @@ def get_spec_decode_runtime_data(engine_args: Any) -> dict[str, Any] | None:
     if method:
         data["method"] = str(method)
     return data
+
+
+def per_dp_rank_max_num_seqs(engine: Any, data_parallel_size: int) -> int | None:
+    """Return TRT-LLM's post-initialization request capacity per attention-DP rank."""
+    if (
+        getattr(engine, "disaggregation_mode", None) == DisaggregationMode.ENCODE
+        and not engine.encoder_available
+    ):
+        return None
+
+    value = engine.llm.args.max_batch_size
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    if (
+        not isinstance(data_parallel_size, int)
+        or isinstance(data_parallel_size, bool)
+        or data_parallel_size <= 0
+    ):
+        return None
+
+    per_rank = value // data_parallel_size
+    if per_rank <= 0:
+        return None
+    if value % data_parallel_size:
+        logging.warning(
+            "TRT-LLM max_batch_size=%d is not divisible by attention DP size=%d; "
+            "advertising conservative per-rank max_num_seqs=%d",
+            value,
+            data_parallel_size,
+            per_rank,
+        )
+    return per_rank

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -65,7 +65,11 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
-from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
+from dynamo.trtllm.utils.trtllm_utils import (
+    deep_update,
+    get_spec_decode_runtime_data,
+    per_dp_rank_max_num_seqs,
+)
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
@@ -537,18 +541,27 @@ async def init_llm_worker(
         runtime_config.kv_state_endpoint = config.kv_state_endpoint
         runtime_config.context_length = config.max_seq_len
 
-        # Set values from config that are available immediately
-        # Note: We populate max_num_seqs and max_num_batched_tokens from config
+        # Set values that are available immediately
+        # Note: We populate max_num_seqs and max_num_batched_tokens
         # to ensure Prometheus metrics are available even without engine stats
 
         # Naming clarification:
-        # - In vLLM: max_num_seqs = maximum concurrent requests (this is an unusual name due to vLLM's historic reasons)
-        # - In TensorRT-LLM: max_batch_size = maximum concurrent requests (clearer name)
+        # - In vLLM: max_num_seqs = maximum concurrent requests per DP rank (this is an unusual name due to vLLM's historic reasons)
+        # - In TensorRT-LLM: max_batch_size = maximum concurrent requests across all DP ranks (clearer name)
         # Both parameters control the same thing: how many requests can be processed simultaneously
 
-        # Need to get max_num_seqs and max_num_batched_tokens from engine_args
+        # Need to get max_num_seqs from the initialized engine and max_num_batched_tokens from engine_args
         # because they can be overridden by --extra-engine-args or --override-engine-args
-        runtime_config.max_num_seqs = engine_args["max_batch_size"]
+
+        # Set data_parallel_size for attention DP mode
+        # This enables the router's scheduler to correctly iterate over all dp_ranks
+        # Need to name ADP as `data_parallel_size` for parity with other frameworks
+        attention_dp_size = engine.get_attention_dp_size()
+        max_num_seqs = per_dp_rank_max_num_seqs(engine, attention_dp_size)
+        if max_num_seqs is not None:
+            runtime_config.max_num_seqs = max_num_seqs
+        runtime_config.data_parallel_size = attention_dp_size
+
         runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
         runtime_config.reasoning_parser = config.dyn_reasoning_parser
         runtime_config.tool_call_parser = config.dyn_tool_call_parser
@@ -565,11 +578,6 @@ async def init_llm_worker(
             config.enable_local_indexer
             and config.disaggregation_mode != DisaggregationMode.DECODE
         )
-        # Set data_parallel_size for attention DP mode
-        # This enables the router's scheduler to correctly iterate over all dp_ranks
-        # Need to name ADP as `data_parallel_size` for parity with other frameworks
-        attention_dp_size = engine.get_attention_dp_size()
-        runtime_config.data_parallel_size = attention_dp_size
 
         # Set topology and KV transfer policy for topology-aware routing
         apply_topology_config(runtime_config)


### PR DESCRIPTION
## Overview:

Standardize Python TensorRT-LLM’s existing `max_num_seqs` registration field as a per-attention-DP-rank capacity.

TensorRT-LLM exposes `max_batch_size` as an engine-wide concurrent-request limit, while Dynamo separately reports `data_parallel_size`. The runtime can therefore derive the local engine capacity consistently as:

`max_num_seqs × data_parallel_size`

## Details:

- Read the finalized post-initialization capacity from `engine.llm.args.max_batch_size`.
- Obtain the represented attention-DP size from `engine.get_attention_dp_size()`.
- Publish:

  `max_num_seqs = floor(max_batch_size / data_parallel_size)`

- Preserve exact capacity when `max_batch_size` is divisible by DP size.
- Conservatively round down when it is not divisible, ensuring the shared runtime never overstates TensorRT-LLM capacity.
  - Example: engine-wide capacity `37` with DP size `4` publishes `max_num_seqs=9`, producing a derived capacity of `36`, not an unsafe `40`.
- Leave `max_num_seqs` unavailable when:
  - Capacity or DP metadata is invalid.
  - Engine capacity is smaller than the DP size.
  - An encode registration has no local scheduler capacity.
- Continue publishing the existing `data_parallel_size` field.
- Add backend-local unit tests for DP-one, exact division, conservative division, invalid metadata, capacity smaller than DP size, and encode-without-scheduler behavior.

## Where should the reviewer start?

1. `components/src/dynamo/trtllm/utils/trtllm_utils.py`
   - `per_dp_rank_max_num_seqs()` and its conservative normalization rules.

2. `components/src/dynamo/trtllm/workers/llm_worker.py`
   - Publication of the finalized per-rank `max_num_seqs` and attention-DP size.

3. `components/src/dynamo/trtllm/tests/test_runtime_metadata.py`
   - Unit coverage at the backend registration contract boundary.

## Related Issues

- Prerequisites of #11928.

**🚫 This PR is NOT linked to a GitHub issue**:

- [x] Confirmed — no related GitHub issue
- Closes DIS-2467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved runtime capacity calculations for data-parallel inference.
  * Added support for encode-only and disaggregated configurations.

* **Bug Fixes**
  * Corrected maximum sequence capacity assignment across attention data-parallel ranks.
  * Added validation for invalid or incompatible batch-size and parallelism settings.
  * Added warnings when configured capacity cannot be evenly distributed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->