### PR TITLE
feat(gms): define persistent KV allocation protocol

### DIFF
--- a/lib/gpu_memory_service/common/locks.py
+++ b/lib/gpu_memory_service/common/locks.py
@@ -8,8 +8,14 @@ class RequestedLockType(str, Enum):
     RW = "rw"
     RO = "ro"
     RW_OR_RO = "rw_or_ro"
+    # Persistent RW: allocations survive client disconnect and can be
+    # re-attached by a new client with the same (engine_id, tag) key.
+    # Used for KV-cache pools where the engine writes every forward pass
+    # and must survive engine restart without losing bytes.
+    RW_PERSISTENT = "rw_persistent"
 
 
 class GrantedLockType(str, Enum):
     RW = "rw"
     RO = "ro"
+    RW_PERSISTENT = "rw_persistent"

--- a/lib/gpu_memory_service/common/protocol/messages.py
+++ b/lib/gpu_memory_service/common/protocol/messages.py
@@ -101,6 +101,99 @@ class FreeAllocationResponse(msgspec.Struct, tag="free_allocation_response"):
     success: bool
 
 
+# ----------------------------------------------------------------------
+# Persistent allocations (separate namespace from the RW/RO/COMMITTED
+# layout machinery). Keyed by (engine_id, tag). Survive client
+# disconnect; can be re-attached. Used for VMM-IPC KV pools.
+# ----------------------------------------------------------------------
+
+
+class ClaimPersistentAllocationRequest(
+    msgspec.Struct,
+    tag="claim_persistent_allocation_request",
+):
+    engine_id: str
+    tag: str
+    size: int
+    # Shared claims allow multiple cooperating engine processes to map the
+    # same persistent KV pool. Writers must then coordinate through KV leases.
+    shared: bool = False
+
+
+class ClaimPersistentAllocationResponse(
+    msgspec.Struct,
+    tag="claim_persistent_allocation_response",
+):
+    allocation_id: str
+    size: int
+    aligned_size: int
+    # True if this claim returned an already-existing allocation
+    # (re-attach). False if a fresh allocation was created.
+    reattached: bool
+
+
+class ReleasePersistentAllocationRequest(
+    msgspec.Struct,
+    tag="release_persistent_allocation_request",
+):
+    engine_id: str
+    tag: str
+
+
+class ReleasePersistentAllocationResponse(
+    msgspec.Struct,
+    tag="release_persistent_allocation_response",
+):
+    released: bool
+
+
+class ExportPersistentAllocationRequest(
+    msgspec.Struct,
+    tag="export_persistent_allocation_request",
+):
+    engine_id: str
+    tag: str
+
+
+class ExportPersistentAllocationResponse(
+    msgspec.Struct,
+    tag="export_persistent_allocation_response",
+):
+    allocation_id: str
+    size: int
+    aligned_size: int
+
+
+class ListPersistentAllocationsRequest(
+    msgspec.Struct,
+    tag="list_persistent_allocations_request",
+):
+    engine_id: Optional[str] = None
+    # When true, list ALL persistent allocations (not just this session's
+    # claims) so a caller can discover orphaned allocations left by a crashed
+    # engine and reclaim their HBM. Defaults false for backward compatibility.
+    include_unclaimed: bool = False
+
+
+class PersistentAllocationInfo(
+    msgspec.Struct,
+    tag="persistent_allocation_info",
+):
+    allocation_id: str
+    engine_id: str
+    tag: str
+    size: int
+    aligned_size: int
+    claimed: bool
+
+
+class ListPersistentAllocationsResponse(
+    msgspec.Struct,
+    tag="list_persistent_allocations_response",
+):
+    allocations: List[PersistentAllocationInfo] = msgspec.field(default_factory=list)
+
+
 class ErrorResponse(msgspec.Struct, tag="error_response"):
     error: str
     code: int = 0
@@ -214,6 +307,16 @@ Message = Union[
     GetRuntimeStateResponse,
     GetEventHistoryRequest,
     GetEventHistoryResponse,
+    # Persistent allocations (KV-pool namespace)
+    ClaimPersistentAllocationRequest,
+    ClaimPersistentAllocationResponse,
+    ReleasePersistentAllocationRequest,
+    ReleasePersistentAllocationResponse,
+    ExportPersistentAllocationRequest,
+    ExportPersistentAllocationResponse,
+    ListPersistentAllocationsRequest,
+    ListPersistentAllocationsResponse,
+    PersistentAllocationInfo,
 ]
 
 _encoder = msgspec.msgpack.Encoder()

--- a/lib/gpu_memory_service/server/rpc.py
+++ b/lib/gpu_memory_service/server/rpc.py
@@ -164,11 +164,20 @@ class GMSRPCServer:
             writer.close()
             return None
 
