### PR TITLE
docs(kubernetes): shadow-engine failover metrics reference

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -177,6 +177,8 @@ navigation:
                     path: kubernetes/observability/logging.md
                   - page: Operator Metrics
                     path: kubernetes/observability/operator-metrics.md
+                  - page: Shadow Engine Failover Metrics
+                    path: kubernetes/observability/shadow-engine-failover-metrics.md
           - section: Scale
             contents:
               - page: Multinode Deployments

--- a/docs/kubernetes/observability/shadow-engine-failover-metrics.md
+++ b/docs/kubernetes/observability/shadow-engine-failover-metrics.md
@@ -1,0 +1,85 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Shadow Engine Failover Metrics
+subtitle: Prometheus metrics and the Grafana dashboard for observing GMS shadow-engine failover.
+---
+
+> ⚠️ **Experimental**: These metrics accompany the experimental
+> [Shadow Engine Failover](../shadow-engine-failover.md) feature; names and the
+> dashboard may change as the feature settles.
+
+## Overview
+
+Each shadow-mode engine emits a small set of self-reported Prometheus metrics
+describing its position in the failover lifecycle (`init → standby → waking →
+active`), plus counters for real failovers. They are exposed on the engine's
+system `/metrics` surface (no extra port) and scraped by the standard
+`dynamo-worker` PodMonitor. A Grafana dashboard renders them per
+DynamoGraphDeployment (DGD).
+
+## The dashboard
+
+The **Dynamo · GMS Shadow-Failover** dashboard ships as a ConfigMap in the
+platform Helm chart (labeled `grafana_dashboard`), so any kube-prometheus-stack
+Grafana with the dashboards sidecar auto-imports it — no manual step. It is
+**multi-DGD aware**: two template variables, **Namespace** and **DGD**, select a
+deployment, and every panel filters to that deployment's failover engines. The
+DGD name comes from the `nvidia.com/dynamo-graph-deployment-name` pod label,
+exposed as the `dynamo_graph_deployment` metric label by the PodMonitor.
+
+## Metric catalog
+
+All metrics are prefixed `dynamo_component_engine_failover_` and labeled
+`engine_id`, `model`, `dynamo_component` (plus `namespace`, `pod`,
+`dynamo_graph_deployment` added by the PodMonitor).
+
+| Metric | Type | What it tells you |
+|---|---|---|
+| `_state` | gauge (1-hot over `state`) | Current lifecycle state. **Source of truth** — `active`/`standby` counts derive from it. A dead engine has no state (series goes stale); "dead" is inferred, not self-reported. |
+| `_state_entered_timestamp_seconds` | gauge | When the current state was entered; `time() - value` is the state age (a climbing age on a stuck engine is a wedge signal). |
+| `_last_state_duration_seconds{state}` | gauge | Duration of the most recent occupancy of each state; `{state="waking"}` is the wake/switch time. |
+| `_transitions_total{from_state,to_state}` | counter | Every transition, including ones too brief for the sampled `_state` gauge to catch (e.g. a sub-second `waking`). |
+| `_switch_attempts_total` | counter | Real failover promotions attempted (a shadow that won a *contended* lock). The initial bootup acquires the lock immediately and is **not** counted. |
+| `_switch_success_total` | counter | Failover promotions that completed and began serving. Derived failures = `attempts − success`. |
+
+### Derived views
+
+- **Active engines** = `count(_state{state="active"} == 1)` — outage (`0`) / split-brain (`>1`).
+- **Shadow ready** = `count(_state{state="standby"} == 1)` — `0` is degraded (one failure from outage).
+- **Failovers / failures** — use range queries (`increase(..[$__range])`) so a failover
+  by an engine that has since died still counts; an instant `sum` would drop it when the series goes stale.
+
+## Durability: counters that can outlive a scrape
+
+Prometheus is pull-based, so a counter increment lives in process memory until
+the next scrape. A failed wake often *is* what kills the process, within the
+scrape interval — so the increment can die unscraped. This is not unique to
+failover; it is the general "event lost before scrape" problem for ephemeral
+work.
+
+The switch counters hedge against it with **write-through persistence**: each
+increment is also written (atomic temp+rename+fsync) to a per-engine file in the
+shared GMS directory, and reloaded on process start. So the count survives the
+death and is re-exposed when the engine (or its restart) comes back — the dying
+process never has to report its own failure.
+
+Two limits remain, and both are covered by other signals rather than by the
+counter:
+
+- An increment that dies **before its very first scrape** was never sampled, so
+  even a range query can't recover it until the engine re-exposes it on restart.
+- An **uncaught kill** (OOM/SIGKILL) may not reach the increment at all.
+
+For both, the **k8s panels** (container restarts, `OOMKilled`, `CrashLoopBackOff`
+from kube-state-metrics) are the immediate witness that a cutover failed — the
+engine can't self-report its own death. The canonical fuller answer for
+attributed, scrape-independent capture is a push mechanism (an event/span emitted
+on the failure path); that is planned as a follow-up.
+
+## Diagnostics
+
+Beyond the failover metrics, the dashboard overlays cluster signals for the
+selected DGD's pods: **container restarts / ready / phase** (kube-state-metrics)
+and **GPU framebuffer used** (DCGM). Note the shadow shares one weight copy via
+GMS, so per-engine GPU memory should not be summed.

