### PR TITLE
perf(replay): defer Dynamo prompt materialization

### DIFF
--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -291,6 +291,7 @@ impl AgenticState {
 pub struct WorkloadDriver {
     policy: SchedulingPolicy,
     prompt_mode: PromptMode,
+    emit_session_metadata: bool,
     trace_block_size: usize,
     engine_block_size: u32,
     sessions: Vec<SessionRuntime>,
@@ -427,6 +428,7 @@ impl WorkloadDriver {
                 dependents,
             }),
             prompt_mode: PromptMode::Full,
+            emit_session_metadata: true,
             trace_block_size,
             engine_block_size: engine_block_size_u32,
             sessions,
@@ -530,6 +532,7 @@ impl WorkloadDriver {
         let mut driver = Self {
             policy,
             prompt_mode,
+            emit_session_metadata: true,
             trace_block_size,
             engine_block_size: engine_block_size_u32,
             sessions,
@@ -540,6 +543,11 @@ impl WorkloadDriver {
             state.activate_pending(&mut driver.sessions, &mut driver.ready_sessions, 0.0);
         }
         Ok(driver)
+    }
+
+    pub(crate) fn without_session_metadata(mut self) -> Self {
+        self.emit_session_metadata = false;
+        self
     }
 
     /// Failure-path companion: release a cap slot and terminate the owning session.
@@ -633,6 +641,7 @@ impl WorkloadDriver {
                 replay_key: turn.replay_key.clone(),
                 scheduled_ready_at_ms,
                 replay_hashes: Some(replay_hashes),
+                emit_session_metadata: self.emit_session_metadata,
                 request,
             });
         }

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -10,6 +10,7 @@ use rand::rngs::StdRng;
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
+use super::trace::{synthesize_trace_tokens, validate_synthesizable_prompt};
 use super::types::{AgenticTrace, ReadyTurn, ReplayRequestHashes, Trace};
 use super::{SYNTHETIC_OUTPUT_SEED, planned_output_token_ids};
 use crate::common::protocols::DirectRequest;
@@ -65,17 +66,65 @@ struct SessionRuntime {
 }
 
 #[derive(Debug)]
