### PR TITLE
fix(planner): discover MDC for truncated Grove names

### DIFF
--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -480,11 +480,10 @@ class KubernetesConnector(PlannerConnector):
     def _extract_mdc_entries(self) -> list[MdcEntry]:
         """Extract MDC entries belonging to this DGD.
 
-        CRs are named after the worker pod. Prefer the actual component names
-        from DGD status because Grove may truncate and hash a long DGD name.
-        Fall back to the DGD name prefix for older or not-yet-ready operators
-        that do not report ``componentNames``. LoRA-adapter wrappers are dropped
-        via :func:`is_model_card`.
+        CRs are named after the worker pod. Match the DGD name prefix and the
+        actual component names from DGD status because Grove may truncate and
+        hash a long DGD name. LoRA-adapter wrappers are dropped via
+        :func:`is_model_card`.
         """
         crs = self._list_worker_metadata_crs()
         component_names = self._get_dgd_component_names()
@@ -493,14 +492,10 @@ class KubernetesConnector(PlannerConnector):
         entries: list[MdcEntry] = []
         for cr in crs:
             cr_name = cr.get("metadata", {}).get("name", "")
-            if component_names:
-                belongs_to_dgd = any(
-                    cr_name == component_name
-                    or cr_name.startswith(f"{component_name}-")
-                    for component_name in component_names
-                )
-            else:
-                belongs_to_dgd = cr_name.startswith(dgd_prefix)
+            belongs_to_dgd = cr_name.startswith(dgd_prefix) or any(
+                cr_name == component_name or cr_name.startswith(f"{component_name}-")
+                for component_name in component_names
+            )
             if not belongs_to_dgd:
                 continue
 

--- a/components/src/dynamo/planner/connectors/kubernetes.py
+++ b/components/src/dynamo/planner/connectors/kubernetes.py
@@ -462,21 +462,46 @@ class KubernetesConnector(PlannerConnector):
                 return []
             raise
 
+    def _get_dgd_component_names(self) -> list[str]:
+        """Return the Kubernetes component names reported in DGD status.
+
+        Grove may truncate and hash long DGD names when it creates component
+        resources. These status names reflect the names actually used by the
+        worker pods and their DynamoWorkerMetadata CRs.
+        """
+        deployment = self.kube_api.get_graph_deployment(self.graph_deployment_name)
+        component_statuses = deployment.get("status", {}).get("components", {}) or {}
+        return [
+            component_name
+            for component_status in component_statuses.values()
+            for component_name in component_status.get("componentNames", []) or []
+        ]
+
     def _extract_mdc_entries(self) -> list[MdcEntry]:
         """Extract MDC entries belonging to this DGD.
 
-        CRs are named after the worker pod (e.g. ``<dgd>-0-<service>-<hash>``),
-        so we filter by the DGD name prefix to avoid picking up entries from
-        other deployments sharing the namespace.  LoRA-adapter wrappers are
-        dropped via :func:`is_model_card`.
+        CRs are named after the worker pod. Prefer the actual component names
+        from DGD status because Grove may truncate and hash a long DGD name.
+        Fall back to the DGD name prefix for older or not-yet-ready operators
+        that do not report ``componentNames``. LoRA-adapter wrappers are dropped
+        via :func:`is_model_card`.
         """
         crs = self._list_worker_metadata_crs()
+        component_names = self._get_dgd_component_names()
         dgd_prefix = f"{self.graph_deployment_name}-"
 
         entries: list[MdcEntry] = []
         for cr in crs:
             cr_name = cr.get("metadata", {}).get("name", "")
-            if not cr_name.startswith(dgd_prefix):
+            if component_names:
+                belongs_to_dgd = any(
+                    cr_name == component_name
+                    or cr_name.startswith(f"{component_name}-")
+                    for component_name in component_names
+                )
+            else:
+                belongs_to_dgd = cr_name.startswith(dgd_prefix)
+            if not belongs_to_dgd:
                 continue
 
             data = cr.get("spec", {}).get("data", {})

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -102,6 +102,22 @@ def _deployment(*components):
     }
 
 
+def _model_card_cr(name, worker_type="decode"):
+    return {
+        "metadata": {"name": name},
+        "spec": {
+            "data": {
+                "model_cards": {
+                    "model": {
+                        "type": "Model",
+                        "card_json": {"worker_type": worker_type},
+                    }
+                }
+            }
+        },
+    }
+
+
 def _deployment_with_worker_status(
     component_kind, runtime_namespace=None, annotations=None
 ):
