### PR TITLE
fix(global-planner): read v1beta1 DGD components

### DIFF
--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -273,6 +273,21 @@ class ScaleRequestHandler:
         node_count = 1 if multinode is None else multinode.get("nodeCount", 2)
         return service.get_gpu_count() * int(node_count)
 
+    @staticmethod
+    def _record_pool_component(
+        components_by_pool: dict[str, str],
+        pool_key: str,
+        component_name: str,
+        dgd_name: str,
+    ) -> None:
+        previous_component = components_by_pool.get(pool_key)
+        if previous_component is not None:
+            raise ValueError(
+                f"DGD {dgd_name!r} components {previous_component!r} and "
+                f"{component_name!r} both resolve to planner pool {pool_key!r}"
+            )
+        components_by_pool[pool_key] = component_name
+
     def _read_dgd_pools(
         self,
         connector: KubernetesConnector,
@@ -285,6 +300,7 @@ class ScaleRequestHandler:
         """
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
         pools: dict[str, PoolSpec] = {}
+        components_by_pool: dict[str, str] = {}
         role_hints = role_hints or {}
         for component_name, component in get_components_by_name(deployment).items():
             pool_key = self._component_role(component_name, component, role_hints)
@@ -308,6 +324,12 @@ class ScaleRequestHandler:
                 pool_key = component_name
             if not pool_key:
                 continue
+            self._record_pool_component(
+                components_by_pool,
+                pool_key,
+                component_name,
+                connector.parent_dgd_name,
+            )
             pools[pool_key] = PoolSpec(
                 sub_type=pool_key,
                 component_name=component_name,
@@ -1093,10 +1115,19 @@ class ScaleRequestHandler:
                 connector.parent_dgd_name
             )
             role_hints = self._component_roles.get(connector_key, {})
+            components_by_pool: dict[str, str] = {}
             for component_name, component in get_components_by_name(deployment).items():
                 sub_type = self._component_role(component_name, component, role_hints)
                 if sub_type:
-                    current_replicas[sub_type] = component.get("replicas", 0)
+                    self._record_pool_component(
+                        components_by_pool,
+                        sub_type,
+                        component_name,
+                        connector.parent_dgd_name,
+                    )
+                    current_replicas[sub_type] = Service(
+                        name=component_name, service=component
+                    ).number_replicas()
 
             logger.info(
                 f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -33,6 +33,7 @@ class PoolSpec:
     """Snapshot of one pool's state read from the DGD spec."""
 
     sub_type: str
+    component_name: str
     current_replicas: int
     gpu_per_replica: int
 
@@ -266,6 +267,12 @@ class ScaleRequestHandler:
             return role_hints.get(component_name, "")
         return ""
 
+    @staticmethod
+    def _gpu_per_replica(component: dict, service: Service) -> int:
+        multinode = component.get("multinode")
+        node_count = 1 if multinode is None else multinode.get("nodeCount", 2)
+        return service.get_gpu_count() * int(node_count)
+
     def _read_dgd_pools(
         self,
         connector: KubernetesConnector,
@@ -289,7 +296,7 @@ class ScaleRequestHandler:
                 V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
             ):
                 try:
-                    gpu_per_replica = service.get_gpu_count()
+                    gpu_per_replica = self._gpu_per_replica(component, service)
                 except ValueError:
                     if component_type == "":
                         # An untyped non-worker component is not a pool.
@@ -303,11 +310,12 @@ class ScaleRequestHandler:
                 continue
             pools[pool_key] = PoolSpec(
                 sub_type=pool_key,
+                component_name=component_name,
                 current_replicas=service.number_replicas(),
                 gpu_per_replica=(
                     gpu_per_replica
                     if gpu_per_replica is not None
-                    else service.get_gpu_count()
+                    else self._gpu_per_replica(component, service)
                 ),
             )
         return pools
@@ -993,10 +1001,11 @@ class ScaleRequestHandler:
                 # patch. Cross-DGD partners get separate per-DGD patches.
                 dgd_targets: dict[str, list[TargetReplica]] = defaultdict(list)
                 dgd_targets[request_key].extend(request.target_replicas)
-                for p_dgd, p_sub, p_desired, _ in selected_partners:
+                for p_dgd, p_sub, p_desired, p_spec in selected_partners:
                     dgd_targets[p_dgd].append(
                         TargetReplica(
                             sub_component_type=SubComponentType(p_sub),
+                            component_name=p_spec.component_name,
                             desired_replicas=p_desired,
                         )
                     )

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -16,6 +16,13 @@ from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.planner.core import budget
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
+from dynamo.planner.monitoring.dgd_services import (
+    V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+    Service,
+    get_component_type,
+    get_components_by_name,
+    get_planner_component_role,
+)
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
 
 logger = logging.getLogger(__name__)
@@ -114,6 +121,10 @@ class ScaleRequestHandler:
         self.min_total_gpus = min_total_gpus
         self.intent_cache_ttl_seconds = intent_cache_ttl_seconds
         self.connectors: dict[str, KubernetesConnector] = {}  # Cache per DGD
+        # Generic v1beta1 ``type: worker`` components need the role supplied by
+        # their Planner's TargetReplica. Specialized prefill/decode components
+        # do not need a hint.
+        self._component_roles: dict[str, dict[str, str]] = {}
         # Per-pool cached desired replicas from recent ScaleRequests, keyed by
         # f"{k8s_ns}/{dgd_name}/{sub_type}". Used to pair opposite-direction
         # intents across requests when one request alone would breach bounds.
@@ -239,37 +250,78 @@ class ScaleRequestHandler:
                 f"Initial total GPUs ({total}) meets floor ({self.min_total_gpus})"
             )
 
