### PR TITLE
fix(trtllm): apply UrlValidationPolicy to video_url to close SSRF gap

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -27,7 +27,11 @@ from tensorrt_llm.inputs.utils import async_load_video
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 
 from dynamo.common.http import HttpStatusError
-from dynamo.common.http.url_validator import UrlValidationError
+from dynamo.common.http.url_validator import (
+    UrlValidationPolicy,
+    UrlValidationError,
+    validate_media_url,
+)
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
 from dynamo.runtime.logging import configure_dynamo_logging
@@ -86,6 +90,13 @@ class MultimodalRequestProcessor:
         # Reuse the shared default so this preprocessor and the vLLM/SGLang
         # backends agree on DYN_MM_VIDEO_NUM_FRAMES.
         self.num_video_frames = max(1, VideoLoader.NUM_FRAMES_DEFAULT)
+
+        # Video URLs go through the same SSRF policy as the image path so the
+        # default (DYN_MM_ALLOW_INTERNAL=0) blocks private/loopback/cloud-
+        # metadata targets (169.254/16, 10/8, kubernetes.default,
+        # metadata.google.internal, ...) and disallows http:// for the worker's
+        # direct `async_load_video` fetch.
+        self._url_policy = UrlValidationPolicy.from_env()
 
         # Input processor used only to size an omitted max_tokens (see
         # _expanded_prompt_len). Optional: unavailable for models without a
@@ -438,7 +449,13 @@ class MultimodalRequestProcessor:
                         400, "Local file access is not allowed for video", url
                     )
                 try:
-                    videos.append(await async_load_video(url, self.num_video_frames))
+                    normalized_url = await validate_media_url(url, self._url_policy)
+                except UrlValidationError as e:
+                    raise HttpStatusError(400, str(e), url) from e
+                try:
+                    videos.append(
+                        await async_load_video(normalized_url, self.num_video_frames)
+                    )
                 except (UrlValidationError, HttpStatusError):
                     raise
                 except Exception as e:

--- a/components/src/dynamo/trtllm/tests/test_multimodal_video_ssrf.py
+++ b/components/src/dynamo/trtllm/tests/test_multimodal_video_ssrf.py
@@ -1,0 +1,281 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SSRF guard for the TRT-LLM `video_url` path.
+
+PR #11896 only rejected `""` / `file://` schemes before handing the URL
+straight to `async_load_video`, leaving the worker free to fetch private
+links (169.254/16, 10/8, `kubernetes.default`, ...) when the default
+`DYN_MM_ALLOW_INTERNAL=0` policy was in effect — unlike the sibling
+`image_url` path which goes through `validate_media_url`. These tests
+pin the closed gap and the unchanged good-path behavior. They stub the
+`tensorrt_llm` modules so they run on CPU-only CI without TRT-LLM.
+"""
+
+import importlib
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+# Stub `tensorrt_llm` so importing `multimodal_processor` works without the
+# real TRT-LLM install. `async_load_video` is an AsyncMock we can reset
+# between tests to inspect / assert call args (single source of truth for
+# whether the worker would actually fetch).
+async_load_video_mock = AsyncMock(return_value=object())
+
+
+def _install_trtllm_stubs() -> None:
+    pkg = types.ModuleType("tensorrt_llm")
+    pkg.__path__ = []  # mark as a package
+    inputs = types.ModuleType("tensorrt_llm.inputs")
+    inputs.__path__ = []
+    inputs_utils = types.ModuleType("tensorrt_llm.inputs.utils")
+    inputs_utils.async_load_video = async_load_video_mock
+    inputs_create = types.ModuleType("tensorrt_llm.inputs.create_input_processor")
+    # `from tensorrt_llm.inputs import create_input_processor` inside __init__
+    inputs.create_input_processor = lambda *a, **kw: None
+    llmapi = types.ModuleType("tensorrt_llm.llmapi")
+    llmapi.__path__ = []
+    llmapi_tokenizer = types.ModuleType("tensorrt_llm.llmapi.tokenizer")
+    llmapi_tokenizer.tokenizer_factory = lambda *a, **kw: MagicMock()
+
+    for name, mod in [
+        ("tensorrt_llm", pkg),
+        ("tensorrt_llm.inputs", inputs),
+        ("tensorrt_llm.inputs.utils", inputs_utils),
+        ("tensorrt_llm.inputs.create_input_processor", inputs_create),
+        ("tensorrt_llm.llmapi", llmapi),
+        ("tensorrt_llm.llmapi.tokenizer", llmapi_tokenizer),
+    ]:
+        sys.modules.setdefault(name, mod)
+
+
+_install_trtllm_stubs()
+
+from dynamo.common.http import HttpStatusError  # noqa: E402
+from dynamo.common.http.url_validator import UrlValidationError  # noqa: E402
+from dynamo.trtllm import multimodal_processor as mmp  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.multimodal,
+    pytest.mark.pre_merge,
+    # CPU-only test: `gpu_0` is the pre-merge CPU stage selector in
+    # .github/workflows/pr.yaml (line 703: "pre_merge and trtllm and gpu_0").
+    pytest.mark.gpu_0,
+]
+
+
+def _reload_processor(monkeypatch):
+    """Reload `mmp` so `UrlValidationPolicy.from_env()` re-reads the env
+    with the per-test monkeypatched vars, then force-bind the video fetcher
+    to our AsyncMock. The bind matters: a real `tensorrt_llm.inputs.utils`
+    can already live in `sys.modules` if another test in the same process
+    imported TRT-LLM first, in which case `sys.modules.setdefault` in
+    `_install_trtllm_stubs` no longer wins and the module-level
+    `from ... import async_load_video` would resolve to the real loader —
+    the opt-in test would then make a real network request. Patching the
+    module name post-reload keeps every test hermetic."""
+    importlib.reload(mmp)
+    monkeypatch.setattr(mmp, "async_load_video", async_load_video_mock)
+
+
+def _make_processor():
+    """Build a processor with a mock tokenizer so `__init__` skips
+    `tokenizer_factory` and the (irrelevant) input-processor path. Reads
+    the class off the (possibly reloaded) module so `importlib.reload`
+    between tests always uses the fresh class + its updated policy."""
+    return mmp.MultimodalRequestProcessor(
+        model_type="multimodal",
+        model_dir="unused",
+        max_file_size_mb=10,
+        tokenizer=MagicMock(),
+    )
+
+
+def _video_request(url: str) -> dict:
+    return {"multi_modal_data": {"video_url": [{"Url": url}]}}
+
+
+@pytest.fixture(autouse=True)
+def _reset_async_load_video():
+    async_load_video_mock.reset_mock()
+    yield
+    async_load_video_mock.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_http_internal_ip_rejected_by_default(monkeypatch):
+    """Link-local metadata IP over http:// is blocked by policy, never
+    reaches `async_load_video`. Would-be SSRF payload: 169.254.169.254."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    # Reload the module so `UrlValidationPolicy.from_env()` re-reads the env
+    # with the defaults restored.
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("http://169.254.169.254/latest/meta-data/")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_https_internal_ip_rejected_by_default(monkeypatch):
+    """Even with https://, an IP literal in the blocked range (RFC1918
+    10/8) is rejected by `is_blocked_ip` before fetch."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("https://10.0.0.1/x.mp4")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_internal_service_host_rejected_by_default(monkeypatch):
+    """`kubernetes.default.svc` is in the blocked-host list exactly so a
+    client cannot probe the in-cluster API via a video_url."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("https://kubernetes.default.svc/api/v1/namespaces")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_public_scheme_rejected_by_default(monkeypatch):
+    """`http://` (even to a public host) is not allowed by the default
+    policy; the worker should not be doing cleartext media fetches."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("http://public.example.com/x.mp4")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_file_scheme_rejected(monkeypatch):
+    """Pre-existing PR guardrail still in force: `file://` is refused
+    outright, regardless of any `DYN_MM_LOCAL_PATH` config — videos are
+    not whitelisted for local-path access like images optionally are."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("file:///etc/passwd")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    assert "Local file access is not allowed" in str(exc.value)
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_https_public_ip_passes_validation(monkeypatch):
+    """Happy path is unchanged: a public IP literal over https:// passes
+    `validate_media_url` (no DNS, no network) and `async_load_video` is
+    invoked with the normalized URL — proving the fix doesn't break the
+    PR's intended video loading path."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    # 1.1.1.1 is Cloudflare DNS, a public IP not in any blocked range.
+    # `validate_url` early-returns on a parseable IP literal without DNS,
+    # so this stays offline.
+    url = "https://1.1.1.1/x.mp4"
+    request = _video_request(url)
+
+    await processor.process_openai_request(
+        request, embeddings=None, ep_disaggregated_params=None
+    )
+    async_load_video_mock.assert_awaited_once()
+    called_url = async_load_video_mock.await_args.args[0]
+    assert called_url == url
+
+
+@pytest.mark.asyncio
+async def test_url_validation_error_propagates(monkeypatch):
+    """Defect regression: before the fix the video_path swallowed
+    `UrlValidationError` as a generic `Exception` and converted it to a
+    400 with a "Failed to load video" message, hiding the SSRF reason.
+    After the fix a `UrlValidationError` is turned into a 400 that keeps
+    the validator's diagnostic (e.g. `http:// URLs are not allowed`)."""
+    monkeypatch.delenv("DYN_MM_ALLOW_INTERNAL", raising=False)
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("http://example.com/x.mp4")
+
+    with pytest.raises(HttpStatusError) as exc:
+        await processor.process_openai_request(
+            request, embeddings=None, ep_disaggregated_params=None
+        )
+    assert exc.value.status == 400
+    # The validator's own SSRF diagnostic, not the generic video-load error.
+    assert "not allowed" in str(exc.value)
+    assert "Failed to load video" not in str(exc.value)
+    async_load_video_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_http_internal_allowed_when_policy_opted_in(monkeypatch):
+    """Operator-controlled escape hatch: with `DYN_MM_ALLOW_INTERNAL=1`
+    the policy allows http:// and private IPs, mirroring the image path.
+    The break-the-fix behavior here would be for the validator to reject
+    http:// even when the env flag opted in."""
+    monkeypatch.setenv("DYN_MM_ALLOW_INTERNAL", "1")
+    monkeypatch.delenv("DYN_MM_LOCAL_PATH", raising=False)
+    _reload_processor(monkeypatch)
+
+    processor = _make_processor()
+    request = _video_request("http://169.254.169.254/latest/meta-data/")
+
+    await processor.process_openai_request(
+        request, embeddings=None, ep_disaggregated_params=None
+    )
+    async_load_video_mock.assert_awaited_once()
+    assert async_load_video_mock.await_args.args[0] == "http://169.254.169.254/latest/meta-data/"
+
+
+# Suppress the unused-import warning for UrlValidationError; kept for
+# downstream consumers that may want to assert against the type.
+_ = UrlValidationError


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

