### PR TITLE
fix(trtllm): publish KV cache capacity

### DIFF
--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -180,7 +180,11 @@ class TensorRTLLMEngine:
 
     def get_kv_cache_capacity(self) -> dict[str, int]:
         """Return the initialized engine's primary GPU KV-cache capacity."""
-        return self.llm.get_kv_cache_capacity()
+        try:
+            get_capacity = self.llm.get_kv_cache_capacity
+        except AttributeError:
+            return {}
+        return get_capacity()
 
     @staticmethod
     def _prune_engine_args_for_autodeploy(engine_args) -> None:

--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -178,6 +178,10 @@ class TensorRTLLMEngine:
         tensor_parallel_size = getattr(self.llm.args, "tensor_parallel_size", 1)
         return tensor_parallel_size if enable_attention_dp else 1
 
+    def get_kv_cache_capacity(self) -> dict[str, int]:
+        """Return the initialized engine's primary GPU KV-cache capacity."""
+        return self.llm.get_kv_cache_capacity()
+
     @staticmethod
     def _prune_engine_args_for_autodeploy(engine_args) -> None:
         """Remove entries from `self.engine_args` that the autodeploy backend does not support."""

--- a/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
@@ -55,6 +55,19 @@ class TestTensorRTLLMEngine:
 
         mocked_cls.assert_called_once()
 
