### PR TITLE
fix(router): serialize active sequence publishing

### DIFF
--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1739,11 +1739,8 @@ mod tests {
     }
 
     impl SequencePublisher for DropResponseOnLoadPublisher {
-        fn publish_event(
-            &self,
-            _event: &ActiveSequenceEvent,
-        ) -> impl std::future::Future<Output = anyhow::Result<()>> + Send {
-            std::future::ready(Ok(()))
+        fn enqueue_event(&self, _event: ActiveSequenceEvent) -> anyhow::Result<()> {
+            Ok(())
         }
 
         fn publish_load(&self, _load: ActiveLoad) {

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -10,7 +10,7 @@
 //! this crate while the runtime glue stays in `lib/llm`.
 
 use dynamo_tokens::SequenceHash;
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::env;
@@ -40,6 +40,9 @@ use crate::protocols::{
 // in ActiveSequencesMultiWorker::force_expire_requests_across_all_workers for
 // more details.
 const FORCE_EXPIRE_REQUESTS_ACROSS_ALL_WORKERS_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Minimum interval between repeated logs for a saturated or unexpectedly closed publish queue.
+const SEQUENCE_PUBLISH_FAILURE_LOG_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Environment override for the stale active-request cleanup guard.
 const DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS: &str = "DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS";
@@ -117,6 +120,104 @@ pub trait SequencePublisher: Send + Sync {
 
     /// Observe that a worker/dp_rank was removed from the router.
     fn observe_worker_removed(&self, _worker: &WorkerWithDpRank, _worker_type: &str) {}
+}
+
+/// Admission failures reported by bounded active-sequence publisher queues.
+#[derive(Debug, thiserror::Error)]
+pub enum SequencePublishQueueError {
+    #[error(
+        "active-sequence publish queue full; dropping newest event \
+         (request_id={request_id}, worker={worker:?}, capacity={capacity})"
+    )]
+    Full {
+        request_id: String,
+        worker: WorkerWithDpRank,
+        capacity: usize,
+    },
+    #[error(
+        "active-sequence publish queue closed; dropping event \
+         (request_id={request_id}, worker={worker:?}, capacity={capacity})"
+    )]
+    Closed {
+        request_id: String,
+        worker: WorkerWithDpRank,
+        capacity: usize,
+        during_shutdown: bool,
+    },
+}
+
+impl SequencePublishQueueError {
+    pub fn full(event: ActiveSequenceEvent, capacity: usize) -> Self {
+        Self::Full {
+            request_id: event.request_id,
+            worker: event.worker,
+            capacity,
+        }
+    }
+
+    pub fn closed(event: ActiveSequenceEvent, capacity: usize, during_shutdown: bool) -> Self {
+        Self::Closed {
+            request_id: event.request_id,
+            worker: event.worker,
+            capacity,
+            during_shutdown,
+        }
+    }
+}
+
+#[derive(Default)]
+struct RateLimitedPublishFailure {
+    last_logged_at: Option<Instant>,
+    suppressed_since_last_log: u64,
+}
+
+impl RateLimitedPublishFailure {
+    fn record(&mut self, now: Instant) -> Option<u64> {
+        let should_log = self.last_logged_at.is_none_or(|last_logged_at| {
+            now.saturating_duration_since(last_logged_at) >= SEQUENCE_PUBLISH_FAILURE_LOG_INTERVAL
+        });
+        if should_log {
+            let failures_since_last_log = self.suppressed_since_last_log.saturating_add(1);
+            self.last_logged_at = Some(now);
+            self.suppressed_since_last_log = 0;
+            Some(failures_since_last_log)
+        } else {
+            self.suppressed_since_last_log = self.suppressed_since_last_log.saturating_add(1);
+            None
+        }
+    }
+}
+
+#[derive(Default)]
+struct SequencePublishFailureLogState {
+    full: RateLimitedPublishFailure,
+    unexpected_closed: RateLimitedPublishFailure,
+    shutdown_closed_logged: bool,
+}
+
+#[derive(Default)]
+struct SequencePublishFailureLogLimiter {
+    state: Mutex<SequencePublishFailureLogState>,
+}
+
+impl SequencePublishFailureLogLimiter {
+    fn record_full(&self, now: Instant) -> Option<u64> {
+        self.state.lock().full.record(now)
+    }
+
+    fn record_unexpected_closed(&self, now: Instant) -> Option<u64> {
+        self.state.lock().unexpected_closed.record(now)
+    }
+
+    fn record_shutdown_closed(&self) -> bool {
+        let mut state = self.state.lock();
+        if state.shutdown_closed_logged {
+            false
+        } else {
+            state.shutdown_closed_logged = true;
+            true
+        }
+    }
 }
 
 /// No-op publisher for callers that do not need active-sequence event transport.
@@ -213,6 +314,7 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     block_size: usize,
     pub(super) router_id: u64,
     pub(super) publisher: Arc<P>,
+    publish_failure_logs: SequencePublishFailureLogLimiter,
     remote_state_updates: watch::Sender<()>,
     #[cfg(test)]
     remote_state_update_count: AtomicUsize,
@@ -355,6 +457,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             block_size,
             router_id,
             publisher,
+            publish_failure_logs: SequencePublishFailureLogLimiter::default(),
             remote_state_updates,
             #[cfg(test)]
             remote_state_update_count: AtomicUsize::new(0),
@@ -441,11 +544,64 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         let request_id = event.request_id.clone();
         let worker = event.worker;
         if let Err(error) = self.publisher.enqueue_event(event) {
-            tracing::error!(
-                request_id = %request_id,
-                worker = ?worker,
-                "failed to enqueue active-sequence event: {error}"
-            );
+            match error.downcast_ref::<SequencePublishQueueError>() {
+                Some(SequencePublishQueueError::Full { capacity, .. }) => {
+                    if let Some(dropped_events) =
+                        self.publish_failure_logs.record_full(Instant::now())
+                    {
+                        tracing::error!(
+                            request_id = %request_id,
+                            worker = ?worker,
+                            capacity,
+                            dropped_events_since_last_log = dropped_events,
+                            error = %format!("{error:#}"),
+                            "active-sequence publish queue full; dropping newest event"
+                        );
+                    }
+                }
+                Some(SequencePublishQueueError::Closed {
+                    capacity,
+                    during_shutdown: true,
+                    ..
+                }) => {
+                    if self.publish_failure_logs.record_shutdown_closed() {
+                        tracing::debug!(
+                            request_id = %request_id,
+                            worker = ?worker,
+                            capacity,
+                            error = %format!("{error:#}"),
+                            "active-sequence publish queue closed during shutdown"
+                        );
+                    }
+                }
+                Some(SequencePublishQueueError::Closed {
+                    capacity,
+                    during_shutdown: false,
+                    ..
+                }) => {
+                    if let Some(dropped_events) = self
+                        .publish_failure_logs
+                        .record_unexpected_closed(Instant::now())
+                    {
+                        tracing::error!(
+                            request_id = %request_id,
+                            worker = ?worker,
+                            capacity,
+                            dropped_events_since_last_log = dropped_events,
+                            error = %format!("{error:#}"),
+                            "active-sequence publish queue closed unexpectedly; dropping event"
+                        );
+                    }
+                }
+                None => {
+                    tracing::error!(
+                        request_id = %request_id,
+                        worker = ?worker,
+                        error = %error,
+                        "failed to enqueue active-sequence event"
+                    );
+                }
+            }
         }
     }
 