fix: TRT-LLM backend skips SSRF validation for video_url

## Details:

<!-- Describe the changes made in this PR. -->

The TRT-LLM worker takes the raw video_url and passes it straight to TensorRT-LLM. 
No validation before the fetch.

Dynamo's UrlValidationPolicy should be enforced to verify the video_url to block cases like:
- private and local IPs , http://169.254.169.254/, https://10.0.0.1/
- plaintext public URLs , http://public.example.com/

The vLLM backend handles the same field through the project's shared validation path. 

```
//  components/src/dynamo/common/multimodal/video_loader.py:111
   async def _load_video_with_vllm(
        self, video_url: str
    ) -> tuple[np.ndarray, Dict[str, Any]]:
    	// Private IPs, http, and metadata hosts are all rejected.
        normalized_url = await validate_media_url(video_url, self._url_policy)
```

`docs/features/multimodal/README.md` ("Security: URL Validation") promises this:

```
All multimodal loaders route remote fetches through a shared URL policy.
```

The vLLM backend keeps that promise. The TRT-LLM backend does not comply with it.


## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added validation for video URLs to block unsafe internal, link-local, unsupported, and local file locations by default.
  * Clear validation errors are returned when a video URL is rejected.
  * Configurable policy support allows approved internal access when enabled.

* **Bug Fixes**
  * Public HTTPS video URLs continue to load using their normalized addresses.

* **Tests**
  * Added regression coverage for blocked URL types, accepted public URLs, error handling, and opt-in internal access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->