@@ -1255,6 +1271,49 @@ async def test_get_actual_worker_counts_no_components(
 # returning the DGD component name for the filter would cause every real-world MDC
 # entry to be skipped, leaving WorkerInfo without ``context_length`` and
 # silently breaking easy-mode load scaling.
+
+
+@pytest.mark.parametrize("pod_suffix", ["", "-f4k85"])
+def test_extract_mdc_entries_uses_truncated_grove_component_name(
+    kubernetes_connector, mock_kube_api, pod_suffix
+):
+    dgd_name = "live-verify-accept-len-win-df9e"
+    component_name = "live-verify-accept-len--473a-0-vllmdecodeworker"
+    cr_name = f"{component_name}{pod_suffix}"
+    deployment = _deployment(_component("VllmDecodeWorker", "decode", replicas=1))
+    deployment["metadata"]["name"] = dgd_name
+    deployment["status"] = {
+        "components": {
+            "VllmDecodeWorker": {"componentNames": [component_name]},
+        }
+    }
+    kubernetes_connector.graph_deployment_name = dgd_name
+    mock_kube_api.get_graph_deployment.return_value = deployment
+    kubernetes_connector._list_worker_metadata_crs = Mock(
+        return_value=[_model_card_cr(cr_name)]
+    )
+
+    assert not cr_name.startswith(f"{dgd_name}-")
+    entries = kubernetes_connector._extract_mdc_entries()
+
+    assert len(entries) == 1
+    assert entries[0].card_json["worker_type"] == "decode"
+
+
+def test_extract_mdc_entries_falls_back_to_dgd_prefix_without_component_names(
+    kubernetes_connector, mock_kube_api
+):
+    deployment = _deployment(_component("VllmDecodeWorker", "decode", replicas=1))
+    deployment["status"] = {"components": {}}
+    mock_kube_api.get_graph_deployment.return_value = deployment
+    kubernetes_connector._list_worker_metadata_crs = Mock(
+        return_value=[_model_card_cr("test-graph-0-vllmdecodeworker-f4k85")]
+    )
+
+    entries = kubernetes_connector._extract_mdc_entries()
+
+    assert len(entries) == 1
+    assert entries[0].card_json["worker_type"] == "decode"
 
 
 def test_resolve_dgd_service_prefill_uses_backend_default_for_filter(

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -1300,11 +1300,15 @@ def test_extract_mdc_entries_uses_truncated_grove_component_name(
     assert entries[0].card_json["worker_type"] == "decode"
 
 
-def test_extract_mdc_entries_falls_back_to_dgd_prefix_without_component_names(
+def test_extract_mdc_entries_uses_dgd_prefix_with_partial_component_names(
     kubernetes_connector, mock_kube_api
 ):
     deployment = _deployment(_component("VllmDecodeWorker", "decode", replicas=1))
-    deployment["status"] = {"components": {}}
+    deployment["status"] = {
+        "components": {
+            "Frontend": {"componentNames": ["test-graph-0-frontend"]},
+        }
+    }
     mock_kube_api.get_graph_deployment.return_value = deployment
     kubernetes_connector._list_worker_metadata_crs = Mock(
         return_value=[_model_card_cr("test-graph-0-vllmdecodeworker-f4k85")]


### PR DESCRIPTION
## Summary

Fix Kubernetes Planner MDC discovery when Grove truncates and hashes component resource names derived from a long DynamoGraphDeployment name.

Planner previously filtered DynamoWorkerMetadata CRs with the original DGD name as a prefix. For long names, the actual worker component and CR names no longer retain that prefix, so complete model cards were ignored indefinitely and Planner fell back to default worker capabilities.

## Changes

- Read the actual Kubernetes component names from `.status.components[*].componentNames`.
- Match a DWM CR when its name equals a component name or starts with `<component-name>-`.
- Retain the original DGD-prefix match so worker discovery remains safe while status is only partially populated.
- Add regression coverage using the exact truncated Grove name observed for DYN-3577, including exact-name, pod-suffix, and partial-status forms.

## Root cause reproduction

With DGD `live-verify-accept-len-win-df9e`, Grove created worker resources under `live-verify-accept-len--473a-...`. Complete decode and prefill DWM CRs existed, and the decode card contained `spec_decode.nextn=1`, but Planner reported 28 consecutive MDC misses for each role and built zero WorkerInfo objects from MDC.

The shorter control DGD retained its original prefix and matched successfully. This makes the failure deterministic based on name normalization, rather than a late-`nextn` timing race.

## Where should the reviewer start?

- `components/src/dynamo/planner/connectors/kubernetes.py`: DGD status component-name lookup and CR matching.
- `components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py`: truncated Grove name and partial-status regression tests.

## Validation

- `PYTHONPATH=$PWD/components/src python -m pytest -q components/src/dynamo/planner/tests/unit` — 477 passed.
- `pre-commit run --files components/src/dynamo/planner/connectors/kubernetes.py components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py` — all hooks passed.
- Kubernetes reproduction confirmed the failing long-name topology and complete DWM contents before the code change.

## Related Issues

- [DYN-3577](https://linear.app/nvidia/issue/DYN-3577/dynamo130planner-mtp-accept-length-discount-never-reaches-load)
