### PR TITLE
feat(container): support overriding nixl wheel files in runtime images

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -89,6 +89,7 @@ vllm:
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"
+  enable_nixl_wheel_override: "false"
   enable_modelexpress: "true"
   modelexpress_version: "0.4.0"
   # aws-sdk-cpp tag for the NIXL OBJ / S3 backend (built in wheel_builder).
@@ -130,6 +131,7 @@ sglang:
   enable_media_ffmpeg: "true"
   enable_gpu_memory_service: "true"
   enable_kvbm: "false"
+  enable_nixl_wheel_override: "false"
   enable_modelexpress: "true"
   modelexpress_version: "0.4.0"
 

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -114,6 +114,7 @@ ARG AWS_SDK_CPP_VERSION={{ context.vllm.aws_sdk_cpp_version }}
 {% if framework in ["vllm", "sglang"] -%}
 # ModelExpress Python client for model loading (optional)
 ARG MODELEXPRESS_VERSION={{ context[framework].modelexpress_version }}
+ARG ENABLE_NIXL_WHEEL_OVERRIDE={{ context[framework].enable_nixl_wheel_override }}
 {%- endif -%}
 
 {% if framework == "sglang" and device == "xpu" -%}

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -131,6 +131,19 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     pip install --break-system-packages --no-deps "distro==1.9.0"
 
+# When ENABLE_NIXL_WHEEL_OVERRIDE is true, install the NIXL wheels built in
+# wheel_builder (nixl-cu* + nixl-meta) instead of using the upstream nixl package
+# pre-installed in the lmsysorg/sglang base image.
+COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
+COPY --chown=dynamo:0 --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+ARG ENABLE_NIXL_WHEEL_OVERRIDE
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    if [ "${ENABLE_NIXL_WHEEL_OVERRIDE}" = "true" ]; then \
+        export PIP_CACHE_DIR=/root/.cache/pip && \
+        pip install --break-system-packages --force-reinstall --no-deps \
+            /opt/dynamo/wheelhouse/nixl/nixl*.whl; \
+    fi
+
 # Install gpu_memory_service wheel if enabled (all targets)
 ARG ENABLE_GPU_MEMORY_SERVICE
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -18,6 +18,7 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 ARG PYTHON_VERSION
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
+ARG ENABLE_NIXL_WHEEL_OVERRIDE
 ARG VLLM_OMNI_REF
 ARG NIXL_REF
 {% if device == "cuda" %}
@@ -140,6 +141,26 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/nixl/nixl*.whl
+{% endif %}
+
+{% if device == "cuda" %}
+# When ENABLE_NIXL_WHEEL_OVERRIDE is true, install the NIXL wheels built in
+# wheel_builder (nixl-cu* + nixl-meta) instead of using the upstream PyPI package
+# pre-installed in the base image. This allows testing a custom NIXL build (e.g. a
+# newer ref or patched version) without waiting for an upstream release.
+COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
+COPY --chown=dynamo:0 --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
+RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    if [ "${ENABLE_NIXL_WHEEL_OVERRIDE}" = "true" ]; then \
+        set -eux; \
+        export UV_CACHE_DIR=/root/.cache/uv; \
+        uv pip install {{ pip_target }} --force-reinstall --no-deps /opt/dynamo/wheelhouse/nixl/nixl*.whl; \
+        install_nixl_from_wheel \
+            --cuda-major "${CUDA_MAJOR}" \
+            --site-packages "${SITE_PACKAGES}" \
+            --prefix "${NIXL_PREFIX}" \
+            --skip-headers; \
+    fi
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -692,7 +692,6 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
     echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
-{% if not (framework == "sglang" and device == "cuda" and target in ("runtime", "dev", "local-dev")) %}
 # Build NIXL wheel → /opt/dynamo/dist/nixl/nixl*.whl (C++ transport library, all targets)
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
@@ -706,7 +705,6 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     fi && \
     cd /workspace/nixl && \
     uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
-{% endif %}
 
 {% if target not in ("dev", "local-dev") %}
 # Copy source code (order matters for layer caching)

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -224,7 +224,7 @@ ENV VIRTUAL_ENV=/workspace/.venv
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
-    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml
+    uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml auditwheel
 
 ARG NIXL_UCX_REF
 
@@ -693,6 +693,8 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
 # Build NIXL wheel → /opt/dynamo/dist/nixl/nixl*.whl (C++ transport library, all targets)
+# Uses contrib/build-wheel.sh approach: build wheel then auditwheel repair to bundle
+# shared libraries (libnixl, UCX plugins, NIXL plugins) into the wheel.
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
@@ -703,8 +705,19 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
     fi && \
+    source ${VIRTUAL_ENV}/bin/activate && \
     cd /workspace/nixl && \
-    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+    ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64") && \
+    WHL_PLATFORM="manylinux_2_28_${ARCH_ALT}" && \
+    UCX_PLUGINS_DIR="/usr/local/ucx/lib/ucx" && \
+    chmod +x contrib/build-wheel.sh contrib/wheel_add_ucx_plugins.py contrib/tomlutil.py && \
+    mkdir -p /opt/dynamo/dist/nixl && \
+    contrib/build-wheel.sh \
+        --python-version $PYTHON_VERSION \
+        --platform "$WHL_PLATFORM" \
+        --output-dir /opt/dynamo/dist/nixl \
+        --ucx-plugins-dir "$UCX_PLUGINS_DIR" \
+        --nixl-plugins-dir "$NIXL_PLUGIN_DIR"
 
 {% if target not in ("dev", "local-dev") %}
 # Copy source code (order matters for layer caching)


### PR DESCRIPTION
## Overview:

Add a new container build argument `ENABLE_NIXL_WHEEL_OVERRIDE` to override NIXL wheel in runtime image.

## Details:

<!-- Describe the changes made in this PR. -->

By default, the final runtime images uses NIXL from the framework upstream container image.
Add an argument to override that and use the NIXL wheel files built during the `wheel_builder` stage, along with `NIXL_REF` argument that already exists, this allows building a final runtime image with a specific NIXL version or commit.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12013" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional NIXL wheel override for vLLM and SGLang container builds.
  * Runtime images can now install locally built NIXL wheels when the override is enabled.
  * NIXL wheels are now consistently built and made available during container image creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->