### PR TITLE
docs(fern): snapshot zh-CN translations at v1.3.0

### DIFF
--- a/fern/translations/zh-CN/pages-v1.3.0/components/kvbm/README.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/components/kvbm/README.md
@@ -1,0 +1,63 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: KVBM
+---
+
+Dynamo KV Block Manager (KVBM) 是一个可扩展的运行时组件，旨在为异构和分布式环境中的推理任务处理 Key-Value (KV) 块的内存分配、管理和远程共享。它可作为 vLLM 和 TensorRT-LLM 等框架的统一内存层和直写缓存。
+
+KVBM 提供：
+- 跨 GPU 内存、固定主机内存、远程 RDMA 可访问内存、本地/分布式 SSD，以及远程文件/对象/云存储系统的**统一内存 API**
+- 支持带有基于事件状态转换的**块生命周期**（allocate → register → match）
+- 与 **[NIXL](https://github.com/ai-dynamo/nixl/blob/main/docs/nixl.md)** 集成；NIXL 是一个动态内存交换层，用于内存块的远程注册、共享和访问
+
+> **开始使用：** 请参阅 [KVBM 指南](/dynamo/dev/user-guides/kv-cache-offloading)，了解安装和部署说明。
+
+## 何时使用 KV Cache 卸载
+
+KV Cache 卸载可以避免代价高昂的 KV Cache 重新计算，从而缩短响应时间并改善用户体验。服务提供方可获得更高吞吐量和更低的单 token 成本，使推理服务更具可扩展性且更高效。
+
+当 KV Cache 超出 GPU 内存，并且缓存复用收益超过数据传输开销时，将 KV cache 卸载到 CPU 或存储最为有效。它在以下场景中尤其有价值：
+
+| 场景 | 收益 |
+|----------|---------|
+| **长会话和多轮对话** | 保留较大的提示前缀，避免重新计算，改善首 token 延迟和吞吐量 |
+| **高并发** | 可将空闲或部分进行中的对话移出 GPU 内存，使活跃请求能够继续处理而不会触及内存限制 |
+| **共享或重复内容** | 跨用户或会话复用（系统提示、模板）可提升缓存命中率，尤其适用于远程或跨实例共享 |
+| **内存或成本受限的部署** | 卸载到 RAM 或 SSD 可降低 GPU 需求，无需增加硬件即可支持更长提示或更多用户 |
+
+## 功能支持矩阵
+
+|  | 功能 | 支持 |
+|--|---------|---------|
+| **Backend** | Local | ✅ |
+|  | Kubernetes | ✅ |
+| **LLM Framework** | vLLM | ✅ |
+|  | TensorRT-LLM | ✅ |
+|  | SGLang | ❌ |
+| **Serving Type** | Aggregated | ✅ |
+|  | Disaggregated | ✅ |
+
+## 架构
+
+![KVBM Architecture](../../assets/img/kvbm-components.svg)
+*Dynamo KV Block Manager 的高层分层架构视图，以及它如何与 LLM 推理生态系统中的不同组件交互*
+
+KVBM 有三个主要逻辑层：
+
+**LLM Inference Runtime Layer** — 顶层包含推理运行时（TensorRT-LLM、vLLM），它们通过专用连接器模块集成到 Dynamo KVBM。这些连接器充当转换层，将运行时特定的操作和事件映射到 KVBM 面向块的内存接口。这样可以将内存管理与推理运行时解耦，从而支持后端可移植性和内存分层。
+
+**KVBM Logic Layer** — 中间层封装核心 KV block manager 逻辑，并作为管理块内存的运行时基础。KVBM adapter 会对来自不同运行时的请求表示和数据布局进行规范化，并将其转发给核心内存管理器。该层实现表查找、内存分配、块布局管理、生命周期状态转换，以及块复用/淘汰策略。
+
+**NIXL Layer** — 底层为所有数据和存储事务提供统一支持。NIXL 支持 P2P GPU 传输、RDMA 和 NVLink 远程内存共享、动态块注册和元数据交换，并为存储后端提供插件接口，包括块内存（GPU HBM、Host DRAM、Remote DRAM、Local SSD）、本地/远程文件系统、对象存储和云存储。
+
+> **了解更多：** 请参阅 [KVBM 设计文档](/dynamo/dev/design-docs/component-design/kvbm-design)，了解详细架构、组件和数据流。
+
+## 后续步骤
+
+- **[KVBM 指南](/dynamo/dev/user-guides/kv-cache-offloading)** — 安装、配置和部署说明
+- **[KVBM 设计](/dynamo/dev/design-docs/component-design/kvbm-design)** — 架构深入解析、组件和数据流
+- **[LMCache 集成](/dynamo/dev/integrations/kv-cache-integrations/lm-cache)** — 将 LMCache 与 Dynamo vLLM 后端配合使用
+- **[FlexKV 集成](/dynamo/dev/integrations/kv-cache-integrations/flex-kv)** — 使用 FlexKV 进行 KV cache 管理
+- **[SGLang HiCache](/dynamo/dev/integrations/kv-cache-integrations/hi-cache)** — 通过 NIXL 启用 SGLang 的分层缓存
+- **[NIXL Documentation](https://github.com/ai-dynamo/nixl/blob/main/docs/nixl.md)** — NIXL 通信库详细信息

--- a/fern/translations/zh-CN/pages-v1.3.0/components/planner/planner-guide.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/components/planner/planner-guide.md
@@ -1,0 +1,235 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Planner 指南
+---
+
+Dynamo Planner 是一个自动扩缩容控制器，会在运行时调整 prefill 和 decode 引擎的副本数，以满足延迟 SLA。它读取流量信号（Prometheus 指标或负载预测器输出）和引擎性能模型，用于决定何时扩容或缩容。
+
+如需快速概览，请参阅 [Planner overview](/dynamo/dev/components/planner)。如需了解架构内部机制，请参阅 [Planner 设计](/dynamo/zh-CN/dev/design-docs/component-design/planner-design)。
+
+## 扩缩容模式
+
+planner 支持四个优化目标，这些目标决定扩缩容决策的方式：
+
+- **`throughput`**（默认）：基于队列深度和 KV cache 利用率使用静态阈值。不需要 SLA 目标或 profiling。开箱即用。
+- **`latency`**：与 `throughput` 采用相同方法，但使用更激进的阈值，即更早扩容并容忍更少排队。适合对延迟敏感的工作负载。
+- **`load`**：使用用户定义的 prefill 队列 token 阈值和 decode KV 利用率阈值，进行反应式的基于负载扩缩容。
+- **`sla`**：使用 Rust 引擎性能模型 shim；原生 AIC 可用时直接使用 AIC 估算，并结合在线 FPM 调优，否则回退到 FPM 回归模型。支持基于吞吐量（预测式）和基于负载（反应式）的扩缩容模式。适合需要精确 SLA 控制的高级用户。
+
+**何时使用哪种模式：**
+
+- 从 **`throughput`**（默认）开始，它无需配置即可立即工作。
+- 如果工作负载有严格的延迟要求，并且你更倾向于过度预配置而不是排队，请切换到 **`latency`**。
+- 当你希望通过 prefill 队列和 decode KV 利用率阈值直接控制扩缩容时，请使用 **`load`**。
+- 当你有部署前 profiling 数据，并希望以特定 TTFT/ITL 值为目标时，请使用 **`sla`**。
+
+## PlannerConfig 参考
+
+planner 通过 `PlannerConfig` JSON/YAML 对象进行配置。使用 profiler 时，该对象位于 DGDR 规范的 `features.planner` 部分下：
+
+```yaml
+features:
+  planner:
+    mode: disagg
+    backend: vllm
+    # optimization_target defaults to "throughput" — works out of the box
+```
+
+对于基于 SLA 的扩缩容：
+
+```yaml
+features:
+  planner:
+    optimization_target: sla
+    enable_throughput_scaling: true
+    enable_load_scaling: false
+    pre_deployment_sweeping_mode: rapid
+    mode: disagg
+    backend: vllm
+```
+
+若要在不改变副本数的情况下评估 Planner 行为，请启用 advisory 模式：
+
+```yaml
+features:
+  planner:
+    advisory: true
+```
+
+advisory 模式仅提供建议。Planner 会计算建议副本数、记录日志、将其导出为诊断信息，并显示在 HTML 报告中。这些建议不会作为扩缩容决策应用：Planner 不会执行扩缩容操作，也不会更改部署。
+
+### 优化目标
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `optimization_target` | string | `throughput` | `throughput`：基于队列/利用率阈值扩缩容。`latency`：激进的低延迟阈值。`load`：用户定义的 prefill 队列和 decode KV 利用率阈值。`sla`：使用 Rust 引擎性能模型，并以 ttft_ms/itl_ms 为目标扩缩容。 |
+
+当 `optimization_target` 为 `throughput`、`latency` 或 `load` 时，会自动启用基于负载的扩缩容，并禁用基于吞吐量的扩缩容。`ttft_ms`/`itl_ms` 字段会被忽略。
+
+### 扩缩容模式字段（SLA 模式）
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `enable_throughput_scaling` | bool | `true` | 启用基于吞吐量的扩缩容。仅在 `optimization_target: sla` 时使用。 |
+| `enable_load_scaling` | bool | `false` | 启用基于负载的扩缩容。仅在 `optimization_target: sla` 时使用。 |
+
+使用 `optimization_target: sla` 时，必须至少启用一种扩缩容模式。
+
+### 部署前扫描
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `pre_deployment_sweeping_mode` | string | `rapid` | 如何生成可选的性能模型启动数据：`rapid`（AIC 仿真，约 30 秒）、`thorough`（真实 GPU，2-4 小时）或 `none`（跳过）。 |
+
+SLA 模式使用 Rust 引擎性能模型 shim。如果配置了 `aic_perf_model`，planner 会用原生 AIC 模型身份和引擎上限初始化 shim；如果该模型不被原生 AIC 支持，shim 会自动回退到基于观测 FPM 的回归模型。如果没有配置 `aic_perf_model`，shim 会从 FPM 回归模型启动，并在自基准测试或在线 FPM 观测足够后变为可用。
+
+启动时，planner 总会先尝试从 `get_perf_metrics` Dynamo 端点获取自基准测试结果。如果不可用，则在配置存在时回退到 rapid 模式 AIC interpolation 数据或 `profile_results_dir` 中 profiler 生成的数据（npz 或 JSON）。这些数据都会转换为 ForwardPassMetrics，并用于调优或启动性能模型。当 `pre_deployment_sweeping_mode: none` 时，planner 仍然可以启动；吞吐量决策会在原生 AIC 可用或在线 FPM 足够之前报告 `model_not_ready`。
+
+手动配置原生 AIC 性能模型：
+
+```yaml
+features:
+  planner:
+    optimization_target: sla
+    aic_perf_model:
+      hf_id: nvidia/Llama-3.1-8B-Instruct-FP8
+      system: h200_sxm
+      backend: vllm
+      prefill_pick: {tp: 1, pp: 1, dp: 1, moe_tp: 1, moe_ep: 1}
+      decode_pick: {tp: 1, pp: 1, dp: 1, moe_tp: 1, moe_ep: 1}
+```
+
+### 基于吞吐量的扩缩容设置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `throughput_adjustment_interval_seconds` | int | `180` | 基于吞吐量的扩缩容决策之间的秒数。 |
+| `throughput_metrics_source` | string | `frontend` | 用于吞吐量扩缩容的 Prometheus 流量来源：`frontend` 从公共 Frontend 读取 `dynamo_frontend_*` 指标；`router` 从 LocalRouter 读取 `dynamo_component_router_*` 指标。在 GlobalPlanner 部署中，为池本地 Planner 使用 `router`。 |
+| `min_endpoint` | int | `1` | 要维持的引擎端点最小数量。 |
+| `max_gpu_budget` | int | `8` | planner 可以分配的 GPU 总数上限。 |
+| `ttft_ms` | float | `500.0` | 用于扩缩容决策的 TTFT SLA 目标（毫秒）。 |
+| `itl_ms` | float | `50.0` | 用于扩缩容决策的 ITL SLA 目标（毫秒）。 |
+
+### 基于负载的扩缩容设置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `load_adjustment_interval_seconds` | int | `5` | FPM 调优更新和基于负载的扩缩容决策之间的秒数。即使只启用了吞吐量扩缩容，实时 FPM 观测也会按此间隔输入到性能模型中。必须短于 `throughput_adjustment_interval_seconds`。 |
+| `max_num_fpm_samples` | int | `64` | 为在线调优或回归保留的 FPM 观测最大数量。 |
+| `fpm_sample_bucket_size` | int | `16` | 用于观测淘汰的 bucket 数量（必须是完全平方数）。 |
+| `load_scaling_down_sensitivity` | int | `80` | 缩容敏感度 0-100（0=永不，100=激进）。 |
+| `load_min_observations` | int | `5` | 做出扩缩容决策前所需的最少观测数。 |
+
+### 通用设置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `mode` | string | `disagg` | Planner 模式：`disagg`、`prefill`、`decode` 或 `agg`。 |
+| `backend` | string | `vllm` | Backend：`vllm`、`sglang`、`trtllm` 或 `mocker`。 |
+| `environment` | string | `kubernetes` | 运行时环境：`kubernetes`、`virtual` 或 `global-planner`。 |
+| `namespace` | string | env `DYN_NAMESPACE` | 部署的 Kubernetes namespace。 |
+| `advisory` | bool | `false` | 仅建议模式。计算、记录、导出并报告建议副本数，但不执行扩缩容操作，也不更改部署。 |
+
+### 流量预测设置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `load_predictor` | string | `arima` | 用于 request count、ISL 和 OSL 的预测方法：`constant`、`arima`、`kalman` 或 `prophet`。KV hit rate 和 speculative decode accept length 等运行时元数据会使用最新的有效观测值。 |
+| `load_predictor_log1p` | bool | `false` | 对被预测的 request count、ISL 和 OSL 数据应用 log1p 变换。 |
+| `prophet_window_size` | int | `50` | Prophet predictor 的窗口大小（秒）。 |
+| `load_predictor_warmup_trace` | string | `null` | 用于引导预测的 warmup trace 文件路径。 |
+
+KV hit rate 和 speculative decode accept length 是引擎/Router 运行时信号，不是流量形状。Planner 会保存每个信号最新的有效观测值，并在新的有效值到达前复用它。冷启动时，缺失的 KV hit rate 表示不做 prefix-cache discount，缺失的 accept length 表示 `1.0`。
+
+### Kalman Filter 设置
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `kalman_q_level` | float | `1.0` | level 组件的 process noise。 |
+| `kalman_q_trend` | float | `0.1` | trend 组件的 process noise。 |
+| `kalman_r` | float | `10.0` | measurement noise。 |
+| `kalman_min_points` | int | `5` | Kalman 预测激活前所需的最少数据点数。 |
+
+### 诊断报告
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `report_interval_hours` | float or `null` | `24.0` | 每 N 小时（模拟时间）生成一份 HTML 诊断报告。设置为 `null` 可禁用周期性报告生成。 |
+| `report_output_dir` | string | `./planner_reports` | HTML 诊断报告的目录。 |
+| `live_dashboard_port` | int | `8080` | 实时诊断 dashboard HTTP 服务器的端口。设置为 `0` 可禁用。启用后，访问 `http://host:port/` 查看累积快照的实时 Plotly 报告。 |
+
+这些报告中展示的同一组诊断信号也会以 `dynamo_planner_*` 前缀导出为 Prometheus 指标，例如估算的 TTFT/ITL（`dynamo_planner_estimated_ttft_ms`、`dynamo_planner_estimated_itl_ms`）、建议副本数（`dynamo_planner_predicted_num_prefill_replicas`、`dynamo_planner_predicted_num_decode_replicas`）、每个引擎的容量和 FPM 队列深度，以及负载/吞吐量扩缩容决策枚举。
+
+Replica Counts 图会将实际 prefill/decode 副本与 Planner 建议的 prefill/decode 副本的离散建议标记叠加显示。当 `advisory: true` 时，这些建议数量仅作为建议；Planner 会记录它本会执行的操作，但不会应用该变更。
+
+### 调度 / plugin pipeline
+
+Planner 默认通过内置 plugin pipeline 运行。基础 pipeline cadence 位于 `PlannerConfig` 的 `scheduling` 子树；plugin 注册、transport 和认证设置位于 `plugin_registration`。
+
+| 字段 | 类型 | 默认值 | 说明 |
+|-------|------|---------|-------------|
+| `scheduling.scale_interval_seconds` | float | 已启用 builtin interval 的最大公约数 | 基础 pipeline cadence。Pipeline 每个 interval 唤醒一次；每个 plugin 的 `execution_interval_seconds` 决定该 plugin 是否在当前 tick 执行。默认值是 `load_adjustment_interval_seconds` 和启用 throughput scaling 时 `throughput_adjustment_interval_seconds` 的最大公约数，以保留现有配置的 fire time。 |
+| `scheduling.tick_max_duration_seconds` | float | `30.0` | 包住完整 plugin pipeline 的外层 deadline。超时会中止当前 tick；下一次 tick 从干净状态继续。 |
+| `plugin_registration.transport.request_timeout_seconds` | float | `5.0` | 单个 plugin RPC timeout。Plugin 超时会触发 `PluginTimeoutError`；该 stage 会继续处理剩余 plugin。 |
+
+现有 planner 字段仍然驱动内置 plugin：
+
+- `load_adjustment_interval_seconds` 调度 `builtin_load_propose`。它读取 FPM 和 worker count 观测，并执行当前 load-based 算法。
+- `throughput_adjustment_interval_seconds` 调度 `builtin_load_predict` 和 `builtin_throughput_propose`。Throughput propose 依赖同一个 tick 里的 prediction，因此只会在 predict plugin 触发的 tick 中执行。
+- 当两个 proposer 在同一个 tick 都产生目标时，load-based scaling 在 throughput-based scaling 之后运行，保留现有行为：throughput 先更新副本数下限，load-based scaling 再在该 floor 之上调整并应用全局 GPU budget clamp。
+- Plugin pipeline 结束后，planner 会对 builtin 和外部 plugin 的目标统一应用最终的 `min_endpoint` 和 GPU-budget safety check，然后才执行扩缩容。
+
+#### DGDR 示例
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: my-deployment
+spec:
+  model: Qwen/Qwen3-0.6B
+  features:
+    planner:
+      optimization_target: sla
+      enable_load_scaling: true
+      ttft: 200.0
+      itl: 10.0
+      pre_deployment_sweeping_mode: rapid
+      scheduling:
+        tick_max_duration_seconds: 30.0
+      plugin_registration:
+        transport:
+          request_timeout_seconds: 5.0
+```
+
+## 与 Profiler 集成
+
+当 profiler 在启用 planner 的情况下运行时，它会：
+
+1. 选择最佳 prefill 和 decode 引擎配置
+2. 生成可选的引擎性能启动数据（prefill TTFT vs ISL、decode ITL vs KV-cache 利用率）
+3. 将 `PlannerConfig` 和可选性能数据保存到独立的 Kubernetes ConfigMaps 中
+4. 将 planner 服务添加到生成的 DGD，并配置为从这些 ConfigMaps 读取
+
+planner 通过 `--config /path/to/planner_config.json` 接收其配置，该文件从 `planner-config-XXXX` ConfigMap 挂载。当生成 thorough 启动数据时，profiling 数据会从 `planner-profile-data-XXXX` ConfigMap 挂载。
+
+请参阅 [Profiler Guide](/dynamo/dev/components/profiler/profiler-guide)，了解完整 profiling 工作流以及如何配置部署前扫描。
+
+## 分层部署
+
+如果你希望一个模型拥有一个公共端点，但同时有多个针对不同请求类别优化的私有 DGD，请使用分层部署：
+
+- 一个包含 `Frontend`、`GlobalRouter` 和 `GlobalPlanner` 的 control DGD
+- 一个或多个 prefill pool DGD
+- 一个或多个 decode pool DGD
+
+在当前工作流中，请为每个目标 pool 独立运行 profiling，然后手动组合最终的 control DGD 和 pool DGD。请参阅 [Global Planner Guide](/dynamo/dev/components/planner/global-planner-guide)。
+
+## 另请参阅
+
+- [Planner overview](/dynamo/dev/components/planner) — 为什么 LLM 推理需要不同的 autoscaler
+- [Planner 设计](/dynamo/zh-CN/dev/design-docs/component-design/planner-design) — 架构和算法内部机制
+- [DGDR Examples](/dynamo/dev/kubernetes-deployment/deploy-models/dgdr-examples) — DGDR YAML 示例、样例配置、高级模式
+- [Global Planner Guide](/dynamo/dev/components/planner/global-planner-guide) — 多 DGD 协调、共享 GPU 预算、单端点多 pool 部署
+- [Profiler Guide](/dynamo/dev/components/profiler/profiler-guide) — profiling 数据的生成方式

--- a/fern/translations/zh-CN/pages-v1.3.0/components/router/README.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/components/router/README.md
@@ -1,0 +1,62 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Router
+---
+
+Dynamo KV Router 通过评估不同 worker 上的计算成本来智能地路由请求。它同时考虑解码成本（来自活动 block）和预填充成本（来自新计算的 block），并利用 KV cache 重叠来尽量减少重复计算。优化 KV Router 对于在分布式推理部署中实现最大吞吐量和最低延迟至关重要。
+
+## 快速开始
+
+我们可以通过 Dynamo frontend 使用 KV Router：
+
+```bash
+python -m dynamo.frontend --router-mode kv --http-port 8000
+```
+
+对于 Kubernetes，请在 Frontend service 上设置 `DYN_ROUTER_MODE=kv`。对于事件驱动的 KV 状态，请使用 [Router Operations](/dynamo/dev/components/router/router-operations#additional-notes) 中描述的后端专用 flag，配置 backend worker 发布 KV cache 事件。仅当你希望使用近似的 cache 状态预测时，才使用 `--no-router-kv-events`。
+
+| 参数 | 默认值 | 描述 |
+|----------|---------|-------------|
+| `--router-mode kv` | `round-robin` | 启用感知 KV cache 的路由 |
+| `--load-aware` | disabled | 使用 KV 活动负载路由，不使用 cache 复用信号；在 frontend 上隐含启用 `--router-mode kv` |
+| `--router-kv-overlap-score-credit` | `1.0` | 设备本地 prefix 重叠的 credit 乘数，范围从 0.0 到 1.0 |
+| `--router-prefill-load-scale` | `1.0` | 在加入 decode block 之前，对调整后的 prompt 侧 prefill 负载进行缩放 |
+| `--router-kv-events` / `--no-router-kv-events` | `--router-kv-events` | 消费 worker KV 事件，或在没有事件时回退到近似路由 |
+| `--router-queue-threshold` | disabled | 背压队列阈值；设置数值后启用队列，`nvext.agent_hints.priority` 会对等待中的请求重新排序 |
+| `--router-queue-policy` | `fcfs` | 队列调度策略：`fcfs`（尾部 TTFT）、`wspt`（平均 TTFT）或 `lcfs`（仅用于比较的反向排序） |
+| `--no-router-track-prefill-tokens` | disabled | 在 router 负载统计中忽略 prompt 侧 prefill token；适用于仅 decode 的路由路径 |
+
+### 独立 Router
+
+你也可以将 KV router 作为独立服务运行（不使用 Dynamo frontend）。更多详细信息请参阅 [Standalone Router component](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/components/src/dynamo/router/)。
+
+有关部署模式和快速开始步骤，请参阅 [Router Guide](/dynamo/dev/user-guides/kv-cache-aware-routing)。有关 CLI 参数和调优指南，请参阅 [Configuration and Tuning](/dynamo/dev/components/router/configuration-and-tuning)。有关 A/B 基准测试，请参阅 [KV Router A/B Benchmarking Guide](/dynamo/dev/benchmarks/kv-router-ab-testing)。
+
+## 前提条件和限制
+
+**要求：**
+- **仅支持动态 endpoint**：KV router 要求使用 `model_input=ModelInput.Tokens` 调用 `register_model()`。你的 backend handler 会接收带有 `token_ids` 的预分词请求，而不是原始文本。
+- Backend worker 必须使用 `model_input=ModelInput.Tokens` 调用 `register_model()`（请参阅 [Backend Guide](/dynamo/dev/backends/custom-backend/python-workers-lower-level)）
+- 使用 KV routing 时请使用动态发现，以便 router 跟踪 worker 实例及其 KV cache 状态
+
+**多模态支持：**
+- **通过多模态 hash 进行图像路由**：在已文档化的 TRT-LLM 和 vLLM router 路径中受支持。
+- **其他 backend 或模态组合**：在依赖多模态 hash routing 之前，请检查相应 backend 的多模态文档。
+
+**限制：**
+- KV routing 不支持静态 endpoint；请使用动态发现，以便 router 跟踪 worker 实例及其 KV cache 状态
+
+对于不使用 KV routing 的基础模型注册，请在静态和动态 endpoint 中使用 `--router-mode round-robin`、`--router-mode random`、`--router-mode least-loaded` 或 `--router-mode device-aware-weighted`。
+
+## 后续步骤
+
+- **[Router Guide](/dynamo/dev/user-guides/kv-cache-aware-routing)**：部署模式、快速开始和页面地图
+- **[Routing Concepts](/dynamo/dev/components/router/routing-concepts)**：成本模型和 worker 选择行为
+- **[Configuration and Tuning](/dynamo/dev/components/router/configuration-and-tuning)**：Router flag、传输模式和指标
+- **[分离式服务](/dynamo/dev/components/router/disaggregated-serving)**：Prefill 和 decode 路由设置
+- **[Router Operations](/dynamo/dev/components/router/router-operations)**：副本、持久化和恢复
+- **[Router Examples](/dynamo/dev/components/router/router-examples)**：Python API 用法、K8s 示例和自定义路由模式
+- **[Router Testing](https://github.com/ai-dynamo/dynamo/blob/5f62ed542a20c273d38555a294dbebe0bd1bddb4/docs/components/router/router-testing.md)**：从 Rust 单元测试到基于 fixture 的 replay 和完整进程 E2E 的测试层级
+- **[Standalone Indexer](/dynamo/dev/components/router/standalone-indexer)**：将 KV indexer 作为单独服务运行，以便独立扩缩容
+- **[Router Design](/dynamo/dev/design-docs/component-design/router-design)**：架构细节、算法和事件传输模式

--- a/fern/translations/zh-CN/pages-v1.3.0/contribution-guide.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/contribution-guide.md
@@ -1,0 +1,433 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 贡献指南
+subtitle: 如何为 Dynamo 做贡献
+max-toc-depth: 3
+---
+
+Dynamo 是一个开源分布式推理平台，由不断壮大的贡献者社区共同构建。该项目采用 [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/LICENSE) 许可证，欢迎各种规模的贡献 -- 从修正错别字到开发重要功能都包括在内。社区贡献已经塑造了 Dynamo 的核心领域，包括后端集成、文档、部署工具和性能改进。
+
+Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并且每月都有新贡献者加入，是增长最快的开源推理项目之一。欢迎查看我们的[提交活动](https://github.com/ai-dynamo/dynamo/graphs/commit-activity)和 [GitHub stars](https://github.com/ai-dynamo/dynamo)。本指南将帮助你开始贡献。
+
+加入社区：
+
+- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf) -- 加入 CNCF Slack，并在 `#ai-dynamo` 中找到我们
+- [Discord](https://discord.gg/D92uqZRjCZ)
+- [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
+- [设计提案](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22) -- 重大功能的 RFC，以带 `dep:*` 标签的 GitHub issue 形式跟踪
+- [Office Hours](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X) -- 双周会议
+- [社区会议](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community)) -- 每周（Wed 10:30 AM PT）开发者社区会议
+- [Dynamo Day 录像](https://nvevents.nvidia.com/dynamoday) -- 来自生产用户的深入分享
+
+## TL;DR
+
+面向有经验的贡献者：
+
+1. Fork 并克隆仓库
+2. 对于 ≥100 行的变更或新功能，请先[创建 issue](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml)
+3. 创建分支：`git checkout -b yourname/fix-router-timeout`
+4. 修改代码，运行 `pre-commit run`
+5. 使用 DCO sign-off 提交：`git commit -s -m "fix: description"`
+6. 打开一个面向 `main` 的 PR
+
+---
+
+## 贡献方式
+
+### 报告 Bug
+
+发现哪里坏了吗？请[提交 bug 报告](https://github.com/ai-dynamo/dynamo/issues/new?template=bug_report.yml)，并包含：
+
+- 复现步骤
+- 预期行为与实际行为
+- 环境详情（OS、GPU、Python 版本、Dynamo 版本）
+
+### 改进文档
+
+我们始终欢迎文档改进：
+
+- 修正错别字或不清楚的说明
+- 添加示例或教程
+- 改进 API 文档
+
+较小的文档修复可以不创建 issue，直接作为 PR 提交。
+
+### 提议功能
+
+有想法吗？请[创建功能请求](https://github.com/ai-dynamo/dynamo/issues/new?template=feature_request.yml)，在实现前与维护者讨论。
+
+### 贡献代码
+
+准备写代码了吗？请参阅下方的[贡献流程](#贡献流程)部分。
+
+### 帮助社区
+
+并非所有贡献都是代码。你还可以：
+
+- 在 [Discord](https://discord.gg/D92uqZRjCZ) 或 [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) 的 `#ai-dynamo` 频道中回答问题
+- 审阅 pull request
+- 分享你如何使用 Dynamo -- 博客文章、演讲或社交媒体都可以
+- 为[仓库](https://github.com/ai-dynamo/dynamo)点 star
+
+---
+
+## 入门
+
+### 查找 Issue
+
+浏览[开放 issue](https://github.com/ai-dynamo/dynamo/issues)，或查找：
+
+| Issue 类型 | 说明 |
+|------------|------|
+| [Good First Issues](https://github.com/ai-dynamo/dynamo/labels/good-first-issue) | 适合初学者，并带有指导 |
+| [Help Wanted](https://github.com/ai-dynamo/dynamo/labels/help-wanted) | 欢迎社区贡献 |
+
+### Fork 并克隆
+
+1. 在 GitHub 上 [Fork 仓库](https://github.com/ai-dynamo/dynamo/fork)
+2. 克隆你的 fork：
+
+```bash
+git clone https://github.com/YOUR-USERNAME/dynamo.git
+cd dynamo
+git remote add upstream https://github.com/ai-dynamo/dynamo.git
+```
+
+### 从源码构建
+
+<Tip>完整构建说明包含在下方。展开折叠区以设置本地开发环境。</Tip>
+
+<details>
+<summary>展开构建说明</summary>
+
+#### 1. 安装系统库
+
+**Ubuntu:**
+
+```bash
+sudo apt install -y build-essential libhwloc-dev libudev-dev pkg-config libclang-dev protobuf-compiler python3-dev cmake
+```
+
+**macOS:**
+
+```bash
+# Install Homebrew if needed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+brew install cmake protobuf
+
+# Verify Metal is accessible
+xcrun -sdk macosx metal
+```
+
+#### 2. 安装 Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+
+#### 3. 创建 Python 虚拟环境
+
+如果你还没有安装 [uv](https://docs.astral.sh/uv/#installation)，请先安装：
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+创建并激活虚拟环境：
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+```
+
+#### 4. 安装构建工具
+
+```bash
+uv pip install pip 'maturin[patchelf]'
+```
+
+[Maturin](https://github.com/PyO3/maturin) 是 Rust-Python 绑定的构建工具。`patchelf` extra 让 maturin 能在构建期间修补原生扩展库路径。
+
+#### 5. 构建 Rust 绑定
+
+```bash
+cd lib/bindings/python
+maturin develop --uv
+```
+
+#### 6. 安装 GPU Memory Service
+
+```bash
+# Return to project root
+cd "$(git rev-parse --show-toplevel)"
+uv pip install -e lib/gpu_memory_service
+```
+
+#### 7. 安装 Wheel
+
+```bash
+uv pip install -e .
+```
+
+#### 8. 验证构建
+
+```bash
+python3 -m dynamo.frontend --help
+```
+
+<Tip>
+VSCode 和 Cursor 用户可以使用 [`.devcontainer`](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/.devcontainer) 文件夹获得预配置的开发环境。详情请参阅 [devcontainer README](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/.devcontainer/README.md)。
+</Tip>
+
+</details>
+
+### 设置 Pre-commit Hooks
+
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
+你已经设置好了！保持好奇 -- 探索代码库，试用[示例](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/examples)，看看各个部分如何协同工作。准备好后，可以从 [Good First Issues](https://github.com/ai-dynamo/dynamo/labels/good-first-issue) 看板中挑选一个 issue，或继续阅读完整贡献流程。
+
+---
+
+## 贡献流程
+
+贡献流程取决于变更的大小和范围。即使不是必需，创建 issue 也是一个很好的开端，可以在投入时间编写 PR 前先与 Dynamo 维护者交流。
+
+| 大小 | 变更行数 | 示例 | 你需要做什么 |
+|------|----------|------|--------------|
+| **XS** | 1–10 | 修正错别字、调整配置 | 直接提交 PR |
+| **S** | 10–100 | 小型 bug 修复、文档改进、聚焦的重构 | 直接提交 PR |
+| **M** | 100–200 | 添加功能、中等规模重构 | 先[创建 issue](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml) |
+| **L** | 200–500 | 多文件功能、新组件 | 先[创建 issue](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml) |
+| **XL** | 500–1000 | 重要功能、跨组件变更 | 先[创建 issue](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml) |
+| **XXL** | 1000+ | 架构变更 | 需要一个 [DEP](https://github.com/ai-dynamo/dynamo/issues/new?template=dep.yml) |
+
+**小型变更（少于 100 行）：** 直接提交 PR -- 不需要 issue。这包括错别字、简单 bug 修复和格式调整。如果你的 PR 处理的是已有且已批准的 issue，请使用 "Fixes #123" 链接它。
+
+**较大变更（≥100 行）：** 请先[创建 Contribution Request](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml) issue，并等待 `approved-for-pr` 标签后再提交 PR。
+
+**架构变更：** 影响多个组件、引入或修改公共 API、改变通信平面架构，或影响后端集成契约的变更，都需要一个 Dynamo Enhancement Proposal (DEP)。DEP 以 `ai-dynamo/dynamo` 仓库中[带 `dep:*` 标签的 GitHub issue](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22) 形式跟踪 -- 在开始实现前，请先[创建 DEP issue](https://github.com/ai-dynamo/dynamo/issues/new?template=dep.yml)。
+
+### 提交 Pull Request
+
+1. **创建 GitHub Issue**（如果需要）— [创建 Contribution Request](https://github.com/ai-dynamo/dynamo/issues/new?template=contribution_request.yml)，说明你要解决的问题、建议方案、预计 PR 大小以及受影响文件。
+
+2. **获得批准** — 等待维护者审阅并添加 `approved-for-pr` 标签。
+
+3. **提交 Pull Request** — [创建 PR](https://github.com/ai-dynamo/dynamo/compare)，并使用 GitHub 关键字引用该 issue（例如 "Fixes #123"）。
+
+4. **处理 Code Rabbit Review** — 回复自动化 Code Rabbit 建议，包括 nitpick。
+
+5. **触发 CI 测试** — 对于外部贡献者，维护者必须评论 `/ok to test COMMIT-ID` 才能运行完整 CI 套件，其中 `COMMIT-ID` 是你最新提交的短 SHA。请求人工审阅前，请修复所有失败的测试。
+
+6. **请求审阅** — 将批准你 issue 的人员添加为 reviewer。根据修改的文件，查看 [CODEOWNERS](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/CODEOWNERS) 了解必需 approver。
+
+<Info>**AI 生成代码：** 虽然我们鼓励使用 AI 工具，但你必须完全理解 PR 中的每一处变更。如果无法解释提交的代码，PR 将被拒绝。</Info>
+
+### 分支命名
+
+使用描述性的分支名，标识你本人和变更内容：
+
+```text
+yourname/fix-description
+```
+
+示例：
+
+```text
+jsmith/fix-router-timeout
+jsmith/add-lora-support
+```
+
+---
+
+## 代码风格与质量
+
+维护者会根据代码风格、测试覆盖率、架构一致性和对审阅反馈的响应情况来评估贡献质量。持续的高质量贡献是在项目中建立信任的基础。
+
+### Pre-commit Hooks
+
+所有 PR 都会通过 [pre-commit hooks](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/.pre-commit-config.yaml) 检查。在[安装 pre-commit](#设置-pre-commit-hooks) 后，在本地运行检查：
+
+```bash
+pre-commit run --all-files
+```
+
+### Commit Message 约定
+
+使用 [conventional commit](https://www.conventionalcommits.org/) 前缀：
+
+| 前缀 | 用途 |
+|------|------|
+| `feat:` | 新功能 |
+| `fix:` | Bug 修复 |
+| `docs:` | 文档变更 |
+| `refactor:` | 代码重构（无行为变更） |
+| `test:` | 添加或更新测试 |
+| `chore:` | 维护、依赖更新 |
+| `ci:` | CI/CD 变更 |
+| `perf:` | 性能改进 |
+
+示例：
+
+```text
+feat(router): add weighted load balancing
+fix(frontend): resolve streaming timeout on large responses
+docs: update quickstart for macOS users
+test(planner): add unit tests for scaling policy
+```
+
+### 语言约定
+
+| 语言 | 风格指南 | 格式化工具 |
+|------|----------|------------|
+| **Python** | [PEP 8](https://peps.python.org/pep-0008/) | `black`, `ruff` |
+| **Rust** | [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) | `cargo fmt`, `cargo clippy` |
+| **Go** | [Effective Go](https://go.dev/doc/effective_go) | `gofmt` |
+
+### 测试
+
+提交 PR 前请运行测试套件：
+
+```bash
+# Run all tests
+pytest tests/
+
+# Run unit tests only
+pytest -m unit tests/
+
+# Run a specific test file
+pytest -s -v tests/test_example.py
+```
+
+对于 Rust 组件：
+
+```bash
+cargo test
+```
+
+对于 Kubernetes operator（Go）：
+
+```bash
+cd deploy/operator
+go test ./... -v
+```
+
+### 通用准则
+
+- 保持 PR 聚焦 -- 每个 PR 只处理一个关注点
+- 编写干净、文档完善、未来贡献者能够理解的代码
+- 为新功能和 bug 修复包含测试
+- 确保构建干净（无警告或错误）
+- 所有测试必须通过
+- 不要提交被注释掉的代码
+- 及时且建设性地回应审阅反馈
+
+### 在本地运行 GitHub Actions
+
+使用 [act](https://nektosact.com/) 在本地运行 workflow：
+
+```bash
+act -j pre-merge-rust
+```
+
+或者使用 [GitHub Local Actions](https://marketplace.visualstudio.com/items?itemName=SanjulaGanepola.github-local-actions) VS Code 扩展。
+
+---
+
+## 预期事项
+
+### 状态标签
+
+| 状态 | 含义 |
+|------|------|
+| `needs-triage` | 我们正在审阅你的 issue |
+| `needs-info` | 我们需要你提供更多详情 |
+| `approved-for-pr` | 已可实现 — 提交 PR |
+| `in-progress` | 有人正在处理 |
+| `blocked` | 正在等待外部依赖 |
+
+### 响应时间
+
+我们的目标是：
+
+- 在几个工作日内**回复**新的 issue
+- 在一周内**分流处理**高优先级 issue
+
+30 天无活动的 issue 可能会被自动关闭（可以重新打开）。
+
+### 审阅流程
+
+提交 PR 并完成[提交 Pull Request](#提交-pull-request)中的步骤后：
+
+1. Reviewer 会提供反馈 -- 请在合理时间内回复所有评论
+2. 如果要求修改，请完成修改并提醒 reviewer 重新审阅
+3. 如果你的 PR 在 7 天内仍未被审阅，可以提醒 reviewer 或留言
+
+### Good First Issues
+
+标记为 `good-first-issue` 的 issue 适合新贡献者。我们会为这些 issue 提供额外指导 -- 请在 issue 描述中查找清晰的验收标准和建议方案。
+
+---
+
+## DCO 与许可
+
+### Developer Certificate of Origin
+
+Dynamo 要求所有贡献都使用 [Developer Certificate of Origin (DCO)](https://developercertificate.org/) 进行签署。这证明你有权根据项目的 [Apache 2.0 license](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/LICENSE) 提交你的贡献。
+
+每个提交都必须包含 sign-off 行：
+
+```text
+Signed-off-by: Jane Smith &lt;jane.smith@email.com&gt;
+```
+
+使用 `-s` 标志可以自动添加：
+
+```bash
+git commit -s -m "fix: your descriptive message"
+```
+
+**要求：**
+
+- 使用真实姓名（不接受化名或匿名贡献）
+- 你的 `user.name` 和 `user.email` 必须在 git 中配置
+
+**DCO 检查失败？** 请参阅我们的 [DCO 故障排除指南](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/DCO.md)，按步骤修复。
+
+### 许可证
+
+通过贡献，你同意你的贡献将依据 [Apache 2.0 License](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/LICENSE) 授权。
+
+---
+
+## 行为准则
+
+我们致力于提供一个欢迎且包容的环境。所有参与者都应遵守我们的 [Code of Conduct](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/CODE_OF_CONDUCT.md)。
+
+---
+
+## 安全
+
+如果你发现安全漏洞，请遵循我们的 [Security Policy](https://github.com/ai-dynamo/dynamo/blob/v1.3.0/SECURITY.md) 中的说明。请不要为安全漏洞创建公开 issue。
+
+---
+
+## 获取帮助
+
+- **CNCF Slack**: [加入 CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)，并在 `#ai-dynamo` 中找到我们
+- **Discord**: [加入我们的社区](https://discord.gg/D92uqZRjCZ)
+- **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
+- **设计提案**: [重大功能的 RFC，以带 `dep:*` 标签的 GitHub issue 形式跟踪](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)
+- **Office Hours**: [双周会议](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
+- **社区会议**: [每周（Wed 10:30 AM PT）开发者社区会议](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community))
+- **Dynamo Day 录像**: [来自生产用户的深入分享](https://nvevents.nvidia.com/dynamoday)
+- **Documentation**: [docs.nvidia.com/dynamo](https://docs.nvidia.com/dynamo/)
+
+感谢你为 Dynamo 做贡献！

--- a/fern/translations/zh-CN/pages-v1.3.0/design-docs/architecture.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/design-docs/architecture.md
@@ -1,0 +1,201 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 总体架构
+subtitle: Dynamo 推理运行时的架构与组件
+---
+
+Dynamo 是面向生成式 AI 系统的分布式推理运行时，适用于必须在变化的流量条件下保持高吞吐、低延迟和高可靠性的场景。它不绑定具体后端（SGLang、TRT-LLM、vLLM 等），并围绕三个相互协作的关注点构建：
+
+- 用于 token 生成的快速 **request path**
+- 用于扩缩容和放置的响应式 **control path**
+- 用于 KV 复用和故障恢复的弹性 **state path**
+
+本文从架构视角介绍 Dynamo，而不是罗列功能：每个平面负责什么、请求如何流转、系统如何自适应，以及在故障下如何保持正确性。
+
+## 设计目标
+
+Dynamo 旨在同时满足以下目标：
+
+1. **延迟稳定性**：在突发流量和混合长度流量下，让 TTFT 和 ITL 保持可预测。
+2. **GPU 效率**：解耦 prefill 和 decode，使二者可以独立扩缩容。
+3. **计算复用**：通过 KV 感知路由和缓存生命周期管理，最大限度减少 KV 重新计算。
+4. **运维弹性**：将 worker 崩溃、重启和过载视为正常运行事件。
+5. **部署可移植性**：支持 Kubernetes 原生控制路径和非 Kubernetes 运行模式。
+
+## 为什么需要这种架构
+
+现代 LLM 服务会反复遇到一些瓶颈：
+
+- **Prefill/decode 不均衡** 会在流量组合变化时导致 GPU 利用率不足（[DistServe](https://arxiv.org/abs/2401.09670)）。
+- **KV 重新计算** 会在路由忽略缓存重叠时增加 TTFT 并浪费计算资源（[DeepSeek](https://arxiv.org/abs/2501.12948)）。
+- 来自长上下文和并发的 **内存压力** 在没有多层缓存管理的情况下会超出 HBM 容量（[KVBM](https://docs.nvidia.com/dynamo/components/kvbm)、[Mooncake](https://kvcache-ai.github.io/Mooncake/design/mooncake-store.html)、[AIBrix](https://blog.vllm.ai/2025/02/21/aibrix-release.html)、[FlexKV](https://github.com/taco-project/FlexKV)、[LMCache](https://lmcache.ai/)）。
+- **动态需求** 会打破静态资源预置的假设（[AzureTrace](https://github.com/Azure/AzurePublicDataset)）。
+- **真实世界故障**（pod 重启、分区、热点过载）需要一等的恢复行为。
+
+Dynamo 通过将服务、控制和状态传播拆分为明确的平面与控制循环来应对这些约束。
+
+## 架构概览
+
+![Dynamo 架构，展示 Request Plane（Client、Frontend、Router、Prefill/Decode workers）、Control Plane（Planner、Dynamo Operator、Dynamo Graph、Grove、Model Express、Runtime Resources）以及 Storage &amp; Events Plane（KVBM、NIXL、Local SSD/NFS/Remote Storage）](../assets/img/dynamo-architecture.svg "Dynamo Architecture")
+
+## 系统模型
+
+### Request Plane（关键数据路径）
+
+request plane 负责请求/响应执行：
+
+- **Frontend** 接收并规范化请求。
+- **Router** 基于负载和 KV 重叠选择 worker。
+- **Prefill workers** 计算 prompt KV 状态。
+- **Decode workers** 生成输出 token。
+
+该路径针对低开销和连续 token 流式输出进行优化。
+
+### Control Plane（自适应与编排路径）
+
+control plane 负责期望状态管理：
+
+- **Planner** 根据实时指标计算扩缩容目标。
+- **Dynamo Operator** 根据 Dynamo CRD 协调 Kubernetes 资源。
+- **Discovery + Endpoints/CRD** 建立存活状态和可发现性。
+- **Grove/KAI Scheduler path** 在多节点 Kubernetes 部署中提供拓扑感知放置和分组扩缩容。
+- **Model Express** 在配置后作为可选的模型管理端点。
+
+该路径针对正确性以及向目标容量收敛进行优化。
+
+### Storage & Events Plane（状态传播路径）
+
+storage/events plane 负责缓存状态可见性和移动：
+
+- **KV Events** 发布缓存生命周期转换。
+- **KVBM** 管理跨内存层级的 block 复用、驱逐以及 offload/recall。
+- **NIXL** 在 workers 和内存域之间执行高速 KV/data 传输。
+
+该路径针对缓存复用和跨 worker 交接效率进行优化。
+
+## 端到端请求叙事（Disaggregated Mode）
+
+1. Client 将请求发送到 **Frontend**。
+2. Frontend 进行校验/预处理，并转发给 **Router**。
+3. Router 选择一个 **Prefill worker**。
+4. Prefill 计算 KV 并返回传输元数据。
+5. Router 选择一个 **Decode worker**。
+6. Decode 接收 KV 状态（通常通过 **NIXL** 传输路径）。
+7. Decode 通过 Frontend 流式返回 token。
+8. **KV Events** 更新缓存可见性，供未来路由决策使用。
+9. **KVBM** 可以根据压力和复用潜力 offload 或 recall KV blocks。
+
+有关流程级细节，请参阅 [Architecture Flow](/dynamo/dev/design-docs/architecture-flow)。
+有关请求传输选项，请参阅 [Request Plane](/dynamo/dev/design-docs/communication-planes/request-plane)。
+
+## 控制循环
+
+### Serving Loop
+
+在 frontend、router、prefill 和 decode workers 之间维持低延迟请求执行。
+
+### Planning Loop
+
+保持容量与需求一致：
+
+- Planner 消费运行时指标。
+- Planner 计算 prefill/decode 目标。
+- Connector layer 将目标应用到运行时资源。
+
+Planner 支持基于吞吐量和基于负载的策略。请参阅 [Planner 设计](/dynamo/zh-CN/dev/design-docs/component-design/planner-design)。
+
+### Resilience Loop
+
+在故障下维持系统连续性：
+
+- Health checks 检测不健康的 workers。
+- Discovery liveness 移除陈旧端点。
+- Graceful shutdown 排空正在处理的工作。
+- Request migration/cancellation 控制正在处理中的行为。
+- Load shedding 防止过载下的级联崩溃。
+
+请参阅 [Fault Tolerance](/dynamo/dev/user-guides/fault-tolerance)。
+
+## Kubernetes 原生实现（CRD + Grove）
+
+在 Kubernetes 部署中，同一架构映射为声明式资源：
+
+- Dynamo Operator 协调 `DynamoGraphDeployment`。
+- 可发现性由 `DynamoWorkerMetadata` + EndpointSlices 派生。
+- Grove 支持的多节点部署将 worker groups 建模为 `PodCliqueSet` 和 `PodClique`。
+- 独立的 prefill/decode 弹性通过 `PodCliqueScalingGroup` 表示，并使用独立的 `replicas` 和 `min` 目标。
+
+图中的 `PodClique A/B`、`ScalingGroup "Prefill"`、`ScalingGroup "Decode"` 和 `(replicas, min)` 等标签表示这种分组扩缩容模型。
+
+## Fault Tolerance 架构
+
+Fault tolerance 嵌入在各层中：
+
+| 层 | 机制 | 实际效果 |
+|------|-----------|------------------|
+| Request | Migration、cancellation | 正在处理的工作可以继续，或按意图终止 |
+| Worker | Health checks、graceful shutdown、endpoint draining | 失败/正在终止的 workers 会安全地停止接收新流量 |
+| System | Request rejection/load shedding | 防止过载在 workers 之间传播 |
+| Infrastructure | Discovery lease expiry、event-path recovery | 移除陈旧成员并重新路由流量 |
+
+该模型假定故障是常规事件，而非异常事件。
+
+## 性能依据
+
+### 分离式服务
+
+分离 prefill 和 decode 可以提升利用率，并支持按阶段扩缩容。
+
+![两个散点图，对比 disagg 和 baseline 配置在单节点与双节点上的性能](../assets/img/disagg-perf-benefit.png)
+
+*在 H100 上使用 vLLM 运行 R1 Distilled Llama 70B FP8 进行测试。3K ISL / 150 OSL。*
+
+### KV-Aware Routing
+
+结合缓存重叠和负载信号的路由可以减少 prefill 重新计算并改善延迟。
+有关外部生产案例研究，请参阅 [How Baseten achieved 2x faster inference with NVIDIA Dynamo](https://www.baseten.co/blog/how-baseten-achieved-2x-faster-inference-with-nvidia-dynamo/#how-baseten-uses-nvidia-dynamo)。
+
+![两个柱状图，对比 Random routing 和带 KV aware routing 的 Dynamo 在 Time To First Token（Dynamo 快 3 倍）与 Avg request latency（Dynamo 快 2 倍）上的表现。](../assets/img/kv-routing.png)
+
+*使用 2 个 H100 节点上的 R1 Distilled Llama 70B FP8，对 R1 发起 100K 个请求进行测试。平均 4K ISL / 800 OSL。*
+
+### KV Block Manager (KVBM)
+
+KVBM 通过多层内存 offload/recall 扩展有效缓存容量。
+
+![折线图，对比 Pure GPU prefix caching with vLLM 和 KVBM host offloading 在 TTFT（Time To First Token）上的表现](../assets/img/kvbm-agg-performance.png)
+
+*使用 H100 上的 Qwen3-8B，在不同 QPS 值下测试。平均 20K ISL / 100 OSL。*
+
+### NIXL Data Transfer
+
+NIXL 通过优化跨异构内存的 worker 间传输行为，降低分布式服务中的 KV 交接成本。
+
+## 实现模型
+
+- **Rust** 用于性能敏感的运行时组件。
+- **Python** 用于后端集成和可扩展性。
+- 模块化子系统边界使 routing、planning、memory 和 transport 可以独立演进。
+
+## 相关文档
+
+- [Architecture Flow](/dynamo/dev/design-docs/architecture-flow)
+- [Router Design](/dynamo/dev/design-docs/component-design/router-design)
+- [Planner 设计](/dynamo/zh-CN/dev/design-docs/component-design/planner-design)
+- [Discovery Plane](/dynamo/dev/design-docs/communication-planes/discovery-plane)
+- [Event Plane](/dynamo/dev/design-docs/communication-planes/event-plane)
+- [Request Plane](/dynamo/dev/design-docs/communication-planes/request-plane)
+- [Fault Tolerance](/dynamo/dev/user-guides/fault-tolerance)
+- [Grove](/dynamo/dev/kubernetes-deployment/scale/grove)
+
+## 致谢
+
+Dynamo 受到以下既有开源工作的启发：
+
+- vLLM
+- SGLang
+- DistServe
+- Mooncake
+- AIBrix
+- BentoML

--- a/fern/translations/zh-CN/pages-v1.3.0/design-docs/disagg-serving.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/design-docs/disagg-serving.md
@@ -1,0 +1,72 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 分离式服务
+---
+
+LLM 请求的预填充和解码阶段具有不同的计算特征和内存占用。将这些阶段拆分到专门的 llm engine 中，可以实现更好的硬件分配、更高的可扩展性以及整体性能提升。例如，对受内存限制的解码阶段使用更大的 TP，而对受计算限制的预填充阶段使用更小的 TP，可以让两个阶段都高效执行。此外，对于长上下文请求，将其预填充阶段分离到专用的 prefill engine 中，可以让正在进行的解码请求得到高效处理，而不会被这些长预填充阻塞。
+
+一次请求的解耦执行主要包含三个步骤：
+1. Prefill engine 计算预填充阶段并生成 KV cache
+2. Prefill engine 将 KV cache 传输到 decode engine
+3. Decode engine 计算解码阶段。
+
+Dynamo 中的解耦设计提供了一个灵活的框架，可在多种条件下实现强劲性能。
+
+## 高效 KV 传输
+
+高性能解耦的关键是高效的 KV 传输。Dynamo 利用 NIXL 将 KV cache 直接从 prefill engine 的 VRAM 传输到 decode engine 的 VRAM。KV 传输是非阻塞的，因此在传输期间 GPU forward pass 仍可继续为其他请求服务。
+
+### Router 编排
+
+解耦 serving 流程由 `PrefillRouter` 编排：
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Frontend
+    participant Router as PrefillRouter
+    participant Prefill as Prefill Worker
+    participant Decode as Decode Worker
+
+    Client->>Frontend: Request
+    Frontend->>Router: Preprocessed Request
+    Router->>Router: Select prefill worker
+    Router->>Prefill: Prefill request
+    Prefill->>Prefill: Compute KV cache
+    Prefill-->>Router: disaggregated_params
+    Router->>Router: Select decode worker
+    Router->>Decode: Decode request + transfer metadata
+    Decode<<->>Prefill: KV transfer (NIXL)
+    Decode->>Decode: Generate tokens
+    Decode-->>Frontend: Stream tokens
+    Frontend-->>Client: Response
+```
+
+1. **Worker 选择**：Router 使用 KV 感知路由（基于 cache 重叠分数和负载）或简单负载均衡来选择 prefill worker。
+
+2. **Prefill 执行**：Router 将预填充请求发送给选定的 prefill worker。Prefill worker 计算 KV cache，并返回包含后端特定传输元数据的 `disaggregated_params`。
+
+3. **Decode 路由**：Router 将 prefill 结果注入到 decode 请求中，然后路由到 decode worker。
+
+4. **KV 传输**：Decode worker 使用传输元数据与 prefill worker 协调。NIXL 使用最佳可用传输方式（NVLink、InfiniBand/UCX 等）处理直接 GPU 到 GPU 传输。
+
+### 后端特定传输元数据
+
+传输元数据格式因后端而异：
+
+- **SGLang**：使用 `bootstrap_info`（host、port、room_id）进行 RDMA bootstrap 协调。SGLang prefill worker 会在初始化期间将其 bootstrap endpoint 发布到 discovery service。借助这种机制，prefill 可以作为后台任务运行，使 decode 阶段能够立即开始，同时 KV 传输并行进行。
+
+- **vLLM**：使用包含 block ID 和远程 worker 连接信息的 `kv_transfer_params`。Prefill 同步运行；decode 会等待 prefill 完成后再继续。
+
+- **TRTLLM**：使用包含序列化 TRT-LLM 内部元数据的 `opaque_state`。Prefill 同步运行；decode 会等待 prefill 完成后再继续。
+
+
+## 运行时可重新配置的 xPyD
+
+Dynamo 的解耦设计支持运行时可重新配置的 xPyD（x 个 prefill worker，y 个 decode worker）。Worker 可以在运行时添加和移除：
+
+- **添加 worker**：Worker 向 discovery service 注册，并发布其 `RuntimeConfig`（包括 KV 容量）。
+- **移除 worker**：Worker 排空活跃请求，并从 discovery 注销。
+
+Router 会通过 discovery service 自动发现新的 worker，并将其纳入路由决策。

--- a/fern/translations/zh-CN/pages-v1.3.0/design-docs/planner-design.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/design-docs/planner-design.md
@@ -1,0 +1,237 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Planner 设计
+---
+
+> 面向贡献者和架构设计者的 **Tier 3 设计文档**。面向用户的文档请参阅 [Planner 指南](/dynamo/zh-CN/dev/components/planner/planner-guide)。
+
+## 概览
+
+Planner 是 Dynamo 的自动扩缩容控制器。它支持两种扩缩容模式：**基于吞吐量** 的模式使用 profiling 数据和流量预测，**基于负载** 的模式使用实时引擎指标和在线回归。本文介绍这两种模式的内部架构、算法和设计取舍。
+
+## 运行时 Pipeline
+
+运行时 planner 由 `OrchestratorEngineAdapter` 驱动。它把本地扩缩容算法包装成 builtin plugins，并运行与外部 gRPC plugins 相同的 plugin pipeline。
+
+1. **OBSERVE**：`NativePlannerBase` 和 engine adapter 收集 worker 数量、流量指标和 forward-pass metrics。观测数据通过 `PipelineContext.observations` 暴露。
+2. **PREDICT**：`builtin_load_predict` 按 throughput interval 运行。它消费流量观测，并为当前 tick 输出预测的请求数、ISL、OSL、KV hit rate 和 speculative accept length。
+3. **PROPOSE**：`builtin_throughput_propose` 消费同一个 tick 的预测结果，并更新 throughput lower bound。`builtin_load_propose` 消费 FPM 和 worker 观测，并执行基于负载的 +/-1 扩缩容算法。
+4. **RECONCILE / CONSTRAIN**：通用 pipeline 合并 builtin 和外部 plugins 的 proposal。CONSTRAIN 之后，engine adapter 会在返回 scaling effect 前应用本地 planner 的最终 `min_endpoint` 和 GPU budget 不变量。
+5. **EXECUTE**：adapter 返回 `PlannerEffects.scale_to`；`NativePlannerBase` 通过配置的 connector 应用这些目标。
+
+为了兼容现有配置和 DGDR 生成的 planner payload，`load_adjustment_interval_seconds` 和 `throughput_adjustment_interval_seconds` 仍然定义 builtin plugin 的 fire interval。基础 `scheduling.scale_interval_seconds` 默认是已启用 interval 的最大公约数，因此现有 load 和 throughput 的 fire time 会保持不变。
+
+![Planner plugin pipeline showing shared builtin state and OBSERVE, PREDICT, PROPOSE, RECONCILE, CONSTRAIN, and EXEC stages](../assets/img/planner-plugin-pipeline.png)
+
+### 为什么需要两个 Scaling Loop
+
+两个 builtin scaling loop 对应不同的控制周期。基于吞吐量的扩缩容是较慢的预测式 capacity loop：它使用更长的流量窗口、负载预测，以及 profiling 或 perf-model 的容量估算，为持续需求提前准备容量。这样可以避免对短期指标噪声做反应，也给 scale-out 留出足够时间，让容量在预测负载到来前完成就绪。
+
+基于负载的扩缩容是更快的反应式 SLA-correction loop。它使用当前 FPM、queue、worker count 和在线 perf-model 观测，处理短期 overload、预测或 profiling 误差、KV hit rate 或 speculative accept length 等 runtime metadata 变化，以及前一次扩缩容之后实际观察到的状态。
+
+当两个 loop 同时启用时，基于吞吐量的扩缩容设置 replica lower bound，基于负载的扩缩容在这个 floor 之上以更高频率调整。这样既不会因为短暂 idle period 移除为近未来需求预测出的容量，也能在实时 SLA 压力出现时，比 throughput interval 更快响应。
+
+### Builtin 共享状态
+
+Pipeline context 是每个 tick 的数据平面：observations、predictions 和 proposals 都是为当前 tick 产生，并通过 public plugin API 在 stage 之间传递。Builtin local planner 还需要跨 tick 状态来保持现有 planner 行为。这些状态保存在 `PlannerScalingState` 中；它是 builtin plugins 和 engine adapter 的私有状态，不是 public gRPC plugin contract。
+
+`PlannerScalingState` 保存：
+
+- **Worker inventory**：当前 ready 的 prefill/decode 数量、expected 数量，以及 prefill 或 decode 扩缩容操作是否仍在进行中。
+- **Perf models**：prefill、decode 或 aggregated `PlannerEnginePerfModel` 实例，包括部署前 benchmark FPM 和在线 FPM 更新。
+- **Throughput lower bounds**：由基于吞吐量的扩缩容产生的当前 prefill/decode floor。基于负载的扩缩容可以扩到这个 floor 之上，但不能缩到这个 floor 之下。
+- **Runtime metadata**：最近观测到的 KV hit rate 和 speculative accept length。这些值使用 last-value 语义，并作为 capacity estimation 的输入特征。
+- **每个 tick 的 diagnostics scratch**：估算的 TTFT/ITL、预测的流量形状、engine RPS、decision reasons、lower bounds，以及 metrics 和 HTML reports 使用的 execution/audit metadata。
+- **Worker capabilities 和 budget 输入**：组件 GPU 数量和运行时能力，用于把最终目标 clamp 到 `min_endpoint` 和 GPU budgets。
+
+Predictor history 不保存在 `PlannerScalingState` 中。`builtin_load_predict` 自己维护 request count、ISL 和 OSL predictor state，并通过 `PredictionData` 把同一个 tick 的输出显式传给后续 stage。这样 PREDICT -> PROPOSE 的依赖是显式的，同时 builtin proposer plugins 仍然可以共享天然跨 tick 的状态，例如 perf-model fitting 和 throughput floors。
+
+## 基于吞吐量的扩缩容
+
+基于吞吐量的扩缩容由两个 builtin plugins 实现：`builtin_load_predict` 和 `builtin_throughput_propose`。
+
+### Step 1: 流量观测
+
+在 throughput cadence 的 tick 上，engine adapter 会根据 `throughput_metrics_source` 从 frontend 或 router 查询 Prometheus 流量指标：
+
+- request count
+- average input sequence length (ISL)
+- average output sequence length (OSL)
+- KV hit rate
+- speculative decode accept length
+
+观测窗口是 `throughput_adjustment_interval_seconds`，而外层 pipeline cadence 仍然是 `scheduling.scale_interval_seconds`。
+
+### Step 2: 负载预测
+
+Planner 会预测下一个 interval 的三个流量形状值：
+
+- `next_num_req`：请求数量
+- `next_isl`：平均 input sequence length
+- `next_osl`：平均 output sequence length
+
+可用的 predictor 实现有四种：
+
+| Predictor    | Algorithm                                | Best For                         |
+| ------------ | ---------------------------------------- | -------------------------------- |
+| **Constant** | `next = current`                         | 稳定工作负载、长 interval |
+| **ARIMA**    | Auto-ARIMA with optional log1p transform | 趋势/季节性模式 |
+| **Kalman**   | Local linear trend Kalman filter         | 突发流量 |
+| **Prophet**  | Facebook Prophet time-series model       | 复杂季节性 |
+
+所有 predictors 都支持从 trace 文件 warm-starting（`--load-predictor-warmup-trace`）。
+
+描述 engine/router 行为的 runtime metadata 不通过这些 predictors 预测。KV hit rate 和 speculative decode accept length 使用 last-value 语义：planner 保存最新的有效 Prometheus 观测，并在新的有效值到来前复用它。冷启动时，KV hit rate 缺失表示不做 discount，accept length 缺失表示 `1.0`。
+
+### Step 3: 容量估算
+
+`builtin_throughput_propose` 消费同一个 tick 的预测结果，并根据配置的 SLA 目标查询 planner perf model 的 prefill/decode capacity。Perf model 会从第一个可用来源启动：
+
+1. worker `get_perf_metrics` self-benchmark data
+2. 配置了 `aic_interpolation` 时的 AI Configurator interpolation
+3. `profile_results_dir` 中的 NPZ/JSON fallback data
+4. 没有 pre-deployment data 时的 live FPM regression warmup
+
+Rust perf shim 可以使用原生 AIC 估算和在线 FPM tuning。KV hit rate 和 speculative accept length 等 runtime metadata 会作为输入特征使用，而不是作为持久 correction-factor flags。
+
+### Step 4: Proposal 和 Lower Bound
+
+Throughput proposer 会把预测负载和每个 engine 的 capacity 转换成 replica targets。当同时启用 throughput 和 load scaling 时，基于吞吐量的扩缩容写入 lower bound；更快的 load-based proposer 可以扩到这个 bound 之上，但不能缩到这个 bound 之下。
+
+### Step 5: 执行扩缩容
+
+合并后的 pipeline result 会变成 `PlannerEffects.scale_to`。运行时 base 随后调用配置的 connector 来应用组件 replica targets。
+
+## Connector 设计
+
+### Interface
+
+```python
+class PlannerConnector(ABC):
+    async def add_component(self, component_name)
+    async def remove_component(self, component_name)
+    # Extended interface (not on ABC, but implemented by both connectors):
+    async def set_component_replicas(self, targets, blocking)
+    async def validate_deployment(self, ...)
+    async def wait_for_deployment_ready(self)
+```
+
+### KubernetesConnector
+
+直接 PATCH DGD resource 来更新 replica counts。operator 会监听 DGD 变更，并 reconcile component deployments。
+
+**设计决策：**
+
+- 使用 `DYN_PARENT_DGD_K8S_NAME` 找到父 DGD（由 operator 注入）
+- 通过 `subComponentType` 字段解析 service（prefill/decode），并 fallback 到 legacy component names
+- 启动时验证 deployment 结构：检查 prefill 和 decode services 是否存在，以及 model names 是否匹配
+
+### VirtualConnector
+
+用于非原生环境（例如自定义 orchestrators）。它通过 `VirtualConnectorCoordinator`（Rust binding）把扩缩容决策写入 distributed runtime。外部系统使用 `VirtualConnectorClient` poll 决策并上报完成。
+
+**扩缩容决策流程：**
+
+1. Planner 向 runtime 写入 `(num_prefill, num_decode, decision_id)`
+2. 外部系统通过 `client.wait()` 读取决策
+3. 外部系统执行扩缩容
+4. 外部系统通过 `client.complete(decision)` 上报完成
+5. Planner 看到 `scaled_decision_id >= decision_id` 后继续
+
+**Timeout**：如果扩缩容在 1800s 内没有 ack（可配置），planner 仍会继续处理新的决策。
+
+## Performance Interpolation
+
+Planner 使用部署前 profiling 数据（NPZ 文件）把 `(throughput, ISL/OSL, context_length)` 映射到 `(TTFT, ITL)`。这些数据来自 SLA-driven profiling 流程，可以是真实 GPU profiling，也可以是 AI Configurator 估算。
+
+维护了两个 interpolators：
+
+- **Prefill interpolator**：映射 `(throughput_per_gpu, ISL) -> TTFT`
+- **Decode interpolator**：映射 `(throughput_per_gpu, context_length) -> ITL`
+
+Interpolators 使用 profiling sweep granularity 来决定精度。granularity 越细，profiling samples 越多，interpolation 也越准确。
+
+## 初始化
+
+`python -m dynamo.planner` entrypoint 加载 `PlannerConfig`，构造 mode-specific planner wrapper，然后初始化所选 connector。运行时 base 会验证 worker topology、发现 worker capabilities、把可用的 pre-deployment FPM 安装到 perf model、启动 builtin 和已配置 plugins，并进入 tick loop。
+
+## Performance Considerations
+
+- **Adjustment interval sizing**：plugin execution interval 必须足够长，让扩缩容操作完成。如果 `load_adjustment_interval_seconds` 或 `throughput_adjustment_interval_seconds` 短于添加/移除 worker 的时间（包括 pod scheduling、model loading 和 registration），后续扩缩容决策可能观察到一个仍在进行中的 replica transition，并 hold 到它完成。
+- **Perf-model bootstrap quality**：基于吞吐量的扩缩容可以从 worker self-benchmark data、AI Configurator interpolation、`profile_results_dir` 文件或 live FPM regression 启动。缺少 bootstrap data 是允许的，但早期决策可能会 hold，直到足够的 live FPM observations 到达。
+- **Interpolation accuracy vs profiling cost**：profiler sweep 中更高的 `prefillInterpolationGranularity` 和 `decodeInterpolationGranularity` 会产生更准确的 bootstrap data，但 profiling 时间也会线性增加。默认 granularity（16 prefill，6 decode）在准确性和 profiling duration 之间做平衡。
+- **Predictor warm-up period**：所有 predictors 都需要 observation history 才能产生可靠预测。ARIMA 和 Prophet 需要多个 adjustment intervals 的数据。Kalman 在 `--kalman-min-points` 个观测之后开始预测。Warm-up 期间，planner 使用 constant predictor 作为 fallback。
+
+## 基于负载的扩缩容
+
+基于负载的模式使用 Dynamo event plane 中的 ForwardPassMetrics (FPM)，在不需要 profiling data 或 KV Router 的情况下做 SLA-aware 扩缩容决策。
+
+### Metrics
+
+每个 engine 会通过 ZMQ -> FpmEventRelay -> event plane 发出每次 iteration 的 `ForwardPassMetrics`。Planner 通过 `FpmEventSubscriber` 订阅，并支持自动 engine discovery 和基于 MDC 的 lifecycle tracking。关键字段包括：
+
+- **wall_time**：每次 iteration 的执行时间（regression target）
+- **scheduled_requests.sum_prefill_tokens**：prefill regression input
+- **scheduled_requests.sum_decode_kv_tokens**：decode regression input
+- **queued_requests**：用于 TTFT/ITL simulation 的 queued prefill/decode load
+- Idle heartbeats（wall_time=0）会被跳过
+
+### Diagnostics
+
+每个 tick 中，scaling state machine 会通过内部 `_diag_*` 字段填充 `TickDiagnostics`，包含中间决策数据，例如 estimated latencies、predicted load、per-engine RPS 和 decision reasons。Adapter layer 读取 `PlannerEffects.diagnostics` 并：
+
+- 设置 Prometheus gauges，例如 `dynamo_planner_estimated_ttft_ms` 和相关估算指标
+- 记录 load-scaling decision reasons 的 enum metrics（`dynamo_planner_load_scaling_decision`）
+- 送入 `DiagnosticsRecorder`，它会累计 per-tick snapshots，并按计划输出基于 Plotly 的 HTML reports
+
+来自 `_collect_fpm()` 的 per-engine FPM queue depths 会以带 label 的 Prometheus gauges 导出。
+
+### Regression Models
+
+三个专用 regression models 位于 `components/src/dynamo/planner/core/perf_model/`：
+
+- **PrefillRegressionModel**：1D regression `sum_prefill_tokens -> wall_time`。通过模拟 chunked prefill scheduling（chunk 大小为 `max_num_batched_tokens`）估算 TTFT。
+- **DecodeRegressionModel**：1D regression `sum_decode_kv_tokens -> wall_time`。估算 total decode load（scheduled + queued + avg decode length）的 ITL。
+- **AggRegressionModel**：2D regression `(sum_prefill_tokens, sum_decode_kv_tokens) -> wall_time`。估算 TTFT（带 piggybacked decode 的 simulated prefill）和 ITL（带 average piggybacked prefill 的 decode）。
+
+### Scaling Decisions
+
+- **Prefill/Decode**：如果所有 engines 的 estimated TTFT/ITL 都大于 SLA，则 scale up；如果所有都小于 `SLA * sensitivity`，则 scale down。
+- **Agg**：如果所有 TTFT 大于 SLA 或所有 ITL 大于 SLA，则 scale up；只有当所有 TTFT 都小于 `SLA * sensitivity` 且所有 ITL 都小于 `SLA * sensitivity` 时才 scale down。
+- 每个 interval 只调整 +/-1（non-blocking，并带 pending-desired guard：扩缩容进行中仍会持续观测 metrics，但不会在前一个操作完成前发出新的 scaling action）。
+
+### 与基于吞吐量的扩缩容共存
+
+当两种模式都启用时，基于吞吐量的扩缩容（更长 interval）会设置 replicas 的 lower bound，而基于负载的扩缩容（更短 interval）负责在这个 floor 之上的实时调整。
+
+### Aggregated Mode
+
+在 aggregated mode（`--mode agg`）下，engines 同时处理 prefill 和 decode，并使用 chunked prefill。Planner 维护 TTFT 和 ITL 两个 regression models，但使用按 worker 时间平均的 metrics（不是瞬时值）进行 regression training，以平滑 chunked prefill noise。如果 prefill 或 decode 任一信号 overload，则 scale up；只有两者都 underload 时才 scale down。
+
+## Known Limitations
+
+1. **Adjustment interval vs scaling latency**：如果 plugin interval 短于扩缩容耗时，后续 tick 可能观察到正在进行中的 transition，并 hold，而不是叠加新的 replica change。
+2. **Average-based prediction**：基于吞吐量的扩缩容使用平均 ISL/OSL，这可能无法很好表示 bimodal 或 heavy-tailed distributions。
+3. **Single DGD scope**：每个 planner instance 只管理一个 DGD。不支持 multi-model/multi-DGD coordination。
+
+## Future Work
+
+- 面向 shared-cluster 场景的 multi-DGD coordination
+- Distribution-aware interpolation（超越 mean ISL/OSL）
+- 基于 observed scaling latency 的 adaptive adjustment interval
+
+## File Map
+
+| File / package | Purpose |
+| --------------- | ------- |
+| `components/src/dynamo/planner/core/base.py` | Runtime I/O loop：收集 observations 并应用 scaling effects。 |
+| `components/src/dynamo/planner/core/state_machine.py` | 本地 planner plugins 使用的 shared builtin scaling state。 |
+| `components/src/dynamo/planner/core/load_scaling.py` | FPM-driven load scaling algorithm。 |
+| `components/src/dynamo/planner/core/throughput_scaling.py` | Prediction-driven throughput scaling algorithm。 |
+| `components/src/dynamo/planner/plugins/builtins/` | 把 local planner algorithms 暴露给 pipeline 的 builtin plugins。 |
+| `components/src/dynamo/planner/plugins/orchestrator/` | PREDICT -> PROPOSE -> RECONCILE -> CONSTRAIN pipeline driver 和 engine adapter。 |
+| `components/src/dynamo/planner/plugins/proto/v1/` | Public gRPC/proto plugin API。 |
+| `components/src/dynamo/planner/monitoring/` | Prometheus、diagnostics reports、live dashboard 和 worker metadata。 |
+| `components/src/dynamo/planner/connectors/` | K8s、virtual、global-planner 和 remote connector implementations。 |
+| `components/src/dynamo/planner/config/` | PlannerConfig schema、defaults、backend component names 和 profiling bootstrap specs。 |

--- a/fern/translations/zh-CN/pages-v1.3.0/fault-tolerance/request-migration.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/fault-tolerance/request-migration.md
@@ -1,0 +1,172 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 请求迁移
+---
+
+本文档介绍 Dynamo 如何实现请求迁移，以便在 LLM 文本生成期间优雅地处理 worker 故障。请求迁移允许正在处理的请求在原始 worker 不可用时继续在其他 worker 上执行，从而提供故障容错能力并改善用户体验。
+
+## 概述
+
+请求迁移通过一个 Migration operator 实现，该 operator 位于 Backend operator 和服务后端之间的 LLM 处理流水线中。当 worker 在请求处理期间发生故障时，迁移系统会保留部分生成状态，并在新的 worker 上重新创建请求，从上一个 worker 中断的位置继续执行。
+
+## 架构组件
+
+### Migrator
+
+迁移系统集成在前端预处理和实际服务后端之间的 LLM 处理流水线中。这个位置使它能够拦截所有通信流，并透明地管理故障场景。
+
+主要职责：
+- 拦截流经流水线的所有请求和响应
+- 通过错误模式匹配检测 worker 故障场景
+- 使用可配置的迁移限制管理重试逻辑
+- 跟踪部分响应状态，以实现无缝续接
+
+### 迁移限制配置
+
+迁移限制在 **frontend** 级别配置，并全局应用于该 frontend 服务的所有模型。此参数指定一个请求最多可以迁移到另一个 worker 的次数：
+
+- 默认行为：不允许迁移（migration_limit=0）
+- 通过 frontend 上的 `--migration-limit` 标志设置
+- 应用于该 frontend 服务的所有模型
+
+### 最大序列长度配置
+
+最大序列长度设置控制迁移系统为某个请求缓存 token 状态的时长。一旦总序列长度（prompt + 已生成 token）超过此限制，该请求的迁移就会被禁用，并停止 token 跟踪：
+
+- 默认行为：无限制（未设置 `--migration-max-seq-len`）
+- 通过 frontend 上的 `--migration-max-seq-len` 标志或 `DYN_MIGRATION_MAX_SEQ_LEN` 环境变量设置
+- 防止因缓存长序列而导致内存无限增长
+- 边界：恰好达到限制时仍可迁移；只有严格超过限制才会禁用迁移
+- 检查会在请求初始化时（prompt 长度）和生成期间（prompt + 输出 token）运行
+
+## Token 状态跟踪和请求迁移
+
+迁移系统的核心能力是通过 token 状态管理来保留并继续部分生成。这确保当 worker 在生成中途发生故障时，新的 worker 可以从确切的故障点无缝继续。
+
+### Token 累积过程
+
+当请求正在处理且响应从 worker 回流时，迁移系统会跟踪每一个已成功生成的 token：
+
+1. **初始请求状态**：系统从包含初始 prompt token 的原始预处理请求开始。
+
+2. **响应跟踪**：当每个响应从 worker 到达时，迁移系统会提取新生成的 token，并将其追加到请求的 token 序列中。这样会累积所有已经生成的 token。
+
+3. **Token 计数管理**：系统还会更新剩余 token 预算，以反映已经生成的 token 数量，确保总生成量保持在最初请求的限制范围内。
+
+### 迁移触发场景
+
+迁移系统处理两种不同的故障场景：
+
+#### 1. 新请求迁移（初始连接失败）
+
+**场景**：创建初始连接时 worker 不可达。
+
+**错误模式**：通信系统报告所选 worker 实例不可用。
+
+**迁移过程**：
+- 在初始 stream 设置期间检测连接失败
+- 递减迁移重试计数
+- 尝试使用原始请求创建新的 stream
+- 由于生成尚未开始，因此没有需要保留的部分状态
+
+#### 2. 进行中请求迁移（stream 中途断开）
+
+**场景**：在收到部分响应后的活跃生成期间连接丢失。
+
+**错误模式**：在生成完成前检测到 stream 终止。
+
+**迁移过程**：
+
+1. **故障检测**：系统通过错误监控检测到 stream 断开。
+
+2. **状态保留**：此时，请求的 token 序列同时包含原始 prompt token 和来自故障 worker 的所有已成功生成 token。
+
+3. **创建新 Stream**：使用累积的请求状态创建新的 stream，确保新 worker 拥有完整上下文。
+
+4. **继续生成**：新 worker 接收带有完整 token 上下文的请求，并从上一个 worker 中断的确切位置继续生成。
+
+### 无缝 Token 流和请求状态演进
+
+从客户端视角看，token 流是连续且不中断的。客户端会持续从第一个 worker 接收 token，直到发生故障，然后无缝地继续从备用 worker 接收 token，而不会感知到底层发生了迁移。
+
+请求状态会在处理过程中动态演进。最初，请求只包含原始 prompt token。随着生成推进，每个成功生成的 token 都会追加到请求的 token 序列中，从而形成一条不断增长的完整对话上下文记录。
+
+当迁移发生时，这个累积状态会传输给新的 worker，新的 worker 使用它重建完整上下文。随后，新 worker 会像从一开始就在处理该请求一样继续生成，但从序列中的当前位置开始。
+
+迁移是透明的，因为：
+1. 转换期间不会丢失或重复 token
+2. 新 worker 通过累积的 token 序列获得完整上下文
+3. 生成会从确切的故障点继续
+4. 响应流保持一致的格式和时序
+
+这种 token 累积机制确保迁移真正无缝，保留所有计算工作，并在 worker 切换过程中维持生成质量。
+
+## 优点
+
+1. **故障容错**：系统在单个 worker 故障期间仍能继续运行
+2. **资源效率**：保留部分生成结果，而不是从头重新开始
+3. **无缝用户体验**：用户在 worker 故障期间不会感到中断
+4. **可配置行为**：迁移限制允许根据部署需求进行调优
+5. **无 Token 丢失**：在迁移过程中完整保留生成状态
+
+## 设计考量
+
+迁移系统的设计包含几个重要的架构考量：
+
+**多模型支持**：由于一个 frontend 可能同时服务多个模型，迁移限制在 frontend 级别配置，并统一应用于所有模型，从而简化运维管理。
+
+**状态管理**：系统不仅仔细跟踪 token 序列，还会跟踪剩余 token 预算、停止条件和采样参数等元数据，以确保状态完整保留。
+
+**错误处理**：迁移系统会区分不同类型的故障，并为每种场景应用合适的恢复策略。
+
+## 监控和指标
+
+迁移系统公开 Prometheus 指标，用于监控迁移活动。这些指标可在 frontend 的 `/metrics` 端点上获取（默认端口 8000）：
+
+- `dynamo_frontend_model_migration_total`：跟踪请求迁移总次数的计数器
+  - 标签：
+    - `model`：正在服务的模型名称
+    - `migration_type`：可以是 `new_request`（初始连接失败）或 `ongoing_request`（stream 中途断开）
+- `dynamo_frontend_model_migration_max_seq_len_exceeded_total`：跟踪因为序列长度超过已配置的 `--migration-max-seq-len` 而禁用迁移的次数的计数器
+  - 标签：
+    - `model`：正在服务的模型名称
+
+**指标输出示例：**
+```text
+dynamo_frontend_model_migration_total{migration_type="ongoing_request",model="Qwen/Qwen3-0.6B"} 3
+dynamo_frontend_model_migration_total{migration_type="new_request",model="Qwen/Qwen3-0.6B"} 1
+dynamo_frontend_model_migration_max_seq_len_exceeded_total{model="Qwen/Qwen3-0.6B"} 2
+```
+
+这些指标可用于：
+- 监控 worker 可靠性和故障模式
+- 在迁移率过高、表明存在基础设施问题时发出告警
+- 跟踪故障容错机制的有效性
+- 监控 `--migration-max-seq-len` 达到限制的频率，这可能表示需要调整该限制
+
+有关 Dynamo 指标的更多信息，请参阅[指标文档](/dynamo/dev/user-guides/observability-local/metrics)。
+
+## 已知限制
+
+### 多个选择（`n > 1`）
+
+对于请求使用 `n > 1` 要求生成多个选择的 OpenAI 兼容请求，**不支持**请求迁移。即使 `--migration-limit` 大于 0，Dynamo 也会为这些请求禁用迁移。
+
+**原因：** 多选择生成会维护各个选择各自的输出状态。迁移部分完成的请求需要分别传输每个选择的已生成 token 状态、剩余 token 预算、完成状态和 decoder 状态。当前迁移路径只保留单一续接状态，因此重试交错的 `n > 1` 请求可能会重复或丢失特定选择的输出。
+
+此限制不影响省略 `n` 或将其设置为 1 的普通单选择请求。
+
+### Guided Decoding（结构化输出）
+
+对于使用 guided decoding（结构化输出 / JSON schema）的请求，**不支持**请求迁移。当 worker 在 guided-decoding 请求期间发生 stream 中途故障时，错误会传播给客户端，而不是尝试迁移。
+
+**原因：** 推理后端会为每个新请求重新初始化 guided-decoding 有限状态机（FSM），并且只在新生成的 token 上推进它，而不会在上下文/prompt token 上推进它。当部分完成的请求迁移到新的 worker 时，新 worker 会把已生成 token 作为上下文重放，但 FSM 会从 schema 根节点开始。这种 token 状态和 FSM 状态之间的不匹配会产生损坏的输出，通常表现为重复或嵌套的 JSON。
+
+此限制同样适用于所有后端（vLLM、SGLang、TRT-LLM）。
+
+**未来方向：** 支持 guided-decoding 请求的迁移将需要在 worker 之间序列化并恢复 FSM 状态，或者在新的 worker 上通过 FSM 重放先前的输出 token。这被跟踪为未来增强功能。
+
+## 运维影响
+
+请求迁移从根本上改变了系统处理故障的方式，从“快速失败”方法转向“优雅降级”模型。这种架构转变在为客户端保持相同外部 API 契约的同时，实现了更高可用性和更好的资源利用率。

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/building-from-source.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/building-from-source.md
@@ -1,0 +1,168 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 从源代码构建
+sidebar-title: 从源代码构建
+description: 从源代码构建 Dynamo，用于开发和贡献
+---
+
+当你想贡献代码、测试开发分支上的功能，或自定义构建时，可以从源代码构建 Dynamo。如果你只是想运行 Dynamo，[本地安装](/dynamo/zh-CN/dev/getting-started/local-installation)指南会更快。
+
+本指南涵盖 Ubuntu 和 macOS。如需一个能自动处理所有这些步骤的容器化开发环境，请参阅 [DevContainer](#devcontainer)。
+
+## 1. 安装系统库
+
+**Ubuntu：**
+
+```bash
+sudo apt install -y build-essential libhwloc-dev libudev-dev pkg-config libclang-dev protobuf-compiler python3-dev cmake
+```
+
+**macOS：**
+
+```bash
+# Install Homebrew if needed
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+brew install cmake protobuf
+
+# Verify Metal is accessible
+xcrun -sdk macosx metal
+```
+
+## 2. 安装 Rust
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+
+## 3. 创建 Python 虚拟环境
+
+如果你还没有安装 [uv](https://docs.astral.sh/uv/#installation)，请先安装：
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+创建并激活虚拟环境：
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+```
+
+## 4. 安装构建工具
+
+```bash
+uv pip install pip 'maturin[patchelf]'
+```
+
+[Maturin](https://github.com/PyO3/maturin) 是 Rust-Python 绑定的构建工具。`patchelf` extra 让 maturin 能在构建期间修补原生扩展库路径。
+
+## 5. 构建 Rust 绑定
+
+```bash
+cd lib/bindings/python
+maturin develop --uv
+```
+
+## 6. 安装 GPU Memory Service
+
+```bash
+# Return to project root
+cd "$(git rev-parse --show-toplevel)"
+uv pip install -e lib/gpu_memory_service
+```
+
+## 7. 安装 Wheel
+
+请安装带有后端附加依赖（backend extra）的 Dynamo，以拉取推理引擎及其 CUDA 依赖。选择你要运行的后端：
+
+```bash
+# 使用 .[vllm] 或 .[sglang] 来安装相应的框架依赖
+uv pip install -e .
+```
+
+<Note>
+仅执行基础的 `uv pip install -e .` 只会安装 Dynamo 运行时和前端。后端附加依赖（`[vllm]` 或 `[sglang]`）会安装运行推理 worker 所需的相应框架依赖。对于 TensorRT-LLM 后端，请改用 `tensorrtllm-runtime` 容器，而不是通过 `uv pip` 安装，以确保安装正确的依赖。更多详情请参阅[本地安装](/dynamo/zh-CN/dev/getting-started/local-installation)。
+</Note>
+
+## 8. 验证构建
+
+```bash
+python3 -m dynamo.frontend --help
+```
+
+你应该会看到 frontend 命令的帮助输出。
+
+## DevContainer
+
+VSCode 和 Cursor 用户可以使用预配置的开发容器，跳过手动设置。DevContainer 会自动安装所有工具链、构建项目，并设置 Python 环境。
+
+针对 vLLM、SGLang 和 TensorRT-LLM 提供了特定框架的容器。有关设置说明，请参阅 [DevContainer README](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/.devcontainer)。
+
+## 设置 Pre-commit Hooks
+
+提交 PR 之前，请安装 pre-commit hooks，以确保你的代码通过 CI 检查：
+
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
+手动对所有文件运行检查：
+
+```bash
+pre-commit run --all-files
+```
+
+## 故障排查
+
+**缺少系统包**
+
+如果 `maturin develop` 因链接器错误失败，请确认已安装所有系统依赖。在 Ubuntu 上：
+
+```bash
+sudo apt install -y build-essential libhwloc-dev libudev-dev pkg-config libclang-dev protobuf-compiler python3-dev cmake
+```
+
+**虚拟环境未激活**
+
+Maturin 会针对当前激活的 Python 解释器进行构建。如果你看到与 Python 或 site-packages 相关的错误，请确保虚拟环境已激活：
+
+```bash
+source .venv/bin/activate
+```
+
+**磁盘空间**
+
+Rust 的 `target/` 目录在开发过程中可能增长到 10 GB 以上。如果构建因磁盘空间错误失败，请清理构建缓存：
+
+```bash
+cargo clean
+```
+
+**vLLM worker 启动失败：FlashInfer sampler 的 JIT 与 CUDA 13 wheels**
+
+在 CUDA 13 源码安装环境下运行 vLLM worker 时，worker 可能在启动阶段因 FlashInfer JIT 错误而中止：
+
+```text
+RuntimeError: Engine core initialization failed.
+...
+cuda/std/__cccl/cuda_toolkit.h:41: error: "CUDA compiler and CUDA toolkit headers are incompatible"
+```
+
+为 CUDA 13 安装解析出的 CUDA wheels 可能存在版本偏差：`torch` 将运行时头文件锁定到 13.0，而 vLLM 的 `tilelang` 依赖会拉取 `nvidia-cuda-nvcc` 13.2。FlashInfer 使用 `nvcc` 针对这些头文件编译其 sampler 内核，版本不匹配会导致构建失败。此问题在上游 [flashinfer#3493](https://github.com/flashinfer-ai/flashinfer/issues/3493) 中追踪。
+
+设置 `VLLM_USE_FLASHINFER_SAMPLER=0`，让 vLLM 回退到原生 sampler：
+
+```bash
+export VLLM_USE_FLASHINFER_SAMPLER=0
+```
+
+## 后续步骤
+
+- [贡献指南](/dynamo/zh-CN/dev/getting-started/contribution-guide) -- 贡献代码的工作流
+- [示例](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/examples) -- 探索代码库
+- [Good First Issues](https://github.com/ai-dynamo/dynamo/labels/good-first-issue) -- 查找可以着手处理的任务

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/introduction.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/introduction.md
@@ -1,0 +1,162 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 简介
+sidebar-title: 简介
+---
+
+Dynamo 是一个开源、高吞吐、低延迟的推理框架，专为在分布式环境中服务生成式 AI 工作负载而设计。本页概述 Dynamo 的设计原则、性能优势和生产级功能。
+
+<Tip>想马上开始？请参阅 [Quickstart](/dynamo/zh-CN/dev/getting-started/quickstart)，几分钟内即可安装并运行 Dynamo。</Tip>
+
+## 为什么选择 Dynamo？
+
+推理引擎优化 GPU；Dynamo 优化围绕它们的整个系统。
+
+- **在任意引擎之上的系统级优化** -- 推理引擎优化单 GPU 前向传递。Dynamo 增加分布式层：分离式服务、智能路由、跨内存层级的 KV 缓存管理，以及自动扩缩容。
+- **可组合的性能提升技术** -- 分离式服务、KV 缓存感知路由和 KV 缓存卸载等技术各自都能提升性能；组合使用时会带来叠加收益。
+- **引擎无关** -- 可与 vLLM、SGLang 和 TensorRT-LLM 配合使用。无需改变服务基础设施即可替换引擎。正在扩展对 Intel XPU 和 AMD 硬件的支持。
+- **面向大规模生产就绪** -- Dynamo 覆盖完整部署生命周期：自动配置（AIConfigurator）、运行时自动扩缩容（Planner）、拓扑感知的 gang scheduling（Grove）、容错和可观测性。
+- **模块化采用** -- 可以从一个组件开始（例如，仅在现有引擎之上使用 Router 实现 KV 感知路由）。按需采用更多组件。每个组件都可通过 pip 独立安装。
+
+## 设计原则
+
+### 面向 AI 推理的坚实基础
+
+Dynamo 在推理引擎之上增加系统级优化。为了提供这些优化，Dynamo 采用操作系统式的方法，为调度、内存管理和数据传输奠定基础。这些基础让 Dynamo 能随着新的系统级性能技术出现而持续演进。
+
+Dynamo 进行系统级设计的动机之一，是支持分离式服务：在不同设备上运行 prefill 和 decode，使两者能够独立扩展和并行化。分离式服务需要三项能力：(1) 调度，用于在不相互干扰的情况下分配 prefill 和 decode 阶段；(2) 内存管理，用于 KV 缓存卸载和载入；(3) 低延迟数据传输，用于在节点之间以及跨内存层级移动 KV 缓存。
+
+![Dynamo 基础：调度、内存管理和数据传输](../assets/img/intro-foundations.svg)
+
+Dynamo 的基础能力最初面向分离式服务，随后扩展到用于多模态的 EPD 分离，现在支持 diffusion、RL 和 agents 等工作负载。
+
+### 模块化且深度集成的生态系统
+
+Dynamo 旨在降低生产环境中替换现有技术栈的负担。它以 Rust crates 和 pip wheels 的形式提供模块化、独立组件。例如，Dynamo 用于调度（Dynamo）、内存管理（KV Block Manager）和数据传输（NIXL）的三项基础能力都可以独立安装：
+
+```bash
+pip install ai-dynamo
+pip install kvbm
+pip install nixl
+```
+
+<Note>
+也提供包含所有依赖项的预构建容器。请参阅 [Release Artifacts](/dynamo/dev/resources/release-artifacts) 了解容器镜像。
+</Note>
+
+Dynamo 生态系统包含以下额外的模块化组件，并会随着时间继续增长：
+
+| 类别 | 产品 | 描述 |
+| :--- | :--- | :--- |
+| **调度** | Dynamo | 面向 GenAI 工作负载的推理服务 |
+| **路由** | Router | 利用 KV 缓存命中率和 KV 缓存负载进行智能路由。将添加更多算法（例如 agentic routing） |
+| **数据传输** | [NIXL](https://github.com/ai-dynamo/nixl) | GPU 与分层存储之间的点对点数据传输（G1：GPU，G2：CPU，G3：SSD，G4：远程） |
+| **内存** | KVBM (KV Block Manager) | 使用可自定义的淘汰策略，跨内存层级（G1-G4）管理 KV 缓存 |
+| **扩缩容 / 云** | Planner | 在给定 SLA 约束（TTFT 和 TPOT）下，实时自动调优 prefill 和 decode 的性能 |
+| | [Grove](https://github.com/ai-dynamo/grove) | 支持 Kubernetes 多节点分离式服务所需的 gang scheduling 和拓扑感知 |
+| | [Model Express](https://github.com/ai-dynamo/model-express) | 通过缓存模型权重并经由 NIXL 将其传输到其他 GPU，快速加载模型权重。未来也将用于容错 |
+| **性能** | [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator) | 基于模型、ISL/OSL、HW 等估算聚合式与分离式服务的性能。以前称为 LLMPet |
+| | [AIPerf](https://github.com/ai-dynamo/aiperf) | 用 Python 编写、重新架构的 GenAI-Perf，具有最大可扩展性；支持分布式基准测试 |
+| | AITune | 给定模型或 pipeline，搜索最适合部署的后端（例如 TensorRT、Torch.compile 等）（即将推出） |
+| | Flex Tensor | 从主机内存向 GPU 流式传输权重，以便在内存容量有限的 GPU 上运行超大语言模型（即将推出） |
+
+这些组件是模块化的，但设计上会作为统一家族协同工作。新组件也将遵循同样的设计原则。
+
+### 促进供应商无关的生态系统
+
+Dynamo ***不是为供应商锁定而设计的***。Dynamo 旨在赋能更广泛的 AI 生态系统，并提供开发者所需的功能，例如与第三方组件集成。
+
+从一开始，Dynamo 就设计为支持所有 LLM 推理引擎（vLLM、SGLang 和 TensorRT-LLM）。未来计划支持更多引擎，以覆盖更多开发者用例。
+
+**也支持非 NVIDIA 硬件**：Dynamo 正在与 Intel 和 AMD 等 HW 供应商合作，扩展硬件支持。
+
+受支持生态系统组件的完整列表：
+
+| **产品领域** | **受支持的生态系统组件** |
+| :--- | :--- |
+| 推理引擎 | SGLang、TensorRT-LLM、vLLM |
+| Kubernetes | Inference gateway |
+| 内存管理 | Dynamo KV Block Manager、[LMCache](/dynamo/dev/integrations/kv-cache-integrations/lm-cache)、[SGLang HiCache](/dynamo/dev/integrations/kv-cache-integrations/hi-cache)、[FlexKV](/dynamo/dev/integrations/kv-cache-integrations/flex-kv) |
+| 网络和存储 | Mooncake、DOCA NetIO、GDS、POSIX、S3、3FS（[通过 NIXL 支持](/dynamo/dev/design-docs/component-design/kvbm-design)） |
+| Multi-HW | Intel XPU、AMD |
+
+## 性能
+
+Dynamo 通过组合三项核心技术实现先进的 LLM 性能：分离式服务、KV 缓存感知路由和 KV 缓存卸载。这些技术由 NIXL 支撑，NIXL 是一种低延迟数据传输层，可在节点之间无缝移动 KV 缓存。
+
+- [KV cache-aware routing](/dynamo/dev/design-docs/component-design/router-design) 根据 worker 负载和现有缓存命中情况智能路由请求。通过复用预先计算的 KV 对，它绕过 prefill 计算，立即开始 decode 阶段。[Baseten](https://www.baseten.co/blog/how-baseten-achieved-2x-faster-inference-with-nvidia-dynamo/#how-baseten-uses-nvidia-dynamo) 应用 Dynamo KV 缓存感知路由后，在 Qwen3 Coder 480B A35B 上实现了 2 倍更快的 TTFT 和 1.6 倍吞吐量。
+
+- [KV cache offloading](/dynamo/dev/design-docs/component-design/kvbm-design) 通过将 KV 缓存从 HBM 移动到主机内存、本地磁盘或远程存储等成本更低的存储层，扩展可用上下文窗口。复用预计算状态可改善 TTFT、降低总体拥有成本（TCO），并支持更长上下文处理。
+
+- [分离式服务](/dynamo/zh-CN/dev/design-docs/disaggregated-serving) 在“设计原则”部分，我们介绍了分离式服务的概念。[InferenceX](https://newsletter.semianalysis.com/p/inferencex-v2-nvidia-blackwell-vs) 展示了它的性能。借助分离式服务和大规模专家并行，DeepSeek V3 可以达到约 7 倍吞吐量/GPU。
+此外，当这三项技术组合在一起时，会产生如下图所示的叠加收益。
+
+![分离式服务、KV 缓存感知路由和 KV 缓存卸载的性能可组合性](../assets/img/intro-perf.svg)
+
+- **分离式服务 + KV Cache-Aware Routing** -- KV 缓存感知路由同时针对计算（prefill）和内存（decode）进行负载均衡，从而同时优化延迟和吞吐量。
+- **分离式服务 + KV Cache Offloading** -- KV 缓存卸载带来更快的 TTFT，并且可以减少 prefill worker 数量以降低 TCO。
+- **KV Cache-Aware Routing + KV Cache Offloading** -- 卸载会增加总体可寻址缓存大小，提高 KV 缓存命中率，进而加速 TTFT。
+
+<Tip>
+准备尝试这些技术？请参阅 [Dynamo recipes](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/recipes)，了解组合分离式服务、路由和卸载的分步部署示例。
+</Tip>
+
+## 从配置到生产级部署
+
+### 使用 AIConfigurator 在 30 秒内找到最佳配置
+
+手动为分离式服务寻找最佳并行度可能需要数天的穷举配置扫描，而这一挑战在大规模环境中只会更加严峻。
+
+Dynamo 的 [AIConfigurator](https://github.com/ai-dynamo/aiconfigurator/) 通过在 30 秒内识别性能最佳的配置来解决这一问题，并清晰预测相较于标准聚合式服务的性能提升。该逻辑原生集成到 Kubernetes Custom Resource Definition (CRD) 和 Dynamo Graph Deployment Request (DGDR) 中，使用户能够使用自动生成的优化配置进行部署。
+
+### 使用 Planner 根据 SLA 自动调整部署
+
+一旦通过 AIConfigurator 或 DGDR 找到离线配置，开发者就可以将所需模型部署到生产环境。然而，生产流量在线上可能变化很大，离线确定的静态配置将无法充分处理流量峰值。
+
+Dynamo 提供 [Planner](/dynamo/zh-CN/dev/design-docs/component-design/planner-design) 来规避这个问题。开发者只需用 TTFT 和 Time Per Output Token (TPOT) 设置 SLA。Planner 会检查在线流量，并自动决定如何扩展 prefill 和 decode worker，从而在维持指定 SLA 的同时有效处理流量峰值。
+
+最近，Planner 已扩展到处理更复杂的场景，例如在相同 SLA 下 Input Sequence Length (ISL) 剧烈变化。请参阅 [Planner documentation](/dynamo/zh-CN/dev/components/planner/planner-guide) 了解更多详细信息。
+
+### 使用 Grove 应用拓扑感知的层级式 Gang Scheduling
+
+当 Planner 决定自动扩缩容时，开发者需要一种方式来有效、独立且分层地扩展 worker。尤其对于 prefill/decode 解耦，prefill 和 decode worker 需要独立扩展以满足指定 SLA，并且需要被调度到物理上彼此接近的位置以获得最佳性能。
+
+Dynamo 提供 [Grove](https://github.com/ai-dynamo/grove)，它是一个 Kubernetes operator，提供单一声明式 API，可用于编排从简单单 pod 部署到复杂多节点解耦系统的任意 AI 推理工作负载。
+
+Grove 支持：
+
+- 层级式 gang scheduling
+- 拓扑感知放置
+- 多级水平自动扩缩容
+- 显式启动顺序
+- 使用可配置替换策略的滚动更新
+
+这些功能对于在数据中心规模部署和扩展推理以获得最佳性能至关重要。
+
+### 确保 LLM 的容错能力
+
+Kubernetes 自带一些容错功能，但 LLM 部署需要专门的容错和韧性机制。Dynamo 在多个层面提供全面的容错机制，确保生产部署中的 LLM 推理可靠运行：
+
+- **Router and Frontend** -- Dynamo 支持启动多个 frontend + router 副本，并通过共享 router 状态提升容错能力。
+- **Request Migration** -- 当 worker 在请求处理过程中失败时，Dynamo 可以将进行中的请求迁移到健康 worker，同时保留部分生成状态，并维持面向客户端的无缝 token 流。
+- **Request Cancellation** -- Dynamo 支持通过 AsyncEngineContext trait 取消进行中的请求，该 trait 提供优雅停止信号和通过请求链传播的层级取消。
+- **Request Rejection (Load Shedding)** -- 当 worker 过载时，Dynamo 会基于 KV 缓存利用率和 prefill token 的可配置阈值，以 HTTP 529 响应拒绝新请求。
+
+### 可观测性
+
+Dynamo 提供内置指标、分布式追踪和日志，用于监控推理部署。请参阅 [Observability Guide](/dynamo/dev/user-guides/observability-local) 了解设置详情。
+
+## 接下来做什么？
+
+探索以下资源以深入了解：
+
+- [Recipes](https://github.com/ai-dynamo/dynamo/tree/v1.3.0/recipes) -- 组合分离式服务、路由和卸载
+- [KV Cache-Aware Routing](/dynamo/dev/user-guides/kv-cache-aware-routing) -- 配置智能请求路由
+- [KV Cache Offloading](/dynamo/dev/user-guides/kv-cache-offloading) -- 设置多层内存管理
+- [Planner](/dynamo/zh-CN/dev/components/planner/planner-guide) -- 配置基于 SLA 的自动扩缩容
+- [Kubernetes Deployment](/dynamo/dev/kubernetes-deployment/start-here/kubernetes-quickstart) -- 使用 Grove 进行大规模部署
+- [Overall Architecture](/dynamo/zh-CN/dev/design-docs/overall-architecture) -- 完整技术设计
+- [Support Matrix](/dynamo/dev/resources/support-matrix) -- 检查硬件和引擎兼容性
+
+**延伸阅读：** [Dynamo Digest](/dynamo/dev/digest)。

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/local-installation.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/local-installation.md
@@ -1,0 +1,346 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 本地安装
+sidebar-title: 本地安装
+description: 使用容器或 PyPI 在本地机器或 VM 上安装并运行 Dynamo
+---
+
+本指南介绍如何在配备一个或多个 GPU 或 XPU 的本地机器或 VM 上安装并运行 Dynamo。完成后，你将拥有一个可工作的 OpenAI 兼容端点，用于提供模型服务。
+
+对于生产环境的多节点集群，请参阅 [Kubernetes 部署指南](/dynamo/dev/kubernetes-deployment/start-here/kubernetes-quickstart)。如需为开发从源码构建，请参阅[从源码构建](/dynamo/zh-CN/dev/getting-started/building-from-source)。
+
+## 系统要求
+
+<Tabs>
+  <Tab title="CUDA">
+
+    | 要求 | 支持范围 |
+    |---|---|
+    | **GPU** | NVIDIA Ampere、Ada Lovelace、Hopper、Blackwell |
+    | **OS** | Ubuntu 22.04、Ubuntu 24.04 |
+    | **架构** | x86_64、ARM64（ARM64 需要 Ubuntu 24.04） |
+    | **CUDA** | 12.9+ 或 13.0+（B300/GB300 需要 CUDA 13） |
+    | **Python** | 3.10、3.12 |
+    | **驱动** | 575.51.03+（CUDA 12）或 580.00.03+（CUDA 13） |
+
+    TensorRT-LLM 不支持 Python 3.11。
+
+  </Tab>
+  <Tab title="XPU">
+
+    | 要求 | 支持范围 |
+    |---|---|
+    | **XPU** | Intel® Data Center GPU Max Series、Intel® Arc™ Pro B-Series Graphics Cards |
+    | **OS** | Ubuntu 24.04 |
+    | **架构** | x86_64 |
+    | **Python** | 3.12 |
+    | **oneAPI** | 2025.3 |
+    | **驱动** | 25.48.36300.8 |
+
+  </Tab>
+</Tabs>
+
+如需查看包含后端框架版本在内的完整兼容性矩阵，请参阅[支持矩阵](/dynamo/dev/resources/support-matrix)。
+
+## 安装 Dynamo
+
+### 选项 A：容器（推荐）
+
+<Tabs>
+  <Tab title="CUDA">
+
+    容器已预安装所有依赖项。无需额外设置。
+
+    ```bash
+    # SGLang
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+
+    # TensorRT-LLM
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
+
+    # vLLM
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
+    ```
+
+  </Tab>
+  <Tab title="XPU">
+
+    从本仓库构建 XPU 运行时镜像。`container/render.py` 支持为 vLLM 和 SGLang 运行时镜像设置 `--device=xpu`。`container/run.sh --device=xpu` 会把 `/dev/dri` 和主机 `render` 组暴露给容器。
+
+    **vLLM**
+
+    ```bash
+    git clone https://github.com/ai-dynamo/dynamo.git
+    cd dynamo
+    container/render.py --framework=vllm --device=xpu --target=runtime
+    docker build -t dynamo:latest-vllm-xpu-runtime \
+      -f container/vllm-runtime-xpu-amd64-rendered.Dockerfile .
+    container/run.sh --image dynamo:latest-vllm-xpu-runtime --device=xpu -it
+    ```
+
+    **SGLang**
+
+    ```bash
+    git clone https://github.com/ai-dynamo/dynamo.git
+    cd dynamo
+    container/render.py --framework=sglang --device=xpu --target=runtime
+    docker build -t dynamo:latest-sglang-xpu-runtime \
+      -f container/sglang-runtime-xpu-amd64-rendered.Dockerfile .
+    container/run.sh --image dynamo:latest-sglang-xpu-runtime --device=xpu -it
+    ```
+
+  </Tab>
+</Tabs>
+
+如需在同一个容器中运行 frontend 和 worker，可选择：
+
+- 使用 `&` 在后台运行进程（请参阅下方“运行 Dynamo”部分），或
+- 打开第二个终端并使用 `docker exec -it <container_id> bash`
+
+如需查看可用版本，请参阅[发布产物](/dynamo/dev/resources/release-artifacts#container-images)；
+如需运行说明，请参阅各后端指南：[SGLang](/dynamo/dev/backends/sg-lang) |
+[TensorRT-LLM](/dynamo/dev/backends/tensor-rt-llm) | [vLLM](/dynamo/dev/backends/v-llm)
+
+### 选项 B：从 PyPI 安装
+
+<Tabs>
+  <Tab title="CUDA">
+
+    仅支持 vLLM 和 SGLang。TensorRT-LLM 请使用选项 A。
+
+    ```bash
+    # Install uv (recommended Python package manager)
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+
+    # Create virtual environment
+    uv venv venv
+    source venv/bin/activate
+    uv pip install pip
+    ```
+
+    为你选择的后端安装系统依赖项和 Dynamo wheel：
+
+    **SGLang**
+
+    ```bash
+    sudo apt install python3-dev
+    uv pip install --prerelease=allow "ai-dynamo[sglang]"
+    ```
+
+    **vLLM**
+
+    ```bash
+    sudo apt install python3-dev libxcb1
+    uv pip install --prerelease=allow "ai-dynamo[vllm]"
+    ```
+
+  </Tab>
+  <Tab title="XPU">
+
+    PyPI 后端 extras 仅适用于 CUDA。对于 XPU，请使用上方“选项 A：容器（推荐）”中的源码构建容器路径。
+
+  </Tab>
+</Tabs>
+
+## 运行 Dynamo
+
+### 发现后端
+
+Dynamo 组件通过共享后端相互发现。可使用两个选项：
+
+| 后端 | 何时使用 | 设置 |
+|---|---|---|
+| **File** | 单机、本地开发 | 无需设置 -- 将 `--discovery-backend file` 传递给所有组件。事件平面会自动默认使用 ZMQ（无需 NATS）。 |
+| **etcd** | 多节点、生产环境 | 需要正在运行的 etcd 实例（如果未指定标志，则为默认值）。事件平面默认使用 NATS。 |
+
+本指南使用 `--discovery-backend file`。如需设置 etcd，请参阅[服务发现](/dynamo/dev/kubernetes-deployment/advanced-platform/service-discovery)。
+
+### 验证安装（可选）
+
+验证 CLI 已安装并可调用：
+
+```bash
+python3 -m dynamo.frontend --help
+```
+
+如果你克隆了仓库，可以运行其他系统检查：
+
+```bash
+python3 dev/sanity_check.py
+```
+
+### 启动 Frontend
+
+```bash
+# Start the OpenAI compatible frontend (default port is 8000)
+python3 -m dynamo.frontend --discovery-backend file
+```
+
+如需在单个终端中运行（在容器中很有用），追加 `> logfile.log 2>&1 &`
+以在后台运行进程：
+
+```bash
+python3 -m dynamo.frontend --discovery-backend file > dynamo.frontend.log 2>&1 &
+```
+
+### 启动 Worker
+
+在另一个终端中（如果使用后台模式，也可以在同一个终端中），为你选择的加速器和后端启动 worker：
+
+<Tabs>
+  <Tab title="CUDA">
+
+    **SGLang**
+
+    ```bash
+    python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+
+    **TensorRT-LLM**
+
+    ```bash
+    python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+
+    在这种本地单机设置中，警告 `Cannot connect to ModelExpress server/transport error. Using direct download.`
+    是预期行为（没有正在运行的 ModelExpress server），可以安全忽略。在配置了 `MODEL_EXPRESS_URL` 的 Kubernetes 部署中，
+    此警告，或相关的 `Failed to resolve local model path after server download`，
+    表示已配置 ModelExpress，但它实际上没有提供缓存模型；
+    请参阅 [Kubernetes 中的模型缓存](/dynamo/dev/kubernetes-deployment/model-loading/model-caching#option-2-modelexpress-p2p-distribution)
+    了解正确配置。
+
+    **vLLM**
+
+    ```bash
+    python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+
+  </Tab>
+  <Tab title="XPU">
+
+    **vLLM**
+
+    ```bash
+    VLLM_TARGET_DEVICE=xpu \
+      python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+
+    **SGLang**
+
+    ```bash
+    python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+
+  </Tab>
+</Tabs>
+
+## 测试你的部署
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen3-0.6B",
+       "messages": [{"role": "user", "content": "Hello!"}],
+       "max_tokens": 50}'
+```
+
+## 故障排除
+
+<Tabs>
+  <Tab title="CUDA">
+
+    **CUDA/驱动版本不匹配**
+
+    运行 `nvidia-smi` 检查你的驱动版本。Dynamo 对 CUDA 12 需要驱动 575.51.03+，对 CUDA 13 需要驱动 580.00.03+。B300/GB300 GPU 需要 CUDA 13。完整要求请参阅[支持矩阵](/dynamo/dev/resources/support-matrix)。
+
+    **模型无法装入 GPU（OOM）**
+
+    默认模型 `Qwen/Qwen3-0.6B` 需要约 2GB GPU 内存。更大的模型需要更多 VRAM：
+
+    | 模型大小 | 近似 VRAM |
+    |---|---|
+    | 7B | 14-16 GB |
+    | 13B | 26-28 GB |
+    | 70B | 140+ GB（多 GPU） |
+
+    从小模型开始，并根据你的硬件逐步扩展。
+
+    **TensorRT-LLM**
+
+    TensorRT-LLM 仅支持容器路径。请使用 `tensorrtllm-runtime`
+    容器（选项 A）。
+
+    **容器运行但未检测到 GPU**
+
+    确保你向 `docker run` 传递了 `--gpus all`。如果没有此标志，容器将无法访问 GPU：
+
+    ```bash
+    # Correct
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+
+    # Wrong -- no GPU access
+    docker run --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    ```
+
+    **vLLM worker 启动失败：FlashInfer sampler 的 JIT 与 CUDA 13 wheels**
+
+    在 CUDA 13 安装环境下运行 vLLM worker 时，worker 可能在启动阶段因 FlashInfer JIT 错误而中止：
+
+    ```text
+    RuntimeError: Engine core initialization failed.
+    ...
+    cuda/std/__cccl/cuda_toolkit.h:41: error: "CUDA compiler and CUDA toolkit headers are incompatible"
+    ```
+
+    为 CUDA 13 安装解析出的 CUDA wheels 可能存在版本偏差：`torch` 将运行时头文件锁定到 13.0，而 vLLM 的 `tilelang` 依赖会拉取 `nvidia-cuda-nvcc` 13.2。FlashInfer 使用 `nvcc` 针对这些头文件编译其 sampler 内核，版本不匹配会导致构建失败。此问题在上游 [flashinfer#3493](https://github.com/flashinfer-ai/flashinfer/issues/3493) 中追踪。
+
+    设置 `VLLM_USE_FLASHINFER_SAMPLER=0`，让 vLLM 回退到原生 sampler：
+
+    ```bash
+    export VLLM_USE_FLASHINFER_SAMPLER=0
+    ```
+
+  </Tab>
+  <Tab title="XPU">
+
+    **XPU/驱动版本不匹配**
+
+    使用[系统要求](#系统要求)中列出的 XPU Driver 25.48.36300.8 和 oneAPI 2025.3 版本。更改驱动栈后，请重新构建 XPU 运行时镜像。
+
+    **模型无法装入 XPU 内存（OOM）**
+
+    默认模型 `Qwen/Qwen3-0.6B` 需要约 2GB 设备内存。更大的模型需要更多内存：
+
+    | 模型大小 | 近似内存 |
+    |---|---|
+    | 7B | 14-16 GB |
+    | 13B | 26-28 GB |
+    | 70B | 140+ GB |
+
+    从小模型开始，并根据你的 XPU 容量逐步扩展。
+
+    **容器运行但未检测到 XPU**
+
+    使用 `container/run.sh --device=xpu`。该包装脚本会添加 `/dev/dri` 和主机 `render` 组以启用 XPU 访问。
+
+    ```bash
+    container/run.sh --image dynamo:latest-vllm-xpu-runtime --device=xpu -it
+    ```
+
+    检查主机是否暴露 `/dev/dri` 并包含 `render` 组：
+
+    ```bash
+    ls -l /dev/dri
+    getent group render
+    ```
+
+  </Tab>
+</Tabs>
+
+## 后续步骤
+
+- [后端指南](/dynamo/dev/backends/sg-lang) -- 后端特定配置和功能
+- [分离式服务](/dynamo/dev/user-guides/disaggregated-serving) -- 独立扩展 prefill 和 decode
+- [KV Cache 感知路由](/dynamo/dev/user-guides/kv-cache-aware-routing) -- 智能请求路由
+- [Kubernetes 部署](/dynamo/dev/kubernetes-deployment/start-here/kubernetes-quickstart) -- 生产环境多节点部署

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/local-installation.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/local-installation.md
@@ -54,13 +54,13 @@ description: 使用容器或 PyPI 在本地机器或 VM 上安装并运行 Dynam
 
     ```bash
     # SGLang
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
 
     # TensorRT-LLM
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0
 
     # vLLM
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
     ```
 
   </Tab>
@@ -152,7 +152,7 @@ Dynamo 组件通过共享后端相互发现。可使用两个选项：
 | 后端 | 何时使用 | 设置 |
 |---|---|---|
 | **File** | 单机、本地开发 | 无需设置 -- 将 `--discovery-backend file` 传递给所有组件。事件平面会自动默认使用 ZMQ（无需 NATS）。 |
-| **etcd** | 多节点、生产环境 | 需要正在运行的 etcd 实例（如果未指定标志，则为默认值）。事件平面默认使用 NATS。 |
+| **etcd** | 多节点、生产环境 | 需要正在运行的 etcd 实例（如果未指定标志，则为默认值）。事件平面仍默认使用 ZMQ；设置 `DYN_EVENT_PLANE=nats` 可切换至 NATS。 |
 
 本指南使用 `--discovery-backend file`。如需设置 etcd，请参阅[服务发现](/dynamo/dev/kubernetes-deployment/advanced-platform/service-discovery)。
 
@@ -277,10 +277,10 @@ curl localhost:8000/v1/chat/completions \
 
     ```bash
     # Correct
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
 
     # Wrong -- no GPU access
-    docker run --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    docker run --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
     ```
 
     **vLLM worker 启动失败：FlashInfer sampler 的 JIT 与 CUDA 13 wheels**

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
@@ -10,16 +10,16 @@ subtitle: 约 5 分钟内在容器中运行一个兼容 OpenAI 的 Dynamo endpoi
 ## 选择你的路径
 
 <CardGroup cols={4}>
-  <Card title="快速开始" icon="regular bolt" href="/dynamo/zh-CN/dev/getting-started/quickstart">
+  <Card title="快速开始" icon="regular bolt" href="/dynamo/zh-CN/v1.3.0/getting-started/quickstart">
     你在这里。容器快速路径。
   </Card>
-  <Card title="本地安装" icon="regular laptop-code" href="/dynamo/zh-CN/dev/getting-started/local-installation">
+  <Card title="本地安装" icon="regular laptop-code" href="/dynamo/zh-CN/v1.3.0/getting-started/local-installation">
     完整演练 — PyPI、配置。
   </Card>
   <Card title="Kubernetes" icon="regular cubes" href="/dynamo/dev/getting-started/kubernetes-deployment">
     生产级多节点集群。
   </Card>
-  <Card title="从源码构建" icon="regular code-branch" href="/dynamo/zh-CN/dev/getting-started/building-from-source">
+  <Card title="从源码构建" icon="regular code-branch" href="/dynamo/zh-CN/v1.3.0/getting-started/building-from-source">
     面向基于 `main` 的贡献者。
   </Card>
 </CardGroup>
@@ -35,17 +35,17 @@ Dynamo 与后端无关 — 每种安装路径都适用于 **SGLang**、**TensorR
 <Tabs>
   <Tab title="SGLang" language="sglang">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0
     ```
   </Tab>
   <Tab title="TensorRT-LLM" language="trtllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.3.0
     ```
   </Tab>
   <Tab title="vLLM" language="vllm">
     ```bash
-    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
     ```
   </Tab>
 </Tabs>

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
@@ -10,16 +10,16 @@ subtitle: 约 5 分钟内在容器中运行一个兼容 OpenAI 的 Dynamo endpoi
 ## 选择你的路径
 
 <CardGroup cols={4}>
-  <Card title="快速开始" icon="regular bolt" href="/dynamo/zh-CN/v1.3.0/getting-started/quickstart">
+  <Card title="快速开始" icon="regular bolt" href="/dynamo/zh-CN/dev/getting-started/quickstart">
     你在这里。容器快速路径。
   </Card>
-  <Card title="本地安装" icon="regular laptop-code" href="/dynamo/zh-CN/v1.3.0/getting-started/local-installation">
+  <Card title="本地安装" icon="regular laptop-code" href="/dynamo/zh-CN/dev/getting-started/local-installation">
     完整演练 — PyPI、配置。
   </Card>
   <Card title="Kubernetes" icon="regular cubes" href="/dynamo/dev/getting-started/kubernetes-deployment">
     生产级多节点集群。
   </Card>
-  <Card title="从源码构建" icon="regular code-branch" href="/dynamo/zh-CN/v1.3.0/getting-started/building-from-source">
+  <Card title="从源码构建" icon="regular code-branch" href="/dynamo/zh-CN/dev/getting-started/building-from-source">
     面向基于 `main` 的贡献者。
   </Card>
 </CardGroup>

--- a/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
+++ b/fern/translations/zh-CN/pages-v1.3.0/getting-started/quickstart.mdx
@@ -1,0 +1,159 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 快速开始
+subtitle: 约 5 分钟内在容器中运行一个兼容 OpenAI 的 Dynamo endpoint。
+---
+
+{/* Looking for the project README? See /README.md at the repo root: https://github.com/ai-dynamo/dynamo/blob/v1.3.0/README.md */}
+
+## 选择你的路径
+
+<CardGroup cols={4}>
+  <Card title="快速开始" icon="regular bolt" href="/dynamo/zh-CN/dev/getting-started/quickstart">
+    你在这里。容器快速路径。
+  </Card>
+  <Card title="本地安装" icon="regular laptop-code" href="/dynamo/zh-CN/dev/getting-started/local-installation">
+    完整演练 — PyPI、配置。
+  </Card>
+  <Card title="Kubernetes" icon="regular cubes" href="/dynamo/dev/getting-started/kubernetes-deployment">
+    生产级多节点集群。
+  </Card>
+  <Card title="从源码构建" icon="regular code-branch" href="/dynamo/zh-CN/dev/getting-started/building-from-source">
+    面向基于 `main` 的贡献者。
+  </Card>
+</CardGroup>
+
+<Note>
+Dynamo 与后端无关 — 每种安装路径都适用于 **SGLang**、**TensorRT-LLM** 和 **vLLM**。选择适合你环境的安装路径，然后选择后端。
+</Note>
+
+## 拉取容器
+
+容器已预安装所有依赖。选择你的后端：
+
+<Tabs>
+  <Tab title="SGLang" language="sglang">
+    ```bash
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.2.1
+    ```
+  </Tab>
+  <Tab title="TensorRT-LLM" language="trtllm">
+    ```bash
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/tensorrtllm-runtime:1.2.1
+    ```
+  </Tab>
+  <Tab title="vLLM" language="vllm">
+    ```bash
+    docker run --gpus all --network host --rm -it nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.1
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+**受限模型需要 Hugging Face token。** Llama、Kimi、Qwen-VL 和其他受限模型要求你的环境中设置 `HF_TOKEN`，并且已在 huggingface.co 接受模型卡片的许可证。启动前请设置 `export HF_TOKEN=hf_…`。
+</Warning>
+
+有关容器版本和标签，请参阅 [Release Artifacts](/dynamo/dev/resources/release-artifacts#container-images)。
+
+## 启动前端
+
+在容器中，在端口 8000 上启动 OpenAI 兼容前端：
+
+```bash
+python3 -m dynamo.frontend --discovery-backend file
+```
+
+<Tip>
+`--discovery-backend file` 可以避免依赖 etcd。若要在同一个终端中运行前端和 worker，请用 `> logfile.log 2>&1 &` 将每条命令放到后台。
+</Tip>
+
+## 启动 Worker
+
+在另一个终端中，为你的后端启动一个 worker：
+
+<Tabs>
+  <Tab title="SGLang" language="sglang">
+    ```bash
+    python3 -m dynamo.sglang --model-path Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+  </Tab>
+  <Tab title="TensorRT-LLM" language="trtllm">
+    ```bash
+    python3 -m dynamo.trtllm --model-path Qwen/Qwen3-0.6B --discovery-backend file
+    ```
+  </Tab>
+  <Tab title="vLLM" language="vllm">
+    ```bash
+    python3 -m dynamo.vllm --model Qwen/Qwen3-0.6B --discovery-backend file \
+      --kv-events-config '{"enable_kv_cache_events": false}'
+    ```
+  </Tab>
+</Tabs>
+
+## 验证和测试
+
+检查端点是否已启动：
+
+```bash
+curl -sf http://localhost:8000/health && echo OK
+```
+
+如果看到 `OK`，发送一个聊天补全请求：
+
+<CodeBlocks>
+```bash title="Request"
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "Qwen/Qwen3-0.6B",
+       "messages": [{"role": "user", "content": "Hello!"}],
+       "max_tokens": 50}'
+```
+
+```json title="Response"
+{
+  "id": "chatcmpl-...",
+  "model": "Qwen/Qwen3-0.6B",
+  "choices": [{
+    "index": 0,
+    "message": {"role": "assistant", "content": "Hello! How can I help you today?"},
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 9, "completion_tokens": 10, "total_tokens": 19}
+}
+```
+</CodeBlocks>
+
+<Info>
+连接被拒绝？前端需要几秒钟才能启动 — 请重试。有关生产环境的存活和就绪探针，请参阅 [Health Checks](/dynamo/dev/user-guides/observability-local/health-checks)。
+</Info>
+
+## 摘自 Digest
+
+<CardGroup cols={2}>
+  <Card title="面向 Agentic Inference 的全栈优化" icon="regular microchip" href="/dynamo/dev/digest/agentic-inference">
+    Dynamo 如何在三层上优化 agentic 工作负载：前端 API、路由器和 KV cache 管理。
+  </Card>
+  <Card title="Flash Indexer：跨星系 KV 路由" icon="regular bolt" href="/dynamo/dev/digest/flash-indexer">
+    Dynamo 的并发全局索引如何经历六次迭代，演进到能够维持超过 100M ops/sec。
+  </Card>
+</CardGroup>
+
+## 深入了解
+
+从[上面的四个选项](#选择你的路径)中选择一条完整安装路径，或探索 Dynamo 底层的工作原理：
+
+<CardGroup cols={2}>
+  <Card title="架构" icon="regular sitemap" href="/dynamo/dev/design-docs/overall-architecture">
+    前端、路由器和 worker 如何协同工作。
+  </Card>
+  <Card title="前端指南" icon="regular bolt" href="/dynamo/dev/components/frontend">
+    Worker 发现、多模型路由、OpenAI 兼容性。
+  </Card>
+  <Card title="KV Cache 感知路由" icon="regular route" href="/dynamo/dev/components/router/routing-concepts#kv-cache-routing">
+    路由器如何为了前缀复用而放置请求。
+  </Card>
+  <Card title="Health Checks" icon="regular heart-pulse" href="/dynamo/dev/user-guides/observability-local/health-checks">
+    生产部署的存活和就绪探针。
+  </Card>
+</CardGroup>

--- a/fern/translations/zh-CN/pages-v1.3.0/tool-calling/README.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/tool-calling/README.md
@@ -1,0 +1,114 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: 工具调用解析（Dynamo）
+subtitle: 使用 Dynamo 内置的工具调用解析器，将模型连接到外部工具和服务
+---
+
+你可以通过工具调用把 Dynamo 连接到外部工具和服务。通过提供一组可用函数，Dynamo 可以为相关函数输出函数参数，你执行这些函数后，即可用外部信息来增强提示。
+
+工具调用由 `tool_choice` 和 `tools` 请求参数控制。
+
+本页介绍默认的 Dynamo 原生路径的解析器名称。如果 Dynamo 未列出适用于你的模型的解析器，请参阅
+[Parser Engine Fallback](/dynamo/dev/user-guides/parsing/parser-engine-fallback)。关于 `--dyn-tool-call-parser` 如何与
+`--dyn-chat-processor` 和 `--dyn-reasoning-parser` 组合（以及哪些组合是无效的），请参阅
+[Parser Configuration](/dynamo/dev/user-guides/parsing/parser-configuration)。
+
+## 前置条件
+
+启动后端 worker 时设置以下 flag 即可启用该功能：
+
+- `--dyn-tool-call-parser`：从下方支持列表中选择工具调用解析器
+
+```bash
+# <backend> 可以是 sglang、trtllm、vllm 等，取决于你的安装
+python -m dynamo.<backend> --help
+```
+
+<Tip>
+如果你的模型默认的 chat template 不支持工具调用，但模型本身支持，你可以为每个 worker 指定自定义 chat template：
+`python -m dynamo.<backend> --custom-jinja-template </path/to/template.jinja>`。
+</Tip>
+
+<Tip>
+如果你的模型还会输出需要与正常内容分离的推理内容，请参阅 [Reasoning Parsing (Dynamo)](/dynamo/dev/user-guides/parsing/reasoning-parsing-dynamo) 了解支持的 `--dyn-reasoning-parser` 取值。
+</Tip>
+
+## 支持的工具调用解析器
+
+下表列出 Dynamo 注册表中当前支持的工具调用解析器。**Upstream name** 列标出 vLLM 或 SGLang 的解析器名称与 Dynamo 不同之处——在使用 `--dyn-chat-processor vllm` 或 `sglang` 时（参阅 [Parser Engine Fallback](/dynamo/dev/user-guides/parsing/parser-engine-fallback)）尤为相关。upstream 列为空表示同名在各处通用。`Dynamo-only` 表示该格式没有对应的上游解析器。
+
+| 解析器名称 | 模型 | Upstream name | 说明 |
+|---|---|---|---|
+| `kimi_k2` | Kimi K2 Instruct/Thinking, Kimi K2.5 | | 与 `--dyn-reasoning-parser kimi` 或 `kimi_k25` 配对 |
+| `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax` | XML `<minimax:tool_call>` |
+| `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML 标签（`<｜DSML｜tool_calls>...`）。别名：`deepseek-v4`、`deepseekv4` |
+| `deepseek_v3` | DeepSeek V3, DeepSeek R1-0528+ | SGLang: `deepseekv3` | 特殊 Unicode 标记 |
+| `deepseek_v3_1` | DeepSeek V3.1 | Dynamo-only | JSON 分隔符 |
+| `deepseek_v3_2` | DeepSeek V3.2+ | Dynamo-only | DSML 标签（`<｜DSML｜function_calls>...`） |
+| `qwen3_coder` | Qwen3.5, Qwen3-Coder | | XML `<tool_call><function=...>` |
+| `glm47` | GLM-4.5, GLM-4.7 | Dynamo-only | XML `<arg_key>/<arg_value>` |
+| `nemotron_deci` | Nemotron-Super / -Ultra / -Deci, Llama-Nemotron-Ultra / -Super | Dynamo-only | `<TOOLCALL>` JSON |
+| `nemotron_nano` | Nemotron-Nano | Dynamo-only | `qwen3_coder` 的别名 |
+| `gemma4` | Google Gemma 4（thinking 模型） | vLLM: `gemma4` | 自定义非 JSON 文法，使用 `<\|"\|>` 字符串分隔符和 `<\|tool_call>...<tool_call\|>` 标记。别名：`gemma-4`。与 `--dyn-reasoning-parser gemma4` 和 `--custom-jinja-template examples/chat_templates/gemma4_tool.jinja` 配对 |
+| `harmony` | gpt-oss-20b / -120b | Dynamo-only | Harmony channel 格式 |
+| `hermes` | Qwen2.5-\*, QwQ-32B, Qwen3-Instruct, Qwen3-Think, NousHermes-2/3 | vLLM: `qwen2_5`; SGLang: `qwen25`（用于 Qwen 模型） | `<tool_call>` JSON |
+| `phi4` | Phi-4, Phi-4-mini, Phi-4-mini-reasoning | vLLM: `phi4_mini_json` | `functools[...]` JSON |
+| `pythonic` | Llama 4 (Scout / Maverick) | | Python 列表式工具语法 |
+| `llama3_json` | Llama 3 / 3.1 / 3.2 / 3.3 Instruct | | `<\|python_tag\|>` 工具语法 |
+| `mistral` | Mistral / Mixtral / Mistral-Nemo, Magistral | | `[TOOL_CALLS]...[/TOOL_CALLS]` |
+| `jamba` | Jamba 1.5 / 1.6 / 1.7 | Dynamo-only | `<tool_calls>` JSON |
+| `default` | *(fallback)* | Dynamo-only | 空 JSON 配置（无 start/end token）。生产环境请优先使用模型专用解析器。 |
+
+<Tip>
+对于 Kimi K2.5 thinking 模型，将 `--dyn-tool-call-parser kimi_k2` 与 [Reasoning Parsing (Dynamo)](/dynamo/dev/user-guides/parsing/reasoning-parsing-dynamo) 中的 `--dyn-reasoning-parser kimi_k25` 配对，以便从同一响应中正确解析 `<think>` 块和工具调用。
+</Tip>
+
+## 示例
+
+### 启动 Dynamo Frontend 和 Backend
+
+```bash
+# 启动后端 worker（或 dynamo.vllm）
+python -m dynamo.sglang --model Qwen/Qwen3.5-4B --dyn-tool-call-parser qwen3_coder --dyn-reasoning-parser qwen3
+
+# 启动 frontend
+python -m dynamo.frontend
+```
+
+### 工具调用请求示例
+
+```bash
+curl -s http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3.5-4B",
+    "messages": [
+      {"role": "user", "content": "What is the weather in San Francisco and New York?"}
+    ],
+    "tools": [{
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a location.",
+        "parameters": {
+          "type": "object",
+          "properties": {"location": {"type": "string"}},
+          "required": ["location"]
+        }
+      }
+    }],
+    "tool_choice": "auto"
+  }'
+```
+
+Dynamo 会从模型输出中解析出工具调用，并在响应中以兼容 OpenAI 的 `tool_calls` 形式呈现。
+
+<Tip>
+如果工具调用返回结果不正确，请向单个复现请求添加 `"logprobs": true` 并分享响应。有关报告问题时需要捕获和包含的内容，请参阅
+[工具调用故障排查](/dynamo/dev/user-guides/parsing/troubleshooting-tool-calls)。
+</Tip>
+
+## 可选：结构化标签（structural tags）
+
+你可以启用 **xgrammar 结构化标签**，让引导式解码在 token 粒度上匹配解析器的工具调用格式。参阅 [Structural tag (guided decoding for tool calls)](https://github.com/ai-dynamo/dynamo/blob/5f62ed542a20c273d38555a294dbebe0bd1bddb4/docs/tool-calling/structural-tag.md)。

--- a/fern/translations/zh-CN/pages-v1.3.0/tool-calling/README.md
+++ b/fern/translations/zh-CN/pages-v1.3.0/tool-calling/README.md
@@ -41,7 +41,8 @@ python -m dynamo.<backend> --help
 | 解析器名称 | 模型 | Upstream name | 说明 |
 |---|---|---|---|
 | `kimi_k2` | Kimi K2 Instruct/Thinking, Kimi K2.5 | | 与 `--dyn-reasoning-parser kimi` 或 `kimi_k25` 配对 |
-| `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax` | XML `<minimax:tool_call>` |
+| `minimax_m2` | MiniMax M2 / M2.1 | vLLM: `minimax_m2` | XML `<minimax:tool_call>` |
+| `minimax_m3` | MiniMax M3 | vLLM: `minimax_m3` | MiniMax 命名空间令牌 XML |
 | `deepseek_v4` | DeepSeek V4 Pro / Flash | vLLM: `deepseek_v4`; SGLang: `deepseekv4` | DSML 标签（`<｜DSML｜tool_calls>...`）。别名：`deepseek-v4`、`deepseekv4` |
 | `deepseek_v3` | DeepSeek V3, DeepSeek R1-0528+ | SGLang: `deepseekv3` | 特殊 Unicode 标记 |
 | `deepseek_v3_1` | DeepSeek V3.1 | Dynamo-only | JSON 分隔符 |


### PR DESCRIPTION
## Summary

Backfills the missing zh-CN translation snapshot for the v1.3.0 stable version.

When v1.3.0 was released, `fern/translations/` did not exist on the `release/1.3.0` branch (the native localization PRs #11161 and #11293 landed on `main` after the release branch diverged). As a result, the release job had no translations to snapshot, leaving `translations/zh-CN/pages-v1.3.0/` absent. Chinese users on the Latest/v1.3.0 version got English fallback for all 13 translated pages.

This PR manually applies the same steps the release job would have run:
- Copies `translations/zh-CN/pages-dev/` → `translations/zh-CN/pages-v1.3.0/`
- Pins `tree/main` and `blob/main` GitHub links to `v1.3.0`
- Runs `convert_callouts.py` over the snapshot
- Runs `resolve_translation_links.py` with `--pages-dir pages-v1.3.0 --version-slug v1.3.0`

## Validation

- 13 files created, matching the 13 files in `pages-dev`
- No remaining `tree/main` or `blob/main` refs in the snapshot
- No structural changes to `fern/docs.yml`, `fern/versions/v1.3.0.yml`, or `pages-dev`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->