+enum PromptTokens {
+    // Full-prompt traces stay in their compact on-disk representation until
+    // dispatch. Delta-cumulative traces remain eager because later turns append
+    // generated output to already-materialized session history.
+    Deferred {
+        input_length: usize,
+        hash_ids: Vec<u64>,
+    },
+    Materialized(Vec<u32>),
+}
+
+impl PromptTokens {
+    fn deferred(input_length: usize, hash_ids: Vec<u64>, trace_block_size: usize) -> Result<Self> {
+        validate_synthesizable_prompt(input_length, &hash_ids, trace_block_size)?;
+        Ok(Self::Deferred {
+            input_length,
+            hash_ids,
+        })
+    }
+
+    fn input_length(&self) -> usize {
+        match self {
+            Self::Deferred { input_length, .. } => *input_length,
+            Self::Materialized(tokens) => tokens.len(),
+        }
+    }
+
+    fn materialize(&self, trace_block_size: usize) -> Vec<u32> {
+        match self {
+            Self::Deferred {
+                input_length,
+                hash_ids,
+            } => synthesize_trace_tokens(*input_length, hash_ids, trace_block_size)
+                .expect("deferred prompt was validated when the workload driver was built"),
+            Self::Materialized(tokens) => tokens.clone(),
+        }
+    }
+
+    fn materialized(&self) -> &[u32] {
+        match self {
+            Self::Deferred { .. } => {
+                unreachable!("delta-cumulative prompts are materialized during driver setup")
+            }
+            Self::Materialized(tokens) => tokens,
+        }
+    }
+}
+
+#[derive(Debug)]
 struct TurnRuntime {
     request_id: Option<String>,
     replay_key: Option<String>,
-    tokens: Vec<u32>,
+    prompt_tokens: PromptTokens,
     max_output_tokens: usize,
     output_token_ids: Option<Vec<u32>>,
     delay_after_previous_ms: f64,
     priority: i32,
     strict_priority: u32,
     policy_class: Option<String>,
-    replay_hashes: Option<ReplayRequestHashes>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -242,6 +291,7 @@ impl AgenticState {
 pub struct WorkloadDriver {
     policy: SchedulingPolicy,
     prompt_mode: PromptMode,
+    trace_block_size: usize,
     engine_block_size: u32,
     sessions: Vec<SessionRuntime>,
     in_flight: FxHashMap<Uuid, InFlightTurn>,
@@ -313,7 +363,7 @@ impl WorkloadDriver {
         let mut sessions = Vec::with_capacity(trace.turns.len());
         let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_OUTPUT_SEED);
 
-        for (session_index, turn) in trace.turns.into_iter().enumerate() {
+        for (session_index, mut turn) in trace.turns.into_iter().enumerate() {
             for dependency in &turn.wait_for {
                 dependents
                     .entry(dependency.clone())
@@ -323,8 +373,11 @@ impl WorkloadDriver {
             remaining_dependencies.push(turn.wait_for.len());
             ready_after_ms.push(0.0);
 
-            let replay_hashes = Some(turn.to_replay_hashes(trace_block_size, engine_block_size)?);
-            let tokens = turn.synthesize_tokens(trace_block_size)?;
+            let prompt_tokens = PromptTokens::deferred(
+                turn.input_length,
+                std::mem::take(&mut turn.hash_ids),
+                trace_block_size,
+            )?;
             let output_token_ids = Some(planned_output_token_ids(
                 turn.output_token_ids,
                 turn.max_output_tokens,
@@ -340,14 +393,13 @@ impl WorkloadDriver {
                 turns: vec![TurnRuntime {
                     request_id: Some(turn.request_id),
                     replay_key: turn.replay_key,
-                    tokens,
+                    prompt_tokens,
                     max_output_tokens: turn.max_output_tokens,
                     output_token_ids,
                     delay_after_previous_ms: turn.delay_after_dependencies_ms,
                     priority: turn.priority,
                     strict_priority: turn.strict_priority,
                     policy_class: turn.policy_class,
-                    replay_hashes,
                 }],
                 cumulative_tokens: Vec::new(),
                 next_turn_index: 0,
@@ -375,6 +427,7 @@ impl WorkloadDriver {
                 dependents,
             }),
             prompt_mode: PromptMode::Full,
+            trace_block_size,
             engine_block_size: engine_block_size_u32,
             sessions,
             in_flight: FxHashMap::default(),
@@ -408,13 +461,17 @@ impl WorkloadDriver {
                 let turns = session
                     .turns
                     .into_iter()
-                    .map(|turn| -> Result<TurnRuntime> {
-                        let replay_hashes = if prompt_mode == PromptMode::Full {
-                            Some(turn.to_replay_hashes(trace_block_size, engine_block_size)?)
-                        } else {
-                            None
+                    .map(|mut turn| -> Result<TurnRuntime> {
+                        let prompt_tokens = match prompt_mode {
+                            PromptMode::Full => PromptTokens::deferred(
+                                turn.input_length,
+                                std::mem::take(&mut turn.hash_ids),
+                                trace_block_size,
+                            )?,
+                            PromptMode::DeltaCumulative => PromptTokens::Materialized(
+                                turn.synthesize_tokens(trace_block_size)?,
+                            ),
                         };
-                        let tokens = turn.synthesize_tokens(trace_block_size)?;
                         let output_token_ids = Some(planned_output_token_ids(
                             turn.output_token_ids,
                             turn.max_output_tokens,
@@ -422,7 +479,7 @@ impl WorkloadDriver {
                         ));
                         Ok(TurnRuntime {
                             request_id: None,
-                            tokens,
+                            prompt_tokens,
                             replay_key: turn.replay_key,
                             max_output_tokens: turn.max_output_tokens,
                             output_token_ids,
@@ -430,7 +487,6 @@ impl WorkloadDriver {
                             priority: turn.priority,
                             strict_priority: turn.strict_priority,
                             policy_class: turn.policy_class,
-                            replay_hashes,
                         })
                     })
                     .collect::<Result<Vec<_>>>()?;
@@ -438,7 +494,7 @@ impl WorkloadDriver {
                     turns
                         .iter()
                         .map(|turn| {
-                            turn.tokens.len()
+                            turn.prompt_tokens.input_length()
                                 + turn
                                     .output_token_ids
                                     .as_ref()
@@ -474,6 +530,7 @@ impl WorkloadDriver {
         let mut driver = Self {
             policy,
             prompt_mode,
+            trace_block_size,
             engine_block_size: engine_block_size_u32,
             sessions,
             in_flight: FxHashMap::default(),
@@ -532,15 +589,16 @@ impl WorkloadDriver {
             let turn = &session.turns[turn_index];
             let arrival_timestamp_ms = self.policy.arrival_timestamp_ms(scheduled_ready_at_ms);
             let (request_tokens, replay_hashes) = match self.prompt_mode {
-                PromptMode::Full => (
-                    turn.tokens.clone(),
-                    turn.replay_hashes
-                        .as_ref()
-                        .expect("full-prompt workload turns precompute replay hashes")
-                        .clone(),
-                ),
+                PromptMode::Full => {
+                    let request_tokens = turn.prompt_tokens.materialize(self.trace_block_size);
+                    let replay_hashes =
+                        ReplayRequestHashes::from_tokens(&request_tokens, self.engine_block_size);
+                    (request_tokens, replay_hashes)
+                }
                 PromptMode::DeltaCumulative => {
-                    session.cumulative_tokens.extend_from_slice(&turn.tokens);
+                    session
+                        .cumulative_tokens
+                        .extend_from_slice(turn.prompt_tokens.materialized());
                     let request_tokens = session.cumulative_tokens.clone();
                     let replay_hashes =
                         ReplayRequestHashes::from_tokens(&request_tokens, self.engine_block_size);
@@ -874,6 +932,60 @@ mod tests {
             }],
         });
         trace
+    }
+
+    #[test]
+    fn full_prompts_remain_deferred_until_dispatch() {
+        let mut driver = WorkloadDriver::new_trace(two_session_trace(), 1).unwrap();
+
+        assert!(driver.sessions.iter().all(|session| {
+            session
+                .turns
+                .iter()
+                .all(|turn| matches!(turn.prompt_tokens, PromptTokens::Deferred { .. }))
+        }));
+
+        let ready = driver.pop_ready(0.0, 1);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].request.tokens, vec![1, 2]);
+        assert!(ready[0].replay_hashes.is_some());
+    }
+
+    #[test]
+    fn delta_cumulative_prompts_remain_materialized_during_setup() {
+        let driver =
+            WorkloadDriver::new_concurrency_accumulating_deltas(two_session_trace(), 1, 1).unwrap();
+
+        assert!(driver.sessions.iter().all(|session| {
+            session
+                .turns
+                .iter()
+                .all(|turn| matches!(turn.prompt_tokens, PromptTokens::Materialized(_)))
+        }));
+    }
+
+    #[test]
+    fn deferred_prompt_validation_preserves_setup_errors() {
+        let trace = Trace {
+            block_size: 4,
+            sessions: vec![SessionTrace {
+                session_id: "invalid".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![TurnTrace {
+                    input_length: 5,
+                    max_output_tokens: 1,
+                    hash_ids: vec![1],
+                    ..Default::default()
+                }],
+            }],
+        };
+
+        let error = WorkloadDriver::new_trace(trace, 4).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("input_length 5 exceeds synthesized capacity 4")
+        );
     }
 
     #[test]

--- a/lib/mocker/src/loadgen/tests.rs
+++ b/lib/mocker/src/loadgen/tests.rs
@@ -7,6 +7,7 @@ use dynamo_kv_router::protocols::{
 use tempfile::NamedTempFile;
 use uuid::Uuid;
 
+use super::trace::{synthesize_trace_tokens, validate_synthesizable_prompt};
 use super::*;
 
 fn write_trace(lines: &[serde_json::Value]) -> NamedTempFile {
@@ -42,6 +43,18 @@ fn request_trace_row(
         row["agent_context"] = agent_context;
     }
     row
+}
+
+#[test]
+fn trace_synthesis_bounds_each_hash_block_to_remaining_input() {
+    let tokens = synthesize_trace_tokens(1, &[7], usize::MAX).unwrap();
+    assert_eq!(tokens, vec![7]);
+}
+
+#[test]
+fn trace_synthesis_rejects_capacity_overflow() {
+    let error = validate_synthesizable_prompt(1, &[7, 8], usize::MAX).unwrap_err();
+    assert!(error.to_string().contains("capacity overflow"));
 }
 
 #[test]

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -121,7 +121,8 @@ pub(super) fn validate_synthesizable_prompt(
         .len()
         .checked_mul(trace_block_size)
         .context("synthesized prompt capacity overflow")?;
-    if synthesizable_capacity < input_length {
+    let required_hash_ids = input_length.div_ceil(trace_block_size);
+    if hash_ids.len() < required_hash_ids {
         bail!(
             "input_length {} exceeds synthesized capacity {}",
             input_length,
@@ -142,9 +143,12 @@ pub(super) fn synthesize_trace_tokens(
     let mut tokens = Vec::with_capacity(input_length);
     for &hash_id in hash_ids {
         let token_id = hash_id as u32;
-        tokens.extend((0..trace_block_size).map(|_| token_id));
-        if tokens.len() >= input_length {
-            tokens.truncate(input_length);
+        let remaining = input_length - tokens.len();
+        tokens.extend(std::iter::repeat_n(
+            token_id,
+            remaining.min(trace_block_size),
+        ));
+        if tokens.len() == input_length {
             break;
         }
     }
@@ -1071,15 +1075,13 @@ impl Trace {
                         turn_idx
                     );
                 }
-                if turn.hash_ids.len() * self.block_size < turn.input_length {
-                    bail!(
-                        "session {} turn {} input_length {} exceeds synthesized capacity {}",
-                        session.session_id,
-                        turn_idx,
-                        turn.input_length,
-                        turn.hash_ids.len() * self.block_size
-                    );
-                }
+                validate_synthesizable_prompt(turn.input_length, &turn.hash_ids, self.block_size)
+                    .with_context(|| {
+                    format!(
+                        "session {} turn {} has invalid prompt",
+                        session.session_id, turn_idx
+                    )
+                })?;
                 if !turn.delay_after_previous_ms.is_finite() || turn.delay_after_previous_ms < 0.0 {
                     bail!(
                         "session {} turn {} has invalid delay {}",

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -109,21 +109,35 @@ fn validate_dynamo_trace_block_size(expected: Option<usize>, embedded: usize) ->
     Ok(())
 }
 
-fn synthesize_trace_tokens(
+pub(super) fn validate_synthesizable_prompt(
+    input_length: usize,
+    hash_ids: &[u64],
+    trace_block_size: usize,
+) -> Result<()> {
+    if trace_block_size == 0 {
+        bail!("trace_block_size must be greater than 0");
+    }
+    let synthesizable_capacity = hash_ids
+        .len()
+        .checked_mul(trace_block_size)
+        .context("synthesized prompt capacity overflow")?;
+    if synthesizable_capacity < input_length {
+        bail!(
+            "input_length {} exceeds synthesized capacity {}",
+            input_length,
+            synthesizable_capacity
+        );
+    }
+
+    Ok(())
+}
+
+pub(super) fn synthesize_trace_tokens(
     input_length: usize,
     hash_ids: &[u64],
     trace_block_size: usize,
 ) -> Result<Vec<u32>> {
-    if trace_block_size == 0 {
-        bail!("trace_block_size must be greater than 0");
-    }
-    if hash_ids.len() * trace_block_size < input_length {
-        bail!(
-            "input_length {} exceeds synthesized capacity {}",
-            input_length,
-            hash_ids.len() * trace_block_size
-        );
-    }
+    validate_synthesizable_prompt(input_length, hash_ids, trace_block_size)?;
 
     let mut tokens = Vec::with_capacity(input_length);
     for &hash_id in hash_ids {

--- a/lib/mocker/src/loadgen/types.rs
+++ b/lib/mocker/src/loadgen/types.rs
@@ -199,5 +199,6 @@ pub struct ReadyTurn {
     pub replay_key: Option<String>,
     pub scheduled_ready_at_ms: f64,
     pub replay_hashes: Option<ReplayRequestHashes>,
+    pub(crate) emit_session_metadata: bool,
     pub request: DirectRequest,
 }

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -120,31 +120,32 @@ pub fn simulate_loaded_trace_with_router_mode_and_options(
     let trace = trace
         .normalize_session_starts()?
         .speed_up_timing(arrival_speedup_ratio)?;
-    if let Some(requests) = single_turn_trace_requests(TraceFileFormat::Dynamo, &trace)? {
-        return crate::replay::offline::simulate_trace(
+    trace.validate_for_trace_mode()?;
+    if trace.is_single_turn() {
+        crate::replay::offline::simulate_trace_workload_without_session_metadata(
             args,
             router_config,
             prefill_load_estimator,
-            requests,
+            trace,
             num_workers,
-            1.0,
             router_mode,
             record_per_request,
             max_sim_time_ms,
             sla,
-        );
+        )
+    } else {
+        crate::replay::offline::simulate_trace_workload(
+            args,
+            router_config,
+            prefill_load_estimator,
+            trace,
+            num_workers,
+            router_mode,
+            record_per_request,
+            max_sim_time_ms,
+            sla,
+        )
     }
-    crate::replay::offline::simulate_trace_workload(
-        args,
-        router_config,
-        prefill_load_estimator,
-        trace,
-        num_workers,
-        router_mode,
-        record_per_request,
-        max_sim_time_ms,
-        sla,
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -164,29 +165,30 @@ pub fn simulate_loaded_trace_disagg_with_router_mode_and_options(
     let trace = trace
         .normalize_session_starts()?
         .speed_up_timing(arrival_speedup_ratio)?;
-    if let Some(requests) = single_turn_trace_requests(TraceFileFormat::Dynamo, &trace)? {
-        return crate::replay::offline::simulate_trace_disagg(
+    trace.validate_for_trace_mode()?;
+    if trace.is_single_turn() {
+        crate::replay::offline::simulate_trace_workload_disagg_without_session_metadata(
             config,
             router_config,
             prefill_load_estimator,
-            requests,
-            1.0,
+            trace,
             router_mode,
             record_per_request,
             max_sim_time_ms,
             sla,
-        );
+        )
+    } else {
+        crate::replay::offline::simulate_trace_workload_disagg(
+            config,
+            router_config,
+            prefill_load_estimator,
+            trace,
+            router_mode,
+            record_per_request,
+            max_sim_time_ms,
+            sla,
+        )
     }
-    crate::replay::offline::simulate_trace_workload_disagg(
-        config,
-        router_config,
-        prefill_load_estimator,
-        trace,
-        router_mode,
-        record_per_request,
-        max_sim_time_ms,
-        sla,
-    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -204,17 +206,7 @@ pub fn simulate_loaded_trace_live_with_router_mode(
     let trace = trace
         .normalize_session_starts()?
         .speed_up_timing(arrival_speedup_ratio)?;
-    if let Some(requests) = single_turn_trace_requests(TraceFileFormat::Dynamo, &trace)? {
-        return online::simulate_trace_requests(
-            args,
-            router_config,
-            prefill_load_estimator,
-            requests,
-            num_workers,
-            1.0,
-            router_mode,
-        );
-    }
+    trace.validate_for_trace_mode()?;
     online::simulate_trace_workload(
         args,
         router_config,
@@ -1414,11 +1406,95 @@ pub fn simulate_concurrency_live_workload_with_router_mode(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::common::protocols::{EngineType, SglangArgs};
+    use crate::common::protocols::{EngineType, SglangArgs, WorkerType};
     use crate::loadgen::{SessionTrace, TurnTrace};
     use std::io::Write;
     use tempfile::NamedTempFile;
     use uuid::Uuid;
+
+    fn replay_test_args() -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(128)
+            .max_num_batched_tokens(Some(64))
+            .max_num_seqs(Some(8))
+            .speedup_ratio(1000.0)
+            .build()
+            .unwrap()
+    }
+
+    fn disagg_test_config() -> OfflineDisaggReplayConfig {
+        OfflineDisaggReplayConfig {
+            prefill_args: MockEngineArgs {
+                worker_type: WorkerType::Prefill,
+                block_size: 4,
+                ..MockEngineArgs::default()
+            },
+            decode_args: MockEngineArgs {
+                worker_type: WorkerType::Decode,
+                block_size: 4,
+                ..MockEngineArgs::default()
+            },
+            num_prefill_workers: 1,
+            num_decode_workers: 1,
+        }
+    }
+
+    fn single_turn_dynamo_trace(first_arrival_timestamp_ms: Option<f64>) -> Trace {
+        Trace {
+            block_size: 4,
+            sessions: vec![SessionTrace {
+                session_id: "request_1".to_string(),
+                first_arrival_timestamp_ms,
+                turns: vec![TurnTrace {
+                    input_length: 4,
+                    max_output_tokens: 1,
+                    hash_ids: vec![1],
+                    delay_after_previous_ms: 0.0,
+                    ..Default::default()
+                }],
+            }],
+        }
+    }
+
+    #[test]
+    fn loaded_dynamo_trace_preserves_request_metadata_contract() {
+        let report = simulate_loaded_trace_with_router_mode_and_options(
+            replay_test_args(),
+            None,
+            None,
+            single_turn_dynamo_trace(Some(0.0)),
+            2,
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            true,
+            None,
+            SlaThresholds::default(),
+        )
+        .unwrap();
+
+        assert_eq!(report.per_request.len(), 1);
+        assert_eq!(report.per_request[0].session_id, None);
+        assert_eq!(report.per_request[0].turn_index, None);
+    }
+
+    #[test]
+    fn loaded_dynamo_disagg_trace_validates_timestamps() {
+        let error = simulate_loaded_trace_disagg_with_router_mode_and_options(
+            disagg_test_config(),
+            None,
+            None,
+            single_turn_dynamo_trace(None),
+            1.0,
+            ReplayRouterMode::RoundRobin,
+            false,
+            None,
+            SlaThresholds::default(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("first_arrival_timestamp_ms"));
+    }
 
     #[test]
     fn one_worker_sglang_impossible_request_returns_dead_end_error() {

--- a/lib/mocker/src/replay/entrypoints.rs
+++ b/lib/mocker/src/replay/entrypoints.rs
@@ -83,9 +83,12 @@ fn single_turn_trace_requests(
     trace_format: TraceFileFormat,
     trace: &Trace,
 ) -> Result<Option<Vec<DirectRequest>>> {
+    // Dynamo request traces retain compact prompt hashes in WorkloadDriver and
+    // materialize only ready requests. The legacy Mooncake path predates that
+    // representation and is intentionally unchanged here.
     if matches!(
         trace_format,
-        TraceFileFormat::Mooncake | TraceFileFormat::MooncakeDelta | TraceFileFormat::Dynamo
+        TraceFileFormat::Mooncake | TraceFileFormat::MooncakeDelta
     ) && trace.is_single_turn()
     {
         // The timestamped request path expects every request to carry an
@@ -1498,7 +1501,7 @@ mod tests {
     }
 
     #[test]
-    fn single_turn_request_trace_formats_use_request_path() {
+    fn single_turn_legacy_trace_formats_use_request_path() {
         let trace = Trace {
             block_size: 4,
             sessions: vec![
@@ -1527,7 +1530,7 @@ mod tests {
             ],
         };
 
-        for trace_format in [TraceFileFormat::Mooncake, TraceFileFormat::Dynamo] {
+        for trace_format in [TraceFileFormat::Mooncake, TraceFileFormat::MooncakeDelta] {
             let requests = single_turn_trace_requests(trace_format, &trace)
                 .unwrap()
                 .expect("single-turn traces should become request traces");
@@ -1536,6 +1539,13 @@ mod tests {
             assert_eq!(requests[0].arrival_timestamp_ms, Some(0.0));
             assert_eq!(requests[1].arrival_timestamp_ms, Some(0.0));
         }
+
+        assert!(
+            single_turn_trace_requests(TraceFileFormat::Dynamo, &trace)
+                .unwrap()
+                .is_none(),
+            "Dynamo traces must retain compact prompts in the workload path"
+        );
     }
 
     #[test]
@@ -1555,7 +1565,7 @@ mod tests {
             }],
         };
 
-        for trace_format in [TraceFileFormat::Mooncake, TraceFileFormat::Dynamo] {
+        for trace_format in [TraceFileFormat::Mooncake, TraceFileFormat::MooncakeDelta] {
             let err = single_turn_trace_requests(trace_format, &trace)
                 .expect_err("missing first_arrival_timestamp_ms must error before reaching the timestamped request path");
             assert!(

--- a/lib/mocker/src/replay/offline/components/admission.rs
+++ b/lib/mocker/src/replay/offline/components/admission.rs
@@ -92,12 +92,16 @@ impl AdmissionQueue {
             (ReplayMode::Trace, AdmissionSource::Workload(driver)) => Ok(driver
                 .pop_ready(now_ms, usize::MAX)
                 .into_iter()
-                .map(|ready| ReadyArrival {
-                    request: ready.request,
-                    arrival_time_ms: ready.scheduled_ready_at_ms,
-                    replay_hashes: ready.replay_hashes,
-                    session_id: Some(ready.session_id),
-                    turn_index: Some(ready.turn_index),
+                .map(|ready| {
+                    let session_id = ready.emit_session_metadata.then_some(ready.session_id);
+                    let turn_index = ready.emit_session_metadata.then_some(ready.turn_index);
+                    ReadyArrival {
+                        request: ready.request,
+                        arrival_time_ms: ready.scheduled_ready_at_ms,
+                        replay_hashes: ready.replay_hashes,
+                        session_id,
+                        turn_index,
+                    }
                 })
                 .collect()),
             (ReplayMode::Concurrency { max_in_flight }, AdmissionSource::Requests(pending)) => {
@@ -124,12 +128,16 @@ impl AdmissionQueue {
                 Ok(driver
                     .pop_ready(now_ms, usize::MAX)
                     .into_iter()
-                    .map(|ready| ReadyArrival {
-                        request: ready.request,
-                        arrival_time_ms: now_ms,
-                        replay_hashes: ready.replay_hashes,
-                        session_id: Some(ready.session_id),
-                        turn_index: Some(ready.turn_index),
+                    .map(|ready| {
+                        let session_id = ready.emit_session_metadata.then_some(ready.session_id);
+                        let turn_index = ready.emit_session_metadata.then_some(ready.turn_index);
+                        ReadyArrival {
+                            request: ready.request,
+                            arrival_time_ms: now_ms,
+                            replay_hashes: ready.replay_hashes,
+                            session_id,
+                            turn_index,
+                        }
                     })
                     .collect())
             }

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -288,6 +288,34 @@ pub(crate) fn simulate_trace_workload(
         num_workers,
         router_mode,
         false,
+        true,
+        record_per_request,
+        max_sim_time_ms,
+        sla,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn simulate_trace_workload_without_session_metadata(
+    args: MockEngineArgs,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    num_workers: usize,
+    router_mode: ReplayRouterMode,
+    record_per_request: bool,
+    max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
+) -> Result<TraceSimulationReport> {
+    simulate_trace_workload_with_delta_mode(
+        args,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        num_workers,
+        router_mode,
+        false,
+        false,
         record_per_request,
         max_sim_time_ms,
         sla,
@@ -338,6 +366,7 @@ pub(crate) fn simulate_trace_workload_accumulating_deltas(
         num_workers,
         router_mode,
         true,
+        true,
         record_per_request,
         max_sim_time_ms,
         sla,
@@ -353,6 +382,7 @@ fn simulate_trace_workload_with_delta_mode(
     num_workers: usize,
     router_mode: ReplayRouterMode,
     accumulate_session_deltas: bool,
+    emit_session_metadata: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
@@ -362,6 +392,7 @@ fn simulate_trace_workload_with_delta_mode(
             args,
             trace,
             accumulate_session_deltas,
+            emit_session_metadata,
             record_per_request,
             max_sim_time_ms,
             sla,
@@ -375,6 +406,7 @@ fn simulate_trace_workload_with_delta_mode(
             num_workers,
             router_mode,
             accumulate_session_deltas,
+            emit_session_metadata,
             record_per_request,
             max_sim_time_ms,
             sla,
@@ -546,8 +578,60 @@ pub(crate) fn simulate_trace_workload_disagg(
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
+    simulate_trace_workload_disagg_with_session_metadata(
+        config,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        router_mode,
+        true,
+        record_per_request,
+        max_sim_time_ms,
+        sla,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn simulate_trace_workload_disagg_without_session_metadata(
+    config: OfflineDisaggReplayConfig,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    router_mode: ReplayRouterMode,
+    record_per_request: bool,
+    max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
+) -> Result<TraceSimulationReport> {
+    simulate_trace_workload_disagg_with_session_metadata(
+        config,
+        router_config,
+        prefill_load_estimator,
+        trace,
+        router_mode,
+        false,
+        record_per_request,
+        max_sim_time_ms,
+        sla,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn simulate_trace_workload_disagg_with_session_metadata(
+    config: OfflineDisaggReplayConfig,
+    router_config: Option<KvRouterConfig>,
+    prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
+    trace: Trace,
+    router_mode: ReplayRouterMode,
+    emit_session_metadata: bool,
+    record_per_request: bool,
+    max_sim_time_ms: Option<f64>,
+    sla: SlaThresholds,
+) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
-    let driver = WorkloadDriver::new_trace(trace, config.prefill_args.block_size)?;
+    let mut driver = WorkloadDriver::new_trace(trace, config.prefill_args.block_size)?;
+    if !emit_session_metadata {
+        driver = driver.without_session_metadata();
+    }
     let (collector, _) = DisaggRuntime::new_workload(
         &config,
         router_config,
@@ -635,6 +719,7 @@ pub(crate) fn simulate_trace_workload_single(
     args: MockEngineArgs,
     trace: Trace,
     accumulate_session_deltas: bool,
+    emit_session_metadata: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
@@ -642,11 +727,14 @@ pub(crate) fn simulate_trace_workload_single(
     let started_at = Instant::now();
     let args = args.normalized()?;
     let engine_block_size = args.block_size;
-    let driver = if accumulate_session_deltas {
+    let mut driver = if accumulate_session_deltas {
         trace.into_delta_accumulating_trace_driver_with_block_size(engine_block_size)?
     } else {
         trace.into_trace_driver_with_block_size(engine_block_size)?
     };
+    if !emit_session_metadata {
+        driver = driver.without_session_metadata();
+    }
     let collector = SingleRuntime::new_workload(args, driver, SingleReplayMode::Trace)
         .with_per_request_records(record_per_request)
         .with_max_sim_time_ms(max_sim_time_ms)
@@ -769,17 +857,21 @@ pub(crate) fn simulate_trace_workload_multi(
     num_workers: usize,
     router_mode: ReplayRouterMode,
     accumulate_session_deltas: bool,
+    emit_session_metadata: bool,
     record_per_request: bool,
     max_sim_time_ms: Option<f64>,
     sla: SlaThresholds,
 ) -> Result<TraceSimulationReport> {
     let started_at = Instant::now();
     let args = args.normalized()?;
-    let driver = if accumulate_session_deltas {
+    let mut driver = if accumulate_session_deltas {
         trace.into_delta_accumulating_trace_driver_with_block_size(args.block_size)?
     } else {
         trace.into_trace_driver_with_block_size(args.block_size)?
     };
+    if !emit_session_metadata {
+        driver = driver.without_session_metadata();
+    }
     let (collector, _) = AggRuntime::new_workload(
         &args,
         router_config,

--- a/lib/mocker/src/replay/offline/mod.rs
+++ b/lib/mocker/src/replay/offline/mod.rs
@@ -22,5 +22,6 @@ pub(crate) use entrypoints::{
     simulate_concurrency_workload, simulate_concurrency_workload_accumulating_deltas,
     simulate_concurrency_workload_disagg, simulate_trace, simulate_trace_disagg,
     simulate_trace_workload, simulate_trace_workload_accumulating_deltas,
-    simulate_trace_workload_disagg,
+    simulate_trace_workload_disagg, simulate_trace_workload_disagg_without_session_metadata,
+    simulate_trace_workload_without_session_metadata,
 };

--- a/lib/mocker/src/replay/online/live_runtime.rs
+++ b/lib/mocker/src/replay/online/live_runtime.rs
@@ -220,7 +220,11 @@ impl LiveRuntime {
 
         loop {
             let now = now_ms(start);
-            let ready_turns = workload.driver.lock().unwrap().pop_ready(now, usize::MAX);
+            // Materialize one prompt at a time so a same-timestamp burst does not block
+            // every request behind synchronous preparation of the full ready backlog.
+            // Mark the CPU-bound section as blocking so Tokio can keep driving request tasks.
+            let ready_turns =
+                tokio::task::block_in_place(|| workload.driver.lock().unwrap().pop_ready(now, 1));
             if !ready_turns.is_empty() {
                 for ready_turn in ready_turns {
                     let guard = cap_enabled.then(|| {
@@ -237,6 +241,7 @@ impl LiveRuntime {
                         guard,
                     ));
                 }
+                tokio::task::yield_now().await;
                 continue;
             }
 


### PR DESCRIPTION
## Summary

- retain full-prompt Dynamo trace inputs as compact `input_length` + `hash_ids` in `WorkloadDriver`
- materialize prompt tokens and engine replay hashes only when each request becomes ready
- route single-turn Dynamo v1 traces through the workload path while preserving the legacy Mooncake request path
- keep delta-cumulative traces eager so their session-history semantics remain unchanged

## Root cause

`WorkloadDriver` eagerly synthesized prompt tokens and replay hashes for all full-prompt turns. Single-turn Dynamo traces additionally used a fast path that converted the entire trace into `DirectRequest`s up front, bypassing the workload driver's scheduling lifecycle.

## Impact and risk

Prompt memory now scales with requests dispatched concurrently instead of total future input tokens, plus the compact hashes retained by the trace. Token synthesis, KV hashing, output-token planning, arrival ordering, and delta-cumulative behavior use the existing algorithms.

The change is intentionally limited to materialization timing. It does not change the trace schema or make token/hash synthesis incremental during an active request.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker --lib -- -D warnings`
- `cargo test -p dynamo-mocker --lib` (524 passed, 1 ignored)

Added coverage verifies that full prompts remain deferred until dispatch, delta-cumulative prompts stay eagerly materialized, setup validation errors are preserved, and Dynamo single-turn traces select the workload path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workload trace handling by deferring full-prompt materialization until dispatch.
  * Added more reliable support for cumulative prompt workloads and multi-turn session history.
  * Added validation for prompt sizes, block sizes, and overflow conditions.

* **Bug Fixes**
  * Corrected trace-format routing so Dynamo traces use the appropriate workload path.
  * Preserved prompt validation errors during workload setup.

* **Tests**
  * Added coverage for prompt materialization timing, validation errors, cumulative prompts, and trace-format behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->