### PR TITLE
fix(vllm): eliminate measurement-noise sources in FPM self-benchmark …

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -351,17 +351,6 @@ def update_engine_config_with_dynamo(
                 "scheduler_cls"
             ] = "dynamo.vllm.instrumented_scheduler.InstrumentedScheduler"
             logger.info("Benchmark mode: auto-enabling InstrumentedScheduler")
-        if os.environ.get("DYN_FPM_GC_POLICY"):
-            existing_ext = getattr(engine_config, "worker_extension_cls", None)
-            if not existing_ext:
-                from dynamo.vllm.gc_policy import WORKER_EXTENSION_CLS
-
-                defaults["worker_extension_cls"] = WORKER_EXTENSION_CLS
-                logger.info(
-                    "Benchmark mode: DYN_FPM_GC_POLICY set, injecting "
-                    "worker_extension_cls=%s",
-                    WORKER_EXTENSION_CLS,
-                )
         elif existing_cls is not None and "InstrumentedScheduler" not in str(
             existing_cls
         ):
@@ -370,6 +359,27 @@ def update_engine_config_with_dynamo(
                 f"--scheduler-cls is set to '{existing_cls}'. Either remove "
                 f"--scheduler-cls or use a subclass of InstrumentedScheduler."
             )
+        if os.environ.get("DYN_FPM_GC_POLICY"):
+            # Class path as a literal, not an import: importing
+            # dynamo.vllm.gc_policy auto-starts the policy in the importing
+            # process, and this launcher process must stay untouched.
+            worker_extension_cls = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
+            existing_ext = getattr(engine_config, "worker_extension_cls", None)
+            if not existing_ext:
+                defaults["worker_extension_cls"] = worker_extension_cls
+                logger.info(
+                    "Benchmark mode: DYN_FPM_GC_POLICY set, injecting "
+                    "worker_extension_cls=%s",
+                    worker_extension_cls,
+                )
+            elif str(existing_ext) != worker_extension_cls:
+                raise ValueError(
+                    f"DYN_FPM_GC_POLICY requires "
+                    f"worker_extension_cls='{worker_extension_cls}' so model "
+                    f"workers apply the GC policy, but --worker-extension-cls "
+                    f"is set to '{existing_ext}'. Remove it or unset "
+                    f"DYN_FPM_GC_POLICY."
+                )
         benchmark_config: Dict[str, Any] = {
             "mode": dynamo_config.benchmark_mode,
             "warmup_iterations": dynamo_config.benchmark_warmup_iterations,

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -351,6 +351,17 @@ def update_engine_config_with_dynamo(
                 "scheduler_cls"
             ] = "dynamo.vllm.instrumented_scheduler.InstrumentedScheduler"
             logger.info("Benchmark mode: auto-enabling InstrumentedScheduler")
+        if os.environ.get("DYN_FPM_GC_POLICY"):
+            existing_ext = getattr(engine_config, "worker_extension_cls", None)
+            if not existing_ext:
+                from dynamo.vllm.gc_policy import WORKER_EXTENSION_CLS
+
+                defaults["worker_extension_cls"] = WORKER_EXTENSION_CLS
+                logger.info(
+                    "Benchmark mode: DYN_FPM_GC_POLICY set, injecting "
+                    "worker_extension_cls=%s",
+                    WORKER_EXTENSION_CLS,
+                )
         elif existing_cls is not None and "InstrumentedScheduler" not in str(
             existing_cls
         ):

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -33,8 +33,9 @@ Coverage:
     imports this module inside every worker, which auto-starts the
     policy (no collective_rpc required). The RPC methods remain
     available for explicit control.
-  * engine-core process - ``InstrumentedScheduler`` imports this module
-    and calls :func:`start_gc_policy` when benchmarking starts.
+  * engine-core process - ``InstrumentedScheduler`` imports this module,
+    calls :func:`start_gc_policy` when benchmarking starts, and
+    :func:`stop_gc_policy` when it deactivates.
 """
 
 from __future__ import annotations
@@ -43,12 +44,14 @@ import gc
 import logging
 import os
 import threading
-import time
 
 logger = logging.getLogger(__name__)
 
 _lock = threading.Lock()
 _started = False
+_stop_event: threading.Event | None = None
+_freeze_thread: threading.Thread | None = None
+_saved_gen2_threshold: int | None = None
 
 WORKER_EXTENSION_CLS = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
 
@@ -68,15 +71,21 @@ def _interval_seconds() -> float:
 
 
 def gc_maintain() -> int:
-    """Collect unfrozen cycles, then freeze survivors. Returns frozen count."""
+    """Reclaim cyclic garbage from an untimed window, then re-freeze.
+
+    Unfreeze first: the periodic ticks freeze unreachable-but-uncollected
+    cycles into the permanent generation, which ``gc.collect()`` never
+    scans. The full-heap walk this costs is why callers must be outside
+    any measured window.
+    """
+    gc.unfreeze()
     gc.collect()
     gc.freeze()
     return gc.get_freeze_count()
 
 
-def _freeze_loop(interval: float) -> None:
-    while True:
-        time.sleep(interval)
+def _freeze_loop(interval: float, stop: threading.Event) -> None:
+    while not stop.wait(interval):
         try:
             # freeze only: O(1) generation-list splice, no heap traversal,
             # no pause. Never collect on the timer (a periodic collect walks
@@ -90,7 +99,7 @@ def _freeze_loop(interval: float) -> None:
 
 def start_gc_policy() -> bool:
     """Idempotently start the env-gated freeze loop in this process."""
-    global _started
+    global _started, _stop_event, _freeze_thread, _saved_gen2_threshold
     if _policy() != "freeze":
         return False
     with _lock:
@@ -100,14 +109,18 @@ def start_gc_policy() -> bool:
         # source: they walk every tracked object and grow with the heap
         # (measured 0.4s -> 9s over a sweep). Disable them outright; gen0/1
         # stay enabled and only walk objects younger than the last freeze.
-        t0, t1, _t2 = gc.get_threshold()
+        t0, t1, _saved_gen2_threshold = gc.get_threshold()
         gc.set_threshold(t0, t1, 1 << 30)
         gc.freeze()
         interval = _interval_seconds()
-        thread = threading.Thread(
-            target=_freeze_loop, args=(interval,), name="fpm-gc-freeze", daemon=True
+        _stop_event = threading.Event()
+        _freeze_thread = threading.Thread(
+            target=_freeze_loop,
+            args=(interval, _stop_event),
+            name="fpm-gc-freeze",
+            daemon=True,
         )
-        thread.start()
+        _freeze_thread.start()
         _started = True
     logger.info(
         "FPM GC policy active: auto-gen2 disabled, gc.freeze() every %.0fs (pid=%d)",
@@ -117,11 +130,36 @@ def start_gc_policy() -> bool:
     return True
 
 
+def stop_gc_policy() -> None:
+    """Restore normal GC once benchmarking ends: stop the freeze loop,
+    re-enable automatic gen2 collections, and reclaim everything frozen so
+    far. Idempotent; no-op if the policy never started."""
+    global _started, _stop_event, _freeze_thread, _saved_gen2_threshold
+    with _lock:
+        if not _started:
+            return
+        _stop_event.set()
+        thread = _freeze_thread
+        t0, t1, _ = gc.get_threshold()
+        gc.set_threshold(t0, t1, _saved_gen2_threshold)
+        _started = False
+        _stop_event = None
+        _freeze_thread = None
+        _saved_gen2_threshold = None
+    thread.join(timeout=5.0)
+    gc.unfreeze()
+    gc.collect()
+    logger.info("FPM GC policy stopped: auto-gen2 restored (pid=%d)", os.getpid())
+
+
 class FpmGcWorkerExtension:
     """vLLM worker extension exposing GC control inside worker processes."""
 
     def fpm_gc_start(self) -> bool:
         return start_gc_policy()
+
+    def fpm_gc_stop(self) -> None:
+        return stop_gc_policy()
 
     def fpm_gc_maintain(self) -> int:
         return gc_maintain()

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -53,8 +53,6 @@ _stop_event: threading.Event | None = None
 _freeze_thread: threading.Thread | None = None
 _saved_gen2_threshold: int | None = None
 
-WORKER_EXTENSION_CLS = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
-
 
 def _policy() -> str:
     return os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower()
@@ -165,7 +163,10 @@ class FpmGcWorkerExtension:
         return gc_maintain()
 
 
-# Auto-start in any process that imports this module (worker processes
-# import it while resolving worker_extension_cls; the engine-core process
-# via InstrumentedScheduler). No-op unless DYN_FPM_GC_POLICY is set.
+# Auto-start when a worker process imports this module while resolving
+# worker_extension_cls (args.py injects the class path as a literal for the
+# same reason: importing this module starts the policy in the importing
+# process). The engine-core process instead imports lazily and starts from
+# InstrumentedScheduler._bench_init, so serving without an active benchmark
+# never runs the policy. No-op unless DYN_FPM_GC_POLICY is set.
 start_gc_policy()

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -1,0 +1,133 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GC pause mitigation for FPM self-benchmarking.
+
+CPython gen2 (full) collections walk every tracked object and trigger on
+the 25% long-lived-growth rule, so their pauses grow with the heap: over a
+30k-point benchmark sweep we measured pauses rising from ~0.4s to ~9s at
+geometrically spaced iteration indices (ratio ~1.23), inside the vLLM
+worker processes. Under TP/DP lockstep a single worker's pause stalls the
+whole forward pass, and with the scheduler's host-side wall_time it lands
+in the measured latency as a 3-200x outlier.
+
+``gc.freeze()`` moves currently tracked objects into the permanent
+generation, excluding them from future collections: after a periodic
+freeze, gen2 only walks objects allocated since the previous tick, so the
+pause is bounded by the allocation rate instead of total heap size.
+The policy's only goal is keeping GC pauses out of measured wall_time:
+automatic gen2 collections are disabled entirely and the periodic tick
+only freezes (no traversal, no pause). Cyclic garbage is therefore NOT
+reclaimed while the policy is active - acceptable for benchmark sweeps;
+long-running processes can reclaim it by calling :func:`gc_maintain`
+from an untimed window.
+
+The policy is env-gated and off by default:
+
+  DYN_FPM_GC_POLICY=freeze        enable the periodic freeze loop
+  DYN_FPM_GC_FREEZE_INTERVAL_S=60 tick interval in seconds
+
+Coverage:
+  * worker processes  - pass ``--worker-extension-cls
+    dynamo.vllm.gc_policy.FpmGcWorkerExtension``; resolving the class
+    imports this module inside every worker, which auto-starts the
+    policy (no collective_rpc required). The RPC methods remain
+    available for explicit control.
+  * engine-core process - ``InstrumentedScheduler`` imports this module
+    and calls :func:`start_gc_policy` when benchmarking starts.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_started = False
+
+WORKER_EXTENSION_CLS = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
+
+
+def _policy() -> str:
+    return os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower()
+
+
+def _interval_seconds() -> float:
+    raw = os.environ.get("DYN_FPM_GC_FREEZE_INTERVAL_S", "60")
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("invalid DYN_FPM_GC_FREEZE_INTERVAL_S=%r, using 60", raw)
+        return 60.0
+    return max(1.0, value)
+
+
+def gc_maintain() -> int:
+    """Collect unfrozen cycles, then freeze survivors. Returns frozen count."""
+    gc.collect()
+    gc.freeze()
+    return gc.get_freeze_count()
+
+
+def _freeze_loop(interval: float) -> None:
+    while True:
+        time.sleep(interval)
+        try:
+            # freeze only: O(1) generation-list splice, no heap traversal,
+            # no pause. Never collect on the timer (a periodic collect walks
+            # the unfrozen heap) and never call gc.get_freeze_count() here
+            # (it walks the whole permanent generation: measured 0.4-4s
+            # pauses once millions of objects are frozen).
+            gc.freeze()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("fpm gc tick failed")
+
+
+def start_gc_policy() -> bool:
+    """Idempotently start the env-gated freeze loop in this process."""
+    global _started
+    if _policy() != "freeze":
+        return False
+    with _lock:
+        if _started:
+            return True
+        # One-time setup. Automatic full (gen2) collections are the pause
+        # source: they walk every tracked object and grow with the heap
+        # (measured 0.4s -> 9s over a sweep). Disable them outright; gen0/1
+        # stay enabled and only walk objects younger than the last freeze.
+        t0, t1, _t2 = gc.get_threshold()
+        gc.set_threshold(t0, t1, 1 << 30)
+        gc.freeze()
+        interval = _interval_seconds()
+        thread = threading.Thread(
+            target=_freeze_loop, args=(interval,), name="fpm-gc-freeze", daemon=True
+        )
+        thread.start()
+        _started = True
+    logger.info(
+        "FPM GC policy active: auto-gen2 disabled, gc.freeze() every %.0fs (pid=%d)",
+        interval,
+        os.getpid(),
+    )
+    return True
+
+
+class FpmGcWorkerExtension:
+    """vLLM worker extension exposing GC control inside worker processes."""
+
+    def fpm_gc_start(self) -> bool:
+        return start_gc_policy()
+
+    def fpm_gc_maintain(self) -> int:
+        return gc_maintain()
+
+
+# Auto-start in any process that imports this module (worker processes
+# import it while resolving worker_extension_cls; the engine-core process
+# via InstrumentedScheduler). No-op unless DYN_FPM_GC_POLICY is set.
+start_gc_policy()

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -136,15 +136,20 @@ def stop_gc_policy() -> None:
     with _lock:
         if not _started:
             return
-        _stop_event.set()
+        stop_event = _stop_event
         thread = _freeze_thread
-        t0, t1, _ = gc.get_threshold()
-        gc.set_threshold(t0, t1, _saved_gen2_threshold)
+        saved_gen2_threshold = _saved_gen2_threshold
+        if stop_event is not None:
+            stop_event.set()
+        if saved_gen2_threshold is not None:
+            t0, t1, _ = gc.get_threshold()
+            gc.set_threshold(t0, t1, saved_gen2_threshold)
         _started = False
         _stop_event = None
         _freeze_thread = None
         _saved_gen2_threshold = None
-    thread.join(timeout=5.0)
+    if thread is not None:
+        thread.join(timeout=5.0)
     gc.unfreeze()
     gc.collect()
     logger.info("FPM GC policy stopped: auto-gen2 restored (pid=%d)", os.getpid())

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1624,11 +1624,12 @@ class InstrumentedScheduler(AsyncScheduler):
 
     def _bench_init(self, vllm_config: "VllmConfig") -> None:
         """Parse benchmark config and initialise state machine."""
-        _fpm_gc_policy.start_gc_policy()
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if not bench_cfg:
             self._bench_active = False
             return
+
+        _fpm_gc_policy.start_gc_policy()
 
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
         raw_mode = cfg.get("mode", "agg")
@@ -1889,7 +1890,28 @@ class InstrumentedScheduler(AsyncScheduler):
                     logger.warning("Benchmark decode phase generated no points")
         warmup_points = self._bench_eager_warmup_points()
         if warmup_points:
-            self._bench_grid.extendleft(reversed(warmup_points))
+            # _bench_pop_next() treats a type mismatch at the queue front as
+            # "phase complete", so each warmup block must stay contiguous
+            # with its phase's real block; mixed-type warmups prepended as a
+            # single run would end PREFILL_SWEEP at the first decode warmup
+            # and DECODE_SWEEP at the first real prefill point.
+            warmup = {
+                point_type: [
+                    point for point in warmup_points if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            real = {
+                point_type: [
+                    point
+                    for point in self._bench_grid
+                    if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            self._bench_grid = deque(
+                warmup["prefill"] + real["prefill"] + warmup["decode"] + real["decode"]
+            )
             logger.info(
                 "Benchmark grid: prepending %d eager-shape warmup point(s); "
                 "their results are discarded",
@@ -2884,6 +2906,9 @@ class InstrumentedScheduler(AsyncScheduler):
         self._last_update_time = 0.0
         if resume_publisher:
             self._publisher.resume()
+        # Benchmark over: re-enable automatic gen2 collections and reclaim
+        # the frozen heap before regular serving resumes.
+        _fpm_gc_policy.stop_gc_policy()
 
     def _bench_abort(self, error: Exception) -> None:
         if self._bench_synchronizer is not None:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -112,7 +112,6 @@ from dynamo.common.forward_pass_metrics import (
     encode,
 )
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.vllm import gc_policy as _fpm_gc_policy
 from dynamo.vllm.benchmark_points import (
     BENCHMARK_MODES,
     BenchmarkMode,
@@ -1629,6 +1628,8 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_active = False
             return
 
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
         _fpm_gc_policy.start_gc_policy()
 
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
@@ -2908,6 +2909,8 @@ class InstrumentedScheduler(AsyncScheduler):
             self._publisher.resume()
         # Benchmark over: re-enable automatic gen2 collections and reclaim
         # the frozen heap before regular serving resumes.
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
         _fpm_gc_policy.stop_gc_policy()
 
     def _bench_abort(self, error: Exception) -> None:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -89,7 +89,7 @@ import time
 import uuid
 from collections import deque
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from itertools import count
 from typing import TYPE_CHECKING, cast
@@ -112,6 +112,7 @@ from dynamo.common.forward_pass_metrics import (
     encode,
 )
 from dynamo.runtime.logging import configure_dynamo_logging
+from dynamo.vllm import gc_policy as _fpm_gc_policy
 from dynamo.vllm.benchmark_points import (
     BENCHMARK_MODES,
     BenchmarkMode,
@@ -163,6 +164,9 @@ class _BenchPhase(enum.Enum):
     PREFILL_SWEEP = "prefill_sweep"
     DECODE_SWEEP = "decode_sweep"
     DONE = "done"
+
+
+EAGER_WARMUP_REASON = "eager_warmup"
 
 
 @dataclass
@@ -1620,6 +1624,7 @@ class InstrumentedScheduler(AsyncScheduler):
 
     def _bench_init(self, vllm_config: "VllmConfig") -> None:
         """Parse benchmark config and initialise state machine."""
+        _fpm_gc_policy.start_gc_policy()
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if not bench_cfg:
             self._bench_active = False
@@ -1828,6 +1833,38 @@ class InstrumentedScheduler(AsyncScheduler):
 
     # -- Grid generation ------------------------------------------------
 
+    def _bench_eager_warmup_points(self) -> list[BenchmarkPoint]:
+        """One discarded replica per eager shape, executed before the sweep.
+
+        Captured shapes are executed during cudagraph capture at startup, so
+        their one-time per-shape costs (first kernel launch and selection,
+        allocator pool growth) are paid before any measurement. Eager shapes
+        (no capture available) get no such implicit warmup: their first
+        execution pays a ~1s one-off (measured 1126ms vs 147ms warm on
+        decode batch 513) and a single-sample sweep books that cost as the
+        point's latency. Prepending one replica per eager shape - deduped by
+        the shape driver: token count for prefill, batch size for decode -
+        puts eager and captured points on the same footing. Replicas run
+        through the normal injection/lockstep/validation path on every rank
+        (grids stay identical by construction) and are dropped at save time.
+        """
+        seen: set[tuple[str, int]] = set()
+        replicas: list[BenchmarkPoint] = []
+        for point in self._bench_grid:
+            if point.expected_capture_size is not None:
+                continue
+            key = (
+                point.point_type,
+                point.total_prefill_tokens
+                if point.point_type == "prefill"
+                else point.batch_size,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            replicas.append(replace(point, sample_reasons=[EAGER_WARMUP_REASON]))
+        return replicas
+
     def _bench_build_grid(self) -> None:
         """Generate the sweep grid once scheduler limits are known."""
         if self._bench_grid_built:
@@ -1850,9 +1887,29 @@ class InstrumentedScheduler(AsyncScheduler):
                 if len(self._bench_grid) == points_before:
                     self._bench_missing_phases.append("decode")
                     logger.warning("Benchmark decode phase generated no points")
-        self._bench_expected_points = len(self._bench_grid)
-        for benchmark_id, point in enumerate(self._bench_grid, start=1):
-            point.benchmark_id = benchmark_id
+        warmup_points = self._bench_eager_warmup_points()
+        if warmup_points:
+            self._bench_grid.extendleft(reversed(warmup_points))
+            logger.info(
+                "Benchmark grid: prepending %d eager-shape warmup point(s); "
+                "their results are discarded",
+                len(warmup_points),
+            )
+        self._bench_expected_points = len(self._bench_grid) - len(warmup_points)
+        # Published results must carry contiguous benchmark IDs starting at 1
+        # (the native-artifact contract), so real points are numbered first;
+        # discarded warmup replicas take IDs after the real range. counter_id
+        # stamping uses point.benchmark_id directly, so execution order and
+        # ID order are independent.
+        real_id = 0
+        warmup_id = self._bench_expected_points
+        for point in self._bench_grid:
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                warmup_id += 1
+                point.benchmark_id = warmup_id
+            else:
+                real_id += 1
+                point.benchmark_id = real_id
         grid_payload = json.dumps(
             [asdict(point) for point in self._bench_grid],
             sort_keys=True,
@@ -3240,6 +3297,17 @@ class InstrumentedScheduler(AsyncScheduler):
                     reason,
                 )
                 self._bench_skip_point(point, reason)
+                self._bench_current_point = None
+                self._bench_current_fpms = []
+                self._bench_point_deadline = 0.0
+                if group_result.stop_requested:
+                    self._bench_request_timeout_stop(point)
+                return
+
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                logger.debug(
+                    "Discarding eager-shape warmup result: %s", point
+                )
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3330,9 +3330,7 @@ class InstrumentedScheduler(AsyncScheduler):
                 return
 
             if EAGER_WARMUP_REASON in point.sample_reasons:
-                logger.debug(
-                    "Discarding eager-shape warmup result: %s", point
-                )
+                logger.debug("Discarding eager-shape warmup result: %s", point)
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -117,18 +117,45 @@ def test_eager_warmup_points_dedupe_and_flag():
     )
 
     grid = [
-        BenchmarkPoint(point_type="decode", batch_size=513, total_kv_read_tokens=513,
-                       expected_capture_size=None),
-        BenchmarkPoint(point_type="decode", batch_size=513, total_kv_read_tokens=2048,
-                       expected_capture_size=None),
-        BenchmarkPoint(point_type="decode", batch_size=512, total_kv_read_tokens=512,
-                       expected_capture_size=512),
-        BenchmarkPoint(point_type="prefill", batch_size=1, total_prefill_tokens=1024,
-                       total_kv_read_tokens=0, expected_capture_size=None),
-        BenchmarkPoint(point_type="prefill", batch_size=2, total_prefill_tokens=1024,
-                       total_kv_read_tokens=4096, expected_capture_size=None),
-        BenchmarkPoint(point_type="prefill", batch_size=1, total_prefill_tokens=256,
-                       total_kv_read_tokens=0, expected_capture_size=256),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=513,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=2048,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=512,
+            total_kv_read_tokens=512,
+            expected_capture_size=512,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=0,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=2,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=4096,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=256,
+            total_kv_read_tokens=0,
+            expected_capture_size=256,
+        ),
     ]
     stub = SimpleNamespace(_bench_grid=grid)
     replicas = InstrumentedScheduler._bench_eager_warmup_points(stub)

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import importlib
+
+import pytest
+
+pytestmark = pytest.mark.pre_merge
+
+
+def _fresh_module(monkeypatch, policy: str | None):
+    if policy is None:
+        monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
+    else:
+        monkeypatch.setenv("DYN_FPM_GC_POLICY", policy)
+    import dynamo.vllm.gc_policy as gc_policy
+
+    return importlib.reload(gc_policy)
+
+
+def test_policy_off_by_default(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    assert gc_policy.start_gc_policy() is False
+
+
+def test_policy_starts_and_is_idempotent(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    try:
+        assert gc_policy.start_gc_policy() is True
+        assert gc_policy.start_gc_policy() is True
+        assert gc.get_threshold()[2] == 1 << 30, "auto gen2 must be disabled"
+    finally:
+        gc.set_threshold(*thresholds)
+        gc.unfreeze()
+
+
+def test_gc_maintain_freezes_objects(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    gc.unfreeze()
+    try:
+        frozen = gc_policy.gc_maintain()
+        assert frozen > 0
+        assert frozen == gc.get_freeze_count()
+    finally:
+        gc.unfreeze()
+
+
+def test_worker_extension_methods(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    ext = gc_policy.FpmGcWorkerExtension()
+    assert ext.fpm_gc_start() is False
+    gc.unfreeze()
+    try:
+        assert ext.fpm_gc_maintain() > 0
+    finally:
+        gc.unfreeze()
+
+
+def test_invalid_interval_falls_back(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "not-a-number")
+    gc_policy = _fresh_module(monkeypatch, None)
+    assert gc_policy._interval_seconds() == 60.0
+
+
+def test_eager_warmup_points_dedupe_and_flag():
+    from types import SimpleNamespace
+
+    from dynamo.vllm.instrumented_scheduler import (
+        EAGER_WARMUP_REASON,
+        BenchmarkPoint,
+        InstrumentedScheduler,
+    )
+
+    grid = [
+        BenchmarkPoint(point_type="decode", batch_size=513, total_kv_read_tokens=513,
+                       expected_capture_size=None),
+        BenchmarkPoint(point_type="decode", batch_size=513, total_kv_read_tokens=2048,
+                       expected_capture_size=None),
+        BenchmarkPoint(point_type="decode", batch_size=512, total_kv_read_tokens=512,
+                       expected_capture_size=512),
+        BenchmarkPoint(point_type="prefill", batch_size=1, total_prefill_tokens=1024,
+                       total_kv_read_tokens=0, expected_capture_size=None),
+        BenchmarkPoint(point_type="prefill", batch_size=2, total_prefill_tokens=1024,
+                       total_kv_read_tokens=4096, expected_capture_size=None),
+        BenchmarkPoint(point_type="prefill", batch_size=1, total_prefill_tokens=256,
+                       total_kv_read_tokens=0, expected_capture_size=256),
+    ]
+    stub = SimpleNamespace(_bench_grid=grid)
+    replicas = InstrumentedScheduler._bench_eager_warmup_points(stub)
+
+    assert [(p.point_type, p.batch_size, p.total_prefill_tokens) for p in replicas] == [
+        ("decode", 513, 0),
+        ("prefill", 1, 1024),
+    ]
+    assert all(p.sample_reasons == [EAGER_WARMUP_REASON] for p in replicas)
+    # originals untouched
+    assert all(EAGER_WARMUP_REASON not in p.sample_reasons for p in grid)

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -3,10 +3,16 @@
 
 import gc
 import importlib
+import weakref
 
 import pytest
 
-pytestmark = pytest.mark.pre_merge
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
 
 
 def _fresh_module(monkeypatch, policy: str | None):
@@ -33,8 +39,22 @@ def test_policy_starts_and_is_idempotent(monkeypatch):
         assert gc_policy.start_gc_policy() is True
         assert gc.get_threshold()[2] == 1 << 30, "auto gen2 must be disabled"
     finally:
-        gc.set_threshold(*thresholds)
-        gc.unfreeze()
+        gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds, "stop must restore the thresholds"
+
+
+def test_stop_is_idempotent_and_allows_restart(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    assert gc_policy.start_gc_policy() is True
+    gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds
+    gc_policy.stop_gc_policy()  # no-op when already stopped
+    assert gc.get_threshold() == thresholds
+    assert gc_policy.start_gc_policy() is True, "restart after stop"
+    gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds
 
 
 def test_gc_maintain_freezes_objects(monkeypatch):
@@ -45,6 +65,28 @@ def test_gc_maintain_freezes_objects(monkeypatch):
         assert frozen > 0
         assert frozen == gc.get_freeze_count()
     finally:
+        gc.unfreeze()
+
+
+def test_gc_maintain_reclaims_cycles_frozen_by_earlier_ticks(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+
+    class Node:
+        pass
+
+    gc.disable()
+    try:
+        node = Node()
+        node.self_ref = node
+        ref = weakref.ref(node)
+        del node
+        # Simulate a periodic tick freezing the still-uncollected cycle
+        # into the permanent generation.
+        gc.freeze()
+        gc_policy.gc_maintain()
+        assert ref() is None, "cycles frozen by a tick must still be reclaimed"
+    finally:
+        gc.enable()
         gc.unfreeze()
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -34,9 +34,9 @@ from vllm.v1.request import RequestStatus  # noqa: E402
 import dynamo.vllm.instrumented_scheduler as instrumented_scheduler_module  # noqa: E402
 from dynamo.vllm.benchmark_points import BenchmarkPoints  # noqa: E402
 from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
+    EAGER_WARMUP_REASON,
     BenchmarkConfig,
     BenchmarkPoint,
-    EAGER_WARMUP_REASON,
     InstrumentedScheduler,
     SkippedBenchmarkPoint,
     _BenchPhase,

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1905,6 +1905,44 @@ def test_agg_grid_contains_piecewise_prefill_then_full_decode_points():
     } == {"FULL"}
 
 
+def test_agg_eager_warmups_stay_contiguous_with_their_phase():
+    """``_bench_pop_next()`` treats a type mismatch at the queue front as
+    "phase complete", so eager warmups of both types prepended as a single
+    run would end PREFILL_SWEEP at the first decode warmup and DECODE_SWEEP
+    at the first real prefill point, silently dropping every real point."""
+    stub = _prefill_grid_stub()
+    stub._bench_grid = deque()
+    stub._bench_grid_built = False
+    stub._bench_missing_phases = []
+    stub._bench_grid_error = None
+    stub._bench_feasible_max_decode_batch_size = 0
+    stub._bench_config.mode = "agg"
+    stub._bench_explicit_points = None
+    # Captures end below the feasible max batch so decode also has eager
+    # shapes; prefill already has them (max tokens 40 > largest capture 16).
+    stub._bench_decode_capture_sizes = [1, 2, 4]
+    stub._bench_decode_cudagraph_mode = "FULL"
+
+    InstrumentedScheduler._bench_build_grid(stub)
+
+    points = list(stub._bench_grid)
+    warmup_types = {
+        point.point_type
+        for point in points
+        if instrumented_scheduler_module.EAGER_WARMUP_REASON in point.sample_reasons
+    }
+    assert warmup_types == {"prefill", "decode"}, "need warmups on both phases"
+
+    # Drain the grid exactly as the phase machine does: prefill until the
+    # front stops matching, then decode.
+    drained = 0
+    for phase in ("prefill", "decode"):
+        while InstrumentedScheduler._bench_pop_next(stub, phase) is not None:
+            drained += 1
+    assert not stub._bench_grid, "phase transitions must consume every point"
+    assert drained == len(points)
+
+
 def test_prefill_kv_read_ladder_is_total_block_aligned():
     stub = _prefill_grid_stub(block_size=8)
 

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -36,6 +36,7 @@ from dynamo.vllm.benchmark_points import BenchmarkPoints  # noqa: E402
 from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
     BenchmarkConfig,
     BenchmarkPoint,
+    EAGER_WARMUP_REASON,
     InstrumentedScheduler,
     SkippedBenchmarkPoint,
     _BenchPhase,
@@ -1344,8 +1345,13 @@ def test_benchmark_grid_has_no_point_cap():
     InstrumentedScheduler._bench_build_grid(stub)
 
     assert stub._bench_expected_points == 4097
-    assert len(stub._bench_grid) == 4097
-    assert [point.benchmark_id for point in stub._bench_grid] == list(range(1, 4098))
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    assert len(real_points) == 4097
+    assert [point.benchmark_id for point in real_points] == list(range(1, 4098))
     assert stub._bench_grid_error is None
 
 
@@ -1370,7 +1376,21 @@ def test_benchmark_grid_assigns_stable_contiguous_ids_and_digest():
 
     InstrumentedScheduler._bench_build_grid(stub)
 
-    assert [point.benchmark_id for point in stub._bench_grid] == [1, 2]
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    warmup_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON in point.sample_reasons
+    ]
+    # Real points own the contiguous 1..N range (native-artifact contract);
+    # discarded eager-warmup replicas take IDs after the real range even
+    # though they execute first.
+    assert [point.benchmark_id for point in real_points] == [1, 2]
+    assert [point.benchmark_id for point in warmup_points] == [3, 4]
     assert len(stub._bench_grid_digest) == 64
 
 


### PR DESCRIPTION


## Overview:

Single-sample self-benchmark `wall_time` measurements are intermittently poisoned by 3–200× outliers, forcing expensive workarounds (measure-N-times-take-median). We root-caused **two independent mechanisms** and fix both, making single-sample collection reach median-of-5 database quality at ~1/3.5 the cost:

1. **CPython gen2 (full) GC inside the engine processes.** A gen2 pass walks every tracked object, so its pause grows with the heap — measured **0.4 s → 9 s** over a 30 k-point sweep — and under TP/DP lockstep a single worker's pause stalls the whole forward pass. Triggers follow CPython's 25 % long-lived-growth rule, producing outliers at geometrically spaced, run-independent iteration indices (ratio ≈ 1.23, identical across nodes/days/topologies) at a fleet-constant ~0.08 %/sample rate.
2. **Eager-shape first-execution cost.** Shapes beyond the cudagraph capture range pay a ~1 s one-off on their first execution — five consecutive repeats of decode batch 513 read `[1126, 147, 147, 144, 144]` ms. Captured shapes are immune because capture itself executes them at startup; a single-sample sweep books the one-off as the eager point's latency.

## Details:

**GC policy (env-gated, off by default — zero behavior change unless enabled):**
- New `dynamo/vllm/gc_policy.py`: on activation, disable automatic gen2 (`gc.set_threshold(t0, t1, 1<<30)`), `gc.freeze()` the engine-init heap once, then run a daemon thread executing a **bare `gc.freeze()`** per tick (O(1) generation-list splice: no traversal, no pause). `gc_maintain()` (collect+freeze) is provided for explicit reclamation from untimed windows.
- Worker processes are covered via vLLM's `worker_extension_cls` (`FpmGcWorkerExtension`, auto-injected in benchmark mode when `DYN_FPM_GC_POLICY` is set and the user configured no extension — collision-safe); the engine-core process starts the policy from `InstrumentedScheduler._bench_init`. No vLLM changes.
- Two rejected variants are documented in the module docstring (both reproduce measurable stalls): periodic `gc.collect()` re-introduces growing full-heap walks (outlier rate 0.082 % → 0.712 %), and per-tick `gc.get_freeze_count()` walks the whole permanent generation (0.4–4 s once millions of objects are frozen).

**Eager-shape warmup (benchmark mode only):**
- `_bench_build_grid` prepends one **discarded warmup replica** per eager shape, deduped by the shape driver (token count for prefill, batch size for decode; typically a handful of replicas ≈ +10 s bring-up).
- Replicas run the normal injection/lockstep/validation path on every rank — DP grids stay identical by construction — and are dropped at save time. Published benchmark IDs stay contiguous (native-artifact contract) because real points are numbered first; `counter_id` stamping uses `point.benchmark_id` directly, so execution order and ID order are independent.

### Validation (GLM-5.2-NVFP4, 4×B200, vLLM 0.25.1)

**Stage 1+2 — A/B on identical 30 480-measurement sweeps** (same node, same GPUs, same point list; only the GC policy toggled):

| run | outliers >3× coordinate median | max pause |
|---|---|---|
| baseline | 25 (0.082 %) — geometric gen2 ladder | **8 900 ms** |
| GC policy on | 2 (0.007 %) | 1 131 ms |

The 2 residual outliers are exactly the first samples of the two eager shapes (decode batch 513 / 1024): their 5 consecutive repeats read `[1126, 147, 147, 144, 144]` ms — first execution pays the one-off, the rest are warm. That is the fingerprint fix 2 targets.

**Stage 3 — both fixes, fresh standard single-sample collection** (the production protocol):

| metric | before fixes | after both fixes |
|---|---|---|
| curve-neighbor poisoned rows (whole DB) | 12, worst 34× | **0** |
| eager decode points (B=513 / B=1024, min-KV) | 1 216 / 1 184 ms (first-touch) | **190 / 185 ms (warm)** |
| LOO prefill (4 097 pts) | 8.02 % / max 2 913 % | **4.74 % / max 125 %** (median-of-5 reference: 4.17 % / 129 %) |
| holdout vs frozen truths (509 pts) | 2.77 % / max 37.8 % | **2.24 % / max 12.2 %** (reference: 1.96 % / 13.5 %) |

Single-sample collection reaches median-of-5 database quality at ~1/3.5 the cost.

**End-to-end, fresh standard single-sample collections with both fixes:**

- curve-neighbor poisoned rows: **12 → 0**
- the two eager decode points read **190 / 185 ms (warm)** vs 1216 / 1184 ms first-touch before
- LOO prefill **4.74 % / max 125 %** and holdout-vs-frozen-truths **2.24 % / max 12.2 %** match the median-of-5 reference (4.17 % / 129 %; 1.96 % / 13.5 %) — at ~1/3.5 the collection cost

No sweep-duration regression, no change to the non-outlier latency distribution, no OOM across four full sweeps with gen2 disabled (worker RSS ≈ +1–2 GB/h, decelerating).

## Where should the reviewer start?

- `components/src/dynamo/vllm/gc_policy.py` — the GC policy incl. design rationale in the module docstring
- `components/src/dynamo/vllm/instrumented_scheduler.py` — `_bench_eager_warmup_points`, the save-time discard, ID numbering; 2-line GC hook in `_bench_init`
- `components/src/dynamo/vllm/args.py` — benchmark-mode `worker_extension_cls` injection
- `components/src/dynamo/vllm/tests/test_gc_policy.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12020" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional garbage-collection policy to improve benchmark stability and reduce pauses.
  * Added configurable background memory maintenance, with manual maintenance controls available during execution.
  * Added eager warmup for benchmark shapes without CUDA-graph capture.

* **Bug Fixes**
  * Warmup runs are now excluded from reported benchmark results, preventing them from affecting performance metrics.

* **Tests**
  * Added coverage for garbage-collection configuration, maintenance behavior, interval handling, and benchmark warmup processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->