### PR TITLE
fix(mocker): repair replay request lifecycles

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -202,10 +202,10 @@ impl RadixCache {
     }
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
-    pub fn insert(&mut self, key: &[u64], value: &[usize]) {
+    pub fn insert(&mut self, key: &[u64], value: &[usize]) -> NodeId {
         let aligned_len = self.page_align(key.len());
         if aligned_len == 0 {
-            return;
+            return self.root;
         }
         assert!(
             value.len() >= aligned_len,
@@ -226,8 +226,7 @@ impl RadixCache {
             let child_id = match self.nodes[current].children.get(&ck).copied() {
                 Some(id) => id,
                 None => {
-                    self.create_child(current, &key[key_offset..], &value[key_offset..]);
-                    return;
+                    return self.create_child(current, &key[key_offset..], &value[key_offset..]);
                 }
             };
 
@@ -243,12 +242,19 @@ impl RadixCache {
                     let intermediate = self.split_node(child_id, common_len);
                     key_offset += common_len;
                     if key_offset < key.len() {
-                        self.create_child(intermediate, &key[key_offset..], &value[key_offset..]);
+                        return self.create_child(
+                            intermediate,
+                            &key[key_offset..],
+                            &value[key_offset..],
+                        );
                     }
+                    return intermediate;
                 }
-                return;
+                return current;
             }
         }
+
+        current
     }
 
     fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
@@ -289,7 +295,7 @@ impl RadixCache {
         inter_id
     }
 
-    fn create_child(&mut self, parent_id: NodeId, key: &[u64], value: &[usize]) {
+    fn create_child(&mut self, parent_id: NodeId, key: &[u64], value: &[usize]) -> NodeId {
         let new_node = TreeNode {
             children: HashMap::new(),
             parent: Some(parent_id),
@@ -307,6 +313,8 @@ impl RadixCache {
 
         self.evictable_leaves.insert(new_id);
         self.evictable_size += key.len();
+
+        new_id
     }
 
     pub fn is_leaf(&self, id: NodeId) -> bool {

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -5,8 +5,8 @@
 //!
 //! Reference: sglang/python/sglang/srt/mem_cache/radix_cache.py
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
-use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 new_key_type! {
@@ -16,23 +16,32 @@ new_key_type! {
 
 /// Manages free / allocated token slot indices for the KV cache pool.
 pub struct TokenPool {
+    next_fresh: usize,
     free: Vec<usize>,
     total: usize,
 }
 
 impl TokenPool {
     pub fn new(total: usize) -> Self {
-        let free: Vec<usize> = (0..total).rev().collect();
-        Self { free, total }
+        Self {
+            next_fresh: 0,
+            free: Vec::new(),
+            total,
+        }
     }
 
     /// Allocate `n` token slots. Returns `None` if not enough free slots.
     pub fn allocate(&mut self, n: usize) -> Option<Vec<usize>> {
-        if self.free.len() < n {
+        if self.available() < n {
             return None;
         }
-        let start = self.free.len() - n;
-        let indices: Vec<usize> = self.free.drain(start..).collect();
+
+        let recycled = n.min(self.free.len());
+        let fresh = n - recycled;
+        let mut indices = Vec::with_capacity(n);
+        indices.extend(self.free.drain(self.free.len() - recycled..));
+        indices.extend(self.next_fresh..self.next_fresh + fresh);
+        self.next_fresh += fresh;
         Some(indices)
     }
 
@@ -42,7 +51,7 @@ impl TokenPool {
     }
 
     pub fn available(&self) -> usize {
-        self.free.len()
+        self.free.len() + self.total - self.next_fresh
     }
 
     pub fn total(&self) -> usize {
@@ -53,7 +62,7 @@ impl TokenPool {
 /// A single node in the radix tree.
 pub struct TreeNode {
     /// Children keyed by `child.key[..page_size]` (a "child key").
-    pub children: HashMap<Vec<u64>, NodeId>,
+    pub children: FxHashMap<Vec<u64>, NodeId>,
     pub parent: Option<NodeId>,
     /// Token IDs stored at this edge.
     pub key: Vec<u64>,
@@ -72,7 +81,7 @@ pub struct RadixCache {
     pub token_pool: TokenPool,
     page_size: usize,
     /// Total token count in evictable nodes.
-    pub evictable_leaves: HashSet<NodeId>,
+    pub evictable_leaves: FxHashSet<NodeId>,
     pub evictable_size: usize,
     /// Total token count in protected (locked) nodes.
     pub protected_size: usize,
@@ -83,7 +92,7 @@ impl RadixCache {
         assert!(page_size >= 1, "page_size must be >= 1");
         let mut nodes = SlotMap::with_key();
         let root = nodes.insert(TreeNode {
-            children: HashMap::new(),
+            children: FxHashMap::default(),
             parent: None,
             key: Vec::new(),
             value: Vec::new(),
@@ -95,7 +104,7 @@ impl RadixCache {
             root,
             token_pool: TokenPool::new(total_tokens),
             page_size,
-            evictable_leaves: HashSet::new(),
+            evictable_leaves: FxHashSet::default(),
             evictable_size: 0,
             protected_size: 0,
         }
@@ -114,8 +123,8 @@ impl RadixCache {
         self.nodes.len()
     }
 
-    fn child_key(&self, key: &[u64]) -> Vec<u64> {
-        key[..self.page_size.min(key.len())].to_vec()
+    fn child_key<'a>(&self, key: &'a [u64]) -> &'a [u64] {
+        &key[..self.page_size.min(key.len())]
     }
 
     fn page_align(&self, len: usize) -> usize {
@@ -147,15 +156,17 @@ impl RadixCache {
 
         while matched < key.len() {
             let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => break,
             };
 
-            let child_key = self.nodes[child_id].key.clone();
-            let common_len = self.key_match(&child_key, &key[matched..]);
+            let (common_len, child_len) = {
+                let child_key = &self.nodes[child_id].key;
+                (self.key_match(child_key, &key[matched..]), child_key.len())
+            };
 
-            if common_len < child_key.len() {
+            if common_len < child_len {
                 if common_len > 0 {
                     let intermediate = self.split_node(child_id, common_len);
                     current = intermediate;
@@ -180,7 +191,7 @@ impl RadixCache {
 
         while matched < key.len() {
             let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => break,
             };
@@ -203,9 +214,44 @@ impl RadixCache {
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
     pub fn insert(&mut self, key: &[u64], value: &[usize]) -> NodeId {
+        self.insert_from(self.root, 0, key, value, false)
+    }
+
+    /// Insert only the suffix after a retained, page-aligned prefix.
+    ///
+    /// `prefix_node` must be the locked terminal node for `prefix_len`. Keeping
+    /// that handle lets decode growth avoid walking the full sequence from the
+    /// root on every completed page.
+    pub fn insert_from_node(
+        &mut self,
+        prefix_node: NodeId,
+        prefix_len: usize,
+        key: &[u64],
+        value: &[usize],
+    ) -> NodeId {
+        self.insert_from(prefix_node, prefix_len, key, value, true)
+    }
+
+    fn insert_from(
+        &mut self,
+        start_node: NodeId,
+        prefix_len: usize,
+        key: &[u64],
+        value: &[usize],
+        allow_locked_tail_extension: bool,
+    ) -> NodeId {
         let aligned_len = self.page_align(key.len());
-        if aligned_len == 0 {
-            return self.root;
+        assert_eq!(
+            prefix_len,
+            self.page_align(prefix_len),
+            "prefix length must be page-aligned"
+        );
+        assert!(
+            prefix_len <= aligned_len,
+            "prefix length {prefix_len} exceeds aligned key length {aligned_len}"
+        );
+        if aligned_len == prefix_len {
+            return start_node;
         }
         assert!(
             value.len() >= aligned_len,
@@ -216,24 +262,39 @@ impl RadixCache {
         let value = &value[..aligned_len];
 
         let now = Instant::now();
-        self.nodes[self.root].last_access_time = now;
+        self.touch_path(start_node, now);
 
-        let mut current = self.root;
-        let mut key_offset: usize = 0;
+        let mut current = start_node;
+        let mut key_offset = prefix_len;
 
         while key_offset < key.len() {
+            let can_extend_leaf = current != self.root
+                && self.nodes[current].children.is_empty()
+                && (self.nodes[current].lock_ref == 0
+                    || (allow_locked_tail_extension
+                        && current == start_node
+                        && self.nodes[current].lock_ref == 1));
+            if can_extend_leaf {
+                return self.extend_leaf(current, &key[key_offset..], &value[key_offset..], now);
+            }
+
             let ck = self.child_key(&key[key_offset..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => {
                     return self.create_child(current, &key[key_offset..], &value[key_offset..]);
                 }
             };
 
-            let child_key = self.nodes[child_id].key.clone();
-            let common_len = self.key_match(&child_key, &key[key_offset..]);
+            let (common_len, child_len) = {
+                let child_key = &self.nodes[child_id].key;
+                (
+                    self.key_match(child_key, &key[key_offset..]),
+                    child_key.len(),
+                )
+            };
 
-            if common_len == child_key.len() {
+            if common_len == child_len {
                 key_offset += common_len;
                 current = child_id;
                 self.nodes[current].last_access_time = now;
@@ -257,34 +318,72 @@ impl RadixCache {
         current
     }
 
-    fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
-        let child = &self.nodes[child_id];
-        let child_parent = child.parent;
-        let child_key = child.key.clone();
-        let child_value = child.value.clone();
-        let child_lock_ref = child.lock_ref;
-        let child_last_access = child.last_access_time;
+    fn touch_path(&mut self, node_id: NodeId, now: Instant) {
+        let mut current = Some(node_id);
+        while let Some(id) = current {
+            self.nodes[id].last_access_time = now;
+            current = self.nodes[id].parent;
+        }
+    }
 
-        let suffix_ck = self.child_key(&child_key[split_pos..]);
-        let mut inter_children = HashMap::new();
+    fn extend_leaf(
+        &mut self,
+        node_id: NodeId,
+        key: &[u64],
+        value: &[usize],
+        now: Instant,
+    ) -> NodeId {
+        let node = &mut self.nodes[node_id];
+        debug_assert!(node.children.is_empty());
+        debug_assert!(node.lock_ref <= 1);
+        node.key.extend_from_slice(key);
+        node.value.extend_from_slice(value);
+        node.last_access_time = now;
+        if node.lock_ref == 0 {
+            self.evictable_size += key.len();
+        } else {
+            self.protected_size += key.len();
+        }
+        node_id
+    }
+
+    fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
+        let (child_parent, original_ck, prefix_key, prefix_value, suffix_ck, lock_ref, accessed) = {
+            let child = &mut self.nodes[child_id];
+            let child_parent = child.parent;
+            let original_ck = child.key[..self.page_size].to_vec();
+            let suffix_key = child.key.split_off(split_pos);
+            let prefix_key = std::mem::replace(&mut child.key, suffix_key);
+            let suffix_value = child.value.split_off(split_pos);
+            let prefix_value = std::mem::replace(&mut child.value, suffix_value);
+            let suffix_ck = child.key[..self.page_size].to_vec();
+            (
+                child_parent,
+                original_ck,
+                prefix_key,
+                prefix_value,
+                suffix_ck,
+                child.lock_ref,
+                child.last_access_time,
+            )
+        };
+
+        let mut inter_children = FxHashMap::default();
         inter_children.insert(suffix_ck, child_id);
 
         let intermediate = TreeNode {
             children: inter_children,
             parent: child_parent,
-            key: child_key[..split_pos].to_vec(),
-            value: child_value[..split_pos].to_vec(),
-            lock_ref: child_lock_ref,
-            last_access_time: child_last_access,
+            key: prefix_key,
+            value: prefix_value,
+            lock_ref,
+            last_access_time: accessed,
         };
         let inter_id = self.nodes.insert(intermediate);
 
         let child = &mut self.nodes[child_id];
-        child.key = child_key[split_pos..].to_vec();
-        child.value = child_value[split_pos..].to_vec();
         child.parent = Some(inter_id);
 
-        let original_ck = self.child_key(&child_key);
         if let Some(parent_id) = child_parent {
             self.nodes[parent_id].children.insert(original_ck, inter_id);
         }
@@ -297,14 +396,14 @@ impl RadixCache {
 
     fn create_child(&mut self, parent_id: NodeId, key: &[u64], value: &[usize]) -> NodeId {
         let new_node = TreeNode {
-            children: HashMap::new(),
+            children: FxHashMap::default(),
             parent: Some(parent_id),
             key: key.to_vec(),
             value: value.to_vec(),
             lock_ref: 0,
             last_access_time: Instant::now(),
         };
-        let ck = self.child_key(key);
+        let ck = self.child_key(key).to_vec();
         let new_id = self.nodes.insert(new_node);
 
         self.evictable_leaves.remove(&parent_id);
@@ -363,11 +462,11 @@ impl RadixCache {
         }
     }
 
-    /// Evict tokens from the cache by LRU order.
+    /// Evict tokens from the cache by LRU order, rounding partial leaves to full pages.
     /// Returns `(num_tokens_evicted, evicted_page_indices)`.
     pub fn evict(&mut self, num_tokens: usize) -> (usize, Vec<usize>) {
         let mut evicted = 0;
-        let mut evicted_indices = Vec::new();
+        let mut evicted_indices = Vec::with_capacity(num_tokens.min(self.evictable_size));
         while evicted < num_tokens {
             let victim = self
                 .evictable_leaves
@@ -379,22 +478,47 @@ impl RadixCache {
                 break;
             };
 
-            let victim_node = &self.nodes[victim_id];
+            let victim_tokens = self.nodes[victim_id].key.len();
+            let remaining = num_tokens - evicted;
+            let eviction_len = remaining
+                .div_ceil(self.page_size)
+                .saturating_mul(self.page_size)
+                .min(victim_tokens);
+
+            // A compressed leaf may span pages. Preserve its indexed prefix when
+            // only the newest suffix pages are needed to satisfy this eviction.
+            if eviction_len < victim_tokens {
+                let split_pos = victim_tokens - eviction_len;
+                let (nodes, token_pool) = (&mut self.nodes, &mut self.token_pool);
+                let victim_node = &mut nodes[victim_id];
+                victim_node.key.truncate(split_pos);
+                let evicted_values = &victim_node.value[split_pos..];
+                token_pool.free(evicted_values);
+                evicted_indices.extend_from_slice(evicted_values);
+                victim_node.value.truncate(split_pos);
+
+                self.evictable_size -= eviction_len;
+                evicted += eviction_len;
+                continue;
+            }
+
+            let victim_node = self
+                .nodes
+                .remove(victim_id)
+                .expect("evictable leaf disappeared before removal");
             let tokens = victim_node.key.len();
-            let pool_indices = victim_node.value.clone();
             let parent_id = victim_node.parent;
-            let victim_key = victim_node.key.clone();
 
             self.evictable_leaves.remove(&victim_id);
             self.evictable_size -= tokens;
             evicted += tokens;
 
-            evicted_indices.extend_from_slice(&pool_indices);
-            self.token_pool.free(&pool_indices);
+            evicted_indices.extend_from_slice(&victim_node.value);
+            self.token_pool.free(&victim_node.value);
 
             if let Some(pid) = parent_id {
-                let ck = self.child_key(&victim_key);
-                self.nodes[pid].children.remove(&ck);
+                let ck = self.child_key(&victim_node.key);
+                self.nodes[pid].children.remove(ck);
 
                 if pid != self.root
                     && self.nodes[pid].children.is_empty()
@@ -403,8 +527,6 @@ impl RadixCache {
                     self.evictable_leaves.insert(pid);
                 }
             }
-
-            self.nodes.remove(victim_id);
         }
         (evicted, evicted_indices)
     }
@@ -488,6 +610,50 @@ mod tests {
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 5);
         cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[10, 20, 30, 40, 50, 60, 70, 80]);
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
+    }
+
+    #[test]
+    fn test_retained_tail_extends_unique_leaf_in_place() {
+        let mut cache = RadixCache::new(100, 4);
+        cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let (_, tail) = cache.match_prefix(&[1, 2, 3, 4]);
+        cache.inc_lock_ref(tail);
+        let nodes_before = cache.num_nodes();
+
+        let extended = cache.insert_from_node(
+            tail,
+            4,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+        );
+
+        assert_eq!(extended, tail);
+        assert_eq!(cache.num_nodes(), nodes_before);
+        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(cache.protected_size, 8);
+        assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
+    }
+
+    #[test]
+    fn test_retained_tail_does_not_extend_shared_leaf_in_place() {
+        let mut cache = RadixCache::new(100, 4);
+        cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let (_, tail) = cache.match_prefix(&[1, 2, 3, 4]);
+        cache.inc_lock_ref(tail);
+        cache.inc_lock_ref(tail);
+        let nodes_before = cache.num_nodes();
+
+        let extended = cache.insert_from_node(
+            tail,
+            4,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+        );
+
+        assert_ne!(extended, tail);
+        assert_eq!(cache.num_nodes(), nodes_before + 1);
+        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4]);
+        assert_eq!(cache.node(extended).key, vec![5, 6, 7, 8]);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -192,19 +192,26 @@ impl SglangKvManager {
     pub fn cache_unfinished_req(
         &mut self,
         token_ids: &[u64],
-        kv_indices: &[usize],
+        kv_indices: &mut [usize],
         last_node: NodeId,
         first_new_token: usize,
     ) -> NodeId {
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
         self.cache.insert(token_ids, kv_indices);
 
-        // Find the new deepest node after insert
-        let (_, new_last_node) = self.cache.match_prefix(token_ids);
+        // Find the new deepest node after insert. Another in-flight request may
+        // have inserted the same materialized blocks first, in which case the
+        // radix cache retains that request's physical pages. Switch this active
+        // request to the canonical pages before releasing its duplicate pages;
+        // otherwise a later retract loses track of the duplicates and leaves
+        // KV publisher refcounts inconsistent with the radix cache.
+        let (matched_len, new_last_node) = self.cache.match_prefix(token_ids);
+        let canonical_indices = self.collect_path_indices(new_last_node);
 
         // Acquire the extended path before releasing the old prefix so
         // destination activation never leaves valid transferred KV unprotected.
         self.cache.inc_lock_ref(new_last_node);
+        self.canonicalize_unfinished_indices(kv_indices, &canonical_indices, matched_len);
         self.cache.dec_lock_ref(last_node);
 
         new_last_node
@@ -283,7 +290,7 @@ impl SglangKvManager {
         self.release_unpublished_indices(surplus);
         prefix_indices.append(&mut unpublished_indices);
         let new_last_node =
-            self.cache_unfinished_req(token_ids, &prefix_indices, last_node, prefix_len);
+            self.cache_unfinished_req(token_ids, &mut prefix_indices, last_node, prefix_len);
         self.log_trace("activate_destination", missing_tokens);
         AllocResult {
             prefix_len,
@@ -391,6 +398,33 @@ impl SglangKvManager {
             let block_end = block_start + block_size;
             if canonical_indices[block_end - 1] != kv_indices[block_end - 1] {
                 unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+            }
+        }
+
+        self.free_indices(&unretained_indices);
+    }
+
+    fn canonicalize_unfinished_indices(
+        &mut self,
+        kv_indices: &mut [usize],
+        canonical_indices: &[usize],
+        matched_len: usize,
+    ) {
+        let block_size = self.cache.page_size();
+        let complete_len = matched_len
+            .min(kv_indices.len())
+            .min(canonical_indices.len())
+            / block_size
+            * block_size;
+        debug_assert!(canonical_indices.len() >= complete_len);
+
+        let mut unretained_indices = Vec::new();
+        for block_start in (0..complete_len).step_by(block_size) {
+            let block_end = block_start + block_size;
+            if kv_indices[block_start..block_end] != canonical_indices[block_start..block_end] {
+                unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+                kv_indices[block_start..block_end]
+                    .copy_from_slice(&canonical_indices[block_start..block_end]);
             }
         }
 
@@ -573,6 +607,7 @@ mod tests {
     use crate::common::protocols::KvCacheEventSink;
     use crate::scheduler::capture_router_event_sink;
     use crate::scheduler::test_utils::{RouterIndexerHarness, stored_hashes};
+    use dynamo_kv_router::RadixTree;
     use dynamo_kv_router::protocols::{RouterEvent, WorkerId, compute_seq_hash_for_block};
 
     const ROUTER_TEST_WORKER_ID: WorkerId = 31;
@@ -758,16 +793,16 @@ mod tests {
         let out_of_domain_token = u32::MAX as u64 + 1;
         let tokens = [out_of_domain_token, 2, 3, 4, 5, 6];
 
-        let alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
+        let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
         let first_last_node =
-            mgr.cache_unfinished_req(&tokens[..2], &alloc.kv_indices, alloc.last_node, 0);
+            mgr.cache_unfinished_req(&tokens[..2], &mut alloc.kv_indices, alloc.last_node, 0);
 
         let mut kv_indices = alloc.kv_indices;
         kv_indices.extend_from_slice(&mgr.cache_mut().token_pool.allocate(4).unwrap());
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
         let last_after_first_cache =
-            mgr.cache_unfinished_req(&tokens[..4], &kv_indices[..4], first_last_node, 2);
+            mgr.cache_unfinished_req(&tokens[..4], &mut kv_indices[..4], first_last_node, 2);
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
         let KvCacheEventData::Stored(first_store) = &events[0].data else {
@@ -909,6 +944,107 @@ mod tests {
     }
 
     #[test]
+    fn unfinished_duplicate_canonicalization_prevents_missing_parent() {
+        let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let mut mgr = SglangKvManager::new(8, 1, KvEventPublishers::new(Some(sink), None), 0);
+        let mut indexer = RadixTree::new();
+
+        let seed_tokens = [1];
+        let seed = mgr.allocate_for_request(&seed_tokens).unwrap();
+        mgr.cache_finished_req(
+            &seed_tokens,
+            &seed.kv_indices,
+            seed.last_node,
+            seed.prefix_len,
+        );
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        // Two requests miss the same suffix before either inserts it. Their
+        // physical suffix pages are distinct even though the logical block is
+        // identical.
+        let shared_tokens = [1, 2];
+        let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
+        let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
+        assert_ne!(first.kv_indices[1], duplicate.kv_indices[1]);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        let first_last = mgr.cache_unfinished_req(
+            &shared_tokens,
+            &mut first.kv_indices,
+            first.last_node,
+            first.prefix_len,
+        );
+        let duplicate_last = mgr.cache_unfinished_req(
+            &shared_tokens,
+            &mut duplicate.kv_indices,
+            duplicate.last_node,
+            duplicate.prefix_len,
+        );
+        assert_eq!(
+            duplicate.kv_indices, first.kv_indices,
+            "the active duplicate must switch to radix-owned canonical pages"
+        );
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        // Mirror retracting the duplicate after its full prefix was cached,
+        // then finish and evict the canonical request.
+        mgr.free_request(duplicate_last);
+        mgr.cache_finished_req(
+            &shared_tokens,
+            &first.kv_indices,
+            first_last,
+            shared_tokens.len(),
+        );
+        mgr.evict(1);
+        mgr.evict(1);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        // Restore only the first block, then extend through the formerly
+        // duplicated block. A leaked duplicate publisher refcount would
+        // suppress re-storing block 2 and emit block 3 with a missing parent.
+        let restored = mgr.allocate_for_request(&seed_tokens).unwrap();
+        mgr.cache_finished_req(
+            &seed_tokens,
+            &restored.kv_indices,
+            restored.last_node,
+            restored.prefix_len,
+        );
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        let extended = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
+        let extension_events = buffer.drain();
+        assert_eq!(stored_event_count(&extension_events), 1);
+        let store = extension_events
+            .iter()
+            .find_map(|event| match &event.event.data {
+                KvCacheEventData::Stored(store) => Some(store),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(
+            store.blocks.len(),
+            2,
+            "both missing descendants must be stored"
+        );
+        for event in extension_events {
+            indexer.apply_event(event).unwrap();
+        }
+
+        mgr.free_indices(&extended.kv_indices[extended.prefix_len..]);
+        mgr.free_request(extended.last_node);
+    }
+
+    #[test]
     fn test_allocate_oom() {
         let mut mgr = SglangKvManager::new(3, 1, KvEventPublishers::default(), 0);
 
@@ -927,10 +1063,10 @@ mod tests {
         let chunk1_len = 3;
         let chunk2_len = 6;
 
-        let alloc1 = mgr.allocate_for_request(&tokens[..chunk1_len]).unwrap();
+        let mut alloc1 = mgr.allocate_for_request(&tokens[..chunk1_len]).unwrap();
         let new_last = mgr.cache_unfinished_req(
             &tokens[..chunk1_len],
-            &alloc1.kv_indices,
+            &mut alloc1.kv_indices,
             alloc1.last_node,
             0,
         );

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -4,7 +4,6 @@
 //! SGLang KV manager — wraps [`RadixCache`] with request-level lifecycle
 //! operations and KV event publishing.
 
-use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::cache::radix_cache::{NodeId, RadixCache};
@@ -15,17 +14,63 @@ use dynamo_kv_router::protocols::{
     KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, compute_block_hash_for_seq,
     compute_next_seq_hash,
 };
+use rustc_hash::FxHashMap;
+
+/// Move-only ownership of an active request's KV slots and protected radix path.
+#[derive(Debug, Default)]
+#[must_use = "an active KV lease must be finished, aborted, or retracted"]
+pub(crate) struct ActiveKvLease {
+    kv_indices: Vec<usize>,
+    cached_tokens: usize,
+    last_node: Option<NodeId>,
+}
+
+impl ActiveKvLease {
+    #[cfg(test)]
+    pub(crate) fn indices(&self) -> &[usize] {
+        &self.kv_indices
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.kv_indices.len()
+    }
+
+    pub(crate) fn cached_tokens(&self) -> usize {
+        self.cached_tokens
+    }
+
+    pub(crate) fn last_index(&self) -> Option<usize> {
+        self.kv_indices.last().copied()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.last_node.is_some()
+    }
+
+    fn last_node(&self) -> NodeId {
+        self.last_node
+            .expect("active KV lease must retain a radix path")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        kv_indices: Vec<usize>,
+        cached_tokens: usize,
+        last_node: NodeId,
+    ) -> Self {
+        Self {
+            kv_indices,
+            cached_tokens,
+            last_node: Some(last_node),
+        }
+    }
+}
 
 /// Result of `allocate_for_request`.
-pub struct AllocResult {
+pub(crate) struct AllocResult {
     /// Number of tokens matched from the prefix cache.
-    pub prefix_len: usize,
-    /// Pool token indices for the allocated input (1 per token).
-    pub kv_indices: Vec<usize>,
-    /// The deepest matched node in the radix tree (used for lock/unlock).
-    /// This is the prefix match point, not the new tokens — new tokens are
-    /// only in kv_indices and get inserted into the tree on completion.
-    pub last_node: NodeId,
+    pub(crate) prefix_len: usize,
+    pub(crate) lease: ActiveKvLease,
 }
 
 pub struct SglangKvManager {
@@ -35,11 +80,11 @@ pub struct SglangKvManager {
     next_event_id: u64,
     /// Maps each complete block's terminal pool_idx → block_hash assigned
     /// during Stored events, so Removed events can use the same block_hash.
-    idx_to_block_hash: HashMap<usize, ExternalSequenceBlockHash>,
+    idx_to_block_hash: FxHashMap<usize, ExternalSequenceBlockHash>,
     /// Tracks how many live pool slots currently advertise the same logical
     /// block hash so router events reflect logical block visibility, not
     /// transient slot ownership.
-    block_hash_refcounts: HashMap<ExternalSequenceBlockHash, usize>,
+    block_hash_refcounts: FxHashMap<ExternalSequenceBlockHash, usize>,
 }
 
 pub struct DecodeTokenReservation {
@@ -70,7 +115,7 @@ impl SglangDestinationReservation {
 }
 
 impl DecodeTokenReservation {
-    pub fn take(&mut self) -> usize {
+    fn take(&mut self) -> usize {
         self.indices
             .pop_front()
             .expect("reserved decode token allocation must be infallible")
@@ -93,8 +138,8 @@ impl SglangKvManager {
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
-            idx_to_block_hash: HashMap::new(),
-            block_hash_refcounts: HashMap::new(),
+            idx_to_block_hash: FxHashMap::default(),
+            block_hash_refcounts: FxHashMap::default(),
         }
     }
 
@@ -108,7 +153,7 @@ impl SglangKvManager {
 
     /// Try to allocate KV cache for a new request.
     /// Returns `None` if the pool doesn't have enough token slots (OOM).
-    pub fn allocate_for_request(&mut self, token_ids: &[u64]) -> Option<AllocResult> {
+    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u64]) -> Option<AllocResult> {
         let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
 
         let new_tokens = token_ids.len() - prefix_len;
@@ -129,8 +174,11 @@ impl SglangKvManager {
 
         Some(AllocResult {
             prefix_len,
-            kv_indices,
-            last_node,
+            lease: ActiveKvLease {
+                kv_indices,
+                cached_tokens: prefix_len,
+                last_node: Some(last_node),
+            },
         })
     }
 
@@ -139,36 +187,105 @@ impl SglangKvManager {
     /// This is used by chunked-prefill continuation where the request still
     /// owns token slots for a prefix that may extend past the radix-tree's
     /// page-aligned cached prefix.
-    pub fn allocate_after_prefix(
+    pub(crate) fn extend_allocation(
         &mut self,
         token_ids: &[u64],
-        prefix_len: usize,
-        prefix_indices: &[usize],
-        last_node: NodeId,
-    ) -> Option<AllocResult> {
-        let new_tokens = token_ids.len().saturating_sub(prefix_len);
-        let new_indices = self.cache.token_pool.allocate(new_tokens)?;
+        lease: &mut ActiveKvLease,
+    ) -> bool {
+        let prefix_len = lease.kv_indices.len();
+        assert!(
+            lease.is_active() && prefix_len <= token_ids.len(),
+            "invalid SGLang KV lease extension: active={}, owned_tokens={prefix_len}, target_tokens={}",
+            lease.is_active(),
+            token_ids.len()
+        );
+        let new_tokens = token_ids.len() - prefix_len;
+        let Some(new_indices) = self.cache.token_pool.allocate(new_tokens) else {
+            return false;
+        };
 
-        let mut kv_indices = prefix_indices[..prefix_len].to_vec();
-        kv_indices.extend_from_slice(&new_indices);
-
-        self.cache.inc_lock_ref(last_node);
-
-        self.publish_stored_event(token_ids, &kv_indices, prefix_len);
+        lease.kv_indices.extend_from_slice(&new_indices);
+        self.publish_stored_event(token_ids, &lease.kv_indices, prefix_len);
         self.log_trace("allocation", new_tokens);
+        true
+    }
 
-        Some(AllocResult {
-            prefix_len,
-            kv_indices,
+    pub(crate) fn extend_cached_prefix(&mut self, token_ids: &[u64], lease: &mut ActiveKvLease) {
+        let complete_len = token_ids.len() / self.cache.page_size() * self.cache.page_size();
+        if complete_len <= lease.cached_tokens {
+            return;
+        }
+        assert!(
+            lease.is_active() && complete_len <= lease.len(),
+            "invalid SGLang KV lease cache extension: active={}, cached_tokens={}, complete_tokens={complete_len}, owned_tokens={}",
+            lease.is_active(),
+            lease.cached_tokens,
+            lease.len()
+        );
+        let last_node = lease.last_node();
+        let new_last_node = self.cache_unfinished_req(
+            token_ids,
+            &mut lease.kv_indices[..complete_len],
             last_node,
-        })
+            lease.cached_tokens,
+        );
+        lease.last_node = Some(new_last_node);
+        lease.cached_tokens = complete_len;
+    }
+
+    pub(crate) fn extend_decode(
+        &mut self,
+        lease: &mut ActiveKvLease,
+        reservation: &mut DecodeTokenReservation,
+    ) {
+        debug_assert!(lease.is_active());
+        let new_idx = reservation.take();
+        self.publish_decode_token(new_idx, lease.last_index());
+        lease.kv_indices.push(new_idx);
+    }
+
+    pub(crate) fn finish(&mut self, token_ids: &[u64], mut lease: ActiveKvLease) {
+        let Some(last_node) = lease.last_node.take() else {
+            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert_eq!(lease.cached_tokens, 0);
+            return;
+        };
+        let complete_len =
+            token_ids.len().min(lease.len()) / self.cache.page_size() * self.cache.page_size();
+        assert!(
+            lease.cached_tokens <= complete_len,
+            "invalid SGLang KV lease finish: cached_tokens={}, complete_tokens={complete_len}, owned_tokens={}",
+            lease.cached_tokens,
+            lease.len()
+        );
+        let unretained_tail = lease.kv_indices.split_off(complete_len);
+        self.free_indices(&unretained_tail);
+
+        if complete_len == 0 {
+            self.cache.dec_lock_ref(last_node);
+            return;
+        }
+        self.cache_finished_req(
+            &token_ids[..complete_len],
+            &lease.kv_indices,
+            last_node,
+            lease.cached_tokens,
+        );
+    }
+
+    pub(crate) fn abort(&mut self, lease: ActiveKvLease) -> bool {
+        self.release_active_lease(lease)
+    }
+
+    pub(crate) fn retract(&mut self, lease: ActiveKvLease) -> bool {
+        self.release_active_lease(lease)
     }
 
     /// Cache a completed request's full sequence into the radix tree.
     ///
     /// Inserts the full token sequence so future requests can reuse it,
     /// then unlocks the path.
-    pub fn cache_finished_req(
+    fn cache_finished_req(
         &mut self,
         token_ids: &[u64],
         kv_indices: &[usize],
@@ -176,8 +293,17 @@ impl SglangKvManager {
         first_new_token: usize,
     ) {
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
-        self.cache.insert(token_ids, kv_indices);
-        self.release_unretained_finished_indices(token_ids, kv_indices);
+        let new_last_node =
+            self.cache
+                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
+        let complete_len =
+            token_ids.len().min(kv_indices.len()) / self.cache.page_size() * self.cache.page_size();
+        self.release_unretained_finished_indices(
+            kv_indices,
+            new_last_node,
+            first_new_token,
+            complete_len,
+        );
         self.cache.dec_lock_ref(last_node);
     }
 
@@ -189,7 +315,7 @@ impl SglangKvManager {
     ///
     /// Returns the new `last_node` that the caller should use for
     /// subsequent calls.
-    pub fn cache_unfinished_req(
+    fn cache_unfinished_req(
         &mut self,
         token_ids: &[u64],
         kv_indices: &mut [usize],
@@ -207,7 +333,9 @@ impl SglangKvManager {
         );
 
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
-        let new_last_node = self.cache.insert(token_ids, kv_indices);
+        let new_last_node =
+            self.cache
+                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
 
         // A concurrent insert can retain different physical pages for the same prefix.
         // Move the active request to canonical pages before releasing its duplicates.
@@ -302,8 +430,11 @@ impl SglangKvManager {
         self.log_trace("activate_destination", missing_tokens);
         AllocResult {
             prefix_len,
-            kv_indices: prefix_indices,
-            last_node: new_last_node,
+            lease: ActiveKvLease {
+                kv_indices: prefix_indices,
+                cached_tokens: token_ids.len() / self.cache.page_size() * self.cache.page_size(),
+                last_node: Some(new_last_node),
+            },
         }
     }
 
@@ -330,16 +461,14 @@ impl SglangKvManager {
         self.log_trace("release_unpublished", indices.len());
     }
 
-    /// Free a request without caching (e.g., aborted request).
-    ///
-    /// Unlocks the path without inserting into the tree.
-    pub fn free_request(&mut self, last_node: NodeId) {
+    #[cfg(test)]
+    fn free_request(&mut self, last_node: NodeId) {
         self.cache.dec_lock_ref(last_node);
     }
 
     /// Return request-owned token slots to the free pool and publish matching
     /// removal events for any slots that were previously advertised to the router.
-    pub fn free_indices(&mut self, indices: &[usize]) {
+    fn free_indices(&mut self, indices: &[usize]) {
         if indices.is_empty() {
             return;
         }
@@ -347,6 +476,25 @@ impl SglangKvManager {
         self.cache.token_pool.free(indices);
         self.publish_removed_event(indices);
         self.log_trace("free", indices.len());
+    }
+
+    fn release_active_lease(&mut self, mut lease: ActiveKvLease) -> bool {
+        let Some(last_node) = lease.last_node.take() else {
+            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert_eq!(lease.cached_tokens, 0);
+            return false;
+        };
+        assert!(
+            lease.cached_tokens <= lease.len(),
+            "invalid SGLang KV lease release: cached_tokens={}, owned_tokens={}",
+            lease.cached_tokens,
+            lease.len()
+        );
+        let owned_suffix = lease.kv_indices.split_off(lease.cached_tokens);
+        let capacity_improved = !owned_suffix.is_empty() || last_node != self.cache.root();
+        self.free_indices(&owned_suffix);
+        self.cache.dec_lock_ref(last_node);
+        capacity_improved
     }
 
     /// Collect token indices from the matched prefix path by walking root→last_node.
@@ -376,37 +524,60 @@ impl SglangKvManager {
         indices
     }
 
-    fn release_unretained_finished_indices(&mut self, token_ids: &[u64], kv_indices: &[usize]) {
+    fn release_unretained_finished_indices(
+        &mut self,
+        kv_indices: &[usize],
+        last_node: NodeId,
+        first_new_token: usize,
+        complete_len: usize,
+    ) {
         let block_size = self.cache.page_size();
-        let complete_len = token_ids.len().min(kv_indices.len()) / block_size * block_size;
         if complete_len == 0 {
             return;
         }
 
-        let (matched_len, last_node) = self.cache.match_prefix(&token_ids[..complete_len]);
-        debug_assert_eq!(
-            matched_len, complete_len,
-            "completed SGLang sequence should be fully cached after insert"
-        );
-        if matched_len < complete_len {
-            return;
-        }
-
-        let canonical_indices = self.collect_path_indices(last_node);
-        debug_assert!(
-            canonical_indices.len() >= complete_len,
-            "cached SGLang sequence path should carry complete KV indices"
-        );
-        if canonical_indices.len() < complete_len {
-            return;
-        }
-
         let mut unretained_indices = Vec::new();
-        for block_start in (0..complete_len).step_by(block_size) {
-            let block_end = block_start + block_size;
-            if canonical_indices[block_end - 1] != kv_indices[block_end - 1] {
-                unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+        let mut current = last_node;
+        let mut path_end = complete_len;
+
+        while path_end > first_new_token {
+            debug_assert_ne!(current, self.cache.root());
+            if current == self.cache.root() {
+                tracing::error!(
+                    path_end,
+                    first_new_token,
+                    complete_len,
+                    "SGLang radix path ended before finished-request reconciliation"
+                );
+                break;
             }
+
+            let node = self.cache.node(current);
+            let node_len = node.value.len();
+            debug_assert!(node_len <= path_end);
+            if node_len > path_end {
+                tracing::error!(
+                    node_len,
+                    path_end,
+                    complete_len,
+                    "SGLang radix node exceeds finished materialized prefix"
+                );
+                break;
+            }
+            let path_start = path_end - node_len;
+            let reconcile_start = path_start.max(first_new_token);
+
+            for block_start in (reconcile_start..path_end).step_by(block_size) {
+                let block_end = block_start + block_size;
+                let node_start = block_start - path_start;
+                let node_end = node_start + block_size;
+                if kv_indices[block_start..block_end] != node.value[node_start..node_end] {
+                    unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+                }
+            }
+
+            path_end = path_start;
+            current = node.parent.unwrap_or(self.cache.root());
         }
 
         self.free_indices(&unretained_indices);
@@ -521,12 +692,23 @@ impl SglangKvManager {
             return 0;
         }
 
-        let mut computed_blocks = Vec::new();
         let first_block_start = first_new_token / block_size * block_size;
-        let local_hashes = self.local_hashes_for_range(&token_ids[first_block_start..complete_len]);
+        let Some(first_unpublished_block) = (first_block_start..complete_len)
+            .step_by(block_size)
+            .find(|&block_start| {
+                let representative_idx = indices[block_start + block_size - 1];
+                !self.idx_to_block_hash.contains_key(&representative_idx)
+            })
+        else {
+            return 0;
+        };
+
+        let mut computed_blocks = Vec::new();
+        let local_hashes =
+            self.local_hashes_for_range(&token_ids[first_unpublished_block..complete_len]);
 
         for (block_idx, tokens_hash) in local_hashes.iter().copied().enumerate() {
-            let block_start = first_block_start + block_idx * block_size;
+            let block_start = first_unpublished_block + block_idx * block_size;
             let block_end = block_start + block_size;
             let representative_idx = indices[block_end - 1];
             if self.idx_to_block_hash.contains_key(&representative_idx) {
@@ -716,12 +898,83 @@ mod tests {
     }
 
     #[test]
+    fn active_kv_lease_has_no_space_overhead() {
+        let previous_fields = std::mem::size_of::<Vec<usize>>()
+            + std::mem::size_of::<usize>()
+            + std::mem::size_of::<Option<NodeId>>();
+
+        assert_eq!(std::mem::size_of::<ActiveKvLease>(), previous_fields);
+    }
+
+    #[test]
+    fn retract_lease_releases_only_the_uncached_suffix() {
+        let mut mgr = SglangKvManager::new(16, 4, KvEventPublishers::default(), 0);
+        let mut alloc = mgr.allocate_for_request(&[1, 2, 3, 4]).unwrap();
+        mgr.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
+        assert!(mgr.extend_allocation(&[1, 2, 3, 4, 5, 6], &mut alloc.lease));
+
+        assert_eq!(alloc.lease.cached_tokens(), 4);
+        assert_eq!(alloc.lease.len(), 6);
+        assert!(mgr.retract(alloc.lease));
+
+        assert_eq!(mgr.cache().token_pool.available(), 12);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 4);
+        assert_eq!(mgr.cache().prefix_match_len(&[1, 2, 3, 4]), 4);
+    }
+
+    #[test]
+    fn retained_tail_split_releases_leases_before_eviction() {
+        let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let mut mgr = SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink), None), 0);
+        let mut indexer = RadixTree::new();
+
+        let first_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut first = mgr.allocate_for_request(&first_tokens[..4]).unwrap();
+        mgr.extend_cached_prefix(&first_tokens[..4], &mut first.lease);
+        let retained_tail = first.lease.last_node();
+        assert!(mgr.extend_allocation(&first_tokens, &mut first.lease));
+        mgr.extend_cached_prefix(&first_tokens, &mut first.lease);
+
+        assert_eq!(first.lease.last_node(), retained_tail);
+        assert_eq!(mgr.cache().num_nodes(), 2);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        let second_tokens = [1, 2, 3, 4, 9, 10, 11, 12];
+        let mut second = mgr.allocate_for_request(&second_tokens).unwrap();
+        assert_eq!(second.prefix_len, 4);
+        assert_eq!(first.lease.last_node(), retained_tail);
+        assert_eq!(mgr.cache().num_nodes(), 3);
+        mgr.extend_cached_prefix(&second_tokens, &mut second.lease);
+        assert_eq!(mgr.cache().num_nodes(), 4);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        mgr.finish(&first_tokens, first.lease);
+        assert!(mgr.retract(second.lease));
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 12);
+
+        mgr.evict(12);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+        assert_eq!(mgr.cache().token_pool.available(), 16);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 0);
+        assert_eq!(mgr.cache().num_nodes(), 1);
+    }
+
+    #[test]
     fn test_allocate_cache_miss() {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
         let result = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(result.prefix_len, 0);
-        assert_eq!(result.kv_indices.len(), 5);
+        assert_eq!(result.lease.kv_indices.len(), 5);
         assert_eq!(mgr.cache().token_pool.available(), 95);
     }
 
@@ -731,13 +984,18 @@ mod tests {
 
         // First request: allocate and cache
         let r1 = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
-        assert_eq!(r1.kv_indices.len(), 5); // 5 pages (page_size=1)
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5], &r1.kv_indices, r1.last_node, 0);
+        assert_eq!(r1.lease.kv_indices.len(), 5); // 5 pages (page_size=1)
+        mgr.cache_finished_req(
+            &[1, 2, 3, 4, 5],
+            &r1.lease.kv_indices,
+            r1.lease.last_node(),
+            0,
+        );
 
         // Second request with shared prefix
         let r2 = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
         assert_eq!(r2.prefix_len, 5);
-        assert_eq!(r2.kv_indices.len(), 7); // 5 reused + 2 new pages
+        assert_eq!(r2.lease.kv_indices.len(), 7); // 5 reused + 2 new pages
         assert_eq!(mgr.cache().token_pool.available(), 93); // 100 - 5 - 2
     }
 
@@ -758,8 +1016,8 @@ mod tests {
             .expect("prefix allocation should fit");
         mgr.cache_finished_req(
             prefix_tokens,
-            &prefix.kv_indices,
-            prefix.last_node,
+            &prefix.lease.kv_indices,
+            prefix.lease.last_node(),
             prefix.prefix_len,
         );
         let partial = mgr
@@ -774,8 +1032,8 @@ mod tests {
             .expect("aligned prompt allocation should fit");
         mgr.cache_finished_req(
             &aligned_tokens,
-            &aligned.kv_indices,
-            aligned.last_node,
+            &aligned.lease.kv_indices,
+            aligned.lease.last_node(),
             aligned.prefix_len,
         );
         let full_hit = mgr
@@ -789,7 +1047,7 @@ mod tests {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
         let result = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
-        mgr.free_request(result.last_node);
+        mgr.free_request(result.lease.last_node());
 
         // Path is unlocked, tokens still allocated in pool
         assert_eq!(mgr.cache().protected_size, 0);
@@ -804,7 +1062,7 @@ mod tests {
         let r = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
         assert_eq!(sink.event_count(), 1); // BlockStored for 3 new pages
 
-        mgr.cache_finished_req(&[1, 2, 3], &r.kv_indices, r.last_node, 0);
+        mgr.cache_finished_req(&[1, 2, 3], &r.lease.kv_indices, r.lease.last_node(), 0);
 
         // Second request with full cache hit → no new events
         let r2 = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
@@ -819,7 +1077,12 @@ mod tests {
             SglangKvManager::new(100, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
 
         let r = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6]).unwrap();
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5, 6], &r.kv_indices, r.last_node, 0);
+        mgr.cache_finished_req(
+            &[1, 2, 3, 4, 5, 6],
+            &r.lease.kv_indices,
+            r.lease.last_node(),
+            0,
+        );
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
@@ -839,6 +1102,31 @@ mod tests {
     }
 
     #[test]
+    fn test_published_prefix_hashes_only_unseen_suffix() {
+        let sink = Arc::new(MockSink::new());
+        let mut mgr =
+            SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let indices = mgr.cache_mut().token_pool.allocate(tokens.len()).unwrap();
+
+        assert_eq!(mgr.publish_stored_event(&tokens[..4], &indices[..4], 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 0);
+
+        let events = sink.clone_events();
+        assert_eq!(events.len(), 2);
+        let KvCacheEventData::Stored(first) = &events[0].data else {
+            panic!("expected first stored event");
+        };
+        let KvCacheEventData::Stored(second) = &events[1].data else {
+            panic!("expected suffix stored event");
+        };
+        assert_eq!(first.blocks.len(), 1);
+        assert_eq!(second.blocks.len(), 1);
+        assert_eq!(second.parent_hash, Some(first.blocks[0].block_hash));
+    }
+
+    #[test]
     fn test_cache_materialization_processes_only_newly_completed_blocks() {
         let sink = Arc::new(MockSink::new());
         let mut mgr = SglangKvManager::new(100, 2, KvEventPublishers::default(), 0);
@@ -846,10 +1134,15 @@ mod tests {
         let tokens = [out_of_domain_token, 2, 3, 4, 5, 6];
 
         let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
-        let first_last_node =
-            mgr.cache_unfinished_req(&tokens[..2], &mut alloc.kv_indices, alloc.last_node, 0);
+        let alloc_last_node = alloc.lease.last_node();
+        let first_last_node = mgr.cache_unfinished_req(
+            &tokens[..2],
+            &mut alloc.lease.kv_indices,
+            alloc_last_node,
+            0,
+        );
 
-        let mut kv_indices = alloc.kv_indices;
+        let mut kv_indices = alloc.lease.kv_indices;
         kv_indices.extend_from_slice(&mgr.cache_mut().token_pool.allocate(4).unwrap());
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
@@ -904,10 +1197,10 @@ mod tests {
         };
         assert_eq!(store.blocks.len(), 3);
 
-        mgr.free_indices(&req1.kv_indices);
+        mgr.free_indices(&req1.lease.kv_indices);
         assert_eq!(sink.event_count(), 1);
 
-        mgr.free_indices(&req2.kv_indices);
+        mgr.free_indices(&req2.lease.kv_indices);
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
         let KvCacheEventData::Removed(remove) = &events[1].data else {
@@ -941,7 +1234,7 @@ mod tests {
         assert_eq!(query_hashes.len(), tokens.len());
         harness.apply_events(allocation_events).await;
 
-        mgr.cache_finished_req(&tokens, &req1.kv_indices, req1.last_node, 0);
+        mgr.cache_finished_req(&tokens, &req1.lease.kv_indices, req1.lease.last_node(), 0);
         let req1_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req1_completion_events),
@@ -959,7 +1252,7 @@ mod tests {
             "canonical completion should retain the first request's slots"
         );
 
-        mgr.cache_finished_req(&tokens, &req2.kv_indices, req2.last_node, 0);
+        mgr.cache_finished_req(&tokens, &req2.lease.kv_indices, req2.lease.last_node(), 0);
         let req2_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req2_completion_events),
@@ -995,6 +1288,41 @@ mod tests {
         harness.shutdown();
     }
 
+    #[tokio::test]
+    async fn retained_tail_eviction_preserves_page_granular_prefix_reuse() {
+        let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let harness = RouterIndexerHarness::new(4, ROUTER_TEST_WORKER_ID);
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink), None), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        let mut request = mgr.allocate_for_request(&tokens[..4]).unwrap();
+        mgr.extend_cached_prefix(&tokens[..4], &mut request.lease);
+        assert!(mgr.extend_allocation(&tokens, &mut request.lease));
+        mgr.extend_cached_prefix(&tokens, &mut request.lease);
+        mgr.finish(&tokens, request.lease);
+
+        let stored_events = buffer.drain();
+        let query_hashes = stored_hashes(&stored_events);
+        assert_eq!(query_hashes.len(), 2);
+        harness.apply_events(stored_events).await;
+        assert_eq!(harness.overlap_for_hashes(query_hashes.clone()).await, 2);
+        assert_eq!(mgr.cache().evictable_size, 8);
+        assert_eq!(mgr.cache().token_pool.available(), 0);
+
+        mgr.evict(4);
+        let eviction_events = buffer.drain();
+        assert_eq!(removed_event_count(&eviction_events), 1);
+        assert_eq!(removed_block_count(&eviction_events), 1);
+        harness.apply_events(eviction_events).await;
+
+        assert_eq!(mgr.cache().prefix_match_len(&tokens), 4);
+        assert_eq!(mgr.cache().evictable_size, 4);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().token_pool.available(), 4);
+        assert_eq!(harness.overlap_for_hashes(query_hashes).await, 1);
+        harness.shutdown();
+    }
+
     #[test]
     fn unfinished_duplicate_canonicalization_prevents_missing_parent() {
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
@@ -1003,12 +1331,7 @@ mod tests {
 
         let seed_tokens = [1, 2, 3, 4];
         let seed = mgr.allocate_for_request(&seed_tokens).unwrap();
-        mgr.cache_finished_req(
-            &seed_tokens,
-            &seed.kv_indices,
-            seed.last_node,
-            seed.prefix_len,
-        );
+        mgr.finish(&seed_tokens, seed.lease);
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1019,29 +1342,20 @@ mod tests {
         let shared_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
         let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
-        let duplicate_suffix = duplicate.kv_indices[seed_tokens.len()..].to_vec();
+        let duplicate_suffix = duplicate.lease.indices()[seed_tokens.len()..].to_vec();
         assert_ne!(
-            first.kv_indices[seed_tokens.len()..],
-            duplicate.kv_indices[seed_tokens.len()..]
+            first.lease.indices()[seed_tokens.len()..],
+            duplicate.lease.indices()[seed_tokens.len()..]
         );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
 
-        let first_last = mgr.cache_unfinished_req(
-            &shared_tokens,
-            &mut first.kv_indices,
-            first.last_node,
-            first.prefix_len,
-        );
-        let duplicate_last = mgr.cache_unfinished_req(
-            &shared_tokens,
-            &mut duplicate.kv_indices,
-            duplicate.last_node,
-            duplicate.prefix_len,
-        );
+        mgr.extend_cached_prefix(&shared_tokens, &mut first.lease);
+        mgr.extend_cached_prefix(&shared_tokens, &mut duplicate.lease);
         assert_eq!(
-            duplicate.kv_indices, first.kv_indices,
+            duplicate.lease.indices(),
+            first.lease.indices(),
             "the active duplicate must switch to radix-owned canonical pages"
         );
         assert_eq!(
@@ -1052,7 +1366,7 @@ mod tests {
         assert!(
             duplicate_suffix
                 .iter()
-                .all(|idx| !duplicate.kv_indices.contains(idx)),
+                .all(|idx| !duplicate.lease.indices().contains(idx)),
             "no duplicate physical slot may remain attached to the active request"
         );
         for event in buffer.drain() {
@@ -1061,13 +1375,8 @@ mod tests {
 
         // Mirror retracting the duplicate after its full prefix was cached,
         // then finish and evict the canonical request.
-        mgr.free_request(duplicate_last);
-        mgr.cache_finished_req(
-            &shared_tokens,
-            &first.kv_indices,
-            first_last,
-            shared_tokens.len(),
-        );
+        assert!(mgr.retract(duplicate.lease));
+        mgr.finish(&shared_tokens, first.lease);
         mgr.evict(seed_tokens.len());
         mgr.evict(seed_tokens.len());
         for event in buffer.drain() {
@@ -1078,12 +1387,7 @@ mod tests {
         // duplicated block. A leaked duplicate publisher refcount would
         // suppress re-storing block 2 and emit block 3 with a missing parent.
         let restored = mgr.allocate_for_request(&seed_tokens).unwrap();
-        mgr.cache_finished_req(
-            &seed_tokens,
-            &restored.kv_indices,
-            restored.last_node,
-            restored.prefix_len,
-        );
+        mgr.finish(&seed_tokens, restored.lease);
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1109,8 +1413,7 @@ mod tests {
             indexer.apply_event(event).unwrap();
         }
 
-        mgr.free_indices(&extended.kv_indices[extended.prefix_len..]);
-        mgr.free_request(extended.last_node);
+        assert!(mgr.abort(extended.lease));
     }
 
     #[test]
@@ -1131,9 +1434,10 @@ mod tests {
         let tokens = [1, 2, 3, 4];
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
         let events_before = sink.event_count();
+        let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 2)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 2)
         }));
 
         assert!(result.is_err());
@@ -1147,11 +1451,12 @@ mod tests {
             SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
-        alloc.kv_indices.truncate(4);
+        alloc.lease.kv_indices.truncate(4);
         let events_before = sink.event_count();
+        let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 0)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 0)
         }));
 
         assert!(result.is_err());
@@ -1178,10 +1483,11 @@ mod tests {
         let chunk2_len = 6;
 
         let mut alloc1 = mgr.allocate_for_request(&tokens[..chunk1_len]).unwrap();
+        let previous_last = alloc1.lease.last_node();
         let new_last = mgr.cache_unfinished_req(
             &tokens[..chunk1_len],
-            &mut alloc1.kv_indices,
-            alloc1.last_node,
+            &mut alloc1.lease.kv_indices,
+            previous_last,
             0,
         );
 

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -197,7 +197,7 @@ impl SglangKvManager {
         first_new_token: usize,
     ) -> NodeId {
         let block_size = self.cache.page_size();
-        let complete_len = token_ids.len().min(kv_indices.len()) / block_size * block_size;
+        let complete_len = token_ids.len() / block_size * block_size;
         assert!(
             first_new_token.is_multiple_of(block_size)
                 && first_new_token <= complete_len
@@ -1134,6 +1134,24 @@ mod tests {
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 2)
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(sink.event_count(), events_before);
+    }
+
+    #[test]
+    fn cache_unfinished_rejects_short_indices_before_publishing() {
+        let sink = Arc::new(MockSink::new());
+        let mut mgr =
+            SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
+        alloc.kv_indices.truncate(4);
+        let events_before = sink.event_count();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 0)
         }));
 
         assert!(result.is_err());

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -196,14 +196,21 @@ impl SglangKvManager {
         last_node: NodeId,
         first_new_token: usize,
     ) -> NodeId {
+        let block_size = self.cache.page_size();
+        let complete_len = token_ids.len().min(kv_indices.len()) / block_size * block_size;
+        assert!(
+            first_new_token.is_multiple_of(block_size)
+                && first_new_token <= complete_len
+                && complete_len <= kv_indices.len(),
+            "invalid SGLang canonicalization range: first_new_token={first_new_token}, complete_len={complete_len}, kv_indices={}",
+            kv_indices.len()
+        );
+
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
         let new_last_node = self.cache.insert(token_ids, kv_indices);
 
         // A concurrent insert can retain different physical pages for the same prefix.
         // Move the active request to canonical pages before releasing its duplicates.
-        let complete_len =
-            token_ids.len().min(kv_indices.len()) / self.cache.page_size() * self.cache.page_size();
-
         // Acquire the extended path before releasing the old prefix so
         // destination activation never leaves valid transferred KV unprotected.
         self.cache.inc_lock_ref(new_last_node);
@@ -418,20 +425,15 @@ impl SglangKvManager {
         debug_assert!(complete_len <= kv_indices.len());
         debug_assert!(first_new_token <= complete_len);
 
-        if !first_new_token.is_multiple_of(block_size)
-            || !complete_len.is_multiple_of(block_size)
-            || complete_len > kv_indices.len()
-            || first_new_token > complete_len
-            || !self.radix_path_covers(last_node, first_new_token, complete_len)
-        {
-            tracing::error!(
-                first_new_token,
-                complete_len,
-                kv_indices = kv_indices.len(),
-                "invalid SGLang canonicalization range or radix path"
-            );
-            return;
-        }
+        assert!(
+            first_new_token.is_multiple_of(block_size)
+                && complete_len.is_multiple_of(block_size)
+                && complete_len <= kv_indices.len()
+                && first_new_token <= complete_len
+                && self.radix_path_covers(last_node, first_new_token, complete_len),
+            "invalid SGLang canonicalization range or radix path: first_new_token={first_new_token}, complete_len={complete_len}, kv_indices={}",
+            kv_indices.len()
+        );
 
         let mut unretained_indices = Vec::new();
         let mut current = last_node;
@@ -1112,16 +1114,30 @@ mod tests {
     }
 
     #[test]
-    fn invalid_canonical_path_does_not_partially_rewrite_or_free_indices() {
+    #[should_panic(expected = "invalid SGLang canonicalization range or radix path")]
+    fn invalid_canonical_path_is_fatal() {
         let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
         let mut indices = mgr.cache_mut().token_pool.allocate(4).unwrap();
-        let original = indices.clone();
         let root = mgr.cache().root();
 
         mgr.canonicalize_unfinished_indices(&mut indices, root, 0, 4);
+    }
 
-        assert_eq!(indices, original);
-        assert_eq!(mgr.cache().token_pool.available(), 4);
+    #[test]
+    fn cache_unfinished_rejects_invalid_range_before_publishing() {
+        let sink = Arc::new(MockSink::new());
+        let mut mgr =
+            SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
+        let tokens = [1, 2, 3, 4];
+        let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
+        let events_before = sink.event_count();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 2)
+        }));
+
+        assert!(result.is_err());
+        assert_eq!(sink.event_count(), events_before);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -418,34 +418,28 @@ impl SglangKvManager {
         debug_assert!(complete_len <= kv_indices.len());
         debug_assert!(first_new_token <= complete_len);
 
+        if !first_new_token.is_multiple_of(block_size)
+            || !complete_len.is_multiple_of(block_size)
+            || complete_len > kv_indices.len()
+            || first_new_token > complete_len
+            || !self.radix_path_covers(last_node, first_new_token, complete_len)
+        {
+            tracing::error!(
+                first_new_token,
+                complete_len,
+                kv_indices = kv_indices.len(),
+                "invalid SGLang canonicalization range or radix path"
+            );
+            return;
+        }
+
         let mut unretained_indices = Vec::new();
         let mut current = last_node;
         let mut path_end = complete_len;
 
         while path_end > first_new_token {
-            debug_assert_ne!(current, self.cache.root());
-            if current == self.cache.root() {
-                tracing::error!(
-                    path_end,
-                    first_new_token,
-                    complete_len,
-                    "SGLang radix path ended before the materialized prefix"
-                );
-                break;
-            }
-
             let node = self.cache.node(current);
             let node_len = node.value.len();
-            debug_assert!(node_len <= path_end);
-            if node_len > path_end {
-                tracing::error!(
-                    node_len,
-                    path_end,
-                    complete_len,
-                    "SGLang radix node exceeds the materialized prefix"
-                );
-                break;
-            }
             let path_start = path_end - node_len;
             let reconcile_start = path_start.max(first_new_token);
 
@@ -465,6 +459,26 @@ impl SglangKvManager {
         }
 
         self.free_indices(&unretained_indices);
+    }
+
+    fn radix_path_covers(
+        &self,
+        mut current: NodeId,
+        first_new_token: usize,
+        mut path_end: usize,
+    ) -> bool {
+        while path_end > first_new_token {
+            if current == self.cache.root() {
+                return false;
+            }
+            let node = self.cache.node(current);
+            if node.value.len() > path_end {
+                return false;
+            }
+            path_end -= node.value.len();
+            current = node.parent.unwrap_or_else(|| self.cache.root());
+        }
+        true
     }
 
     /// Evict tokens from the cache, publish BlockRemoved events, and log a trace.
@@ -1095,6 +1109,19 @@ mod tests {
 
         mgr.free_indices(&extended.kv_indices[extended.prefix_len..]);
         mgr.free_request(extended.last_node);
+    }
+
+    #[test]
+    fn invalid_canonical_path_does_not_partially_rewrite_or_free_indices() {
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
+        let mut indices = mgr.cache_mut().token_pool.allocate(4).unwrap();
+        let original = indices.clone();
+        let root = mgr.cache().root();
+
+        mgr.canonicalize_unfinished_indices(&mut indices, root, 0, 4);
+
+        assert_eq!(indices, original);
+        assert_eq!(mgr.cache().token_pool.available(), 4);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -197,21 +197,22 @@ impl SglangKvManager {
         first_new_token: usize,
     ) -> NodeId {
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
-        self.cache.insert(token_ids, kv_indices);
+        let new_last_node = self.cache.insert(token_ids, kv_indices);
 
-        // Find the new deepest node after insert. Another in-flight request may
-        // have inserted the same materialized blocks first, in which case the
-        // radix cache retains that request's physical pages. Switch this active
-        // request to the canonical pages before releasing its duplicate pages;
-        // otherwise a later retract loses track of the duplicates and leaves
-        // KV publisher refcounts inconsistent with the radix cache.
-        let (matched_len, new_last_node) = self.cache.match_prefix(token_ids);
-        let canonical_indices = self.collect_path_indices(new_last_node);
+        // A concurrent insert can retain different physical pages for the same prefix.
+        // Move the active request to canonical pages before releasing its duplicates.
+        let complete_len =
+            token_ids.len().min(kv_indices.len()) / self.cache.page_size() * self.cache.page_size();
 
         // Acquire the extended path before releasing the old prefix so
         // destination activation never leaves valid transferred KV unprotected.
         self.cache.inc_lock_ref(new_last_node);
-        self.canonicalize_unfinished_indices(kv_indices, &canonical_indices, matched_len);
+        self.canonicalize_unfinished_indices(
+            kv_indices,
+            new_last_node,
+            first_new_token,
+            complete_len,
+        );
         self.cache.dec_lock_ref(last_node);
 
         new_last_node
@@ -407,25 +408,60 @@ impl SglangKvManager {
     fn canonicalize_unfinished_indices(
         &mut self,
         kv_indices: &mut [usize],
-        canonical_indices: &[usize],
-        matched_len: usize,
+        last_node: NodeId,
+        first_new_token: usize,
+        complete_len: usize,
     ) {
         let block_size = self.cache.page_size();
-        let complete_len = matched_len
-            .min(kv_indices.len())
-            .min(canonical_indices.len())
-            / block_size
-            * block_size;
-        debug_assert!(canonical_indices.len() >= complete_len);
+        debug_assert_eq!(complete_len % block_size, 0);
+        debug_assert_eq!(first_new_token % block_size, 0);
+        debug_assert!(complete_len <= kv_indices.len());
+        debug_assert!(first_new_token <= complete_len);
 
         let mut unretained_indices = Vec::new();
-        for block_start in (0..complete_len).step_by(block_size) {
-            let block_end = block_start + block_size;
-            if kv_indices[block_start..block_end] != canonical_indices[block_start..block_end] {
-                unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
-                kv_indices[block_start..block_end]
-                    .copy_from_slice(&canonical_indices[block_start..block_end]);
+        let mut current = last_node;
+        let mut path_end = complete_len;
+
+        while path_end > first_new_token {
+            debug_assert_ne!(current, self.cache.root());
+            if current == self.cache.root() {
+                tracing::error!(
+                    path_end,
+                    first_new_token,
+                    complete_len,
+                    "SGLang radix path ended before the materialized prefix"
+                );
+                break;
             }
+
+            let node = self.cache.node(current);
+            let node_len = node.value.len();
+            debug_assert!(node_len <= path_end);
+            if node_len > path_end {
+                tracing::error!(
+                    node_len,
+                    path_end,
+                    complete_len,
+                    "SGLang radix node exceeds the materialized prefix"
+                );
+                break;
+            }
+            let path_start = path_end - node_len;
+            let reconcile_start = path_start.max(first_new_token);
+
+            for block_start in (reconcile_start..path_end).step_by(block_size) {
+                let block_end = block_start + block_size;
+                let node_start = block_start - path_start;
+                let node_end = node_start + block_size;
+                let canonical = &node.value[node_start..node_end];
+                if kv_indices[block_start..block_end] != *canonical {
+                    unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+                    kv_indices[block_start..block_end].copy_from_slice(canonical);
+                }
+            }
+
+            path_end = path_start;
+            current = node.parent.unwrap_or_else(|| self.cache.root());
         }
 
         self.free_indices(&unretained_indices);
@@ -946,10 +982,10 @@ mod tests {
     #[test]
     fn unfinished_duplicate_canonicalization_prevents_missing_parent() {
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
-        let mut mgr = SglangKvManager::new(8, 1, KvEventPublishers::new(Some(sink), None), 0);
+        let mut mgr = SglangKvManager::new(32, 4, KvEventPublishers::new(Some(sink), None), 0);
         let mut indexer = RadixTree::new();
 
-        let seed_tokens = [1];
+        let seed_tokens = [1, 2, 3, 4];
         let seed = mgr.allocate_for_request(&seed_tokens).unwrap();
         mgr.cache_finished_req(
             &seed_tokens,
@@ -964,10 +1000,14 @@ mod tests {
         // Two requests miss the same suffix before either inserts it. Their
         // physical suffix pages are distinct even though the logical block is
         // identical.
-        let shared_tokens = [1, 2];
+        let shared_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
         let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
-        assert_ne!(first.kv_indices[1], duplicate.kv_indices[1]);
+        let duplicate_suffix = duplicate.kv_indices[seed_tokens.len()..].to_vec();
+        assert_ne!(
+            first.kv_indices[seed_tokens.len()..],
+            duplicate.kv_indices[seed_tokens.len()..]
+        );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -988,6 +1028,17 @@ mod tests {
             duplicate.kv_indices, first.kv_indices,
             "the active duplicate must switch to radix-owned canonical pages"
         );
+        assert_eq!(
+            mgr.cache().token_pool.available(),
+            24,
+            "every duplicate slot in the four-token page must return to the pool"
+        );
+        assert!(
+            duplicate_suffix
+                .iter()
+                .all(|idx| !duplicate.kv_indices.contains(idx)),
+            "no duplicate physical slot may remain attached to the active request"
+        );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1001,8 +1052,8 @@ mod tests {
             first_last,
             shared_tokens.len(),
         );
-        mgr.evict(1);
-        mgr.evict(1);
+        mgr.evict(seed_tokens.len());
+        mgr.evict(seed_tokens.len());
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1021,7 +1072,9 @@ mod tests {
             indexer.apply_event(event).unwrap();
         }
 
-        let extended = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
+        let extended = mgr
+            .allocate_for_request(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+            .unwrap();
         let extension_events = buffer.drain();
         assert_eq!(stored_event_count(&extension_events), 1);
         let store = extension_events

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -326,6 +326,8 @@ where
 struct TraceRequestStats {
     arrival_time_ms: f64,
     first_admit_ms: Option<f64>,
+    terminal_time_ms: Option<f64>,
+    terminal_status: Option<ReplayTerminalStatus>,
     token_times_ms: Vec<f64>,
     input_length: usize,
     requested_output_length: usize,
@@ -362,7 +364,6 @@ struct PerRequestDetail {
     decode_reused_input_tokens: Option<usize>,
     prefill_route_overlap_tokens: Option<usize>,
     decode_route_overlap_tokens: Option<usize>,
-    terminal_status: Option<ReplayTerminalStatus>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
@@ -391,6 +392,7 @@ pub struct PerRequestRecord {
     pub uuid: String,
     pub arrival_time_ms: f64,
     pub first_admit_ms: Option<f64>,
+    pub terminal_time_ms: f64,
     pub first_token_ms: Option<f64>,
     pub last_token_ms: Option<f64>,
     pub ttft_ms: Option<f64>,
@@ -598,6 +600,8 @@ impl TraceCollector {
             TraceRequestStats {
                 arrival_time_ms,
                 first_admit_ms: None,
+                terminal_time_ms: None,
+                terminal_status: None,
                 token_times_ms: Vec::with_capacity(requested_output_length),
                 input_length,
                 requested_output_length,
@@ -740,9 +744,15 @@ impl TraceCollector {
         }
     }
 
-    pub(crate) fn on_terminal(&mut self, uuid: Uuid, status: ReplayTerminalStatus) {
-        if let Some(detail) = self.detail_mut(uuid) {
-            detail.terminal_status.get_or_insert(status);
+    pub(crate) fn on_terminal(
+        &mut self,
+        uuid: Uuid,
+        terminal_time_ms: f64,
+        status: ReplayTerminalStatus,
+    ) {
+        if let Some(stats) = self.requests.get_mut(&uuid) {
+            stats.terminal_time_ms.get_or_insert(terminal_time_ms);
+            stats.terminal_status.get_or_insert(status);
         }
     }
 
@@ -842,10 +852,18 @@ impl TraceCollector {
             if stats.first_admit_ms.is_none() {
                 continue;
             }
-            let Some(first_token_ms) = stats.first_token_ms() else {
-                continue;
+            let terminal_time_ms = match stats.terminal_status {
+                Some(ReplayTerminalStatus::Completed) => {
+                    stats.terminal_time_ms.or_else(|| stats.last_token_ms())
+                }
+                None => stats.last_token_ms(),
+                Some(
+                    ReplayTerminalStatus::Rejected
+                    | ReplayTerminalStatus::Canceled
+                    | ReplayTerminalStatus::Failed,
+                ) => None,
             };
-            let Some(last_token_ms) = stats.last_token_ms() else {
+            let Some(terminal_time_ms) = terminal_time_ms else {
                 continue;
             };
 
@@ -855,7 +873,13 @@ impl TraceCollector {
             total_output_tokens += output_length;
             total_reused_tokens += stats.reused_input_tokens;
             total_first_admission_reused_tokens += stats.first_admission_reused_input_tokens;
-            duration_ms = duration_ms.max(last_token_ms);
+            duration_ms = duration_ms.max(terminal_time_ms);
+
+            let (Some(first_token_ms), Some(last_token_ms)) =
+                (stats.first_token_ms(), stats.last_token_ms())
+            else {
+                continue;
+            };
 
             let ttft_ms = (first_token_ms - stats.arrival_time_ms).max(0.0);
             let e2e_ms = (last_token_ms - stats.arrival_time_ms).max(0.0);
@@ -966,7 +990,10 @@ impl TraceCollector {
             let Some(detail) = stats.detail.as_deref() else {
                 continue;
             };
-            let Some(terminal_status) = detail.terminal_status else {
+            let Some(terminal_status) = stats.terminal_status else {
+                continue;
+            };
+            let Some(terminal_time_ms) = stats.terminal_time_ms else {
                 continue;
             };
             let first_token_ms = stats.first_token_ms();
@@ -977,6 +1004,7 @@ impl TraceCollector {
                 uuid: uuid.to_string(),
                 arrival_time_ms: stats.arrival_time_ms,
                 first_admit_ms: stats.first_admit_ms,
+                terminal_time_ms,
                 first_token_ms,
                 last_token_ms,
                 ttft_ms: first_token_ms.map(|time| (time - stats.arrival_time_ms).max(0.0)),
@@ -1179,6 +1207,28 @@ mod tests {
         assert_eq!(actual.std_ms, expected.std_ms);
     }
 
+    #[test]
+    fn completed_zero_output_request_counts_without_latency_samples() {
+        let mut collector = TraceCollector::default();
+        collector.set_static_worker_count(0, 1);
+        collector.set_gpus_per_worker(0, 4);
+        let uuid = Uuid::from_u128(99);
+        collector.on_arrival(uuid, 0.0, 32, 0);
+        collector.on_admit(uuid, 5.0, 8);
+        collector.on_terminal(uuid, 25.0, ReplayTerminalStatus::Completed);
+
+        let report = collector.finish();
+
+        assert_eq!(report.request_counts.completed_requests, 1);
+        assert_eq!(report.request_counts.total_input_tokens, 32);
+        assert_eq!(report.request_counts.total_output_tokens, 0);
+        assert_eq!(report.throughput.duration_ms, 25.0);
+        assert_eq!(report.throughput.decode_worker_seconds, 0.025);
+        assert!((report.throughput.gpu_hours - 0.1 / 3600.0).abs() < 1e-12);
+        assert_eq!(report.latency.ttft.mean_ms, 0.0);
+        assert_eq!(report.latency.e2e.mean_ms, 0.0);
+    }
+
     /// With per-request capture on, a standard disagg-style request lifecycle
     /// (arrival → admit → prefill_assigned → decode_assigned → tokens) yields
     /// exactly one record with all fields populated correctly.
@@ -1202,7 +1252,7 @@ mod tests {
         collector.on_token(uuid, 60.0);
         collector.on_token(uuid, 75.0);
         collector.on_token(uuid, 95.0);
-        collector.on_terminal(uuid, ReplayTerminalStatus::Completed);
+        collector.on_terminal(uuid, 95.0, ReplayTerminalStatus::Completed);
 
         let report = collector.finish();
         assert_eq!(report.per_request.len(), 1);
@@ -1210,6 +1260,7 @@ mod tests {
         assert_eq!(rec.uuid, uuid.to_string());
         assert_eq!(rec.arrival_time_ms, 0.0);
         assert_eq!(rec.first_admit_ms, Some(5.0));
+        assert_eq!(rec.terminal_time_ms, 95.0);
         assert_eq!(rec.first_token_ms, Some(50.0));
         assert_eq!(rec.last_token_ms, Some(95.0));
         assert_eq!(rec.ttft_ms, Some(50.0));
@@ -1248,7 +1299,7 @@ mod tests {
         collector.on_decode_assigned(uuid, 1);
         collector.on_token(uuid, 30.0);
         collector.on_token(uuid, 45.0);
-        collector.on_terminal(uuid, ReplayTerminalStatus::Completed);
+        collector.on_terminal(uuid, 45.0, ReplayTerminalStatus::Completed);
 
         let report = collector.finish();
         assert_eq!(report.per_request.len(), 1);
@@ -1417,7 +1468,7 @@ mod tests {
             collector.on_admit(uuid, arrival + 1.0, 0);
             collector.on_decode_assigned(uuid, 0);
             collector.on_token(uuid, arrival + 5.0);
-            collector.on_terminal(uuid, ReplayTerminalStatus::Completed);
+            collector.on_terminal(uuid, arrival + 5.0, ReplayTerminalStatus::Completed);
         }
         let report = collector.finish();
         let arrivals: Vec<f64> = report
@@ -1442,7 +1493,7 @@ mod tests {
         collector.on_decode_assigned(uuid, 1);
         collector.on_token(uuid, 20.0);
         collector.on_token(uuid, 25.0);
-        collector.on_terminal(uuid, ReplayTerminalStatus::Completed);
+        collector.on_terminal(uuid, 25.0, ReplayTerminalStatus::Completed);
 
         let report = collector.finish();
         let line = serde_json::to_string(&report.per_request[0])
@@ -1471,7 +1522,7 @@ mod tests {
         ] {
             let uuid = Uuid::from_u128(uuid_n);
             collector.on_arrival(uuid, uuid_n as f64, 64, 2);
-            collector.on_terminal(uuid, status);
+            collector.on_terminal(uuid, uuid_n as f64 + 1.0, status);
         }
         collector.on_arrival(Uuid::from_u128(4), 4.0, 64, 2);
 

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -483,6 +483,12 @@ impl SlaThresholds {
         }
         true
     }
+
+    fn is_good_without_tokens(&self, e2e_ms: f64) -> bool {
+        self.ttft_ms.is_none()
+            && self.itl_ms.is_none()
+            && self.e2e_ms.is_some_and(|bound| e2e_ms <= bound)
+    }
 }
 
 #[derive(Debug, Default)]
@@ -852,18 +858,10 @@ impl TraceCollector {
             if stats.first_admit_ms.is_none() {
                 continue;
             }
-            let terminal_time_ms = match stats.terminal_status {
-                Some(ReplayTerminalStatus::Completed) => {
-                    stats.terminal_time_ms.or_else(|| stats.last_token_ms())
-                }
-                None => stats.last_token_ms(),
-                Some(
-                    ReplayTerminalStatus::Rejected
-                    | ReplayTerminalStatus::Canceled
-                    | ReplayTerminalStatus::Failed,
-                ) => None,
-            };
-            let Some(terminal_time_ms) = terminal_time_ms else {
+            if stats.terminal_status != Some(ReplayTerminalStatus::Completed) {
+                continue;
+            }
+            let Some(terminal_time_ms) = stats.terminal_time_ms else {
                 continue;
             };
 
@@ -878,6 +876,10 @@ impl TraceCollector {
             let (Some(first_token_ms), Some(last_token_ms)) =
                 (stats.first_token_ms(), stats.last_token_ms())
             else {
+                let e2e_ms = (terminal_time_ms - stats.arrival_time_ms).max(0.0);
+                if sla.is_set() && sla.is_good_without_tokens(e2e_ms) {
+                    goodput_requests += 1;
+                }
                 continue;
             };
 
@@ -1229,6 +1231,50 @@ mod tests {
         assert_eq!(report.latency.e2e.mean_ms, 0.0);
     }
 
+    #[test]
+    fn token_before_simulation_cap_does_not_count_as_completion() {
+        let mut collector = TraceCollector::default();
+        let uuid = Uuid::from_u128(100);
+        collector.on_arrival(uuid, 0.0, 32, 4);
+        collector.on_admit(uuid, 5.0, 0);
+        collector.on_token(uuid, 25.0);
+
+        let report = collector.finish();
+
+        assert_eq!(report.request_counts.completed_requests, 0);
+        assert_eq!(report.request_counts.total_input_tokens, 0);
+        assert_eq!(report.request_counts.total_output_tokens, 0);
+        assert_eq!(report.throughput.duration_ms, 0.0);
+    }
+
+    #[test]
+    fn zero_output_goodput_requires_e2e_only_sla() {
+        let collect = |sla| {
+            let mut collector = TraceCollector::default();
+            collector.set_sla_thresholds(sla);
+            let uuid = Uuid::from_u128(101);
+            collector.on_arrival(uuid, 0.0, 32, 0);
+            collector.on_admit(uuid, 5.0, 0);
+            collector.on_terminal(uuid, 100.0, ReplayTerminalStatus::Completed);
+            collector.finish().goodput.unwrap().completed_requests
+        };
+
+        assert_eq!(
+            collect(SlaThresholds {
+                e2e_ms: Some(100.0),
+                ..Default::default()
+            }),
+            1
+        );
+        assert_eq!(
+            collect(SlaThresholds {
+                ttft_ms: Some(1_000.0),
+                ..Default::default()
+            }),
+            0
+        );
+    }
+
     /// With per-request capture on, a standard disagg-style request lifecycle
     /// (arrival → admit → prefill_assigned → decode_assigned → tokens) yields
     /// exactly one record with all fields populated correctly.
@@ -1323,6 +1369,7 @@ mod tests {
         collector.on_decode_assigned(uuid, 0);
         collector.on_token(uuid, 50.0);
         collector.on_token(uuid, 60.0);
+        collector.on_terminal(uuid, 60.0, ReplayTerminalStatus::Completed);
 
         assert!(collector.requests[&uuid].detail.is_none());
 
@@ -1348,6 +1395,8 @@ mod tests {
         for &t in token_times_ms {
             collector.on_token(uuid, t);
         }
+        let terminal_time_ms = token_times_ms.last().copied().unwrap_or(arrival_ms);
+        collector.on_terminal(uuid, terminal_time_ms, ReplayTerminalStatus::Completed);
     }
 
     /// Goodput classifies a request "good" using aiperf's average ITL,
@@ -1558,6 +1607,7 @@ mod tests {
         collector.on_admit(uuid, 1.0, 0);
         collector.on_admit(uuid, 2.0, 80);
         collector.on_token(uuid, 3.0);
+        collector.on_terminal(uuid, 3.0, ReplayTerminalStatus::Completed);
 
         let report = collector.finish();
 

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -158,6 +158,7 @@ mod tests {
         collector.on_token(uuid, 11.0);
         collector.on_token(uuid, 12.0);
         collector.on_token(uuid, 110.0);
+        collector.on_terminal(uuid, 110.0, ReplayTerminalStatus::Completed);
 
         let report = collector.finish();
 

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -1397,6 +1397,53 @@ mod tests {
     }
 
     #[test]
+    fn sglang_zero_output_request_does_not_block_following_work() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .block_size(4)
+            .num_gpu_blocks(32)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .speedup_ratio(1000.0)
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+        let requests = vec![
+            DirectRequest {
+                tokens: vec![1; 4],
+                max_output_tokens: 0,
+                uuid: Some(Uuid::from_u128(9_000)),
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            },
+            DirectRequest {
+                tokens: vec![2; 4],
+                max_output_tokens: 1,
+                uuid: Some(Uuid::from_u128(9_001)),
+                arrival_timestamp_ms: Some(1.0),
+                ..Default::default()
+            },
+        ];
+
+        let (collector, _) =
+            run_trace_multi_collect_with_stats(&args, requests, 1, ReplayRouterMode::RoundRobin);
+        let mut snapshots = collector.snapshots();
+        snapshots.sort_by_key(|snapshot| snapshot.requested_output_length);
+
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].requested_output_length, 0);
+        assert_eq!(snapshots[0].output_length, 0);
+        assert!(snapshots[0].first_admit_ms.is_some());
+        assert_eq!(snapshots[0].first_token_ms, None);
+        assert_eq!(snapshots[1].requested_output_length, 1);
+        assert_eq!(snapshots[1].output_length, 1);
+    }
+
+    #[test]
     fn sglang_completion_visible_fpm_reaches_aggregated_buffer() {
         let pending = normalize_trace_requests(
             vec![DirectRequest {

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -1441,6 +1441,10 @@ mod tests {
         assert_eq!(snapshots[0].first_token_ms, None);
         assert_eq!(snapshots[1].requested_output_length, 1);
         assert_eq!(snapshots[1].output_length, 1);
+
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 2);
+        assert_eq!(report.request_counts.total_output_tokens, 1);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -514,7 +514,7 @@ impl AggRuntime {
             } else {
                 ReplayTerminalStatus::Completed
             };
-            self.collector.on_terminal(signal.uuid, status);
+            self.collector.on_terminal(signal.uuid, self.now_ms, status);
             #[cfg(test)]
             self.remove_active_request(signal.uuid);
             if let Some(router) = self.router.as_mut() {

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -605,7 +605,7 @@ impl DisaggRuntime {
     ) -> Result<()> {
         if matches!(outcome, HandoffActionOutcome::Failed(_)) {
             self.collector
-                .on_terminal(uuid, ReplayTerminalStatus::Failed);
+                .on_terminal(uuid, self.now_ms, ReplayTerminalStatus::Failed);
         }
         let actions = self
             .state_mut(uuid)?
@@ -624,7 +624,7 @@ impl DisaggRuntime {
             _ => None,
         };
         if let Some(status) = terminal_status {
-            self.collector.on_terminal(uuid, status);
+            self.collector.on_terminal(uuid, self.now_ms, status);
         }
         let actions = self.state_mut(uuid)?.coordinator.on_fact(fact)?;
         self.action_queues.enqueue_all(uuid, actions);
@@ -1168,7 +1168,7 @@ impl DisaggRuntime {
             }
             Some(HandoffCompletion::Canceled) => {
                 self.collector
-                    .on_terminal(uuid, ReplayTerminalStatus::Canceled);
+                    .on_terminal(uuid, self.now_ms, ReplayTerminalStatus::Canceled);
                 self.cancel_prefill_route(uuid)?;
                 self.cancel_decode_route(uuid)?;
                 self.finish_logical_request(uuid, true)?;
@@ -1382,7 +1382,7 @@ impl DisaggRuntime {
         if signal.rejected {
             let handoff_id = self.state(signal.uuid)?.handoff_id;
             self.collector
-                .on_terminal(signal.uuid, ReplayTerminalStatus::Rejected);
+                .on_terminal(signal.uuid, self.now_ms, ReplayTerminalStatus::Rejected);
             return self.apply_handoff_fact(signal.uuid, HandoffFact::Failed { handoff_id });
         }
 
@@ -1454,7 +1454,8 @@ impl DisaggRuntime {
         } else {
             ReplayTerminalStatus::Completed
         };
-        self.collector.on_terminal(signal.uuid, terminal_status);
+        self.collector
+            .on_terminal(signal.uuid, self.now_ms, terminal_status);
         self.finish_logical_request(signal.uuid, false)?;
         self.dispatch_decode_admissions(admissions)?;
         Ok(())

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -1371,6 +1371,7 @@ impl DisaggRuntime {
     /// Process one prefill output signal, including router updates and decode handoff scheduling.
     fn process_prefill_signal(&mut self, signal: OutputSignal) -> Result<()> {
         if !signal.rejected
+            && signal.token_id.is_some()
             && let Some(capture) = self.conformance_capture.as_mut()
         {
             capture.source_output_tokens += 1;

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -355,6 +355,42 @@ fn run_trace_with_details(
     collector.finish()
 }
 
+#[rstest::rstest]
+#[case(EngineType::Vllm)]
+#[case(EngineType::Sglang)]
+fn zero_output_disagg_does_not_count_a_source_token(#[case] engine_type: EngineType) {
+    let mut config = match engine_type {
+        EngineType::Vllm => disagg_config(),
+        EngineType::Sglang => sglang_disagg_config(),
+        EngineType::Trtllm => unreachable!(),
+    };
+    config.num_prefill_workers = 1;
+    config.num_decode_workers = 1;
+    let request = DirectRequest {
+        tokens: vec![1; 64],
+        max_output_tokens: 0,
+        uuid: Some(Uuid::from_u128(90_010)),
+        arrival_timestamp_ms: Some(0.0),
+        ..Default::default()
+    };
+    let mut runtime =
+        DisaggRuntime::new_handoff_conformance(&config, VecDeque::from([request])).unwrap();
+
+    runtime.run_to_completion().unwrap();
+
+    assert_eq!(
+        runtime
+            .conformance_capture
+            .as_ref()
+            .unwrap()
+            .source_output_tokens,
+        0
+    );
+    let report = std::mem::take(&mut runtime.collector).finish();
+    assert_eq!(report.request_counts.completed_requests, 1);
+    assert_eq!(report.request_counts.total_output_tokens, 0);
+}
+
 fn multiturn_trace() -> Trace {
     Trace {
         block_size: 64,

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -255,7 +255,8 @@ impl SingleRuntime {
             } else {
                 ReplayTerminalStatus::Completed
             };
-            self.collector.on_terminal(signal.uuid, status);
+            self.collector
+                .on_terminal(signal.uuid, self.current_time_ms, status);
         }
         for _ in 0..completed_requests {
             self.progress.inc_completed();

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -332,6 +332,7 @@ mod tests {
     use crate::common::protocols::EngineType;
     use crate::loadgen::{SessionTrace, Trace, TurnTrace};
     use crate::replay::{ReplayTerminalStatus, TraceRequestStatsSnapshot, TraceSimulationReport};
+    use crate::scheduler::EnginePassResult;
     use rstest::rstest;
     use std::collections::{HashMap, VecDeque};
     use uuid::Uuid;
@@ -348,6 +349,17 @@ mod tests {
     struct ManualConcurrencyResult {
         report: TraceSimulationReport,
         snapshots: HashMap<Uuid, TraceRequestStatsSnapshot>,
+    }
+
+    fn record_manual_terminals(collector: &mut TraceCollector, pass: &EnginePassResult) {
+        for signal in pass.output_signals.iter().filter(|signal| signal.completed) {
+            let status = if signal.rejected {
+                ReplayTerminalStatus::Rejected
+            } else {
+                ReplayTerminalStatus::Completed
+            };
+            collector.on_terminal(signal.uuid, pass.end_ms, status);
+        }
     }
 
     fn enqueue_trace_arrivals_manual(
@@ -534,6 +546,7 @@ mod tests {
             }
 
             let pass = worker.execute_pass(&mut collector, current_time_ms);
+            record_manual_terminals(&mut collector, &pass);
             if first_decode_end_ms == 0.0 && !pass.output_signals.is_empty() {
                 first_decode_end_ms = pass.end_ms;
             }
@@ -587,6 +600,7 @@ mod tests {
             }
 
             let pass = worker.execute_pass(&mut collector, current_time_ms);
+            record_manual_terminals(&mut collector, &pass);
             current_time_ms = pass.end_ms;
         }
 

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -150,7 +150,7 @@ impl DisaggRequestState {
 
     pub(crate) fn build_prefill_request(&self) -> Result<DirectRequest> {
         let mut request = self.original_request()?.clone();
-        request.max_output_tokens = 1;
+        request.max_output_tokens = request.max_output_tokens.min(1);
         Ok(request)
     }
 

--- a/lib/mocker/src/replay/online/demux.rs
+++ b/lib/mocker/src/replay/online/demux.rs
@@ -21,9 +21,9 @@ async fn process_output_signal(
     router: &ReplayRouter,
     stats: &SharedLiveRuntimeStats,
 ) {
-    // Rejected requests never ran: skip the phantom token / prefill-mark, but
-    // still fall through to the completion path to notify the waiter below.
-    if !output.rejected {
+    // Signals without a token (rejections and zero-output terminals) must skip
+    // token accounting and the first-token callback, but still complete below.
+    if !output.rejected && output.token_id.is_some() {
         collector.on_token(output.uuid, batch_time_ms);
     }
 
@@ -31,7 +31,7 @@ async fn process_output_signal(
         return;
     };
 
-    if !output.rejected && state.mark_first_token_once() {
+    if !output.rejected && output.token_id.is_some() && state.mark_first_token_once() {
         tracing::debug!(uuid = %output.uuid, "replay_diag: demux on_first_token start");
         match router.on_first_token(output.uuid).await {
             Ok(true) => stats.record_prefill_marked(),

--- a/lib/mocker/src/replay/online/demux.rs
+++ b/lib/mocker/src/replay/online/demux.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 
 use crate::common::protocols::OutputSignal;
-use crate::replay::{TraceCollector, TraceSimulationReport};
+use crate::replay::{ReplayTerminalStatus, TraceCollector, TraceSimulationReport};
 use crate::scheduler::AdmissionEvent;
 
 use super::ReplayRouter;
@@ -47,6 +47,13 @@ async fn process_output_signal(
     if !output.completed || !state.mark_completed_once() {
         return;
     }
+
+    let terminal_status = if output.rejected {
+        ReplayTerminalStatus::Rejected
+    } else {
+        ReplayTerminalStatus::Completed
+    };
+    collector.on_terminal(output.uuid, batch_time_ms, terminal_status);
 
     tracing::debug!(uuid = %output.uuid, "replay_diag: demux on_complete start");
     match router.on_complete(output.uuid).await {

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -483,6 +483,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn free_clears_prefill_load_without_first_token() {
+        let args = MockEngineArgs::builder()
+            .block_size(64)
+            .max_num_batched_tokens(Some(64))
+            .build()
+            .unwrap();
+        let router = ReplayRouter::new(
+            ReplayRouterMode::KvRouter,
+            &args,
+            Some(KvRouterConfig {
+                router_track_prefill_tokens: true,
+                ..KvRouterConfig::default()
+            }),
+            None,
+            1,
+        )
+        .unwrap();
+        let uuid = Uuid::from_u128(4);
+
+        router
+            .select_worker(&priority_request(4, 0, 0), 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            router.debug_potential_loads(0, true)[0].potential_prefill_tokens,
+            64
+        );
+
+        router.on_complete(uuid).await.unwrap();
+
+        assert_eq!(
+            router.debug_potential_loads(0, true)[0].potential_prefill_tokens,
+            0
+        );
+        router.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn online_replay_forwards_policy_class_and_returns_config_errors() {
         let args = MockEngineArgs::builder()
             .block_size(64)

--- a/lib/mocker/src/replay/online/tests.rs
+++ b/lib/mocker/src/replay/online/tests.rs
@@ -548,10 +548,11 @@ fn test_online_trace_replay_sglang_zero_output_drains_without_phantom_token() {
     )
     .unwrap();
 
-    // Zero-output trace rows are terminally drained but do not manufacture a
-    // token or latency sample. The normal follower must still complete.
+    // Zero-output trace rows count as completed prefill work but do not
+    // manufacture a token or latency sample. The normal follower also completes.
     assert_eq!(report.request_counts.num_requests, 2);
-    assert_eq!(report.request_counts.completed_requests, 1);
+    assert_eq!(report.request_counts.completed_requests, 2);
+    assert_eq!(report.request_counts.total_input_tokens, 128);
     assert_eq!(report.request_counts.total_output_tokens, 2);
 }
 

--- a/lib/mocker/src/replay/online/tests.rs
+++ b/lib/mocker/src/replay/online/tests.rs
@@ -534,6 +534,28 @@ fn test_online_trace_replay_sglang_single_worker_completes() {
 }
 
 #[test]
+fn test_online_trace_replay_sglang_zero_output_drains_without_phantom_token() {
+    let mut zero_output = request(103, 7, Some(0.0));
+    zero_output.max_output_tokens = 0;
+    let report = simulate_trace_requests(
+        sglang_replay_args(),
+        None,
+        None,
+        vec![zero_output, request(104, 8, Some(1.0))],
+        1,
+        1.0,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap();
+
+    // Zero-output trace rows are terminally drained but do not manufacture a
+    // token or latency sample. The normal follower must still complete.
+    assert_eq!(report.request_counts.num_requests, 2);
+    assert_eq!(report.request_counts.completed_requests, 1);
+    assert_eq!(report.request_counts.total_output_tokens, 2);
+}
+
+#[test]
 fn test_online_trace_replay_sglang_kv_router_smoke() {
     let args = sglang_replay_args();
     let requests = vec![request(111, 9, Some(0.0)), request(112, 9, Some(500.0))];

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -108,7 +108,7 @@ fn pass() -> EnginePassResult {
         completed_requests: 1,
         output_signals: vec![OutputSignal {
             uuid: request_id,
-            token_id: None,
+            token_id: Some(1),
             completed: true,
             rejected: false,
             handoff_delay_ms: None,

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -125,12 +125,12 @@ pub(crate) fn build_fpm_snapshot(
 }
 
 /// Return (visible output tokens, request-forwards) for accept-length
-/// accounting. One output signal corresponds to one visible token; multiple
-/// signals with the same UUID in a pass are an MTP/spec-decode burst.
+/// accounting. A signal with a token corresponds to one visible token; multiple
+/// token signals with the same UUID in a pass are an MTP/spec-decode burst.
 pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, usize) {
     let visible_tokens = output_signals
         .iter()
-        .filter(|signal| !signal.rejected)
+        .filter(|signal| !signal.rejected && signal.token_id.is_some())
         .count();
     if visible_tokens == 0 {
         return (0, 0);
@@ -138,7 +138,7 @@ pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, u
 
     let request_forwards = output_signals
         .iter()
-        .filter(|signal| !signal.rejected)
+        .filter(|signal| !signal.rejected && signal.token_id.is_some())
         .map(|signal| signal.uuid)
         .collect::<std::collections::HashSet<_>>()
         .len();
@@ -571,6 +571,43 @@ mod tests {
         assert_eq!(acc.count, 0);
         assert_eq!(acc.sum, 0.0);
         assert_eq!(acc.variance(), 0.0);
+    }
+
+    #[test]
+    fn accept_length_ignores_terminal_signals_without_tokens() {
+        let token_uuid = Uuid::from_u128(1);
+        let signals = [
+            OutputSignal {
+                uuid: Uuid::from_u128(2),
+                token_id: None,
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            },
+            OutputSignal {
+                uuid: token_uuid,
+                token_id: Some(7),
+                completed: false,
+                rejected: false,
+                handoff_delay_ms: None,
+            },
+            OutputSignal {
+                uuid: token_uuid,
+                token_id: Some(8),
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            },
+            OutputSignal {
+                uuid: Uuid::from_u128(3),
+                token_id: Some(9),
+                completed: true,
+                rejected: true,
+                handoff_delay_ms: None,
+            },
+        ];
+
+        assert_eq!(accept_length_sample(&signals), (2, 1));
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -623,6 +623,7 @@ impl SglangCore {
         let scheduled_decode_lens: Vec<u64> = self
             .running
             .iter()
+            .filter(|req| req.remaining_output_tokens() > 0)
             .map(|req| req.current_sequence_len() as u64)
             .collect();
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -704,13 +704,16 @@ impl SglangCore {
                     .map(|reservation| reservation.request.prompt_len() as u64),
             );
         let fpm = build_fpm_snapshot(
-            prefill_fpm.iter().map(|p| {
-                (
-                    p.prompt_len as u64,
-                    p.prefix_tokens as u64,
-                    p.tokens_computed as u64,
-                )
-            }),
+            prefill_fpm
+                .iter()
+                .filter(|p| p.tokens_computed > 0)
+                .map(|p| {
+                    (
+                        p.prompt_len as u64,
+                        p.prefix_tokens as u64,
+                        p.tokens_computed as u64,
+                    )
+                }),
             scheduled_decode_lens.into_iter(),
             queued_prefills,
             ordinary_queued_decodes.chain(preactivation_decodes),

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -642,7 +642,9 @@ impl SglangCore {
 
         if let Some(collector) = collector {
             for signal in &decode.output_signals {
-                collector.on_token(signal.uuid, decode.end_ms);
+                if signal.token_id.is_some() {
+                    collector.on_token(signal.uuid, decode.end_ms);
+                }
             }
         }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -65,10 +65,8 @@ impl ReservedSglangDecode {
         let allocated_tokens = kv.allocated_tokens;
         let prompt_tokens = request.prompt_tokens.clone();
         let alloc = kv_manager.activate_destination(kv, &prompt_tokens);
-        request.last_node = Some(alloc.last_node);
-        request.kv_indices = alloc.kv_indices;
+        request.kv_lease = alloc.lease;
         request.materialized_tokens = request.prompt_len();
-        request.cached_tokens = request.page_aligned_materialized_tokens(block_size);
         request.allocated_tokens = allocated_tokens;
         request.debug_assert_invariants(block_size);
         request
@@ -446,12 +444,7 @@ impl SglangCore {
         let Some(mut request) = request else {
             return false;
         };
-        let capacity_improved = !request.kv_indices.is_empty() || request.last_node.is_some();
-        self.kv_manager
-            .free_indices(&request.kv_indices[request.cached_tokens..]);
-        if let Some(last_node) = request.last_node.take() {
-            self.kv_manager.free_request(last_node);
-        }
+        let capacity_improved = self.kv_manager.abort(std::mem::take(&mut request.kv_lease));
         self.source_holds.remove_request(request_id);
         self.active_destination_handoffs.remove_request(request_id);
         if capacity_improved {

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -66,7 +66,7 @@ pub(super) fn cache_materialized_prefix(
     let sequence = req.sequence_prefix(aligned_tokens);
     let new_last = kv_manager.cache_unfinished_req(
         &sequence,
-        &req.kv_indices[..aligned_tokens],
+        &mut req.kv_indices[..aligned_tokens],
         last_node,
         req.cached_tokens,
     );
@@ -207,6 +207,51 @@ pub(super) fn simulate_decode_step_with_sampler(
         };
     }
 
+    // A zero-output request has no decode work. Leaving it in `running` would
+    // schedule an empty burst forever: it can neither emit a token nor reach
+    // the completion path below. Production traces may contain such rows for
+    // several terminal reasons, so the scheduler must drain them defensively.
+    let already_completed_indices = running
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, req)| (req.remaining_output_tokens() == 0).then_some(idx))
+        .collect::<Vec<_>>();
+    let mut output_signals = already_completed_indices
+        .iter()
+        .map(|&idx| {
+            let req = &running[idx];
+            OutputSignal {
+                uuid: req.uuid,
+                token_id: None,
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: compute_prefill_handoff_delay_ms(
+                    config.worker_type,
+                    true,
+                    req.prompt_len(),
+                    config.kv_transfer_bandwidth,
+                    config.kv_bytes_per_token,
+                ),
+            }
+        })
+        .collect::<Vec<_>>();
+    let no_token_signal_count = output_signals.len();
+    let mut completed_requests = already_completed_indices
+        .iter()
+        .rev()
+        .map(|&idx| running.remove(idx))
+        .collect::<Vec<_>>();
+    completed_requests.reverse();
+
+    if running.is_empty() {
+        return DecodeResult {
+            completed_requests,
+            output_signals,
+            end_ms: current_time_ms,
+            ..DecodeResult::default()
+        };
+    }
+
     let max_burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
         1
     } else {
@@ -216,10 +261,11 @@ pub(super) fn simulate_decode_step_with_sampler(
     let retracted_any = !retracted.is_empty();
     if running.is_empty() {
         return DecodeResult {
+            completed_requests,
+            output_signals,
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
-            ..DecodeResult::default()
         };
     }
 
@@ -253,10 +299,11 @@ pub(super) fn simulate_decode_step_with_sampler(
             "Failed to reserve speculative decode tokens after capacity preflight"
         );
         return DecodeResult {
+            completed_requests,
+            output_signals,
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
-            ..DecodeResult::default()
         };
     };
 
@@ -273,7 +320,7 @@ pub(super) fn simulate_decode_step_with_sampler(
             }
         })
         .collect::<Vec<_>>();
-    let mut output_signals = Vec::with_capacity(sampled_bursts.iter().copied().sum::<usize>());
+    output_signals.reserve(sampled_bursts.iter().copied().sum::<usize>());
     let mut completed_indices = Vec::new();
 
     for (idx, (req, burst)) in running.iter_mut().zip(sampled_bursts).enumerate() {
@@ -318,15 +365,16 @@ pub(super) fn simulate_decode_step_with_sampler(
 
     debug_assert_eq!(
         reservation.len(),
-        reserved_tokens.saturating_sub(output_signals.len())
+        reserved_tokens.saturating_sub(output_signals.len() - no_token_signal_count)
     );
     kv_manager.release_decode_reservation(reservation);
 
-    let mut completed_requests = Vec::with_capacity(completed_indices.len());
+    let mut newly_completed_requests = Vec::with_capacity(completed_indices.len());
     for &idx in completed_indices.iter().rev() {
-        completed_requests.push(running.remove(idx));
+        newly_completed_requests.push(running.remove(idx));
     }
-    completed_requests.reverse();
+    newly_completed_requests.reverse();
+    completed_requests.extend(newly_completed_requests);
 
     DecodeResult {
         requests: retracted,

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -207,10 +207,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         };
     }
 
-    // A zero-output request has no decode work. Leaving it in `running` would
-    // schedule an empty burst forever: it can neither emit a token nor reach
-    // the completion path below. Production traces may contain such rows for
-    // several terminal reasons, so the scheduler must drain them defensively.
+    // Terminal requests have no decode work and otherwise remain in `running` forever.
     let already_completed_indices = running
         .iter()
         .enumerate()

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -52,26 +52,23 @@ pub(super) fn cache_materialized_prefix(
     config: &SglangConfig,
 ) {
     let aligned_tokens = req.page_aligned_materialized_tokens(config.block_size);
-    if aligned_tokens == 0 || aligned_tokens <= req.cached_tokens {
+    if aligned_tokens == 0 || aligned_tokens <= req.cached_tokens() {
         return;
     }
 
-    let last_node = req.last_node.unwrap_or_else(|| {
+    if !req.kv_lease.is_active() {
         panic!(
-            "cache_materialized_prefix: request {} has aligned_tokens={aligned_tokens} but last_node is None",
+            "cache_materialized_prefix: request {} has aligned_tokens={aligned_tokens} but no active KV lease",
             req.uuid
-        )
-    });
+        );
+    }
 
-    let sequence = req.sequence_prefix(aligned_tokens);
-    let new_last = kv_manager.cache_unfinished_req(
-        &sequence,
-        &mut req.kv_indices[..aligned_tokens],
-        last_node,
-        req.cached_tokens,
-    );
-    req.last_node = Some(new_last);
-    req.cached_tokens = aligned_tokens;
+    if aligned_tokens <= req.prompt_tokens.len() {
+        kv_manager.extend_cached_prefix(&req.prompt_tokens[..aligned_tokens], &mut req.kv_lease);
+    } else {
+        let sequence = req.sequence_prefix(aligned_tokens).into_owned();
+        kv_manager.extend_cached_prefix(&sequence, &mut req.kv_lease);
+    }
     req.debug_assert_invariants(config.block_size);
 }
 
@@ -115,10 +112,7 @@ fn check_decode_mem_for_burst(
         };
 
         let mut req = running.remove(idx);
-        kv_manager.free_indices(&req.kv_indices[req.cached_tokens..]);
-        if let Some(last_node) = req.last_node.take() {
-            kv_manager.free_request(last_node);
-        }
+        kv_manager.retract(std::mem::take(&mut req.kv_lease));
         req.reset_for_retract();
         req.debug_assert_invariants(config.block_size);
         retracted.push(req);
@@ -171,24 +165,16 @@ pub(super) fn cleanup_completed_request(
     kv_manager: &mut SglangKvManager,
     block_size: usize,
 ) {
-    let sequence = request.sequence_tokens();
-    let tokens_to_cache = floor_to_block(sequence.len(), block_size);
-    if request.kv_indices.len() > tokens_to_cache {
-        kv_manager.free_indices(&request.kv_indices[tokens_to_cache..]);
-    }
-
-    let Some(last_node) = request.last_node.take() else {
+    let tokens_to_cache = floor_to_block(request.current_sequence_len(), block_size);
+    if !request.kv_lease.is_active() {
         return;
-    };
-    if tokens_to_cache > 0 {
-        kv_manager.cache_finished_req(
-            &sequence[..tokens_to_cache],
-            &request.kv_indices[..tokens_to_cache],
-            last_node,
-            request.cached_tokens,
-        );
+    }
+    let lease = std::mem::take(&mut request.kv_lease);
+    if tokens_to_cache <= request.prompt_len() {
+        kv_manager.finish(&request.prompt_tokens[..tokens_to_cache], lease);
     } else {
-        kv_manager.free_request(last_node);
+        let sequence = request.sequence_tokens().into_owned();
+        kv_manager.finish(&sequence[..tokens_to_cache], lease);
     }
 }
 
@@ -323,11 +309,7 @@ pub(super) fn simulate_decode_step_with_sampler(
     for (idx, (req, burst)) in running.iter_mut().zip(sampled_bursts).enumerate() {
         for _ in 0..burst {
             let crossing_page_boundary = req.current_sequence_len() + 1 > req.allocated_tokens;
-            let last_idx = req.kv_indices.last().copied();
-            let new_idx = reservation.take();
-            kv_manager.publish_decode_token(new_idx, last_idx);
-
-            req.kv_indices.push(new_idx);
+            kv_manager.extend_decode(&mut req.kv_lease, &mut reservation);
             if crossing_page_boundary {
                 req.allocated_tokens += config.block_size;
             }

--- a/lib/mocker/src/scheduler/sglang/policy.rs
+++ b/lib/mocker/src/scheduler/sglang/policy.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 
-use crate::cache::radix_cache::RadixCache;
 use crate::kv_manager::SglangKvManager;
+use rustc_hash::FxHashSet;
 
 use super::config::{
     IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD, IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD,
@@ -25,30 +25,19 @@ pub(super) fn apply_schedule_policy(
             }
 
             let page_size = config.block_size.max(1);
-            let total_tokens = waiting
-                .iter()
-                .map(SglangRequest::current_sequence_len)
-                .sum::<usize>()
-                .max(page_size);
-            let mut waiting_queue_cache = RadixCache::new(total_tokens, page_size);
-            let mut temporary_deprioritized = HashSet::new();
+            let duplicate_prefix_len =
+                IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD.div_ceil(page_size) * page_size;
+            let mut waiting_prefixes = FxHashSet::default();
             let mut scored = Vec::with_capacity(waiting.len());
 
             for req in waiting.drain(..) {
                 let sequence = req.sequence_tokens();
                 let prefix_len = kv_manager.cache().prefix_match_len(&sequence);
+                let deprioritized = prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD
+                    && sequence.len() >= duplicate_prefix_len
+                    && !waiting_prefixes.insert(sequence[..duplicate_prefix_len].to_vec());
 
-                if prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD {
-                    let in_batch_prefix = waiting_queue_cache.prefix_match_len(&sequence);
-                    if in_batch_prefix >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD {
-                        temporary_deprioritized.insert(req.uuid);
-                    } else if !sequence.is_empty() {
-                        let values: Vec<usize> = (0..sequence.len()).collect();
-                        waiting_queue_cache.insert(&sequence, &values);
-                    }
-                }
-
-                scored.push((prefix_len, temporary_deprioritized.contains(&req.uuid), req));
+                scored.push((prefix_len, deprioritized, req));
             }
 
             scored.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)));

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -142,6 +142,14 @@ pub(super) fn get_new_batch_prefill(
         }
 
         req.last_node = Some(alloc.last_node);
+        // A fresh/retracted request may match blocks that are already owned by
+        // the radix cache. Keep that ownership boundary on the request so a
+        // decode retraction only frees the newly allocated suffix. Treating
+        // the matched prefix as request-owned would return canonical cache
+        // slots to the token pool while the radix tree still references them.
+        if req.materialized_tokens == 0 {
+            req.cached_tokens = alloc.prefix_len;
+        }
         req.kv_indices = alloc.kv_indices;
         req.materialized_tokens = chunk_end;
         req.allocated_tokens = ceil_to_block(chunk_end, config.block_size);

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -142,11 +142,8 @@ pub(super) fn get_new_batch_prefill(
         }
 
         req.last_node = Some(alloc.last_node);
-        // A fresh/retracted request may match blocks that are already owned by
-        // the radix cache. Keep that ownership boundary on the request so a
-        // decode retraction only frees the newly allocated suffix. Treating
-        // the matched prefix as request-owned would return canonical cache
-        // slots to the token pool while the radix tree still references them.
+        // Cache-hit prefix pages are radix-owned; retraction may free only the
+        // newly allocated suffix.
         if req.materialized_tokens == 0 {
             req.cached_tokens = alloc.prefix_len;
         }

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -136,6 +136,7 @@ pub(super) fn get_new_batch_prefill(
             oom = true;
             break;
         };
+        let tokens_computed = chunk_end.saturating_sub(alloc.prefix_len);
 
         if let Some(node) = prev_node {
             kv_manager.free_request(node);
@@ -158,7 +159,7 @@ pub(super) fn get_new_batch_prefill(
         });
         prefill_fpm.push(PrefillFpmItem {
             prompt_len: req.prompt_len(),
-            tokens_computed: chunk_tokens,
+            tokens_computed,
             prefix_tokens: alloc.prefix_len,
         });
 

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -105,7 +105,7 @@ pub(super) fn get_new_batch_prefill(
 
         let chunk_end = req.materialized_tokens + chunk_tokens;
         let old_allocated_tokens = req.allocated_tokens;
-        let prev_node = req.last_node.take();
+        let mut lease = std::mem::take(&mut req.kv_lease);
         let alloc_tokens = req.sequence_prefix(chunk_end);
         let actual_new_tokens = alloc_tokens.len().saturating_sub(req.materialized_tokens);
         let available = kv_manager.cache().token_pool.available();
@@ -113,58 +113,48 @@ pub(super) fn get_new_batch_prefill(
             kv_manager.evict(actual_new_tokens - available);
         }
 
-        let alloc = if req.materialized_tokens > 0 {
-            let last_node = prev_node.unwrap_or_else(|| {
+        let prefix_len = if req.materialized_tokens > 0 {
+            if !lease.is_active() {
                 panic!(
-                    "prefill: request {} has materialized_tokens={} but last_node is None",
+                    "prefill: request {} has materialized_tokens={} but no active KV lease",
                     req.uuid, req.materialized_tokens
-                )
-            });
-            kv_manager.allocate_after_prefix(
-                &alloc_tokens,
-                req.materialized_tokens,
-                &req.kv_indices[..req.materialized_tokens],
-                last_node,
-            )
+                );
+            }
+            kv_manager
+                .extend_allocation(&alloc_tokens, &mut lease)
+                .then_some(req.materialized_tokens)
         } else {
-            kv_manager.allocate_for_request(&alloc_tokens)
+            kv_manager.allocate_for_request(&alloc_tokens).map(|alloc| {
+                lease = alloc.lease;
+                alloc.prefix_len
+            })
         };
 
-        let Some(alloc) = alloc else {
-            req.last_node = prev_node;
+        let Some(prefix_len) = prefix_len else {
+            req.kv_lease = lease;
             rejected.push_back(req);
             oom = true;
             break;
         };
-        let tokens_computed = chunk_end.saturating_sub(alloc.prefix_len);
+        let tokens_computed = chunk_end.saturating_sub(prefix_len);
 
-        if let Some(node) = prev_node {
-            kv_manager.free_request(node);
-        }
-
-        req.last_node = Some(alloc.last_node);
-        // Cache-hit prefix pages are radix-owned; retraction may free only the
-        // newly allocated suffix.
-        if req.materialized_tokens == 0 {
-            req.cached_tokens = alloc.prefix_len;
-        }
-        req.kv_indices = alloc.kv_indices;
+        req.kv_lease = lease;
         req.materialized_tokens = chunk_end;
         req.allocated_tokens = ceil_to_block(chunk_end, config.block_size);
         req.debug_assert_invariants(config.block_size);
 
         admissions.push(AdmissionEvent {
             uuid: req.uuid,
-            reused_input_tokens: alloc.prefix_len,
+            reused_input_tokens: prefix_len,
         });
         prefill_fpm.push(PrefillFpmItem {
             prompt_len: req.prompt_len(),
             tokens_computed,
-            prefix_tokens: alloc.prefix_len,
+            prefix_tokens: prefix_len,
         });
 
         total_isl += chunk_end;
-        total_prefix += alloc.prefix_len;
+        total_prefix += prefix_len;
         rem_total_tokens -= (req.allocated_tokens - old_allocated_tokens + output_reserve) as f64;
         rem_input_tokens -= charged_input_tokens;
         rem_chunk_tokens -= charged_input_tokens;

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -1,25 +1,24 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use uuid::Uuid;
 
-use crate::cache::radix_cache::NodeId;
 use crate::common::protocols::DirectRequest;
+use crate::kv_manager::sglang_backend::ActiveKvLease;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct SglangRequest {
     pub(super) uuid: Uuid,
     pub(super) prompt_tokens: Vec<u64>,
     pub(super) max_output_tokens: usize,
     pub(super) planned_output_ids: Option<Vec<u32>>,
     pub(super) output_ids: Vec<u32>,
-    pub(super) last_node: Option<NodeId>,
-    pub(super) kv_indices: Vec<usize>,
+    pub(super) kv_lease: ActiveKvLease,
     pub(super) materialized_tokens: usize,
-    pub(super) cached_tokens: usize,
     pub(super) allocated_tokens: usize,
 }
 
@@ -46,23 +45,40 @@ impl SglangRequest {
     }
 
     pub(super) fn extra_reserved_tokens(&self) -> usize {
-        self.allocated_tokens.saturating_sub(self.kv_indices.len())
+        self.allocated_tokens.saturating_sub(self.kv_len())
+    }
+
+    #[cfg(test)]
+    pub(super) fn kv_indices(&self) -> &[usize] {
+        self.kv_lease.indices()
+    }
+
+    pub(super) fn kv_len(&self) -> usize {
+        self.kv_lease.len()
+    }
+
+    pub(super) fn cached_tokens(&self) -> usize {
+        self.kv_lease.cached_tokens()
     }
 
     pub(super) fn page_aligned_materialized_tokens(&self, block_size: usize) -> usize {
         self.materialized_tokens / block_size * block_size
     }
 
-    pub(super) fn sequence_tokens(&self) -> Vec<u64> {
+    pub(super) fn sequence_tokens(&self) -> Cow<'_, [u64]> {
+        if self.output_ids.is_empty() {
+            return Cow::Borrowed(&self.prompt_tokens);
+        }
+
         let mut sequence = self.prompt_tokens.clone();
         sequence.extend(self.output_ids.iter().map(|&token| token as u64));
-        sequence
+        Cow::Owned(sequence)
     }
 
-    pub(super) fn sequence_prefix(&self, len: usize) -> Vec<u64> {
+    pub(super) fn sequence_prefix(&self, len: usize) -> Cow<'_, [u64]> {
         let prompt_len = self.prompt_len();
         if len <= prompt_len {
-            return self.prompt_tokens[..len].to_vec();
+            return Cow::Borrowed(&self.prompt_tokens[..len]);
         }
 
         let mut prefix = self.prompt_tokens.clone();
@@ -71,7 +87,7 @@ impl SglangRequest {
                 .iter()
                 .map(|&token| token as u64),
         );
-        prefix
+        Cow::Owned(prefix)
     }
 
     pub(super) fn next_output_token(&self) -> u32 {
@@ -100,10 +116,10 @@ impl SglangRequest {
             let block_size = _block_size;
             let sequence_len = self.current_sequence_len();
             debug_assert!(
-                self.cached_tokens <= self.materialized_tokens,
+                self.cached_tokens() <= self.materialized_tokens,
                 "request {} cached {} tokens but materialized {}",
                 self.uuid,
-                self.cached_tokens,
+                self.cached_tokens(),
                 self.materialized_tokens
             );
             debug_assert!(
@@ -113,11 +129,11 @@ impl SglangRequest {
                 self.materialized_tokens
             );
             debug_assert_eq!(
-                self.kv_indices.len(),
+                self.kv_len(),
                 self.materialized_tokens,
                 "request {} has {} kv indices but {} materialized tokens",
                 self.uuid,
-                self.kv_indices.len(),
+                self.kv_len(),
                 self.materialized_tokens
             );
             debug_assert!(
@@ -128,11 +144,11 @@ impl SglangRequest {
                 self.materialized_tokens
             );
             debug_assert_eq!(
-                self.cached_tokens % block_size,
+                self.cached_tokens() % block_size,
                 0,
                 "request {} cached tokens {} are not page-aligned to block size {block_size}",
                 self.uuid,
-                self.cached_tokens
+                self.cached_tokens()
             );
             debug_assert!(
                 self.allocated_tokens == 0 || self.allocated_tokens.is_multiple_of(block_size),
@@ -147,21 +163,19 @@ impl SglangRequest {
                 self.extra_reserved_tokens()
             );
             debug_assert_eq!(
-                self.last_node.is_some(),
+                self.kv_lease.is_active(),
                 self.materialized_tokens > 0,
-                "request {} has last_node={} but materialized_tokens={}",
+                "request {} has active_kv={} but materialized_tokens={}",
                 self.uuid,
-                self.last_node.is_some(),
+                self.kv_lease.is_active(),
                 self.materialized_tokens
             );
         }
     }
 
     pub(super) fn reset_for_retract(&mut self) {
-        self.last_node = None;
-        self.kv_indices.clear();
+        debug_assert!(!self.kv_lease.is_active());
         self.materialized_tokens = 0;
-        self.cached_tokens = 0;
         self.allocated_tokens = 0;
     }
 }
@@ -177,10 +191,8 @@ impl From<DirectRequest> for SglangRequest {
                 .map_or(req.max_output_tokens, Vec::len),
             planned_output_ids: req.output_token_ids,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
+            kv_lease: ActiveKvLease::default(),
             materialized_tokens: 0,
-            cached_tokens: 0,
             allocated_tokens: 0,
         }
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -25,6 +25,7 @@ use crate::common::protocols::{
     SglangArgs,
 };
 use crate::kv_manager::SglangKvManager;
+use crate::kv_manager::sglang_backend::ActiveKvLease;
 use crate::scheduler::test_utils::{
     CapturingFpmSink, RouterIndexerHarness, nth_stored_hashes, removed_event_count, stored_hashes,
 };
@@ -79,10 +80,8 @@ fn make_decoded_request(
         max_output_tokens,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: Some(alloc.last_node),
-        kv_indices: alloc.kv_indices,
+        kv_lease: alloc.lease,
         materialized_tokens: prompt_len,
-        cached_tokens: 0,
         allocated_tokens: ceil_to_block(prompt_len, config.block_size),
     }];
     let result = simulate_decode_step(&mut running, kv_manager, config, 0.0, false);
@@ -129,10 +128,8 @@ fn zero_output_completion_survives_decode_reservation_failure() {
             max_output_tokens: 0,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(zero_alloc.last_node),
-            kv_indices: zero_alloc.kv_indices,
+            kv_lease: zero_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         },
         SglangRequest {
@@ -141,10 +138,8 @@ fn zero_output_completion_survives_decode_reservation_failure() {
             max_output_tokens: 1,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(normal_alloc.last_node),
-            kv_indices: normal_alloc.kv_indices,
+            kv_lease: normal_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         },
     ];
@@ -184,22 +179,16 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     let prompt = vec![1, 2, 3, 4];
 
     let cached = kv_manager.allocate_for_request(&prompt).unwrap();
-    kv_manager.cache_finished_req(
-        &prompt,
-        &cached.kv_indices,
-        cached.last_node,
-        cached.prefix_len,
-    );
+    let cached_indices = cached.lease.indices().to_vec();
+    kv_manager.finish(&prompt, cached.lease);
     let mut waiting = VecDeque::from([SglangRequest {
         uuid: Uuid::from_u128(90_002),
         prompt_tokens: prompt.clone(),
         max_output_tokens: 1,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: None,
-        kv_indices: Vec::new(),
         materialized_tokens: 0,
-        cached_tokens: 0,
+        kv_lease: ActiveKvLease::default(),
         allocated_tokens: 0,
     }]);
     let req = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[])
@@ -207,8 +196,8 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         .pop()
         .unwrap();
 
-    assert_eq!(req.cached_tokens, prompt.len());
-    assert_eq!(req.kv_indices, cached.kv_indices);
+    assert_eq!(req.cached_tokens(), prompt.len());
+    assert_eq!(req.kv_indices(), cached_indices);
 
     // Leave four free slots and one block of page growth for the cache-hit
     // request. Reserved page overhead makes check_decode_mem retract it, while
@@ -221,10 +210,8 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         max_output_tokens: 1,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: Some(blocker_alloc.last_node),
-        kv_indices: blocker_alloc.kv_indices,
+        kv_lease: blocker_alloc.lease,
         materialized_tokens: 3,
-        cached_tokens: 0,
         allocated_tokens: 4,
     };
     buffer.drain();
@@ -753,7 +740,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("activated request must be prebuilt-ready");
-        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_eq!(ready.kv_indices(), reserved_indices);
         assert_eq!(destination.running.len(), 1);
         assert!(destination.kv_manager.cache().protected_size >= protected_before_activation);
         let activation_stores = stored_hashes(&destination.drain_kv_events());
@@ -778,7 +765,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("full running batch must keep request ready");
-        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_eq!(ready.kv_indices(), reserved_indices);
         assert_no_republished_stores(&activation_stores, &stored_hashes(&blocked.kv_events));
 
         let blocker_terminal = execute(&mut destination, blocked.end_ms);
@@ -809,7 +796,7 @@ mod destination_lifecycle {
             .iter()
             .find(|request| request.uuid == logical_uuid)
             .expect("prebuilt request must enter the running batch");
-        assert!(running.kv_indices.starts_with(&reserved_indices));
+        assert!(running.kv_indices().starts_with(&reserved_indices));
         assert_no_republished_stores(&activation_stores, &stored_hashes(&admitted.kv_events));
 
         let terminal = execute(&mut destination, admitted.end_ms);
@@ -1031,10 +1018,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1043,10 +1028,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: vec![6, 7],
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1078,10 +1061,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             });
         }
@@ -1092,10 +1073,8 @@ mod scheduling {
             max_output_tokens: 1,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         });
 
@@ -1160,10 +1139,8 @@ mod core_behavior {
             max_output_tokens: 3,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1192,10 +1169,8 @@ mod core_behavior {
             max_output_tokens: 2,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1227,10 +1202,8 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1239,10 +1212,8 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1265,19 +1236,18 @@ mod core_behavior {
                 .unwrap(),
         );
         let mut kv_manager = SglangKvManager::new(64, 4, KvEventPublishers::default(), 0);
-        let alloc = kv_manager
+        let mut alloc = kv_manager
             .allocate_for_request(&[1, 2, 3, 4, 5, 6])
             .unwrap();
+        kv_manager.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4, 5, 6],
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(alloc.last_node),
-            kv_indices: alloc.kv_indices,
+            kv_lease: alloc.lease,
             materialized_tokens: 6,
-            cached_tokens: 4,
             allocated_tokens: 8,
         }];
 
@@ -1320,10 +1290,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(base_alloc.last_node),
-            kv_indices: base_alloc.kv_indices,
+            kv_lease: base_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1335,10 +1303,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(fast_alloc.last_node),
-            kv_indices: fast_alloc.kv_indices,
+            kv_lease: fast_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1386,10 +1352,8 @@ mod core_behavior {
                 max_output_tokens: 10,
                 planned_output_ids: None,
                 output_ids: vec![11, 12, 13],
-                last_node: None,
-                kv_indices: first,
+                kv_lease: ActiveKvLease::from_parts(first, 4, kv_manager.cache().root()),
                 materialized_tokens: 7,
-                cached_tokens: 4,
                 allocated_tokens: 8,
             },
             SglangRequest {
@@ -1398,10 +1362,8 @@ mod core_behavior {
                 max_output_tokens: 10,
                 planned_output_ids: None,
                 output_ids: vec![21],
-                last_node: None,
-                kv_indices: second,
+                kv_lease: ActiveKvLease::from_parts(second, 4, kv_manager.cache().root()),
                 materialized_tokens: 5,
-                cached_tokens: 4,
                 allocated_tokens: 8,
             },
         ];
@@ -1410,7 +1372,7 @@ mod core_behavior {
         assert_eq!(retracted.len(), 1);
         assert_eq!(retracted[0].output_ids, vec![21]);
         assert_eq!(retracted[0].materialized_tokens, 0);
-        assert!(retracted[0].kv_indices.is_empty());
+        assert!(retracted[0].kv_indices().is_empty());
     }
 
     #[test]
@@ -1431,10 +1393,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(alloc.last_node),
-            kv_indices: alloc.kv_indices,
+            kv_lease: alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1729,10 +1689,8 @@ mod router_events {
             max_output_tokens: 2,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         };
         let first_output = expected_request.next_output_token();
@@ -1831,10 +1789,8 @@ mod router_events {
             max_output_tokens: 3,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -90,6 +90,151 @@ fn make_decoded_request(
     running.pop().unwrap()
 }
 
+#[test]
+fn zero_output_request_completes_after_prefill() {
+    let mut core = SglangCore::new(test_args(32, 4, 16));
+    let uuid = core.receive(direct_request(vec![1, 2, 3, 4], 0));
+
+    let pass = core.execute_pass_internal(None, 0.0);
+
+    assert!(core.is_empty());
+    assert_eq!(pass.completed_requests, 1);
+    assert!(matches!(
+        pass.output_signals.as_slice(),
+        [OutputSignal {
+            uuid: signal_uuid,
+            token_id: None,
+            completed: true,
+            rejected: false,
+            ..
+        }] if *signal_uuid == uuid
+    ));
+}
+
+#[test]
+fn zero_output_completion_survives_decode_reservation_failure() {
+    let config = SglangConfig::from_args(&test_args(2, 4, 16));
+    let mut kv_manager = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
+    let zero_alloc = kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
+    let normal_alloc = kv_manager.allocate_for_request(&[5, 6, 7, 8]).unwrap();
+    let zero_uuid = Uuid::from_u128(90_004);
+    let normal_uuid = Uuid::from_u128(90_005);
+    let mut running = vec![
+        SglangRequest {
+            uuid: zero_uuid,
+            prompt_tokens: vec![1, 2, 3, 4],
+            max_output_tokens: 0,
+            planned_output_ids: None,
+            output_ids: Vec::new(),
+            last_node: Some(zero_alloc.last_node),
+            kv_indices: zero_alloc.kv_indices,
+            materialized_tokens: 4,
+            cached_tokens: 0,
+            allocated_tokens: 4,
+        },
+        SglangRequest {
+            uuid: normal_uuid,
+            prompt_tokens: vec![5, 6, 7, 8],
+            max_output_tokens: 1,
+            planned_output_ids: None,
+            output_ids: Vec::new(),
+            last_node: Some(normal_alloc.last_node),
+            kv_indices: normal_alloc.kv_indices,
+            materialized_tokens: 4,
+            cached_tokens: 0,
+            allocated_tokens: 4,
+        },
+    ];
+
+    // The normal request cannot reserve a decode token while both prompts own
+    // the entire pool. Its retry must not discard the zero-output completion.
+    let result = decode::simulate_decode_step_with_sampler(
+        &mut running,
+        &mut kv_manager,
+        &config,
+        None,
+        0.0,
+        false,
+    );
+
+    assert_eq!(running.len(), 1);
+    assert_eq!(running[0].uuid, normal_uuid);
+    assert_eq!(result.completed_requests.len(), 1);
+    assert!(matches!(
+        result.output_signals.as_slice(),
+        [OutputSignal {
+            uuid: signal_uuid,
+            token_id: None,
+            completed: true,
+            rejected: false,
+            ..
+        }] if *signal_uuid == zero_uuid
+    ));
+}
+
+#[test]
+fn fresh_prefill_tracks_cache_owned_prefix_indices() {
+    let args = test_args(8, 4, 16);
+    let config = SglangConfig::from_args(&args);
+    let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+    let mut kv_manager = SglangKvManager::new(11, 4, KvEventPublishers::new(Some(sink), None), 0);
+    let prompt = vec![1, 2, 3, 4];
+
+    let cached = kv_manager.allocate_for_request(&prompt).unwrap();
+    kv_manager.cache_finished_req(
+        &prompt,
+        &cached.kv_indices,
+        cached.last_node,
+        cached.prefix_len,
+    );
+    let mut waiting = VecDeque::from([SglangRequest {
+        uuid: Uuid::from_u128(90_002),
+        prompt_tokens: prompt.clone(),
+        max_output_tokens: 1,
+        planned_output_ids: None,
+        output_ids: Vec::new(),
+        last_node: None,
+        kv_indices: Vec::new(),
+        materialized_tokens: 0,
+        cached_tokens: 0,
+        allocated_tokens: 0,
+    }]);
+    let req = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[])
+        .can_run
+        .pop()
+        .unwrap();
+
+    assert_eq!(req.cached_tokens, prompt.len());
+    assert_eq!(req.kv_indices, cached.kv_indices);
+
+    // Leave four free slots and one block of page growth for the cache-hit
+    // request. Reserved page overhead makes check_decode_mem retract it, while
+    // the remaining request still fits without evicting the cached prompt.
+    let blocker_tokens = vec![9, 10, 11];
+    let blocker_alloc = kv_manager.allocate_for_request(&blocker_tokens).unwrap();
+    let blocker = SglangRequest {
+        uuid: Uuid::from_u128(90_003),
+        prompt_tokens: blocker_tokens,
+        max_output_tokens: 1,
+        planned_output_ids: None,
+        output_ids: Vec::new(),
+        last_node: Some(blocker_alloc.last_node),
+        kv_indices: blocker_alloc.kv_indices,
+        materialized_tokens: 3,
+        cached_tokens: 0,
+        allocated_tokens: 4,
+    };
+    buffer.drain();
+
+    let mut running = vec![req, blocker];
+    let retracted = decode::check_decode_mem(&mut running, &mut kv_manager, &config);
+    assert_eq!(retracted.len(), 1);
+    assert_eq!(retracted[0].uuid, Uuid::from_u128(90_002));
+    assert_eq!(removed_event_count(&buffer.drain()), 0);
+    assert_eq!(kv_manager.cache().token_pool.available(), 4);
+    assert_eq!(kv_manager.cache_mut().match_prefix(&prompt).0, prompt.len());
+}
+
 mod source_holds {
     use super::*;
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -2203,6 +2203,49 @@ mod forward_pass_metrics {
     }
 
     #[test]
+    fn fully_cached_zero_output_request_is_not_forward_pass_work() {
+        let mut core = SglangCore::new(fpm_args());
+        let tokens = (0..8).collect::<Vec<_>>();
+        let mut collector = crate::replay::TraceCollector::default();
+
+        core.receive(DirectRequest {
+            tokens: tokens.clone(),
+            max_output_tokens: 0,
+            uuid: Some(Uuid::from_u128(90_004)),
+            ..Default::default()
+        });
+        let seed_pass = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(seed_pass.completed_requests, 1);
+
+        let uuid = core.receive(DirectRequest {
+            tokens,
+            max_output_tokens: 0,
+            uuid: Some(Uuid::from_u128(90_005)),
+            ..Default::default()
+        });
+        let pass = core.execute_pass(&mut collector, seed_pass.end_ms);
+
+        assert_eq!(pass.completed_requests, 1);
+        assert_eq!(pass.mocker_metrics.sglang_cache_hit_tokens, 8);
+        assert_eq!(pass.mocker_metrics.sglang_cache_total_tokens, 8);
+        let fpm = pass.fpm.as_ref().unwrap();
+        assert_eq!(fpm.num_prefill_requests, 0);
+        assert_eq!(fpm.sum_prefill_tokens, 0);
+        assert_eq!(fpm.num_decode_requests, 0);
+        assert_eq!(fpm.sum_decode_kv_tokens, 0);
+        assert!(matches!(
+            pass.output_signals.as_slice(),
+            [OutputSignal {
+                uuid: signal_uuid,
+                token_id: None,
+                completed: true,
+                rejected: false,
+                ..
+            }] if *signal_uuid == uuid
+        ));
+    }
+
+    #[test]
     fn test_fpm_empty_pass_is_zeroed() {
         let mut core = SglangCore::new(fpm_args());
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -99,6 +99,9 @@ fn zero_output_request_completes_after_prefill() {
 
     assert!(core.is_empty());
     assert_eq!(pass.completed_requests, 1);
+    let fpm = pass.fpm.as_ref().unwrap();
+    assert_eq!(fpm.num_decode_requests, 0);
+    assert_eq!(fpm.sum_decode_kv_tokens, 0);
     assert!(matches!(
         pass.output_signals.as_slice(),
         [OutputSignal {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1923,25 +1923,67 @@ impl VllmCore {
         decode_start_ms: f64,
     ) -> (Duration, Vec<OutputSignal>) {
         let mut ready = Vec::with_capacity(self.state.running.len());
+        let mut already_complete = Vec::new();
         let mut total_length = 0usize;
         for uuid in self.state.running.iter().copied() {
             let Some(request) = self.state.requests.get(&uuid) else {
                 continue;
             };
-            if request.num_computed_tokens < request.sequence.len()
-                || policy::generation_complete(&request.sequence, self.args.max_model_len)
-            {
+            if request.num_computed_tokens < request.sequence.len() {
+                continue;
+            }
+            if policy::generation_complete(&request.sequence, self.args.max_model_len) {
+                already_complete.push(uuid);
                 continue;
             }
             ready.push(uuid);
             total_length += request.sequence.len();
         }
+
+        // Zero-output requests (and requests whose prompt exactly reaches the
+        // model-length limit) are terminal after prefill. They must release
+        // their runnable slot without manufacturing an output token.
+        let mut output_signals = Vec::with_capacity(already_complete.len() + ready.len());
+        for uuid in already_complete {
+            let request = self
+                .state
+                .requests
+                .get(&uuid)
+                .expect("terminal request must remain scheduler-owned");
+            let handoff_delay_ms = compute_prefill_handoff_delay_ms(
+                self.args.worker_type,
+                true,
+                request.sequence.num_input_tokens(),
+                self.args.kv_transfer_bandwidth,
+                self.args.kv_bytes_per_token,
+            );
+            let effects = split_terminal_effects(request.sequence.terminal_signals());
+            debug_assert!(effects.immediate.is_empty());
+            self.complete_source(uuid, effects.cleanup);
+            output_signals.push(OutputSignal {
+                uuid,
+                token_id: None,
+                completed: true,
+                rejected: false,
+                handoff_delay_ms,
+            });
+        }
+
         if ready.is_empty() {
-            return (Duration::ZERO, Vec::new());
+            if !output_signals.is_empty() {
+                self.state.compact_running();
+            }
+            return (Duration::ZERO, output_signals);
         }
 
         if self.speculative_sampler.is_some() {
-            return self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
+            if !output_signals.is_empty() {
+                self.state.compact_running();
+            }
+            let (decode_time, mut speculative_signals) =
+                self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
+            output_signals.append(&mut speculative_signals);
+            return (decode_time, output_signals);
         }
 
         // For prefill workers, the first decode token is produced as part of
@@ -1962,8 +2004,7 @@ impl VllmCore {
             (dt, decode_start_ms + dt.as_secs_f64() * 1000.0)
         };
 
-        let mut output_signals = Vec::with_capacity(ready.len());
-        let mut running_changed = false;
+        let mut running_changed = !output_signals.is_empty();
         for uuid in ready {
             let mut emitted = false;
             let mut emitted_token_id = None;

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1933,33 +1933,27 @@ impl VllmCore {
                 continue;
             }
             if policy::generation_complete(&request.sequence, self.args.max_model_len) {
-                already_complete.push(uuid);
+                let handoff_delay_ms = compute_prefill_handoff_delay_ms(
+                    self.args.worker_type,
+                    true,
+                    request.sequence.num_input_tokens(),
+                    self.args.kv_transfer_bandwidth,
+                    self.args.kv_bytes_per_token,
+                );
+                let effects = split_terminal_effects(request.sequence.terminal_signals());
+                debug_assert!(effects.immediate.is_empty());
+                already_complete.push((uuid, handoff_delay_ms, effects.cleanup));
                 continue;
             }
             ready.push(uuid);
             total_length += request.sequence.len();
         }
 
-        // Zero-output requests (and requests whose prompt exactly reaches the
-        // model-length limit) are terminal after prefill. They must release
-        // their runnable slot without manufacturing an output token.
+        // Requests already terminal after prefill must release their running slots
+        // without manufacturing an output token.
         let mut output_signals = Vec::with_capacity(already_complete.len() + ready.len());
-        for uuid in already_complete {
-            let request = self
-                .state
-                .requests
-                .get(&uuid)
-                .expect("terminal request must remain scheduler-owned");
-            let handoff_delay_ms = compute_prefill_handoff_delay_ms(
-                self.args.worker_type,
-                true,
-                request.sequence.num_input_tokens(),
-                self.args.kv_transfer_bandwidth,
-                self.args.kv_bytes_per_token,
-            );
-            let effects = split_terminal_effects(request.sequence.terminal_signals());
-            debug_assert!(effects.immediate.is_empty());
-            self.complete_source(uuid, effects.cleanup);
+        for (uuid, handoff_delay_ms, cleanup) in already_complete {
+            self.complete_source(uuid, cleanup);
             output_signals.push(OutputSignal {
                 uuid,
                 token_id: None,
@@ -1977,9 +1971,11 @@ impl VllmCore {
         }
 
         if self.speculative_sampler.is_some() {
-            if !output_signals.is_empty() {
-                self.state.compact_running();
+            if output_signals.is_empty() {
+                return self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
             }
+
+            self.state.compact_running();
             let (decode_time, mut speculative_signals) =
                 self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
             output_signals.append(&mut speculative_signals);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -109,6 +109,7 @@ struct ScheduledWork {
     total_tokens: usize,
     prompt_tokens: usize,
     prefix_tokens: usize,
+    terminal_after_schedule: bool,
     /// Full prompt length, captured at schedule time for FPM variance calculation.
     prompt_len: usize,
     /// Total sequence length (prompt + generated) at schedule time, used for
@@ -1676,9 +1677,10 @@ impl VllmCore {
             ))
         });
 
-        let scheduled_decodes = scheduled
-            .values()
-            .filter_map(|work| (work.prompt_tokens == 0).then_some(work.sequence_len as u64));
+        let scheduled_decodes = scheduled.values().filter_map(|work| {
+            (work.prompt_tokens == 0 && !work.terminal_after_schedule)
+                .then_some(work.sequence_len as u64)
+        });
 
         let queued_prefills = self.state.waiting.iter().filter_map(|uuid| {
             let request = self.state.requests.get(uuid)?;
@@ -1881,12 +1883,16 @@ impl VllmCore {
             .get(&uuid)
             .map(|r| r.sequence.len())
             .unwrap_or(0);
+        let terminal_after_schedule = self.state.requests.get(&uuid).is_some_and(|request| {
+            policy::generation_complete(&request.sequence, self.args.max_model_len)
+        });
         scheduled.insert(
             uuid,
             ScheduledWork {
                 total_tokens: tokens_used,
                 prompt_tokens,
                 prefix_tokens: prompt_before,
+                terminal_after_schedule,
                 prompt_len,
                 sequence_len,
             },

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -96,6 +96,9 @@ fn zero_output_request_completes_after_prefill(#[case] engine_type: EngineType) 
     assert!(core.state.requests.is_empty());
     assert_eq!(core.kv_manager.num_active_blocks(), 0);
     assert_eq!(pass.completed_requests, 1);
+    let fpm = pass.fpm.as_ref().unwrap();
+    assert_eq!(fpm.num_decode_requests, 0);
+    assert_eq!(fpm.sum_decode_kv_tokens, 0);
     assert!(matches!(
         pass.output_signals.as_slice(),
         [OutputSignal {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -48,7 +48,12 @@ fn assert_scheduler_idle(metrics: &MockerMetrics) {
 }
 
 fn make_args() -> MockEngineArgs {
+    make_args_for_engine(EngineType::Vllm)
+}
+
+fn make_args_for_engine(engine_type: EngineType) -> MockEngineArgs {
     MockEngineArgs::builder()
+        .engine_type(engine_type)
         .block_size(4)
         .num_gpu_blocks(6)
         .max_num_batched_tokens(Some(8))
@@ -73,9 +78,11 @@ fn router_args() -> MockEngineArgs {
         .unwrap()
 }
 
-#[test]
-fn zero_output_request_completes_after_prefill() {
-    let mut core = VllmCore::new(make_args());
+#[rstest]
+#[case(EngineType::Vllm)]
+#[case(EngineType::Trtllm)]
+fn zero_output_request_completes_after_prefill(#[case] engine_type: EngineType) {
+    let mut core = VllmCore::new(make_args_for_engine(engine_type));
     let uuid = core.receive(DirectRequest {
         tokens: vec![1, 2, 3, 4],
         max_output_tokens: 0,
@@ -99,6 +106,58 @@ fn zero_output_request_completes_after_prefill() {
             ..
         }] if *signal_uuid == uuid
     ));
+}
+
+#[test]
+fn speculative_batch_drains_zero_output_before_emitting_tokens() {
+    let args = MockEngineArgs::builder()
+        .block_size(4)
+        .num_gpu_blocks(8)
+        .max_num_batched_tokens(Some(8))
+        .max_num_seqs(Some(2))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(false)
+        .speedup_ratio(0.0)
+        .aic_nextn(Some(2))
+        .aic_nextn_accept_rates(Some("1,1".to_string()))
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    let zero_uuid = core.receive(DirectRequest {
+        tokens: vec![1, 2, 3, 4],
+        max_output_tokens: 0,
+        uuid: Some(Uuid::from_u128(90_002)),
+        ..Default::default()
+    });
+    let normal_uuid = core.receive(DirectRequest {
+        tokens: vec![5, 6, 7, 8],
+        max_output_tokens: 3,
+        uuid: Some(Uuid::from_u128(90_003)),
+        ..Default::default()
+    });
+    let mut collector = crate::replay::TraceCollector::default();
+
+    let pass = core.execute_pass(&mut collector, 0.0);
+
+    assert!(core.state.requests.is_empty());
+    assert_eq!(core.kv_manager.num_active_blocks(), 0);
+    assert_eq!(pass.completed_requests, 2);
+    assert_eq!(
+        pass.output_signals
+            .iter()
+            .filter(|signal| signal.uuid == zero_uuid && signal.token_id.is_none())
+            .count(),
+        1
+    );
+    assert_eq!(
+        pass.output_signals
+            .iter()
+            .filter(|signal| signal.uuid == normal_uuid && signal.token_id.is_some())
+            .count(),
+        3
+    );
+    assert_eq!(pass.accept_length_output_tokens, 3);
+    assert_eq!(pass.accept_length_decode_forwards, 1);
 }
 
 mod source_holds {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -73,6 +73,34 @@ fn router_args() -> MockEngineArgs {
         .unwrap()
 }
 
+#[test]
+fn zero_output_request_completes_after_prefill() {
+    let mut core = VllmCore::new(make_args());
+    let uuid = core.receive(DirectRequest {
+        tokens: vec![1, 2, 3, 4],
+        max_output_tokens: 0,
+        uuid: Some(Uuid::from_u128(90_001)),
+        ..Default::default()
+    });
+    let mut collector = crate::replay::TraceCollector::default();
+
+    let pass = core.execute_pass(&mut collector, 0.0);
+
+    assert!(core.state.requests.is_empty());
+    assert_eq!(core.kv_manager.num_active_blocks(), 0);
+    assert_eq!(pass.completed_requests, 1);
+    assert!(matches!(
+        pass.output_signals.as_slice(),
+        [OutputSignal {
+            uuid: signal_uuid,
+            token_id: None,
+            completed: true,
+            rejected: false,
+            ..
+        }] if *signal_uuid == uuid
+    ));
+}
+
 mod source_holds {
     use super::*;
 

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -112,6 +112,46 @@ fn zero_output_request_completes_after_prefill(#[case] engine_type: EngineType) 
 }
 
 #[test]
+fn fully_cached_zero_output_request_is_not_decode_fpm_work() {
+    let mut core = VllmCore::new(router_args());
+    let tokens = vec![1, 2, 3, 4];
+    let mut collector = crate::replay::TraceCollector::default();
+
+    core.receive(DirectRequest {
+        tokens: tokens.clone(),
+        max_output_tokens: 0,
+        uuid: Some(Uuid::from_u128(90_002)),
+        ..Default::default()
+    });
+    let seed_pass = core.execute_pass(&mut collector, 0.0);
+    assert_eq!(seed_pass.completed_requests, 1);
+
+    let uuid = core.receive(DirectRequest {
+        tokens,
+        max_output_tokens: 0,
+        uuid: Some(Uuid::from_u128(90_003)),
+        ..Default::default()
+    });
+    let pass = core.execute_pass(&mut collector, seed_pass.end_ms);
+
+    assert_eq!(pass.completed_requests, 1);
+    let fpm = pass.fpm.as_ref().unwrap();
+    assert_eq!(fpm.num_prefill_requests, 0);
+    assert_eq!(fpm.num_decode_requests, 0);
+    assert_eq!(fpm.sum_decode_kv_tokens, 0);
+    assert!(matches!(
+        pass.output_signals.as_slice(),
+        [OutputSignal {
+            uuid: signal_uuid,
+            token_id: None,
+            completed: true,
+            rejected: false,
+            ..
+        }] if *signal_uuid == uuid
+    ));
+}
+
+#[test]
 fn speculative_batch_drains_zero_output_before_emitting_tokens() {
     let args = MockEngineArgs::builder()
         .block_size(4)


### PR DESCRIPTION
## Overview:

Repair request lifecycle handling that could stall static replay on zero-output rows and could corrupt SGLang KV ownership under cache pressure.

## Details:

- drain already-terminal zero-output requests in SGLang, vLLM, and TRT-LLM paths without fabricating output tokens
- preserve explicit no-token terminal signals through replay accounting, including completion/input/duration totals while keeping token latency and accept-length metrics token-gated
- preserve OSL=0 through disaggregated prefill and exclude fully cached terminal-only work from prefill/decode FPM estimates
- retain SGLang prefix-cache ownership across retraction and canonicalize only newly materialized concurrent duplicate pages
- add focused scheduler, replay, router, collector, and KV lifecycle regressions

### Root cause

Zero-output requests entered the running decode set but could neither emit a token nor reach terminal cleanup. This permanently consumed scheduler slots and eventually stalled static replay.

Separately, fresh cache hits did not copy their matched prefix into `cached_tokens`, so retraction could free cache-owned canonical pages. Concurrent unfinished inserts could also leave duplicate physical pages and publisher refcounts behind instead of switching the active request to the radix cache's canonical pages. Under KV pressure, that state divergence could suppress a required parent store and make the replay router reject a child block.

### Impact

Static replay now drains and counts zero-output rows as completed prefill work, while generation-bearing metrics remain token-based. SGLang KV page ownership and router-visible refcounts remain consistent through cache hits, duplicate unfinished insertion, and retraction without adding full-prefix work at every page boundary.

### Validation

- `cargo test -p dynamo-mocker` — 549 passed, 1 pre-existing ignored
- focused zero-output tests with `kvbm-offload` — 11 passed
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- release PyO3 build with `--features aic-forward-pass`
- real 34-row DeepSeek V4 Flash shard with four zero-output rows drained successfully
- guarded DeepSeek V4 Pro replay reached 53,150 completions with no missing-parent warning or panic; the old build failed deterministically at 40,488

AIConfigurator pinning and the external AutoscalingArena trace-preparation changes are intentionally excluded from this PR.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/sglang/decode.rs` and `lib/mocker/src/scheduler/vllm/core.rs` for zero-output terminal scheduling
- `lib/mocker/src/replay/collector.rs` for explicit terminal accounting and goodput semantics
- `lib/mocker/src/kv_manager/sglang_backend.rs` for canonical KV ownership and retraction handling

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requests configured to produce zero output now complete cleanly without generating phantom tokens or blocking subsequent work.
  - Improved completion handling across SGLang and vLLM scheduling paths, including edge cases during concurrent processing.
  - Improved KV-cache consistency for duplicate or partially completed requests, preventing missing parent relationships and incorrect cache eviction.
  - Preserved correct cache ownership during prefill and decode retraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
