### PR TITLE
perf(mocker): streamline SGLang radix scheduling [DYN-3851]

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -32,17 +32,23 @@ impl TokenPool {
 
     /// Allocate `n` token slots. Returns `None` if not enough free slots.
     pub fn allocate(&mut self, n: usize) -> Option<Vec<usize>> {
+        let mut indices = Vec::new();
+        self.allocate_into(n, &mut indices).then_some(indices)
+    }
+
+    /// Append `n` allocated token slots to `indices` without an intermediate vector.
+    pub fn allocate_into(&mut self, n: usize, indices: &mut Vec<usize>) -> bool {
         if self.available() < n {
-            return None;
+            return false;
         }
 
+        indices.reserve(n);
         let recycled = n.min(self.free.len());
         let fresh = n - recycled;
-        let mut indices = Vec::with_capacity(n);
         indices.extend(self.free.drain(self.free.len() - recycled..));
         indices.extend(self.next_fresh..self.next_fresh + fresh);
         self.next_fresh += fresh;
-        Some(indices)
+        true
     }
 
     /// Return token slots to the free pool.
@@ -62,10 +68,10 @@ impl TokenPool {
 /// A single node in the radix tree.
 pub struct TreeNode {
     /// Children keyed by `child.key[..page_size]` (a "child key").
-    pub children: FxHashMap<Vec<u64>, NodeId>,
+    pub children: FxHashMap<Vec<u32>, NodeId>,
     pub parent: Option<NodeId>,
     /// Token IDs stored at this edge.
-    pub key: Vec<u64>,
+    pub key: Vec<u32>,
     /// KV cache pool token indices. Length = `key.len()`.
     pub value: Vec<usize>,
     /// Walk-to-root reference count (protected when > 0).
@@ -123,7 +129,7 @@ impl RadixCache {
         self.nodes.len()
     }
 
-    fn child_key<'a>(&self, key: &'a [u64]) -> &'a [u64] {
+    fn child_key<'a>(&self, key: &'a [u32]) -> &'a [u32] {
         &key[..self.page_size.min(key.len())]
     }
 
@@ -131,7 +137,7 @@ impl RadixCache {
         len / self.page_size * self.page_size
     }
 