-    def _read_dgd_pools(self, connector: KubernetesConnector) -> dict[str, PoolSpec]:
+    @staticmethod
+    def _component_role(
+        component_name: str,
+        component: dict,
+        role_hints: dict[str, str],
+    ) -> str:
+        explicit_role = get_planner_component_role(component)
+        if explicit_role:
+            return explicit_role
+        if get_component_type(component) in (
+            "",
+            V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+        ):
+            return role_hints.get(component_name, "")
+        return ""
+
+    def _read_dgd_pools(
+        self,
+        connector: KubernetesConnector,
+        role_hints: Optional[dict[str, str]] = None,
+    ) -> dict[str, PoolSpec]:
         """Read the current pool state for one DGD.
 
-        Returns a map from sub_component_type to PoolSpec. Pools with 0
-        gpu_per_replica are included for completeness but contribute 0 to
-        budget math.
+        Returns a map from sub_component_type to PoolSpec. An unmapped generic
+        worker is keyed by component name so it still contributes to the total.
         """
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
         pools: dict[str, PoolSpec] = {}
-        services = deployment.get("spec", {}).get("services", {})
-        for svc_spec in services.values():
-            sub_type = svc_spec.get("subComponentType", "")
-            if not sub_type:
+        role_hints = role_hints or {}
+        for component_name, component in get_components_by_name(deployment).items():
+            pool_key = self._component_role(component_name, component, role_hints)
+            component_type = get_component_type(component)
+            service = Service(name=component_name, service=component)
+            gpu_per_replica = None
+            if not pool_key and component_type in (
+                "",
+                V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+            ):
+                try:
+                    gpu_per_replica = service.get_gpu_count()
+                except ValueError:
+                    if component_type == "":
+                        # An untyped non-worker component is not a pool.
+                        continue
+                    raise
+                # Count an as-yet-unmapped worker in the cluster total. Once
+                # its Planner sends a request, the component-name hint replaces
+                # this key with its prefill/decode role.
+                pool_key = component_name
+            if not pool_key:
                 continue
