### PR TITLE
fix(profiler): honor requested replay router mode [DYN-3851]

### DIFF
--- a/components/src/dynamo/profiler/tests/test_replay_optimize.py
+++ b/components/src/dynamo/profiler/tests/test_replay_optimize.py
@@ -755,6 +755,24 @@ def test_optimizer_starts_with_requested_kv_router_mode(
     assert set(seen_prefill_scales) == {2.0}
 
 
+def test_agg_optimizer_rejects_single_worker_kv_state_before_replay(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        replay_optimize.aic,
+        "_enumerate_dense_tp_candidates",
+        lambda backend, system: ([4], [4]),
+    )
+    monkeypatch.setattr(
+        replay_optimize.evaluate,
+        "_run_agg_replay_for_state",
+        lambda **kwargs: pytest.fail("unsupported state reached replay"),
+    )
+
+    with pytest.raises(ValueError, match="no TP candidates fit"):
+        optimize_dense_agg_with_replay(_agg_spec(total_gpus=4))
+
+
 def test_disagg_optimizer_supports_latency_objective(monkeypatch) -> None:
     def fake_run(**kwargs):
         state = kwargs["state"]

--- a/components/src/dynamo/profiler/tests/test_replay_optimize.py
+++ b/components/src/dynamo/profiler/tests/test_replay_optimize.py
@@ -709,6 +709,52 @@ def test_optimizer_supports_round_robin_router_mode(monkeypatch) -> None:
     assert set(seen_prefill_scales) == {1.0}
 
 
+@pytest.mark.parametrize("topology", ["aggregated", "disaggregated"])
+def test_optimizer_starts_with_requested_kv_router_mode(
+    monkeypatch, topology: str
+) -> None:
+    seen_router_modes: list[str] = []
+    seen_credits: list[float] = []
+    seen_prefill_scales: list[float] = []
+
+    def fake_run(**kwargs):
+        state = kwargs["state"]
+        seen_router_modes.append(state.router_mode)
+        seen_credits.append(state.overlap_score_credit)
+        seen_prefill_scales.append(state.prefill_load_scale)
+        return {
+            "output_throughput_tok_s": 1000.0,
+            "mean_ttft_ms": 100.0,
+            "p95_ttft_ms": 120.0,
+            "mean_tpot_ms": 10.0,
+            "p95_tpot_ms": 12.0,
+            "mean_e2e_latency_ms": 200.0,
+            "p95_e2e_latency_ms": 220.0,
+        }
+
+    monkeypatch.setattr(
+        replay_optimize.aic,
+        "_enumerate_dense_tp_candidates",
+        lambda backend, system: ([1, 2], [1, 2]),
+    )
+    if topology == "aggregated":
+        monkeypatch.setattr(
+            replay_optimize.evaluate, "_run_agg_replay_for_state", fake_run
+        )
+        optimize_dense_agg_with_replay(
+            _agg_spec(overlap_credits=[0.5], prefill_load_scales=[2.0])
+        )
+    else:
+        monkeypatch.setattr(replay_optimize.evaluate, "_run_replay_for_state", fake_run)
+        optimize_dense_disagg_with_replay(
+            _disagg_spec(overlap_credits=[0.5], prefill_load_scales=[2.0])
+        )
+
+    assert set(seen_router_modes) == {"kv_router"}
+    assert set(seen_credits) == {0.5}
+    assert set(seen_prefill_scales) == {2.0}
+
+
 def test_disagg_optimizer_supports_latency_objective(monkeypatch) -> None:
     def fake_run(**kwargs):
         state = kwargs["state"]

--- a/components/src/dynamo/profiler/utils/replay_optimize/search.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/search.py
@@ -175,15 +175,17 @@ def _select_initial_state(
     *,
     prefill_tps: Sequence[int],
     decode_tps: Sequence[int],
+    router_mode: Literal["kv_router", "round_robin"],
     overlap_score_credit: float,
+    prefill_load_scale: float,
     max_total_gpus: int,
 ) -> DenseReplayState:
     initial_states = _iter_tp_states_with_equal_workers(
         prefill_tps=prefill_tps,
         decode_tps=decode_tps,
-        router_mode="round_robin",
+        router_mode=router_mode,
         overlap_score_credit=overlap_score_credit,
-        prefill_load_scale=1.0,
+        prefill_load_scale=prefill_load_scale,
         max_total_gpus=max_total_gpus,
     )
     if initial_states:
@@ -198,13 +200,16 @@ def _select_initial_state(
 def _select_initial_agg_state(
     *,
     tps: Sequence[int],
+    router_mode: Literal["kv_router", "round_robin"],
+    overlap_score_credit: float,
+    prefill_load_scale: float,
     max_total_gpus: int,
 ) -> DenseAggReplayState:
     states = _iter_agg_tp_states_with_max_workers(
         tps=tps,
-        router_mode="round_robin",
-        overlap_score_credit=0.0,
-        prefill_load_scale=1.0,
+        router_mode=router_mode,
+        overlap_score_credit=overlap_score_credit,
+        prefill_load_scale=prefill_load_scale,
         max_total_gpus=max_total_gpus,
     )
     if states:
@@ -284,10 +289,22 @@ def optimize_dense_disagg_with_replay(
         )
 
     cache: dict[DenseReplayState, dict[str, float | int | bool | str]] = {}
+    initial_router_states = _router_states(
+        router_mode=spec.router.mode,
+        overlap_score_credits=overlap_credits,
+        prefill_load_scales=prefill_load_scales,
+    )
+    (
+        initial_router_mode,
+        initial_overlap_credit,
+        initial_prefill_load_scale,
+    ) = initial_router_states[0]
     incumbent = _select_initial_state(
         prefill_tps=prefill_tps,
         decode_tps=decode_tps,
-        overlap_score_credit=overlap_credits[0],
+        router_mode=initial_router_mode,
+        overlap_score_credit=initial_overlap_credit,
+        prefill_load_scale=initial_prefill_load_scale,
         max_total_gpus=spec.hardware.totalGpus,
     )
 
@@ -401,8 +418,22 @@ def optimize_dense_agg_with_replay(
         )
 
     cache: dict[DenseAggReplayState, dict[str, float | int | bool | str]] = {}
+    initial_router_states = _router_states(
+        router_mode=spec.router.mode,
+        overlap_score_credits=overlap_credits,
+        prefill_load_scales=prefill_load_scales,
+    )
+    (
+        initial_router_mode,
+        initial_overlap_credit,
+        initial_prefill_load_scale,
+    ) = initial_router_states[0]
     incumbent = _select_initial_agg_state(
-        tps=tps, max_total_gpus=spec.hardware.totalGpus
+        tps=tps,
+        router_mode=initial_router_mode,
+        overlap_score_credit=initial_overlap_credit,
+        prefill_load_scale=initial_prefill_load_scale,
+        max_total_gpus=spec.hardware.totalGpus,
     )
 
     executor = (

--- a/components/src/dynamo/profiler/utils/replay_optimize/search.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/search.py
@@ -159,6 +159,11 @@ def _iter_agg_tp_states_with_max_workers(
         workers = max_total_gpus // tp
         if workers < 1:
             continue
+        if not _supports_agg_router_mode(
+            workers=workers,
+            router_mode=router_mode,
+        ):
+            continue
         states.append(
             DenseAggReplayState(
                 tp=tp,


### PR DESCRIPTION
## Summary

- initialize replay optimization from the router mode requested by `RouterSpec` instead of always starting in round-robin
- carry the initial overlap credit and prefill-load scale into both aggregated and disaggregated searches
- preserve existing round-robin and combined-mode behavior while preventing KV-only searches from evaluating round-robin states

## Validation

- Targeted `replay_optimize` unit tests with local Rust-bound imports stubbed for collection: 5 passed (KV-only aggregate/disaggregated regressions plus existing round-robin and combined-mode coverage)
- File-scoped pre-commit checks passed, including Black, Ruff, Flake8, codespell, and pytest marker validation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Replay optimization now starts with the requested router mode, overlap credit, and prefill load scale across aggregated and disaggregated topologies.
  - Initial replay states consistently honor the configured router settings instead of using default values.

- **Tests**
  - Added coverage validating optimizer startup behavior for both supported topology types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->