+    def test_get_kv_cache_capacity_delegates_to_llm(self):
+        capacity = {
+            "maxNumBlocks": 123,
+            "tokensPerBlock": 64,
+            "maxNumTokens": 7872,
+        }
+        engine = TensorRTLLMEngine(engine_args={})
+        engine._llm = mock.Mock()
+        engine._llm.get_kv_cache_capacity.return_value = capacity
+
+        assert engine.get_kv_cache_capacity() == capacity
+        engine._llm.get_kv_cache_capacity.assert_called_once_with()
+
     @pytest.mark.parametrize(
         "engine_args, is_forbidden",
         [

--- a/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_autodeploy.py
@@ -68,6 +68,12 @@ class TestTensorRTLLMEngine:
         assert engine.get_kv_cache_capacity() == capacity
         engine._llm.get_kv_cache_capacity.assert_called_once_with()
 
+    def test_get_kv_cache_capacity_returns_empty_when_api_is_unavailable(self):
+        engine = TensorRTLLMEngine(engine_args={})
+        engine._llm = mock.Mock(spec=[])
+
+        assert engine.get_kv_cache_capacity() == {}
+
     @pytest.mark.parametrize(
         "engine_args, is_forbidden",
         [

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -24,7 +24,10 @@ from dynamo.trtllm.args import Config, parse_args
 from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
-from dynamo.trtllm.workers.llm_worker import init_llm_worker
+from dynamo.trtllm.workers.llm_worker import (
+    _populate_kv_cache_capacity,
+    init_llm_worker,
+)
 
 # Get path relative to this test file
 REPO_ROOT = Path(__file__).resolve().parents[5]
@@ -46,6 +49,46 @@ pytestmark = [
 # Create TRTLLM-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_trtllm_cli = make_cli_args_fixture("dynamo.trtllm")
+
+
+def test_populate_kv_cache_capacity_publishes_engine_values():
+    runtime_config = mock.Mock()
+    engine = mock.Mock()
+    engine.get_kv_cache_capacity.return_value = {
+        "maxNumBlocks": 123,
+        "tokensPerBlock": 64,
+        "maxNumTokens": 7872,
+    }
+
+    block_size = _populate_kv_cache_capacity(runtime_config, engine, 32)
+
+    assert runtime_config.total_kv_blocks == 123
+    assert block_size == 64
+
+
+def test_populate_kv_cache_capacity_falls_back_when_unavailable(caplog):
+    runtime_config = mock.Mock()
+    engine = mock.Mock()
+    engine.get_kv_cache_capacity.return_value = {}
+
+    with caplog.at_level("WARNING"):
+        block_size = _populate_kv_cache_capacity(runtime_config, engine, 32)
+
+    assert block_size == 32
+    assert "Planner KV-rate scaling will remain unavailable" in caplog.text
+
+
+def test_populate_kv_cache_capacity_rejects_invalid_values():
+    runtime_config = mock.Mock()
+    engine = mock.Mock()
+    engine.get_kv_cache_capacity.return_value = {
+        "maxNumBlocks": 0,
+        "tokensPerBlock": 64,
+        "maxNumTokens": 0,
+    }
+
+    with pytest.raises(ValueError, match="Invalid TRT-LLM KV-cache capacity"):
+        _populate_kv_cache_capacity(runtime_config, engine, 32)
 
 
 def test_custom_jinja_template_invalid_path(mock_trtllm_cli):

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -57,7 +57,7 @@ from dynamo.llm import (
 from dynamo.runtime import DistributedRuntime
 from dynamo.trtllm.args import Config
 from dynamo.trtllm.constants import DisaggregationMode, Modality
-from dynamo.trtllm.engine import Backend, get_llm_engine
+from dynamo.trtllm.engine import Backend, TensorRTLLMEngine, get_llm_engine
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.publisher import DYNAMO_COMPONENT_REGISTRY, get_publisher
@@ -131,6 +131,36 @@ def _sync_config_from_engine_args(config: Config, engine_args: dict) -> None:
     for field_name in ("max_seq_len", "max_num_tokens", "max_batch_size"):
         if field_name in engine_args:
             setattr(config, field_name, engine_args[field_name])
+
+
+def _populate_kv_cache_capacity(
+    runtime_config: ModelRuntimeConfig,
+    engine: TensorRTLLMEngine,
+    fallback_block_size: int,
+) -> int:
+    """Publish engine KV capacity and return its effective block size."""
+    capacity = engine.get_kv_cache_capacity()
+    if not capacity:
+        logging.warning(
+            "TRT-LLM did not report KV-cache capacity; Planner KV-rate scaling "
+            "will remain unavailable"
+        )
+        return fallback_block_size
+
+    total_kv_blocks = capacity["maxNumBlocks"]
+    kv_cache_block_size = capacity["tokensPerBlock"]
+    if total_kv_blocks <= 0 or kv_cache_block_size <= 0:
+        raise ValueError(f"Invalid TRT-LLM KV-cache capacity: {capacity}")
+
+    runtime_config.total_kv_blocks = total_kv_blocks
+    logging.info(
+        "TRT-LLM KV-cache capacity: total_kv_blocks=%d, "
+        "kv_cache_block_size=%d, max_kv_tokens=%d",
+        total_kv_blocks,
+        kv_cache_block_size,
+        total_kv_blocks * kv_cache_block_size,
+    )
+    return kv_cache_block_size
 
 
 def _register_memory_routes(runtime, handler) -> None:
@@ -527,15 +557,15 @@ async def init_llm_worker(
         if shutdown_endpoints is not None:
             shutdown_endpoints[:] = [endpoint]
 
-        # should ideally call get_engine_runtime_config
-        # this is because we don't have a good way to
-        # get total_kv_blocks from the engine yet without calling get_stats_async
-        # This causes an issue because get_stats_async doesn't work when no requests are sent to the engine
-        # So for now, we just set the parsers from the config
-        # TODO: fix this once we have a better way to get total_kv_blocks
         runtime_config = ModelRuntimeConfig()
         runtime_config.kv_state_endpoint = config.kv_state_endpoint
         runtime_config.context_length = config.max_seq_len
+
+        kv_cache_block_size = config.kv_block_size
+        if config.disaggregation_mode != DisaggregationMode.ENCODE:
+            kv_cache_block_size = _populate_kv_cache_capacity(
+                runtime_config, engine, kv_cache_block_size
+            )
 
         # Set values from config that are available immediately
         # Note: We populate max_num_seqs and max_num_batched_tokens from config
@@ -590,11 +620,6 @@ async def init_llm_worker(
             f"Set runtime config max_num_batched_tokens: {runtime_config.max_num_batched_tokens}"
         )
         logging.info(f"Set runtime config data_parallel_size: {attention_dp_size}")
-
-        # The get_engine_runtime_config function exists but is not called here due to:
-        # 1. get_stats_async requires active requests to work properly
-        # 2. We need runtime config during registration, before any requests are made
-        # 3. total_kv_blocks would ideally come from engine stats but is not critical for basic operation
 
         # Initialize TensorRT-LLM MetricsCollector and register with global REGISTRY
         # This enables exposing TRT-LLM's native Prometheus metrics (request latency, TTFT, TPOT, etc.)
@@ -673,7 +698,7 @@ async def init_llm_worker(
             connector=connector,
             runtime=runtime,  # Pass runtime for graceful shutdown
             metrics_collector=metrics_collector,
-            kv_block_size=config.kv_block_size,
+            kv_block_size=kv_cache_block_size,
             shutdown_event=shutdown_event,
             encoder_cache_capacity_gb=config.multimodal_embedding_cache_capacity_gb,
             additional_metrics=additional_metrics,
@@ -731,7 +756,7 @@ async def init_llm_worker(
             endpoint,
             config.model,
             config.served_model_name,
-            kv_cache_block_size=config.kv_block_size,
+            kv_cache_block_size=kv_cache_block_size,
             runtime_config=runtime_config,
             custom_template_path=config.custom_jinja_template,
             media_decoder=media_decoder,
@@ -768,7 +793,7 @@ async def init_llm_worker(
                 # Use the connect endpoint directly (already provided by get_consolidator_endpoints)
                 consolidator_publisher = KvEventPublisher(
                     endpoint=endpoint,
-                    kv_block_size=config.kv_block_size,
+                    kv_block_size=kv_cache_block_size,
                     zmq_endpoint=consolidator_output_connect_endpoint,
                     zmq_topic="",
                     enable_local_indexer=config.enable_local_indexer,
@@ -783,7 +808,7 @@ async def init_llm_worker(
                 endpoint,
                 engine,
                 int(endpoint.connection_id()),
-                config.kv_block_size,
+                kv_cache_block_size,
                 metrics_labels,
                 component_gauges=component_gauges,
                 additional_metrics=additional_metrics,


### PR DESCRIPTION
## Summary

- read primary GPU KV-cache capacity from TensorRT-LLM at worker startup
- publish `total_kv_blocks` and the engine-reported block size in model registration metadata
- use the same effective block size for request handling and KV event publication
- preserve the existing configured block-size fallback when a backend does not report capacity

This enables Planner decode KV-rate scaling to compute `max_kv_tokens` for TensorRT-LLM workers.

Tracks [DYN-3575](https://linear.app/nvidia/issue/DYN-3575/dynamo130planner-trt-llm-worker-never-reports-total-kv-blockskv-cache). Uses the capacity API added by [NVIDIA/TensorRT-LLM#15385](https://github.com/NVIDIA/TensorRT-LLM/pull/15385), available in the `1.3.0rc21` dependency pinned by Dynamo main.

## Validation

- file-scoped pre-commit formatting and lint hooks: passed
- `test_trtllm_autodeploy.py` in `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21`: 18 passed
- `test_trtllm_unit.py -k populate_kv_cache_capacity` in the same image: 3 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for deriving KV-cache capacity from the initialized TensorRT-LLM engine.
  * Runtime components now use the engine-reported KV-cache block size and total block capacity when available.
  * Added a fallback to the configured block size when capacity information is unavailable.

* **Bug Fixes**
  * Invalid KV-cache capacity values are now detected and reported instead of being used.

* **Tests**
  * Added coverage for engine delegation, fallback behavior, capacity publication, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->