-            gpu_per_replica = int(
-                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
-            )
-            replicas = svc_spec.get("replicas", 0)
-            pools[sub_type] = PoolSpec(
-                sub_type=sub_type,
-                current_replicas=replicas,
-                gpu_per_replica=gpu_per_replica,
+            pools[pool_key] = PoolSpec(
+                sub_type=pool_key,
+                current_replicas=service.number_replicas(),
+                gpu_per_replica=(
+                    gpu_per_replica
+                    if gpu_per_replica is not None
+                    else service.get_gpu_count()
+                ),
             )
         return pools
 
-    def _read_all_pools(self) -> dict[str, dict[str, PoolSpec]]:
+    def _read_all_pools(
+        self, require_complete: bool = False
+    ) -> dict[str, dict[str, PoolSpec]]:
         """Read current pool state for every known DGD.
 
         Returns a map of dgd_key -> (sub_type -> PoolSpec). Each arbitration
         call reads fresh state once; cross-DGD partner search and budget math
         both consume this snapshot to avoid re-hitting the K8s API per lookup.
+        When ``require_complete`` is true, any unreadable DGD fails the whole
+        snapshot so budget enforcement cannot under-count cluster usage.
 
         Snapshots ``self.connectors`` up-front via ``list(...)``: this method
         runs on a worker thread (see ``asyncio.to_thread`` in scale_request),
@@ -282,8 +334,12 @@ class ScaleRequestHandler:
         all_pools: dict[str, dict[str, PoolSpec]] = {}
         for key, connector in list(self.connectors.items()):
             try:
-                all_pools[key] = self._read_dgd_pools(connector)
+                all_pools[key] = self._read_dgd_pools(
+                    connector, self._component_roles.get(key)
+                )
             except Exception as e:
+                if require_complete:
+                    raise RuntimeError(f"Failed to read DGD for {key}: {e}") from e
                 logger.warning(f"Failed to read DGD for {key}: {e}")
                 all_pools[key] = {}
         return all_pools
@@ -317,11 +373,13 @@ class ScaleRequestHandler:
         In the hot arbitration path, prefer ``_total_gpus_from_snapshot`` with
         a pre-read ``_read_all_pools`` result.
 
-        NOTE: GPU count is read from spec.services[].resources.limits.gpu only.
-        GPUs specified via resources.requests.gpu or extraPodSpec resource
-        overrides are not counted.
+        NOTE: GPU count is read from the v1beta1 component's main container,
+        preferring resources.limits.nvidia.com/gpu and falling back to requests.
         """
-        return self._total_gpus_from_snapshot(self._read_all_pools(), overrides)
+        return self._total_gpus_from_snapshot(
+            self._read_all_pools(require_complete=self._budget_enforcement_enabled()),
+            overrides,
+        )
 
     # ------------------------------------------------------------------ #
     # Intent cache helpers                                               #
@@ -355,6 +413,12 @@ class ScaleRequestHandler:
                 last_desired=target.desired_replicas,
                 last_seen_at=now,
             )
+
+    def _remember_component_roles(self, dgd_key: str, request: ScaleRequest) -> None:
+        role_hints = self._component_roles.setdefault(dgd_key, {})
+        for target in request.target_replicas:
+            if target.component_name:
+                role_hints[target.component_name] = target.sub_component_type.value
 
     def _pair_tolerance(
         self,
@@ -792,13 +856,16 @@ class ScaleRequestHandler:
             # so concurrent requests from different pools cannot both pass
             # against the same pre-scale replica counts.
             async with self._scale_lock:
+                self._remember_component_roles(connector_key, request)
                 # Read ALL known DGDs' current state once. Cross-DGD partner
                 # search needs to see every pool's current replicas and
                 # gpu_per_replica; cross-DGD budget math also consumes this.
                 # Run the synchronous K8s GETs off-thread so the event loop
                 # (health checks, other endpoints) isn't blocked for the
                 # N round-trips it takes across managed DGDs.
-                all_pools = await asyncio.to_thread(self._read_all_pools)
+                all_pools = await asyncio.to_thread(
+                    self._read_all_pools, self._budget_enforcement_enabled()
+                )
                 dgd_pools = all_pools.get(connector_key, {})
 
                 # Always update the intent cache with this request's targets,
@@ -1016,10 +1083,11 @@ class ScaleRequestHandler:
             deployment = connector.kube_api.get_graph_deployment(
                 connector.parent_dgd_name
             )
-            for service_name, service_spec in deployment["spec"]["services"].items():
-                sub_type = service_spec.get("subComponentType", "")
+            role_hints = self._component_roles.get(connector_key, {})
+            for component_name, component in get_components_by_name(deployment).items():
+                sub_type = self._component_role(component_name, component, role_hints)
                 if sub_type:
-                    current_replicas[sub_type] = service_spec.get("replicas", 0)
+                    current_replicas[sub_type] = component.get("replicas", 0)
 
             logger.info(
                 f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -56,14 +56,7 @@ async def test_handler_authorization_success(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={
-                "spec": {
-                    "services": {
-                        "prefill-svc": {"subComponentType": "prefill", "replicas": 3},
-                        "decode-svc": {"subComponentType": "decode", "replicas": 5},
-                    }
-                }
-            }
+            return_value=_dgd_spec(prefill_replicas=3, decode_replicas=5)
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -149,7 +142,7 @@ async def test_handler_multiple_dgds(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"services": {}}}
+            return_value={"spec": {"components": []}}
         )
 
         # Process both requests
@@ -331,7 +324,7 @@ async def test_handler_blocking_mode(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"services": {}}}
+            return_value={"spec": {"components": []}}
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -350,23 +343,70 @@ async def test_handler_blocking_mode(mock_runtime):
 
 
 def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
-    """Build a DGD deployment spec with prefill + decode services."""
+    """Build a v1beta1 DGD spec with prefill and decode components."""
     return {
         "spec": {
-            "services": {
-                "prefill-svc": {
-                    "subComponentType": "prefill",
+            "components": [
+                {
+                    "name": "prefill-svc",
+                    "type": "prefill",
                     "replicas": prefill_replicas,
-                    "resources": {"limits": {"gpu": prefill_gpu}},
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "main",
+                                    "resources": {
+                                        "limits": {"nvidia.com/gpu": prefill_gpu}
+                                    },
+                                }
+                            ]
+                        }
+                    },
                 },
-                "decode-svc": {
-                    "subComponentType": "decode",
+                {
+                    "name": "decode-svc",
+                    "type": "decode",
                     "replicas": decode_replicas,
-                    "resources": {"limits": {"gpu": decode_gpu}},
+                    "podTemplate": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "main",
+                                    "resources": {
+                                        "limits": {"nvidia.com/gpu": decode_gpu}
+                                    },
+                                }
+                            ]
+                        }
+                    },
                 },
-            }
+            ]
         }
     }
+
+
+def _worker_dgd_spec(
+    replicas, gpu=1, component_name="worker-svc", component_type="worker"
+):
+    """Build a v1beta1 DGD spec with one generic worker component."""
+    component = {
+        "name": component_name,
+        "replicas": replicas,
+        "podTemplate": {
+            "spec": {
+                "containers": [
+                    {
+                        "name": "main",
+                        "resources": {"limits": {"nvidia.com/gpu": gpu}},
+                    }
+                ]
+            }
+        },
+    }
+    if component_type is not None:
+        component["type"] = component_type
+    return {"spec": {"components": [component]}}
 
 
 def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
@@ -387,6 +427,8 @@ def _scale_req(
     caller_ns="app-ns",
     prefill=None,
     decode=None,
+    prefill_component_name=None,
+    decode_component_name=None,
 ):
     """Build a ScaleRequest with one or both pool targets set."""
     targets = []
@@ -394,6 +436,7 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.PREFILL,
+                component_name=prefill_component_name,
                 desired_replicas=prefill,
             )
         )
@@ -401,6 +444,7 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.DECODE,
+                component_name=decode_component_name,
                 desired_replicas=decode,
             )
         )
@@ -423,6 +467,113 @@ async def _run(handler, request):
 # ---------------------------------------------------------------------------- #
 # min_total_gpus / arbitration tests                                           #
 # ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_role_used_for_budget_and_readback(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 4
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _worker_dgd_spec(replicas=1, gpu=2),
+    )
+
+    req = _scale_req(
+        caller_ns="default-my-dgd",
+        decode=2,
+        decode_component_name="worker-svc",
+    )
+    results = await _run(handler, req)
+
+    assert results[0]["status"] == "success"
+    assert results[0]["current_replicas"] == {"decode": 1}
+    connector.set_component_replicas.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_scale_rejected_above_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 2
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _worker_dgd_spec(replicas=1, gpu=2),
+    )
+
+    req = _scale_req(
+        caller_ns="default-my-dgd",
+        decode=2,
+        decode_component_name="worker-svc",
+    )
+    results = await _run(handler, req)
+
+    assert results[0]["status"] == "rejected"
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_untyped_worker_in_other_dgd_counts_toward_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-dgd-a", "default-dgd-b"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 6
+    connector_a = _install_connector(
+        handler,
+        "default/dgd-a",
+        _dgd_spec(prefill_replicas=1, decode_replicas=1),
+        parent_dgd_name="dgd-a",
+    )
+    connector_b = _install_connector(
+        handler,
+        "default/dgd-b",
+        _worker_dgd_spec(replicas=2, gpu=2, component_type=None),
+        parent_dgd_name="dgd-b",
+    )
+
+    results = await _run(
+        handler,
+        _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2),
+    )
+
+    assert results[0]["status"] == "rejected"
+    connector_a.set_component_replicas.assert_not_called()
+    connector_b.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_budget_request_fails_when_dgd_snapshot_is_incomplete(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 6
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _dgd_spec(prefill_replicas=1, decode_replicas=1),
+    )
+    connector.kube_api.get_graph_deployment.side_effect = RuntimeError("API timeout")
+
+    results = await _run(
+        handler,
+        _scale_req(caller_ns="default-my-dgd", prefill=2),
+    )
+
+    assert results[0]["status"] == "error"
+    assert "Failed to read DGD" in results[0]["message"]
+    connector.set_component_replicas.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -760,7 +911,7 @@ async def test_cross_dgd_asymmetric_pair_rejected_above_ceiling(mock_runtime):
         max_total_gpus=10,
     )
     # DGD-A: prefill=4 (1 GPU each) + decode=0 → 4 GPUs.
