### PR TITLE
perf(mocker): optimize SGLang radix cache lifecycle [DYN-3851]

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -5,8 +5,8 @@
 //!
 //! Reference: sglang/python/sglang/srt/mem_cache/radix_cache.py
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
-use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
 new_key_type! {
@@ -16,23 +16,32 @@ new_key_type! {
 
 /// Manages free / allocated token slot indices for the KV cache pool.
 pub struct TokenPool {
+    next_fresh: usize,
     free: Vec<usize>,
     total: usize,
 }
 
 impl TokenPool {
     pub fn new(total: usize) -> Self {
-        let free: Vec<usize> = (0..total).rev().collect();
-        Self { free, total }
+        Self {
+            next_fresh: 0,
+            free: Vec::new(),
+            total,
+        }
     }
 
     /// Allocate `n` token slots. Returns `None` if not enough free slots.
     pub fn allocate(&mut self, n: usize) -> Option<Vec<usize>> {
-        if self.free.len() < n {
+        if self.available() < n {
             return None;
         }
-        let start = self.free.len() - n;
-        let indices: Vec<usize> = self.free.drain(start..).collect();
+
+        let recycled = n.min(self.free.len());
+        let fresh = n - recycled;
+        let mut indices = Vec::with_capacity(n);
+        indices.extend(self.free.drain(self.free.len() - recycled..));
+        indices.extend(self.next_fresh..self.next_fresh + fresh);
+        self.next_fresh += fresh;
         Some(indices)
     }
 
@@ -42,7 +51,7 @@ impl TokenPool {
     }
 
     pub fn available(&self) -> usize {
-        self.free.len()
+        self.free.len() + self.total - self.next_fresh
     }
 
     pub fn total(&self) -> usize {
@@ -53,7 +62,7 @@ impl TokenPool {
 /// A single node in the radix tree.
 pub struct TreeNode {
     /// Children keyed by `child.key[..page_size]` (a "child key").
-    pub children: HashMap<Vec<u64>, NodeId>,
+    pub children: FxHashMap<Vec<u64>, NodeId>,
     pub parent: Option<NodeId>,
     /// Token IDs stored at this edge.
     pub key: Vec<u64>,
@@ -72,7 +81,7 @@ pub struct RadixCache {
     pub token_pool: TokenPool,
     page_size: usize,
     /// Total token count in evictable nodes.
-    pub evictable_leaves: HashSet<NodeId>,
+    pub evictable_leaves: FxHashSet<NodeId>,
     pub evictable_size: usize,
     /// Total token count in protected (locked) nodes.
     pub protected_size: usize,
@@ -83,7 +92,7 @@ impl RadixCache {
         assert!(page_size >= 1, "page_size must be >= 1");
         let mut nodes = SlotMap::with_key();
         let root = nodes.insert(TreeNode {
-            children: HashMap::new(),
+            children: FxHashMap::default(),
             parent: None,
             key: Vec::new(),
             value: Vec::new(),
@@ -95,7 +104,7 @@ impl RadixCache {
             root,
             token_pool: TokenPool::new(total_tokens),
             page_size,
-            evictable_leaves: HashSet::new(),
+            evictable_leaves: FxHashSet::default(),
             evictable_size: 0,
             protected_size: 0,
         }
@@ -114,8 +123,8 @@ impl RadixCache {
         self.nodes.len()
     }
 
-    fn child_key(&self, key: &[u64]) -> Vec<u64> {
-        key[..self.page_size.min(key.len())].to_vec()
+    fn child_key<'a>(&self, key: &'a [u64]) -> &'a [u64] {
+        &key[..self.page_size.min(key.len())]
     }
 
     fn page_align(&self, len: usize) -> usize {
@@ -147,15 +156,17 @@ impl RadixCache {
 
         while matched < key.len() {
             let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => break,
             };
 
-            let child_key = self.nodes[child_id].key.clone();
-            let common_len = self.key_match(&child_key, &key[matched..]);
+            let (common_len, child_len) = {
+                let child_key = &self.nodes[child_id].key;
+                (self.key_match(child_key, &key[matched..]), child_key.len())
+            };
 
-            if common_len < child_key.len() {
+            if common_len < child_len {
                 if common_len > 0 {
                     let intermediate = self.split_node(child_id, common_len);
                     current = intermediate;
@@ -180,7 +191,7 @@ impl RadixCache {
 
         while matched < key.len() {
             let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => break,
             };
@@ -203,9 +214,44 @@ impl RadixCache {
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
     pub fn insert(&mut self, key: &[u64], value: &[usize]) -> NodeId {
+        self.insert_from(self.root, 0, key, value, false)
+    }
+
+    /// Insert only the suffix after a retained, page-aligned prefix.
+    ///
+    /// `prefix_node` must be the locked terminal node for `prefix_len`. Keeping
+    /// that handle lets decode growth avoid walking the full sequence from the
+    /// root on every completed page.
+    pub fn insert_from_node(
+        &mut self,
+        prefix_node: NodeId,
+        prefix_len: usize,
+        key: &[u64],
+        value: &[usize],
+    ) -> NodeId {
+        self.insert_from(prefix_node, prefix_len, key, value, true)
+    }
+
+    fn insert_from(
+        &mut self,
+        start_node: NodeId,
+        prefix_len: usize,
+        key: &[u64],
+        value: &[usize],
+        allow_locked_tail_extension: bool,
+    ) -> NodeId {
         let aligned_len = self.page_align(key.len());
-        if aligned_len == 0 {
-            return self.root;
+        assert_eq!(
+            prefix_len,
+            self.page_align(prefix_len),
+            "prefix length must be page-aligned"
+        );
+        assert!(
+            prefix_len <= aligned_len,
+            "prefix length {prefix_len} exceeds aligned key length {aligned_len}"
+        );
+        if aligned_len == prefix_len {
+            return start_node;
         }
         assert!(
             value.len() >= aligned_len,
@@ -216,24 +262,39 @@ impl RadixCache {
         let value = &value[..aligned_len];
 
         let now = Instant::now();
-        self.nodes[self.root].last_access_time = now;
+        self.touch_path(start_node, now);
 
-        let mut current = self.root;
-        let mut key_offset: usize = 0;
+        let mut current = start_node;
+        let mut key_offset = prefix_len;
 
         while key_offset < key.len() {
+            let can_extend_leaf = current != self.root
+                && self.nodes[current].children.is_empty()
+                && (self.nodes[current].lock_ref == 0
+                    || (allow_locked_tail_extension
+                        && current == start_node
+                        && self.nodes[current].lock_ref == 1));
+            if can_extend_leaf {
+                return self.extend_leaf(current, &key[key_offset..], &value[key_offset..], now);
+            }
+
             let ck = self.child_key(&key[key_offset..]);
-            let child_id = match self.nodes[current].children.get(&ck).copied() {
+            let child_id = match self.nodes[current].children.get(ck).copied() {
                 Some(id) => id,
                 None => {
                     return self.create_child(current, &key[key_offset..], &value[key_offset..]);
                 }
             };
 
-            let child_key = self.nodes[child_id].key.clone();
-            let common_len = self.key_match(&child_key, &key[key_offset..]);
+            let (common_len, child_len) = {
+                let child_key = &self.nodes[child_id].key;
+                (
+                    self.key_match(child_key, &key[key_offset..]),
+                    child_key.len(),
+                )
+            };
 
-            if common_len == child_key.len() {
+            if common_len == child_len {
                 key_offset += common_len;
                 current = child_id;
                 self.nodes[current].last_access_time = now;
@@ -257,34 +318,72 @@ impl RadixCache {
         current
     }
 
-    fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
-        let child = &self.nodes[child_id];
-        let child_parent = child.parent;
-        let child_key = child.key.clone();
-        let child_value = child.value.clone();
-        let child_lock_ref = child.lock_ref;
-        let child_last_access = child.last_access_time;
+    fn touch_path(&mut self, node_id: NodeId, now: Instant) {
+        let mut current = Some(node_id);
+        while let Some(id) = current {
+            self.nodes[id].last_access_time = now;
+            current = self.nodes[id].parent;
+        }
+    }
 
-        let suffix_ck = self.child_key(&child_key[split_pos..]);
-        let mut inter_children = HashMap::new();
+    fn extend_leaf(
+        &mut self,
+        node_id: NodeId,
+        key: &[u64],
+        value: &[usize],
+        now: Instant,
+    ) -> NodeId {
+        let node = &mut self.nodes[node_id];
+        debug_assert!(node.children.is_empty());
+        debug_assert!(node.lock_ref <= 1);
+        node.key.extend_from_slice(key);
+        node.value.extend_from_slice(value);
+        node.last_access_time = now;
+        if node.lock_ref == 0 {
+            self.evictable_size += key.len();
+        } else {
+            self.protected_size += key.len();
+        }
+        node_id
+    }
+
+    fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
+        let (child_parent, original_ck, prefix_key, prefix_value, suffix_ck, lock_ref, accessed) = {
+            let child = &mut self.nodes[child_id];
+            let child_parent = child.parent;
+            let original_ck = child.key[..self.page_size].to_vec();
+            let suffix_key = child.key.split_off(split_pos);
+            let prefix_key = std::mem::replace(&mut child.key, suffix_key);
+            let suffix_value = child.value.split_off(split_pos);
+            let prefix_value = std::mem::replace(&mut child.value, suffix_value);
+            let suffix_ck = child.key[..self.page_size].to_vec();
+            (
+                child_parent,
+                original_ck,
+                prefix_key,
+                prefix_value,
+                suffix_ck,
+                child.lock_ref,
+                child.last_access_time,
+            )
+        };
+
+        let mut inter_children = FxHashMap::default();
         inter_children.insert(suffix_ck, child_id);
 
         let intermediate = TreeNode {
             children: inter_children,
             parent: child_parent,
-            key: child_key[..split_pos].to_vec(),
-            value: child_value[..split_pos].to_vec(),
-            lock_ref: child_lock_ref,
-            last_access_time: child_last_access,
+            key: prefix_key,
+            value: prefix_value,
+            lock_ref,
+            last_access_time: accessed,
         };
         let inter_id = self.nodes.insert(intermediate);
 
         let child = &mut self.nodes[child_id];
-        child.key = child_key[split_pos..].to_vec();
-        child.value = child_value[split_pos..].to_vec();
         child.parent = Some(inter_id);
 
-        let original_ck = self.child_key(&child_key);
         if let Some(parent_id) = child_parent {
             self.nodes[parent_id].children.insert(original_ck, inter_id);
         }
@@ -297,14 +396,14 @@ impl RadixCache {
 
     fn create_child(&mut self, parent_id: NodeId, key: &[u64], value: &[usize]) -> NodeId {
         let new_node = TreeNode {
-            children: HashMap::new(),
+            children: FxHashMap::default(),
             parent: Some(parent_id),
             key: key.to_vec(),
             value: value.to_vec(),
             lock_ref: 0,
             last_access_time: Instant::now(),
         };
-        let ck = self.child_key(key);
+        let ck = self.child_key(key).to_vec();
         let new_id = self.nodes.insert(new_node);
 
         self.evictable_leaves.remove(&parent_id);
@@ -379,22 +478,23 @@ impl RadixCache {
                 break;
             };
 
-            let victim_node = &self.nodes[victim_id];
+            let victim_node = self
+                .nodes
+                .remove(victim_id)
+                .expect("evictable leaf disappeared before removal");
             let tokens = victim_node.key.len();
-            let pool_indices = victim_node.value.clone();
             let parent_id = victim_node.parent;
-            let victim_key = victim_node.key.clone();
 
             self.evictable_leaves.remove(&victim_id);
             self.evictable_size -= tokens;
             evicted += tokens;
 
-            evicted_indices.extend_from_slice(&pool_indices);
-            self.token_pool.free(&pool_indices);
+            evicted_indices.extend_from_slice(&victim_node.value);
+            self.token_pool.free(&victim_node.value);
 
             if let Some(pid) = parent_id {
-                let ck = self.child_key(&victim_key);
-                self.nodes[pid].children.remove(&ck);
+                let ck = self.child_key(&victim_node.key);
+                self.nodes[pid].children.remove(ck);
 
                 if pid != self.root
                     && self.nodes[pid].children.is_empty()
@@ -403,8 +503,6 @@ impl RadixCache {
                     self.evictable_leaves.insert(pid);
                 }
             }
-
-            self.nodes.remove(victim_id);
         }
         (evicted, evicted_indices)
     }
@@ -488,6 +586,50 @@ mod tests {
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 5);
         cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[10, 20, 30, 40, 50, 60, 70, 80]);
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
+    }
+
+    #[test]
+    fn test_retained_tail_extends_unique_leaf_in_place() {
+        let mut cache = RadixCache::new(100, 4);
+        cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let (_, tail) = cache.match_prefix(&[1, 2, 3, 4]);
+        cache.inc_lock_ref(tail);
+        let nodes_before = cache.num_nodes();
+
+        let extended = cache.insert_from_node(
+            tail,
+            4,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+        );
+
+        assert_eq!(extended, tail);
+        assert_eq!(cache.num_nodes(), nodes_before);
+        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(cache.protected_size, 8);
+        assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
+    }
+
+    #[test]
+    fn test_retained_tail_does_not_extend_shared_leaf_in_place() {
+        let mut cache = RadixCache::new(100, 4);
+        cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let (_, tail) = cache.match_prefix(&[1, 2, 3, 4]);
+        cache.inc_lock_ref(tail);
+        cache.inc_lock_ref(tail);
+        let nodes_before = cache.num_nodes();
+
+        let extended = cache.insert_from_node(
+            tail,
+            4,
+            &[1, 2, 3, 4, 5, 6, 7, 8],
+            &[0, 1, 2, 3, 4, 5, 6, 7],
+        );
+
+        assert_ne!(extended, tail);
+        assert_eq!(cache.num_nodes(), nodes_before + 1);
+        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4]);
+        assert_eq!(cache.node(extended).key, vec![5, 6, 7, 8]);
     }
 
     #[test]

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -462,11 +462,11 @@ impl RadixCache {
         }
     }
 
-    /// Evict tokens from the cache by LRU order.
+    /// Evict tokens from the cache by LRU order, rounding partial leaves to full pages.
     /// Returns `(num_tokens_evicted, evicted_page_indices)`.
     pub fn evict(&mut self, num_tokens: usize) -> (usize, Vec<usize>) {
         let mut evicted = 0;
-        let mut evicted_indices = Vec::new();
+        let mut evicted_indices = Vec::with_capacity(num_tokens.min(self.evictable_size));
         while evicted < num_tokens {
             let victim = self
                 .evictable_leaves
@@ -477,6 +477,30 @@ impl RadixCache {
             let Some(victim_id) = victim else {
                 break;
             };
+
+            let victim_tokens = self.nodes[victim_id].key.len();
+            let remaining = num_tokens - evicted;
+            let eviction_len = remaining
+                .div_ceil(self.page_size)
+                .saturating_mul(self.page_size)
+                .min(victim_tokens);
+
+            // A compressed leaf may span pages. Preserve its indexed prefix when
+            // only the newest suffix pages are needed to satisfy this eviction.
+            if eviction_len < victim_tokens {
+                let split_pos = victim_tokens - eviction_len;
+                let (nodes, token_pool) = (&mut self.nodes, &mut self.token_pool);
+                let victim_node = &mut nodes[victim_id];
+                victim_node.key.truncate(split_pos);
+                let evicted_values = &victim_node.value[split_pos..];
+                token_pool.free(evicted_values);
+                evicted_indices.extend_from_slice(evicted_values);
+                victim_node.value.truncate(split_pos);
+
+                self.evictable_size -= eviction_len;
+                evicted += eviction_len;
+                continue;
+            }
 
             let victim_node = self
                 .nodes

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -16,16 +16,61 @@ use dynamo_kv_router::protocols::{
 };
 use rustc_hash::FxHashMap;
 
+/// Move-only ownership of an active request's KV slots and protected radix path.
+#[derive(Debug, Default)]
+#[must_use = "an active KV lease must be finished, aborted, or retracted"]
+pub(crate) struct ActiveKvLease {
+    kv_indices: Vec<usize>,
+    cached_tokens: usize,
+    last_node: Option<NodeId>,
+}
+
+impl ActiveKvLease {
+    #[cfg(test)]
+    pub(crate) fn indices(&self) -> &[usize] {
+        &self.kv_indices
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.kv_indices.len()
+    }
+
+    pub(crate) fn cached_tokens(&self) -> usize {
+        self.cached_tokens
+    }
+
+    pub(crate) fn last_index(&self) -> Option<usize> {
+        self.kv_indices.last().copied()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.last_node.is_some()
+    }
+
+    fn last_node(&self) -> NodeId {
+        self.last_node
+            .expect("active KV lease must retain a radix path")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_parts(
+        kv_indices: Vec<usize>,
+        cached_tokens: usize,
+        last_node: NodeId,
+    ) -> Self {
+        Self {
+            kv_indices,
+            cached_tokens,
+            last_node: Some(last_node),
+        }
+    }
+}
+
 /// Result of `allocate_for_request`.
-pub struct AllocResult {
+pub(crate) struct AllocResult {
     /// Number of tokens matched from the prefix cache.
-    pub prefix_len: usize,
-    /// Pool token indices for the allocated input (1 per token).
-    pub kv_indices: Vec<usize>,
-    /// The deepest matched node in the radix tree (used for lock/unlock).
-    /// This is the prefix match point, not the new tokens — new tokens are
-    /// only in kv_indices and get inserted into the tree on completion.
-    pub last_node: NodeId,
+    pub(crate) prefix_len: usize,
+    pub(crate) lease: ActiveKvLease,
 }
 
 pub struct SglangKvManager {
@@ -70,7 +115,7 @@ impl SglangDestinationReservation {
 }
 
 impl DecodeTokenReservation {
-    pub fn take(&mut self) -> usize {
+    fn take(&mut self) -> usize {
         self.indices
             .pop_front()
             .expect("reserved decode token allocation must be infallible")
@@ -108,7 +153,7 @@ impl SglangKvManager {
 
     /// Try to allocate KV cache for a new request.
     /// Returns `None` if the pool doesn't have enough token slots (OOM).
-    pub fn allocate_for_request(&mut self, token_ids: &[u64]) -> Option<AllocResult> {
+    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u64]) -> Option<AllocResult> {
         let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
 
         let new_tokens = token_ids.len() - prefix_len;
@@ -129,8 +174,11 @@ impl SglangKvManager {
 
         Some(AllocResult {
             prefix_len,
-            kv_indices,
-            last_node,
+            lease: ActiveKvLease {
+                kv_indices,
+                cached_tokens: prefix_len,
+                last_node: Some(last_node),
+            },
         })
     }
 
@@ -139,38 +187,105 @@ impl SglangKvManager {
     /// This is used by chunked-prefill continuation where the request still
     /// owns token slots for a prefix that may extend past the radix-tree's
     /// page-aligned cached prefix.
-    pub fn allocate_after_prefix(
+    pub(crate) fn extend_allocation(
         &mut self,
         token_ids: &[u64],
-        prefix_len: usize,
-        mut prefix_indices: Vec<usize>,
-        last_node: NodeId,
-    ) -> Result<AllocResult, Vec<usize>> {
-        let new_tokens = token_ids.len().saturating_sub(prefix_len);
+        lease: &mut ActiveKvLease,
+    ) -> bool {
+        let prefix_len = lease.kv_indices.len();
+        assert!(
+            lease.is_active() && prefix_len <= token_ids.len(),
+            "invalid SGLang KV lease extension: active={}, owned_tokens={prefix_len}, target_tokens={}",
+            lease.is_active(),
+            token_ids.len()
+        );
+        let new_tokens = token_ids.len() - prefix_len;
         let Some(new_indices) = self.cache.token_pool.allocate(new_tokens) else {
-            return Err(prefix_indices);
+            return false;
         };
 
-        debug_assert_eq!(prefix_indices.len(), prefix_len);
-        prefix_indices.extend_from_slice(&new_indices);
-
-        self.cache.inc_lock_ref(last_node);
-
-        self.publish_stored_event(token_ids, &prefix_indices, prefix_len);
+        lease.kv_indices.extend_from_slice(&new_indices);
+        self.publish_stored_event(token_ids, &lease.kv_indices, prefix_len);
         self.log_trace("allocation", new_tokens);
+        true
+    }
 
-        Ok(AllocResult {
-            prefix_len,
-            kv_indices: prefix_indices,
+    pub(crate) fn extend_cached_prefix(&mut self, token_ids: &[u64], lease: &mut ActiveKvLease) {
+        let complete_len = token_ids.len() / self.cache.page_size() * self.cache.page_size();
+        if complete_len <= lease.cached_tokens {
+            return;
+        }
+        assert!(
+            lease.is_active() && complete_len <= lease.len(),
+            "invalid SGLang KV lease cache extension: active={}, cached_tokens={}, complete_tokens={complete_len}, owned_tokens={}",
+            lease.is_active(),
+            lease.cached_tokens,
+            lease.len()
+        );
+        let last_node = lease.last_node();
+        let new_last_node = self.cache_unfinished_req(
+            token_ids,
+            &mut lease.kv_indices[..complete_len],
             last_node,
-        })
+            lease.cached_tokens,
+        );
+        lease.last_node = Some(new_last_node);
+        lease.cached_tokens = complete_len;
+    }
+
+    pub(crate) fn extend_decode(
+        &mut self,
+        lease: &mut ActiveKvLease,
+        reservation: &mut DecodeTokenReservation,
+    ) {
+        debug_assert!(lease.is_active());
+        let new_idx = reservation.take();
+        self.publish_decode_token(new_idx, lease.last_index());
+        lease.kv_indices.push(new_idx);
+    }
+
+    pub(crate) fn finish(&mut self, token_ids: &[u64], mut lease: ActiveKvLease) {
+        let Some(last_node) = lease.last_node.take() else {
+            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert_eq!(lease.cached_tokens, 0);
+            return;
+        };
+        let complete_len =
+            token_ids.len().min(lease.len()) / self.cache.page_size() * self.cache.page_size();
+        assert!(
+            lease.cached_tokens <= complete_len,
+            "invalid SGLang KV lease finish: cached_tokens={}, complete_tokens={complete_len}, owned_tokens={}",
+            lease.cached_tokens,
+            lease.len()
+        );
+        let unretained_tail = lease.kv_indices.split_off(complete_len);
+        self.free_indices(&unretained_tail);
+
+        if complete_len == 0 {
+            self.cache.dec_lock_ref(last_node);
+            return;
+        }
+        self.cache_finished_req(
+            &token_ids[..complete_len],
+            &lease.kv_indices,
+            last_node,
+            lease.cached_tokens,
+        );
+    }
+
+    pub(crate) fn abort(&mut self, lease: ActiveKvLease) -> bool {
+        self.release_active_lease(lease)
+    }
+
+    pub(crate) fn retract(&mut self, lease: ActiveKvLease) -> bool {
+        self.release_active_lease(lease)
     }
 
     /// Cache a completed request's full sequence into the radix tree.
     ///
     /// Inserts the full token sequence so future requests can reuse it,
     /// then unlocks the path.
-    pub fn cache_finished_req(
+    fn cache_finished_req(
         &mut self,
         token_ids: &[u64],
         kv_indices: &[usize],
@@ -200,7 +315,7 @@ impl SglangKvManager {
     ///
     /// Returns the new `last_node` that the caller should use for
     /// subsequent calls.
-    pub fn cache_unfinished_req(
+    fn cache_unfinished_req(
         &mut self,
         token_ids: &[u64],
         kv_indices: &mut [usize],
@@ -315,8 +430,11 @@ impl SglangKvManager {
         self.log_trace("activate_destination", missing_tokens);
         AllocResult {
             prefix_len,
-            kv_indices: prefix_indices,
-            last_node: new_last_node,
+            lease: ActiveKvLease {
+                kv_indices: prefix_indices,
+                cached_tokens: token_ids.len() / self.cache.page_size() * self.cache.page_size(),
+                last_node: Some(new_last_node),
+            },
         }
     }
 
@@ -343,16 +461,14 @@ impl SglangKvManager {
         self.log_trace("release_unpublished", indices.len());
     }
 
-    /// Free a request without caching (e.g., aborted request).
-    ///
-    /// Unlocks the path without inserting into the tree.
-    pub fn free_request(&mut self, last_node: NodeId) {
+    #[cfg(test)]
+    fn free_request(&mut self, last_node: NodeId) {
         self.cache.dec_lock_ref(last_node);
     }
 
     /// Return request-owned token slots to the free pool and publish matching
     /// removal events for any slots that were previously advertised to the router.
-    pub fn free_indices(&mut self, indices: &[usize]) {
+    fn free_indices(&mut self, indices: &[usize]) {
         if indices.is_empty() {
             return;
         }
@@ -360,6 +476,25 @@ impl SglangKvManager {
         self.cache.token_pool.free(indices);
         self.publish_removed_event(indices);
         self.log_trace("free", indices.len());
+    }
+
+    fn release_active_lease(&mut self, mut lease: ActiveKvLease) -> bool {
+        let Some(last_node) = lease.last_node.take() else {
+            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert_eq!(lease.cached_tokens, 0);
+            return false;
+        };
+        assert!(
+            lease.cached_tokens <= lease.len(),
+            "invalid SGLang KV lease release: cached_tokens={}, owned_tokens={}",
+            lease.cached_tokens,
+            lease.len()
+        );
+        let owned_suffix = lease.kv_indices.split_off(lease.cached_tokens);
+        let capacity_improved = !owned_suffix.is_empty() || last_node != self.cache.root();
+        self.free_indices(&owned_suffix);
+        self.cache.dec_lock_ref(last_node);
+        capacity_improved
     }
 
     /// Collect token indices from the matched prefix path by walking root→last_node.
@@ -752,12 +887,38 @@ mod tests {
     }
 
     #[test]
+    fn active_kv_lease_has_no_space_overhead() {
+        let previous_fields = std::mem::size_of::<Vec<usize>>()
+            + std::mem::size_of::<usize>()
+            + std::mem::size_of::<Option<NodeId>>();
+
+        assert_eq!(std::mem::size_of::<ActiveKvLease>(), previous_fields);
+    }
+
+    #[test]
+    fn retract_lease_releases_only_the_uncached_suffix() {
+        let mut mgr = SglangKvManager::new(16, 4, KvEventPublishers::default(), 0);
+        let mut alloc = mgr.allocate_for_request(&[1, 2, 3, 4]).unwrap();
+        mgr.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
+        assert!(mgr.extend_allocation(&[1, 2, 3, 4, 5, 6], &mut alloc.lease));
+
+        assert_eq!(alloc.lease.cached_tokens(), 4);
+        assert_eq!(alloc.lease.len(), 6);
+        assert!(mgr.retract(alloc.lease));
+
+        assert_eq!(mgr.cache().token_pool.available(), 12);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 4);
+        assert_eq!(mgr.cache().prefix_match_len(&[1, 2, 3, 4]), 4);
+    }
+
+    #[test]
     fn test_allocate_cache_miss() {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
         let result = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(result.prefix_len, 0);
-        assert_eq!(result.kv_indices.len(), 5);
+        assert_eq!(result.lease.kv_indices.len(), 5);
         assert_eq!(mgr.cache().token_pool.available(), 95);
     }
 
@@ -767,13 +928,18 @@ mod tests {
 
         // First request: allocate and cache
         let r1 = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
-        assert_eq!(r1.kv_indices.len(), 5); // 5 pages (page_size=1)
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5], &r1.kv_indices, r1.last_node, 0);
+        assert_eq!(r1.lease.kv_indices.len(), 5); // 5 pages (page_size=1)
+        mgr.cache_finished_req(
+            &[1, 2, 3, 4, 5],
+            &r1.lease.kv_indices,
+            r1.lease.last_node(),
+            0,
+        );
 
         // Second request with shared prefix
         let r2 = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
         assert_eq!(r2.prefix_len, 5);
-        assert_eq!(r2.kv_indices.len(), 7); // 5 reused + 2 new pages
+        assert_eq!(r2.lease.kv_indices.len(), 7); // 5 reused + 2 new pages
         assert_eq!(mgr.cache().token_pool.available(), 93); // 100 - 5 - 2
     }
 
@@ -794,8 +960,8 @@ mod tests {
             .expect("prefix allocation should fit");
         mgr.cache_finished_req(
             prefix_tokens,
-            &prefix.kv_indices,
-            prefix.last_node,
+            &prefix.lease.kv_indices,
+            prefix.lease.last_node(),
             prefix.prefix_len,
         );
         let partial = mgr
@@ -810,8 +976,8 @@ mod tests {
             .expect("aligned prompt allocation should fit");
         mgr.cache_finished_req(
             &aligned_tokens,
-            &aligned.kv_indices,
-            aligned.last_node,
+            &aligned.lease.kv_indices,
+            aligned.lease.last_node(),
             aligned.prefix_len,
         );
         let full_hit = mgr
@@ -825,7 +991,7 @@ mod tests {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
         let result = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
-        mgr.free_request(result.last_node);
+        mgr.free_request(result.lease.last_node());
 
         // Path is unlocked, tokens still allocated in pool
         assert_eq!(mgr.cache().protected_size, 0);
@@ -840,7 +1006,7 @@ mod tests {
         let r = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
         assert_eq!(sink.event_count(), 1); // BlockStored for 3 new pages
 
-        mgr.cache_finished_req(&[1, 2, 3], &r.kv_indices, r.last_node, 0);
+        mgr.cache_finished_req(&[1, 2, 3], &r.lease.kv_indices, r.lease.last_node(), 0);
 
         // Second request with full cache hit → no new events
         let r2 = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
@@ -855,7 +1021,12 @@ mod tests {
             SglangKvManager::new(100, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
 
         let r = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6]).unwrap();
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5, 6], &r.kv_indices, r.last_node, 0);
+        mgr.cache_finished_req(
+            &[1, 2, 3, 4, 5, 6],
+            &r.lease.kv_indices,
+            r.lease.last_node(),
+            0,
+        );
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
@@ -882,10 +1053,15 @@ mod tests {
         let tokens = [out_of_domain_token, 2, 3, 4, 5, 6];
 
         let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
-        let first_last_node =
-            mgr.cache_unfinished_req(&tokens[..2], &mut alloc.kv_indices, alloc.last_node, 0);
+        let alloc_last_node = alloc.lease.last_node();
+        let first_last_node = mgr.cache_unfinished_req(
+            &tokens[..2],
+            &mut alloc.lease.kv_indices,
+            alloc_last_node,
+            0,
+        );
 
-        let mut kv_indices = alloc.kv_indices;
+        let mut kv_indices = alloc.lease.kv_indices;
         kv_indices.extend_from_slice(&mgr.cache_mut().token_pool.allocate(4).unwrap());
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
@@ -940,10 +1116,10 @@ mod tests {
         };
         assert_eq!(store.blocks.len(), 3);
 
-        mgr.free_indices(&req1.kv_indices);
+        mgr.free_indices(&req1.lease.kv_indices);
         assert_eq!(sink.event_count(), 1);
 
-        mgr.free_indices(&req2.kv_indices);
+        mgr.free_indices(&req2.lease.kv_indices);
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
         let KvCacheEventData::Removed(remove) = &events[1].data else {
@@ -977,7 +1153,7 @@ mod tests {
         assert_eq!(query_hashes.len(), tokens.len());
         harness.apply_events(allocation_events).await;
 
-        mgr.cache_finished_req(&tokens, &req1.kv_indices, req1.last_node, 0);
+        mgr.cache_finished_req(&tokens, &req1.lease.kv_indices, req1.lease.last_node(), 0);
         let req1_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req1_completion_events),
@@ -995,7 +1171,7 @@ mod tests {
             "canonical completion should retain the first request's slots"
         );
 
-        mgr.cache_finished_req(&tokens, &req2.kv_indices, req2.last_node, 0);
+        mgr.cache_finished_req(&tokens, &req2.lease.kv_indices, req2.lease.last_node(), 0);
         let req2_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req2_completion_events),
@@ -1041,8 +1217,8 @@ mod tests {
         let seed = mgr.allocate_for_request(&seed_tokens).unwrap();
         mgr.cache_finished_req(
             &seed_tokens,
-            &seed.kv_indices,
-            seed.last_node,
+            &seed.lease.kv_indices,
+            seed.lease.last_node(),
             seed.prefix_len,
         );
         for event in buffer.drain() {
@@ -1055,29 +1231,31 @@ mod tests {
         let shared_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
         let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
-        let duplicate_suffix = duplicate.kv_indices[seed_tokens.len()..].to_vec();
+        let duplicate_suffix = duplicate.lease.kv_indices[seed_tokens.len()..].to_vec();
         assert_ne!(
-            first.kv_indices[seed_tokens.len()..],
-            duplicate.kv_indices[seed_tokens.len()..]
+            first.lease.kv_indices[seed_tokens.len()..],
+            duplicate.lease.kv_indices[seed_tokens.len()..]
         );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
 
+        let first_previous_last = first.lease.last_node();
         let first_last = mgr.cache_unfinished_req(
             &shared_tokens,
-            &mut first.kv_indices,
-            first.last_node,
+            &mut first.lease.kv_indices,
+            first_previous_last,
             first.prefix_len,
         );
+        let duplicate_previous_last = duplicate.lease.last_node();
         let duplicate_last = mgr.cache_unfinished_req(
             &shared_tokens,
-            &mut duplicate.kv_indices,
-            duplicate.last_node,
+            &mut duplicate.lease.kv_indices,
+            duplicate_previous_last,
             duplicate.prefix_len,
         );
         assert_eq!(
-            duplicate.kv_indices, first.kv_indices,
+            duplicate.lease.kv_indices, first.lease.kv_indices,
             "the active duplicate must switch to radix-owned canonical pages"
         );
         assert_eq!(
@@ -1088,7 +1266,7 @@ mod tests {
         assert!(
             duplicate_suffix
                 .iter()
-                .all(|idx| !duplicate.kv_indices.contains(idx)),
+                .all(|idx| !duplicate.lease.kv_indices.contains(idx)),
             "no duplicate physical slot may remain attached to the active request"
         );
         for event in buffer.drain() {
@@ -1100,7 +1278,7 @@ mod tests {
         mgr.free_request(duplicate_last);
         mgr.cache_finished_req(
             &shared_tokens,
-            &first.kv_indices,
+            &first.lease.kv_indices,
             first_last,
             shared_tokens.len(),
         );
@@ -1116,8 +1294,8 @@ mod tests {
         let restored = mgr.allocate_for_request(&seed_tokens).unwrap();
         mgr.cache_finished_req(
             &seed_tokens,
-            &restored.kv_indices,
-            restored.last_node,
+            &restored.lease.kv_indices,
+            restored.lease.last_node(),
             restored.prefix_len,
         );
         for event in buffer.drain() {
@@ -1145,8 +1323,8 @@ mod tests {
             indexer.apply_event(event).unwrap();
         }
 
-        mgr.free_indices(&extended.kv_indices[extended.prefix_len..]);
-        mgr.free_request(extended.last_node);
+        mgr.free_indices(&extended.lease.kv_indices[extended.prefix_len..]);
+        mgr.free_request(extended.lease.last_node());
     }
 
     #[test]
@@ -1167,9 +1345,10 @@ mod tests {
         let tokens = [1, 2, 3, 4];
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
         let events_before = sink.event_count();
+        let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 2)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 2)
         }));
 
         assert!(result.is_err());
@@ -1183,11 +1362,12 @@ mod tests {
             SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
-        alloc.kv_indices.truncate(4);
+        alloc.lease.kv_indices.truncate(4);
         let events_before = sink.event_count();
+        let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.kv_indices, alloc.last_node, 0)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 0)
         }));
 
         assert!(result.is_err());
@@ -1214,10 +1394,11 @@ mod tests {
         let chunk2_len = 6;
 
         let mut alloc1 = mgr.allocate_for_request(&tokens[..chunk1_len]).unwrap();
+        let previous_last = alloc1.lease.last_node();
         let new_last = mgr.cache_unfinished_req(
             &tokens[..chunk1_len],
-            &mut alloc1.kv_indices,
-            alloc1.last_node,
+            &mut alloc1.lease.kv_indices,
+            previous_last,
             0,
         );
 

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -692,12 +692,23 @@ impl SglangKvManager {
             return 0;
         }
 
-        let mut computed_blocks = Vec::new();
         let first_block_start = first_new_token / block_size * block_size;
-        let local_hashes = self.local_hashes_for_range(&token_ids[first_block_start..complete_len]);
+        let Some(first_unpublished_block) = (first_block_start..complete_len)
+            .step_by(block_size)
+            .find(|&block_start| {
+                let representative_idx = indices[block_start + block_size - 1];
+                !self.idx_to_block_hash.contains_key(&representative_idx)
+            })
+        else {
+            return 0;
+        };
+
+        let mut computed_blocks = Vec::new();
+        let local_hashes =
+            self.local_hashes_for_range(&token_ids[first_unpublished_block..complete_len]);
 
         for (block_idx, tokens_hash) in local_hashes.iter().copied().enumerate() {
-            let block_start = first_block_start + block_idx * block_size;
+            let block_start = first_unpublished_block + block_idx * block_size;
             let block_end = block_start + block_size;
             let representative_idx = indices[block_end - 1];
             if self.idx_to_block_hash.contains_key(&representative_idx) {
@@ -1088,6 +1099,31 @@ mod tests {
             store.blocks[0].block_hash,
             ExternalSequenceBlockHash(expected_sequence[0])
         );
+    }
+
+    #[test]
+    fn test_published_prefix_hashes_only_unseen_suffix() {
+        let sink = Arc::new(MockSink::new());
+        let mut mgr =
+            SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let indices = mgr.cache_mut().token_pool.allocate(tokens.len()).unwrap();
+
+        assert_eq!(mgr.publish_stored_event(&tokens[..4], &indices[..4], 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 0);
+
+        let events = sink.clone_events();
+        assert_eq!(events.len(), 2);
+        let KvCacheEventData::Stored(first) = &events[0].data else {
+            panic!("expected first stored event");
+        };
+        let KvCacheEventData::Stored(second) = &events[1].data else {
+            panic!("expected suffix stored event");
+        };
+        assert_eq!(first.blocks.len(), 1);
+        assert_eq!(second.blocks.len(), 1);
+        assert_eq!(second.parent_hash, Some(first.blocks[0].block_hash));
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -4,7 +4,6 @@
 //! SGLang KV manager — wraps [`RadixCache`] with request-level lifecycle
 //! operations and KV event publishing.
 
-use std::collections::HashMap;
 use std::collections::VecDeque;
 
 use crate::cache::radix_cache::{NodeId, RadixCache};
@@ -15,6 +14,7 @@ use dynamo_kv_router::protocols::{
     KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, compute_block_hash_for_seq,
     compute_next_seq_hash,
 };
+use rustc_hash::FxHashMap;
 
 /// Result of `allocate_for_request`.
 pub struct AllocResult {
@@ -35,11 +35,11 @@ pub struct SglangKvManager {
     next_event_id: u64,
     /// Maps each complete block's terminal pool_idx → block_hash assigned
     /// during Stored events, so Removed events can use the same block_hash.
-    idx_to_block_hash: HashMap<usize, ExternalSequenceBlockHash>,
+    idx_to_block_hash: FxHashMap<usize, ExternalSequenceBlockHash>,
     /// Tracks how many live pool slots currently advertise the same logical
     /// block hash so router events reflect logical block visibility, not
     /// transient slot ownership.
-    block_hash_refcounts: HashMap<ExternalSequenceBlockHash, usize>,
+    block_hash_refcounts: FxHashMap<ExternalSequenceBlockHash, usize>,
 }
 
 pub struct DecodeTokenReservation {
@@ -93,8 +93,8 @@ impl SglangKvManager {
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
-            idx_to_block_hash: HashMap::new(),
-            block_hash_refcounts: HashMap::new(),
+            idx_to_block_hash: FxHashMap::default(),
+            block_hash_refcounts: FxHashMap::default(),
         }
     }
 
@@ -143,23 +143,25 @@ impl SglangKvManager {
         &mut self,
         token_ids: &[u64],
         prefix_len: usize,
-        prefix_indices: &[usize],
+        mut prefix_indices: Vec<usize>,
         last_node: NodeId,
-    ) -> Option<AllocResult> {
+    ) -> Result<AllocResult, Vec<usize>> {
         let new_tokens = token_ids.len().saturating_sub(prefix_len);
-        let new_indices = self.cache.token_pool.allocate(new_tokens)?;
+        let Some(new_indices) = self.cache.token_pool.allocate(new_tokens) else {
+            return Err(prefix_indices);
+        };
 
-        let mut kv_indices = prefix_indices[..prefix_len].to_vec();
-        kv_indices.extend_from_slice(&new_indices);
+        debug_assert_eq!(prefix_indices.len(), prefix_len);
+        prefix_indices.extend_from_slice(&new_indices);
 
         self.cache.inc_lock_ref(last_node);
 
-        self.publish_stored_event(token_ids, &kv_indices, prefix_len);
+        self.publish_stored_event(token_ids, &prefix_indices, prefix_len);
         self.log_trace("allocation", new_tokens);
 
-        Some(AllocResult {
+        Ok(AllocResult {
             prefix_len,
-            kv_indices,
+            kv_indices: prefix_indices,
             last_node,
         })
     }
@@ -176,8 +178,17 @@ impl SglangKvManager {
         first_new_token: usize,
     ) {
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
-        self.cache.insert(token_ids, kv_indices);
-        self.release_unretained_finished_indices(token_ids, kv_indices);
+        let new_last_node =
+            self.cache
+                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
+        let complete_len =
+            token_ids.len().min(kv_indices.len()) / self.cache.page_size() * self.cache.page_size();
+        self.release_unretained_finished_indices(
+            kv_indices,
+            new_last_node,
+            first_new_token,
+            complete_len,
+        );
         self.cache.dec_lock_ref(last_node);
     }
 
@@ -207,7 +218,9 @@ impl SglangKvManager {
         );
 
         self.publish_stored_event(token_ids, kv_indices, first_new_token);
-        let new_last_node = self.cache.insert(token_ids, kv_indices);
+        let new_last_node =
+            self.cache
+                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
 
         // A concurrent insert can retain different physical pages for the same prefix.
         // Move the active request to canonical pages before releasing its duplicates.
@@ -376,37 +389,60 @@ impl SglangKvManager {
         indices
     }
 
-    fn release_unretained_finished_indices(&mut self, token_ids: &[u64], kv_indices: &[usize]) {
+    fn release_unretained_finished_indices(
+        &mut self,
+        kv_indices: &[usize],
+        last_node: NodeId,
+        first_new_token: usize,
+        complete_len: usize,
+    ) {
         let block_size = self.cache.page_size();
-        let complete_len = token_ids.len().min(kv_indices.len()) / block_size * block_size;
         if complete_len == 0 {
             return;
         }
 
-        let (matched_len, last_node) = self.cache.match_prefix(&token_ids[..complete_len]);
-        debug_assert_eq!(
-            matched_len, complete_len,
-            "completed SGLang sequence should be fully cached after insert"
-        );
-        if matched_len < complete_len {
-            return;
-        }
-
-        let canonical_indices = self.collect_path_indices(last_node);
-        debug_assert!(
-            canonical_indices.len() >= complete_len,
-            "cached SGLang sequence path should carry complete KV indices"
-        );
-        if canonical_indices.len() < complete_len {
-            return;
-        }
-
         let mut unretained_indices = Vec::new();
-        for block_start in (0..complete_len).step_by(block_size) {
-            let block_end = block_start + block_size;
-            if canonical_indices[block_end - 1] != kv_indices[block_end - 1] {
-                unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+        let mut current = last_node;
+        let mut path_end = complete_len;
+
+        while path_end > first_new_token {
+            debug_assert_ne!(current, self.cache.root());
+            if current == self.cache.root() {
+                tracing::error!(
+                    path_end,
+                    first_new_token,
+                    complete_len,
+                    "SGLang radix path ended before finished-request reconciliation"
+                );
+                break;
             }
+
+            let node = self.cache.node(current);
+            let node_len = node.value.len();
+            debug_assert!(node_len <= path_end);
+            if node_len > path_end {
+                tracing::error!(
+                    node_len,
+                    path_end,
+                    complete_len,
+                    "SGLang radix node exceeds finished materialized prefix"
+                );
+                break;
+            }
+            let path_start = path_end - node_len;
+            let reconcile_start = path_start.max(first_new_token);
+
+            for block_start in (reconcile_start..path_end).step_by(block_size) {
+                let block_end = block_start + block_size;
+                let node_start = block_start - path_start;
+                let node_end = node_start + block_size;
+                if kv_indices[block_start..block_end] != node.value[node_start..node_end] {
+                    unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+                }
+            }
+
+            path_end = path_start;
+            current = node.parent.unwrap_or(self.cache.root());
         }
 
         self.free_indices(&unretained_indices);

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -913,6 +913,51 @@ mod tests {
     }
 
     #[test]
+    fn retained_tail_split_releases_leases_before_eviction() {
+        let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let mut mgr = SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink), None), 0);
+        let mut indexer = RadixTree::new();
+
+        let first_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut first = mgr.allocate_for_request(&first_tokens[..4]).unwrap();
+        mgr.extend_cached_prefix(&first_tokens[..4], &mut first.lease);
+        let retained_tail = first.lease.last_node();
+        assert!(mgr.extend_allocation(&first_tokens, &mut first.lease));
+        mgr.extend_cached_prefix(&first_tokens, &mut first.lease);
+
+        assert_eq!(first.lease.last_node(), retained_tail);
+        assert_eq!(mgr.cache().num_nodes(), 2);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        let second_tokens = [1, 2, 3, 4, 9, 10, 11, 12];
+        let mut second = mgr.allocate_for_request(&second_tokens).unwrap();
+        assert_eq!(second.prefix_len, 4);
+        assert_eq!(first.lease.last_node(), retained_tail);
+        assert_eq!(mgr.cache().num_nodes(), 3);
+        mgr.extend_cached_prefix(&second_tokens, &mut second.lease);
+        assert_eq!(mgr.cache().num_nodes(), 4);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+
+        mgr.finish(&first_tokens, first.lease);
+        assert!(mgr.retract(second.lease));
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 12);
+
+        mgr.evict(12);
+        for event in buffer.drain() {
+            indexer.apply_event(event).unwrap();
+        }
+        assert_eq!(mgr.cache().token_pool.available(), 16);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().evictable_size, 0);
+        assert_eq!(mgr.cache().num_nodes(), 1);
+    }
+
+    #[test]
     fn test_allocate_cache_miss() {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
@@ -1215,12 +1260,7 @@ mod tests {
 
         let seed_tokens = [1, 2, 3, 4];
         let seed = mgr.allocate_for_request(&seed_tokens).unwrap();
-        mgr.cache_finished_req(
-            &seed_tokens,
-            &seed.lease.kv_indices,
-            seed.lease.last_node(),
-            seed.prefix_len,
-        );
+        mgr.finish(&seed_tokens, seed.lease);
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1231,31 +1271,20 @@ mod tests {
         let shared_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
         let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
-        let duplicate_suffix = duplicate.lease.kv_indices[seed_tokens.len()..].to_vec();
+        let duplicate_suffix = duplicate.lease.indices()[seed_tokens.len()..].to_vec();
         assert_ne!(
-            first.lease.kv_indices[seed_tokens.len()..],
-            duplicate.lease.kv_indices[seed_tokens.len()..]
+            first.lease.indices()[seed_tokens.len()..],
+            duplicate.lease.indices()[seed_tokens.len()..]
         );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
 
-        let first_previous_last = first.lease.last_node();
-        let first_last = mgr.cache_unfinished_req(
-            &shared_tokens,
-            &mut first.lease.kv_indices,
-            first_previous_last,
-            first.prefix_len,
-        );
-        let duplicate_previous_last = duplicate.lease.last_node();
-        let duplicate_last = mgr.cache_unfinished_req(
-            &shared_tokens,
-            &mut duplicate.lease.kv_indices,
-            duplicate_previous_last,
-            duplicate.prefix_len,
-        );
+        mgr.extend_cached_prefix(&shared_tokens, &mut first.lease);
+        mgr.extend_cached_prefix(&shared_tokens, &mut duplicate.lease);
         assert_eq!(
-            duplicate.lease.kv_indices, first.lease.kv_indices,
+            duplicate.lease.indices(),
+            first.lease.indices(),
             "the active duplicate must switch to radix-owned canonical pages"
         );
         assert_eq!(
@@ -1266,7 +1295,7 @@ mod tests {
         assert!(
             duplicate_suffix
                 .iter()
-                .all(|idx| !duplicate.lease.kv_indices.contains(idx)),
+                .all(|idx| !duplicate.lease.indices().contains(idx)),
             "no duplicate physical slot may remain attached to the active request"
         );
         for event in buffer.drain() {
@@ -1275,13 +1304,8 @@ mod tests {
 
         // Mirror retracting the duplicate after its full prefix was cached,
         // then finish and evict the canonical request.
-        mgr.free_request(duplicate_last);
-        mgr.cache_finished_req(
-            &shared_tokens,
-            &first.lease.kv_indices,
-            first_last,
-            shared_tokens.len(),
-        );
+        assert!(mgr.retract(duplicate.lease));
+        mgr.finish(&shared_tokens, first.lease);
         mgr.evict(seed_tokens.len());
         mgr.evict(seed_tokens.len());
         for event in buffer.drain() {
@@ -1292,12 +1316,7 @@ mod tests {
         // duplicated block. A leaked duplicate publisher refcount would
         // suppress re-storing block 2 and emit block 3 with a missing parent.
         let restored = mgr.allocate_for_request(&seed_tokens).unwrap();
-        mgr.cache_finished_req(
-            &seed_tokens,
-            &restored.lease.kv_indices,
-            restored.lease.last_node(),
-            restored.prefix_len,
-        );
+        mgr.finish(&seed_tokens, restored.lease);
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
@@ -1323,8 +1342,7 @@ mod tests {
             indexer.apply_event(event).unwrap();
         }
 
-        mgr.free_indices(&extended.lease.kv_indices[extended.prefix_len..]);
-        mgr.free_request(extended.lease.last_node());
+        assert!(mgr.abort(extended.lease));
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -1288,6 +1288,41 @@ mod tests {
         harness.shutdown();
     }
 
+    #[tokio::test]
+    async fn retained_tail_eviction_preserves_page_granular_prefix_reuse() {
+        let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let harness = RouterIndexerHarness::new(4, ROUTER_TEST_WORKER_ID);
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink), None), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        let mut request = mgr.allocate_for_request(&tokens[..4]).unwrap();
+        mgr.extend_cached_prefix(&tokens[..4], &mut request.lease);
+        assert!(mgr.extend_allocation(&tokens, &mut request.lease));
+        mgr.extend_cached_prefix(&tokens, &mut request.lease);
+        mgr.finish(&tokens, request.lease);
+
+        let stored_events = buffer.drain();
+        let query_hashes = stored_hashes(&stored_events);
+        assert_eq!(query_hashes.len(), 2);
+        harness.apply_events(stored_events).await;
+        assert_eq!(harness.overlap_for_hashes(query_hashes.clone()).await, 2);
+        assert_eq!(mgr.cache().evictable_size, 8);
+        assert_eq!(mgr.cache().token_pool.available(), 0);
+
+        mgr.evict(4);
+        let eviction_events = buffer.drain();
+        assert_eq!(removed_event_count(&eviction_events), 1);
+        assert_eq!(removed_block_count(&eviction_events), 1);
+        harness.apply_events(eviction_events).await;
+
+        assert_eq!(mgr.cache().prefix_match_len(&tokens), 4);
+        assert_eq!(mgr.cache().evictable_size, 4);
+        assert_eq!(mgr.cache().protected_size, 0);
+        assert_eq!(mgr.cache().token_pool.available(), 4);
+        assert_eq!(harness.overlap_for_hashes(query_hashes).await, 1);
+        harness.shutdown();
+    }
+
     #[test]
     fn unfinished_duplicate_canonicalization_prevents_missing_parent() {
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -1441,6 +1441,10 @@ mod tests {
         assert_eq!(snapshots[0].first_token_ms, None);
         assert_eq!(snapshots[1].requested_output_length, 1);
         assert_eq!(snapshots[1].output_length, 1);
+
+        let report = collector.finish();
+        assert_eq!(report.request_counts.completed_requests, 2);
+        assert_eq!(report.request_counts.total_output_tokens, 1);
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -65,10 +65,8 @@ impl ReservedSglangDecode {
         let allocated_tokens = kv.allocated_tokens;
         let prompt_tokens = request.prompt_tokens.clone();
         let alloc = kv_manager.activate_destination(kv, &prompt_tokens);
-        request.last_node = Some(alloc.last_node);
-        request.kv_indices = alloc.kv_indices;
+        request.kv_lease = alloc.lease;
         request.materialized_tokens = request.prompt_len();
-        request.cached_tokens = request.page_aligned_materialized_tokens(block_size);
         request.allocated_tokens = allocated_tokens;
         request.debug_assert_invariants(block_size);
         request
@@ -446,12 +444,7 @@ impl SglangCore {
         let Some(mut request) = request else {
             return false;
         };
-        let capacity_improved = !request.kv_indices.is_empty() || request.last_node.is_some();
-        self.kv_manager
-            .free_indices(&request.kv_indices[request.cached_tokens..]);
-        if let Some(last_node) = request.last_node.take() {
-            self.kv_manager.free_request(last_node);
-        }
+        let capacity_improved = self.kv_manager.abort(std::mem::take(&mut request.kv_lease));
         self.source_holds.remove_request(request_id);
         self.active_destination_handoffs.remove_request(request_id);
         if capacity_improved {

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -52,35 +52,23 @@ pub(super) fn cache_materialized_prefix(
     config: &SglangConfig,
 ) {
     let aligned_tokens = req.page_aligned_materialized_tokens(config.block_size);
-    if aligned_tokens == 0 || aligned_tokens <= req.cached_tokens {
+    if aligned_tokens == 0 || aligned_tokens <= req.cached_tokens() {
         return;
     }
 
-    let last_node = req.last_node.unwrap_or_else(|| {
+    if !req.kv_lease.is_active() {
         panic!(
-            "cache_materialized_prefix: request {} has aligned_tokens={aligned_tokens} but last_node is None",
+            "cache_materialized_prefix: request {} has aligned_tokens={aligned_tokens} but no active KV lease",
             req.uuid
-        )
-    });
+        );
+    }
 
-    let new_last = if aligned_tokens <= req.prompt_len() {
-        kv_manager.cache_unfinished_req(
-            &req.prompt_tokens[..aligned_tokens],
-            &mut req.kv_indices[..aligned_tokens],
-            last_node,
-            req.cached_tokens,
-        )
+    if aligned_tokens <= req.prompt_tokens.len() {
+        kv_manager.extend_cached_prefix(&req.prompt_tokens[..aligned_tokens], &mut req.kv_lease);
     } else {
         let sequence = req.sequence_prefix(aligned_tokens).into_owned();
-        kv_manager.cache_unfinished_req(
-            &sequence,
-            &mut req.kv_indices[..aligned_tokens],
-            last_node,
-            req.cached_tokens,
-        )
-    };
-    req.last_node = Some(new_last);
-    req.cached_tokens = aligned_tokens;
+        kv_manager.extend_cached_prefix(&sequence, &mut req.kv_lease);
+    }
     req.debug_assert_invariants(config.block_size);
 }
 
@@ -124,10 +112,7 @@ fn check_decode_mem_for_burst(
         };
 
         let mut req = running.remove(idx);
-        kv_manager.free_indices(&req.kv_indices[req.cached_tokens..]);
-        if let Some(last_node) = req.last_node.take() {
-            kv_manager.free_request(last_node);
-        }
+        kv_manager.retract(std::mem::take(&mut req.kv_lease));
         req.reset_for_retract();
         req.debug_assert_invariants(config.block_size);
         retracted.push(req);
@@ -181,32 +166,15 @@ pub(super) fn cleanup_completed_request(
     block_size: usize,
 ) {
     let tokens_to_cache = floor_to_block(request.current_sequence_len(), block_size);
-    if request.kv_indices.len() > tokens_to_cache {
-        kv_manager.free_indices(&request.kv_indices[tokens_to_cache..]);
-    }
-
-    let Some(last_node) = request.last_node.take() else {
+    if !request.kv_lease.is_active() {
         return;
-    };
-    if tokens_to_cache > 0 {
-        if tokens_to_cache <= request.prompt_len() {
-            kv_manager.cache_finished_req(
-                &request.prompt_tokens[..tokens_to_cache],
-                &request.kv_indices[..tokens_to_cache],
-                last_node,
-                request.cached_tokens,
-            );
-        } else {
-            let sequence = request.sequence_tokens().into_owned();
-            kv_manager.cache_finished_req(
-                &sequence[..tokens_to_cache],
-                &request.kv_indices[..tokens_to_cache],
-                last_node,
-                request.cached_tokens,
-            );
-        }
+    }
+    let lease = std::mem::take(&mut request.kv_lease);
+    if tokens_to_cache <= request.prompt_len() {
+        kv_manager.finish(&request.prompt_tokens[..tokens_to_cache], lease);
     } else {
-        kv_manager.free_request(last_node);
+        let sequence = request.sequence_tokens().into_owned();
+        kv_manager.finish(&sequence[..tokens_to_cache], lease);
     }
 }
 
@@ -341,11 +309,7 @@ pub(super) fn simulate_decode_step_with_sampler(
     for (idx, (req, burst)) in running.iter_mut().zip(sampled_bursts).enumerate() {
         for _ in 0..burst {
             let crossing_page_boundary = req.current_sequence_len() + 1 > req.allocated_tokens;
-            let last_idx = req.kv_indices.last().copied();
-            let new_idx = reservation.take();
-            kv_manager.publish_decode_token(new_idx, last_idx);
-
-            req.kv_indices.push(new_idx);
+            kv_manager.extend_decode(&mut req.kv_lease, &mut reservation);
             if crossing_page_boundary {
                 req.allocated_tokens += config.block_size;
             }

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -63,13 +63,22 @@ pub(super) fn cache_materialized_prefix(
         )
     });
 
-    let sequence = req.sequence_prefix(aligned_tokens);
-    let new_last = kv_manager.cache_unfinished_req(
-        &sequence,
-        &mut req.kv_indices[..aligned_tokens],
-        last_node,
-        req.cached_tokens,
-    );
+    let new_last = if aligned_tokens <= req.prompt_len() {
+        kv_manager.cache_unfinished_req(
+            &req.prompt_tokens[..aligned_tokens],
+            &mut req.kv_indices[..aligned_tokens],
+            last_node,
+            req.cached_tokens,
+        )
+    } else {
+        let sequence = req.sequence_prefix(aligned_tokens).into_owned();
+        kv_manager.cache_unfinished_req(
+            &sequence,
+            &mut req.kv_indices[..aligned_tokens],
+            last_node,
+            req.cached_tokens,
+        )
+    };
     req.last_node = Some(new_last);
     req.cached_tokens = aligned_tokens;
     req.debug_assert_invariants(config.block_size);
@@ -171,8 +180,7 @@ pub(super) fn cleanup_completed_request(
     kv_manager: &mut SglangKvManager,
     block_size: usize,
 ) {
-    let sequence = request.sequence_tokens();
-    let tokens_to_cache = floor_to_block(sequence.len(), block_size);
+    let tokens_to_cache = floor_to_block(request.current_sequence_len(), block_size);
     if request.kv_indices.len() > tokens_to_cache {
         kv_manager.free_indices(&request.kv_indices[tokens_to_cache..]);
     }
@@ -181,12 +189,22 @@ pub(super) fn cleanup_completed_request(
         return;
     };
     if tokens_to_cache > 0 {
-        kv_manager.cache_finished_req(
-            &sequence[..tokens_to_cache],
-            &request.kv_indices[..tokens_to_cache],
-            last_node,
-            request.cached_tokens,
-        );
+        if tokens_to_cache <= request.prompt_len() {
+            kv_manager.cache_finished_req(
+                &request.prompt_tokens[..tokens_to_cache],
+                &request.kv_indices[..tokens_to_cache],
+                last_node,
+                request.cached_tokens,
+            );
+        } else {
+            let sequence = request.sequence_tokens().into_owned();
+            kv_manager.cache_finished_req(
+                &sequence[..tokens_to_cache],
+                &request.kv_indices[..tokens_to_cache],
+                last_node,
+                request.cached_tokens,
+            );
+        }
     } else {
         kv_manager.free_request(last_node);
     }

--- a/lib/mocker/src/scheduler/sglang/policy.rs
+++ b/lib/mocker/src/scheduler/sglang/policy.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashSet, VecDeque};
+use std::collections::VecDeque;
 
-use crate::cache::radix_cache::RadixCache;
 use crate::kv_manager::SglangKvManager;
+use rustc_hash::FxHashSet;
 
 use super::config::{
     IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD, IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD,
@@ -25,30 +25,19 @@ pub(super) fn apply_schedule_policy(
             }
 
             let page_size = config.block_size.max(1);
-            let total_tokens = waiting
-                .iter()
-                .map(SglangRequest::current_sequence_len)
-                .sum::<usize>()
-                .max(page_size);
-            let mut waiting_queue_cache = RadixCache::new(total_tokens, page_size);
-            let mut temporary_deprioritized = HashSet::new();
+            let duplicate_prefix_len =
+                IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD.div_ceil(page_size) * page_size;
+            let mut waiting_prefixes = FxHashSet::default();
             let mut scored = Vec::with_capacity(waiting.len());
 
             for req in waiting.drain(..) {
                 let sequence = req.sequence_tokens();
                 let prefix_len = kv_manager.cache().prefix_match_len(&sequence);
+                let deprioritized = prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD
+                    && sequence.len() >= duplicate_prefix_len
+                    && !waiting_prefixes.insert(sequence[..duplicate_prefix_len].to_vec());
 
-                if prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD {
-                    let in_batch_prefix = waiting_queue_cache.prefix_match_len(&sequence);
-                    if in_batch_prefix >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD {
-                        temporary_deprioritized.insert(req.uuid);
-                    } else if !sequence.is_empty() {
-                        let values: Vec<usize> = (0..sequence.len()).collect();
-                        waiting_queue_cache.insert(&sequence, &values);
-                    }
-                }
-
-                scored.push((prefix_len, temporary_deprioritized.contains(&req.uuid), req));
+                scored.push((prefix_len, deprioritized, req));
             }
 
             scored.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)));

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -106,6 +106,8 @@ pub(super) fn get_new_batch_prefill(
         let chunk_end = req.materialized_tokens + chunk_tokens;
         let old_allocated_tokens = req.allocated_tokens;
         let prev_node = req.last_node.take();
+        let prefix_indices =
+            (req.materialized_tokens > 0).then(|| std::mem::take(&mut req.kv_indices));
         let alloc_tokens = req.sequence_prefix(chunk_end);
         let actual_new_tokens = alloc_tokens.len().saturating_sub(req.materialized_tokens);
         let available = kv_manager.cache().token_pool.available();
@@ -120,12 +122,18 @@ pub(super) fn get_new_batch_prefill(
                     req.uuid, req.materialized_tokens
                 )
             });
-            kv_manager.allocate_after_prefix(
+            match kv_manager.allocate_after_prefix(
                 &alloc_tokens,
                 req.materialized_tokens,
-                &req.kv_indices[..req.materialized_tokens],
+                prefix_indices.expect("materialized request must retain its KV indices"),
                 last_node,
-            )
+            ) {
+                Ok(alloc) => Some(alloc),
+                Err(indices) => {
+                    req.kv_indices = indices;
+                    None
+                }
+            }
         } else {
             kv_manager.allocate_for_request(&alloc_tokens)
         };

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -105,9 +105,7 @@ pub(super) fn get_new_batch_prefill(
 
         let chunk_end = req.materialized_tokens + chunk_tokens;
         let old_allocated_tokens = req.allocated_tokens;
-        let prev_node = req.last_node.take();
-        let prefix_indices =
-            (req.materialized_tokens > 0).then(|| std::mem::take(&mut req.kv_indices));
+        let mut lease = std::mem::take(&mut req.kv_lease);
         let alloc_tokens = req.sequence_prefix(chunk_end);
         let actual_new_tokens = alloc_tokens.len().saturating_sub(req.materialized_tokens);
         let available = kv_manager.cache().token_pool.available();
@@ -115,64 +113,48 @@ pub(super) fn get_new_batch_prefill(
             kv_manager.evict(actual_new_tokens - available);
         }
 
-        let alloc = if req.materialized_tokens > 0 {
-            let last_node = prev_node.unwrap_or_else(|| {
+        let prefix_len = if req.materialized_tokens > 0 {
+            if !lease.is_active() {
                 panic!(
-                    "prefill: request {} has materialized_tokens={} but last_node is None",
+                    "prefill: request {} has materialized_tokens={} but no active KV lease",
                     req.uuid, req.materialized_tokens
-                )
-            });
-            match kv_manager.allocate_after_prefix(
-                &alloc_tokens,
-                req.materialized_tokens,
-                prefix_indices.expect("materialized request must retain its KV indices"),
-                last_node,
-            ) {
-                Ok(alloc) => Some(alloc),
-                Err(indices) => {
-                    req.kv_indices = indices;
-                    None
-                }
+                );
             }
+            kv_manager
+                .extend_allocation(&alloc_tokens, &mut lease)
+                .then_some(req.materialized_tokens)
         } else {
-            kv_manager.allocate_for_request(&alloc_tokens)
+            kv_manager.allocate_for_request(&alloc_tokens).map(|alloc| {
+                lease = alloc.lease;
+                alloc.prefix_len
+            })
         };
 
-        let Some(alloc) = alloc else {
-            req.last_node = prev_node;
+        let Some(prefix_len) = prefix_len else {
+            req.kv_lease = lease;
             rejected.push_back(req);
             oom = true;
             break;
         };
-        let tokens_computed = chunk_end.saturating_sub(alloc.prefix_len);
+        let tokens_computed = chunk_end.saturating_sub(prefix_len);
 
-        if let Some(node) = prev_node {
-            kv_manager.free_request(node);
-        }
-
-        req.last_node = Some(alloc.last_node);
-        // Cache-hit prefix pages are radix-owned; retraction may free only the
-        // newly allocated suffix.
-        if req.materialized_tokens == 0 {
-            req.cached_tokens = alloc.prefix_len;
-        }
-        req.kv_indices = alloc.kv_indices;
+        req.kv_lease = lease;
         req.materialized_tokens = chunk_end;
         req.allocated_tokens = ceil_to_block(chunk_end, config.block_size);
         req.debug_assert_invariants(config.block_size);
 
         admissions.push(AdmissionEvent {
             uuid: req.uuid,
-            reused_input_tokens: alloc.prefix_len,
+            reused_input_tokens: prefix_len,
         });
         prefill_fpm.push(PrefillFpmItem {
             prompt_len: req.prompt_len(),
             tokens_computed,
-            prefix_tokens: alloc.prefix_len,
+            prefix_tokens: prefix_len,
         });
 
         total_isl += chunk_end;
-        total_prefix += alloc.prefix_len;
+        total_prefix += prefix_len;
         rem_total_tokens -= (req.allocated_tokens - old_allocated_tokens + output_reserve) as f64;
         rem_input_tokens -= charged_input_tokens;
         rem_chunk_tokens -= charged_input_tokens;

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -53,16 +54,20 @@ impl SglangRequest {
         self.materialized_tokens / block_size * block_size
     }
 
-    pub(super) fn sequence_tokens(&self) -> Vec<u64> {
+    pub(super) fn sequence_tokens(&self) -> Cow<'_, [u64]> {
+        if self.output_ids.is_empty() {
+            return Cow::Borrowed(&self.prompt_tokens);
+        }
+
         let mut sequence = self.prompt_tokens.clone();
         sequence.extend(self.output_ids.iter().map(|&token| token as u64));
-        sequence
+        Cow::Owned(sequence)
     }
 
-    pub(super) fn sequence_prefix(&self, len: usize) -> Vec<u64> {
+    pub(super) fn sequence_prefix(&self, len: usize) -> Cow<'_, [u64]> {
         let prompt_len = self.prompt_len();
         if len <= prompt_len {
-            return self.prompt_tokens[..len].to_vec();
+            return Cow::Borrowed(&self.prompt_tokens[..len]);
         }
 
         let mut prefix = self.prompt_tokens.clone();
@@ -71,7 +76,7 @@ impl SglangRequest {
                 .iter()
                 .map(|&token| token as u64),
         );
-        prefix
+        Cow::Owned(prefix)
     }
 
     pub(super) fn next_output_token(&self) -> u32 {

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -7,20 +7,18 @@ use std::hash::{Hash, Hasher};
 
 use uuid::Uuid;
 
-use crate::cache::radix_cache::NodeId;
 use crate::common::protocols::DirectRequest;
+use crate::kv_manager::sglang_backend::ActiveKvLease;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub(super) struct SglangRequest {
     pub(super) uuid: Uuid,
     pub(super) prompt_tokens: Vec<u64>,
     pub(super) max_output_tokens: usize,
     pub(super) planned_output_ids: Option<Vec<u32>>,
     pub(super) output_ids: Vec<u32>,
-    pub(super) last_node: Option<NodeId>,
-    pub(super) kv_indices: Vec<usize>,
+    pub(super) kv_lease: ActiveKvLease,
     pub(super) materialized_tokens: usize,
-    pub(super) cached_tokens: usize,
     pub(super) allocated_tokens: usize,
 }
 
@@ -47,7 +45,20 @@ impl SglangRequest {
     }
 
     pub(super) fn extra_reserved_tokens(&self) -> usize {
-        self.allocated_tokens.saturating_sub(self.kv_indices.len())
+        self.allocated_tokens.saturating_sub(self.kv_len())
+    }
+
+    #[cfg(test)]
+    pub(super) fn kv_indices(&self) -> &[usize] {
+        self.kv_lease.indices()
+    }
+
+    pub(super) fn kv_len(&self) -> usize {
+        self.kv_lease.len()
+    }
+
+    pub(super) fn cached_tokens(&self) -> usize {
+        self.kv_lease.cached_tokens()
     }
 
     pub(super) fn page_aligned_materialized_tokens(&self, block_size: usize) -> usize {
@@ -105,10 +116,10 @@ impl SglangRequest {
             let block_size = _block_size;
             let sequence_len = self.current_sequence_len();
             debug_assert!(
-                self.cached_tokens <= self.materialized_tokens,
+                self.cached_tokens() <= self.materialized_tokens,
                 "request {} cached {} tokens but materialized {}",
                 self.uuid,
-                self.cached_tokens,
+                self.cached_tokens(),
                 self.materialized_tokens
             );
             debug_assert!(
@@ -118,11 +129,11 @@ impl SglangRequest {
                 self.materialized_tokens
             );
             debug_assert_eq!(
-                self.kv_indices.len(),
+                self.kv_len(),
                 self.materialized_tokens,
                 "request {} has {} kv indices but {} materialized tokens",
                 self.uuid,
-                self.kv_indices.len(),
+                self.kv_len(),
                 self.materialized_tokens
             );
             debug_assert!(
@@ -133,11 +144,11 @@ impl SglangRequest {
                 self.materialized_tokens
             );
             debug_assert_eq!(
-                self.cached_tokens % block_size,
+                self.cached_tokens() % block_size,
                 0,
                 "request {} cached tokens {} are not page-aligned to block size {block_size}",
                 self.uuid,
-                self.cached_tokens
+                self.cached_tokens()
             );
             debug_assert!(
                 self.allocated_tokens == 0 || self.allocated_tokens.is_multiple_of(block_size),
@@ -152,21 +163,19 @@ impl SglangRequest {
                 self.extra_reserved_tokens()
             );
             debug_assert_eq!(
-                self.last_node.is_some(),
+                self.kv_lease.is_active(),
                 self.materialized_tokens > 0,
-                "request {} has last_node={} but materialized_tokens={}",
+                "request {} has active_kv={} but materialized_tokens={}",
                 self.uuid,
-                self.last_node.is_some(),
+                self.kv_lease.is_active(),
                 self.materialized_tokens
             );
         }
     }
 
     pub(super) fn reset_for_retract(&mut self) {
-        self.last_node = None;
-        self.kv_indices.clear();
+        debug_assert!(!self.kv_lease.is_active());
         self.materialized_tokens = 0;
-        self.cached_tokens = 0;
         self.allocated_tokens = 0;
     }
 }
@@ -182,10 +191,8 @@ impl From<DirectRequest> for SglangRequest {
                 .map_or(req.max_output_tokens, Vec::len),
             planned_output_ids: req.output_token_ids,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
+            kv_lease: ActiveKvLease::default(),
             materialized_tokens: 0,
-            cached_tokens: 0,
             allocated_tokens: 0,
         }
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -25,6 +25,7 @@ use crate::common::protocols::{
     SglangArgs,
 };
 use crate::kv_manager::SglangKvManager;
+use crate::kv_manager::sglang_backend::ActiveKvLease;
 use crate::scheduler::test_utils::{
     CapturingFpmSink, RouterIndexerHarness, nth_stored_hashes, removed_event_count, stored_hashes,
 };
@@ -79,10 +80,8 @@ fn make_decoded_request(
         max_output_tokens,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: Some(alloc.last_node),
-        kv_indices: alloc.kv_indices,
+        kv_lease: alloc.lease,
         materialized_tokens: prompt_len,
-        cached_tokens: 0,
         allocated_tokens: ceil_to_block(prompt_len, config.block_size),
     }];
     let result = simulate_decode_step(&mut running, kv_manager, config, 0.0, false);
@@ -129,10 +128,8 @@ fn zero_output_completion_survives_decode_reservation_failure() {
             max_output_tokens: 0,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(zero_alloc.last_node),
-            kv_indices: zero_alloc.kv_indices,
+            kv_lease: zero_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         },
         SglangRequest {
@@ -141,10 +138,8 @@ fn zero_output_completion_survives_decode_reservation_failure() {
             max_output_tokens: 1,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(normal_alloc.last_node),
-            kv_indices: normal_alloc.kv_indices,
+            kv_lease: normal_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         },
     ];
@@ -184,22 +179,16 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     let prompt = vec![1, 2, 3, 4];
 
     let cached = kv_manager.allocate_for_request(&prompt).unwrap();
-    kv_manager.cache_finished_req(
-        &prompt,
-        &cached.kv_indices,
-        cached.last_node,
-        cached.prefix_len,
-    );
+    let cached_indices = cached.lease.indices().to_vec();
+    kv_manager.finish(&prompt, cached.lease);
     let mut waiting = VecDeque::from([SglangRequest {
         uuid: Uuid::from_u128(90_002),
         prompt_tokens: prompt.clone(),
         max_output_tokens: 1,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: None,
-        kv_indices: Vec::new(),
         materialized_tokens: 0,
-        cached_tokens: 0,
+        kv_lease: ActiveKvLease::default(),
         allocated_tokens: 0,
     }]);
     let req = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[])
@@ -207,8 +196,8 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         .pop()
         .unwrap();
 
-    assert_eq!(req.cached_tokens, prompt.len());
-    assert_eq!(req.kv_indices, cached.kv_indices);
+    assert_eq!(req.cached_tokens(), prompt.len());
+    assert_eq!(req.kv_indices(), cached_indices);
 
     // Leave four free slots and one block of page growth for the cache-hit
     // request. Reserved page overhead makes check_decode_mem retract it, while
@@ -221,10 +210,8 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         max_output_tokens: 1,
         planned_output_ids: None,
         output_ids: Vec::new(),
-        last_node: Some(blocker_alloc.last_node),
-        kv_indices: blocker_alloc.kv_indices,
+        kv_lease: blocker_alloc.lease,
         materialized_tokens: 3,
-        cached_tokens: 0,
         allocated_tokens: 4,
     };
     buffer.drain();
@@ -753,7 +740,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("activated request must be prebuilt-ready");
-        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_eq!(ready.kv_indices(), reserved_indices);
         assert_eq!(destination.running.len(), 1);
         assert!(destination.kv_manager.cache().protected_size >= protected_before_activation);
         let activation_stores = stored_hashes(&destination.drain_kv_events());
@@ -778,7 +765,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("full running batch must keep request ready");
-        assert_eq!(ready.kv_indices, reserved_indices);
+        assert_eq!(ready.kv_indices(), reserved_indices);
         assert_no_republished_stores(&activation_stores, &stored_hashes(&blocked.kv_events));
 
         let blocker_terminal = execute(&mut destination, blocked.end_ms);
@@ -809,7 +796,7 @@ mod destination_lifecycle {
             .iter()
             .find(|request| request.uuid == logical_uuid)
             .expect("prebuilt request must enter the running batch");
-        assert!(running.kv_indices.starts_with(&reserved_indices));
+        assert!(running.kv_indices().starts_with(&reserved_indices));
         assert_no_republished_stores(&activation_stores, &stored_hashes(&admitted.kv_events));
 
         let terminal = execute(&mut destination, admitted.end_ms);
@@ -1031,10 +1018,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1043,10 +1028,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: vec![6, 7],
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1078,10 +1061,8 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             });
         }
@@ -1092,10 +1073,8 @@ mod scheduling {
             max_output_tokens: 1,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         });
 
@@ -1160,10 +1139,8 @@ mod core_behavior {
             max_output_tokens: 3,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1192,10 +1169,8 @@ mod core_behavior {
             max_output_tokens: 2,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1227,10 +1202,8 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1239,10 +1212,8 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 output_ids: Vec::new(),
-                last_node: None,
-                kv_indices: Vec::new(),
                 materialized_tokens: 0,
-                cached_tokens: 0,
+                kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1265,19 +1236,18 @@ mod core_behavior {
                 .unwrap(),
         );
         let mut kv_manager = SglangKvManager::new(64, 4, KvEventPublishers::default(), 0);
-        let alloc = kv_manager
+        let mut alloc = kv_manager
             .allocate_for_request(&[1, 2, 3, 4, 5, 6])
             .unwrap();
+        kv_manager.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
             prompt_tokens: vec![1, 2, 3, 4, 5, 6],
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(alloc.last_node),
-            kv_indices: alloc.kv_indices,
+            kv_lease: alloc.lease,
             materialized_tokens: 6,
-            cached_tokens: 4,
             allocated_tokens: 8,
         }];
 
@@ -1320,10 +1290,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(base_alloc.last_node),
-            kv_indices: base_alloc.kv_indices,
+            kv_lease: base_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1335,10 +1303,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(fast_alloc.last_node),
-            kv_indices: fast_alloc.kv_indices,
+            kv_lease: fast_alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1386,10 +1352,8 @@ mod core_behavior {
                 max_output_tokens: 10,
                 planned_output_ids: None,
                 output_ids: vec![11, 12, 13],
-                last_node: None,
-                kv_indices: first,
+                kv_lease: ActiveKvLease::from_parts(first, 4, kv_manager.cache().root()),
                 materialized_tokens: 7,
-                cached_tokens: 4,
                 allocated_tokens: 8,
             },
             SglangRequest {
@@ -1398,10 +1362,8 @@ mod core_behavior {
                 max_output_tokens: 10,
                 planned_output_ids: None,
                 output_ids: vec![21],
-                last_node: None,
-                kv_indices: second,
+                kv_lease: ActiveKvLease::from_parts(second, 4, kv_manager.cache().root()),
                 materialized_tokens: 5,
-                cached_tokens: 4,
                 allocated_tokens: 8,
             },
         ];
@@ -1410,7 +1372,7 @@ mod core_behavior {
         assert_eq!(retracted.len(), 1);
         assert_eq!(retracted[0].output_ids, vec![21]);
         assert_eq!(retracted[0].materialized_tokens, 0);
-        assert!(retracted[0].kv_indices.is_empty());
+        assert!(retracted[0].kv_indices().is_empty());
     }
 
     #[test]
@@ -1431,10 +1393,8 @@ mod core_behavior {
             max_output_tokens: 4,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: Some(alloc.last_node),
-            kv_indices: alloc.kv_indices,
+            kv_lease: alloc.lease,
             materialized_tokens: 4,
-            cached_tokens: 0,
             allocated_tokens: 4,
         }];
 
@@ -1729,10 +1689,8 @@ mod router_events {
             max_output_tokens: 2,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         };
         let first_output = expected_request.next_output_token();
@@ -1831,10 +1789,8 @@ mod router_events {
             max_output_tokens: 3,
             planned_output_ids: None,
             output_ids: Vec::new(),
-            last_node: None,
-            kv_indices: Vec::new(),
             materialized_tokens: 0,
-            cached_tokens: 0,
+            kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
         }]);
 


### PR DESCRIPTION
## Summary

Stacked on #12025.

- Compress SGLang mocker radix-cache growth and avoid per-token leaf insertion, repeated prefix materialization, and redundant KV-index copies on scheduler hot paths.
- Add a move-only `ActiveKvLease` that keeps KV indices, the cached-token boundary, and the protected radix tail in one ownership object. `SglangKvManager` now owns extend, finish, abort, and retract transitions so scheduler callers cannot independently free the wrong suffix or unlock an inconsistent path.
- Preserve the optimized layout: the lease has exactly the footprint of the previous three fields and adds no refcount, mutex, heap allocation, or per-token outer-`Option` branch.
- Add regressions for duplicate canonicalization/missing-parent behavior, retained-tail ownership, cache-owned prefix indices, lease layout, and suffix-only retraction.

Reviewer guide: the compressed-radix behavior is in `radix_cache.rs`; ownership and state transitions are concentrated in `sglang_backend.rs`; the remaining scheduler changes replace direct field/free/unlock manipulation with those manager APIs. Upstream SGLang data-structure parity is intentionally out of scope.

## Validation

- Canonical 1,000-request Mooncake replay, 10 alternating paired trials: median wall time fell from `32.205051s` to `19.394082s` (`39.779%` ratio-of-medians improvement, `40.205%` median paired improvement, `1.661x` speedup). Request and token totals were unchanged: 1,000 completions, 9,792,030 input tokens, and 199,084 output tokens.
- Lease-only overhead campaign, 12 alternating paired 50-iteration trials: six wins and six losses, `-0.140%` median paired delta, with all deterministic replay fields matching. Samply showed no lease-only transition among the top 40 self-time entries.
- Samply profiling reduced radix insertion sampled CPU from `2.190s` to `0.227s` and total sampled CPU from `9.889s` to `5.656s` in the local profiling workload.
- `cargo test -p dynamo-mocker`: 553 passed, 1 ignored.
- The repository Python marker hook could not run against the stale local `_core.abi3.so` because it lacks `FrontendExtensionContext`; all other commit hooks passed.