@@ -1649,6 +1805,34 @@ mod tests {
         sequences.free(&request_id, Instant::now()).unwrap();
 
         assert!(state.events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn active_sequence_publish_failure_logs_are_aggregated() {
+        let limiter = SequencePublishFailureLogLimiter::default();
+        let now = Instant::now();
+
+        assert_eq!(limiter.record_full(now), Some(1));
+        assert_eq!(limiter.record_full(now + Duration::from_secs(1)), None);
+        assert_eq!(
+            limiter.record_full(now + SEQUENCE_PUBLISH_FAILURE_LOG_INTERVAL),
+            Some(2)
+        );
+
+        assert_eq!(limiter.record_unexpected_closed(now), Some(1));
+        assert_eq!(
+            limiter.record_unexpected_closed(now + Duration::from_secs(1)),
+            None
+        );
+        assert_eq!(
+            limiter.record_unexpected_closed(
+                now + SEQUENCE_PUBLISH_FAILURE_LOG_INTERVAL + Duration::from_secs(1)
+            ),
+            Some(2)
+        );
+
+        assert!(limiter.record_shutdown_closed());
+        assert!(!limiter.record_shutdown_closed());
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -14,7 +14,7 @@ use parking_lot::RwLock;
 use rustc_hash::FxHashMap;
 use std::collections::HashMap;
 use std::env;
-use std::future::{self, Future};
+use std::future::Future;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -87,21 +87,11 @@ fn active_request_expiry_duration_from_lookup(
 ///
 /// Implementations provide the runtime-specific transport (e.g., NATS EventPublisher,
 /// Prometheus gauges) while the business logic in [`ActiveSequencesMultiWorker`] stays
-/// runtime-agnostic.
+/// runtime-agnostic. Implementations enqueue accepted replica-sync events synchronously so
+/// lifecycle callers never await transport I/O, and publish successful enqueues in FIFO order.
 pub trait SequencePublisher: Send + Sync {
-    /// Publish a replica-sync event to peer routers.
-    fn publish_event(
-        &self,
-        event: &ActiveSequenceEvent,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send;
-
-    /// Publish an owned replica-sync event, avoiding a clone when supported by the transport.
-    fn publish_event_owned(
-        &self,
-        event: ActiveSequenceEvent,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send {
-        async move { self.publish_event(&event).await }
-    }
+    /// Enqueue a replica-sync event for publication to peer routers.
+    fn enqueue_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()>;
 
     /// Fire-and-forget publish of an [`ActiveLoad`] metric payload.
     fn publish_load(&self, load: ActiveLoad);
@@ -133,11 +123,8 @@ pub trait SequencePublisher: Send + Sync {
 pub struct NoopSequencePublisher;
 
 impl SequencePublisher for NoopSequencePublisher {
-    fn publish_event(
-        &self,
-        _event: &ActiveSequenceEvent,
-    ) -> impl Future<Output = anyhow::Result<()>> + Send {
-        future::ready(Ok(()))
+    fn enqueue_event(&self, _event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        Ok(())
     }
 
     fn publish_load(&self, _load: ActiveLoad) {}
@@ -444,25 +431,22 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         }
     }
 
-    fn spawn_publish_event(&self, event: ActiveSequenceEvent) {
+    fn enqueue_publish_event(&self, event: ActiveSequenceEvent) {
         if !self.replica_sync {
             return;
         }
 
         // TODO: Publish explicit prompt-load decay timestamps with these events so peer routers
         // can mirror the same oldest-prefill anchor instead of approximating from receive time.
-        let publisher = Arc::clone(&self.publisher);
-        tokio::spawn(async move {
-            let request_id = event.request_id.clone();
-            let worker = event.worker;
-            if let Err(e) = publisher.publish_event_owned(event).await {
-                tracing::error!(
-                    request_id = %request_id,
-                    worker = ?worker,
-                    "failed to publish active sequence event: {e}"
-                );
-            }
-        });
+        let request_id = event.request_id.clone();
+        let worker = event.worker;
+        if let Err(error) = self.publisher.enqueue_event(event) {
+            tracing::error!(
+                request_id = %request_id,
+                worker = ?worker,
+                "failed to enqueue active-sequence event: {error}"
+            );
+        }
     }
 
     /// Subscribe to remote lifecycle updates that were applied through replica sync.
@@ -634,7 +618,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         });
         self.add_request_local(req, decay_now, lazily_register_worker)?;
         if let Some(event) = event {
-            self.spawn_publish_event(event);
+            self.enqueue_publish_event(event);
         }
         Ok(())
     }
@@ -1132,7 +1116,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             mutate_fn,
             remove_mapping,
         )?;
-        self.spawn_publish_event(ActiveSequenceEvent {
+        self.enqueue_publish_event(ActiveSequenceEvent {
             request_id: request_id.clone(),
             worker,
             data: event_data,
@@ -1157,7 +1141,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 
         let lora_name = self.request_index.lora_for(request_id);
         self.mutate_request_worker_load_state_local(worker, request_id, decay_now, mutate_fn)?;
-        self.spawn_publish_event(ActiveSequenceEvent {
+        self.enqueue_publish_event(ActiveSequenceEvent {
             request_id: request_id.clone(),
             worker,
             data: event_data,
@@ -1411,6 +1395,7 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingPublisherState {
+        events: Mutex<Vec<ActiveSequenceEventData>>,
         single_loads: Mutex<Vec<ActiveLoad>>,
         load_batches: Mutex<Vec<Vec<ActiveLoad>>>,
         observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
@@ -1424,6 +1409,7 @@ mod tests {
         }
 
         fn clear(&self) {
+            self.events.lock().unwrap().clear();
             self.single_loads.lock().unwrap().clear();
             self.load_batches.lock().unwrap().clear();
             self.observations.lock().unwrap().clear();
@@ -1437,11 +1423,9 @@ mod tests {
     }
 
     impl SequencePublisher for RecordingPublisher {
-        fn publish_event(
-            &self,
-            _event: &ActiveSequenceEvent,
-        ) -> impl Future<Output = anyhow::Result<()>> + Send {
-            future::ready(Ok(()))
+        fn enqueue_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
+            self.state.events.lock().unwrap().push(event.data);
+            Ok(())
         }
 
         fn publish_load(&self, load: ActiveLoad) {
@@ -1482,11 +1466,8 @@ mod tests {
     }
 
     impl SequencePublisher for BlockingPublisher {
-        fn publish_event(
-            &self,
-            _event: &ActiveSequenceEvent,
-        ) -> impl Future<Output = anyhow::Result<()>> + Send {
-            future::ready(Ok(()))
+        fn enqueue_event(&self, _event: ActiveSequenceEvent) -> anyhow::Result<()> {
+            Ok(())
         }
 
         fn publish_load(&self, _load: ActiveLoad) {}
@@ -1605,6 +1586,69 @@ mod tests {
             router_id: 99,
             lora_name: None,
         }
+    }
+
+    fn local_sequence_request(request_id: &str, worker: WorkerWithDpRank) -> SequenceRequest {
+        SequenceRequest {
+            request_id: request_id.to_string(),
+            token_sequence: Some(vec![1, 2, 3]),
+            track_prefill_tokens: true,
+            expected_output_tokens: None,
+            prefill_load_hint: tracking_hint(12),
+            worker,
+            lora_name: None,
+        }
+    }
+
+    #[test]
+    fn active_sequence_publish_enqueues_lifecycle_in_order() {
+        let (sequences, state) = make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let worker = WorkerWithDpRank::new(1, 0);
+        let request_id = "ordered".to_string();
+
+        sequences
+            .add_request(local_sequence_request(&request_id, worker), Instant::now())
+            .unwrap();
+        sequences
+            .mark_prefill_completed(&request_id, Instant::now())
+            .unwrap();
+        sequences.free(&request_id, Instant::now()).unwrap();
+
+        assert!(matches!(
+            state.events.lock().unwrap().as_slice(),
+            [
+                ActiveSequenceEventData::AddRequest { .. },
+                ActiveSequenceEventData::MarkPrefillCompleted,
+                ActiveSequenceEventData::Free,
+            ]
+        ));
+    }
+
+    #[test]
+    fn active_sequence_publish_skips_enqueue_when_replica_sync_disabled() {
+        let state = Arc::new(RecordingPublisherState::default());
+        let sequences = ActiveSequencesMultiWorker::new(
+            RecordingPublisher {
+                state: Arc::clone(&state),
+            },
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            false,
+            0,
+            "test",
+        );
+        let worker = WorkerWithDpRank::new(1, 0);
+        let request_id = "disabled".to_string();
+
+        sequences
+            .add_request(local_sequence_request(&request_id, worker), Instant::now())
+            .unwrap();
+        sequences
+            .mark_prefill_completed(&request_id, Instant::now())
+            .unwrap();
+        sequences.free(&request_id, Instant::now()).unwrap();
+
+        assert!(state.events.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -94,6 +94,9 @@ fn active_request_expiry_duration_from_lookup(
 /// lifecycle callers never await transport I/O, and publish successful enqueues in FIFO order.
 pub trait SequencePublisher: Send + Sync {
     /// Enqueue a replica-sync event for publication to peer routers.
+    ///
+    /// Queue-backed implementations must preserve [`SequencePublishQueueError`] as the error
+    /// source for admission failures so callers can classify queue saturation and closure.
     fn enqueue_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()>;
 
     /// Fire-and-forget publish of an [`ActiveLoad`] metric payload.
@@ -541,6 +544,9 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 
         // TODO: Publish explicit prompt-load decay timestamps with these events so peer routers
         // can mirror the same oldest-prefill anchor instead of approximating from receive time.
+        // FIFO begins at this enqueue boundary. Local mutation completes first, so overlapping
+        // lifecycle calls can enqueue in a different order from their local mutations; replica
+        // sync is best-effort and peer expiry reconciles stale state.
         let request_id = event.request_id.clone();
         let worker = event.worker;
         if let Err(error) = self.publisher.enqueue_event(event) {

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc, oneshot};
@@ -13,7 +13,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
-use crate::sequences::{SequencePublisher, SequenceSubscriber};
+use crate::sequences::{SequencePublishQueueError, SequencePublisher, SequenceSubscriber};
 use crate::services::common::zmq::{create_bound_pub_socket, create_sub_socket, validate_endpoint};
 
 pub(crate) const REPLICA_EVENT_CHANNEL_CAPACITY: usize = 100_000;
@@ -34,6 +34,7 @@ pub(crate) type ReplicaEventSender = mpsc::Sender<ScopedReplicaEvent>;
 pub(crate) struct ReplicaSyncConfig {
     process_id: u64,
     outbound_tx: ReplicaEventSender,
+    cancel_token: CancellationToken,
 }
 
 #[derive(Debug)]
@@ -72,10 +73,15 @@ impl Drop for ReplicaSyncRuntime {
 }
 
 impl ReplicaSyncConfig {
-    pub(crate) fn new(process_id: u64, outbound_tx: ReplicaEventSender) -> Self {
+    pub(crate) fn new(
+        process_id: u64,
+        outbound_tx: ReplicaEventSender,
+        cancel_token: CancellationToken,
+    ) -> Self {
         Self {
             process_id,
             outbound_tx,
+            cancel_token,
         }
     }
 
@@ -107,6 +113,7 @@ struct ScopedReplicaPublisher {
     routing_group: Arc<str>,
     block_size: u32,
     tx: ReplicaEventSender,
+    cancel_token: CancellationToken,
 }
 
 impl ScopedSequencePublisher {
@@ -119,6 +126,7 @@ impl ScopedSequencePublisher {
         routing_group: Arc<str>,
         block_size: u32,
         tx: ReplicaEventSender,
+        cancel_token: CancellationToken,
     ) -> Self {
         Self {
             replica: Some(ScopedReplicaPublisher {
@@ -126,6 +134,7 @@ impl ScopedSequencePublisher {
                 routing_group,
                 block_size,
                 tx,
+                cancel_token,
             }),
         }
     }
@@ -144,24 +153,24 @@ impl SequencePublisher for ScopedSequencePublisher {
         };
         match replica.tx.try_send(envelope) {
             Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(event)) => Err(anyhow!(
-                "replica publisher channel full; dropping newest event \
-                     (model_name={}, routing_group={}, request_id={}, worker={:?}, capacity={})",
-                event.model_name,
-                event.routing_group,
-                event.event.request_id,
-                event.event.worker,
-                replica.tx.max_capacity()
-            )),
-            Err(mpsc::error::TrySendError::Closed(event)) => Err(anyhow!(
-                "replica publisher channel closed; dropping event \
-                     (model_name={}, routing_group={}, request_id={}, worker={:?}, capacity={})",
-                event.model_name,
-                event.routing_group,
-                event.event.request_id,
-                event.event.worker,
-                replica.tx.max_capacity()
-            )),
+            Err(mpsc::error::TrySendError::Full(event)) => {
+                let error = SequencePublishQueueError::full(event.event, replica.tx.max_capacity());
+                Err(anyhow::Error::new(error).context(format!(
+                    "replica publisher for model_name={} routing_group={}",
+                    event.model_name, event.routing_group
+                )))
+            }
+            Err(mpsc::error::TrySendError::Closed(event)) => {
+                let error = SequencePublishQueueError::closed(
+                    event.event,
+                    replica.tx.max_capacity(),
+                    replica.cancel_token.is_cancelled(),
+                );
+                Err(anyhow::Error::new(error).context(format!(
+                    "replica publisher for model_name={} routing_group={}",
+                    event.model_name, event.routing_group
+                )))
+            }
         }
     }
 
@@ -233,7 +242,7 @@ pub(crate) fn setup_replica_sync(
     let (outbound_tx, publisher_task) =
         start_replica_publisher(&bind_endpoint, cancel_token.clone())?;
     Ok(Some(ReplicaSyncRuntime {
-        config: ReplicaSyncConfig::new(process_id, outbound_tx),
+        config: ReplicaSyncConfig::new(process_id, outbound_tx, cancel_token.clone()),
         cancel_token,
         publisher_task: Mutex::new(Some(publisher_task)),
     }))
@@ -261,6 +270,7 @@ pub(crate) fn setup_scoped_replica_sync(
             Arc::from(routing_group),
             block_size,
             config.outbound_tx.clone(),
+            config.cancel_token.clone(),
         ),
         enabled: true,
         process_id: config.process_id,
@@ -596,19 +606,48 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn scoped_publisher_drops_when_outbound_channel_is_full() {
+    async fn scoped_publisher_reports_full_and_closed_channels() {
         let (tx, mut rx) = mpsc::channel(1);
-        let publisher =
-            ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("group"), 16, tx);
+        let cancel_token = CancellationToken::new();
+        let publisher = ScopedSequencePublisher::enabled(
+            Arc::from("model"),
+            Arc::from("group"),
+            16,
+            tx,
+            cancel_token.clone(),
+        );
         let event = event().event;
 
         publisher.enqueue_event(event.clone()).unwrap();
-        let error = publisher.enqueue_event(event).unwrap_err().to_string();
+        let full = publisher.enqueue_event(event.clone()).unwrap_err();
 
         assert_eq!(rx.len(), 1);
         assert_eq!(rx.recv().await.unwrap().event.request_id, "request");
-        assert!(error.contains("channel full"));
-        assert!(error.contains("capacity=1"));
+        let full = format!("{full:#}");
+        assert!(full.contains("queue full"));
+        assert!(full.contains("model_name=model"));
+        assert!(full.contains("routing_group=group"));
+        assert!(full.contains("capacity=1"));
+
+        drop(rx);
+        let unexpected_closed = publisher.enqueue_event(event.clone()).unwrap_err();
+        assert!(matches!(
+            unexpected_closed.downcast_ref::<SequencePublishQueueError>(),
+            Some(SequencePublishQueueError::Closed {
+                during_shutdown: false,
+                ..
+            })
+        ));
+
+        cancel_token.cancel();
+        let shutdown_closed = publisher.enqueue_event(event).unwrap_err();
+        assert!(matches!(
+            shutdown_closed.downcast_ref::<SequencePublishQueueError>(),
+            Some(SequencePublishQueueError::Closed {
+                during_shutdown: true,
+                ..
+            })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -669,11 +708,11 @@ mod tests {
             start_replica_publisher(&endpoint_b, cancel_token.child_token()).unwrap();
         let registry_a = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
             cancel_token.clone(),
-            ReplicaSyncConfig::new(11, outbound_a),
+            ReplicaSyncConfig::new(11, outbound_a, cancel_token.clone()),
         ));
         let registry_b = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
             cancel_token.clone(),
-            ReplicaSyncConfig::new(22, outbound_b),
+            ReplicaSyncConfig::new(22, outbound_b, cancel_token.clone()),
         ));
         let dispatch_registry_b = Arc::clone(&registry_b);
         let peer_b =

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashSet;
-use std::future::{self, Future};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -133,35 +132,37 @@ impl ScopedSequencePublisher {
 }
 
 impl SequencePublisher for ScopedSequencePublisher {
-    fn publish_event(
-        &self,
-        event: &ActiveSequenceEvent,
-    ) -> impl Future<Output = Result<()>> + Send {
+    fn enqueue_event(&self, event: ActiveSequenceEvent) -> Result<()> {
         let Some(replica) = &self.replica else {
-            return future::ready(Ok(()));
+            return Ok(());
         };
         let envelope = ScopedReplicaEvent {
             model_name: replica.model_name.to_string(),
             routing_group: replica.routing_group.to_string(),
             block_size: replica.block_size,
-            event: event.clone(),
+            event,
         };
-        let result = match replica.tx.try_send(envelope) {
+        match replica.tx.try_send(envelope) {
             Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(event)) => {
-                tracing::trace!(
-                    model_name = %event.model_name,
-                    routing_group = %event.routing_group,
-                    request_id = %event.event.request_id,
-                    "Replica publisher channel full; dropping event"
-                );
-                Ok(())
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                Err(anyhow!("replica publisher channel is closed"))
-            }
-        };
-        future::ready(result)
+            Err(mpsc::error::TrySendError::Full(event)) => Err(anyhow!(
+                "replica publisher channel full; dropping newest event \
+                     (model_name={}, routing_group={}, request_id={}, worker={:?}, capacity={})",
+                event.model_name,
+                event.routing_group,
+                event.event.request_id,
+                event.event.worker,
+                replica.tx.max_capacity()
+            )),
+            Err(mpsc::error::TrySendError::Closed(event)) => Err(anyhow!(
+                "replica publisher channel closed; dropping event \
+                     (model_name={}, routing_group={}, request_id={}, worker={:?}, capacity={})",
+                event.model_name,
+                event.routing_group,
+                event.event.request_id,
+                event.event.worker,
+                replica.tx.max_capacity()
+            )),
+        }
     }
 
     fn publish_load(&self, _load: ActiveLoad) {}
@@ -601,11 +602,13 @@ mod tests {
             ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("group"), 16, tx);
         let event = event().event;
 
-        publisher.publish_event(&event).await.unwrap();
-        publisher.publish_event(&event).await.unwrap();
+        publisher.enqueue_event(event.clone()).unwrap();
+        let error = publisher.enqueue_event(event).unwrap_err().to_string();
 
         assert_eq!(rx.len(), 1);
         assert_eq!(rx.recv().await.unwrap().event.request_id, "request");
+        assert!(error.contains("channel full"));
+        assert!(error.contains("capacity=1"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -685,9 +685,10 @@ mod tests {
     #[tokio::test]
     async fn replica_dispatch_rejects_self_and_requires_matching_registered_worker() {
         let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let cancel_token = CancellationToken::new();
         let registry = SlotTrackerRegistry::new_with_replica_sync(
-            CancellationToken::new(),
-            ReplicaSyncConfig::new(7, outbound_tx),
+            cancel_token.clone(),
+            ReplicaSyncConfig::new(7, outbound_tx, cancel_token),
         );
         let key = key("default");
         registry.register(key.clone(), 1, 16, 0, 1).unwrap();

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -656,7 +656,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 mod tests {
     use std::{
         collections::HashMap,
-        future,
         sync::{
             Arc, Mutex,
             atomic::{AtomicBool, Ordering},
@@ -703,11 +702,8 @@ mod tests {
     struct NoopSequencePublisher;
 
     impl SequencePublisher for NoopSequencePublisher {
-        fn publish_event(
-            &self,
-            _event: &ActiveSequenceEvent,
-        ) -> impl future::Future<Output = anyhow::Result<()>> + Send {
-            future::ready(Ok(()))
+        fn enqueue_event(&self, _event: ActiveSequenceEvent) -> anyhow::Result<()> {
+            Ok(())
         }
 
         fn publish_load(&self, _load: ActiveLoad) {}

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -10,8 +10,8 @@
 mod direct_zmq;
 
 pub use dynamo_kv_router::multi_worker_sequence::{
-    ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
-    SequenceSubscriber,
+    ActiveSequencesMultiWorker, SequenceError, SequencePublishQueueError, SequencePublisher,
+    SequenceRequest, SequenceSubscriber,
 };
 use dynamo_kv_router::protocols::{
     ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventBatch, MAX_REPLICA_BATCH_DURATION,
@@ -26,6 +26,7 @@ use dynamo_runtime::transports::event_plane::{
     EventPublisher, EventSubscriber, EventTransportKind, TypedEventSubscriber,
 };
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
@@ -61,31 +62,38 @@ fn active_sequence_event_wire_format(
 
 struct ActiveSequenceEventSender {
     event_tx: mpsc::Sender<ActiveSequenceEvent>,
+    cancellation_token: CancellationToken,
 }
 
 impl ActiveSequenceEventSender {
-    fn channel(capacity: usize) -> (Self, mpsc::Receiver<ActiveSequenceEvent>) {
+    fn channel(
+        capacity: usize,
+        cancellation_token: CancellationToken,
+    ) -> (Self, mpsc::Receiver<ActiveSequenceEvent>) {
         let (event_tx, event_rx) = mpsc::channel(capacity);
-        (Self { event_tx }, event_rx)
+        (
+            Self {
+                event_tx,
+                cancellation_token,
+            },
+            event_rx,
+        )
     }
 
     fn enqueue(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
         match self.event_tx.try_send(event) {
             Ok(()) => Ok(()),
-            Err(mpsc::error::TrySendError::Full(event)) => anyhow::bail!(
-                "active-sequence publish queue full; dropping newest event \
-                 (request_id={}, worker={:?}, capacity={})",
-                event.request_id,
-                event.worker,
-                self.event_tx.max_capacity()
-            ),
-            Err(mpsc::error::TrySendError::Closed(event)) => anyhow::bail!(
-                "active-sequence publish queue closed; dropping event \
-                 (request_id={}, worker={:?}, capacity={})",
-                event.request_id,
-                event.worker,
-                self.event_tx.max_capacity()
-            ),
+            Err(mpsc::error::TrySendError::Full(event)) => {
+                Err(SequencePublishQueueError::full(event, self.event_tx.max_capacity()).into())
+            }
+            Err(mpsc::error::TrySendError::Closed(event)) => {
+                Err(SequencePublishQueueError::closed(
+                    event,
+                    self.event_tx.max_capacity(),
+                    self.cancellation_token.is_cancelled(),
+                )
+                .into())
+            }
         }
     }
 }
@@ -93,11 +101,12 @@ impl ActiveSequenceEventSender {
 fn active_sequence_event_channel(
     enabled: bool,
     capacity: usize,
+    cancellation_token: &CancellationToken,
 ) -> Option<(
     ActiveSequenceEventSender,
     mpsc::Receiver<ActiveSequenceEvent>,
 )> {
-    enabled.then(|| ActiveSequenceEventSender::channel(capacity))
+    enabled.then(|| ActiveSequenceEventSender::channel(capacity, cancellation_token.child_token()))
 }
 
 /// Concrete [`SequencePublisher`] backed by the runtime event plane and Prometheus gauges.
@@ -170,8 +179,21 @@ impl SequencePublisher for RuntimeSequencePublisher {
     }
 }
 
-async fn run_replica_singleton_publisher(
-    publisher: EventPublisher,
+trait SingletonEventPublisher: Send + Sync {
+    fn publish_event(
+        &self,
+        event: &ActiveSequenceEvent,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+}
+
+impl SingletonEventPublisher for EventPublisher {
+    async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
+        self.publish(event).await
+    }
+}
+
+async fn run_replica_singleton_publisher<P: SingletonEventPublisher>(
+    publisher: P,
     mut event_rx: mpsc::Receiver<ActiveSequenceEvent>,
     cancellation_token: CancellationToken,
 ) {
@@ -183,7 +205,7 @@ async fn run_replica_singleton_publisher(
                 None => break,
             },
         };
-        if let Err(error) = publisher.publish(&event).await {
+        if let Err(error) = publisher.publish_event(&event).await {
             tracing::error!(
                 request_id = %event.request_id,
                 worker = ?event.worker,
@@ -364,9 +386,12 @@ pub async fn create_multi_worker_sequences(
     cancellation_token: CancellationToken,
 ) -> Result<Arc<ActiveSequencesMulti>> {
     let transport_kind = endpoint.drt().default_event_transport_kind();
-    let event_sender = if let Some((event_sender, event_rx)) =
-        active_sequence_event_channel(replica_sync, REPLICA_EVENT_CHANNEL_CAPACITY)
-    {
+    let event_sender = if let Some((event_sender, event_rx)) = active_sequence_event_channel(
+        replica_sync,
+        REPLICA_EVENT_CHANNEL_CAPACITY,
+        &cancellation_token,
+    ) {
+        let publisher_cancellation_token = event_sender.cancellation_token.clone();
         let event_publisher = EventPublisher::for_endpoint_with_transport(
             &endpoint,
             ACTIVE_SEQUENCES_SUBJECT,
@@ -378,14 +403,14 @@ pub async fn create_multi_worker_sequences(
                 tokio::spawn(run_replica_singleton_publisher(
                     event_publisher,
                     event_rx,
-                    cancellation_token.child_token(),
+                    publisher_cancellation_token,
                 ));
             }
             ActiveSequenceEventWireFormat::Batch => {
                 tokio::spawn(run_replica_batch_publisher(
                     event_publisher,
                     event_rx,
-                    cancellation_token.child_token(),
+                    publisher_cancellation_token,
                 ));
             }
         }
@@ -494,9 +519,46 @@ mod tests {
         }
     }
 
+    struct BlockingSingletonPublisher {
+        attempted_tx: mpsc::UnboundedSender<&'static str>,
+        release_add: Arc<tokio::sync::Notify>,
+        active: Arc<std::sync::atomic::AtomicUsize>,
+        max_active: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl SingletonEventPublisher for BlockingSingletonPublisher {
+        async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
+            let event_name = match &event.data {
+                ActiveSequenceEventData::AddRequest { .. } => "add",
+                ActiveSequenceEventData::MarkPrefillCompleted => "mark",
+                ActiveSequenceEventData::Free => "free",
+            };
+            let active = self
+                .active
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                + 1;
+            self.max_active
+                .fetch_max(active, std::sync::atomic::Ordering::SeqCst);
+            self.attempted_tx.send(event_name).unwrap();
+
+            if event_name == "add" {
+                self.release_add.notified().await;
+            }
+
+            self.active
+                .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+
+            if event_name == "mark" {
+                anyhow::bail!("synthetic singleton publish failure");
+            }
+            Ok(())
+        }
+    }
+
     #[test]
     fn active_sequence_publish_sender_preserves_lifecycle_order() {
-        let (sender, mut event_rx) = ActiveSequenceEventSender::channel(3);
+        let (sender, mut event_rx) =
+            ActiveSequenceEventSender::channel(3, CancellationToken::new());
         sender.enqueue(add_event("ordered")).unwrap();
         sender.enqueue(mark_event("ordered")).unwrap();
         sender.enqueue(free_event("ordered")).unwrap();
@@ -517,7 +579,8 @@ mod tests {
 
     #[test]
     fn active_sequence_publish_sender_drops_newest_when_full() {
-        let (sender, mut event_rx) = ActiveSequenceEventSender::channel(1);
+        let (sender, mut event_rx) =
+            ActiveSequenceEventSender::channel(1, CancellationToken::new());
         sender.enqueue(add_event("accepted")).unwrap();
 
         let error = sender
@@ -533,7 +596,86 @@ mod tests {
 
     #[test]
     fn active_sequence_publish_channel_is_absent_when_replica_sync_disabled() {
-        assert!(active_sequence_event_channel(false, 1).is_none());
+        assert!(active_sequence_event_channel(false, 1, &CancellationToken::new()).is_none());
+    }
+
+    #[test]
+    fn active_sequence_publish_sender_classifies_closed_queue_by_cancellation() {
+        let cancellation_token = CancellationToken::new();
+        let (sender, event_rx) = ActiveSequenceEventSender::channel(1, cancellation_token.clone());
+        drop(event_rx);
+
+        let unexpected = sender.enqueue(free_event("unexpected")).unwrap_err();
+        assert!(matches!(
+            unexpected.downcast_ref::<SequencePublishQueueError>(),
+            Some(SequencePublishQueueError::Closed {
+                during_shutdown: false,
+                ..
+            })
+        ));
+
+        cancellation_token.cancel();
+        let shutdown = sender.enqueue(free_event("shutdown")).unwrap_err();
+        assert!(matches!(
+            shutdown.downcast_ref::<SequencePublishQueueError>(),
+            Some(SequencePublishQueueError::Closed {
+                during_shutdown: true,
+                ..
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn active_sequence_singleton_publisher_serializes_and_stops_on_cancellation() {
+        let (attempted_tx, mut attempted_rx) = mpsc::unbounded_channel();
+        let release_add = Arc::new(tokio::sync::Notify::new());
+        let active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let max_active = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let publisher = BlockingSingletonPublisher {
+            attempted_tx,
+            release_add: Arc::clone(&release_add),
+            active,
+            max_active: Arc::clone(&max_active),
+        };
+        let (event_tx, event_rx) = mpsc::channel(3);
+        event_tx.send(add_event("ordered")).await.unwrap();
+        event_tx.send(mark_event("ordered")).await.unwrap();
+        event_tx.send(free_event("ordered")).await.unwrap();
+
+        let cancellation_token = CancellationToken::new();
+        let task = tokio::spawn(run_replica_singleton_publisher(
+            publisher,
+            event_rx,
+            cancellation_token.clone(),
+        ));
+
+        let first = tokio::time::timeout(std::time::Duration::from_secs(1), attempted_rx.recv())
+            .await
+            .expect("AddRequest publish should start")
+            .expect("attempt channel should remain open");
+        assert_eq!(first, "add");
+        assert!(attempted_rx.try_recv().is_err());
+        assert_eq!(max_active.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        release_add.notify_one();
+        let mut attempted = vec![first];
+        for _ in 0..2 {
+            attempted.push(
+                tokio::time::timeout(std::time::Duration::from_secs(1), attempted_rx.recv())
+                    .await
+                    .expect("all queued publishes should be attempted")
+                    .expect("attempt channel should remain open"),
+            );
+        }
+
+        assert_eq!(attempted, ["add", "mark", "free"]);
+        assert_eq!(max_active.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        cancellation_token.cancel();
+        tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("singleton publisher should stop after cancellation")
+            .expect("singleton publisher task should not panic");
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -205,7 +205,13 @@ async fn run_replica_singleton_publisher<P: SingletonEventPublisher>(
                 None => break,
             },
         };
-        if let Err(error) = publisher.publish_event(&event).await {
+        // Replica sync is best-effort, so cancellation drops an in-flight publish rather than
+        // delaying shutdown on transport backpressure.
+        let publish_result = tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            result = publisher.publish_event(&event) => result,
+        };
+        if let Err(error) = publish_result {
             tracing::error!(
                 request_id = %event.request_id,
                 worker = ?event.worker,
@@ -670,6 +676,13 @@ mod tests {
 
         assert_eq!(attempted, ["add", "mark", "free"]);
         assert_eq!(max_active.load(std::sync::atomic::Ordering::SeqCst), 1);
+
+        event_tx.send(add_event("blocked")).await.unwrap();
+        let blocked = tokio::time::timeout(std::time::Duration::from_secs(1), attempted_rx.recv())
+            .await
+            .expect("blocked AddRequest publish should start")
+            .expect("attempt channel should remain open");
+        assert_eq!(blocked, "add");
 
         cancellation_token.cancel();
         tokio::time::timeout(std::time::Duration::from_secs(1), task)

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -40,8 +40,8 @@ use dynamo_kv_router::protocols::PrefillLoadHint;
 #[cfg(test)]
 use dynamo_runtime::transports::event_plane::MsgpackCodec;
 
-// Match the existing standalone replica-sync queue. Senders wait asynchronously when it is full,
-// preserving the pre-existing fire-and-forget behavior rather than dropping lifecycle events.
+// Match the existing standalone replica-sync queue. Lifecycle callers enqueue without awaiting;
+// if the queue is full, the newest event is dropped without blocking the local mutation.
 const REPLICA_EVENT_CHANNEL_CAPACITY: usize = 100_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -59,40 +59,60 @@ fn active_sequence_event_wire_format(
     }
 }
 
-enum ActiveSequenceEventPublisher {
-    Nats(Box<EventPublisher>),
-    Zmq(mpsc::Sender<ActiveSequenceEvent>),
+struct ActiveSequenceEventSender {
+    event_tx: mpsc::Sender<ActiveSequenceEvent>,
 }
 
-/// Concrete [`SequencePublisher`] backed by the runtime event plane and Prometheus gauges.
-pub struct RuntimeSequencePublisher {
-    event_publisher: Option<ActiveSequenceEventPublisher>,
-    metrics_publisher: Arc<EventPublisher>,
-    worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
-}
+impl ActiveSequenceEventSender {
+    fn channel(capacity: usize) -> (Self, mpsc::Receiver<ActiveSequenceEvent>) {
+        let (event_tx, event_rx) = mpsc::channel(capacity);
+        (Self { event_tx }, event_rx)
+    }
 
-impl RuntimeSequencePublisher {
-    async fn publish_owned_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
-        let Some(event_publisher) = &self.event_publisher else {
-            return Ok(());
-        };
-        match event_publisher {
-            ActiveSequenceEventPublisher::Nats(publisher) => publisher.publish(&event).await,
-            ActiveSequenceEventPublisher::Zmq(event_tx) => event_tx
-                .send(event)
-                .await
-                .map_err(|_| anyhow::anyhow!("active-sequence replica publisher is closed")),
+    fn enqueue(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        match self.event_tx.try_send(event) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(event)) => anyhow::bail!(
+                "active-sequence publish queue full; dropping newest event \
+                 (request_id={}, worker={:?}, capacity={})",
+                event.request_id,
+                event.worker,
+                self.event_tx.max_capacity()
+            ),
+            Err(mpsc::error::TrySendError::Closed(event)) => anyhow::bail!(
+                "active-sequence publish queue closed; dropping event \
+                 (request_id={}, worker={:?}, capacity={})",
+                event.request_id,
+                event.worker,
+                self.event_tx.max_capacity()
+            ),
         }
     }
 }
 
-impl SequencePublisher for RuntimeSequencePublisher {
-    async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
-        self.publish_owned_event(event.clone()).await
-    }
+fn active_sequence_event_channel(
+    enabled: bool,
+    capacity: usize,
+) -> Option<(
+    ActiveSequenceEventSender,
+    mpsc::Receiver<ActiveSequenceEvent>,
+)> {
+    enabled.then(|| ActiveSequenceEventSender::channel(capacity))
+}
 
-    async fn publish_event_owned(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
-        self.publish_owned_event(event).await
+/// Concrete [`SequencePublisher`] backed by the runtime event plane and Prometheus gauges.
+pub struct RuntimeSequencePublisher {
+    event_sender: Option<ActiveSequenceEventSender>,
+    metrics_publisher: Arc<EventPublisher>,
+    worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
+}
+
+impl SequencePublisher for RuntimeSequencePublisher {
+    fn enqueue_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        let Some(event_sender) = &self.event_sender else {
+            return Ok(());
+        };
+        event_sender.enqueue(event)
     }
 
     fn publish_load(&self, load: ActiveLoad) {
@@ -147,6 +167,30 @@ impl SequencePublisher for RuntimeSequencePublisher {
     fn observe_worker_removed(&self, worker: &WorkerWithDpRank, worker_type: &str) {
         self.worker_status_metrics
             .remove_worker(worker.worker_id, worker.dp_rank, worker_type);
+    }
+}
+
+async fn run_replica_singleton_publisher(
+    publisher: EventPublisher,
+    mut event_rx: mpsc::Receiver<ActiveSequenceEvent>,
+    cancellation_token: CancellationToken,
+) {
+    loop {
+        let event = tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            event = event_rx.recv() => match event {
+                Some(event) => event,
+                None => break,
+            },
+        };
+        if let Err(error) = publisher.publish(&event).await {
+            tracing::error!(
+                request_id = %event.request_id,
+                worker = ?event.worker,
+                error = %error,
+                "Failed to publish active-sequence replica event"
+            );
+        }
     }
 }
 
@@ -320,7 +364,9 @@ pub async fn create_multi_worker_sequences(
     cancellation_token: CancellationToken,
 ) -> Result<Arc<ActiveSequencesMulti>> {
     let transport_kind = endpoint.drt().default_event_transport_kind();
-    let event_publisher = if replica_sync {
+    let event_sender = if let Some((event_sender, event_rx)) =
+        active_sequence_event_channel(replica_sync, REPLICA_EVENT_CHANNEL_CAPACITY)
+    {
         let event_publisher = EventPublisher::for_endpoint_with_transport(
             &endpoint,
             ACTIVE_SEQUENCES_SUBJECT,
@@ -328,19 +374,22 @@ pub async fn create_multi_worker_sequences(
         )
         .await?;
         match active_sequence_event_wire_format(transport_kind) {
-            ActiveSequenceEventWireFormat::Singleton => Some(ActiveSequenceEventPublisher::Nats(
-                Box::new(event_publisher),
-            )),
+            ActiveSequenceEventWireFormat::Singleton => {
+                tokio::spawn(run_replica_singleton_publisher(
+                    event_publisher,
+                    event_rx,
+                    cancellation_token.child_token(),
+                ));
+            }
             ActiveSequenceEventWireFormat::Batch => {
-                let (event_tx, event_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
                 tokio::spawn(run_replica_batch_publisher(
                     event_publisher,
                     event_rx,
                     cancellation_token.child_token(),
                 ));
-                Some(ActiveSequenceEventPublisher::Zmq(event_tx))
             }
         }
+        Some(event_sender)
     } else {
         None
     };
@@ -349,7 +398,7 @@ pub async fn create_multi_worker_sequences(
     let worker_status_metrics = RouterWorkerStatusMetrics::from_component(endpoint.component());
 
     let publisher = RuntimeSequencePublisher {
-        event_publisher,
+        event_sender,
         metrics_publisher,
         worker_status_metrics,
     };
@@ -418,6 +467,73 @@ mod tests {
             router_id: 7,
             lora_name: None,
         }
+    }
+
+    fn add_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: None,
+                track_prefill_tokens: false,
+                expected_output_tokens: None,
+                prefill_load_hint: None,
+            },
+            router_id: 7,
+            lora_name: None,
+        }
+    }
+
+    fn mark_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::MarkPrefillCompleted,
+            router_id: 7,
+            lora_name: None,
+        }
+    }
+
+    #[test]
+    fn active_sequence_publish_sender_preserves_lifecycle_order() {
+        let (sender, mut event_rx) = ActiveSequenceEventSender::channel(3);
+        sender.enqueue(add_event("ordered")).unwrap();
+        sender.enqueue(mark_event("ordered")).unwrap();
+        sender.enqueue(free_event("ordered")).unwrap();
+
+        assert!(matches!(
+            event_rx.try_recv().unwrap().data,
+            ActiveSequenceEventData::AddRequest { .. }
+        ));
+        assert!(matches!(
+            event_rx.try_recv().unwrap().data,
+            ActiveSequenceEventData::MarkPrefillCompleted
+        ));
+        assert!(matches!(
+            event_rx.try_recv().unwrap().data,
+            ActiveSequenceEventData::Free
+        ));
+    }
+
+    #[test]
+    fn active_sequence_publish_sender_drops_newest_when_full() {
+        let (sender, mut event_rx) = ActiveSequenceEventSender::channel(1);
+        sender.enqueue(add_event("accepted")).unwrap();
+
+        let error = sender
+            .enqueue(free_event("dropped"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("queue full"));
+        assert!(error.contains("request_id=dropped"));
+        assert!(error.contains("capacity=1"));
+        assert_eq!(event_rx.len(), 1);
+        assert_eq!(event_rx.try_recv().unwrap().request_id, "accepted");
+    }
+
+    #[test]
+    fn active_sequence_publish_channel_is_absent_when_replica_sync_disabled() {
+        assert!(active_sequence_event_channel(false, 1).is_none());
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::future;
 use std::sync::Arc;
 
 use crate::common::protocols::MockEngineArgs;
@@ -19,11 +18,8 @@ use dynamo_kv_router::{
 pub(super) struct ReplayNoopPublisher;
 
 impl SequencePublisher for ReplayNoopPublisher {
-    fn publish_event(
-        &self,
-        _event: &ActiveSequenceEvent,
-    ) -> impl future::Future<Output = anyhow::Result<()>> + Send {
-        future::ready(Ok(()))
+    fn enqueue_event(&self, _event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        Ok(())
     }
 
     fn publish_load(&self, _load: ActiveLoad) {}


### PR DESCRIPTION
## Overview:

Serialize active-sequence lifecycle publication without the duplicate tracker-owned dispatcher. Lifecycle mutations now synchronously enqueue into the transport publisher, so accepted events retain FIFO order without spawning one task per event.

## Details:

- replace the async `SequencePublisher` publication API with an owned synchronous enqueue boundary
- use one bounded 100,000-event queue per runtime publisher
- feed ZMQ directly into the existing batch publisher task and use one equivalent singleton publisher task for NATS
- drop the newest event on queue overflow while leaving the local lifecycle mutation successful
- aggregate repeated full-queue and unexpectedly-closed diagnostics at 30-second intervals
- classify queue closure with the publisher cancellation token and log expected shutdown closure once at debug level
- preserve request, worker, capacity, and standalone model/routing-group context in queue diagnostics
- preserve the existing NATS singleton and ZMQ batch wire formats, batch limits, and concurrent replica ingestion
- keep standalone replica sync on its existing process-level outbound queue

## Where should the reviewer start?

- `lib/kv-router/src/sequences/multi_worker.rs` for the synchronous tracker-to-publisher boundary and failure-log aggregation
- `lib/llm/src/kv_router/sequence.rs` for the shared sender, cancellation classification, and transport-specific publisher tasks

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Summary

- eliminate the tracker queue-to-task-to-runtime-queue chain
- guarantee FIFO ordering among successfully enqueued lifecycle events
- retain bounded best-effort behavior without blocking local state updates
- avoid overflow log floods and shutdown-time error noise

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router sequences::multi_worker::tests --lib`
- `cargo test -p dynamo-kv-router --features standalone-slot-tracker services::common::replica_sync::tests --lib`
- `cargo test -p dynamo-llm kv_router::sequence::tests --lib`
- `cargo test -p dynamo-llm mixed_replica_batch_updates_lora_load_in_order --lib`
- `cargo check -p dynamo-mocker --lib`
- `cargo clippy -p dynamo-kv-router -p dynamo-llm --lib --tests -- -D warnings`