-    # DGD-B: one agg pool reusing "decode" subComponentType with 2 GPU/worker,
+    # DGD-B: one agg pool reusing the "decode" component type with 2 GPU/worker,
     #   3 workers → 6 GPUs. Total cluster=10.
     _install_connector(
         handler,

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from dynamo.global_planner.scale_handler import PoolIntent, ScaleRequestHandler
-from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner import KubernetesConnector, SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleRequest
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 
@@ -342,9 +342,16 @@ async def test_handler_blocking_mode(mock_runtime):
 # ---------------------------------------------------------------------------- #
 
 
-def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
+def _dgd_spec(
+    prefill_replicas,
+    decode_replicas,
+    prefill_gpu=1,
+    decode_gpu=1,
+    prefill_node_count=None,
+    decode_node_count=None,
+):
     """Build a v1beta1 DGD spec with prefill and decode components."""
-    return {
+    deployment = {
         "spec": {
             "components": [
                 {
@@ -384,6 +391,12 @@ def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
             ]
         }
     }
+    components = deployment["spec"]["components"]
+    if prefill_node_count is not None:
+        components[0]["multinode"] = {"nodeCount": prefill_node_count}
+    if decode_node_count is not None:
+        components[1]["multinode"] = {"nodeCount": decode_node_count}
+    return deployment
 
 
 def _worker_dgd_spec(
@@ -417,6 +430,20 @@ def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"
     connector.parent_dgd_name = parent_dgd_name
     connector.kube_api = MagicMock()
     connector.kube_api.get_graph_deployment = MagicMock(return_value=dgd_spec_dict)
+    handler.connectors[dgd_key] = connector
+    return connector
+
+
+def _install_real_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
+    """Attach a real KubernetesConnector backed by a mocked Kubernetes API."""
+    connector = KubernetesConnector.__new__(KubernetesConnector)
+    connector.parent_dgd_name = parent_dgd_name
+    connector.graph_deployment_name = parent_dgd_name
+    connector.raise_not_ready = True
+    connector.kube_api = MagicMock()
+    connector.kube_api.get_graph_deployment.return_value = dgd_spec_dict
+    connector.kube_api.is_deployment_ready.return_value = True
+    connector.kube_api.wait_for_graph_deployment_ready = AsyncMock()
     handler.connectors[dgd_key] = connector
     return connector
 
@@ -515,6 +542,72 @@ async def test_generic_worker_scale_rejected_above_budget(mock_runtime):
         decode_component_name="worker-svc",
     )
     results = await _run(handler, req)
+
+    assert results[0]["status"] == "rejected"
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_partner_keeps_component_name(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-dgd-a", "default-dgd-b"],
+        k8s_namespace="default",
+    )
+    handler.min_total_gpus = 9
+    handler.max_total_gpus = 9
+    connector_a = _install_connector(
+        handler,
+        "default/dgd-a",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="dgd-a",
+    )
+    connector_b = _install_real_connector(
+        handler,
+        "default/dgd-b",
+        _worker_dgd_spec(replicas=3),
+        parent_dgd_name="dgd-b",
+    )
+    handler._component_roles["default/dgd-b"] = {"worker-svc": "decode"}
+    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+        last_desired=4, last_seen_at=time.time()
+    )
+
+    results = await _run(
+        handler,
+        _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2),
+    )
+
+    assert results[0]["status"] == "success"
+    connector_a.set_component_replicas.assert_called_once()
+    connector_b.kube_api.update_graph_replicas.assert_called_once_with(
+        "dgd-b", "worker-svc", 4
+    )
+
+
+@pytest.mark.asyncio
+async def test_multinode_gpu_count_enforces_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 12
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _dgd_spec(
+            prefill_replicas=1,
+            decode_replicas=0,
+            prefill_gpu=4,
+            prefill_node_count=2,
+        ),
+    )
+
+    results = await _run(
+        handler,
+        _scale_req(caller_ns="default-my-dgd", prefill=2),
+    )
 
     assert results[0]["status"] == "rejected"
     connector.set_component_replicas.assert_not_called()

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -422,6 +422,17 @@ def _worker_dgd_spec(
     return {"spec": {"components": [component]}}
 
 
+def _two_worker_dgd_spec(replicas=1, gpu=1):
+    """Build a DGD with two generic workers that can resolve to one role."""
+    deployment = _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-a")
+    deployment["spec"]["components"].extend(
+        _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-b")["spec"][
+            "components"
+        ]
+    )
+    return deployment
+
+
 def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
     """Attach a mocked KubernetesConnector to the handler for one DGD."""
     connector = AsyncMock()
