### PR TITLE
feat(operator): make Tilt target architecture configurable

### DIFF
--- a/deploy/operator/Tiltfile
+++ b/deploy/operator/Tiltfile
@@ -45,6 +45,7 @@ settings = {
     'enable_kai_scheduler': False,      # GPU-aware scheduling for multi-node
     'enable_grove':         False,      # PodClique-based multi-node orchestration
     'skip_codegen':         False,      # skip make generate/manifests for faster iteration
+    'goarch':               'amd64',    # target architecture for operator binaries
     'image_pull_secret':    '',         # name of docker-registry Secret for private registries
     'helm_values':          {},         # extra --set overrides passed to helm template
 }
@@ -71,6 +72,7 @@ ENABLE_ETCD          = settings['enable_etcd']
 ENABLE_KAI_SCHEDULER = settings['enable_kai_scheduler']
 ENABLE_GROVE         = settings['enable_grove']
 IMAGE_PULL_SECRET    = settings['image_pull_secret']
+GOARCH               = settings['goarch']
 
 # ---------------------------------------------------------------------------
 # Operator version — passed as --operator-version to the manager binary.
@@ -122,10 +124,10 @@ IMG_REF  = IMG + ':' + IMG_TAG
 # Compile operator binaries locally (much faster than building in Docker)
 # ---------------------------------------------------------------------------
 def compile_manager():
-    return 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOWORK=off go build -o tilt_bin/manager ./cmd/main.go'
+    return 'CGO_ENABLED=0 GOOS=linux GOARCH=%s GOWORK=off go build -o tilt_bin/manager ./cmd/main.go' % GOARCH
 
 def compile_dgd_override_tool():
-    return 'CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOWORK=off go build -o tilt_bin/dgd-apply-overrides ./cmd/dgd-apply-overrides'
+    return 'CGO_ENABLED=0 GOOS=linux GOARCH=%s GOWORK=off go build -o tilt_bin/dgd-apply-overrides ./cmd/dgd-apply-overrides' % GOARCH
 
 local_resource(
     'manager-build',

--- a/docs/kubernetes/tilt-dev-setup.md
+++ b/docs/kubernetes/tilt-dev-setup.md
@@ -89,11 +89,15 @@ registry: docker.io/myuser
 # Set to true when you haven't changed API types (faster iteration).
 skip_codegen: true
 
+# Target architecture for the operator binaries.
+# Use arm64 for an ARM-based kind cluster.
+goarch: amd64
+
 # Target namespace for the operator and related resources.
 # namespace: dynamo-system
 
 # Subchart toggles
-# enable_nats: true            # Required for DGD/DGDR workloads (default: true)
+# enable_nats: true            # Only for NATS-based transports or features
 # enable_etcd: false           # Only if discoveryBackend is "etcd"
 # enable_kai_scheduler: false  # GPU-aware scheduling for multi-node
 # enable_grove: false          # PodClique-based multi-node orchestration
@@ -112,7 +116,8 @@ skip_codegen: true
 | `registry` | string | `""` | Container registry prefix (e.g. `docker.io/myuser`). Also settable via `REGISTRY` env var, which takes precedence. |
 | `namespace` | string | `dynamo-system` | Namespace for the operator Deployment and related resources. |
 | `skip_codegen` | bool | `false` | Skip `make generate && make manifests` before applying CRDs. Set to `true` when you haven't changed API types. |
-| `enable_nats` | bool | `true` | Deploy NATS subchart. Required for DGD/DGDR workloads (workers use it for communication). |
+| `goarch` | string | `amd64` | Target architecture for the operator binaries. |
+| `enable_nats` | bool | `false` | Deploy the NATS subchart for NATS-based transports or features. |
 | `enable_etcd` | bool | `false` | Deploy etcd subchart. Only needed when `discoveryBackend` is `etcd`. |
 | `enable_kai_scheduler` | bool | `false` | Deploy kai-scheduler for GPU-aware scheduling in multi-node setups. |
 | `enable_grove` | bool | `false` | Deploy Grove for PodClique-based multi-node orchestration. |
@@ -151,9 +156,9 @@ MPI SSH key provisioning at runtime — no external setup needed.
 
 ### What Each Resource Does
 
-**manager-build** — Runs `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build` to
-compile the operator binary. Re-runs on changes to `api/`, `cmd/`, `internal/`,
-`go.mod`, or `go.sum`.
+**manager-build** compiles the operator binary with `GOOS=linux` and `GOARCH`
+set from `goarch`. Re-runs on changes to `api/`, `cmd/`, `internal/`, `go.mod`,
+or `go.sum`.
 
 **crds** — Applies generated CRDs from `deploy/operator/config/crd/bases` using server-side apply.
 When `skip_codegen` is `false`, runs `make generate && make manifests` first.


### PR DESCRIPTION
## Summary

- add a goarch Tilt setting with an amd64 default
- use the configured architecture for both operator Go binaries
- document the setting and align the documented NATS default with the Tiltfile

## Validation

- git diff --check
- ran Tilt against the ARM64 kind-dynamo cluster with goarch: arm64
- verified both generated binaries are Linux ARM64 executables
- verified the Dynamo Operator deployment remains 1/1 ready
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable operator build architecture support, including ARM targets.

* **Documentation**
  * Updated Tilt development setup guidance with the new architecture option.
  * Clarified namespace, subchart, messaging, and manager-build configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->