### PR TITLE
fix(cargo): pin aiconfigurator-core to the v0.9.0 release for crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ kvbm-physical = { path = "lib/kvbm-physical", version = "1.3.0" }
 velo = { version = "0.1.0" }
 
 # External dependencies
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", version = "0.9.0", package = "aiconfigurator-core" }
 anyhow = { version = "1" }
 lru = { version = "0.16" }
 async-nats = { version = "0.49.1", features = ["service"] }


### PR DESCRIPTION
Why this is necessary
---------------------
`aiconfigurator-core` is declared in the root Cargo.toml [workspace.dependencies] as a git dependency with NO version. `cargo publish` rejects any dependency that lacks a version requirement, so `dynamo-mocker` — the only crate that references aiconfigurator-core (via its optional, off-by-default `aic-forward-pass` feature) — cannot be published to crates.io at all:

    error: all dependencies must have a version requirement specified when publishing.
    dependency `aiconfigurator-core` does not specify a version

Because `dynamo-llm` depends on `dynamo-mocker`, this blocks both from the crates.io release. Every other workspace dependency already carries a version; this was the lone exception.

The fix
-------
Add `version = "0.9.0"` — the version the pinned rev (ffbab157) declares, already on crates.io. The rev is UNCHANGED, so builds are byte-for-byte identical and Cargo.lock is untouched; this only adds the version metadata cargo needs at publish time.

Stay on 0.9.0 — do NOT bump to 0.10.0
-------------------------------------
The version MUST remain 0.9.0. Per the 1.3.0 release decision (NVBug 6422983), this line ships on aiconfigurator 0.9.0 and the 0.10 migration is deferred to 1.4.0: aiconfigurator 0.10.0 is an incompatible restructure (it removes profiler SDK modules and changes the AIC Rust engine wire-format). PR #11732 already capped the Python side to `aiconfigurator>=0.9.0,<0.10.0`; this keeps the Rust dependency consistent on 0.9.0. Bumping aiconfigurator-core to 0.10.0 here would reintroduce the exact untested pairing that decision avoids.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core configuration component reference to explicitly specify version 0.9.0.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->