@@ -583,6 +594,75 @@ async def test_generic_worker_partner_keeps_component_name(mock_runtime):
     connector_b.kube_api.update_graph_replicas.assert_called_once_with(
         "dgd-b", "worker-svc", 4
     )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_resolved_pool_rejected_in_budget_snapshot(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    handler.max_total_gpus = 4
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _two_worker_dgd_spec(),
+    )
+    handler._component_roles["default/my-dgd"] = {
+        "worker-a": "decode",
+        "worker-b": "decode",
+    }
+
+    results = await _run(
+        handler,
+        _scale_req(
+            caller_ns="default-my-dgd",
+            decode=2,
+            decode_component_name="worker-a",
+        ),
+    )
+
+    assert results[0]["status"] == "error"
+    assert "'worker-a' and 'worker-b'" in results[0]["message"]
+    assert "planner pool 'decode'" in results[0]["message"]
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_resolved_pool_rejected_during_readback(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _worker_dgd_spec(replicas=1, component_name="worker-a"),
+    )
+    connector.kube_api.get_graph_deployment.side_effect = [
+        _worker_dgd_spec(replicas=1, component_name="worker-a"),
+        _two_worker_dgd_spec(),
+    ]
+    handler._component_roles["default/my-dgd"] = {
+        "worker-a": "decode",
+        "worker-b": "decode",
+    }
+
+    results = await _run(
+        handler,
+        _scale_req(
+            caller_ns="default-my-dgd",
+            decode=2,
+            decode_component_name="worker-a",
+        ),
+    )
+
+    assert results[0]["status"] == "error"
+    assert "'worker-a' and 'worker-b'" in results[0]["message"]
+    assert "planner pool 'decode'" in results[0]["message"]
+    connector.set_component_replicas.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- read GlobalPlanner pool inventory from v1beta1 `spec.components` instead of removed `spec.services`
- resolve replica roles from component `type` or request component-name hints, including generic and untyped workers
- read GPU counts from the main container `nvidia.com/gpu` resources and fail closed when a budget snapshot is incomplete
- update GlobalPlanner fixtures and regression coverage to use the real v1beta1 schema

## Root cause

GlobalPlanner budget accounting and post-scale readback still parsed the v1alpha1 DGD shape. On v1beta1 deployments this made GPU usage appear as zero, then raised `KeyError("services")` after a successful scale patch.

## Validation

- `KUBECONFIG=/dev/null .venv/bin/python -m pytest -xvv components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py` — 42 passed
- `KUBECONFIG=/dev/null .venv/bin/python -m pytest -xvv components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py -k "service_get_gpu_count or get_gpu_counts"` — 11 passed
- target-file pre-commit hooks passed with `pytest-marker-report` skipped; that repository-wide hook cannot collect an unrelated KVBM test in this local environment because `kvbm.trtllm_integration` is unavailable
- independent agentic review completed with no remaining findings

## Related Issues

**This PR is NOT linked to a public GitHub issue:**

- [x] Confirmed — internal tracking: [DYN-3557](https://linear.app/nvidia/issue/DYN-3557/dynamo130planner-globalplanner-reads-the-deprecated-dgd-specservices), NVBug 6470497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component-role detection for more accurate scaling decisions across deployment configurations.
  * Corrected GPU pool discovery, including support for generic worker components.
  * Prevented budget enforcement from proceeding when cluster pool information cannot be read reliably.
  * Updated replica reporting to reflect component-role mappings consistently.

* **Tests**
  * Added coverage for worker GPU budgets, cross-deployment counting, untyped components, and snapshot-read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->