-        granted_mode = await self._gms.acquire_lock(
-            msg.lock_type,
-            msg.timeout_ms,
-            session_id,
-        )
+        try:
+            granted_mode = await self._gms.acquire_lock(
+                msg.lock_type,
+                msg.timeout_ms,
+                session_id,
+            )
+        except OperationNotAllowed as exc:
+            try:
+                await send_message(writer, ErrorResponse(error=str(exc)))
+            except Exception as send_exc:
+                logger.debug("Handshake rejection send failed: %s", send_exc)
+            finally:
+                writer.close()
+            return None
         if granted_mode is None:
             try:
                 await send_message(

--- a/lib/gpu_memory_service/server/session.py
+++ b/lib/gpu_memory_service/server/session.py
@@ -148,6 +148,13 @@ class GMSSessionManager:
                     return None
             return GrantedLockType.RO
 
+        if mode == RequestedLockType.RW_PERSISTENT:
+            raise OperationNotAllowed(
+                "persistent allocation sessions are not implemented"
+            )
+        if mode != RequestedLockType.RW_OR_RO:
+            raise OperationNotAllowed(f"unsupported lock type: {mode}")
+
         async with self._condition:
             if self._can_grant_rw() and not self._locking.committed:
                 self._reserved_rw_session_id = session_id

--- a/lib/gpu_memory_service/tests/test_persistent_protocol.py
+++ b/lib/gpu_memory_service/tests/test_persistent_protocol.py
@@ -6,7 +6,6 @@
 import asyncio
 
 import pytest
-
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.protocol.messages import (
     ClaimPersistentAllocationRequest,

--- a/lib/gpu_memory_service/tests/test_persistent_protocol.py
+++ b/lib/gpu_memory_service/tests/test_persistent_protocol.py
@@ -26,6 +26,12 @@ from gpu_memory_service.server import rpc as rpc_module
 from gpu_memory_service.server.rpc import GMSRPCServer
 from gpu_memory_service.server.session import GMSSessionManager, OperationNotAllowed
 
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
 
 @pytest.mark.parametrize(
     "message",

--- a/lib/gpu_memory_service/tests/test_persistent_protocol.py
+++ b/lib/gpu_memory_service/tests/test_persistent_protocol.py
@@ -10,6 +10,7 @@ from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.protocol.messages import (
     ClaimPersistentAllocationRequest,
     ClaimPersistentAllocationResponse,
+    ErrorResponse,
     ExportPersistentAllocationRequest,
     ExportPersistentAllocationResponse,
     HandshakeRequest,
@@ -21,6 +22,8 @@ from gpu_memory_service.common.protocol.messages import (
     decode_message,
     encode_message,
 )
+from gpu_memory_service.server import rpc as rpc_module
+from gpu_memory_service.server.rpc import GMSRPCServer
 from gpu_memory_service.server.session import GMSSessionManager, OperationNotAllowed
 
 
@@ -92,5 +95,53 @@ def test_persistent_lock_request_fails_closed_until_implemented():
                 timeout_ms=0,
                 session_id="session-0",
             )
+
+    asyncio.run(exercise())
+
+
+def test_persistent_lock_handshake_rejects_only_requesting_client(monkeypatch):
+    class RejectingGMS:
+        committed = False
+
+        async def acquire_lock(self, mode, timeout_ms, session_id):
+            raise OperationNotAllowed(
+                "persistent allocation sessions are not implemented"
+            )
+
+    class Writer:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    responses = []
+
+    async def fake_recv_message(reader, recv_buffer):
+        return (
+            HandshakeRequest(lock_type=RequestedLockType.RW_PERSISTENT),
+            -1,
+            recv_buffer,
+        )
+
+    async def fake_send_message(writer, response):
+        responses.append(response)
+
+    async def exercise():
+        server = object.__new__(GMSRPCServer)
+        server._gms = RejectingGMS()
+        writer = Writer()
+        monkeypatch.setattr(rpc_module, "recv_message", fake_recv_message)
+        monkeypatch.setattr(rpc_module, "send_message", fake_send_message)
+
+        conn = await server._do_handshake(object(), writer, "session-0")
+
+        assert conn is None
+        assert responses == [
+            ErrorResponse(
+                error="persistent allocation sessions are not implemented",
+            )
+        ]
+        assert writer.closed
 
     asyncio.run(exercise())

--- a/lib/gpu_memory_service/tests/test_persistent_protocol.py
+++ b/lib/gpu_memory_service/tests/test_persistent_protocol.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the persistent allocation wire contracts."""
+
+import asyncio
+
+import pytest
+
+from gpu_memory_service.common.locks import RequestedLockType
+from gpu_memory_service.common.protocol.messages import (
+    ClaimPersistentAllocationRequest,
+    ClaimPersistentAllocationResponse,
+    ExportPersistentAllocationRequest,
+    ExportPersistentAllocationResponse,
+    HandshakeRequest,
+    ListPersistentAllocationsRequest,
+    ListPersistentAllocationsResponse,
+    PersistentAllocationInfo,
+    ReleasePersistentAllocationRequest,
+    ReleasePersistentAllocationResponse,
+    decode_message,
+    encode_message,
+)
+from gpu_memory_service.server.session import GMSSessionManager, OperationNotAllowed
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        HandshakeRequest(lock_type=RequestedLockType.RW_PERSISTENT),
+        ClaimPersistentAllocationRequest(
+            engine_id="engine-0",
+            tag="kv",
+            size=4096,
+            shared=True,
+        ),
+        ClaimPersistentAllocationResponse(
+            allocation_id="allocation-0",
+            size=4096,
+            aligned_size=65536,
+            reattached=False,
+        ),
+        ReleasePersistentAllocationRequest(engine_id="engine-0", tag="kv"),
+        ReleasePersistentAllocationResponse(released=True),
+        ExportPersistentAllocationRequest(engine_id="engine-0", tag="kv"),
+        ExportPersistentAllocationResponse(
+            allocation_id="allocation-0",
+            size=4096,
+            aligned_size=65536,
+        ),
+        ListPersistentAllocationsRequest(
+            engine_id="engine-0",
+            include_unclaimed=True,
+        ),
+        ListPersistentAllocationsResponse(
+            allocations=[
+                PersistentAllocationInfo(
+                    allocation_id="allocation-0",
+                    engine_id="engine-0",
+                    tag="kv",
+                    size=4096,
+                    aligned_size=65536,
+                    claimed=True,
+                )
+            ]
+        ),
+        PersistentAllocationInfo(
+            allocation_id="allocation-0",
+            engine_id="engine-0",
+            tag="kv",
+            size=4096,
+            aligned_size=65536,
+            claimed=False,
+        ),
+    ],
+)
+def test_persistent_messages_round_trip(message):
+    decoded = decode_message(encode_message(message))
+    assert decoded == message
+    assert type(decoded) is type(message)
+
+
+def test_persistent_lock_request_fails_closed_until_implemented():
+    async def exercise():
+        sessions = GMSSessionManager()
+        with pytest.raises(
+            OperationNotAllowed,
+            match="persistent allocation sessions are not implemented",
+        ):
+            await sessions.acquire_lock(
+                RequestedLockType.RW_PERSISTENT,
+                timeout_ms=0,
+                session_id="session-0",
+            )
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Overview:

This PR defines how an engine asks GMS for GPU memory that is meant to survive an engine crash. It adds only the request and response contract; GMS deliberately rejects the new mode until the next PR implements it.

## Details:

- Define the persistent-allocation lock and RPC contracts.
- Distinguish non-destructive session unclaim from allocation-destroying release.
- Keep unsupported persistent sessions fail-closed until the next PR implements them.
- Test wire round trips and client-scoped handshake rejection.

### Why it is needed

Separates the public lifetime contract from CUDA allocation behavior. Explicit unclaim is required for transactional client setup: a failed reattach must drop its claim without deleting the surviving pool.

## Where should the reviewer start?

`lib/gpu_memory_service/common/protocol/messages.py` for the wire contract, then `lib/gpu_memory_service/tests/test_persistent_protocol.py`.

## Validation

- Focused protocol suite: 14 passed.
- Exact pinned Black/isort checks pass locally.

## Related Issues

- Design/API specification: #14832 (shared with #14576; protocol-only merge does not complete the DEP).
- Relates to #12053

## Stack

Checkpoint 1/12 for #12053.

- Previous: 
- Next: #14576
- Linear project: [vLLM POC — GMS KV Failover](https://linear.app/nvidia/project/vllm-poc-gms-kv-failover-722cab6cb4ed)

## Complete minimal vLLM PR train

1. #12056 — Define the persistent-memory API and fail closed until it is implemented.
2. #14576 — Keep KV HBM alive in the GMS daemon after vLLM dies.
3. #14577 — Let a replacement process reattach that memory through PyTorch.
4. #12057 — Prevent primary/shadow conflicts with crash-safe block leases.
5. #14578 — Define the minimal content-hash-to-slot recovery metadata.
6. #14579 — Store that metadata locally and fence stale writers.
7. #14581 — Put vLLM KV tensors into a compatible persistent GMS pool.
8. #13398 — Publish completed native blocks and hydrate the shadow BlockPool.
9. #14583 — Activate the integration safely during vLLM startup.
10. #14584 — Make failover promotion and lease reclamation race-safe.
11. #14587 — Keep a warm sleeping shadow and switch serving ownership safely.
12. #12032 — Prove exact-output, real-cache-hit failover in the five-process E2E test.