--- a/docs/kubernetes/observability/shadow-engine-failover-metrics.md
+++ b/docs/kubernetes/observability/shadow-engine-failover-metrics.md
@@ -15,18 +15,22 @@ Each shadow-mode engine emits a small set of self-reported Prometheus metrics
 describing its position in the failover lifecycle (`init → standby → waking →
 active`), plus counters for real failovers. They are exposed on the engine's
 system `/metrics` surface (no extra port) and scraped by the standard
-`dynamo-worker` PodMonitor. A Grafana dashboard renders them per
-DynamoGraphDeployment (DGD).
+`dynamo-worker` PodMonitor — **one PodMonitor per platform install** that selects
+all Dynamo worker pods by label, not one per DGD. The per-DGD split is a
+relabeling (below), defined in the operator chart's `prometheus.yaml`, so changes
+there are what flow through to the generated scrape config. A Grafana dashboard
+renders them per DynamoGraphDeployment (DGD).
 
 ## The dashboard
 
-The **Dynamo · GMS Shadow-Failover** dashboard ships as a ConfigMap in the
-platform Helm chart (labeled `grafana_dashboard`), so any kube-prometheus-stack
-Grafana with the dashboards sidecar auto-imports it — no manual step. It is
-**multi-DGD aware**: two template variables, **Namespace** and **DGD**, select a
-deployment, and every panel filters to that deployment's failover engines. The
-DGD name comes from the `nvidia.com/dynamo-graph-deployment-name` pod label,
-exposed as the `dynamo_graph_deployment` metric label by the PodMonitor.
+The **Dynamo · GMS Shadow-Failover** dashboard ships alongside the other Dynamo
+dashboards from the cluster infra repo, as a ConfigMap labeled
+`grafana_dashboard`, so any kube-prometheus-stack Grafana with the dashboards
+sidecar auto-imports it — no manual step. It is **multi-DGD aware**: two template
+variables, **Namespace** and **DGD**, select a deployment, and every panel
+filters to that deployment's failover engines. The DGD name comes from the
+`nvidia.com/dynamo-graph-deployment-name` pod label, which the worker
+PodMonitor's relabeling exposes as the `dynamo_graph_deployment` metric label.
 
 ## Metric catalog
 

--- a/docs/kubernetes/shadow-engine-failover.md
+++ b/docs/kubernetes/shadow-engine-failover.md
@@ -119,6 +119,12 @@ active/passive failover; use the `failover` field for the shadow engine flow.
 - It is not covered by the normal v1beta1 compatibility guarantees while it
   lives under `experimental`.
 
+## Observability
+
+Shadow-mode engines emit failover-lifecycle metrics (state, transitions, and
+real-failover counters) and ship a per-DGD Grafana dashboard with the platform
+chart. See [Shadow Engine Failover Metrics](observability/shadow-engine-failover-metrics.md).
+
 ## API Placement
 
 For `v1alpha1` `DynamoGraphDeployment`, GMS and failover are service-level


### PR DESCRIPTION
Follow-up to #11664 (GMS shadow-failover observability). Splits the observability docs out of the code PR so wording can be iterated separately.

## Summary
Adds `docs/kubernetes/observability/shadow-engine-failover-metrics.md`: metric catalog, derived views, the write-through counter-durability scheme (+ death-before-scrape limits with the k8s panels as witness), and diagnostics. Registers it under Observability and links it from the shadow-engine-failover page.

## Validation
Fern docs build (frontmatter + index only; no code).

Open wording items still worth a look: the exact PodMonitor phrasing and the dashboard shipping location (now corrected to the infra repo, matching the other Dynamo dashboards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for monitoring shadow-engine failover with Prometheus metrics and a Grafana dashboard.
  * Documented engine lifecycle, transition, failover, and diagnostic metrics, including multi-DGD dashboard views.
  * Added observability guidance and linked the new metrics documentation from the Kubernetes deployment guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->