### PR TITLE
feat(recipes): add GPQA-Diamond accuracy check for GLM-5.2

### DIFF
--- a/docs/recipes/glm-5-2.mdx
+++ b/docs/recipes/glm-5-2.mdx
@@ -231,6 +231,31 @@ All four targets serve GLM-5.2 on SGLang with KV-aware routing and EAGLE-style M
 | **KV offload** | HiCache CPU | HiCache CPU | None | None |
 | **Max context** | 500K | 500K | 250K | 250K |
 
+## Accuracy
+
+The checkpoints these targets serve are already accuracy-validated — [nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) publishes GPQA-Diamond results for the quantized model alongside its FP8 baseline. However, it can still be reassuring to perform a final accuracy check to ensure no bugs have crept in along the path to deployment. The `accuracy/accuracy.yaml` Job does this as an A/B test against the model card: it runs AIPerf's GPQA-Diamond benchmark, sending the 198 real GPQA-Diamond questions as chat requests through your deployed DGD (A) and comparing the graded score to the checkpoint's published number (B). Each answer is graded by extracting the chosen A/B/C/D letter and exact-matching against ground truth. Compare the score to the model-card number, not to a fixed threshold.
+
+Edit `ENDPOINT` in `accuracy/accuracy.yaml` to your deployed frontend service, then run the Job. `glm-5-2-gpqa` is a fixed-name Job, so clear any prior run before re-applying (for example when switching `ENDPOINT` to a different target):
+
+```bash
+kubectl delete job glm-5-2-gpqa -n ${NAMESPACE} --ignore-not-found
+kubectl apply -f recipes/glm-5.2/accuracy/accuracy.yaml -n ${NAMESPACE}
+kubectl logs -f -l app=glm-5-2-gpqa -n ${NAMESPACE}
+```
+
+Measured results for all four targets, each against its checkpoint's model-card GPQA-Diamond baseline, with 0 errors and 0 unparsed answers on every run:
+
+| Target | Checkpoint | Model card | This recipe (aiperf) |
+|---|---|---:|---:|
+| B200 aggregated | nvidia/GLM-5.2-NVFP4 | 89.39 | 88.89 (176/198) |
+| B200 disaggregated | nvidia/GLM-5.2-NVFP4 | 89.39 | 90.91 (180/198) |
+| H200 aggregated | zai-org/GLM-5.2-FP8 | 89.52 | 87.88 (174/198) |
+| H200 disaggregated | zai-org/GLM-5.2-FP8 | 89.52 | 89.39 (177/198) |
+
+The baselines above come from NVIDIA's [NVFP4 model card](https://huggingface.co/nvidia/GLM-5.2-NVFP4), measured at the same sampling this recipe uses (temperature 1.0, top_p 0.95, max_new_tokens 100k): NVFP4 89.39 and the FP8 baseline 89.52. Z.ai's own FP8 card reports GPQA-Diamond at 91.2 under a different eval harness — the NVIDIA numbers are used here so the comparison is like-for-like.
+
+Scores are harness-dependent — different evaluation tools produce slightly different numbers on the same model, so compare the general range, not exact decimals. A single run of 198 questions at temperature 1.0 varies by a few points between runs: each score carries a 95% binomial confidence interval of about ±4.0-4.6 points, and every model-card baseline falls within its config's interval. The spread between targets is not a sign that one serving mode or SKU is more accurate than another. Remove any `SGLANG_SIMULATE_ACC_LEN` env (a perf-only synthetic spec-decode setting) from the deployment before running, since it corrupts outputs. See `recipes/glm-5.2/accuracy/README.md` for methodology and caveats.
+
 ## Notes
 
 - Speculative decoding uses EAGLE-style MTP with draft length 3, measured at a SpeedBench acceptance length of 2.69.

--- a/recipes/glm-5.2/README.md
+++ b/recipes/glm-5.2/README.md
@@ -107,6 +107,36 @@ Modified Mooncake traces are provided to showcase the value of KV-aware routing 
 
 
 
