### PR TITLE
fix(sglang): register all sidecar DP ranks

### DIFF
--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -565,13 +565,10 @@ fn build_engine_config(
         .get("enable_dp_attention")
         .and_then(Value::as_bool)
         .unwrap_or(false);
-    let nnodes = client::json_u32(&discovery.server_info, "nnodes")
-        .unwrap_or(1)
-        .max(1);
-    let node_rank = client::json_u32(&discovery.server_info, "node_rank").unwrap_or(0);
     let (data_parallel_start_rank, data_parallel_size) = if enable_dp_attention && dp_size > 1 {
-        let local_size = (dp_size / nnodes).max(1);
-        (Some(node_rank.saturating_mul(local_size)), Some(local_size))
+        // Native gRPC is exposed by the rank-zero frontend for the complete
+        // multi-node SGLang endpoint, so one sidecar registers every DP rank.
+        (Some(0), Some(dp_size))
     } else {
         (Some(0), Some(1))
     };
@@ -610,7 +607,9 @@ fn build_engine_config(
 mod tests {
     use serde_json::json;
 
-    use super::{Discovery, resolve_bootstrap_host_with_local};
+    use super::{
+        DisaggregationMode, Discovery, build_engine_config, resolve_bootstrap_host_with_local,
+    };
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
         Discovery {
@@ -687,5 +686,25 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("--bootstrap-host"));
+    }
+
+    #[test]
+    fn multi_node_grpc_endpoint_registers_all_dp_ranks() {
+        let config = build_engine_config(
+            &discovery(json!({
+                "dp_size": 16,
+                "enable_dp_attention": true,
+                "nnodes": 4,
+                "node_rank": 0,
+            })),
+            DisaggregationMode::Decode,
+            None,
+            None,
+        )
+        .unwrap();
+        let registration = config.llm.unwrap();
+
+        assert_eq!(registration.data_parallel_start_rank, Some(0));
+        assert_eq!(registration.data_parallel_size, Some(16));
     }
 }


### PR DESCRIPTION
## Overview:

Register the full endpoint-level data-parallel rank range when the Dynamo SGLang sidecar connects to a multi-node native-gRPC SGLang server.

The native gRPC endpoint is exposed only by the rank-zero SGLang frontend, but the sidecar previously divided `dp_size` by `nnodes` and advertised only the leader node's local ranks. For a DP16 decoder spread across four nodes, Dynamo discovered only DP0–3 and never routed requests to DP4–15.

## Details:

- Advertise `data_parallel_start_rank = 0` and the complete endpoint `data_parallel_size` for DP-attention workers.
- Keep single-rank registration unchanged when DP attention is disabled.
- Add a regression test for a DP16 decoder distributed over four nodes.
- Preserve the existing one-sidecar-per-endpoint launch model; no SGLang gRPC API change is required.

Validation:
- `cargo fmt --all -- --check`
- `cargo test -p dynamo-sglang-sidecar` (23 unit tests and 1 executable contract test passed)
- Lyris GB300 C1024 DSV4 run `2464317`: 10,240/10,240 requests succeeded, Dynamo registered DP0–15, and follower decoder nodes processed batches.

## Where should the reviewer start?

`lib/sidecar/sglang/src/engine.rs`, specifically `build_engine_config` and `multi_node_grpc_endpoint_registers_all_dp_ranks`.

## Related Issues

**🔗 This PR is linked to an issue:**
- Closes [DIS-2483](https://linear.app/nvidia/issue/DIS-2483/register-all-dp-ranks-for-multi-node-sglang-sidecar-endpoints)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-node distributed processing setup for native gRPC deployments.
  * Ensured all distributed processing ranks are registered consistently, improving coordination and reliability across nodes.
  * Added coverage for multi-node rank registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->