### PR TITLE
feat(runtime): add QUIC response transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,14 +2794,18 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "prometheus",
+ "quinn",
  "rand 0.9.4",
  "rayon",
+ "rcgen",
  "regex",
  "reqwest 0.12.28",
  "rmp-serde",
  "rstest 0.23.0",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
+ "sha2",
  "socket2 0.5.10",
  "stdio-override",
  "temp-env",
@@ -7090,6 +7094,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "qlog"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f15b83c59e6b945f2261c95a1dd9faf239187f32ff0a96af1d1d28c4557f919"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7149,6 +7165,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
+ "qlog",
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
@@ -8501,6 +8518,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,8 @@ rcgen = { version = "0.13" }
 tokio-rustls = { version = "0.26" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2" }
+quinn = { version = "0.11.9", default-features = false, features = ["runtime-tokio", "rustls-ring", "qlog"] }
+sha2 = { version = "0.10" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/benchmarks/frontend/scripts/analysis/summarize_quic_metrics.py
+++ b/benchmarks/frontend/scripts/analysis/summarize_quic_metrics.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Calculate steady-window QUIC response indicators from Prometheus snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+
+
+def read_snapshot(paths: list[Path]) -> dict[str, float]:
+    values: dict[str, float] = defaultdict(float)
+    for path in paths:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            fields = line.split()
+            if len(fields) < 2:
+                continue
+            metric = fields[0].split("{", 1)[0]
+            if not metric.startswith("dynamo_quic_response_"):
+                continue
+            try:
+                values[metric] += float(fields[1])
+            except ValueError:
+                continue
+    return dict(values)
+
+
+def delta(before: dict[str, float], after: dict[str, float], metric: str) -> float:
+    return after.get(metric, 0.0) - before.get(metric, 0.0)
+
+
+def ratio(numerator: float, denominator: float) -> float | None:
+    return numerator / denominator if denominator > 0 else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--before", nargs="+", required=True, type=Path)
+    parser.add_argument("--after", nargs="+", required=True, type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+
+    before = read_snapshot(args.before)
+    after = read_snapshot(args.after)
+    payloads = delta(
+        before, after, "dynamo_quic_response_payloads_total"
+    )
+    datagrams = delta(
+        before, after, "dynamo_quic_response_udp_tx_datagrams_total"
+    )
+    stream_frames = delta(
+        before, after, "dynamo_quic_response_stream_frames_tx_total"
+    )
+    transmit_ios = delta(
+        before, after, "dynamo_quic_response_udp_tx_ios_total"
+    )
+    connection_blocked = delta(
+        before,
+        after,
+        "dynamo_quic_response_connection_blocked_frames_tx_total",
+    )
+    stream_blocked = delta(
+        before, after, "dynamo_quic_response_stream_blocked_frames_tx_total"
+    )
+    reconnects = delta(
+        before, after, "dynamo_quic_response_reconnects_total"
+    )
+    connection_failures = delta(
+        before, after, "dynamo_quic_response_connection_failures_total"
+    )
+
+    summary = {
+        "window_deltas": {
+            "response_payloads": payloads,
+            "udp_tx_datagrams": datagrams,
+            "quic_stream_frames": stream_frames,
+            "udp_tx_ios": transmit_ios,
+            "connection_flow_control_blocked": connection_blocked,
+            "stream_flow_control_blocked": stream_blocked,
+            "reconnects": reconnects,
+            "connection_failures": connection_failures,
+        },
+        "response_payloads_per_udp_tx_datagram": ratio(payloads, datagrams),
+        "quic_stream_frames_per_udp_tx_datagram": ratio(
+            stream_frames, datagrams
+        ),
+        "udp_tx_datagrams_per_udp_tx_io": ratio(datagrams, transmit_ios),
+        "passes_packet_density_gate": (
+            datagrams > 0 and payloads / datagrams >= 2.0
+        ),
+        "requires_high_window_comparison": (
+            connection_blocked > 0 or stream_blocked > 0
+        ),
+        "passes_connection_stability_gate": (
+            reconnects == 0 and connection_failures == 0
+        ),
+    }
+    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/frontend/scripts/analysis/summarize_quic_qlog.py
+++ b/benchmarks/frontend/scripts/analysis/summarize_quic_qlog.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Summarize response-stream packet multiplexing from Quinn qlog captures.
+
+Input may be qlog JSON text sequences (one object per line) or a regular JSON
+document. The output is deliberately small and stable so a locked benchmark can
+include it directly in comparison.json and enforce the >=50% multi-stream gate.
+
+Quinn 0.11's built-in packet_sent events omit the frames array. For those
+captures, pass the worker's short diagnostic JSON log with --quinn-trace-log.
+Quinn emits every STREAM frame inside a per-packet `send` span, so the fallback
+groups exact stream IDs by that span. Without either source of frame details,
+the analyzer fails the gate instead of inferring sharing from aggregate counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable
+
+
+def _objects(path: Path) -> Iterable[Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        yield json.loads(text)
+        return
+    except json.JSONDecodeError:
+        pass
+
+    for line_number, line in enumerate(text.splitlines(), 1):
+        line = line.strip()
+        if not line or line == "\x1e":
+            continue
+        if line.startswith("\x1e"):
+            line = line[1:]
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError as error:
+            raise ValueError(f"{path}:{line_number}: invalid qlog JSON: {error}") from error
+
+
+def _walk(value: Any) -> Iterable[dict[str, Any]]:
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _stream_ids(packet: dict[str, Any]) -> set[str]:
+    data = packet.get("data")
+    frames = data.get("frames", []) if isinstance(data, dict) else []
+    stream_ids: set[str] = set()
+    for frame in frames:
+        if not isinstance(frame, dict):
+            continue
+        frame_type = str(frame.get("frame_type", frame.get("frameType", ""))).lower()
+        if frame_type != "stream":
+            continue
+        stream_id = frame.get("stream_id", frame.get("streamId"))
+        if stream_id is not None:
+            stream_ids.add(str(stream_id))
+    return stream_ids
+
+
+def _trace_packet_streams(paths: list[Path]) -> tuple[dict[str, set[str]], int]:
+    packets: dict[str, set[str]] = {}
+    stream_frame_events = 0
+    for path_index, path in enumerate(paths):
+        for root in _objects(path):
+            for event in _walk(root):
+                target = str(event.get("target", ""))
+                message = str(event.get("message", "")).upper()
+                if not target.startswith("quinn_proto::") or message != "STREAM":
+                    continue
+                if str(event.get("span_name", "")) != "send":
+                    continue
+                stream_id = event.get("id")
+                if stream_id is None:
+                    continue
+                span_id = event.get("span_id")
+                if span_id is not None:
+                    packet_key = f"{path_index}:span:{span_id}"
+                else:
+                    packet_number = event.get("pn")
+                    if packet_number is None:
+                        continue
+                    packet_key = (
+                        f"{path_index}:pn:{event.get('space', 'unknown')}:{packet_number}"
+                    )
+                packets.setdefault(packet_key, set()).add(str(stream_id))
+                stream_frame_events += 1
+    return packets, stream_frame_events
+
+
+def summarize(paths: list[Path], trace_paths: list[Path]) -> dict[str, Any]:
+    histogram: Counter[int] = Counter()
+    packet_count = 0
+    packet_sent_events = 0
+    packet_sent_events_with_frame_details = 0
+    for path in paths:
+        for root in _objects(path):
+            for event in _walk(root):
+                name = str(event.get("name", "")).lower()
+                if not name.endswith("packet_sent"):
+                    continue
+                packet_sent_events += 1
+                data = event.get("data")
+                if isinstance(data, dict) and isinstance(data.get("frames"), list):
+                    packet_sent_events_with_frame_details += 1
+                stream_ids = _stream_ids(event)
+                if not stream_ids:
+                    continue
+                packet_count += 1
+                histogram[len(stream_ids)] += 1
+
+    frame_detail_source = "qlog" if packet_count else None
+    trace_frame_events = 0
+    if not packet_count and trace_paths:
+        trace_packets, trace_frame_events = _trace_packet_streams(trace_paths)
+        for stream_ids in trace_packets.values():
+            packet_count += 1
+            histogram[len(stream_ids)] += 1
+        if packet_count:
+            frame_detail_source = "quinn_trace_log"
+
+    multi_stream_packets = sum(
+        count for stream_count, count in histogram.items() if stream_count >= 2
+    )
+    percentage = (
+        100.0 * multi_stream_packets / packet_count if packet_count else 0.0
+    )
+    return {
+        "qlog_files": [str(path) for path in paths],
+        "quinn_trace_log_files": [str(path) for path in trace_paths],
+        "packet_sent_events": packet_sent_events,
+        "packet_sent_events_with_frame_details": packet_sent_events_with_frame_details,
+        "quinn_trace_stream_frame_events": trace_frame_events,
+        "response_carrying_packets": packet_count,
+        "multi_response_stream_packets": multi_stream_packets,
+        "multi_response_stream_packet_percentage": percentage,
+        "distinct_response_streams_per_packet_histogram": {
+            str(key): histogram[key] for key in sorted(histogram)
+        },
+        "passes_50_percent_gate": packet_count > 0 and percentage >= 50.0,
+        "frame_detail_available": frame_detail_source is not None,
+        "frame_detail_source": frame_detail_source,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("qlog", nargs="+", type=Path)
+    parser.add_argument("--quinn-trace-log", nargs="*", default=[], type=Path)
+    parser.add_argument("--output", type=Path)
+    args = parser.parse_args()
+    summary = summarize(args.qlog, args.quinn_trace_log)
+    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/frontend/scripts/analysis/test_summarize_quic_qlog.py
+++ b/benchmarks/frontend/scripts/analysis/test_summarize_quic_qlog.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from benchmarks.frontend.scripts.analysis.summarize_quic_qlog import summarize
+
+
+class SummarizeQuicQlogTest(unittest.TestCase):
+    def test_uses_packet_spans_when_stock_qlog_has_no_frames(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            qlog = root / "capture.sqlog"
+            trace = root / "worker.jsonl"
+            qlog.write_text(
+                "\n".join(
+                    json.dumps(
+                        {
+                            "name": "transport:packet_sent",
+                            "data": {"header": {"packet_number": packet_number}},
+                        }
+                    )
+                    for packet_number in range(2)
+                ),
+                encoding="utf-8",
+            )
+            trace.write_text(
+                "\n".join(
+                    json.dumps(
+                        {
+                            "target": "quinn_proto::connection::streams::state",
+                            "message": "STREAM",
+                            "span_name": "send",
+                            "span_id": span_id,
+                            "pn": packet_number,
+                            "space": "Data",
+                            "id": stream_id,
+                        }
+                    )
+                    for span_id, packet_number, stream_id in [
+                        ("packet-a", 0, "0"),
+                        ("packet-a", 0, "4"),
+                        ("packet-b", 1, "8"),
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = summarize([qlog], [trace])
+
+        self.assertEqual(result["frame_detail_source"], "quinn_trace_log")
+        self.assertEqual(result["response_carrying_packets"], 2)
+        self.assertEqual(result["multi_response_stream_packets"], 1)
+        self.assertEqual(result["multi_response_stream_packet_percentage"], 50.0)
+        self.assertTrue(result["passes_50_percent_gate"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/design-docs/request-plane.md
+++ b/docs/design-docs/request-plane.md
@@ -38,6 +38,47 @@ For example, a deployment with TCP request plane can use different KV event plan
 - **ZMQ KV events (local indexer)**: requests use TCP, KV events use direct ZMQ pub/sub, and persistence lives on workers.
 - **No KV events**: requests use TCP and KV routing predicts cache state from routing decisions.
 
+## Response Transport
+
+**Experimental.** Dynamo sends worker-to-frontend streaming responses over QUIC. Request dispatch
+continues to use the configured request plane, and bidirectional request bodies continue to use a
+TCP stream. A worker reuses one QUIC connection to each frontend and opens one QUIC stream for each
+logical response. Dynamo does not fall back to TCP when the QUIC response connection fails.
+
+Configure the shared TCP request-stream and QUIC response listener with these environment variables:
+
+- `DYN_RESPONSE_STREAM_HOST`: Network interface to advertise. When unset, Dynamo detects a routable
+  local address.
+- `DYN_RESPONSE_STREAM_PORT`: Numeric port for both protocols. TCP and User Datagram Protocol (UDP)
+  bind the same port number independently. When unset or set to `0`, Dynamo selects an available
+  port.
+
+`DYN_TCP_RESPONSE_STREAM_HOST` and `DYN_TCP_RESPONSE_STREAM_PORT` remain compatibility fallbacks.
+The canonical `DYN_RESPONSE_STREAM_*` variables take precedence.
+
+Allow pod-to-pod UDP traffic from workers to frontends on the response-stream port. For
+bidirectional requests, also allow pod-to-pod TCP traffic on that port. If a Kubernetes
+`NetworkPolicy` or firewall requires a fixed port, set `DYN_RESPONSE_STREAM_PORT` explicitly and
+permit both protocols.
+
+Use Linux networking with Generic Segmentation Offload (GSO) support when available. GSO can reduce
+UDP transmit CPU use, but it does not increase the number of logical response streams carried in an
+individual QUIC packet. Validate response packet density and end-to-end performance on the target
+cluster.
+
+When transport metrics report flow-control stalls during a benchmark, set
+`DYN_RESPONSE_STREAM_HIGH_WINDOW=1` on frontends and workers for a diagnostic comparison. This
+changes the per-stream receive window from 256 KiB to 1 MiB and the connection receive and send
+windows from 8 MiB to 32 MiB. Keep the default configuration unless the comparison removes stalls
+and improves the locked workload.
+
+Set `DYN_RESPONSE_QLOG_PATH` to a writable path prefix only for a short diagnostic capture, and
+unset it for performance measurements. Quinn 0.11's built-in `packet_sent` qlog events do not
+include frame lists. For exact distinct-streams-per-packet qualification, capture worker logs with
+`DYN_LOGGING_JSONL=1` and `DYN_LOG=quinn_proto=trace` during the same short run, then pass those logs
+to the included qlog analyzer with `--quinn-trace-log`. The fallback groups `STREAM` frame IDs by
+Quinn's per-packet `send` span. It fails closed if neither capture contains frame details.
+
 ## Configuration
 
 ### Environment Variable

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -205,6 +205,45 @@ The `dynamo_component_errors_total` counter is labeled with `error_type`, identi
 | `publish_response` | Streaming | The engine produced response chunks but the worker could not push one of them back to the frontend (write failed mid-stream). **Also fires on client cancellation** — the frontend disconnecting before the stream finishes — so this counter can be inflated by user-aborted requests. |
 | `publish_final` | Teardown | All response chunks were sent, but the worker could not deliver the final stream-complete marker. The connection died right at the end. |
 
+### QUIC Response Transport Metrics
+
+**Experimental.** Frontends and workers expose process-level `dynamo_quic_response_*` metrics. The
+series have no peer or stream labels, except `dynamo_quic_response_resets_total`, whose `reason`
+label uses a fixed set of transport reasons.
+
+| Metric | Meaning |
+|---|---|
+| `dynamo_quic_response_active_connections` | Open QUIC response connections. |
+| `dynamo_quic_response_active_streams` | Open logical response streams. |
+| `dynamo_quic_response_handshakes_total` | Completed client or server handshakes. |
+| `dynamo_quic_response_handshake_failures_total` | QUIC handshakes rejected or failed. |
+| `dynamo_quic_response_reconnects_total` | Cached connections replaced after failure. |
+| `dynamo_quic_response_connection_failures_total` | Established connections that closed. This must not increase during a locked measurement window. |
+| `dynamo_quic_response_stream_open_stalls_total` | Stream opens that exceeded the five-second timeout. |
+| `dynamo_quic_response_payloads_total` | Logical payload frames completed by response senders. |
+| `dynamo_quic_response_udp_tx_bytes_total` | UDP bytes transmitted by active worker connections. |
+| `dynamo_quic_response_udp_tx_datagrams_total` | UDP datagrams transmitted by active worker connections. |
+| `dynamo_quic_response_udp_tx_ios_total` | UDP transmit I/O operations. This can be lower than datagrams when GSO or syscall batching is active. |
+| `dynamo_quic_response_stream_frames_tx_total` | QUIC `STREAM` frames transmitted. |
+| `dynamo_quic_response_connection_blocked_frames_tx_total` | Connection-level flow-control blocked frames. |
+| `dynamo_quic_response_stream_blocked_frames_tx_total` | Stream-level flow-control blocked frames. |
+| `dynamo_quic_response_lost_packets_total` | Packets Quinn reports lost. |
+| `dynamo_quic_response_lost_bytes_total` | Bytes Quinn reports lost. |
+| `dynamo_quic_response_rtt_microseconds` | Highest current round-trip time across response connections. |
+| `dynamo_quic_response_mtu_bytes` | Lowest current path maximum transmission unit across response connections. |
+
+Calculate packet density over the same steady-state interval for both counters:
+
+```promql
+sum(rate(dynamo_quic_response_payloads_total[1m]))
+/
+sum(rate(dynamo_quic_response_udp_tx_datagrams_total[1m]))
+```
+
+Use `dynamo_quic_response_stream_frames_tx_total` over UDP datagrams as supporting packetization
+evidence. Report UDP datagrams over UDP I/O operations separately as GSO or syscall-batching
+evidence; it does not measure how many response streams share one QUIC packet.
+
 ### Specialized Component Metrics
 
 Some components expose additional metrics specific to their functionality:

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2496,13 +2496,17 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "prometheus",
+ "quinn",
  "rand 0.9.4",
  "rayon",
+ "rcgen",
  "regex",
  "reqwest",
  "rmp-serde",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
+ "sha2",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tmq",
@@ -6418,6 +6422,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "qlog"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f15b83c59e6b945f2261c95a1dd9faf239187f32ff0a96af1d1d28c4557f919"
+dependencies = [
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smallvec",
+]
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6471,6 +6487,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
+ "qlog",
  "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.2",
@@ -6679,6 +6696,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -7616,6 +7646,9 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snap"
@@ -9889,6 +9922,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -104,6 +104,10 @@ rayon = { version = "1.10" }
 regex = { version = "1" }
 socket2 = { version = "0.5.8" }
 tokio-rayon = { version = "2.1" }
+quinn = { workspace = true }
+rcgen = { workspace = true }
+rustls = { workspace = true }
+sha2 = { workspace = true }
 
 # Kubernetes discovery backend
 kube = { version = "2.0.1", default-features = false, features = ["runtime", "derive", "client", "rustls-tls", "aws-lc-rs"] }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -616,8 +616,18 @@ pub mod request_plane {
     pub const DYN_REQUEST_PLANE_CODEC: &str = "DYN_REQUEST_PLANE_CODEC";
 }
 
-/// TCP response stream server (CallHome listener) environment variables
+/// Response stream listener environment variables.
+///
+/// The canonical names configure both the QUIC response listener and the TCP
+/// request-stream listener. The legacy TCP-prefixed names remain fallbacks.
 pub mod tcp_response_stream {
+    pub const DYN_RESPONSE_STREAM_PORT: &str = "DYN_RESPONSE_STREAM_PORT";
+    pub const DYN_RESPONSE_STREAM_HOST: &str = "DYN_RESPONSE_STREAM_HOST";
+    /// Base path for short diagnostic qlog captures. Unset during performance runs.
+    pub const DYN_RESPONSE_QLOG_PATH: &str = "DYN_RESPONSE_QLOG_PATH";
+    /// Benchmark-only high flow-control window configuration.
+    pub const DYN_RESPONSE_STREAM_HIGH_WINDOW: &str = "DYN_RESPONSE_STREAM_HIGH_WINDOW";
+
     /// Port for the TCP response stream server.
     /// If unset or 0, the OS assigns a free ephemeral port.
     pub const DYN_TCP_RESPONSE_STREAM_PORT: &str = "DYN_TCP_RESPONSE_STREAM_PORT";
@@ -870,6 +880,10 @@ mod tests {
             router::DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS,
             request_plane::DYN_REQUEST_PLANE_CODEC,
             // TCP Response Stream
+            tcp_response_stream::DYN_RESPONSE_STREAM_PORT,
+            tcp_response_stream::DYN_RESPONSE_STREAM_HOST,
+            tcp_response_stream::DYN_RESPONSE_QLOG_PATH,
+            tcp_response_stream::DYN_RESPONSE_STREAM_HIGH_WINDOW,
             tcp_response_stream::DYN_TCP_RESPONSE_STREAM_PORT,
             tcp_response_stream::DYN_TCP_RESPONSE_STREAM_HOST,
             // Event Plane

--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -50,6 +50,7 @@ pub struct DistributedRuntime {
     nats_client: Option<transports::nats::Client>,
     network_manager: Arc<NetworkManager>,
     tcp_server: Arc<OnceCell<Arc<transports::tcp::server::TcpStreamServer>>>,
+    quic_server: Arc<OnceCell<Arc<crate::pipeline::network::quic::QuicStreamServer>>>,
     system_status_server: Arc<OnceLock<Arc<system_status_server::SystemStatusServerInfo>>>,
     request_plane: RequestPlaneMode,
 
@@ -198,6 +199,7 @@ impl DistributedRuntime {
             network_manager: Arc::new(network_manager),
             nats_client,
             tcp_server: Arc::new(OnceCell::new()),
+            quic_server: Arc::new(OnceCell::new()),
             system_status_server: Arc::new(OnceLock::new()),
             discovery_client,
             discovery_metadata,
@@ -230,6 +232,12 @@ impl DistributedRuntime {
                     Ok(())
                 }));
         }
+
+        distributed_runtime
+            .metrics_registry
+            .add_expfmt_callback(std::sync::Arc::new(|| {
+                Ok(crate::pipeline::network::quic::prometheus_exposition())
+            }));
 
         // Handle system status server initialization
         if let Some(cancel_token) = cancel_token {
@@ -365,19 +373,21 @@ impl DistributedRuntime {
         Ok(self
             .tcp_server
             .get_or_try_init(async move {
-                let port = match std::env::var(tcp_response_stream::DYN_TCP_RESPONSE_STREAM_PORT) {
+                let configured_port = std::env::var(tcp_response_stream::DYN_RESPONSE_STREAM_PORT)
+                    .or_else(|_| std::env::var(tcp_response_stream::DYN_TCP_RESPONSE_STREAM_PORT));
+                let port = match configured_port {
                     Ok(p) => p.parse::<u16>().map_err(|_| {
                         PipelineError::Generic(format!(
-                            "invalid {}: '{}' is not a valid port number",
-                            tcp_response_stream::DYN_TCP_RESPONSE_STREAM_PORT,
+                            "invalid response stream port: '{}' is not a valid port number",
                             p
                         ))
                     })?,
                     Err(_) => 0,
                 };
-                let interface = std::env::var(tcp_response_stream::DYN_TCP_RESPONSE_STREAM_HOST)
+                let interface = std::env::var(tcp_response_stream::DYN_RESPONSE_STREAM_HOST)
+                    .or_else(|_| std::env::var(tcp_response_stream::DYN_TCP_RESPONSE_STREAM_HOST))
                     .ok()
-                    .filter(|h| !h.is_empty());
+                    .filter(|host| !host.is_empty());
 
                 let host_suffix = interface
                     .as_ref()
@@ -395,6 +405,43 @@ impl DistributedRuntime {
                 let options = tcp::server::ServerOptions { port, interface };
                 let server = tcp::server::TcpStreamServer::new(options).await?;
                 Ok::<_, PipelineError>(server)
+            })
+            .await?
+            .clone())
+    }
+
+    /// Response-only QUIC server. It intentionally binds UDP to the exact
+    /// address and numeric port selected by the TCP request-stream listener;
+    /// TCP and UDP can share the port number.
+    pub async fn quic_server(
+        &self,
+    ) -> Result<Arc<crate::pipeline::network::quic::QuicStreamServer>> {
+        Ok(self
+            .quic_server
+            .get_or_try_init(async {
+                let tcp_server = self.tcp_server().await.map_err(|error| {
+                    PipelineError::Generic(format!(
+                        "failed to start TCP request stream server: {error:#}"
+                    ))
+                })?;
+                let address = tcp_server.local_ip().parse().map_err(|error| {
+                    PipelineError::Generic(format!(
+                        "invalid resolved response stream address {}: {error}",
+                        tcp_server.local_ip()
+                    ))
+                })?;
+                crate::pipeline::network::quic::QuicStreamServer::new(
+                    crate::pipeline::network::quic::ServerOptions {
+                        address,
+                        port: tcp_server.local_port(),
+                    },
+                )
+                .await
+                .map_err(|error| {
+                    PipelineError::Generic(format!(
+                        "failed to start QUIC response stream server: {error:#}"
+                    ))
+                })
             })
             .await?
             .clone())

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -12,6 +12,7 @@ pub mod codec;
 pub mod egress;
 pub mod ingress;
 pub mod manager;
+pub mod quic;
 pub mod tcp;
 
 use crate::SystemHealth;

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -32,6 +32,7 @@ use crate::pipeline::network::StreamReceiver;
 use crate::pipeline::network::StreamSender;
 use crate::pipeline::network::TwoPartCodec;
 use crate::pipeline::network::codec::TwoPartMessage;
+use crate::pipeline::network::quic;
 use crate::pipeline::network::tcp;
 use crate::pipeline::{ManyIn, ManyOut, PipelineError, ResponseStream, SingleIn};
 use crate::protocols::maybe_error::MaybeError;
@@ -338,6 +339,10 @@ fn subject_of(conn_info: &ConnectionInfo) -> Option<String> {
         .map(|ci| ci.subject)
 }
 
+fn response_registration_of(conn_info: &ConnectionInfo) -> Result<uuid::Uuid> {
+    Ok(quic::QuicResponseConnectionInfo::try_from(conn_info.clone())?.response_registration_id)
+}
+
 pub struct AddressedRequest<T> {
     request: T,
     address: String,
@@ -377,8 +382,11 @@ pub struct AddressedPushRouter {
     // Request transport (unified trait object - works with all transports)
     req_client: Arc<dyn RequestPlaneClient>,
 
-    // Response transport (TCP streaming - unchanged)
-    resp_transport: Arc<tcp::server::TcpStreamServer>,
+    // TCP remains only for upstream-to-worker request streams.
+    request_stream_transport: Arc<tcp::server::TcpStreamServer>,
+
+    // Worker-to-frontend responses use QUIC.
+    response_transport: Arc<quic::QuicStreamServer>,
 }
 
 impl AddressedPushRouter {
@@ -388,11 +396,13 @@ impl AddressedPushRouter {
     /// The client is provided as a trait object, hiding the specific implementation.
     pub fn new(
         req_client: Arc<dyn RequestPlaneClient>,
-        resp_transport: Arc<tcp::server::TcpStreamServer>,
+        request_stream_transport: Arc<tcp::server::TcpStreamServer>,
+        response_transport: Arc<quic::QuicStreamServer>,
     ) -> Result<Arc<Self>> {
         Ok(Arc::new(Self {
             req_client,
-            resp_transport,
+            request_stream_transport,
+            response_transport,
         }))
     }
 
@@ -401,28 +411,35 @@ impl AddressedPushRouter {
     ) -> Result<Arc<Self>> {
         let manager = provider.drt().network_manager();
         let req_client = manager.create_client()?;
-        let resp_transport = provider.drt().tcp_server().await?;
+        let request_stream_transport = provider.drt().tcp_server().await?;
+        let response_transport = provider.drt().quic_server().await?;
 
         tracing::debug!(
             transport = req_client.transport_name(),
             "Creating AddressedPushRouter with request plane client"
         );
 
-        Self::new(req_client, resp_transport)
+        Self::new(req_client, request_stream_transport, response_transport)
     }
 
     /// Cancel all pending response-stream registrations for an instance.
     pub async fn cancel_instance_streams(&self, instance_id: &EndpointInstanceId) -> usize {
-        self.resp_transport
-            .cancel_instance_streams(instance_id)
-            .await
+        let (request_streams, responses) = tokio::join!(
+            self.request_stream_transport
+                .cancel_instance_streams(instance_id),
+            self.response_transport.cancel_instance_streams(instance_id),
+        );
+        request_streams + responses
     }
 
     /// Clear the tombstone after an instance reappears in discovery.
     pub async fn clear_instance_tombstone(&self, instance_id: &EndpointInstanceId) {
-        self.resp_transport
-            .clear_instance_tombstone(instance_id)
-            .await
+        tokio::join!(
+            self.request_stream_transport
+                .clear_instance_tombstone(instance_id),
+            self.response_transport
+                .clear_instance_tombstone(instance_id),
+        );
     }
 
     /// Bidirectional generation. Note that it doesn't implement the AsyncEngine trait directly
@@ -498,26 +515,34 @@ impl AddressedPushRouter {
         // Tombstone check: if discovery already removed the worker, fail fast
         // with a migratable error rather than writing to the request plane.
         // Dropping the held registrations on this return runs their cleanup.
-        let recv_subject = subject_of(&recv_registered.connection_info);
+        let recv_registration = response_registration_of(&recv_registered.connection_info)?;
         let send_subject = send_registered
             .as_ref()
             .and_then(|r| subject_of(&r.connection_info));
-        if let (Some(subject), Some(inst)) = (&recv_subject, instance)
-            && !self
-                .resp_transport
-                .associate_instance(
-                    subject,
-                    send_subject.as_deref(),
-                    &inst.endpoint_instance_id(),
-                )
-                .await
-        {
-            return Err(anyhow::anyhow!(
-                DynamoError::builder()
-                    .error_type(ErrorType::Disconnected)
-                    .message("Worker removed before request could be sent (tombstoned instance)")
-                    .build()
-            ));
+        if let Some(inst) = instance {
+            let instance_id = inst.endpoint_instance_id();
+            let response_ok = self
+                .response_transport
+                .associate_instance(recv_registration, &instance_id)
+                .await;
+            let request_ok = match send_subject.as_deref() {
+                Some(subject) => {
+                    self.request_stream_transport
+                        .associate_request_instance(subject, &instance_id)
+                        .await
+                }
+                None => true,
+            };
+            if !response_ok || !request_ok {
+                return Err(anyhow::anyhow!(
+                    DynamoError::builder()
+                        .error_type(ErrorType::Disconnected)
+                        .message(
+                            "Worker removed before request could be sent (tombstoned instance)"
+                        )
+                        .build()
+                ));
+            }
         }
 
         let buffer = build_request_envelope(
@@ -637,8 +662,27 @@ impl AddressedPushRouter {
             .enable_response_stream(enable_response_stream)
             .build()?;
 
-        let pending: PendingConnections = self.resp_transport.register(options).await;
-        let (send_stream, recv_stream) = pending.into_parts();
+        let send_stream = if enable_request_stream {
+            let request_options = StreamOptions::builder()
+                .context(options.context.clone())
+                .enable_request_stream(true)
+                .enable_response_stream(false)
+                .send_buffer_count(options.send_buffer_count)
+                .recv_buffer_count(options.recv_buffer_count)
+                .build()?;
+            let pending: PendingConnections = self
+                .request_stream_transport
+                .register(request_options)
+                .await;
+            pending.send_stream
+        } else {
+            None
+        };
+        let recv_stream = if enable_response_stream {
+            Some(self.response_transport.register_response(options).await)
+        } else {
+            None
+        };
 
         // Transport-layer invariant: the data plane produces exactly the halves
         // we requested. A mismatch is a bug in the transport, not a runtime

--- a/lib/runtime/src/pipeline/network/ingress/push_handler.rs
+++ b/lib/runtime/src/pipeline/network/ingress/push_handler.rs
@@ -147,7 +147,7 @@ where
     Adapter: Send + Sync + 'static,
 {
     /// Pump every chunk from the engine's response stream out to the
-    /// upstream-side `StreamSender`, plus the terminal complete-final
+    /// upstream-side QUIC response sender, plus the terminal complete-final
     /// frame. Captures the per-frame metrics, the publish-failure error
     /// classification (client-side disconnect vs. real failure), and the
     /// health-check notifier policy (notify only on non-error chunks and
@@ -155,7 +155,7 @@ where
     async fn pump_response_stream<U>(
         &self,
         mut stream: ManyOut<U>,
-        publisher: &StreamSender,
+        publisher: &mut crate::pipeline::network::quic::ResponseStreamSender,
         payload_codec: RequestPlanePayloadCodec,
     ) where
         U: Data + std::fmt::Debug,
@@ -596,10 +596,8 @@ where
             WORK_HANDLER_NETWORK_TRANSIT_SECONDS.observe(transit_ns as f64 / 1_000_000_000.0);
         }
 
-        // todo - eventually have a handler class which will returned an abstracted object, but for now,
-        // we only support tcp here, so we can just unwrap the connection info
-        tracing::trace!("creating tcp response stream");
-        let mut publisher = tcp::client::TcpClient::create_response_stream(
+        tracing::trace!("creating QUIC response stream");
+        let mut publisher = crate::pipeline::network::quic::create_response_stream(
             request.context(),
             response_connection_info,
             self.metrics().map(|m| m.cancellation_total.clone()),
@@ -656,12 +654,16 @@ where
                 }
 
                 let _result = publisher.send_prologue(Some(error_string)).await;
+                let _ = publisher.finish();
                 Err(e)?
             }
         };
 
-        self.pump_response_stream(stream, &publisher, payload_codec)
+        self.pump_response_stream(stream, &mut publisher, payload_codec)
             .await;
+        publisher.finish().map_err(|error| {
+            PipelineError::Generic(format!("Failed to finish QUIC response stream: {error:#}"))
+        })?;
 
         // Ensure the metrics guard is not dropped until the end of the function.
         // Drop fires "request completed" log via RAII.

--- a/lib/runtime/src/pipeline/network/quic.rs
+++ b/lib/runtime/src/pipeline/network/quic.rs
@@ -1,0 +1,2206 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Response-only QUIC transport.
+//!
+//! A frontend owns one QUIC endpoint and advertises a pinned ephemeral
+//! certificate. Workers reuse one connection to that endpoint and open one
+//! bidirectional QUIC stream per logical response. The worker-to-frontend half
+//! carries the response prologue and length-prefixed payloads; the reverse half
+//! carries cancellation controls.
+
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    net::{IpAddr, SocketAddr},
+    sync::{
+        Arc, Mutex as StdMutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+
+use anyhow::{Context as _, Result, bail};
+use bytes::{Bytes, BytesMut};
+use dashmap::DashMap;
+use parking_lot::Mutex;
+use quinn::{Connection, Endpoint, RecvStream, SendStream, TransportConfig, VarInt};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use socket2::{Domain, Protocol, Socket, Type};
+use tokio::{io::AsyncReadExt, sync::oneshot, time};
+use uuid::Uuid;
+
+use super::{ConnectionInfo, RegisteredStream, StreamOptions, StreamReceiver};
+use crate::{discovery::EndpointInstanceId, engine::AsyncEngineContext};
+
+pub const ALPN: &[u8] = b"dynamo-response-v1";
+pub const PROTOCOL_VERSION: u16 = 1;
+
+const STREAM_RECEIVE_WINDOW: u32 = 256 * 1024;
+const CONNECTION_WINDOW: u32 = 8 * 1024 * 1024;
+const SEND_WINDOW: u64 = 8 * 1024 * 1024;
+const HIGH_STREAM_RECEIVE_WINDOW: u32 = 1024 * 1024;
+const HIGH_CONNECTION_WINDOW: u32 = 32 * 1024 * 1024;
+const HIGH_SEND_WINDOW: u64 = 32 * 1024 * 1024;
+const MAX_BIDI_STREAMS: u32 = 4096;
+const UDP_SOCKET_BUFFER: usize = 8 * 1024 * 1024;
+const IDLE_TIMEOUT: Duration = Duration::from_secs(300);
+const OPEN_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_ERROR_BYTES: usize = 64 * 1024;
+const TOMBSTONE_TTL: Duration = Duration::from_secs(5);
+
+const STATUS_SUCCESS: u8 = 0;
+const STATUS_ERROR: u8 = 1;
+const CONTROL_STOP: u8 = 1;
+const CONTROL_KILL: u8 = 2;
+
+// Stable application error codes. These are intentionally transport-local and
+// must not be generated dynamically from error strings.
+const RESET_MALFORMED: u32 = 0x100;
+const RESET_UNKNOWN_REGISTRATION: u32 = 0x101;
+const RESET_OVERSIZED_FRAME: u32 = 0x103;
+const RESET_RECEIVER_DROPPED: u32 = 0x104;
+const RESET_PUBLISHER_DROPPED: u32 = 0x105;
+const RESET_KILLED: u32 = 0x106;
+
+fn reset_code(code: u32) -> VarInt {
+    VarInt::from_u32(code)
+}
+
+fn validate_payload_size(length: usize) -> Result<()> {
+    let max = super::get_tcp_max_message_size().min(u32::MAX as usize);
+    if length > max {
+        bail!("QUIC response frame of {length} bytes exceeds {max}");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QuicResponseConnectionInfo {
+    pub protocol_version: u16,
+    pub address: String,
+    pub frontend_server_id: Uuid,
+    pub response_registration_id: Uuid,
+    pub context: String,
+    pub certificate_fingerprint: [u8; 32],
+}
+
+impl QuicResponseConnectionInfo {
+    pub fn validate(&self) -> Result<()> {
+        if self.protocol_version != PROTOCOL_VERSION {
+            bail!(
+                "unsupported QUIC response protocol version {}; expected {}",
+                self.protocol_version,
+                PROTOCOL_VERSION
+            );
+        }
+        self.address
+            .parse::<SocketAddr>()
+            .context("invalid QUIC response address")?;
+        if self.frontend_server_id.is_nil() {
+            bail!("QUIC frontend server ID must not be nil");
+        }
+        if self.response_registration_id.is_nil() {
+            bail!("QUIC response registration ID must not be nil");
+        }
+        if self.context.is_empty() {
+            bail!("QUIC response context must not be empty");
+        }
+        if self.certificate_fingerprint == [0; 32] {
+            bail!("QUIC certificate fingerprint must not be all zeroes");
+        }
+        Ok(())
+    }
+}
+
+impl From<QuicResponseConnectionInfo> for ConnectionInfo {
+    fn from(info: QuicResponseConnectionInfo) -> Self {
+        Self {
+            transport: "quic_response".to_string(),
+            info: serde_json::to_string(&info).expect("QuicResponseConnectionInfo must serialize"),
+        }
+    }
+}
+
+impl TryFrom<ConnectionInfo> for QuicResponseConnectionInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(info: ConnectionInfo) -> Result<Self> {
+        if info.transport != "quic_response" {
+            bail!(
+                "invalid transport {}; expected quic_response",
+                info.transport
+            );
+        }
+        let info: Self = serde_json::from_str(&info.info)
+            .context("failed to decode QUIC response connection info")?;
+        info.validate()?;
+        Ok(info)
+    }
+}
+
+/// Process-wide counters whose values can be sampled around a locked benchmark
+/// window. Quinn connection statistics are exposed separately by
+/// [`client_connection_stats`].
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct QuicResponseCounters {
+    pub handshakes: u64,
+    pub handshake_failures: u64,
+    pub reconnects: u64,
+    pub connection_failures: u64,
+    pub stream_open_stalls: u64,
+    pub active_connections: u64,
+    pub active_streams: u64,
+    pub response_payloads: u64,
+    pub malformed_resets: u64,
+    pub unknown_registration_resets: u64,
+    pub receiver_dropped_resets: u64,
+    pub publisher_dropped_resets: u64,
+    pub oversized_frame_resets: u64,
+    pub killed_resets: u64,
+}
+
+#[derive(Default)]
+struct Counters {
+    handshakes: AtomicU64,
+    handshake_failures: AtomicU64,
+    reconnects: AtomicU64,
+    connection_failures: AtomicU64,
+    stream_open_stalls: AtomicU64,
+    active_connections: AtomicU64,
+    active_streams: AtomicU64,
+    response_payloads: AtomicU64,
+    malformed_resets: AtomicU64,
+    unknown_registration_resets: AtomicU64,
+    receiver_dropped_resets: AtomicU64,
+    publisher_dropped_resets: AtomicU64,
+    oversized_frame_resets: AtomicU64,
+    killed_resets: AtomicU64,
+}
+
+static COUNTERS: Counters = Counters {
+    handshakes: AtomicU64::new(0),
+    handshake_failures: AtomicU64::new(0),
+    reconnects: AtomicU64::new(0),
+    connection_failures: AtomicU64::new(0),
+    stream_open_stalls: AtomicU64::new(0),
+    active_connections: AtomicU64::new(0),
+    active_streams: AtomicU64::new(0),
+    response_payloads: AtomicU64::new(0),
+    malformed_resets: AtomicU64::new(0),
+    unknown_registration_resets: AtomicU64::new(0),
+    receiver_dropped_resets: AtomicU64::new(0),
+    publisher_dropped_resets: AtomicU64::new(0),
+    oversized_frame_resets: AtomicU64::new(0),
+    killed_resets: AtomicU64::new(0),
+};
+static CLIENT_UDP_SEND_BUFFER: AtomicU64 = AtomicU64::new(0);
+static CLIENT_UDP_RECV_BUFFER: AtomicU64 = AtomicU64::new(0);
+static SERVER_UDP_SEND_BUFFER: AtomicU64 = AtomicU64::new(0);
+static SERVER_UDP_RECV_BUFFER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Default)]
+struct ClosedConnectionCounters {
+    udp_tx_bytes: AtomicU64,
+    udp_tx_datagrams: AtomicU64,
+    udp_tx_ios: AtomicU64,
+    udp_rx_bytes: AtomicU64,
+    udp_rx_datagrams: AtomicU64,
+    udp_rx_ios: AtomicU64,
+    stream_frames_tx: AtomicU64,
+    connection_blocked_frames_tx: AtomicU64,
+    stream_blocked_frames_tx: AtomicU64,
+    lost_packets: AtomicU64,
+    lost_bytes: AtomicU64,
+}
+
+static CLOSED_CONNECTION_COUNTERS: ClosedConnectionCounters = ClosedConnectionCounters {
+    udp_tx_bytes: AtomicU64::new(0),
+    udp_tx_datagrams: AtomicU64::new(0),
+    udp_tx_ios: AtomicU64::new(0),
+    udp_rx_bytes: AtomicU64::new(0),
+    udp_rx_datagrams: AtomicU64::new(0),
+    udp_rx_ios: AtomicU64::new(0),
+    stream_frames_tx: AtomicU64::new(0),
+    connection_blocked_frames_tx: AtomicU64::new(0),
+    stream_blocked_frames_tx: AtomicU64::new(0),
+    lost_packets: AtomicU64::new(0),
+    lost_bytes: AtomicU64::new(0),
+};
+
+fn record_closed_connection(connection: &Connection) {
+    let stats = connection.stats();
+    macro_rules! add {
+        ($field:ident, $value:expr) => {
+            CLOSED_CONNECTION_COUNTERS
+                .$field
+                .fetch_add($value, Ordering::Relaxed)
+        };
+    }
+    add!(udp_tx_bytes, stats.udp_tx.bytes);
+    add!(udp_tx_datagrams, stats.udp_tx.datagrams);
+    add!(udp_tx_ios, stats.udp_tx.ios);
+    add!(udp_rx_bytes, stats.udp_rx.bytes);
+    add!(udp_rx_datagrams, stats.udp_rx.datagrams);
+    add!(udp_rx_ios, stats.udp_rx.ios);
+    add!(stream_frames_tx, stats.frame_tx.stream);
+    add!(connection_blocked_frames_tx, stats.frame_tx.data_blocked);
+    add!(stream_blocked_frames_tx, stats.frame_tx.stream_data_blocked);
+    add!(lost_packets, stats.path.lost_packets);
+    add!(lost_bytes, stats.path.lost_bytes);
+}
+
+pub fn counters() -> QuicResponseCounters {
+    QuicResponseCounters {
+        handshakes: COUNTERS.handshakes.load(Ordering::Relaxed),
+        handshake_failures: COUNTERS.handshake_failures.load(Ordering::Relaxed),
+        reconnects: COUNTERS.reconnects.load(Ordering::Relaxed),
+        connection_failures: COUNTERS.connection_failures.load(Ordering::Relaxed),
+        stream_open_stalls: COUNTERS.stream_open_stalls.load(Ordering::Relaxed),
+        active_connections: COUNTERS.active_connections.load(Ordering::Relaxed),
+        active_streams: COUNTERS.active_streams.load(Ordering::Relaxed),
+        response_payloads: COUNTERS.response_payloads.load(Ordering::Relaxed),
+        malformed_resets: COUNTERS.malformed_resets.load(Ordering::Relaxed),
+        unknown_registration_resets: COUNTERS.unknown_registration_resets.load(Ordering::Relaxed),
+        receiver_dropped_resets: COUNTERS.receiver_dropped_resets.load(Ordering::Relaxed),
+        publisher_dropped_resets: COUNTERS.publisher_dropped_resets.load(Ordering::Relaxed),
+        oversized_frame_resets: COUNTERS.oversized_frame_resets.load(Ordering::Relaxed),
+        killed_resets: COUNTERS.killed_resets.load(Ordering::Relaxed),
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct QuicConnectionStats {
+    pub address: String,
+    pub frontend_server_id: Uuid,
+    pub udp_tx_bytes: u64,
+    pub udp_tx_datagrams: u64,
+    pub udp_tx_ios: u64,
+    pub udp_rx_bytes: u64,
+    pub udp_rx_datagrams: u64,
+    pub udp_rx_ios: u64,
+    pub stream_frames_tx: u64,
+    pub connection_blocked_frames_tx: u64,
+    pub stream_blocked_frames_tx: u64,
+    pub rtt_micros: u64,
+    pub mtu: u16,
+    pub lost_packets: u64,
+    pub lost_bytes: u64,
+}
+
+/// Direct response sender: there is no application mpsc between the engine and
+/// Quinn. Each `send` makes the frame available to Quinn immediately.
+pub struct ResponseStreamSender {
+    send: SendStream,
+    payload_count: u64,
+    prologue_sent: bool,
+    payloads_allowed: bool,
+    finished: bool,
+}
+
+impl ResponseStreamSender {
+    async fn new(mut send: SendStream, registration_id: Uuid) -> Result<Self> {
+        send.write_all(&registration_id.as_u128().to_be_bytes())
+            .await
+            .context("failed to write QUIC response registration ID")?;
+        Ok(Self {
+            send,
+            payload_count: 0,
+            prologue_sent: false,
+            payloads_allowed: false,
+            finished: false,
+        })
+    }
+
+    pub async fn send_prologue(&mut self, error: Option<String>) -> Result<(), String> {
+        if self.prologue_sent {
+            return Err("QUIC response prologue already sent".to_string());
+        }
+        let (status, error) = match error {
+            Some(error) => (STATUS_ERROR, error.into_bytes()),
+            None => (STATUS_SUCCESS, Vec::new()),
+        };
+        if error.len() > MAX_ERROR_BYTES || error.len() > u32::MAX as usize {
+            return Err(format!(
+                "QUIC response prologue error exceeds {MAX_ERROR_BYTES} bytes"
+            ));
+        }
+        let mut header = [0u8; 5];
+        header[0] = status;
+        header[1..].copy_from_slice(&(error.len() as u32).to_be_bytes());
+        let mut chunks = [Bytes::copy_from_slice(&header), Bytes::from(error)];
+        self.send
+            .write_all_chunks(&mut chunks)
+            .await
+            .map_err(|e| e.to_string())?;
+        self.prologue_sent = true;
+        self.payloads_allowed = status == STATUS_SUCCESS;
+        Ok(())
+    }
+
+    pub async fn send(&mut self, data: Bytes) -> Result<()> {
+        if !self.prologue_sent {
+            bail!("QUIC response payload sent before prologue");
+        }
+        if !self.payloads_allowed {
+            bail!("QUIC error response cannot carry payload frames");
+        }
+        if let Err(error) = validate_payload_size(data.len()) {
+            self.reset(RESET_OVERSIZED_FRAME);
+            return Err(error);
+        }
+        let length = Bytes::copy_from_slice(&(data.len() as u32).to_be_bytes());
+        let mut chunks = [length, data];
+        self.send
+            .write_all_chunks(&mut chunks)
+            .await
+            .context("failed to write QUIC response frame")?;
+        self.payload_count += 1;
+        Ok(())
+    }
+
+    pub fn finish(&mut self) -> Result<()> {
+        if !self.prologue_sent {
+            bail!("QUIC response finished before prologue");
+        }
+        if !self.finished {
+            self.send
+                .finish()
+                .context("failed to finish QUIC response")?;
+            self.finished = true;
+        }
+        Ok(())
+    }
+
+    fn reset(&mut self, code: u32) {
+        let _ = self.send.reset(reset_code(code));
+        if code == RESET_OVERSIZED_FRAME {
+            COUNTERS
+                .oversized_frame_resets
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        self.finished = true;
+    }
+}
+
+impl Drop for ResponseStreamSender {
+    fn drop(&mut self) {
+        COUNTERS
+            .response_payloads
+            .fetch_add(self.payload_count, Ordering::Relaxed);
+        COUNTERS.active_streams.fetch_sub(1, Ordering::Relaxed);
+        if !self.finished {
+            let _ = self.send.reset(reset_code(RESET_PUBLISHER_DROPPED));
+            COUNTERS
+                .publisher_dropped_resets
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ConnectionKey {
+    address: SocketAddr,
+    frontend_server_id: Uuid,
+    certificate_fingerprint: [u8; 32],
+    protocol_version: u16,
+}
+
+struct ClientPool {
+    endpoints: StdMutex<HashMap<bool, Endpoint>>,
+    connections: Arc<DashMap<ConnectionKey, Connection>>,
+    connecting: DashMap<ConnectionKey, Arc<tokio::sync::Mutex<()>>>,
+    qlog: Option<quinn::QlogStream>,
+}
+
+impl ClientPool {
+    fn new() -> Self {
+        Self::new_with_qlog(None)
+    }
+
+    fn new_with_qlog(qlog: Option<quinn::QlogStream>) -> Self {
+        Self {
+            endpoints: StdMutex::new(HashMap::new()),
+            connections: Arc::new(DashMap::new()),
+            connecting: DashMap::new(),
+            qlog,
+        }
+    }
+
+    fn endpoint(&self, ipv6: bool) -> Result<Endpoint> {
+        let mut endpoints = self.endpoints.lock().expect("QUIC endpoint mutex poisoned");
+        if let Some(endpoint) = endpoints.get(&ipv6) {
+            return Ok(endpoint.clone());
+        }
+        let bind = if ipv6 {
+            "[::]:0".parse().expect("valid IPv6 wildcard")
+        } else {
+            "0.0.0.0:0".parse().expect("valid IPv4 wildcard")
+        };
+        let (socket, send_buffer, recv_buffer) = udp_socket(bind)?;
+        CLIENT_UDP_SEND_BUFFER.store(send_buffer as u64, Ordering::Relaxed);
+        CLIENT_UDP_RECV_BUFFER.store(recv_buffer as u64, Ordering::Relaxed);
+        tracing::info!(
+            requested_send_buffer = UDP_SOCKET_BUFFER,
+            actual_send_buffer = send_buffer,
+            requested_recv_buffer = UDP_SOCKET_BUFFER,
+            actual_recv_buffer = recv_buffer,
+            "configured QUIC client UDP socket buffers"
+        );
+        let endpoint = Endpoint::new(
+            quinn::EndpointConfig::default(),
+            None,
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )?;
+        endpoints.insert(ipv6, endpoint.clone());
+        Ok(endpoint)
+    }
+
+    async fn connection(&self, info: &QuicResponseConnectionInfo) -> Result<Connection> {
+        let address = info.address.parse::<SocketAddr>()?;
+        let key = ConnectionKey {
+            address,
+            frontend_server_id: info.frontend_server_id,
+            certificate_fingerprint: info.certificate_fingerprint,
+            protocol_version: info.protocol_version,
+        };
+        if let Some(connection) = self.connections.get(&key)
+            && connection.close_reason().is_none()
+        {
+            return Ok(connection.clone());
+        }
+
+        let connect_lock = self
+            .connecting
+            .entry(key.clone())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        let _guard = connect_lock.lock().await;
+        if let Some(connection) = self.connections.get(&key)
+            && connection.close_reason().is_none()
+        {
+            return Ok(connection.clone());
+        }
+
+        if let Some((_, closed)) = self.connections.remove(&key) {
+            record_closed_connection(&closed);
+            COUNTERS.reconnects.fetch_add(1, Ordering::Relaxed);
+            COUNTERS.active_connections.fetch_sub(1, Ordering::Relaxed);
+        }
+
+        let endpoint = self.endpoint(address.is_ipv6())?;
+        let config = client_config(info.certificate_fingerprint, self.qlog.clone())?;
+        let connecting = endpoint
+            .connect_with(config, address, "dynamo-response")
+            .context("failed to start QUIC connection")?;
+        let connection = match time::timeout(OPEN_TIMEOUT, connecting).await {
+            Ok(Ok(connection)) => connection,
+            Ok(Err(error)) => {
+                COUNTERS.handshake_failures.fetch_add(1, Ordering::Relaxed);
+                return Err(error.into());
+            }
+            Err(_) => {
+                COUNTERS.handshake_failures.fetch_add(1, Ordering::Relaxed);
+                bail!("timed out establishing QUIC response connection");
+            }
+        };
+        COUNTERS.handshakes.fetch_add(1, Ordering::Relaxed);
+        COUNTERS.active_connections.fetch_add(1, Ordering::Relaxed);
+        self.connections.insert(key.clone(), connection.clone());
+        let connections = self.connections.clone();
+        let observed = connection.clone();
+        tokio::spawn(async move {
+            let _ = observed.closed().await;
+            COUNTERS.connection_failures.fetch_add(1, Ordering::Relaxed);
+            let should_remove = connections
+                .get(&key)
+                .is_some_and(|current| current.stable_id() == observed.stable_id());
+            if should_remove && let Some((_, closed)) = connections.remove(&key) {
+                record_closed_connection(&closed);
+                COUNTERS.active_connections.fetch_sub(1, Ordering::Relaxed);
+            }
+        });
+        Ok(connection)
+    }
+
+    fn invalidate(&self, info: &QuicResponseConnectionInfo) {
+        let Ok(address) = info.address.parse::<SocketAddr>() else {
+            return;
+        };
+        let key = ConnectionKey {
+            address,
+            frontend_server_id: info.frontend_server_id,
+            certificate_fingerprint: info.certificate_fingerprint,
+            protocol_version: info.protocol_version,
+        };
+        if let Some((_, closed)) = self.connections.remove(&key) {
+            record_closed_connection(&closed);
+            COUNTERS.active_connections.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    fn stats(&self) -> Vec<QuicConnectionStats> {
+        self.connections
+            .iter()
+            .map(|entry| {
+                let stats = entry.value().stats();
+                QuicConnectionStats {
+                    address: entry.key().address.to_string(),
+                    frontend_server_id: entry.key().frontend_server_id,
+                    udp_tx_bytes: stats.udp_tx.bytes,
+                    udp_tx_datagrams: stats.udp_tx.datagrams,
+                    udp_tx_ios: stats.udp_tx.ios,
+                    udp_rx_bytes: stats.udp_rx.bytes,
+                    udp_rx_datagrams: stats.udp_rx.datagrams,
+                    udp_rx_ios: stats.udp_rx.ios,
+                    stream_frames_tx: stats.frame_tx.stream,
+                    connection_blocked_frames_tx: stats.frame_tx.data_blocked,
+                    stream_blocked_frames_tx: stats.frame_tx.stream_data_blocked,
+                    rtt_micros: stats.path.rtt.as_micros() as u64,
+                    mtu: stats.path.current_mtu,
+                    lost_packets: stats.path.lost_packets,
+                    lost_bytes: stats.path.lost_bytes,
+                }
+            })
+            .collect()
+    }
+}
+
+static CLIENT_POOL: OnceLock<ClientPool> = OnceLock::new();
+static QLOG_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct ProcessIdentity {
+    frontend_server_id: Uuid,
+    certificate: Vec<u8>,
+    private_key: Vec<u8>,
+    certificate_fingerprint: [u8; 32],
+}
+
+static PROCESS_IDENTITY: OnceLock<ProcessIdentity> = OnceLock::new();
+
+fn process_identity() -> Result<&'static ProcessIdentity> {
+    if let Some(identity) = PROCESS_IDENTITY.get() {
+        return Ok(identity);
+    }
+    let generated = rcgen::generate_simple_self_signed(vec!["dynamo-response".to_string()])?;
+    let certificate = generated.cert.der().to_vec();
+    let identity = ProcessIdentity {
+        frontend_server_id: Uuid::new_v4(),
+        certificate_fingerprint: Sha256::digest(&certificate).into(),
+        certificate,
+        private_key: generated.key_pair.serialize_der(),
+    };
+    let _ = PROCESS_IDENTITY.set(identity);
+    Ok(PROCESS_IDENTITY
+        .get()
+        .expect("QUIC process identity was just initialized"))
+}
+
+fn client_pool() -> &'static ClientPool {
+    CLIENT_POOL.get_or_init(ClientPool::new)
+}
+
+pub fn client_connection_stats() -> Vec<QuicConnectionStats> {
+    client_pool().stats()
+}
+
+/// Prometheus exposition generated at scrape time. All series are process
+/// aggregates with either no labels or a fixed reset-reason label set.
+pub fn prometheus_exposition() -> String {
+    let counters = counters();
+    let connections = client_connection_stats();
+    let sum = |f: fn(&QuicConnectionStats) -> u64| connections.iter().map(f).sum::<u64>();
+    let closed = |counter: &AtomicU64| counter.load(Ordering::Relaxed);
+    let udp_tx_datagrams =
+        sum(|stats| stats.udp_tx_datagrams) + closed(&CLOSED_CONNECTION_COUNTERS.udp_tx_datagrams);
+    let udp_tx_ios = sum(|stats| stats.udp_tx_ios) + closed(&CLOSED_CONNECTION_COUNTERS.udp_tx_ios);
+    let stream_frames =
+        sum(|stats| stats.stream_frames_tx) + closed(&CLOSED_CONNECTION_COUNTERS.stream_frames_tx);
+    let packet_density = if udp_tx_datagrams == 0 {
+        0.0
+    } else {
+        counters.response_payloads as f64 / udp_tx_datagrams as f64
+    };
+    let stream_frame_density = if udp_tx_datagrams == 0 {
+        0.0
+    } else {
+        stream_frames as f64 / udp_tx_datagrams as f64
+    };
+    let datagrams_per_io = if udp_tx_ios == 0 {
+        0.0
+    } else {
+        udp_tx_datagrams as f64 / udp_tx_ios as f64
+    };
+    let rtt_micros = connections
+        .iter()
+        .map(|stats| stats.rtt_micros)
+        .max()
+        .unwrap_or_default();
+    let mtu = connections
+        .iter()
+        .map(|stats| stats.mtu as u64)
+        .min()
+        .unwrap_or_default();
+
+    format!(
+        concat!(
+            "# TYPE dynamo_quic_response_active_connections gauge\n",
+            "dynamo_quic_response_active_connections {}\n",
+            "# TYPE dynamo_quic_response_active_streams gauge\n",
+            "dynamo_quic_response_active_streams {}\n",
+            "# TYPE dynamo_quic_response_handshakes_total counter\n",
+            "dynamo_quic_response_handshakes_total {}\n",
+            "dynamo_quic_response_handshake_failures_total {}\n",
+            "# TYPE dynamo_quic_response_reconnects_total counter\n",
+            "dynamo_quic_response_reconnects_total {}\n",
+            "dynamo_quic_response_connection_failures_total {}\n",
+            "# TYPE dynamo_quic_response_stream_open_stalls_total counter\n",
+            "dynamo_quic_response_stream_open_stalls_total {}\n",
+            "# TYPE dynamo_quic_response_payloads_total counter\n",
+            "dynamo_quic_response_payloads_total {}\n",
+            "# TYPE dynamo_quic_response_resets_total counter\n",
+            "dynamo_quic_response_resets_total{{reason=\"malformed\"}} {}\n",
+            "dynamo_quic_response_resets_total{{reason=\"unknown_registration\"}} {}\n",
+            "dynamo_quic_response_resets_total{{reason=\"receiver_dropped\"}} {}\n",
+            "dynamo_quic_response_resets_total{{reason=\"publisher_dropped\"}} {}\n",
+            "dynamo_quic_response_resets_total{{reason=\"oversized_frame\"}} {}\n",
+            "dynamo_quic_response_resets_total{{reason=\"killed\"}} {}\n",
+            "# TYPE dynamo_quic_response_udp_tx_bytes_total counter\n",
+            "dynamo_quic_response_udp_tx_bytes_total {}\n",
+            "dynamo_quic_response_udp_tx_datagrams_total {}\n",
+            "dynamo_quic_response_udp_tx_ios_total {}\n",
+            "dynamo_quic_response_udp_rx_bytes_total {}\n",
+            "dynamo_quic_response_udp_rx_datagrams_total {}\n",
+            "dynamo_quic_response_udp_rx_ios_total {}\n",
+            "dynamo_quic_response_stream_frames_tx_total {}\n",
+            "dynamo_quic_response_connection_blocked_frames_tx_total {}\n",
+            "dynamo_quic_response_stream_blocked_frames_tx_total {}\n",
+            "dynamo_quic_response_lost_packets_total {}\n",
+            "dynamo_quic_response_lost_bytes_total {}\n",
+            "# TYPE dynamo_quic_response_rtt_microseconds gauge\n",
+            "dynamo_quic_response_rtt_microseconds {}\n",
+            "dynamo_quic_response_mtu_bytes {}\n",
+            "dynamo_quic_response_payloads_per_udp_datagram {}\n",
+            "dynamo_quic_response_stream_frames_per_udp_datagram {}\n",
+            "dynamo_quic_response_udp_datagrams_per_io {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"client\",direction=\"send\",kind=\"requested\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"client\",direction=\"send\",kind=\"actual\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"client\",direction=\"receive\",kind=\"requested\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"client\",direction=\"receive\",kind=\"actual\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"server\",direction=\"send\",kind=\"requested\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"server\",direction=\"send\",kind=\"actual\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"server\",direction=\"receive\",kind=\"requested\"}} {}\n",
+            "dynamo_quic_response_udp_socket_buffer_bytes{{role=\"server\",direction=\"receive\",kind=\"actual\"}} {}\n",
+        ),
+        counters.active_connections,
+        counters.active_streams,
+        counters.handshakes,
+        counters.handshake_failures,
+        counters.reconnects,
+        counters.connection_failures,
+        counters.stream_open_stalls,
+        counters.response_payloads,
+        counters.malformed_resets,
+        counters.unknown_registration_resets,
+        counters.receiver_dropped_resets,
+        counters.publisher_dropped_resets,
+        counters.oversized_frame_resets,
+        counters.killed_resets,
+        sum(|stats| stats.udp_tx_bytes) + closed(&CLOSED_CONNECTION_COUNTERS.udp_tx_bytes),
+        udp_tx_datagrams,
+        udp_tx_ios,
+        sum(|stats| stats.udp_rx_bytes) + closed(&CLOSED_CONNECTION_COUNTERS.udp_rx_bytes),
+        sum(|stats| stats.udp_rx_datagrams) + closed(&CLOSED_CONNECTION_COUNTERS.udp_rx_datagrams),
+        sum(|stats| stats.udp_rx_ios) + closed(&CLOSED_CONNECTION_COUNTERS.udp_rx_ios),
+        stream_frames,
+        sum(|stats| stats.connection_blocked_frames_tx)
+            + closed(&CLOSED_CONNECTION_COUNTERS.connection_blocked_frames_tx),
+        sum(|stats| stats.stream_blocked_frames_tx)
+            + closed(&CLOSED_CONNECTION_COUNTERS.stream_blocked_frames_tx),
+        sum(|stats| stats.lost_packets) + closed(&CLOSED_CONNECTION_COUNTERS.lost_packets),
+        sum(|stats| stats.lost_bytes) + closed(&CLOSED_CONNECTION_COUNTERS.lost_bytes),
+        rtt_micros,
+        mtu,
+        packet_density,
+        stream_frame_density,
+        datagrams_per_io,
+        UDP_SOCKET_BUFFER,
+        CLIENT_UDP_SEND_BUFFER.load(Ordering::Relaxed),
+        UDP_SOCKET_BUFFER,
+        CLIENT_UDP_RECV_BUFFER.load(Ordering::Relaxed),
+        UDP_SOCKET_BUFFER,
+        SERVER_UDP_SEND_BUFFER.load(Ordering::Relaxed),
+        UDP_SOCKET_BUFFER,
+        SERVER_UDP_RECV_BUFFER.load(Ordering::Relaxed),
+    )
+}
+
+pub async fn create_response_stream(
+    context: Arc<dyn AsyncEngineContext>,
+    info: ConnectionInfo,
+    cancellation_counter: Option<prometheus::IntCounter>,
+) -> Result<ResponseStreamSender> {
+    create_response_stream_in_pool(client_pool(), context, info, cancellation_counter).await
+}
+
+async fn create_response_stream_in_pool(
+    pool: &ClientPool,
+    context: Arc<dyn AsyncEngineContext>,
+    info: ConnectionInfo,
+    cancellation_counter: Option<prometheus::IntCounter>,
+) -> Result<ResponseStreamSender> {
+    let info = QuicResponseConnectionInfo::try_from(info)?;
+    if info.context != context.id() {
+        bail!(
+            "QUIC response context mismatch: connection has {}, request has {}",
+            info.context,
+            context.id()
+        );
+    }
+
+    for attempt in 0..2 {
+        let connection = pool.connection(&info).await?;
+        let opened = time::timeout(OPEN_TIMEOUT, connection.open_bi()).await;
+        let (send, recv) = match opened {
+            Ok(Ok(streams)) => streams,
+            Ok(Err(error)) if attempt == 0 => {
+                tracing::warn!(%error, "cached QUIC connection could not open a stream; reconnecting");
+                COUNTERS.reconnects.fetch_add(1, Ordering::Relaxed);
+                pool.invalidate(&info);
+                continue;
+            }
+            Ok(Err(error)) => return Err(error.into()),
+            Err(_) => {
+                COUNTERS.stream_open_stalls.fetch_add(1, Ordering::Relaxed);
+                COUNTERS.reconnects.fetch_add(1, Ordering::Relaxed);
+                pool.invalidate(&info);
+                if attempt == 0 {
+                    continue;
+                }
+                bail!("timed out opening QUIC response stream");
+            }
+        };
+
+        COUNTERS.active_streams.fetch_add(1, Ordering::Relaxed);
+        spawn_control_reader(recv, context, cancellation_counter);
+        return match ResponseStreamSender::new(send, info.response_registration_id).await {
+            Ok(sender) => Ok(sender),
+            Err(error) => {
+                COUNTERS.active_streams.fetch_sub(1, Ordering::Relaxed);
+                Err(error)
+            }
+        };
+    }
+    unreachable!("QUIC stream-open retry loop returns on both attempts")
+}
+
+fn spawn_control_reader(
+    mut recv: RecvStream,
+    context: Arc<dyn AsyncEngineContext>,
+    cancellation_counter: Option<prometheus::IntCounter>,
+) {
+    tokio::spawn(async move {
+        loop {
+            match recv.read_u8().await {
+                Ok(CONTROL_STOP) => {
+                    if let Some(counter) = &cancellation_counter {
+                        counter.inc();
+                    }
+                    context.stop();
+                }
+                Ok(CONTROL_KILL) => {
+                    if let Some(counter) = &cancellation_counter {
+                        counter.inc();
+                    }
+                    context.kill();
+                    break;
+                }
+                Ok(value) => {
+                    tracing::warn!(value, "malformed QUIC response control");
+                    COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                    context.kill();
+                    let _ = recv.stop(reset_code(RESET_MALFORMED));
+                    break;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(error) => {
+                    tracing::debug!(%error, "QUIC response control stream ended");
+                    if !context.is_stopped() {
+                        context.kill();
+                    }
+                    break;
+                }
+            }
+        }
+    });
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ServerOptions {
+    pub address: IpAddr,
+    pub port: u16,
+}
+
+struct RequestedResponse {
+    context: Arc<dyn AsyncEngineContext>,
+    connection: oneshot::Sender<Result<StreamReceiver, String>>,
+    send_buffer_count: usize,
+}
+
+#[derive(Default)]
+struct ServerState {
+    pending: HashMap<Uuid, RequestedResponse>,
+    registration_instance: HashMap<Uuid, EndpointInstanceId>,
+    instance_registrations: HashMap<EndpointInstanceId, HashSet<Uuid>>,
+    removed_instances: HashMap<EndpointInstanceId, time::Instant>,
+}
+
+pub struct QuicStreamServer {
+    local_addr: SocketAddr,
+    frontend_server_id: Uuid,
+    certificate_fingerprint: [u8; 32],
+    state: Arc<Mutex<ServerState>>,
+    _endpoint: Endpoint,
+}
+
+impl QuicStreamServer {
+    pub async fn new(options: ServerOptions) -> Result<Arc<Self>> {
+        let identity = process_identity()?;
+        let cert_der = CertificateDer::from(identity.certificate.clone());
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(identity.private_key.clone()));
+
+        let mut tls = rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()?
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key)?;
+        tls.alpn_protocols = vec![ALPN.to_vec()];
+        tls.max_early_data_size = 0;
+        let crypto = quinn::crypto::rustls::QuicServerConfig::try_from(tls)?;
+        let mut server_config = quinn::ServerConfig::with_crypto(Arc::new(crypto));
+        server_config.transport_config(Arc::new(server_transport_config()?));
+
+        let bind = SocketAddr::new(options.address, options.port);
+        let (socket, send_buffer, recv_buffer) = udp_socket(bind)?;
+        SERVER_UDP_SEND_BUFFER.store(send_buffer as u64, Ordering::Relaxed);
+        SERVER_UDP_RECV_BUFFER.store(recv_buffer as u64, Ordering::Relaxed);
+        let local_addr = socket.local_addr()?;
+        tracing::info!(
+            address = %local_addr,
+            requested_send_buffer = UDP_SOCKET_BUFFER,
+            actual_send_buffer = send_buffer,
+            requested_recv_buffer = UDP_SOCKET_BUFFER,
+            actual_recv_buffer = recv_buffer,
+            "configured QUIC response server UDP socket"
+        );
+        let endpoint = Endpoint::new(
+            quinn::EndpointConfig::default(),
+            Some(server_config),
+            socket,
+            Arc::new(quinn::TokioRuntime),
+        )?;
+        let state = Arc::new(Mutex::new(ServerState::default()));
+        tokio::spawn(accept_connections(endpoint.clone(), state.clone()));
+
+        Ok(Arc::new(Self {
+            local_addr,
+            frontend_server_id: identity.frontend_server_id,
+            certificate_fingerprint: identity.certificate_fingerprint,
+            state,
+            _endpoint: endpoint,
+        }))
+    }
+
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+
+    pub async fn register_response(
+        self: &Arc<Self>,
+        options: StreamOptions,
+    ) -> RegisteredStream<StreamReceiver> {
+        assert!(options.enable_response_stream);
+        let registration_id = Uuid::new_v4();
+        let context_id = options.context.id().to_string();
+        let (tx, rx) = oneshot::channel();
+        self.state.lock().pending.insert(
+            registration_id,
+            RequestedResponse {
+                context: options.context,
+                connection: tx,
+                send_buffer_count: options.send_buffer_count,
+            },
+        );
+        let info = QuicResponseConnectionInfo {
+            protocol_version: PROTOCOL_VERSION,
+            address: self.local_addr.to_string(),
+            frontend_server_id: self.frontend_server_id,
+            response_registration_id: registration_id,
+            context: context_id,
+            certificate_fingerprint: self.certificate_fingerprint,
+        };
+        let state = self.state.clone();
+        RegisteredStream::new(info.into(), rx).with_cleanup(move || {
+            remove_registration(&state, registration_id);
+        })
+    }
+
+    pub async fn associate_instance(&self, registration_id: Uuid, id: &EndpointInstanceId) -> bool {
+        let mut state = self.state.lock();
+        prune_tombstones(&mut state.removed_instances);
+        if state.removed_instances.contains_key(id) {
+            state.pending.remove(&registration_id);
+            return false;
+        }
+        state
+            .registration_instance
+            .insert(registration_id, id.clone());
+        state
+            .instance_registrations
+            .entry(id.clone())
+            .or_default()
+            .insert(registration_id);
+        true
+    }
+
+    pub async fn cancel_response_stream(&self, registration_id: Uuid) {
+        remove_registration(&self.state, registration_id);
+    }
+
+    pub async fn cancel_instance_streams(&self, id: &EndpointInstanceId) -> usize {
+        let mut state = self.state.lock();
+        prune_tombstones(&mut state.removed_instances);
+        state
+            .removed_instances
+            .insert(id.clone(), time::Instant::now());
+        let registrations = state.instance_registrations.remove(id).unwrap_or_default();
+        for registration_id in &registrations {
+            state.pending.remove(registration_id);
+            state.registration_instance.remove(registration_id);
+        }
+        registrations.len()
+    }
+
+    pub async fn clear_instance_tombstone(&self, id: &EndpointInstanceId) {
+        self.state.lock().removed_instances.remove(id);
+    }
+}
+
+fn remove_registration(state: &Mutex<ServerState>, registration_id: Uuid) {
+    let mut state = state.lock();
+    state.pending.remove(&registration_id);
+    if let Some(instance) = state.registration_instance.remove(&registration_id)
+        && let Some(registrations) = state.instance_registrations.get_mut(&instance)
+    {
+        registrations.remove(&registration_id);
+        if registrations.is_empty() {
+            state.instance_registrations.remove(&instance);
+        }
+    }
+}
+
+fn take_registration(
+    state: &Mutex<ServerState>,
+    registration_id: Uuid,
+) -> Option<RequestedResponse> {
+    let mut state = state.lock();
+    let pending = state.pending.remove(&registration_id);
+    if let Some(instance) = state.registration_instance.remove(&registration_id)
+        && let Some(registrations) = state.instance_registrations.get_mut(&instance)
+    {
+        registrations.remove(&registration_id);
+        if registrations.is_empty() {
+            state.instance_registrations.remove(&instance);
+        }
+    }
+    pending
+}
+
+fn prune_tombstones(tombstones: &mut HashMap<EndpointInstanceId, time::Instant>) {
+    let now = time::Instant::now();
+    tombstones.retain(|_, inserted| now.saturating_duration_since(*inserted) < TOMBSTONE_TTL);
+}
+
+async fn accept_connections(endpoint: Endpoint, state: Arc<Mutex<ServerState>>) {
+    while let Some(incoming) = endpoint.accept().await {
+        let state = state.clone();
+        tokio::spawn(async move {
+            match incoming.await {
+                Ok(connection) => {
+                    COUNTERS.handshakes.fetch_add(1, Ordering::Relaxed);
+                    COUNTERS.active_connections.fetch_add(1, Ordering::Relaxed);
+                    while let Ok((send, recv)) = connection.accept_bi().await {
+                        let state = state.clone();
+                        COUNTERS.active_streams.fetch_add(1, Ordering::Relaxed);
+                        tokio::spawn(async move {
+                            if let Err(error) = process_response_stream(send, recv, state).await {
+                                tracing::debug!(%error, "QUIC response stream failed");
+                            }
+                            COUNTERS.active_streams.fetch_sub(1, Ordering::Relaxed);
+                        });
+                    }
+                    COUNTERS.connection_failures.fetch_add(1, Ordering::Relaxed);
+                    COUNTERS.active_connections.fetch_sub(1, Ordering::Relaxed);
+                }
+                Err(error) => {
+                    COUNTERS.handshake_failures.fetch_add(1, Ordering::Relaxed);
+                    tracing::warn!(%error, "QUIC response handshake failed");
+                }
+            }
+        });
+    }
+}
+
+async fn process_response_stream(
+    mut control: SendStream,
+    recv: RecvStream,
+    state: Arc<Mutex<ServerState>>,
+) -> Result<()> {
+    let mut reader = ChunkReader::new(recv);
+    let registration_bytes = match reader.read_bytes(16).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+            reader.stop(RESET_MALFORMED);
+            let _ = control.reset(reset_code(RESET_MALFORMED));
+            return Err(error);
+        }
+    };
+    let registration_id = Uuid::from_u128(u128::from_be_bytes(
+        registration_bytes
+            .as_ref()
+            .try_into()
+            .expect("registration frame is exactly 16 bytes"),
+    ));
+    let Some(requested) = take_registration(&state, registration_id) else {
+        COUNTERS
+            .unknown_registration_resets
+            .fetch_add(1, Ordering::Relaxed);
+        reader.stop(RESET_UNKNOWN_REGISTRATION);
+        let _ = control.reset(reset_code(RESET_UNKNOWN_REGISTRATION));
+        bail!("unknown or duplicate QUIC response registration {registration_id}");
+    };
+
+    let prologue = match reader.read_bytes(5).await {
+        Ok(prologue) => prologue,
+        Err(error) => {
+            COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+            reader.stop(RESET_MALFORMED);
+            let _ = control.reset(reset_code(RESET_MALFORMED));
+            let _ = requested
+                .connection
+                .send(Err("QUIC response ended before its prologue".to_string()));
+            return Err(error);
+        }
+    };
+    let status = prologue[0];
+    let error_len = u32::from_be_bytes(prologue[1..5].try_into().unwrap()) as usize;
+    if error_len > MAX_ERROR_BYTES {
+        COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+        reader.stop(RESET_MALFORMED);
+        let _ = control.reset(reset_code(RESET_MALFORMED));
+        let _ = requested.connection.send(Err(format!(
+            "QUIC response error prologue exceeds {MAX_ERROR_BYTES} bytes"
+        )));
+        return Ok(());
+    }
+    let error = match reader.read_bytes(error_len).await {
+        Ok(error) => error,
+        Err(read_error) => {
+            COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+            reader.stop(RESET_MALFORMED);
+            let _ = control.reset(reset_code(RESET_MALFORMED));
+            let _ = requested.connection.send(Err(
+                "QUIC response ended inside its error prologue".to_string()
+            ));
+            return Err(read_error);
+        }
+    };
+    match status {
+        STATUS_ERROR => {
+            let error = match String::from_utf8(error.to_vec()) {
+                Ok(error) => error,
+                Err(_) => {
+                    COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                    reader.stop(RESET_MALFORMED);
+                    let _ = control.reset(reset_code(RESET_MALFORMED));
+                    let _ = requested
+                        .connection
+                        .send(Err("QUIC response error is not UTF-8".to_string()));
+                    return Ok(());
+                }
+            };
+            match reader.read_optional_u32().await {
+                Ok(None) => {}
+                Ok(Some(_)) => {
+                    COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                    reader.stop(RESET_MALFORMED);
+                    let _ = control.reset(reset_code(RESET_MALFORMED));
+                    let _ = requested.connection.send(Err(
+                        "QUIC error response carried a payload frame".to_string(),
+                    ));
+                    return Ok(());
+                }
+                Err(read_error) => {
+                    COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                    reader.stop(RESET_MALFORMED);
+                    let _ = control.reset(reset_code(RESET_MALFORMED));
+                    let _ = requested.connection.send(Err(
+                        "QUIC error response ended with a partial frame".to_string(),
+                    ));
+                    return Err(read_error);
+                }
+            }
+            let _ = requested.connection.send(Err(error));
+            let _ = control.finish();
+            return Ok(());
+        }
+        STATUS_SUCCESS if error_len == 0 => {}
+        _ => {
+            COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+            reader.stop(RESET_MALFORMED);
+            let _ = control.reset(reset_code(RESET_MALFORMED));
+            let _ = requested
+                .connection
+                .send(Err("malformed QUIC response prologue".to_string()));
+            return Ok(());
+        }
+    }
+
+    let (payload_tx, payload_rx) = tokio::sync::mpsc::channel(requested.send_buffer_count.max(1));
+    if requested
+        .connection
+        .send(Ok(StreamReceiver { rx: payload_rx }))
+        .is_err()
+    {
+        COUNTERS
+            .receiver_dropped_resets
+            .fetch_add(1, Ordering::Relaxed);
+        reader.stop(RESET_RECEIVER_DROPPED);
+        let _ = control.reset(reset_code(RESET_RECEIVER_DROPPED));
+        return Ok(());
+    }
+
+    let context = requested.context;
+    enum ControlClose {
+        Finish,
+        Reset(u32),
+    }
+    let (control_close_tx, mut control_close_rx) = oneshot::channel();
+    let control_context = context.clone();
+    let control_task = tokio::spawn(async move {
+        tokio::select! {
+            biased;
+            close = &mut control_close_rx => {
+                match close.unwrap_or(ControlClose::Reset(RESET_MALFORMED)) {
+                    ControlClose::Finish => { let _ = control.finish(); }
+                    ControlClose::Reset(code) => { let _ = control.reset(reset_code(code)); }
+                }
+            }
+            _ = control_context.killed() => {
+                let _ = control.write_all(&[CONTROL_KILL]).await;
+                let _ = control.finish();
+            }
+            _ = control_context.stopped() => {
+                if control.write_all(&[CONTROL_STOP]).await.is_ok() {
+                    // Stop is graceful. Keep the reverse stream alive so a later
+                    // hard kill can still be delivered while final output drains.
+                    tokio::select! {
+                        _ = control_context.killed() => {
+                            let _ = control.write_all(&[CONTROL_KILL]).await;
+                        }
+                        close = &mut control_close_rx => {
+                            match close.unwrap_or(ControlClose::Reset(RESET_MALFORMED)) {
+                                ControlClose::Finish => {}
+                                ControlClose::Reset(code) => {
+                                    let _ = control.reset(reset_code(code));
+                                    return;
+                                }
+                            }
+                        }
+                    }
+                }
+                let _ = control.finish();
+            }
+        }
+    });
+
+    let (close, result) = loop {
+        tokio::select! {
+            biased;
+            _ = context.killed() => {
+                COUNTERS.killed_resets.fetch_add(1, Ordering::Relaxed);
+                reader.stop(RESET_KILLED);
+                break (ControlClose::Reset(RESET_KILLED), Ok(()));
+            }
+            _ = payload_tx.closed() => {
+                COUNTERS.receiver_dropped_resets.fetch_add(1, Ordering::Relaxed);
+                reader.stop(RESET_RECEIVER_DROPPED);
+                break (ControlClose::Reset(RESET_RECEIVER_DROPPED), Ok(()));
+            }
+            length = reader.read_optional_u32() => {
+                let length = match length {
+                    Ok(Some(length)) => length,
+                    Ok(None) => break (ControlClose::Finish, Ok(())),
+                    Err(error) => {
+                        COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                        reader.stop(RESET_MALFORMED);
+                        break (ControlClose::Reset(RESET_MALFORMED), Err(error));
+                    }
+                };
+                let length = length as usize;
+                if let Err(error) = validate_payload_size(length) {
+                    COUNTERS.oversized_frame_resets.fetch_add(1, Ordering::Relaxed);
+                    reader.stop(RESET_OVERSIZED_FRAME);
+                    break (
+                        ControlClose::Reset(RESET_OVERSIZED_FRAME),
+                        Err(error),
+                    );
+                }
+                let payload = match reader.read_bytes(length).await {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        COUNTERS.malformed_resets.fetch_add(1, Ordering::Relaxed);
+                        reader.stop(RESET_MALFORMED);
+                        break (ControlClose::Reset(RESET_MALFORMED), Err(error));
+                    }
+                };
+                if payload_tx.send(payload).await.is_err() {
+                    COUNTERS.receiver_dropped_resets.fetch_add(1, Ordering::Relaxed);
+                    reader.stop(RESET_RECEIVER_DROPPED);
+                    break (ControlClose::Reset(RESET_RECEIVER_DROPPED), Ok(()));
+                }
+            }
+        }
+    };
+    let _ = control_close_tx.send(close);
+    let _ = control_task.await;
+    result
+}
+
+/// Reads ordered QUIC stream chunks without copying contiguous payloads.
+/// Headers are tiny and copied into fixed storage; a payload is coalesced only
+/// when Quinn delivered it across multiple chunks.
+struct ChunkReader {
+    recv: RecvStream,
+    chunks: VecDeque<Bytes>,
+    finished: bool,
+}
+
+impl ChunkReader {
+    fn new(recv: RecvStream) -> Self {
+        Self {
+            recv,
+            chunks: VecDeque::new(),
+            finished: false,
+        }
+    }
+
+    fn stop(&mut self, code: u32) {
+        let _ = self.recv.stop(reset_code(code));
+    }
+
+    async fn fill(&mut self) -> Result<bool> {
+        if !self.chunks.is_empty() {
+            return Ok(true);
+        }
+        if self.finished {
+            return Ok(false);
+        }
+        match self.recv.read_chunk(64 * 1024, true).await? {
+            Some(chunk) => {
+                self.chunks.push_back(chunk.bytes);
+                Ok(true)
+            }
+            None => {
+                self.finished = true;
+                Ok(false)
+            }
+        }
+    }
+
+    async fn read_optional_u32(&mut self) -> Result<Option<u32>> {
+        if !self.fill().await? {
+            return Ok(None);
+        }
+        let bytes = self.read_bytes(4).await?;
+        Ok(Some(u32::from_be_bytes(bytes.as_ref().try_into().unwrap())))
+    }
+
+    async fn read_bytes(&mut self, len: usize) -> Result<Bytes> {
+        if len == 0 {
+            return Ok(Bytes::new());
+        }
+        if !self.fill().await? {
+            bail!("QUIC response stream ended with a partial frame");
+        }
+        if self.chunks.front().is_some_and(|chunk| chunk.len() >= len) {
+            let chunk = self.chunks.front_mut().unwrap();
+            let result = chunk.split_to(len);
+            if chunk.is_empty() {
+                self.chunks.pop_front();
+            }
+            return Ok(result);
+        }
+
+        let mut remaining = len;
+        let mut result = BytesMut::with_capacity(len);
+        while remaining != 0 {
+            if !self.fill().await? {
+                bail!("QUIC response stream ended with a partial frame");
+            }
+            let available = self.chunks.front().unwrap().len().min(remaining);
+            let chunk = self.chunks.front_mut().unwrap().split_to(available);
+            result.extend_from_slice(&chunk);
+            remaining -= available;
+            if self.chunks.front().unwrap().is_empty() {
+                self.chunks.pop_front();
+            }
+        }
+        Ok(result.freeze())
+    }
+}
+
+fn server_transport_config() -> Result<TransportConfig> {
+    let (stream_receive_window, connection_window, send_window) = flow_control_windows();
+    let mut transport = TransportConfig::default();
+    transport
+        .max_concurrent_bidi_streams(VarInt::from_u32(MAX_BIDI_STREAMS))
+        .max_concurrent_uni_streams(VarInt::from_u32(0))
+        .stream_receive_window(VarInt::from_u32(stream_receive_window))
+        .receive_window(VarInt::from_u32(connection_window))
+        .send_window(send_window)
+        .send_fairness(true)
+        .mtu_discovery_config(Some(Default::default()))
+        .enable_segmentation_offload(true)
+        .max_idle_timeout(Some(IDLE_TIMEOUT.try_into()?));
+    Ok(transport)
+}
+
+fn client_transport_config(qlog: Option<quinn::QlogStream>) -> Result<TransportConfig> {
+    let (_, connection_window, send_window) = flow_control_windows();
+    let mut transport = TransportConfig::default();
+    transport
+        .max_concurrent_bidi_streams(VarInt::from_u32(MAX_BIDI_STREAMS))
+        .max_concurrent_uni_streams(VarInt::from_u32(0))
+        .receive_window(VarInt::from_u32(connection_window))
+        .send_window(send_window)
+        .send_fairness(true)
+        .mtu_discovery_config(Some(Default::default()))
+        .enable_segmentation_offload(true)
+        .max_idle_timeout(Some(IDLE_TIMEOUT.try_into()?));
+    if let Some(stream) = qlog.or(diagnostic_qlog_stream()?) {
+        transport.qlog_stream(Some(stream));
+    }
+    Ok(transport)
+}
+
+fn flow_control_windows() -> (u32, u32, u64) {
+    if crate::config::env_is_truthy(
+        crate::config::environment_names::tcp_response_stream::DYN_RESPONSE_STREAM_HIGH_WINDOW,
+    ) {
+        (
+            HIGH_STREAM_RECEIVE_WINDOW,
+            HIGH_CONNECTION_WINDOW,
+            HIGH_SEND_WINDOW,
+        )
+    } else {
+        (STREAM_RECEIVE_WINDOW, CONNECTION_WINDOW, SEND_WINDOW)
+    }
+}
+
+fn diagnostic_qlog_stream() -> Result<Option<quinn::QlogStream>> {
+    let Ok(base_path) = std::env::var(
+        crate::config::environment_names::tcp_response_stream::DYN_RESPONSE_QLOG_PATH,
+    ) else {
+        return Ok(None);
+    };
+    if base_path.is_empty() {
+        return Ok(None);
+    }
+    let sequence = QLOG_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let path = format!("{base_path}.{}.{}.sqlog", std::process::id(), sequence);
+    let file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create QUIC qlog at {path}"))?;
+    let mut config = quinn::QlogConfig::default();
+    config
+        .writer(Box::new(file))
+        .title(Some("Dynamo QUIC response transport".to_string()))
+        .description(Some(
+            "Diagnostic capture; disable DYN_RESPONSE_QLOG_PATH for performance measurements"
+                .to_string(),
+        ));
+    let stream = config.into_stream();
+    tracing::info!(%path, "enabled diagnostic QUIC qlog capture");
+    Ok(stream)
+}
+
+fn client_config(
+    fingerprint: [u8; 32],
+    qlog: Option<quinn::QlogStream>,
+) -> Result<quinn::ClientConfig> {
+    let verifier = Arc::new(FingerprintVerifier {
+        fingerprint,
+        provider: Arc::new(rustls::crypto::ring::default_provider()),
+    });
+    let mut tls = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()?
+    .dangerous()
+    .with_custom_certificate_verifier(verifier)
+    .with_no_client_auth();
+    tls.alpn_protocols = vec![ALPN.to_vec()];
+    tls.enable_early_data = false;
+    let crypto = quinn::crypto::rustls::QuicClientConfig::try_from(tls)?;
+    let mut config = quinn::ClientConfig::new(Arc::new(crypto));
+    config.transport_config(Arc::new(client_transport_config(qlog)?));
+    Ok(config)
+}
+
+#[derive(Debug)]
+struct FingerprintVerifier {
+    fingerprint: [u8; 32],
+    provider: Arc<rustls::crypto::CryptoProvider>,
+}
+
+impl rustls::client::danger::ServerCertVerifier for FingerprintVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        let actual: [u8; 32] = Sha256::digest(end_entity.as_ref()).into();
+        if actual != self.fingerprint {
+            return Err(rustls::Error::General(
+                "QUIC response certificate fingerprint mismatch".to_string(),
+            ));
+        }
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        rustls::crypto::verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+fn udp_socket(bind: SocketAddr) -> Result<(std::net::UdpSocket, usize, usize)> {
+    let domain = if bind.is_ipv6() {
+        Domain::IPV6
+    } else {
+        Domain::IPV4
+    };
+    let socket = Socket::new(domain, Type::DGRAM, Some(Protocol::UDP))?;
+    if bind.is_ipv6() {
+        socket.set_only_v6(true)?;
+    }
+    socket.set_reuse_address(true)?;
+    socket.set_send_buffer_size(UDP_SOCKET_BUFFER)?;
+    socket.set_recv_buffer_size(UDP_SOCKET_BUFFER)?;
+    let actual_send_buffer = socket.send_buffer_size()?;
+    let actual_recv_buffer = socket.recv_buffer_size()?;
+    socket.bind(&bind.into())?;
+    socket.set_nonblocking(true)?;
+    Ok((socket.into(), actual_send_buffer, actual_recv_buffer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{engine::AsyncEngineContextProvider, pipeline::Context};
+    use futures::future::join_all;
+
+    #[test]
+    fn connection_info_rejects_wrong_version() {
+        let info = QuicResponseConnectionInfo {
+            protocol_version: PROTOCOL_VERSION + 1,
+            address: "127.0.0.1:1234".to_string(),
+            frontend_server_id: Uuid::new_v4(),
+            response_registration_id: Uuid::new_v4(),
+            context: "request".to_string(),
+            certificate_fingerprint: [1; 32],
+        };
+        assert!(info.validate().is_err());
+
+        let valid = QuicResponseConnectionInfo {
+            protocol_version: PROTOCOL_VERSION,
+            address: "127.0.0.1:1234".to_string(),
+            frontend_server_id: Uuid::new_v4(),
+            response_registration_id: Uuid::new_v4(),
+            context: "request".to_string(),
+            certificate_fingerprint: [1; 32],
+        };
+        assert!(valid.validate().is_ok());
+        for invalid in [
+            QuicResponseConnectionInfo {
+                address: "not-a-socket".to_string(),
+                ..valid.clone()
+            },
+            QuicResponseConnectionInfo {
+                frontend_server_id: Uuid::nil(),
+                ..valid.clone()
+            },
+            QuicResponseConnectionInfo {
+                response_registration_id: Uuid::nil(),
+                ..valid.clone()
+            },
+            QuicResponseConnectionInfo {
+                context: String::new(),
+                ..valid.clone()
+            },
+            QuicResponseConnectionInfo {
+                certificate_fingerprint: [0; 32],
+                ..valid
+            },
+        ] {
+            assert!(invalid.validate().is_err());
+        }
+    }
+
+    #[tokio::test]
+    async fn error_prologue_and_size_limit_are_enforced() {
+        let max_payload =
+            crate::pipeline::network::get_tcp_max_message_size().min(u32::MAX as usize);
+        assert!(validate_payload_size(max_payload).is_ok());
+        assert!(validate_payload_size(max_payload + 1).is_err());
+
+        let pool = ClientPool::new();
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        sender
+            .send_prologue(Some("worker failed".to_string()))
+            .await
+            .unwrap();
+        assert!(
+            sender
+                .send(Bytes::from_static(b"invalid payload"))
+                .await
+                .is_err()
+        );
+        sender.finish().unwrap();
+        let (_, provider) = registered.into_parts();
+        match provider.await.unwrap() {
+            Ok(_) => panic!("error prologue produced a response stream"),
+            Err(error) => assert_eq!(error, "worker failed"),
+        }
+
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info,
+            None,
+        )
+        .await
+        .unwrap();
+        let error = "x".repeat(MAX_ERROR_BYTES + 1);
+        assert!(sender.send_prologue(Some(error)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn chunk_reader_retains_contiguous_payload_and_coalesces_fragments() {
+        // The transport integration tests cover RecvStream. Keep the framing
+        // invariant independently testable with the exact queue operations the
+        // decoder uses.
+        let contiguous = Bytes::from_static(b"abcdef");
+        let pointer = contiguous.as_ptr();
+        let mut queue = VecDeque::from([contiguous]);
+        let sliced = queue.front_mut().unwrap().split_to(3);
+        assert_eq!(sliced.as_ptr(), pointer);
+        assert_eq!(&sliced[..], b"abc");
+
+        let mut coalesced = BytesMut::with_capacity(4);
+        for chunk in [Bytes::from_static(b"ab"), Bytes::from_static(b"cd")] {
+            coalesced.extend_from_slice(&chunk);
+        }
+        assert_eq!(&coalesced.freeze()[..], b"abcd");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn one_connection_carries_one_thousand_logical_responses() {
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+        let frontend_id = server.frontend_server_id;
+        let pool = Arc::new(ClientPool::new());
+
+        let responses = (0u32..1000)
+            .map(|sequence| {
+                let server = server.clone();
+                let pool = pool.clone();
+                async move {
+                    let upstream = Context::new(());
+                    let registered = server
+                        .register_response(
+                            StreamOptions::builder()
+                                .context(upstream.context())
+                                .enable_request_stream(false)
+                                .enable_response_stream(true)
+                                .build()
+                                .unwrap(),
+                        )
+                        .await;
+                    let info = registered.connection_info.clone();
+                    let downstream = Context::with_id_and_metadata(
+                        (),
+                        upstream.id().to_string(),
+                        Default::default(),
+                    );
+                    let worker = tokio::spawn(async move {
+                        let mut sender =
+                            create_response_stream_in_pool(&pool, downstream.context(), info, None)
+                                .await
+                                .unwrap();
+                        sender.send_prologue(None).await.unwrap();
+                        sender
+                            .send(Bytes::copy_from_slice(&sequence.to_be_bytes()))
+                            .await
+                            .unwrap();
+                        sender
+                            .send(Bytes::from_static(b"second-frame"))
+                            .await
+                            .unwrap();
+                        sender.finish().unwrap();
+                    });
+
+                    let (_, provider) = registered.into_parts();
+                    let mut receiver = provider.await.unwrap().unwrap();
+                    assert_eq!(
+                        receiver.rx.recv().await.unwrap(),
+                        Bytes::copy_from_slice(&sequence.to_be_bytes())
+                    );
+                    assert_eq!(
+                        receiver.rx.recv().await.unwrap(),
+                        Bytes::from_static(b"second-frame")
+                    );
+                    assert!(receiver.rx.recv().await.is_none());
+                    worker.await.unwrap();
+                }
+            })
+            .collect::<Vec<_>>();
+        join_all(responses).await;
+
+        let matching_connections = pool
+            .connections
+            .iter()
+            .filter(|entry| entry.key().frontend_server_id == frontend_id)
+            .count();
+        assert_eq!(matching_connections, 1);
+    }
+
+    #[tokio::test]
+    async fn certificate_fingerprint_is_pinned() {
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+        let pool = ClientPool::new();
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let mut info =
+            QuicResponseConnectionInfo::try_from(registered.connection_info.clone()).unwrap();
+        info.certificate_fingerprint[0] ^= 0xff;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        assert!(
+            create_response_stream_in_pool(&pool, downstream.context(), info.into(), None)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn sustained_small_response_burst_produces_multiple_stream_frames_per_datagram() {
+        let pool = Arc::new(ClientPool::new());
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+        let barrier = Arc::new(tokio::sync::Barrier::new(129));
+        let mut publishers = Vec::new();
+        let mut consumers = Vec::new();
+
+        for sequence in 0u32..128 {
+            let upstream = Context::new(());
+            let registered = server
+                .register_response(
+                    StreamOptions::builder()
+                        .context(upstream.context())
+                        .enable_request_stream(false)
+                        .enable_response_stream(true)
+                        .build()
+                        .unwrap(),
+                )
+                .await;
+            let downstream =
+                Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+            let mut sender = create_response_stream_in_pool(
+                &pool,
+                downstream.context(),
+                registered.connection_info.clone(),
+                None,
+            )
+            .await
+            .unwrap();
+            sender.send_prologue(None).await.unwrap();
+            let (_, provider) = registered.into_parts();
+            consumers.push(tokio::spawn(async move {
+                let mut receiver = provider.await.unwrap().unwrap();
+                assert_eq!(
+                    receiver.rx.recv().await.unwrap(),
+                    Bytes::copy_from_slice(&sequence.to_be_bytes())
+                );
+                assert!(receiver.rx.recv().await.is_none());
+            }));
+            let barrier = barrier.clone();
+            publishers.push(tokio::spawn(async move {
+                barrier.wait().await;
+                sender
+                    .send(Bytes::copy_from_slice(&sequence.to_be_bytes()))
+                    .await
+                    .unwrap();
+                sender.finish().unwrap();
+            }));
+        }
+
+        barrier.wait().await;
+        for result in join_all(publishers).await {
+            result.unwrap();
+        }
+        for result in join_all(consumers).await {
+            result.unwrap();
+        }
+        time::sleep(Duration::from_millis(50)).await;
+
+        let connection = pool.connections.iter().next().unwrap();
+        let stats = connection.value().stats();
+        assert!(
+            stats.frame_tx.stream > stats.udp_tx.datagrams,
+            "sustained burst did not produce more STREAM frames ({}) than UDP datagrams ({})",
+            stats.frame_tx.stream,
+            stats.udp_tx.datagrams,
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn stalled_response_does_not_block_a_sibling_stream() {
+        let pool = Arc::new(ClientPool::new());
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+
+        let stalled_upstream = Context::new(());
+        let stalled_registration = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(stalled_upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .send_buffer_count(1)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let stalled_downstream = Context::with_id_and_metadata(
+            (),
+            stalled_upstream.id().to_string(),
+            Default::default(),
+        );
+        let mut stalled_sender = create_response_stream_in_pool(
+            &pool,
+            stalled_downstream.context(),
+            stalled_registration.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        stalled_sender.send_prologue(None).await.unwrap();
+        let (_, stalled_provider) = stalled_registration.into_parts();
+        let stalled_receiver = stalled_provider.await.unwrap().unwrap();
+        let stalled_writer = tokio::spawn(async move {
+            let payload = Bytes::from(vec![7u8; 64 * 1024]);
+            loop {
+                stalled_sender.send(payload.clone()).await.unwrap();
+            }
+        });
+
+        let sibling_upstream = Context::new(());
+        let sibling_registration = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(sibling_upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let sibling_downstream = Context::with_id_and_metadata(
+            (),
+            sibling_upstream.id().to_string(),
+            Default::default(),
+        );
+        let sibling_info = sibling_registration.connection_info.clone();
+        let sibling = async {
+            let mut sender = create_response_stream_in_pool(
+                &pool,
+                sibling_downstream.context(),
+                sibling_info,
+                None,
+            )
+            .await
+            .unwrap();
+            sender.send_prologue(None).await.unwrap();
+            sender.send(Bytes::from_static(b"sibling")).await.unwrap();
+            sender.finish().unwrap();
+            let (_, provider) = sibling_registration.into_parts();
+            let mut receiver = provider.await.unwrap().unwrap();
+            assert_eq!(
+                receiver.rx.recv().await.unwrap(),
+                Bytes::from_static(b"sibling")
+            );
+            assert!(receiver.rx.recv().await.is_none());
+        };
+        time::timeout(Duration::from_secs(2), sibling)
+            .await
+            .expect("stalled stream blocked its sibling");
+
+        stalled_writer.abort();
+        drop(stalled_receiver);
+    }
+
+    #[tokio::test]
+    async fn stop_is_graceful_and_kill_is_forwarded_on_reverse_half() {
+        let pool = ClientPool::new();
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        sender.send_prologue(None).await.unwrap();
+        let (_, provider) = registered.into_parts();
+        let mut receiver = provider.await.unwrap().unwrap();
+        upstream.context().stop();
+        time::timeout(Duration::from_secs(1), downstream.context().stopped())
+            .await
+            .expect("Stop was not forwarded");
+        sender
+            .send(Bytes::from_static(b"graceful-final"))
+            .await
+            .unwrap();
+        sender.finish().unwrap();
+        assert_eq!(
+            receiver.rx.recv().await.unwrap(),
+            Bytes::from_static(b"graceful-final")
+        );
+
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        sender.send_prologue(None).await.unwrap();
+        let (_, provider) = registered.into_parts();
+        let _receiver = provider.await.unwrap().unwrap();
+        upstream.context().kill();
+        time::timeout(Duration::from_secs(1), downstream.context().killed())
+            .await
+            .expect("Kill was not forwarded");
+    }
+
+    #[tokio::test]
+    async fn unknown_registration_resets_only_that_stream() {
+        let pool = ClientPool::new();
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let valid_info = registered.connection_info.clone();
+        let mut bad_info = QuicResponseConnectionInfo::try_from(valid_info.clone()).unwrap();
+        bad_info.response_registration_id = Uuid::new_v4();
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut bad_sender =
+            create_response_stream_in_pool(&pool, downstream.context(), bad_info.into(), None)
+                .await
+                .unwrap();
+        let mut reset_observed = bad_sender.send_prologue(None).await.is_err();
+        if !reset_observed {
+            for _ in 0..100 {
+                if bad_sender.send(Bytes::from_static(b"bad")).await.is_err() {
+                    reset_observed = true;
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+        assert!(reset_observed, "unknown registration stream was not reset");
+
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut valid_sender =
+            create_response_stream_in_pool(&pool, downstream.context(), valid_info.clone(), None)
+                .await
+                .unwrap();
+        valid_sender.send_prologue(None).await.unwrap();
+        valid_sender
+            .send(Bytes::from_static(b"valid"))
+            .await
+            .unwrap();
+        valid_sender.finish().unwrap();
+        let (_, provider) = registered.into_parts();
+        let mut receiver = provider.await.unwrap().unwrap();
+        assert_eq!(
+            receiver.rx.recv().await.unwrap(),
+            Bytes::from_static(b"valid")
+        );
+
+        let duplicate_context =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut duplicate_sender =
+            create_response_stream_in_pool(&pool, duplicate_context.context(), valid_info, None)
+                .await
+                .unwrap();
+        let mut duplicate_reset = duplicate_sender.send_prologue(None).await.is_err();
+        if !duplicate_reset {
+            for _ in 0..100 {
+                if duplicate_sender
+                    .send(Bytes::from_static(b"duplicate"))
+                    .await
+                    .is_err()
+                {
+                    duplicate_reset = true;
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        }
+        assert!(
+            duplicate_reset,
+            "duplicate registration stream was not reset"
+        );
+    }
+
+    #[tokio::test]
+    async fn publisher_reset_closes_receiver_and_connection_reopens() {
+        let pool = ClientPool::new();
+        let server = QuicStreamServer::new(ServerOptions {
+            address: "127.0.0.1".parse().unwrap(),
+            port: 0,
+        })
+        .await
+        .unwrap();
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        sender.send_prologue(None).await.unwrap();
+        let (_, provider) = registered.into_parts();
+        let mut receiver = provider.await.unwrap().unwrap();
+        drop(sender);
+        let after_reset = time::timeout(Duration::from_secs(1), receiver.rx.recv())
+            .await
+            .expect("publisher reset did not close receiver");
+        assert!(after_reset.is_none(), "publisher reset emitted a payload");
+
+        let old_connection = pool.connections.iter().next().unwrap().value().clone();
+        old_connection.close(reset_code(RESET_KILLED), b"test connection loss");
+        time::sleep(Duration::from_millis(20)).await;
+
+        let upstream = Context::new(());
+        let registered = server
+            .register_response(
+                StreamOptions::builder()
+                    .context(upstream.context())
+                    .enable_request_stream(false)
+                    .enable_response_stream(true)
+                    .build()
+                    .unwrap(),
+            )
+            .await;
+        let downstream =
+            Context::with_id_and_metadata((), upstream.id().to_string(), Default::default());
+        let mut sender = create_response_stream_in_pool(
+            &pool,
+            downstream.context(),
+            registered.connection_info.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+        sender.send_prologue(None).await.unwrap();
+        sender
+            .send(Bytes::from_static(b"reconnected"))
+            .await
+            .unwrap();
+        sender.finish().unwrap();
+        let (_, provider) = registered.into_parts();
+        let mut receiver = provider.await.unwrap().unwrap();
+        assert_eq!(
+            receiver.rx.recv().await.unwrap(),
+            Bytes::from_static(b"reconnected")
+        );
+    }
+}

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -241,6 +241,14 @@ impl TcpStreamServer {
         }))
     }
 
+    pub fn local_ip(&self) -> &str {
+        &self.local_ip
+    }
+
+    pub fn local_port(&self) -> u16 {
+        self.local_port
+    }
+
     /// Associate one or both halves of a registration with a backend instance.
     ///
     /// `recv_subject` is the response-stream subject (always present on TCP);
@@ -290,6 +298,27 @@ impl TcpStreamServer {
         if let Some(s) = send_subject {
             entry.insert((StreamType::Request, s.to_string()));
         }
+        true
+    }
+
+    /// Associate only the TCP request-stream half with an instance. Response
+    /// registrations live in the sibling QUIC server.
+    pub async fn associate_request_instance(&self, subject: &str, id: &EndpointInstanceId) -> bool {
+        let mut state = self.state.lock();
+        let now = Instant::now();
+        prune_tombstones(&mut state.removed_instances, now);
+        if state.removed_instances.contains_key(id) {
+            state.tx_subjects.remove(subject);
+            return false;
+        }
+        state
+            .subject_instance
+            .insert(subject.to_string(), id.clone());
+        state
+            .instance_subjects
+            .entry(id.clone())
+            .or_default()
+            .insert((StreamType::Request, subject.to_string()));
         true
     }
 


### PR DESCRIPTION
## Summary

- Add a response-only transport built on Quinn 0.11, Tokio, and rustls while retaining TCP for request streams.
- Use one persistent QUIC connection per worker/frontend pair and one bidirectional QUIC stream per logical response, with certificate fingerprint pinning, fixed framing/reset semantics, flow-control defaults, and no application batching timer.
- Move response registration, cancellation, and tombstone handling to the QUIC server; add bounded-cardinality transport metrics plus packet-density and qlog analysis helpers.
- Document UDP deployment requirements, compatibility environment variables, and the qualification metrics.
- Retain the legacy TCP response implementation for the same-base qualification campaign. The candidate does not silently fall back to it.

This starts from `cfdc8d53cec827c58925dc8916f7e0192557b17f` and is intended for direct comparison with an untouched legacy TCP worktree at that exact SHA. QUIC provides native stream multiplexing and allows Quinn to packetize data from multiple response streams without an application-level response-delay timer.

## Validation

- `cargo fmt --all`
- `cargo clippy -p dynamo-runtime --all-targets -- -D warnings`
- Focused QUIC tests: 10 passed, including 1,000 logical responses over one connection, certificate pinning, framing/registration, sibling progress under a stalled stream, controls/resets, and reconnect behavior.
- `cargo test -p dynamo-runtime -- --skip pipeline::network::egress::push_router::tests::transport_resolution_falls_back_when_selected_instance_disappears`: 498 library tests passed, plus all exercised runtime integration tests and 42 doctests. The skipped test timed out after 120 seconds on both this branch and the untouched same-SHA TCP baseline.
- `fern check`: 0 errors, 2 warnings.
- `fern docs broken-links`: passed.
- Python analysis unit test and `py_compile`: passed.
- `uvx maturin build --release --manifest-path lib/bindings/python/Cargo.toml`: passed.

## Qualification status

This is intentionally a draft. The locked same-base AIPerf campaign and short qlog captures have not yet been run, so this PR does not claim packet-density or performance qualification. Legacy TCP response support remains until QUIC passes the agreed correctness, packet-batching, throughput, TTFT, and CPU/softirq gates.