+## Accuracy
+
+The checkpoints these recipes serve are already accuracy-validated (see
+[nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4)), but it
+can still be reassuring to run a final accuracy check to ensure no bugs have
+crept in along the path to deployment. The [`accuracy/`](accuracy/) folder
+contains a GPQA-Diamond evaluation Job (`aiperf --accuracy-benchmark
+gpqa_diamond`) that A/B tests the deployed endpoint against the checkpoint's
+model card:
+
+| Benchmark | Model card¹ | This recipe (aiperf) | Config |
+|---|---:|---:|---|
+| GPQA-Diamond | 89.39 (NVFP4) | 90.91 (180/198, 0 unparsed) | disagg-b200 |
+| GPQA-Diamond | 89.39 (NVFP4) | 88.89 (176/198, 0 unparsed) | agg-b200 |
+| GPQA-Diamond | 89.52 (FP8) | 89.39 (177/198, 0 unparsed) | disagg-h200 |
+| GPQA-Diamond | 89.52 (FP8) | 87.88 (174/198, 0 unparsed) | agg-h200 |
+
+¹ Baselines from NVIDIA's [NVFP4 model card](https://huggingface.co/nvidia/GLM-5.2-NVFP4),
+measured at matched sampling (temperature 1.0, top_p 0.95, max_new_tokens 100k):
+NVFP4 89.39, FP8 baseline 89.52. B200 recipes serve `nvidia/GLM-5.2-NVFP4`; H200
+recipes serve [`zai-org/GLM-5.2-FP8`](https://huggingface.co/zai-org/GLM-5.2-FP8),
+whose own card reports 91.2 under Z.ai's harness — the 89.52 baseline is used here
+because it matches this recipe's sampling.
+
+All four configs score close to their model-card baseline with no errors or
+unparsed answers. The small spread between configs (~2-3%) is normal run-to-run
+variation at temperature=1.0 — not a sign that one serving mode or SKU is more
+accurate than another. See [accuracy/README.md](accuracy/README.md) for
+methodology and caveats.
+
 ## Limitations
 
 - B200 recipes support up to 500K context lengths. The full 1M context length is not supported out of the box.

--- a/recipes/glm-5.2/accuracy/README.md
+++ b/recipes/glm-5.2/accuracy/README.md
@@ -1,0 +1,94 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# glm-5.2 — Accuracy Check (GPQA-Diamond)
+
+The checkpoints this recipe serves are already accuracy-validated:
+[nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) publishes
+GPQA-Diamond results for the quantized model alongside its FP8 baseline.
+However, it can still be reassuring to perform a final accuracy check on the
+deployed endpoint to ensure no bugs have crept in along the path to deployment
+— a stale env var or misconfigured flag can silently corrupt outputs while
+throughput looks healthy.
+
+This check is an **A/B test**, not an absolute capability claim: A is the
+score measured through this recipe's deployment; B is the checkpoint's
+published model-card number. Dataset contamination, if any, affects both
+sides equally and cancels out.
+
+## Reference vs measured
+
+| Benchmark | Model card (checkpoint)¹ | This recipe (aiperf)² | Config |
+|---|---:|---:|---|
+| GPQA-Diamond | 89.39 (NVFP4) | 90.91 (180/198, 0 unparsed) | disagg-b200 |
+| GPQA-Diamond | 89.39 (NVFP4) | 88.89 (176/198, 0 unparsed) | agg-b200 |
+| GPQA-Diamond | 89.52 (FP8) | 89.39 (177/198, 0 unparsed) | disagg-h200 |
+| GPQA-Diamond | 89.52 (FP8) | 87.88 (174/198, 0 unparsed) | agg-h200 |
+
+All four configs score close to their checkpoint's model-card baseline with no
+errors or unparsed answers. (B200 recipes serve the NVFP4 checkpoint; H200
+recipes serve FP8 — compare each row to its own baseline.) The small spread
+between configs (~2-3%) is expected: at temperature=1.0 the model samples
+randomly, so two runs on the same 198 questions will naturally differ by a few
+answers. Statistically, each score over n=198 questions carries a 95% binomial
+confidence interval of about ±4.0-4.6 points, and every model-card baseline
+falls within its config's interval (the largest deviation is 0.75 standard
+errors) — the differences are not a sign that one serving mode or SKU is more
+accurate than another.
+
+¹ Both baselines are from NVIDIA's
+  [GLM-5.2-NVFP4 model card](https://huggingface.co/nvidia/GLM-5.2-NVFP4), measured
+  at temperature 1.0, top_p 0.95, max_new_tokens 100k: NVFP4 89.39 and the FP8
+  baseline 89.52. B200 recipes serve the NVFP4 checkpoint; H200 recipes serve
+  [zai-org/GLM-5.2-FP8](https://huggingface.co/zai-org/GLM-5.2-FP8), whose own card
+  reports 91.2 under Z.ai's harness — the 89.52 baseline is used here because it
+  matches this recipe's sampling.
+² aiperf accuracy mode: simple-evals prompt template (0-shot, deterministic
+  SHA-256 choice shuffling), lighteval letter-extraction grading, same
+  sampling as the card. **Different evaluation tools can produce slightly
+  different scores even on the same model — compare the general range, not
+  exact decimals.** A single run of 198 questions at temperature=1.0 can vary
+  by a few percent between runs.
+
+## How it works
+
+1. `accuracy.yaml` waits for the target deployment, then runs
+   `aiperf profile --accuracy-benchmark gpqa_diamond`: the 198 real
+   GPQA-Diamond questions are sent as ordinary chat requests through the full
+   serving path.
+2. Each response is graded by extracting the chosen A/B/C/D letter
+   (lighteval's extractive matcher) and exact-matching against ground truth.
+   Responses with no extractable letter are counted wrong but flagged
+   `unparsed` — a nonzero unparsed count means formatting/truncation problems,
+   not wrong answers; investigate before trusting the score.
+3. The scored summary prints to the job log and to
+   `/model-cache/accuracy/<epoch>_<job-name>/accuracy_results.csv` on the
+   model-cache PVC (same layout as the perf benchmark).
+
+## Run
+
+```bash
+# glm-5-2-gpqa is a fixed-name Job; clear any prior run before re-applying
+# (e.g. when switching ENDPOINT to a different target).
+kubectl delete job glm-5-2-gpqa -n $NAMESPACE --ignore-not-found
+kubectl apply -f accuracy.yaml -n $NAMESPACE     # edit ENDPOINT to pick a variant
+kubectl logs -f -l app=glm-5-2-gpqa -n $NAMESPACE
+```
+
+## Requirements & caveats
+
+- **Remove `SGLANG_SIMULATE_ACC_LEN`** (and related `SGLANG_SIMULATE_ACC_*`
+  envs) from the deployment if present — it pins synthetic spec-decode
+  acceptance for perf benchmarking and corrupts outputs. Accuracy must be
+  measured with real verification.
+- The HF token in `hf-token-secret` must have accepted the gated
+  [Idavidrein/gpqa](https://huggingface.co/datasets/Idavidrein/gpqa) terms.
+- `MAX_TOKENS=100000`: reasoning chains average ~24k tokens and occasionally
+  approach 100k; a smaller cap truncates chains mid-thought and deflates the
+  score via unparsed answers.
+- Replica counts don't affect accuracy (it's per-request); a minimal 1-replica
+  deployment is sufficient and cheapest.
+- aiperf prints an advisory recommending temperature 0 for reproducibility;
+  temp 1.0 is used deliberately to match the model-card methodology.

--- a/recipes/glm-5.2/accuracy/accuracy.yaml
+++ b/recipes/glm-5.2/accuracy/accuracy.yaml
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# AIPerf GPQA-Diamond accuracy check for glm-5.2 DGDs.
+#
+# One Job covers all variants. Edit ENDPOINT below to select a DGD:
+#   agg-b200-agentic         ENDPOINT=glm52-agg-b200-agentic-frontend:8000  (agg)
+#   agg-h200-agentic         ENDPOINT=glm52-agg-h200-agentic-frontend:8000  (agg)
+#   disagg-b200-agentic      ENDPOINT=glm52-disagg-b200-agentic-frontend:8000  (disagg)
+#   disagg-h200-agentic      ENDPOINT=glm52-disagg-h200-agentic-frontend:8000  (disagg)
+#
+# NOT a perf benchmark: sends the 198 real GPQA-Diamond questions as chat
+# requests through the deployment and grades the answers (simple-evals
+# template, lighteval letter extraction). Compare the score to the
+# checkpoint's model-card GPQA number — see ../accuracy/README.md.
+#
+# Prerequisites:
+# - Target DGD is Ready (see ../README.md); 1-replica deployments suffice
+#   (accuracy is per-request and independent of replica count)
+# - accuracy must be measured WITHOUT synthetic spec-decode acceptance: if
+#   the deployment sets SGLANG_SIMULATE_ACC_LEN (perf-only), remove it first
+# - hf-token-secret token has accepted the gated Idavidrein/gpqa terms
+#
+# Results: /model-cache/accuracy/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glm-5-2-gpqa
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 14400
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: glm-5-2-gpqa
+    spec:
+      # Prefer co-locating the eval pod with the target DGD frontend for
+      # network locality, but schedule anywhere if that node is full
+      # (preferred, not required: frontends often land on busy shared CPU
+      # nodes with no headroom for the eval pod's requests).
+      affinity:
+        podAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: nvidia.com/dynamo-component-type
+                  operator: In
+                  values:
+                  - frontend
+                - key: nvidia.com/dynamo-graph-deployment-name
+                  operator: In
+                  values:
+                  - glm52-disagg-b200-agentic  # Update to match your ENDPOINT target DGD
+              topologyKey: kubernetes.io/hostname
+      # tolerations: # Uncomment and populate for tainted frontend nodes.
+      containers:
+      - name: accuracy
+        # python + pip rather than the NGC aiperf image: the lighteval GPQA
+        # grader requires the aiperf [accuracy] extras, which the runtime
+        # image does not ship.
+        image: python:3.12-slim
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          export COLUMNS=200
+          pip install --no-cache-dir "aiperf[accuracy]==0.11.0" > /dev/null
+          EPOCH=$(date +%s)
+
+          wait_for_model_ready() {
+            python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          endpoint = os.environ["ENDPOINT"]
+          model = os.environ["TARGET_MODEL"]
+          max_attempts = int(os.environ.get("WAIT_FOR_MODEL_MAX_ATTEMPTS", "720"))
+          url = f"http://{endpoint}/v1/models"
+
+          print(f"Waiting for model '{model}' at {url} (max {max_attempts} attempts) ...")
+          for attempt in range(1, max_attempts + 1):
+              try:
+                  with urllib.request.urlopen(url, timeout=5) as response:
+                      payload = json.load(response)
+                  if any(item.get("id") == model for item in payload.get("data", [])):
+                      print(json.dumps(payload, indent=2))
+                      raise SystemExit(0)
+              except Exception:
+                  pass
+
+              if attempt == max_attempts:
+                  break
+              timestamp = time.strftime("%H:%M:%S")
+              print(f"[{timestamp}] not ready (attempt {attempt}/{max_attempts}), sleeping 5s")
+              time.sleep(5)
+
+          raise SystemExit(
+              f"model '{model}' did not become ready after {max_attempts} attempts"
+          )
+          PY
+          }
+
+          wait_for_model_ready
+          RUN_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          mkdir -p "$RUN_DIR"
+          echo "=============================================="
+          echo "GPQA-Diamond Accuracy Check (aiperf)"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Sampling:     temperature=${TEMPERATURE} top_p=${TOP_P} max_tokens=${MAX_TOKENS}"
+          echo "Artifact dir: ${RUN_DIR}"
+          echo "=============================================="
+
+          aiperf profile             -m "$TARGET_MODEL"             --tokenizer "$TARGET_MODEL"             --tokenizer-trust-remote-code             --url "http://$ENDPOINT"             --endpoint-type chat             --accuracy-benchmark gpqa_diamond             --num-requests "$NUM_REQUESTS"             --concurrency "$CONCURRENCY"             --extra-inputs temperature:"$TEMPERATURE"             --extra-inputs top_p:"$TOP_P"             --extra-inputs max_tokens:"$MAX_TOKENS"             --extra-inputs max_completion_tokens:"$MAX_TOKENS"             --request-timeout-seconds 3600             --random-seed 42             --ui simple             --artifact-dir "$RUN_DIR"
+          echo ""
+          echo "===== ACCURACY RESULTS ====="
+          cat "$RUN_DIR"/accuracy_results.csv
+          echo "Done. Artifacts: ${RUN_DIR}"
+        env:
+        # --- Edit ENDPOINT to target one of the glm-5.2 DGDs. ---
+        - name: ENDPOINT
+          value: glm52-disagg-b200-agentic-frontend:8000
+        # --- The remainder is shared across all variants. ---
+        - name: TARGET_MODEL
+          value: zai-org/GLM-5.2
+        # Sampling matches the checkpoint model-card eval methodology; scores
+        # are only comparable under matched sampling. A generous MAX_TOKENS is
+        # required: truncated reasoning chains grade as unparsed/wrong.
+        - name: TEMPERATURE
+          value: "1.0"
+        - name: TOP_P
+          value: "0.95"
+        - name: MAX_TOKENS
+          value: "100000"
+        - name: NUM_REQUESTS
+          value: "198"
+        - name: CONCURRENCY
+          value: "10"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/accuracy
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        envFrom:
+        - secretRef:
+            name: hf-token-secret
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "16"
+            memory: 64Gi
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache


### PR DESCRIPTION
## What
Adds a GPQA-Diamond accuracy check to the GLM-5.2 recipe: an aiperf-based Kubernetes Job that A/B tests a deployed endpoint against the checkpoint's model-card baseline, plus measured results for all four targets and docs.

## Why
The checkpoints the recipe serves are already accuracy-validated ([nvidia/GLM-5.2-NVFP4](https://huggingface.co/nvidia/GLM-5.2-NVFP4) publishes GPQA-Diamond results for the quantized model alongside its FP8 baseline). However, it can still be reassuring to perform a final accuracy check to ensure no bugs have crept in along the path to deployment — a stale env var or misconfigured flag can silently corrupt outputs while throughput looks healthy.

## How
`recipes/glm-5.2/accuracy/accuracy.yaml` runs `aiperf profile --accuracy-benchmark gpqa_diamond`: it sends the 198 GPQA-Diamond questions as chat requests through a deployed DGD and grades each answer (simple-evals prompt, lighteval letter extraction) against ground truth, comparing the score (A) to the checkpoint's published model-card number (B). One Job covers all four targets via the `ENDPOINT` env var. Sampling matches the model-card methodology (temperature 1.0, top_p 0.95, max_new_tokens 100k).

## Results
Measured against the NVIDIA model-card baseline (B200 serves NVFP4, H200 serves FP8), 0 errors and 0 unparsed answers on every run. Each score is a proportion over the same 198 questions, so it carries a binomial 95% confidence interval of ±(1.96·√(p(1−p)/198)) ≈ ±4.0–4.6 points:

| Config | Score | 95% CI | Model card | Card inside CI? |
|---|---:|---|---:|---|
| disagg-b200 | 90.91 (180/198) | [86.9, 94.9] | 89.39 | ✅ |
| agg-b200 | 88.89 (176/198) | [84.5, 93.3] | 89.39 | ✅ |
| disagg-h200 | 89.39 (177/198) | [85.1, 93.7] | 89.52 | ✅ |
| agg-h200 | 87.88 (174/198) | [83.3, 92.4] | 89.52 | ✅ |

Every model-card baseline falls within its config's confidence interval (largest deviation: agg-h200 at 0.75σ below baseline, two-sided p≈0.45). The scores are statistically indistinguishable from the model card. Note the resolution limit: a single n=198 run can detect regressions of roughly ≥4 points — sufficient to catch deployment bugs, which typically cause large drops.

## Testing
- Ran the accuracy Job against all four deployed GLM-5.2 DGDs (B200, H200) — results above.
- `fern check` passes with 0 errors on the docs page.

Fixes #12018

🤖 Generated with [Claude Code](https://claude.com/claude-code)