### PR TITLE
fix: use SGLang host for bootstrap discovery

### DIFF
--- a/lib/sidecar/sglang/src/args.rs
+++ b/lib/sidecar/sglang/src/args.rs
@@ -23,8 +23,9 @@ pub struct Args {
 
     /// Reachable host that decode workers use to connect to a prefill worker's
     /// SGLang disaggregation bootstrap port. By default this is derived from
-    /// `dist_init_addr`, then a routable local address. This is required when
-    /// discovery exposes only loopback or wildcard addresses.
+    /// SGLang's concrete `host`, then `dist_init_addr`, then a routable local
+    /// address. This is required when discovery exposes only loopback or
+    /// wildcard addresses.
     #[arg(long, env = "SGLANG_DISAGGREGATION_BOOTSTRAP_HOST")]
     pub bootstrap_host: Option<String>,
 

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -477,6 +477,14 @@ fn resolve_bootstrap_host_with_local(
     if let Some(host) = explicit.filter(|host| !host.trim().is_empty()) {
         return Ok(Some(host.trim().to_string()));
     }
+    let from_server = discovery
+        .server_info
+        .get("host")
+        .and_then(Value::as_str)
+        .filter(|host| is_routable_host(host));
+    if let Some(host) = from_server {
+        return Ok(Some(host.trim().to_string()));
+    }
     let from_dist = discovery
         .server_info
         .get("dist_init_addr")
@@ -628,11 +636,29 @@ mod tests {
     }
 
     #[test]
-    fn dist_init_addr_precedes_local_address() {
+    fn server_host_precedes_dist_init_addr() {
         let host = resolve_bootstrap_host_with_local(
             None,
             "http://127.0.0.1:30001",
-            &discovery(json!({"dist_init_addr": "10.0.0.1:20000"})),
+            &discovery(json!({
+                "host": "10.0.0.1",
+                "dist_init_addr": "10.0.0.2:20000"
+            })),
+            "10.0.0.3",
+        )
+        .unwrap();
+        assert_eq!(host.as_deref(), Some("10.0.0.1"));
+    }
+
+    #[test]
+    fn wildcard_server_host_uses_dist_init_addr() {
+        let host = resolve_bootstrap_host_with_local(
+            None,
+            "http://127.0.0.1:30001",
+            &discovery(json!({
+                "host": "0.0.0.0",
+                "dist_init_addr": "10.0.0.1:20000"
+            })),
             "10.0.0.2",
         )
         .unwrap();


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Use the concrete SGLang host when publishing the prefill bootstrap endpoint. This preserves topology owned by SGLang and avoids synthesizing a container-local address when one is already available.

### How This Was Implemented

- Prefer a non-loopback, non-wildcard `host` from `GetServerInfo` after an explicit override.
- Retain existing `dist_init_addr`, local-IP, and endpoint fallbacks.
- Add precedence and wildcard-fallback coverage.

<details>
<summary>Walkthrough</summary>

`GetServerInfo` includes resolved SGLang server arguments. The sidecar now selects a concrete `host` before the existing fallback chain, while rejecting loopback and wildcard values that a decode pod cannot reach.

```mermaid
flowchart LR
    SGLang["SGLang GetServerInfo"] --> Sidecar["Dynamo SGLang sidecar"]
    Sidecar --> Router["Dynamo router"]
    Router --> Decode["SGLang decode worker"]
```
</details>

### Validation

- `cargo fmt --check`
- `cargo test -p dynamo-sglang-sidecar`
<!-- codex-pr-description:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefill bootstrap host discovery by prioritizing a routable server host when available.
  * Added safer fallback handling for wildcard or loopback addresses, using the configured distribution address or a routable local address instead.
  * Clarified bootstrap host behavior and requirements in the argument documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->