-    fn key_match(&self, key0: &[u64], key1: &[u64]) -> usize {
+    fn key_match(&self, key0: &[u32], key1: &[u32]) -> usize {
         if self.page_size == 1 {
             key0.iter().zip(key1).take_while(|(a, b)| a == b).count()
         } else {
@@ -147,7 +153,7 @@ impl RadixCache {
         }
     }
 
-    pub fn match_prefix(&mut self, key: &[u64]) -> (usize, NodeId) {
+    pub fn match_prefix(&mut self, key: &[u32]) -> (usize, NodeId) {
         let now = Instant::now();
         self.nodes[self.root].last_access_time = now;
 
@@ -185,7 +191,7 @@ impl RadixCache {
 
     /// Read-only prefix match length (does not mutate timestamps or split nodes).
     /// Used for LPM scheduling scoring.
-    pub fn prefix_match_len(&self, key: &[u64]) -> usize {
+    pub fn prefix_match_len(&self, key: &[u32]) -> usize {
         let mut current = self.root;
         let mut matched: usize = 0;
 
@@ -213,7 +219,7 @@ impl RadixCache {
     }
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
-    pub fn insert(&mut self, key: &[u64], value: &[usize]) -> NodeId {
+    pub fn insert(&mut self, key: &[u32], value: &[usize]) -> NodeId {
         self.insert_from(self.root, 0, key, value, false)
     }
 
@@ -226,7 +232,7 @@ impl RadixCache {
         &mut self,
         prefix_node: NodeId,
         prefix_len: usize,
-        key: &[u64],
+        key: &[u32],
         value: &[usize],
     ) -> NodeId {
         self.insert_from(prefix_node, prefix_len, key, value, true)
@@ -236,7 +242,7 @@ impl RadixCache {
         &mut self,
         start_node: NodeId,
         prefix_len: usize,
-        key: &[u64],
+        key: &[u32],
         value: &[usize],
         allow_locked_tail_extension: bool,
     ) -> NodeId {
@@ -329,7 +335,7 @@ impl RadixCache {
     fn extend_leaf(
         &mut self,
         node_id: NodeId,
-        key: &[u64],
+        key: &[u32],
         value: &[usize],
         now: Instant,
     ) -> NodeId {
@@ -394,7 +400,7 @@ impl RadixCache {
         inter_id
     }
 
-    fn create_child(&mut self, parent_id: NodeId, key: &[u64], value: &[usize]) -> NodeId {
+    fn create_child(&mut self, parent_id: NodeId, key: &[u32], value: &[usize]) -> NodeId {
         let new_node = TreeNode {
             children: FxHashMap::default(),
             parent: Some(parent_id),
@@ -548,6 +554,7 @@ mod tests {
     fn test_token_pool_allocate_and_free() {
         let mut pool = TokenPool::new(10);
         assert_eq!(pool.available(), 10);
+        assert!(pool.allocate(usize::MAX).is_none());
         let a = pool.allocate(3).unwrap();
         assert_eq!(a.len(), 3);
         assert_eq!(pool.available(), 7);
@@ -558,6 +565,22 @@ mod tests {
         assert_eq!(pool.available(), 3);
         pool.free(&b);
         assert_eq!(pool.available(), 10);
+    }
+
+    #[test]
+    fn test_allocate_into_failure_is_atomic() {
+        let mut pool = TokenPool::new(6);
+        let allocated = pool.allocate(4).unwrap();
+        pool.free(&allocated[1..3]);
+        let available_before = pool.available();
+        let mut destination = vec![99];
+
+        assert!(!pool.allocate_into(available_before + 1, &mut destination));
+        assert_eq!(destination, vec![99]);
+        assert_eq!(pool.available(), available_before);
+
+        let subsequent = pool.allocate(available_before).unwrap();
+        assert_eq!(subsequent, vec![1, 2, 4, 5]);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -4,8 +4,6 @@
 //! SGLang KV manager — wraps [`RadixCache`] with request-level lifecycle
 //! operations and KV event publishing.
 
-use std::collections::VecDeque;
-
 use crate::cache::radix_cache::{NodeId, RadixCache};
 use crate::common::kv_cache_trace;
 use crate::common::protocols::KvEventPublishers;
@@ -88,7 +86,8 @@ pub struct SglangKvManager {
 }
 
 pub struct DecodeTokenReservation {
-    indices: VecDeque<usize>,
+    indices: Vec<usize>,
+    next: usize,
 }
 
 pub struct SglangDestinationReservation {
@@ -116,13 +115,16 @@ impl SglangDestinationReservation {
 
 impl DecodeTokenReservation {
     fn take(&mut self) -> usize {
-        self.indices
-            .pop_front()
-            .expect("reserved decode token allocation must be infallible")
+        let idx = *self
+            .indices
+            .get(self.next)
+            .expect("reserved decode token allocation must be infallible");
+        self.next += 1;
+        idx
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.indices.len()
+        self.indices.len() - self.next
     }
 }
 
@@ -153,17 +155,21 @@ impl SglangKvManager {
 
     /// Try to allocate KV cache for a new request.
     /// Returns `None` if the pool doesn't have enough token slots (OOM).
-    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u64]) -> Option<AllocResult> {
+    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u32]) -> Option<AllocResult> {
         let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
 
         let new_tokens = token_ids.len() - prefix_len;
 
         let prefix_indices = self.collect_path_indices(last_node);
 
-        let new_indices = self.cache.token_pool.allocate(new_tokens)?;
-
         let mut kv_indices = prefix_indices;
-        kv_indices.extend_from_slice(&new_indices);
+        if !self
+            .cache
+            .token_pool
+            .allocate_into(new_tokens, &mut kv_indices)
+        {
+            return None;
+        }
 
         self.cache.inc_lock_ref(last_node);
 
@@ -189,7 +195,7 @@ impl SglangKvManager {
     /// page-aligned cached prefix.
     pub(crate) fn extend_allocation(
         &mut self,
-        token_ids: &[u64],
+        token_ids: &[u32],
         lease: &mut ActiveKvLease,
     ) -> bool {
         let prefix_len = lease.kv_indices.len();
@@ -200,17 +206,20 @@ impl SglangKvManager {
             token_ids.len()
         );
         let new_tokens = token_ids.len() - prefix_len;
-        let Some(new_indices) = self.cache.token_pool.allocate(new_tokens) else {
+        if !self
+            .cache
+            .token_pool
+            .allocate_into(new_tokens, &mut lease.kv_indices)
+        {
             return false;
-        };
+        }
 
-        lease.kv_indices.extend_from_slice(&new_indices);
         self.publish_stored_event(token_ids, &lease.kv_indices, prefix_len);
         self.log_trace("allocation", new_tokens);
         true
     }
 
-    pub(crate) fn extend_cached_prefix(&mut self, token_ids: &[u64], lease: &mut ActiveKvLease) {
+    pub(crate) fn extend_cached_prefix(&mut self, token_ids: &[u32], lease: &mut ActiveKvLease) {
         let complete_len = token_ids.len() / self.cache.page_size() * self.cache.page_size();
         if complete_len <= lease.cached_tokens {
             return;
@@ -244,7 +253,7 @@ impl SglangKvManager {
         lease.kv_indices.push(new_idx);
     }
 
-    pub(crate) fn finish(&mut self, token_ids: &[u64], mut lease: ActiveKvLease) {
+    pub(crate) fn finish(&mut self, token_ids: &[u32], mut lease: ActiveKvLease) {
         let Some(last_node) = lease.last_node.take() else {
             debug_assert!(lease.kv_indices.is_empty());
             debug_assert_eq!(lease.cached_tokens, 0);
@@ -258,8 +267,8 @@ impl SglangKvManager {
             lease.cached_tokens,
             lease.len()
         );
-        let unretained_tail = lease.kv_indices.split_off(complete_len);
-        self.free_indices(&unretained_tail);
+        self.free_indices(&lease.kv_indices[complete_len..]);
+        lease.kv_indices.truncate(complete_len);
 
         if complete_len == 0 {
             self.cache.dec_lock_ref(last_node);
@@ -287,7 +296,7 @@ impl SglangKvManager {
     /// then unlocks the path.
     fn cache_finished_req(
         &mut self,
-        token_ids: &[u64],
+        token_ids: &[u32],
         kv_indices: &[usize],
         last_node: NodeId,
         first_new_token: usize,
@@ -317,7 +326,7 @@ impl SglangKvManager {
     /// subsequent calls.
     fn cache_unfinished_req(
         &mut self,
-        token_ids: &[u64],
+        token_ids: &[u32],
         kv_indices: &mut [usize],
         last_node: NodeId,
         first_new_token: usize,
@@ -337,18 +346,22 @@ impl SglangKvManager {
             self.cache
                 .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
 
-        // A concurrent insert can retain different physical pages for the same prefix.
+        // An interleaved insert can retain different physical pages for the same prefix.
         // Move the active request to canonical pages before releasing its duplicates.
         // Acquire the extended path before releasing the old prefix so
         // destination activation never leaves valid transferred KV unprotected.
-        self.cache.inc_lock_ref(new_last_node);
+        if new_last_node != last_node {
+            self.cache.inc_lock_ref(new_last_node);
+        }
         self.canonicalize_unfinished_indices(
             kv_indices,
             new_last_node,
             first_new_token,
             complete_len,
         );
-        self.cache.dec_lock_ref(last_node);
+        if new_last_node != last_node {
+            self.cache.dec_lock_ref(last_node);
+        }
 
         new_last_node
     }
@@ -366,14 +379,12 @@ impl SglangKvManager {
         self.cache
             .token_pool
             .allocate(count)
-            .map(|indices| DecodeTokenReservation {
-                indices: indices.into(),
-            })
+            .map(|indices| DecodeTokenReservation { indices, next: 0 })
     }
 
     pub(crate) fn reserve_destination(
         &mut self,
-        token_ids: &[u64],
+        token_ids: &[u32],
     ) -> Option<SglangDestinationReservation> {
         let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
         let mut prefix_indices = self.collect_path_indices(last_node);
@@ -412,7 +423,7 @@ impl SglangKvManager {
     pub(crate) fn activate_destination(
         &mut self,
         reservation: SglangDestinationReservation,
-        token_ids: &[u64],
+        token_ids: &[u32],
     ) -> AllocResult {
         let SglangDestinationReservation {
             prefix_len,
@@ -449,8 +460,12 @@ impl SglangKvManager {
     }
 
     pub fn release_decode_reservation(&mut self, reservation: DecodeTokenReservation) {
-        let indices = reservation.indices.into_iter().collect::<Vec<_>>();
-        self.release_unpublished_indices(indices);
+        let indices = &reservation.indices[reservation.next..];
+        if indices.is_empty() {
+            return;
+        }
+        self.cache.token_pool.free(indices);
+        self.log_trace("release_unpublished", indices.len());
     }
 
     fn release_unpublished_indices(&mut self, indices: Vec<usize>) {
@@ -490,9 +505,9 @@ impl SglangKvManager {
             lease.cached_tokens,
             lease.len()
         );
-        let owned_suffix = lease.kv_indices.split_off(lease.cached_tokens);
+        let owned_suffix = &lease.kv_indices[lease.cached_tokens..];
         let capacity_improved = !owned_suffix.is_empty() || last_node != self.cache.root();
-        self.free_indices(&owned_suffix);
+        self.free_indices(owned_suffix);
         self.cache.dec_lock_ref(last_node);
         capacity_improved
     }
@@ -678,7 +693,7 @@ impl SglangKvManager {
 
     fn publish_stored_event(
         &mut self,
-        token_ids: &[u64],
+        token_ids: &[u32],
         indices: &[usize],
         first_new_token: usize,
     ) -> usize {
@@ -778,17 +793,9 @@ impl SglangKvManager {
         hashed_blocks
     }
 
-    fn local_hashes_for_range(&self, token_ids: &[u64]) -> Vec<LocalBlockHash> {
-        let tokens = token_ids
-            .iter()
-            .map(|&token| {
-                u32::try_from(token).unwrap_or_else(|_| {
-                    panic!("local_hashes_for_range: token {token} exceeds router u32 token domain")
-                })
-            })
-            .collect::<Vec<_>>();
+    fn local_hashes_for_range(&self, token_ids: &[u32]) -> Vec<LocalBlockHash> {
         compute_block_hash_for_seq(
-            &tokens,
+            token_ids,
             self.cache.page_size() as u32,
             BlockHashOptions::default(),
         )
@@ -904,6 +911,29 @@ mod tests {
             + std::mem::size_of::<Option<NodeId>>();
 
         assert_eq!(std::mem::size_of::<ActiveKvLease>(), previous_fields);
+    }
+
+    #[test]
+    fn partially_consumed_decode_reservation_releases_only_unused_slots() {
+        let mut mgr = SglangKvManager::new(4, 1, KvEventPublishers::default(), 0);
+        let mut reservation = mgr.reserve_decode_tokens(3).unwrap();
+        let consumed = reservation.take();
+        assert_eq!(reservation.len(), 2);
+        let mut expected_unused = reservation.indices[reservation.next..].to_vec();
+
+        mgr.release_decode_reservation(reservation);
+        assert_eq!(mgr.cache().available_tokens(), 3);
+
+        let mut reallocated = mgr
+            .cache_mut()
+            .token_pool
+            .allocate(expected_unused.len())
+            .unwrap();
+        expected_unused.sort_unstable();
+        reallocated.sort_unstable();
+        assert_eq!(reallocated, expected_unused);
+        assert!(reallocated.windows(2).all(|pair| pair[0] != pair[1]));
+        assert!(!reallocated.contains(&consumed));
     }
 
     #[test]
@@ -1130,8 +1160,7 @@ mod tests {
     fn test_cache_materialization_processes_only_newly_completed_blocks() {
         let sink = Arc::new(MockSink::new());
         let mut mgr = SglangKvManager::new(100, 2, KvEventPublishers::default(), 0);
-        let out_of_domain_token = u32::MAX as u64 + 1;
-        let tokens = [out_of_domain_token, 2, 3, 4, 5, 6];
+        let tokens = [1, 2, 3, 4, 5, 6];
 
         let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
         let alloc_last_node = alloc.lease.last_node();
@@ -1170,15 +1199,6 @@ mod tests {
             1,
             "finished cache should store only the newly completed block"
         );
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "local_hashes_for_range: token 4294967296 exceeds router u32 token domain"
-    )]
-    fn test_local_hashes_reject_out_of_domain_tokens() {
-        let mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
-        let _ = mgr.local_hashes_for_range(&[u32::MAX as u64 + 1]);
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -63,8 +63,7 @@ impl ReservedSglangDecode {
     fn activate(self, kv_manager: &mut SglangKvManager, block_size: usize) -> SglangRequest {
         let Self { mut request, kv } = self;
         let allocated_tokens = kv.allocated_tokens;
-        let prompt_tokens = request.prompt_tokens.clone();
-        let alloc = kv_manager.activate_destination(kv, &prompt_tokens);
+        let alloc = kv_manager.activate_destination(kv, request.prompt_tokens());
         request.kv_lease = alloc.lease;
         request.materialized_tokens = request.prompt_len();
         request.allocated_tokens = allocated_tokens;
@@ -323,7 +322,7 @@ impl SglangCore {
         {
             self.destination_reservation_attempts += 1;
         }
-        let reservation = self.kv_manager.reserve_destination(&request.prompt_tokens);
+        let reservation = self.kv_manager.reserve_destination(request.prompt_tokens());
         self.pending_destinations.mark_front_attempted(generation);
         let Some(kv) = reservation else {
             return Vec::new();

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -166,11 +166,7 @@ pub(super) fn cleanup_completed_request(
         return;
     }
     let lease = std::mem::take(&mut request.kv_lease);
-    if tokens_to_cache <= request.prompt_len() {
-        kv_manager.finish(&request.prompt_tokens()[..tokens_to_cache], lease);
-    } else {
-        kv_manager.finish(request.sequence_prefix(tokens_to_cache), lease);
-    }
+    kv_manager.finish(request.sequence_prefix(tokens_to_cache), lease);
 }
 
 pub(super) fn simulate_decode_step_with_sampler(

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -63,12 +63,8 @@ pub(super) fn cache_materialized_prefix(
         );
     }
 
-    if aligned_tokens <= req.prompt_tokens.len() {
-        kv_manager.extend_cached_prefix(&req.prompt_tokens[..aligned_tokens], &mut req.kv_lease);
-    } else {
-        let sequence = req.sequence_prefix(aligned_tokens).into_owned();
-        kv_manager.extend_cached_prefix(&sequence, &mut req.kv_lease);
-    }
+    let sequence = &req.sequence_tokens[..aligned_tokens];
+    kv_manager.extend_cached_prefix(sequence, &mut req.kv_lease);
     req.debug_assert_invariants(config.block_size);
 }
 
@@ -171,10 +167,9 @@ pub(super) fn cleanup_completed_request(
     }
     let lease = std::mem::take(&mut request.kv_lease);
     if tokens_to_cache <= request.prompt_len() {
-        kv_manager.finish(&request.prompt_tokens[..tokens_to_cache], lease);
+        kv_manager.finish(&request.prompt_tokens()[..tokens_to_cache], lease);
     } else {
-        let sequence = request.sequence_tokens().into_owned();
-        kv_manager.finish(&sequence[..tokens_to_cache], lease);
+        kv_manager.finish(request.sequence_prefix(tokens_to_cache), lease);
     }
 }
 
@@ -290,23 +285,18 @@ pub(super) fn simulate_decode_step_with_sampler(
         };
     };
 
-    let sampled_bursts = running
-        .iter()
-        .map(|req| {
-            let remaining = req.remaining_output_tokens();
-            if config.worker_type == crate::common::protocols::WorkerType::Prefill {
-                remaining.min(1)
-            } else if let Some(sampler) = sampler.as_deref_mut() {
-                sampler.sample_output_tokens(remaining)
-            } else {
-                remaining.min(1)
-            }
-        })
-        .collect::<Vec<_>>();
-    output_signals.reserve(sampled_bursts.iter().copied().sum::<usize>());
+    output_signals.reserve(running.len());
     let mut completed_indices = Vec::new();
 
-    for (idx, (req, burst)) in running.iter_mut().zip(sampled_bursts).enumerate() {
+    for (idx, req) in running.iter_mut().enumerate() {
+        let remaining = req.remaining_output_tokens();
+        let burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
+            remaining.min(1)
+        } else if let Some(sampler) = sampler.as_deref_mut() {
+            sampler.sample_output_tokens(remaining)
+        } else {
+            remaining.min(1)
+        };
         for _ in 0..burst {
             let crossing_page_boundary = req.current_sequence_len() + 1 > req.allocated_tokens;
             kv_manager.extend_decode(&mut req.kv_lease, &mut reservation);

--- a/lib/mocker/src/scheduler/sglang/policy.rs
+++ b/lib/mocker/src/scheduler/sglang/policy.rs
@@ -32,7 +32,7 @@ pub(super) fn apply_schedule_policy(
 
             for req in waiting.drain(..) {
                 let sequence = req.sequence_tokens();
-                let prefix_len = kv_manager.cache().prefix_match_len(&sequence);
+                let prefix_len = kv_manager.cache().prefix_match_len(sequence);
                 let deprioritized = prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD
                     && sequence.len() >= duplicate_prefix_len
                     && !waiting_prefixes.insert(sequence[..duplicate_prefix_len].to_vec());

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -121,10 +121,10 @@ pub(super) fn get_new_batch_prefill(
                 );
             }
             kv_manager
-                .extend_allocation(&alloc_tokens, &mut lease)
+                .extend_allocation(alloc_tokens, &mut lease)
                 .then_some(req.materialized_tokens)
         } else {
-            kv_manager.allocate_for_request(&alloc_tokens).map(|alloc| {
+            kv_manager.allocate_for_request(alloc_tokens).map(|alloc| {
                 lease = alloc.lease;
                 alloc.prefix_len
             })

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::borrow::Cow;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
@@ -13,10 +12,10 @@ use crate::kv_manager::sglang_backend::ActiveKvLease;
 #[derive(Debug)]
 pub(super) struct SglangRequest {
     pub(super) uuid: Uuid,
-    pub(super) prompt_tokens: Vec<u64>,
+    pub(super) sequence_tokens: Vec<u32>,
+    pub(super) prompt_len: usize,
     pub(super) max_output_tokens: usize,
     pub(super) planned_output_ids: Option<Vec<u32>>,
-    pub(super) output_ids: Vec<u32>,
     pub(super) kv_lease: ActiveKvLease,
     pub(super) materialized_tokens: usize,
     pub(super) allocated_tokens: usize,
@@ -24,15 +23,15 @@ pub(super) struct SglangRequest {
 
 impl SglangRequest {
     pub(super) fn prompt_len(&self) -> usize {
-        self.prompt_tokens.len()
+        self.prompt_len
     }
 
     pub(super) fn output_len(&self) -> usize {
-        self.output_ids.len()
+        self.sequence_tokens.len() - self.prompt_len
     }
 
     pub(super) fn current_sequence_len(&self) -> usize {
-        self.prompt_len() + self.output_len()
+        self.sequence_tokens.len()
     }
 
     pub(super) fn extend_input_len(&self) -> usize {
@@ -65,29 +64,21 @@ impl SglangRequest {
         self.materialized_tokens / block_size * block_size
     }
 
-    pub(super) fn sequence_tokens(&self) -> Cow<'_, [u64]> {
-        if self.output_ids.is_empty() {
-            return Cow::Borrowed(&self.prompt_tokens);
-        }
-
-        let mut sequence = self.prompt_tokens.clone();
-        sequence.extend(self.output_ids.iter().map(|&token| token as u64));
-        Cow::Owned(sequence)
+    pub(super) fn prompt_tokens(&self) -> &[u32] {
+        &self.sequence_tokens[..self.prompt_len]
     }
 
-    pub(super) fn sequence_prefix(&self, len: usize) -> Cow<'_, [u64]> {
-        let prompt_len = self.prompt_len();
-        if len <= prompt_len {
-            return Cow::Borrowed(&self.prompt_tokens[..len]);
-        }
+    pub(super) fn sequence_tokens(&self) -> &[u32] {
+        &self.sequence_tokens
+    }
 
-        let mut prefix = self.prompt_tokens.clone();
-        prefix.extend(
-            self.output_ids[..len - prompt_len]
-                .iter()
-                .map(|&token| token as u64),
-        );
-        Cow::Owned(prefix)
+    pub(super) fn sequence_prefix(&self, len: usize) -> &[u32] {
+        &self.sequence_tokens[..len]
+    }
+
+    #[cfg(test)]
+    pub(super) fn output_tokens(&self) -> &[u32] {
+        &self.sequence_tokens[self.prompt_len..]
     }
 
     pub(super) fn next_output_token(&self) -> u32 {
@@ -106,7 +97,7 @@ impl SglangRequest {
     }
 
     pub(super) fn append_output_token(&mut self, token: u32) {
-        self.output_ids.push(token);
+        self.sequence_tokens.push(token);
         self.materialized_tokens += 1;
     }
 
@@ -115,6 +106,12 @@ impl SglangRequest {
         {
             let block_size = _block_size;
             let sequence_len = self.current_sequence_len();
+            debug_assert!(
+                self.prompt_len <= sequence_len,
+                "request {} has prompt_len={} but only {sequence_len} sequence tokens",
+                self.uuid,
+                self.prompt_len
+            );
             debug_assert!(
                 self.cached_tokens() <= self.materialized_tokens,
                 "request {} cached {} tokens but materialized {}",
@@ -182,15 +179,18 @@ impl SglangRequest {
 
 impl From<DirectRequest> for SglangRequest {
     fn from(req: DirectRequest) -> Self {
+        let prompt_len = req.tokens.len();
+        let max_output_tokens = req
+            .output_token_ids
+            .as_ref()
+            .map_or(req.max_output_tokens, Vec::len);
+        let sequence_tokens = req.tokens;
         Self {
             uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
-            prompt_tokens: req.tokens.iter().map(|&t| t as u64).collect(),
-            max_output_tokens: req
-                .output_token_ids
-                .as_ref()
-                .map_or(req.max_output_tokens, Vec::len),
+            sequence_tokens,
+            prompt_len,
+            max_output_tokens,
             planned_output_ids: req.output_token_ids,
-            output_ids: Vec::new(),
             kv_lease: ActiveKvLease::default(),
             materialized_tokens: 0,
             allocated_tokens: 0,

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -1400,7 +1400,7 @@ mod core_behavior {
 
         simulate_decode_step(&mut running, &mut kv_manager, &config, 0.0, false);
         let prefix = running[0].sequence_prefix(4);
-        assert_eq!(kv_manager.cache().prefix_match_len(&prefix), 4);
+        assert_eq!(kv_manager.cache().prefix_match_len(prefix), 4);
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -69,17 +69,17 @@ fn direct_request(tokens: Vec<u32>, max_output_tokens: usize) -> DirectRequest {
 fn make_decoded_request(
     kv_manager: &mut SglangKvManager,
     config: &SglangConfig,
-    prompt_tokens: Vec<u64>,
+    prompt_tokens: Vec<u32>,
     max_output_tokens: usize,
 ) -> SglangRequest {
     let prompt_len = prompt_tokens.len();
     let alloc = kv_manager.allocate_for_request(&prompt_tokens).unwrap();
     let mut running = vec![SglangRequest {
         uuid: Uuid::new_v4(),
-        prompt_tokens,
+        sequence_tokens: prompt_tokens,
+        prompt_len,
         max_output_tokens,
         planned_output_ids: None,
-        output_ids: Vec::new(),
         kv_lease: alloc.lease,
         materialized_tokens: prompt_len,
         allocated_tokens: ceil_to_block(prompt_len, config.block_size),
@@ -124,20 +124,20 @@ fn zero_output_completion_survives_decode_reservation_failure() {
     let mut running = vec![
         SglangRequest {
             uuid: zero_uuid,
-            prompt_tokens: vec![1, 2, 3, 4],
+            sequence_tokens: vec![1, 2, 3, 4],
+            prompt_len: 4,
             max_output_tokens: 0,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: zero_alloc.lease,
             materialized_tokens: 4,
             allocated_tokens: 4,
         },
         SglangRequest {
             uuid: normal_uuid,
-            prompt_tokens: vec![5, 6, 7, 8],
+            sequence_tokens: vec![5, 6, 7, 8],
+            prompt_len: 4,
             max_output_tokens: 1,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: normal_alloc.lease,
             materialized_tokens: 4,
             allocated_tokens: 4,
@@ -183,10 +183,10 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     kv_manager.finish(&prompt, cached.lease);
     let mut waiting = VecDeque::from([SglangRequest {
         uuid: Uuid::from_u128(90_002),
-        prompt_tokens: prompt.clone(),
+        sequence_tokens: prompt.clone(),
+        prompt_len: prompt.len(),
         max_output_tokens: 1,
         planned_output_ids: None,
-        output_ids: Vec::new(),
         materialized_tokens: 0,
         kv_lease: ActiveKvLease::default(),
         allocated_tokens: 0,
@@ -206,10 +206,10 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     let blocker_alloc = kv_manager.allocate_for_request(&blocker_tokens).unwrap();
     let blocker = SglangRequest {
         uuid: Uuid::from_u128(90_003),
-        prompt_tokens: blocker_tokens,
+        sequence_tokens: blocker_tokens,
+        prompt_len: 3,
         max_output_tokens: 1,
         planned_output_ids: None,
-        output_ids: Vec::new(),
         kv_lease: blocker_alloc.lease,
         materialized_tokens: 3,
         allocated_tokens: 4,
@@ -1014,20 +1014,20 @@ mod scheduling {
         let mut waiting = VecDeque::from([
             SglangRequest {
                 uuid: no_match_uuid,
-                prompt_tokens: vec![9, 8, 7],
+                sequence_tokens: vec![9, 8, 7],
+                prompt_len: 3,
                 max_output_tokens: 1,
                 planned_output_ids: None,
-                output_ids: Vec::new(),
                 materialized_tokens: 0,
                 kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
                 uuid: match_uuid,
-                prompt_tokens: vec![1, 2, 3, 4, 5],
+                sequence_tokens: vec![1, 2, 3, 4, 5, 6, 7],
+                prompt_len: 5,
                 max_output_tokens: 1,
                 planned_output_ids: None,
-                output_ids: vec![6, 7],
                 materialized_tokens: 0,
                 kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
@@ -1057,10 +1057,10 @@ mod scheduling {
         for _ in 0..33 {
             waiting.push_back(SglangRequest {
                 uuid: Uuid::new_v4(),
-                prompt_tokens: duplicate_prefix.clone(),
+                sequence_tokens: duplicate_prefix.clone(),
+                prompt_len: duplicate_prefix.len(),
                 max_output_tokens: 1,
                 planned_output_ids: None,
-                output_ids: Vec::new(),
                 materialized_tokens: 0,
                 kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
@@ -1069,10 +1069,10 @@ mod scheduling {
         let unique_uuid = Uuid::new_v4();
         waiting.push_back(SglangRequest {
             uuid: unique_uuid,
-            prompt_tokens: (100..132).collect(),
+            sequence_tokens: (100..132).collect(),
+            prompt_len: 32,
             max_output_tokens: 1,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             materialized_tokens: 0,
             kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
@@ -1135,10 +1135,10 @@ mod core_behavior {
         let mut kv_manager = SglangKvManager::new(10000, 4, KvEventPublishers::default(), 0);
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1; 6],
+            sequence_tokens: vec![1; 6],
+            prompt_len: 6,
             max_output_tokens: 3,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             materialized_tokens: 0,
             kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
@@ -1165,10 +1165,10 @@ mod core_behavior {
         let mut kv_manager = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1; 16],
+            sequence_tokens: vec![1; 16],
+            prompt_len: 16,
             max_output_tokens: 2,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             materialized_tokens: 0,
             kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
@@ -1198,20 +1198,20 @@ mod core_behavior {
         let mut waiting = VecDeque::from([
             SglangRequest {
                 uuid: first_uuid,
-                prompt_tokens: vec![1; 7],
+                sequence_tokens: vec![1; 7],
+                prompt_len: 7,
                 max_output_tokens: 3,
                 planned_output_ids: None,
-                output_ids: Vec::new(),
                 materialized_tokens: 0,
                 kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
                 uuid: second_uuid,
-                prompt_tokens: vec![2; 8],
+                sequence_tokens: vec![2; 8],
+                prompt_len: 8,
                 max_output_tokens: 3,
                 planned_output_ids: None,
-                output_ids: Vec::new(),
                 materialized_tokens: 0,
                 kv_lease: ActiveKvLease::default(),
                 allocated_tokens: 0,
@@ -1242,10 +1242,10 @@ mod core_behavior {
         kv_manager.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1, 2, 3, 4, 5, 6],
+            sequence_tokens: vec![1, 2, 3, 4, 5, 6],
+            prompt_len: 6,
             max_output_tokens: 4,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: alloc.lease,
             materialized_tokens: 6,
             allocated_tokens: 8,
@@ -1286,10 +1286,10 @@ mod core_behavior {
         let base_alloc = base_kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut base_running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1, 2, 3, 4],
+            sequence_tokens: vec![1, 2, 3, 4],
+            prompt_len: 4,
             max_output_tokens: 4,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: base_alloc.lease,
             materialized_tokens: 4,
             allocated_tokens: 4,
@@ -1299,10 +1299,10 @@ mod core_behavior {
         let fast_alloc = fast_kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut fast_running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1, 2, 3, 4],
+            sequence_tokens: vec![1, 2, 3, 4],
+            prompt_len: 4,
             max_output_tokens: 4,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: fast_alloc.lease,
             materialized_tokens: 4,
             allocated_tokens: 4,
@@ -1348,20 +1348,20 @@ mod core_behavior {
         let mut running = vec![
             SglangRequest {
                 uuid: Uuid::new_v4(),
-                prompt_tokens: vec![1, 2, 3, 4],
+                sequence_tokens: vec![1, 2, 3, 4, 11, 12, 13],
+                prompt_len: 4,
                 max_output_tokens: 10,
                 planned_output_ids: None,
-                output_ids: vec![11, 12, 13],
                 kv_lease: ActiveKvLease::from_parts(first, 4, kv_manager.cache().root()),
                 materialized_tokens: 7,
                 allocated_tokens: 8,
             },
             SglangRequest {
                 uuid: Uuid::new_v4(),
-                prompt_tokens: vec![9, 8, 7, 6],
+                sequence_tokens: vec![9, 8, 7, 6, 21],
+                prompt_len: 4,
                 max_output_tokens: 10,
                 planned_output_ids: None,
-                output_ids: vec![21],
                 kv_lease: ActiveKvLease::from_parts(second, 4, kv_manager.cache().root()),
                 materialized_tokens: 5,
                 allocated_tokens: 8,
@@ -1370,7 +1370,7 @@ mod core_behavior {
 
         let retracted = decode::check_decode_mem(&mut running, &mut kv_manager, &config);
         assert_eq!(retracted.len(), 1);
-        assert_eq!(retracted[0].output_ids, vec![21]);
+        assert_eq!(retracted[0].output_tokens(), &[21]);
         assert_eq!(retracted[0].materialized_tokens, 0);
         assert!(retracted[0].kv_indices().is_empty());
     }
@@ -1389,10 +1389,10 @@ mod core_behavior {
         let alloc = kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1, 2, 3, 4],
+            sequence_tokens: vec![1, 2, 3, 4],
+            prompt_len: 4,
             max_output_tokens: 4,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             kv_lease: alloc.lease,
             materialized_tokens: 4,
             allocated_tokens: 4,
@@ -1685,10 +1685,10 @@ mod router_events {
         let prompt_tokens = vec![101, 202];
         let mut expected_request = SglangRequest {
             uuid,
-            prompt_tokens: prompt_tokens.iter().map(|&token| token as u64).collect(),
+            sequence_tokens: prompt_tokens.clone(),
+            prompt_len: prompt_tokens.len(),
             max_output_tokens: 2,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             materialized_tokens: 0,
             kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,
@@ -1785,10 +1785,10 @@ mod router_events {
 
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
-            prompt_tokens: vec![1, 2, 3, 4, 5, 6],
+            sequence_tokens: vec![1, 2, 3, 4, 5, 6],
+            prompt_len: 6,
             max_output_tokens: 3,
             planned_output_ids: None,
-            output_ids: Vec::new(),
             materialized_tokens: 0,
             kv_lease: ActiveKvLease::default(),
             allocated_tokens: 0,


### PR DESCRIPTION
## Summary

- Keep each SGLang request in one append-only `u32` token sequence so decode caching borrows the retained prefix instead of rebuilding prompt plus output on every completed page.
- Use native `u32` radix keys and router hash inputs, append token-pool allocations directly into active leases, consume decode reservations with a vector cursor, release suffixes through borrowed slices, and sample decode bursts inline.
- Skip redundant release/reacquire walks when a retained radix node is unchanged while preserving path reference counting for interleaved requests that share prefixes.
- Validate pool capacity before reserving allocation memory and cover failed append atomicity plus exact, unique release of partially consumed decode reservations.

Reviewer guide: `request.rs` and `radix_cache.rs` contain the representation changes; `sglang_backend.rs` contains the slot and lease lifecycle; `decode.rs` contains the hot-path allocation changes. The remaining changes adapt scheduler call sites and regression fixtures.

Non-goals: this does not remove radix path reference counts, change canonical page ownership, alter eviction recency semantics, or convert `ActiveKvLease` to a tail-only representation.

## Validation

- Canonical 1,000-request Mooncake replay, four SGLang workers with KV-aware routing, eight alternating 50-iteration pairs on a pinned physical CPU core: median wall time moved from `10.676775s` to `7.380573s` (**30.873% lower**, **1.4466x**), with the optimized candidate winning 8/8 pairs. Baseline CV was 0.617%; optimized CV was 0.504%.
- Deterministic correctness reports matched for request counts, token counts, prefix reuse, simulated duration, worker time, and GPU-hour accounting.
- `cargo test -p dynamo-mocker`: 561 passed, 1 ignored, 0 failed.
- `cargo fmt --all -- --check` and `git diff --check` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved token and KV-cache handling for more efficient request processing.
  - Reduced unnecessary memory allocations during token allocation, caching, and request completion.
  - Improved handling of partially consumed reservations and cache cleanup.

- **Bug Fixes**
  - Corrected release behavior when only part of a decode reservation is used.
  - Prevented redundant cache reference updates during request finalization.

- **Tests**
  - Added coverage for allocation failures, atomic behavior, and partial reservation cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->