### PR TITLE
feat(container/AWS): Update to EFA Installer 1.49.0

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -34,40 +34,23 @@
 
 packages:
   # --- EFA (Elastic Fabric Adapter) components ---
-  # Installed by container/templates/aws.Dockerfile via the AWS-published
-  # `efa_installer.sh` (efa_version 1.47.0). The installer drops binaries
-  # directly without registering with apt, so dpkg/python/rust/go
-  # generators can't see them. This YAML overlay attributes them.
-  #
-  # Image filter:
-  #   - vllm-runtime-efa: baseline (nvcr.io/nvidia/cuda:X.Y-runtime) has
-  #     no libfabric, so EFA legitimately adds both libs.
-  #   - trtllm-runtime-efa: baseline (cuda-dl-base) already ships
-  #     libfabric-aws@2.1.0amzn5.0, but the EFA installer may install a
-  #     different version; explicit attribution closes the version-skew
-  #     gap defensively.
-  #   - (sglang-runtime-efa intentionally omitted: sglang's upstream
-  #     image already ships libfabric1@1.17.0-3build2; the make_efa
-  #     build is redundant and appears to be dead config.)
   - name: libfabric
-    # AWS fork: shipped by EFA installer 1.47.0 as libfabric1-aws_2.4.0amzn1.0
-    # (Ubuntu 24.04 DEB). The `amzn1.0` suffix indicates an AWS patch set on
-    # top of upstream libfabric 2.4.0; preserved here for OSRB traceability.
-    version: 2.4.0amzn1.0
+    version: 2.4.0amzn5.0
     license: BSD-2-Clause
-    source: https://github.com/ofiwg/libfabric
+    source: https://github.com/aws/libfabric
     images:
       - vllm-runtime-efa
       - trtllm-runtime-efa
+      - sglang-runtime-efa
 
   - name: aws-ofi-nccl
-    # Shipped by EFA installer 1.47.0 as libnccl-ofi_1.18.0-1 (Ubuntu 24.04 DEB).
-    version: 1.18.0
+    version: 1.20.0
     license: Apache-2.0
     source: https://github.com/aws/aws-ofi-nccl
     images:
       - vllm-runtime-efa
       - trtllm-runtime-efa
+      - sglang-runtime-efa
 
   # --- From-source binaries built in wheel_builder / dynamo_base and copied
   # into the runtime images (no apt/pip/cargo metadata, so the python/rust/dpkg

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -43,7 +43,7 @@ dynamo:
   nixl_gdrcopy_ref: v2.5.2
   nixl_ucx_efa_ref: 9d2b88a1f67faf9876f267658bd077b379b8bb76
   nixl_libfabric_repo: https://github.com/ofiwg/libfabric.git
-  nixl_libfabric_ref: v2.5.1
+  nixl_libfabric_ref: v2.4.0
   # Keep in sync with upstream NIXL's contrib/Dockerfile.manylinux.
   hwloc_version: 2.12.2
   enable_kvbm: "true"
@@ -54,7 +54,7 @@ dynamo:
   nv_codec_headers_ref: "n13.0.19.0"
   libvpx_ref: "v1.14.1"
   sccache_version: "v0.14.0"
-  efa_version: 1.47.0
+  efa_version: 1.49.0
 
 vllm:
   cuda13.0:

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -27,44 +27,16 @@ USER root
 #   --no-verify: Skip GPG verification (optional, can be removed if verification is needed)
 # Cache apt downloads; sharing=locked avoids apt/dpkg races with concurrent builds.
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    mkdir -p /tmp/efa && \
-    cd /tmp/efa && \
     curl --retry 3 --retry-delay 2 -fsSL -o aws-efa-installer-${EFA_VERSION}.tar.gz \
         https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_VERSION}.tar.gz && \
     tar -xf aws-efa-installer-${EFA_VERSION}.tar.gz && \
     cd aws-efa-installer && \
     apt-get update && \
     ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify && \
-    rm -rf /tmp/efa && \
-    rm -rf /opt/amazon/aws-ofi-nccl /etc/ld.so.conf.d/aws-ofi-nccl.conf && \
+    cd .. && rm -rf aws-efa-installer* && \
     ldconfig
 
 ENV EFA_VERSION="${EFA_VERSION}"
-
-ARG NIXL_LIBFABRIC_REF
-
-# Copy the wheel_builder-built libfabric and register it with the dynamic linker
-# ONLY if the EFA-bundled libfabric is older than NIXL_LIBFABRIC_REF.
-# When a future EFA installer ships libfabric >= the version we build, the
-# version comparison evaluates to false and this becomes a no-op automatically.
-RUN --mount=from=wheel_builder,source=/usr/local/libfabric,target=/tmp/libfabric_build \
-    EFA_PC=$(find /opt/amazon/efa -path '*/pkgconfig/libfabric.pc' 2>/dev/null | head -n1) && \
-    EFA_LIBFABRIC_RAW=$(cat "$EFA_PC" 2>/dev/null | grep '^Version:' | awk '{print $2}') && \
-    EFA_LIBFABRIC_VER=$(echo "$EFA_LIBFABRIC_RAW" | grep -oE '^[0-9]+\.[0-9]+(\.[0-9]+)?') && \
-    REF_VER=$(echo "${NIXL_LIBFABRIC_REF}" | sed 's/^v//') && \
-    if [ -n "$EFA_LIBFABRIC_VER" ] && [ -n "$REF_VER" ] && \
-       [ "$(printf '%s\n' "$EFA_LIBFABRIC_VER" "$REF_VER" | sort -V | head -n1)" = "$EFA_LIBFABRIC_VER" ] && \
-       [ "$EFA_LIBFABRIC_VER" != "$REF_VER" ]; then \
-        rm -rf /opt/amazon/efa && \
-        cp -Pfr /tmp/libfabric_build /opt/amazon/efa && \
-        sed -i 's|^prefix=.*|prefix=/opt/amazon/efa|' /opt/amazon/efa/lib/pkgconfig/libfabric.pc && \
-        echo "/opt/amazon/efa/lib" > /etc/ld.so.conf.d/000_efa.conf && \
-        rm -f /etc/ld.so.conf.d/efa.conf && \
-        ldconfig && \
-        echo "[aws] libfabric overlay: ${REF_VER} (overwrites EFA stock ${EFA_LIBFABRIC_RAW})"; \
-    else \
-        echo "[aws] libfabric overlay: skipped (EFA stock ${EFA_LIBFABRIC_RAW:-unknown} >= ${REF_VER})"; \
-    fi
 
 {% if framework == "trtllm" %}
 # After the upstream mesonpy refactor, libplugin_LIBFABRIC.so lands under the


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

* Bump EFA Installer version to 1.49.0
* Revert overriding libfabric, use EFA Installer's provided libfabric.

## Details:

<!-- Describe the changes made in this PR. -->

* Updated the EFA Installer to 1.49.0.
* Reverted #9727 - EFA (AWS) container now uses the EFA Installer provided libfabric.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the AWS EFA installation process for improved compatibility and reliability.
  * Refreshed default versions for AWS EFA and Libfabric components in container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->