### PR TITLE
fix(inference-gateway): forward full request body to EPP KV-router scorer

### DIFF
--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
@@ -27,8 +27,6 @@ limitations under the License.
 package disagg
 
 import (
-	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 	"sync"
@@ -71,15 +69,7 @@ func readPrefillEnabled(cycleState *schedtypes.CycleState) bool {
 
 // buildRequestJSON builds an OpenAI-compatible JSON string from a GAIE LLMRequest.
 func buildRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
-	requestBody, err := dynscorer.BuildOpenAIRequest(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to build OpenAI request: %w", err)
-	}
-	data, err := json.Marshal(requestBody)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal request JSON: %w", err)
-	}
-	return string(data), nil
+	return dynscorer.BuildOpenAIRequestJSON(req)
 }
 
 // serializeEndpoints converts endpoints to a JSON string for the FFI filter.

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -283,16 +283,10 @@ func SerializeEndpointsToJSON(endpoints []schedtypes.Endpoint) (string, error) {
 	return string(data), nil
 }
 
-// BuildOpenAIRequestJSON serializes the request as an OpenAI-compatible JSON
-// body for the Rust router's FFI.
-//
-// A successfully parsed OpenAI request always yields a populated Payload holding
-// the complete body, so it is forwarded verbatim (overriding only the resolved
-// target model). This preserves tool_calls, tool_call_id, tools, and reasoning
-// content that the router's strict parse and chat-template rendering require —
-// fields the typed ChatCompletions view does not model. When the payload is
-// unavailable the request cannot be KV-routed, so an error is returned and the
-// scorer falls back to non-KV routing rather than a lossy reconstruction.
+// BuildOpenAIRequestJSON forwards the full request body (req.Body.Payload) to
+// the Rust router's FFI, overriding only the model, so tool-calling and
+// reasoning fields survive the router's parse and chat-template render. Errors
+// when no payload is available so the scorer falls back to non-KV routing.
 func BuildOpenAIRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
 	if req == nil || req.Body == nil {
 		return "", fmt.Errorf("missing request body")
@@ -305,7 +299,7 @@ func BuildOpenAIRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
 
 	requestBody := make(map[string]any, len(pm))
 	maps.Copy(requestBody, pm)
-	// Route on the resolved target model, not whatever alias the caller sent.
+	// Route on the resolved target model.
 	if strings.TrimSpace(req.TargetModel) != "" {
 		requestBody["model"] = req.TargetModel
 	}

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -283,127 +283,38 @@ func SerializeEndpointsToJSON(endpoints []schedtypes.Endpoint) (string, error) {
 	return string(data), nil
 }
 
-func BuildOpenAIRequest(req *schedtypes.InferenceRequest) (map[string]any, error) {
+// BuildOpenAIRequestJSON serializes the request as an OpenAI-compatible JSON
+// body for the Rust router's FFI.
+//
+// A successfully parsed OpenAI request always yields a populated Payload holding
+// the complete body, so it is forwarded verbatim (overriding only the resolved
+// target model). This preserves tool_calls, tool_call_id, tools, and reasoning
+// content that the router's strict parse and chat-template rendering require —
+// fields the typed ChatCompletions view does not model. When the payload is
+// unavailable the request cannot be KV-routed, so an error is returned and the
+// scorer falls back to non-KV routing rather than a lossy reconstruction.
+func BuildOpenAIRequestJSON(req *schedtypes.InferenceRequest) (string, error) {
 	if req == nil || req.Body == nil {
-		return nil, fmt.Errorf("missing request body")
+		return "", fmt.Errorf("missing request body")
 	}
 
-	// Prefer the full, original request body. The Rust router parses this JSON
-	// and re-renders the model's chat template to tokenize for KV-aware routing,
-	// so it needs the complete message structure — tool_calls, tool_call_id,
-	// tools, reasoning/thinking content, multimodal parts, etc. The typed
-	// ChatCompletions view only models role+content; reconstructing from it
-	// drops those fields, which breaks routing in two ways:
-	//  1. On tool-calling turns the router's strict parse fails (a role:"tool"
-	//     message is missing the required tool_call_id), route_decode_request
-	//     returns an error, no worker is selected, and the request is dropped
-	//     as 503 "no healthy upstream" — multi-turn tool calling is unroutable.
-	//  2. Even when parsing succeeds, the chat template renders an incomplete
-	//     prompt, so reasoning/tool parsing is lost (e.g. on non-streaming
-	//     requests) and tokenization no longer matches what the worker sees.
-	if pm, ok := req.Body.Payload.(fwkrh.PayloadMap); ok && len(pm) > 0 {
-		requestBody := make(map[string]any, len(pm))
-		maps.Copy(requestBody, pm)
-		// Route on the resolved target model, not whatever alias the caller sent.
-		if strings.TrimSpace(req.TargetModel) != "" {
-			requestBody["model"] = req.TargetModel
-		}
-		return requestBody, nil
+	pm, ok := req.Body.Payload.(fwkrh.PayloadMap)
+	if !ok || len(pm) == 0 {
+		return "", fmt.Errorf("request payload unavailable; cannot build KV-routing request")
 	}
 
-	// Fallback: the raw payload is unavailable (not unmarshaled). Reconstruct a
-	// minimal request from the framework's typed view. Tool-calling turns cannot
-	// be represented here, but plain chat/completion routing still works.
-	return buildOpenAIRequestFromTyped(req)
-}
-
-// buildOpenAIRequestFromTyped reconstructs a minimal request from the
-// framework's typed request view. The typed Message only models role+content,
-// so this cannot preserve tool-calling fields (tool_calls / tool_call_id / name)
-// or other structure the raw payload carries; it is only used when the raw
-// payload is unavailable.
-func buildOpenAIRequestFromTyped(req *schedtypes.InferenceRequest) (map[string]any, error) {
-	requestBody := make(map[string]any)
-
-	if req.Body.ChatCompletions != nil && len(req.Body.ChatCompletions.Messages) > 0 {
-		messages := make([]map[string]any, 0, len(req.Body.ChatCompletions.Messages))
-		anyNonEmpty := false
-		for _, msg := range req.Body.ChatCompletions.Messages {
-			content := msg.Content.PlainText()
-			if strings.TrimSpace(content) != "" {
-				anyNonEmpty = true
-			}
-			messages = append(messages, map[string]any{
-				"role":    msg.Role,
-				"content": content,
-			})
-		}
-		if !anyNonEmpty {
-			return nil, fmt.Errorf("empty chat messages")
-		}
-		requestBody["messages"] = messages
-	} else if req.Body.Completions != nil && !req.Body.Completions.Prompt.IsEmpty() {
-		addCompletionPrompt(requestBody, req.Body.Completions.Prompt)
-	} else {
-		return nil, fmt.Errorf("no messages or prompt provided")
-	}
-
+	requestBody := make(map[string]any, len(pm))
+	maps.Copy(requestBody, pm)
+	// Route on the resolved target model, not whatever alias the caller sent.
 	if strings.TrimSpace(req.TargetModel) != "" {
 		requestBody["model"] = req.TargetModel
-	} else {
-		requestBody["model"] = "default"
 	}
 
-	// Forward the caller's nvext block so the Rust router can lift
-	// nvext.agent_hints.priority into priority_jump.
-	if nvext := extractNvext(req.Body.Payload); nvext != nil {
-		requestBody["nvext"] = nvext
+	data, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request JSON: %w", err)
 	}
-	if cacheSalt := extractTopLevelCacheSalt(req.Body.Payload); cacheSalt != "" {
-		requestBody["cache_salt"] = cacheSalt
-	}
-
-	return requestBody, nil
-}
-
-func addCompletionPrompt(requestBody map[string]any, prompt fwkrh.Prompt) {
-	if len(prompt.TokenIDs) > 0 {
-		tokenIDs := make([]uint32, len(prompt.TokenIDs))
-		copy(tokenIDs, prompt.TokenIDs)
-		requestBody["prompt"] = tokenIDs
-		return
-	}
-
-	// Keep non-token completions on the legacy chat-shaped scorer path.
-	requestBody["messages"] = []map[string]any{
-		{
-			"role":    "user",
-			"content": prompt.PlainText(),
-		},
-	}
-}
-
-// extractNvext returns the caller-supplied nvext object from the PayloadMap,
-// or nil when the payload is not a map or does not contain an nvext object.
-//
-// This is how routing hints — most notably nvext.agent_hints.priority — reach
-// the Rust router via the FFI JSON.
-func extractNvext(payload fwkrh.RequestPayload) map[string]any {
-	pm, ok := payload.(fwkrh.PayloadMap)
-	if !ok {
-		return nil
-	}
-	nvext, _ := pm["nvext"].(map[string]any)
-	return nvext
-}
-
-func extractTopLevelCacheSalt(payload fwkrh.RequestPayload) string {
-	pm, ok := payload.(fwkrh.PayloadMap)
-	if !ok {
-		return ""
-	}
-	cacheSalt, _ := pm["cache_salt"].(string)
-	return cacheSalt
+	return string(data), nil
 }
 
 // CallAddRequest registers a request with the router's bookkeeping.

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -101,6 +101,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 	"sync"
@@ -283,11 +284,46 @@ func SerializeEndpointsToJSON(endpoints []schedtypes.Endpoint) (string, error) {
 }
 
 func BuildOpenAIRequest(req *schedtypes.InferenceRequest) (map[string]any, error) {
-	requestBody := make(map[string]any)
-
 	if req == nil || req.Body == nil {
 		return nil, fmt.Errorf("missing request body")
 	}
+
+	// Prefer the full, original request body. The Rust router parses this JSON
+	// and re-renders the model's chat template to tokenize for KV-aware routing,
+	// so it needs the complete message structure — tool_calls, tool_call_id,
+	// tools, reasoning/thinking content, multimodal parts, etc. The typed
+	// ChatCompletions view only models role+content; reconstructing from it
+	// drops those fields, which breaks routing in two ways:
+	//  1. On tool-calling turns the router's strict parse fails (a role:"tool"
+	//     message is missing the required tool_call_id), route_decode_request
+	//     returns an error, no worker is selected, and the request is dropped
+	//     as 503 "no healthy upstream" — multi-turn tool calling is unroutable.
+	//  2. Even when parsing succeeds, the chat template renders an incomplete
+	//     prompt, so reasoning/tool parsing is lost (e.g. on non-streaming
+	//     requests) and tokenization no longer matches what the worker sees.
+	if pm, ok := req.Body.Payload.(fwkrh.PayloadMap); ok && len(pm) > 0 {
+		requestBody := make(map[string]any, len(pm))
+		maps.Copy(requestBody, pm)
+		// Route on the resolved target model, not whatever alias the caller sent.
+		if strings.TrimSpace(req.TargetModel) != "" {
+			requestBody["model"] = req.TargetModel
+		}
+		return requestBody, nil
+	}
+
+	// Fallback: the raw payload is unavailable (not unmarshaled). Reconstruct a
+	// minimal request from the framework's typed view. Tool-calling turns cannot
+	// be represented here, but plain chat/completion routing still works.
+	return buildOpenAIRequestFromTyped(req)
+}
+
+// buildOpenAIRequestFromTyped reconstructs a minimal request from the
+// framework's typed request view. The typed Message only models role+content,
+// so this cannot preserve tool-calling fields (tool_calls / tool_call_id / name)
+// or other structure the raw payload carries; it is only used when the raw
+// payload is unavailable.
+func buildOpenAIRequestFromTyped(req *schedtypes.InferenceRequest) (map[string]any, error) {
+	requestBody := make(map[string]any)
 
 	if req.Body.ChatCompletions != nil && len(req.Body.ChatCompletions.Messages) > 0 {
 		messages := make([]map[string]any, 0, len(req.Body.ChatCompletions.Messages))

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
@@ -169,3 +169,80 @@ func TestBuildOpenAIRequest_CompletionsStringArrayPromptKeepsLegacyMessageShape(
 		t.Fatalf("expected single user message with content='hello world', got %#v", messages)
 	}
 }
+
+// TestBuildOpenAIRequest_PreservesToolCallFields pins the contract that a
+// multi-turn tool conversation survives intact in the JSON sent across FFI to
+// the Rust router. The router parses this body and re-renders the model's chat
+// template to tokenize, so it needs the full message structure. If tool_calls /
+// tool_call_id are dropped, the router's strict parse fails with
+// "missing field tool_call_id" and the request is unroutable (503 no healthy
+// upstream); reasoning/tool parsing is also lost when the template renders an
+// incomplete prompt.
+func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
+	toolCall := map[string]any{
+		"id":   "call-abc",
+		"type": "function",
+		"function": map[string]any{
+			"name":      "get_current_weather",
+			"arguments": `{"location":"Tokyo"}`,
+		},
+	}
+	req := &schedtypes.InferenceRequest{
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			// The typed view only carries role+content; the raw payload below is
+			// the source of truth and must be forwarded verbatim.
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{
+					{Role: "user", Content: fwkrh.Content{Raw: "weather in Tokyo?"}},
+					{Role: "assistant", Content: fwkrh.Content{Raw: ""}},
+					{Role: "tool", Content: fwkrh.Content{Raw: "18C rain"}},
+				},
+			},
+			Payload: fwkrh.PayloadMap{
+				"model": "alias-model",
+				"messages": []any{
+					map[string]any{"role": "user", "content": "weather in Tokyo?"},
+					map[string]any{"role": "assistant", "content": nil, "tool_calls": []any{toolCall}},
+					map[string]any{"role": "tool", "tool_call_id": "call-abc", "content": "18C rain"},
+				},
+			},
+		},
+	}
+
+	body, err := BuildOpenAIRequest(req)
+	if err != nil {
+		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
+	}
+
+	// Target model must override the caller's alias.
+	if got := body["model"]; got != "test-model" {
+		t.Fatalf("expected model=test-model, got %v", got)
+	}
+
+	msgs, ok := body["messages"].([]any)
+	if !ok {
+		t.Fatalf("expected messages []any from raw payload, got %T", body["messages"])
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	}
+
+	// Assistant turn must retain tool_calls.
+	assistant, ok := msgs[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected assistant message map, got %T", msgs[1])
+	}
+	if _, ok := assistant["tool_calls"].([]any); !ok {
+		t.Fatalf("assistant message lost tool_calls: %#v", assistant)
+	}
+
+	// Tool turn must retain tool_call_id (the field whose loss caused the 503).
+	tool, ok := msgs[2].(map[string]any)
+	if !ok {
+		t.Fatalf("expected tool message map, got %T", msgs[2])
+	}
+	if got := tool["tool_call_id"]; got != "call-abc" {
+		t.Fatalf("tool message lost tool_call_id: got %v in %#v", got, tool)
+	}
+}

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go
@@ -17,27 +17,35 @@ limitations under the License.
 package dynamo_kv_scorer
 
 import (
-	"reflect"
+	"encoding/json"
 	"testing"
 
 	fwkrh "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/requesthandling"
 	schedtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/interface/scheduling"
 )
 
-// TestBuildOpenAIRequest_ForwardsAgentHintsPriority pins the contract that
-// nvext.agent_hints.priority arriving on the original request body is
-// preserved in the JSON sent across FFI to the Rust router. Without this,
-// the router falls back to priority_jump=0.0 for every request and queue
-// ordering silently regresses.
-func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
+// ffiBody builds the FFI JSON and parses it back into a map for assertions.
+func ffiBody(t *testing.T, req *schedtypes.InferenceRequest) map[string]any {
+	t.Helper()
+	s, err := BuildOpenAIRequestJSON(req)
+	if err != nil {
+		t.Fatalf("BuildOpenAIRequestJSON returned error: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(s), &body); err != nil {
+		t.Fatalf("failed to unmarshal FFI JSON: %v (json=%s)", err, s)
+	}
+	return body
+}
+
+// TestBuildOpenAIRequestJSON_ForwardsAgentHintsPriority pins the contract that
+// nvext.agent_hints.priority on the original request body is preserved in the
+// JSON sent across FFI to the Rust router. Without it, the router falls back to
+// priority_jump=0.0 for every request and queue ordering silently regresses.
+func TestBuildOpenAIRequestJSON_ForwardsAgentHintsPriority(t *testing.T) {
 	req := &schedtypes.InferenceRequest{
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
-			ChatCompletions: &fwkrh.ChatCompletionsRequest{
-				Messages: []fwkrh.Message{
-					{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
-				},
-			},
 			Payload: fwkrh.PayloadMap{
 				"messages": []any{map[string]any{"role": "user", "content": "hi"}},
 				"model":    "test-model",
@@ -46,11 +54,7 @@ func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
 		},
 	}
 
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
-
+	body := ffiBody(t, req)
 	nvext, ok := body["nvext"].(map[string]any)
 	if !ok {
 		t.Fatalf("expected nvext to be a map, got %T", body["nvext"])
@@ -59,20 +63,17 @@ func TestBuildOpenAIRequest_ForwardsAgentHintsPriority(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected agent_hints to be a map, got %T", nvext["agent_hints"])
 	}
-	if got := hints["priority"]; got != 7 {
-		t.Fatalf("expected priority=7 forwarded to FFI body, got %v", got)
+	if got := hints["priority"]; got != float64(7) { // JSON numbers decode to float64
+		t.Fatalf("expected priority=7 forwarded to FFI body, got %v (%T)", got, got)
 	}
 }
 
-func TestBuildOpenAIRequest_ForwardsLegacyTopLevelCacheSalt(t *testing.T) {
+// TestBuildOpenAIRequestJSON_ForwardsLegacyTopLevelCacheSalt verifies a
+// top-level cache_salt on the request body is forwarded to the router.
+func TestBuildOpenAIRequestJSON_ForwardsLegacyTopLevelCacheSalt(t *testing.T) {
 	req := &schedtypes.InferenceRequest{
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
-			ChatCompletions: &fwkrh.ChatCompletionsRequest{
-				Messages: []fwkrh.Message{
-					{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
-				},
-			},
 			Payload: fwkrh.PayloadMap{
 				"messages":   []any{map[string]any{"role": "user", "content": "hi"}},
 				"model":      "test-model",
@@ -81,104 +82,20 @@ func TestBuildOpenAIRequest_ForwardsLegacyTopLevelCacheSalt(t *testing.T) {
 		},
 	}
 
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
+	body := ffiBody(t, req)
 	if got := body["cache_salt"]; got != "tenant-legacy" {
 		t.Fatalf("expected legacy cache_salt forwarded to FFI body, got %v", got)
 	}
 }
 
-func TestBuildOpenAIRequest_CompletionsTokenPromptUsesPromptIDs(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
-		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{TokenIDs: []uint32{101, 102, 103}},
-			},
-		},
-	}
-
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
-
-	if _, ok := body["messages"]; ok {
-		t.Fatalf("did not expect token-id completions to synthesize messages: %v", body["messages"])
-	}
-	if got := body["prompt"]; !reflect.DeepEqual(got, []uint32{101, 102, 103}) {
-		t.Fatalf("expected prompt token IDs, got %#v", got)
-	}
-	if got := body["model"]; got != "test-model" {
-		t.Fatalf("expected model=test-model, got %v", got)
-	}
-}
-
-func TestBuildOpenAIRequest_CompletionsTextPromptKeepsLegacyMessageShape(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
-		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{Raw: "hello"},
-			},
-		},
-	}
-
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
-
-	if _, ok := body["prompt"]; ok {
-		t.Fatalf("did not expect text completions to change to prompt field: %v", body["prompt"])
-	}
-	messages, ok := body["messages"].([]map[string]any)
-	if !ok {
-		t.Fatalf("expected legacy messages shape, got %#v", body["messages"])
-	}
-	if len(messages) != 1 || messages[0]["role"] != "user" || messages[0]["content"] != "hello" {
-		t.Fatalf("expected single user message with content=hello, got %#v", messages)
-	}
-}
-
-func TestBuildOpenAIRequest_CompletionsStringArrayPromptKeepsLegacyMessageShape(t *testing.T) {
-	req := &schedtypes.InferenceRequest{
-		TargetModel: "test-model",
-		Body: &fwkrh.InferenceRequestBody{
-			Completions: &fwkrh.CompletionsRequest{
-				Prompt: fwkrh.Prompt{Strings: []string{"hello", "world"}},
-			},
-		},
-	}
-
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
-
-	if _, ok := body["prompt"]; ok {
-		t.Fatalf("did not expect string-array completions to change to prompt field: %v", body["prompt"])
-	}
-	messages, ok := body["messages"].([]map[string]any)
-	if !ok {
-		t.Fatalf("expected legacy messages shape, got %#v", body["messages"])
-	}
-	if len(messages) != 1 || messages[0]["role"] != "user" || messages[0]["content"] != "hello world" {
-		t.Fatalf("expected single user message with content='hello world', got %#v", messages)
-	}
-}
-
-// TestBuildOpenAIRequest_PreservesToolCallFields pins the contract that a
-// multi-turn tool conversation survives intact in the JSON sent across FFI to
-// the Rust router. The router parses this body and re-renders the model's chat
-// template to tokenize, so it needs the full message structure. If tool_calls /
-// tool_call_id are dropped, the router's strict parse fails with
-// "missing field tool_call_id" and the request is unroutable (503 no healthy
-// upstream); reasoning/tool parsing is also lost when the template renders an
-// incomplete prompt.
-func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
+// TestBuildOpenAIRequestJSON_PreservesToolCallFields pins the contract that a
+// multi-turn tool conversation survives intact in the JSON sent across FFI. The
+// router parses this body and re-renders the model's chat template to tokenize,
+// so it needs the full message structure. If tool_calls / tool_call_id are
+// dropped, the router's strict parse fails ("missing field tool_call_id") and
+// the request is unroutable (503 no healthy upstream); reasoning/tool parsing is
+// also lost when the template renders an incomplete prompt.
+func TestBuildOpenAIRequestJSON_PreservesToolCallFields(t *testing.T) {
 	toolCall := map[string]any{
 		"id":   "call-abc",
 		"type": "function",
@@ -190,15 +107,6 @@ func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
 	req := &schedtypes.InferenceRequest{
 		TargetModel: "test-model",
 		Body: &fwkrh.InferenceRequestBody{
-			// The typed view only carries role+content; the raw payload below is
-			// the source of truth and must be forwarded verbatim.
-			ChatCompletions: &fwkrh.ChatCompletionsRequest{
-				Messages: []fwkrh.Message{
-					{Role: "user", Content: fwkrh.Content{Raw: "weather in Tokyo?"}},
-					{Role: "assistant", Content: fwkrh.Content{Raw: ""}},
-					{Role: "tool", Content: fwkrh.Content{Raw: "18C rain"}},
-				},
-			},
 			Payload: fwkrh.PayloadMap{
 				"model": "alias-model",
 				"messages": []any{
@@ -210,10 +118,7 @@ func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
 		},
 	}
 
-	body, err := BuildOpenAIRequest(req)
-	if err != nil {
-		t.Fatalf("BuildOpenAIRequest returned error: %v", err)
-	}
+	body := ffiBody(t, req)
 
 	// Target model must override the caller's alias.
 	if got := body["model"]; got != "test-model" {
@@ -221,11 +126,8 @@ func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
 	}
 
 	msgs, ok := body["messages"].([]any)
-	if !ok {
-		t.Fatalf("expected messages []any from raw payload, got %T", body["messages"])
-	}
-	if len(msgs) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(msgs))
+	if !ok || len(msgs) != 3 {
+		t.Fatalf("expected 3 messages, got %#v", body["messages"])
 	}
 
 	// Assistant turn must retain tool_calls.
@@ -244,5 +146,50 @@ func TestBuildOpenAIRequest_PreservesToolCallFields(t *testing.T) {
 	}
 	if got := tool["tool_call_id"]; got != "call-abc" {
 		t.Fatalf("tool message lost tool_call_id: got %v in %#v", got, tool)
+	}
+}
+
+// TestBuildOpenAIRequestJSON_ForwardsCompletionsPayload verifies a /v1/completions
+// body is forwarded verbatim (the Rust preprocessor handles it via the prompt
+// field), with only the model overridden to the resolved target.
+func TestBuildOpenAIRequestJSON_ForwardsCompletionsPayload(t *testing.T) {
+	req := &schedtypes.InferenceRequest{
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			Payload: fwkrh.PayloadMap{
+				"model":  "alias-model",
+				"prompt": "hello world",
+			},
+		},
+	}
+
+	body := ffiBody(t, req)
+	if got := body["prompt"]; got != "hello world" {
+		t.Fatalf("expected prompt forwarded, got %v", got)
+	}
+	if got := body["model"]; got != "test-model" {
+		t.Fatalf("expected model overridden to test-model, got %v", got)
+	}
+}
+
+// TestBuildOpenAIRequestJSON_MissingPayloadReturnsError verifies that when the
+// raw payload is unavailable the request is not KV-routable: an error is
+// returned so the scorer falls back to non-KV routing rather than a lossy
+// role/content reconstruction (which would drop tool-calling fields).
+func TestBuildOpenAIRequestJSON_MissingPayloadReturnsError(t *testing.T) {
+	req := &schedtypes.InferenceRequest{
+		TargetModel: "test-model",
+		Body: &fwkrh.InferenceRequestBody{
+			ChatCompletions: &fwkrh.ChatCompletionsRequest{
+				Messages: []fwkrh.Message{
+					{Role: "user", Content: fwkrh.Content{Raw: "hi"}},
+				},
+			},
+			// No Payload set — the typed view cannot carry tool-calling fields.
+		},
+	}
+
+	if _, err := BuildOpenAIRequestJSON(req); err == nil {
+		t.Fatalf("expected an error when the raw payload is unavailable, got nil")
 	}
 }


### PR DESCRIPTION
## Overview

The EPP KV-router prefill/decode scorer builds its routing request via `BuildOpenAIRequest`, which reconstructs each message from the framework's **typed** `ChatCompletions` view as only `{role, content}`. The upstream GAIE `Message` type models just `Role` and `Content`, so `tool_calls`, `tool_call_id`, `name`, `tools`, and reasoning/thinking content are dropped at parse time and never reach the body handed to the Rust router.

The Rust router (`route_decode_request` → `preprocess_request`) parses that JSON into the strict `NvCreateChatCompletionRequest` and re-renders the model's chat template to tokenize for KV-aware routing. Feeding it the stripped body breaks two things:

1. **Multi-turn tool calls are unroutable (503 "no healthy upstream").** A `role:"tool"` message missing the required `tool_call_id` fails deserialization (`missing field tool_call_id`); `route_decode_request` returns an error, no worker is selected, and the request is dropped by the gateway. Single-turn requests work; any conversation with a tool result is dead.
2. **Non-streaming reasoning/tool parsing is lost.** With `tool_calls` / `tools` / reasoning content missing, the chat template renders an incomplete prompt, so tokenization diverges from what the worker processes and the reasoning/tool parsers do not engage.

## Summary

Forward the full original request body to the EPP scorer's Rust router instead of a lossy `{role, content}` reconstruction, so tool-calling and reasoning fields survive for the router's strict parse and chat-template rendering. The same fix resolves both issues, since both stem from the router being handed an incomplete request.

## Details

- `BuildOpenAIRequest` now forwards the raw request body from `req.Body.Payload` (a `PayloadMap` that retains every field), overriding only `model` with the resolved target.
- The previous typed reconstruction is preserved as `buildOpenAIRequestFromTyped`, used only when the raw payload is unavailable; `nvext` and `cache_salt` handling are unchanged there.
- The tool fields cannot be recovered from the typed `Message` (it has no `ToolCalls` / `ToolCallID` / `Name`), so the raw payload is the only source that still carries them — a typed-path tweak isn't possible.
- Adds `TestBuildOpenAIRequest_PreservesToolCallFields`.

## Where should the reviewer start?

- `deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go` — `BuildOpenAIRequest` and the new `buildOpenAIRequestFromTyped` fallback.
- `deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin_test.go` — new `TestBuildOpenAIRequest_PreservesToolCallFields`.

## Validation

- `go test ./deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/...` — new test plus existing `BuildOpenAIRequest` tests pass (payload-bearing cases go through the passthrough, preserving `nvext.agent_hints.priority` and `cache_salt`; completion cases with no payload use the typed fallback).
- Validated end-to-end on a KV-routed disaggregated deployment: multi-turn tool calls now route instead of returning 503, and non-streaming requests parse reasoning/tool output.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue