### PR TITLE
refactor(planner): decouple global planner decision logic from K8s and drt

### DIFF
--- a/components/src/dynamo/global_planner/capacity_manager.py
+++ b/components/src/dynamo/global_planner/capacity_manager.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Capacity backend for the GlobalPlanner — reads and writes scaling state.
+
+:class:`CapacityManager` is the infrastructure-facing base class the
+:class:`~dynamo.global_planner.orchestrator.Orchestrator` drives to **observe**
+current pool state and **actuate** replica changes. It defines a neutral,
+infrastructure-agnostic surface (``observe`` / ``actuate`` / ``discover`` /
+``ensure_participant`` / ``knows`` / ``current_replicas``) keyed by opaque
+``participant_id``; the orchestrator never sees Kubernetes concepts.
+
+:class:`KubernetesCapacityManager` is the concrete Kubernetes backend — the only
+place in the control loop that touches Kubernetes. A ``participant_id`` there is
+``"{cluster_name}/{deployment_name}"``, and the read/write logic is lifted
+verbatim from the pre-refactor ``ScaleRequestHandler`` so behavior is unchanged.
+
+Offline replay can add another backend (in-memory) by subclassing
+:class:`CapacityManager` and implementing the same surface — no orchestrator
+change required.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+from dynamo.planner import KubernetesConnector, TargetReplica
+from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PoolSpec:
+    """Snapshot of one pool's state read from a backend.
+
+    Infrastructure-agnostic: the budget math consumes only these three fields.
+    Pools with ``gpu_per_replica == 0`` are included for completeness but
+    contribute 0 to budget totals.
+    """
+
+    sub_type: str
+    current_replicas: int
+    gpu_per_replica: int
+
+
+# participant_id -> (sub_type -> PoolSpec)
+PoolSnapshot = dict[str, dict[str, PoolSpec]]
+
+
+class CapacityManager:
+    """Base capacity backend: observe and actuate scaling state.
+
+    Neutral contract keyed by opaque ``participant_id``. Concrete backends
+    override the observe/actuate surface; ``discover`` defaults to a no-op for
+    backends (such as an in-memory replay backend) that have nothing to
+    pre-populate.
+    """
+
+    def discover(self, managed_callers: Optional[set[str]]) -> list[str]:
+        """Pre-populate the participant set at startup (no-op by default).
+
+        ``managed_callers`` scopes discovery in explicit mode, or ``None`` for
+        implicit mode. Returns the discovered participant identities.
+        """
+        return []
+
+    def ensure_participant(
+        self,
+        participant_id: str,
+        *,
+        caller_name: str,
+        cluster_name: str,
+        deployment_name: str,
+    ) -> None:
+        """Register a participant (idempotent) so it counts toward the budget and
+        can be actuated."""
+        raise NotImplementedError
+
+    def knows(self, participant_id: str) -> bool:
+        """Whether ``participant_id`` has been registered/discovered."""
+        raise NotImplementedError
+
+    def observe(self) -> PoolSnapshot:
+        """Read current pool state for every known participant."""
+        raise NotImplementedError
+
+    async def actuate(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        *,
+        blocking: bool,
+    ) -> None:
+        """Apply desired replica targets to one participant."""
+        raise NotImplementedError
+
+    def current_replicas(self, participant_id: str) -> dict[str, int]:
+        """Read back current replica counts as ``{sub_type: replicas}``."""
+        raise NotImplementedError
+
+
+class KubernetesCapacityManager(CapacityManager):
+    """Observe / actuate capacity via ``KubernetesConnector`` per deployment.
+
+    A ``participant_id`` is ``"{cluster_name}/{deployment_name}"``. One
+    ``KubernetesConnector`` is cached per participant.
+    """
+
+    def __init__(self, cluster_name: str):
+        self.cluster_name = cluster_name
+        # participant_id -> KubernetesConnector
+        self.connectors: dict[str, KubernetesConnector] = {}
+
+    # ------------------------------------------------------------------ #
+    # Discovery / registration                                           #
+    # ------------------------------------------------------------------ #
+
+    def _managed_deployment_names(
+        self, managed_callers: Optional[set[str]]
+    ) -> Optional[set[str]]:
+        """Derive the deployment names this GlobalPlanner manages.
+
+        Returns a set of deployment names in explicit mode, or ``None`` in
+        implicit mode. The operator convention is
+        ``DYN_NAMESPACE = "{cluster_name}-{deployment_name}"``, so the deployment
+        name is the caller identity with the cluster prefix stripped.
+        """
+        if managed_callers is None:
+            return None
+
+        prefix = f"{self.cluster_name}-"
+        names = set()
+        for caller in managed_callers:
+            if caller.startswith(prefix):
+                names.add(caller[len(prefix) :])
+            else:
+                logger.warning(
+                    f"Managed caller '{caller}' does not start with "
+                    f"expected prefix '{prefix}'; cannot derive deployment name"
+                )
+        return names
+
+    def discover(self, managed_callers: Optional[set[str]]) -> list[str]:
+        """Pre-populate connectors for deployments managed by this GlobalPlanner.
+
+        Ensures the GPU budget accounts for deployments that already exist at
+        startup, even if they haven't sent a scale request yet. In explicit mode
+        (``managed_callers`` set) only matching deployments are discovered; in
+        implicit mode (``None``) all deployments in the cluster are discovered.
+        """
+        managed_deployment_names = self._managed_deployment_names(managed_callers)
+        try:
+            kube_api = KubernetesAPI(self.cluster_name)
+            dgds = kube_api.list_graph_deployments()
+            discovered: list[str] = []
+            for dgd in dgds:
+                name = dgd.get("metadata", {}).get("name", "")
+                if not name:
+                    continue
+                # In explicit mode, skip deployments not in the managed set.
+                if (
+                    managed_deployment_names is not None
+                    and name not in managed_deployment_names
+                ):
+                    continue
+                participant_id = f"{self.cluster_name}/{name}"
+                if participant_id not in self.connectors:
+                    connector = KubernetesConnector(
+                        dynamo_namespace="discovered",
+                        k8s_namespace=self.cluster_name,
+                        parent_dgd_name=name,
+                        raise_not_ready=True,
+                    )
+                    self.connectors[participant_id] = connector
+                discovered.append(name)
+            logger.info(
+                f"Discovered {len(discovered)} existing deployments: {discovered}"
+            )
+            return discovered
+        except Exception as e:
+            logger.warning(f"Failed to discover existing deployments: {e}")
+            return []
+
+    def ensure_participant(
+        self,
+        participant_id: str,
+        *,
+        caller_name: str,
+        cluster_name: str,
+        deployment_name: str,
+    ) -> None:
+        if participant_id not in self.connectors:
+            connector = KubernetesConnector(
+                dynamo_namespace=caller_name,
+                k8s_namespace=cluster_name,
+                parent_dgd_name=deployment_name,
+                raise_not_ready=True,
+            )
+            self.connectors[participant_id] = connector
+            logger.debug(f"Created new connector for {participant_id}")
+        else:
+            logger.debug(f"Reusing cached connector for {participant_id}")
+
+    def knows(self, participant_id: str) -> bool:
+        return participant_id in self.connectors
+
+    # ------------------------------------------------------------------ #
+    # Observe                                                            #
+    # ------------------------------------------------------------------ #
+
+    def observe(self) -> PoolSnapshot:
+        """Read current pool state for every known deployment.
+
+        Snapshots ``self.connectors`` up-front via ``list(...)``: this runs on a
+        worker thread (the orchestrator calls it via ``asyncio.to_thread``), and
+        a concurrent first-time request for another deployment can insert into
+        the dict before it blocks on the scale lock. Without the snapshot, that
+        insertion races iteration.
+        """
+        all_pools: PoolSnapshot = {}
+        for key, connector in list(self.connectors.items()):
+            try:
+                all_pools[key] = self._read_pools(connector)
+            except Exception as e:
+                logger.warning(f"Failed to read deployment for {key}: {e}")
+                all_pools[key] = {}
+        return all_pools
+
+    def _read_pools(self, connector: KubernetesConnector) -> dict[str, PoolSpec]:
+        """Read the current pool state for one deployment.
+
+        Returns a map from sub_type to PoolSpec. Pools with 0 gpu_per_replica are
+        included for completeness but contribute 0 to budget math. GPU count is
+        read from ``spec.services[].resources.limits.gpu`` only.
+        """
+        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
+        pools: dict[str, PoolSpec] = {}
+        services = deployment.get("spec", {}).get("services", {})
+        for svc_spec in services.values():
+            sub_type = svc_spec.get("subComponentType", "")
+            if not sub_type:
+                continue
+            gpu_per_replica = int(
+                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
+            )
+            replicas = svc_spec.get("replicas", 0)
+            pools[sub_type] = PoolSpec(
+                sub_type=sub_type,
+                current_replicas=replicas,
+                gpu_per_replica=gpu_per_replica,
+            )
+        return pools
+
+    # ------------------------------------------------------------------ #
+    # Actuate                                                            #
+    # ------------------------------------------------------------------ #
+
+    async def actuate(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        *,
+        blocking: bool,
+    ) -> None:
+        """Apply desired replica targets to one participant.
+
+        Raises ``DynamoGraphDeploymentNotReadyError`` when the participant is not
+        in a state that can accept scaling; the orchestrator maps that to a soft
+        rejection.
+        """
+        connector = self.connectors[participant_id]
+        await connector.set_component_replicas(targets, blocking=blocking)
+
+    def current_replicas(self, participant_id: str) -> dict[str, int]:
+        connector = self.connectors[participant_id]
+        current_replicas: dict[str, int] = {}
+        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
+        for service_name, service_spec in deployment["spec"]["services"].items():
+            sub_type = service_spec.get("subComponentType", "")
+            if sub_type:
+                current_replicas[sub_type] = service_spec.get("replicas", 0)
+        return current_replicas

--- a/components/src/dynamo/global_planner/capacity_manager.py
+++ b/components/src/dynamo/global_planner/capacity_manager.py
@@ -59,7 +59,6 @@ class CapacityManager:
     def ensure_participant(
         self,
         participant_id: str,
-        *,
         caller_name: str,
         namespace: str,
         deployment_name: str,
@@ -80,7 +79,6 @@ class CapacityManager:
         self,
         participant_id: str,
         targets: list[TargetReplica],
-        *,
         blocking: bool,
     ) -> None:
         """Apply desired replica targets to one participant."""

--- a/components/src/dynamo/global_planner/capacity_manager.py
+++ b/components/src/dynamo/global_planner/capacity_manager.py
@@ -7,8 +7,9 @@
 :class:`~dynamo.global_planner.orchestrator.Orchestrator` drives to **observe**
 current pool state and **scale** replicas. It defines a neutral,
 infrastructure-agnostic surface (``observe`` / ``scale`` / ``discover`` /
-``ensure_participant`` / ``participant_exists`` / ``current_replicas``) keyed by
-opaque ``participant_id``; the orchestrator never sees Kubernetes concepts.
+``ensure_participant`` / ``participant_exists`` / ``remember_roles`` /
+``current_replicas``) keyed by opaque ``participant_id``; the orchestrator never
+sees Kubernetes concepts.
 
 The concrete Kubernetes backend is
 :class:`~dynamo.global_planner.kubernetes_capacity_manager.KubernetesCapacityManager`.
@@ -26,14 +27,17 @@ from dynamo.planner import TargetReplica
 class PoolSpec:
     """Snapshot of one pool's state read from a backend.
 
-    Infrastructure-agnostic: the budget math consumes only these three fields.
-    Pools with ``gpu_per_replica == 0`` are included for completeness but
-    contribute 0 to budget totals.
+    Infrastructure-agnostic: the budget math consumes only ``current_replicas``
+    and ``gpu_per_replica``. ``component_name`` is an opaque backend handle for
+    the pool (empty for backends that don't need one); it round-trips through the
+    orchestrator so a paired scale can target the right component. Pools with
+    ``gpu_per_replica == 0`` contribute 0 to budget totals.
     """
 
     sub_type: str
     current_replicas: int
     gpu_per_replica: int
+    component_name: str = ""
 
 
 # participant_id -> (sub_type -> PoolSpec)
@@ -71,8 +75,22 @@ class CapacityManager:
         """Whether ``participant_id`` has been registered/discovered."""
         raise NotImplementedError
 
-    def observe(self) -> PoolSnapshot:
-        """Read current pool state for every known participant."""
+    def remember_roles(self, participant_id: str, targets: list[TargetReplica]) -> None:
+        """Record any backend-specific hints carried by a request's targets
+        (e.g. ``TargetReplica.component_name``) before the next ``observe``.
+
+        No-op by default; backends that need request context to read pool state
+        override it. The orchestrator forwards ``targets`` opaquely.
+        """
+        return None
+
+    def observe(self, require_complete: bool = False) -> PoolSnapshot:
+        """Read current pool state for every known participant.
+
+        When ``require_complete`` is true, a failure to read any participant
+        raises instead of being skipped, so budget enforcement cannot
+        under-count usage from a partially-read snapshot.
+        """
         raise NotImplementedError
 
     async def scale(

--- a/components/src/dynamo/global_planner/capacity_manager.py
+++ b/components/src/dynamo/global_planner/capacity_manager.py
@@ -1,35 +1,25 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Capacity backend for the GlobalPlanner — reads and writes scaling state.
+"""Capacity backend contract for the GlobalPlanner — reads and writes scaling state.
 
 :class:`CapacityManager` is the infrastructure-facing base class the
 :class:`~dynamo.global_planner.orchestrator.Orchestrator` drives to **observe**
-current pool state and **actuate** replica changes. It defines a neutral,
-infrastructure-agnostic surface (``observe`` / ``actuate`` / ``discover`` /
-``ensure_participant`` / ``knows`` / ``current_replicas``) keyed by opaque
-``participant_id``; the orchestrator never sees Kubernetes concepts.
+current pool state and **scale** replicas. It defines a neutral,
+infrastructure-agnostic surface (``observe`` / ``scale`` / ``discover`` /
+``ensure_participant`` / ``participant_exists`` / ``current_replicas``) keyed by
+opaque ``participant_id``; the orchestrator never sees Kubernetes concepts.
 
-:class:`KubernetesCapacityManager` is the concrete Kubernetes backend — the only
-place in the control loop that touches Kubernetes. A ``participant_id`` there is
-``"{cluster_name}/{deployment_name}"``, and the read/write logic is lifted
-verbatim from the pre-refactor ``ScaleRequestHandler`` so behavior is unchanged.
-
-Offline replay can add another backend (in-memory) by subclassing
-:class:`CapacityManager` and implementing the same surface — no orchestrator
-change required.
+The concrete Kubernetes backend is
+:class:`~dynamo.global_planner.kubernetes_capacity_manager.KubernetesCapacityManager`.
 """
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from dynamo.planner import KubernetesConnector, TargetReplica
-from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
-
-logger = logging.getLogger(__name__)
+from dynamo.planner import TargetReplica
 
 
 @dataclass
@@ -51,19 +41,18 @@ PoolSnapshot = dict[str, dict[str, PoolSpec]]
 
 
 class CapacityManager:
-    """Base capacity backend: observe and actuate scaling state.
+    """Base capacity backend: observe pool state and scale replicas.
 
     Neutral contract keyed by opaque ``participant_id``. Concrete backends
-    override the observe/actuate surface; ``discover`` defaults to a no-op for
-    backends (such as an in-memory replay backend) that have nothing to
-    pre-populate.
+    override the observe/scale surface; ``discover`` defaults to a no-op for
+    backends that have nothing to pre-populate.
     """
 
-    def discover(self, managed_callers: Optional[set[str]]) -> list[str]:
+    def discover(self, managed_deployments: Optional[set[str]]) -> list[str]:
         """Pre-populate the participant set at startup (no-op by default).
 
-        ``managed_callers`` scopes discovery in explicit mode, or ``None`` for
-        implicit mode. Returns the discovered participant identities.
+        ``managed_deployments`` scopes discovery in explicit mode, or ``None``
+        for implicit mode. Returns the discovered participant identities.
         """
         return []
 
@@ -72,14 +61,14 @@ class CapacityManager:
         participant_id: str,
         *,
         caller_name: str,
-        cluster_name: str,
+        namespace: str,
         deployment_name: str,
     ) -> None:
         """Register a participant (idempotent) so it counts toward the budget and
-        can be actuated."""
+        can be scaled."""
         raise NotImplementedError
 
-    def knows(self, participant_id: str) -> bool:
+    def participant_exists(self, participant_id: str) -> bool:
         """Whether ``participant_id`` has been registered/discovered."""
         raise NotImplementedError
 
@@ -87,7 +76,7 @@ class CapacityManager:
         """Read current pool state for every known participant."""
         raise NotImplementedError
 
-    async def actuate(
+    async def scale(
         self,
         participant_id: str,
         targets: list[TargetReplica],
@@ -100,186 +89,3 @@ class CapacityManager:
     def current_replicas(self, participant_id: str) -> dict[str, int]:
         """Read back current replica counts as ``{sub_type: replicas}``."""
         raise NotImplementedError
-
-
-class KubernetesCapacityManager(CapacityManager):
-    """Observe / actuate capacity via ``KubernetesConnector`` per deployment.
-
-    A ``participant_id`` is ``"{cluster_name}/{deployment_name}"``. One
-    ``KubernetesConnector`` is cached per participant.
-    """
-
-    def __init__(self, cluster_name: str):
-        self.cluster_name = cluster_name
-        # participant_id -> KubernetesConnector
-        self.connectors: dict[str, KubernetesConnector] = {}
-
-    # ------------------------------------------------------------------ #
-    # Discovery / registration                                           #
-    # ------------------------------------------------------------------ #
-
-    def _managed_deployment_names(
-        self, managed_callers: Optional[set[str]]
-    ) -> Optional[set[str]]:
-        """Derive the deployment names this GlobalPlanner manages.
-
-        Returns a set of deployment names in explicit mode, or ``None`` in
-        implicit mode. The operator convention is
-        ``DYN_NAMESPACE = "{cluster_name}-{deployment_name}"``, so the deployment
-        name is the caller identity with the cluster prefix stripped.
-        """
-        if managed_callers is None:
-            return None
-
-        prefix = f"{self.cluster_name}-"
-        names = set()
-        for caller in managed_callers:
-            if caller.startswith(prefix):
-                names.add(caller[len(prefix) :])
-            else:
-                logger.warning(
-                    f"Managed caller '{caller}' does not start with "
-                    f"expected prefix '{prefix}'; cannot derive deployment name"
-                )
-        return names
-
-    def discover(self, managed_callers: Optional[set[str]]) -> list[str]:
-        """Pre-populate connectors for deployments managed by this GlobalPlanner.
-
-        Ensures the GPU budget accounts for deployments that already exist at
-        startup, even if they haven't sent a scale request yet. In explicit mode
-        (``managed_callers`` set) only matching deployments are discovered; in
-        implicit mode (``None``) all deployments in the cluster are discovered.
-        """
-        managed_deployment_names = self._managed_deployment_names(managed_callers)
-        try:
-            kube_api = KubernetesAPI(self.cluster_name)
-            dgds = kube_api.list_graph_deployments()
-            discovered: list[str] = []
-            for dgd in dgds:
-                name = dgd.get("metadata", {}).get("name", "")
-                if not name:
-                    continue
-                # In explicit mode, skip deployments not in the managed set.
-                if (
-                    managed_deployment_names is not None
-                    and name not in managed_deployment_names
-                ):
-                    continue
-                participant_id = f"{self.cluster_name}/{name}"
-                if participant_id not in self.connectors:
-                    connector = KubernetesConnector(
-                        dynamo_namespace="discovered",
-                        k8s_namespace=self.cluster_name,
-                        parent_dgd_name=name,
-                        raise_not_ready=True,
-                    )
-                    self.connectors[participant_id] = connector
-                discovered.append(name)
-            logger.info(
-                f"Discovered {len(discovered)} existing deployments: {discovered}"
-            )
-            return discovered
-        except Exception as e:
-            logger.warning(f"Failed to discover existing deployments: {e}")
-            return []
-
-    def ensure_participant(
-        self,
-        participant_id: str,
-        *,
-        caller_name: str,
-        cluster_name: str,
-        deployment_name: str,
-    ) -> None:
-        if participant_id not in self.connectors:
-            connector = KubernetesConnector(
-                dynamo_namespace=caller_name,
-                k8s_namespace=cluster_name,
-                parent_dgd_name=deployment_name,
-                raise_not_ready=True,
-            )
-            self.connectors[participant_id] = connector
-            logger.debug(f"Created new connector for {participant_id}")
-        else:
-            logger.debug(f"Reusing cached connector for {participant_id}")
-
-    def knows(self, participant_id: str) -> bool:
-        return participant_id in self.connectors
-
-    # ------------------------------------------------------------------ #
-    # Observe                                                            #
-    # ------------------------------------------------------------------ #
-
-    def observe(self) -> PoolSnapshot:
-        """Read current pool state for every known deployment.
-
-        Snapshots ``self.connectors`` up-front via ``list(...)``: this runs on a
-        worker thread (the orchestrator calls it via ``asyncio.to_thread``), and
-        a concurrent first-time request for another deployment can insert into
-        the dict before it blocks on the scale lock. Without the snapshot, that
-        insertion races iteration.
-        """
-        all_pools: PoolSnapshot = {}
-        for key, connector in list(self.connectors.items()):
-            try:
-                all_pools[key] = self._read_pools(connector)
-            except Exception as e:
-                logger.warning(f"Failed to read deployment for {key}: {e}")
-                all_pools[key] = {}
-        return all_pools
-
-    def _read_pools(self, connector: KubernetesConnector) -> dict[str, PoolSpec]:
-        """Read the current pool state for one deployment.
-
-        Returns a map from sub_type to PoolSpec. Pools with 0 gpu_per_replica are
-        included for completeness but contribute 0 to budget math. GPU count is
-        read from ``spec.services[].resources.limits.gpu`` only.
-        """
-        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
-        pools: dict[str, PoolSpec] = {}
-        services = deployment.get("spec", {}).get("services", {})
-        for svc_spec in services.values():
-            sub_type = svc_spec.get("subComponentType", "")
-            if not sub_type:
-                continue
-            gpu_per_replica = int(
-                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
-            )
-            replicas = svc_spec.get("replicas", 0)
-            pools[sub_type] = PoolSpec(
-                sub_type=sub_type,
-                current_replicas=replicas,
-                gpu_per_replica=gpu_per_replica,
-            )
-        return pools
-
-    # ------------------------------------------------------------------ #
-    # Actuate                                                            #
-    # ------------------------------------------------------------------ #
-
-    async def actuate(
-        self,
-        participant_id: str,
-        targets: list[TargetReplica],
-        *,
-        blocking: bool,
-    ) -> None:
-        """Apply desired replica targets to one participant.
-
-        Raises ``DynamoGraphDeploymentNotReadyError`` when the participant is not
-        in a state that can accept scaling; the orchestrator maps that to a soft
-        rejection.
-        """
-        connector = self.connectors[participant_id]
-        await connector.set_component_replicas(targets, blocking=blocking)
-
-    def current_replicas(self, participant_id: str) -> dict[str, int]:
-        connector = self.connectors[participant_id]
-        current_replicas: dict[str, int] = {}
-        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
-        for service_name, service_spec in deployment["spec"]["services"].items():
-            sub_type = service_spec.get("subComponentType", "")
-            if sub_type:
-                current_replicas[sub_type] = service_spec.get("replicas", 0)
-        return current_replicas

--- a/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Kubernetes backend for the GlobalPlanner capacity control loop.
+
+:class:`KubernetesCapacityManager` is the concrete
+:class:`~dynamo.global_planner.capacity_manager.CapacityManager` — the only place
+in the control loop that touches Kubernetes. A ``participant_id`` is
+``"{namespace}/{deployment_name}"``, and the read/write logic is lifted
+verbatim from the pre-refactor ``ScaleRequestHandler`` so behavior is unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from dynamo.global_planner.capacity_manager import (
+    CapacityManager,
+    PoolSnapshot,
+    PoolSpec,
+)
+from dynamo.planner import KubernetesConnector, TargetReplica
+from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
+
+logger = logging.getLogger(__name__)
+
+
+class KubernetesCapacityManager(CapacityManager):
+    """Observe / scale capacity via ``KubernetesConnector`` per deployment.
+
+    A ``participant_id`` is ``"{namespace}/{deployment_name}"``. One
+    ``KubernetesConnector`` is cached per participant.
+    """
+
+    def __init__(self, namespace: str):
+        self.namespace = namespace
+        # participant_id -> KubernetesConnector
+        self.connectors: dict[str, KubernetesConnector] = {}
+
+    # ------------------------------------------------------------------ #
+    # Discovery / registration                                           #
+    # ------------------------------------------------------------------ #
+
+    def _managed_deployment_names(
+        self, managed_deployments: Optional[set[str]]
+    ) -> Optional[set[str]]:
+        """Derive the deployment names this GlobalPlanner manages.
+
+        Returns a set of deployment names in explicit mode, or ``None`` in
+        implicit mode. The operator convention is
+        ``DYN_NAMESPACE = "{namespace}-{deployment_name}"``, so the deployment
+        name is the managed identity with the namespace prefix stripped.
+        """
+        if managed_deployments is None:
+            return None
+
+        prefix = f"{self.namespace}-"
+        names = set()
+        for deployment in managed_deployments:
+            if deployment.startswith(prefix):
+                names.add(deployment[len(prefix) :])
+            else:
+                logger.warning(
+                    f"Managed deployment '{deployment}' does not start with "
+                    f"expected prefix '{prefix}'; cannot derive deployment name"
+                )
+        return names
+
+    def discover(self, managed_deployments: Optional[set[str]]) -> list[str]:
+        """Pre-populate connectors for deployments managed by this GlobalPlanner.
+
+        Ensures the GPU budget accounts for deployments that already exist at
+        startup, even if they haven't sent a scale request yet. In explicit mode
+        (``managed_deployments`` set) only matching deployments are discovered; in
+        implicit mode (``None``) all deployments in the namespace are discovered.
+        """
+        managed_deployment_names = self._managed_deployment_names(managed_deployments)
+        try:
+            kube_api = KubernetesAPI(self.namespace)
+            dgds = kube_api.list_graph_deployments()
+            discovered: list[str] = []
+            for dgd in dgds:
+                name = dgd.get("metadata", {}).get("name", "")
+                if not name:
+                    continue
+                # In explicit mode, skip deployments not in the managed set.
+                if (
+                    managed_deployment_names is not None
+                    and name not in managed_deployment_names
+                ):
+                    continue
+                participant_id = f"{self.namespace}/{name}"
+                if participant_id not in self.connectors:
+                    connector = KubernetesConnector(
+                        dynamo_namespace="discovered",
+                        k8s_namespace=self.namespace,
+                        parent_dgd_name=name,
+                        raise_not_ready=True,
+                    )
+                    self.connectors[participant_id] = connector
+                discovered.append(name)
+            logger.info(
+                f"Discovered {len(discovered)} existing deployments: {discovered}"
+            )
+            return discovered
+        except Exception as e:
+            logger.warning(f"Failed to discover existing deployments: {e}")
+            return []
+
+    def ensure_participant(
+        self,
+        participant_id: str,
+        *,
+        caller_name: str,
+        namespace: str,
+        deployment_name: str,
+    ) -> None:
+        if participant_id not in self.connectors:
+            connector = KubernetesConnector(
+                dynamo_namespace=caller_name,
+                k8s_namespace=namespace,
+                parent_dgd_name=deployment_name,
+                raise_not_ready=True,
+            )
+            self.connectors[participant_id] = connector
+            logger.debug(f"Created new connector for {participant_id}")
+        else:
+            logger.debug(f"Reusing cached connector for {participant_id}")
+
+    def participant_exists(self, participant_id: str) -> bool:
+        return participant_id in self.connectors
+
+    # ------------------------------------------------------------------ #
+    # Observe                                                            #
+    # ------------------------------------------------------------------ #
+
+    def observe(self) -> PoolSnapshot:
+        """Read current pool state for every known deployment.
+
+        Snapshots ``self.connectors`` up-front via ``list(...)``: this runs on a
+        worker thread (the orchestrator calls it via ``asyncio.to_thread``), and
+        a concurrent first-time request for another deployment can insert into
+        the dict before it blocks on the scale lock. Without the snapshot, that
+        insertion races iteration.
+        """
+        all_pools: PoolSnapshot = {}
+        for key, connector in list(self.connectors.items()):
+            try:
+                all_pools[key] = self._read_pools(connector)
+            except Exception as e:
+                logger.warning(f"Failed to read deployment for {key}: {e}")
+                all_pools[key] = {}
+        return all_pools
+
+    def _read_pools(self, connector: KubernetesConnector) -> dict[str, PoolSpec]:
+        """Read the current pool state for one deployment.
+
+        Returns a map from sub_type to PoolSpec. Pools with 0 gpu_per_replica are
+        included for completeness but contribute 0 to budget math. GPU count is
+        read from ``spec.services[].resources.limits.gpu`` only.
+        """
+        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
+        pools: dict[str, PoolSpec] = {}
+        services = deployment.get("spec", {}).get("services", {})
+        for svc_spec in services.values():
+            sub_type = svc_spec.get("subComponentType", "")
+            if not sub_type:
+                continue
+            gpu_per_replica = int(
+                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
+            )
+            replicas = svc_spec.get("replicas", 0)
+            pools[sub_type] = PoolSpec(
+                sub_type=sub_type,
+                current_replicas=replicas,
+                gpu_per_replica=gpu_per_replica,
+            )
+        return pools
+
+    # ------------------------------------------------------------------ #
+    # Scale                                                              #
+    # ------------------------------------------------------------------ #
+
+    async def scale(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        *,
+        blocking: bool,
+    ) -> None:
+        """Apply desired replica targets to one participant.
+
+        Raises ``DynamoGraphDeploymentNotReadyError`` when the participant is not
+        in a state that can accept scaling; the orchestrator maps that to a soft
+        rejection.
+        """
+        connector = self.connectors[participant_id]
+        await connector.set_component_replicas(targets, blocking=blocking)
+
+    def current_replicas(self, participant_id: str) -> dict[str, int]:
+        connector = self.connectors[participant_id]
+        current_replicas: dict[str, int] = {}
+        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
+        for service_name, service_spec in deployment["spec"]["services"].items():
+            sub_type = service_spec.get("subComponentType", "")
+            if sub_type:
+                current_replicas[sub_type] = service_spec.get("replicas", 0)
+        return current_replicas

--- a/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
@@ -111,7 +111,6 @@ class KubernetesCapacityManager(CapacityManager):
     def ensure_participant(
         self,
         participant_id: str,
-        *,
         caller_name: str,
         namespace: str,
         deployment_name: str,
@@ -186,7 +185,6 @@ class KubernetesCapacityManager(CapacityManager):
         self,
         participant_id: str,
         targets: list[TargetReplica],
-        *,
         blocking: bool,
     ) -> None:
         """Apply desired replica targets to one participant.

--- a/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/kubernetes_capacity_manager.py
@@ -6,8 +6,12 @@
 :class:`KubernetesCapacityManager` is the concrete
 :class:`~dynamo.global_planner.capacity_manager.CapacityManager` — the only place
 in the control loop that touches Kubernetes. A ``participant_id`` is
-``"{namespace}/{deployment_name}"``, and the read/write logic is lifted
-verbatim from the pre-refactor ``ScaleRequestHandler`` so behavior is unchanged.
+``"{namespace}/{deployment_name}"``.
+
+Pool state is read from the v1beta1 DGD component model (``spec.components[]``):
+a component's planner pool is its explicit ``prefill``/``decode`` type, or — for
+a generic ``worker`` — the role hinted by its Planner's
+``TargetReplica.component_name`` (remembered via :meth:`remember_roles`).
 """
 
 from __future__ import annotations
@@ -22,6 +26,13 @@ from dynamo.global_planner.capacity_manager import (
 )
 from dynamo.planner import KubernetesConnector, TargetReplica
 from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
+from dynamo.planner.monitoring.dgd_services import (
+    V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+    Service,
+    get_component_type,
+    get_components_by_name,
+    get_planner_component_role,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +48,10 @@ class KubernetesCapacityManager(CapacityManager):
         self.namespace = namespace
         # participant_id -> KubernetesConnector
         self.connectors: dict[str, KubernetesConnector] = {}
+        # participant_id -> {component_name: planner_role}. Generic ``worker``
+        # components need the role supplied by their Planner's TargetReplica;
+        # specialized prefill/decode components do not need a hint.
+        self._component_roles: dict[str, dict[str, str]] = {}
 
     # ------------------------------------------------------------------ #
     # Discovery / registration                                           #
@@ -130,12 +145,24 @@ class KubernetesCapacityManager(CapacityManager):
     def participant_exists(self, participant_id: str) -> bool:
         return participant_id in self.connectors
 
+    def remember_roles(self, participant_id: str, targets: list[TargetReplica]) -> None:
+        """Remember each target's ``component_name -> planner role`` hint so a
+        later ``observe`` can map generic ``worker`` components to prefill/decode.
+        """
+        role_hints = self._component_roles.setdefault(participant_id, {})
+        for target in targets:
+            if target.component_name:
+                role_hints[target.component_name] = target.sub_component_type.value
+
     # ------------------------------------------------------------------ #
     # Observe                                                            #
     # ------------------------------------------------------------------ #
 
-    def observe(self) -> PoolSnapshot:
+    def observe(self, require_complete: bool = False) -> PoolSnapshot:
         """Read current pool state for every known deployment.
+
+        When ``require_complete`` is true, any unreadable deployment fails the
+        whole snapshot so budget enforcement cannot under-count cluster usage.
 
         Snapshots ``self.connectors`` up-front via ``list(...)``: this runs on a
         worker thread (the orchestrator calls it via ``asyncio.to_thread``), and
@@ -146,34 +173,111 @@ class KubernetesCapacityManager(CapacityManager):
         all_pools: PoolSnapshot = {}
         for key, connector in list(self.connectors.items()):
             try:
-                all_pools[key] = self._read_pools(connector)
+                all_pools[key] = self._read_pools(
+                    connector, self._component_roles.get(key)
+                )
             except Exception as e:
+                if require_complete:
+                    raise RuntimeError(
+                        f"Failed to read deployment for {key}: {e}"
+                    ) from e
                 logger.warning(f"Failed to read deployment for {key}: {e}")
                 all_pools[key] = {}
         return all_pools
 
-    def _read_pools(self, connector: KubernetesConnector) -> dict[str, PoolSpec]:
-        """Read the current pool state for one deployment.
+    def _component_role(
+        self,
+        component_name: str,
+        component: dict,
+        role_hints: dict[str, str],
+    ) -> str:
+        """Resolve a component's planner pool role.
 
-        Returns a map from sub_type to PoolSpec. Pools with 0 gpu_per_replica are
-        included for completeness but contribute 0 to budget math. GPU count is
-        read from ``spec.services[].resources.limits.gpu`` only.
+        An explicit ``prefill``/``decode`` type wins; otherwise a generic or
+        untyped worker takes the remembered role hint (if any); else ``""``.
+        """
+        explicit_role = get_planner_component_role(component)
+        if explicit_role:
+            return explicit_role
+        if get_component_type(component) in (
+            "",
+            V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+        ):
+            return role_hints.get(component_name, "")
+        return ""
+
+    @staticmethod
+    def _gpu_per_replica(component: dict, service: Service) -> int:
+        """GPUs per replica = main-container GPUs × node count (multinode)."""
+        multinode = component.get("multinode")
+        node_count = 1 if multinode is None else multinode.get("nodeCount", 2)
+        return service.get_gpu_count() * int(node_count)
+
+    @staticmethod
+    def _record_pool_component(
+        components_by_pool: dict[str, str],
+        pool_key: str,
+        component_name: str,
+        deployment_name: str,
+    ) -> None:
+        """Guard against two components resolving to the same planner pool."""
+        previous_component = components_by_pool.get(pool_key)
+        if previous_component is not None:
+            raise ValueError(
+                f"Deployment {deployment_name!r} components {previous_component!r} "
+                f"and {component_name!r} both resolve to planner pool {pool_key!r}"
+            )
+        components_by_pool[pool_key] = component_name
+
+    def _read_pools(
+        self,
+        connector: KubernetesConnector,
+        role_hints: Optional[dict[str, str]] = None,
+    ) -> dict[str, PoolSpec]:
+        """Read the current pool state for one deployment (v1beta1 components).
+
+        An unmapped generic worker is keyed by component name so it still
+        contributes to the total; once its Planner sends a request, the
+        component-name hint replaces that key with its prefill/decode role.
         """
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
         pools: dict[str, PoolSpec] = {}
-        services = deployment.get("spec", {}).get("services", {})
-        for svc_spec in services.values():
-            sub_type = svc_spec.get("subComponentType", "")
-            if not sub_type:
+        components_by_pool: dict[str, str] = {}
+        role_hints = role_hints or {}
+        for component_name, component in get_components_by_name(deployment).items():
+            pool_key = self._component_role(component_name, component, role_hints)
+            component_type = get_component_type(component)
+            service = Service(name=component_name, service=component)
+            gpu_per_replica = None
+            if not pool_key and component_type in (
+                "",
+                V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
+            ):
+                try:
+                    gpu_per_replica = self._gpu_per_replica(component, service)
+                except ValueError:
+                    if component_type == "":
+                        # An untyped non-worker component is not a pool.
+                        continue
+                    raise
+                pool_key = component_name
+            if not pool_key:
                 continue
-            gpu_per_replica = int(
-                svc_spec.get("resources", {}).get("limits", {}).get("gpu", 0)
+            self._record_pool_component(
+                components_by_pool,
+                pool_key,
+                component_name,
+                connector.parent_dgd_name,
             )
-            replicas = svc_spec.get("replicas", 0)
-            pools[sub_type] = PoolSpec(
-                sub_type=sub_type,
-                current_replicas=replicas,
-                gpu_per_replica=gpu_per_replica,
+            pools[pool_key] = PoolSpec(
+                sub_type=pool_key,
+                component_name=component_name,
+                current_replicas=service.number_replicas(),
+                gpu_per_replica=(
+                    gpu_per_replica
+                    if gpu_per_replica is not None
+                    else self._gpu_per_replica(component, service)
+                ),
             )
         return pools
 
@@ -198,10 +302,20 @@ class KubernetesCapacityManager(CapacityManager):
 
     def current_replicas(self, participant_id: str) -> dict[str, int]:
         connector = self.connectors[participant_id]
+        role_hints = self._component_roles.get(participant_id, {})
         current_replicas: dict[str, int] = {}
+        components_by_pool: dict[str, str] = {}
         deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
-        for service_name, service_spec in deployment["spec"]["services"].items():
-            sub_type = service_spec.get("subComponentType", "")
+        for component_name, component in get_components_by_name(deployment).items():
+            sub_type = self._component_role(component_name, component, role_hints)
             if sub_type:
-                current_replicas[sub_type] = service_spec.get("replicas", 0)
+                self._record_pool_component(
+                    components_by_pool,
+                    sub_type,
+                    component_name,
+                    connector.parent_dgd_name,
+                )
+                current_replicas[sub_type] = Service(
+                    name=component_name, service=component
+                ).number_replicas()
         return current_replicas

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -128,6 +128,10 @@ class Orchestrator:
     ):
         self.capacity_manager = capacity_manager
 
+        # TODO(global-planner): Validate configuration and requests at the
+        # boundary: reject min > max and invalid TTLs, preserve an explicit empty
+        # allowlist instead of treating it as None, and reject empty, duplicate,
+        # unknown, or negative targets before caching, mediation, or execution.
         # Budget bounds + intent cache.
         self.max_total_gpus = max_total_gpus
         self.min_total_gpus = min_total_gpus
@@ -135,6 +139,11 @@ class Orchestrator:
         # Injected clock — production uses wall-clock; offline replay passes a
         # sim-time source so intent-cache TTL is meaningful there too.
         self._now = now
+        # TODO(global-planner): Replace process-local discovery,
+        # participant/intent state, and locking with fail-closed cluster-wide
+        # coordination, and register participants inside the same serialized
+        # boundary as observe/decide/apply so the hard GPU ceiling always uses a
+        # complete snapshot.
         # Per-pool cached desired replicas from recent requests, keyed by
         # f"{participant_id}/{sub_type}". Used to pair opposite-direction intents
         # across requests when one request alone would breach bounds.
@@ -195,6 +204,10 @@ class Orchestrator:
         below the floor. Only runs when budget enforcement is enabled."""
         if not self.budget_enforcement_enabled():
             return
+        # TODO(global-planner): Add ongoing lifecycle reconciliation after
+        # startup: discover new participants, evict deleted participants,
+        # connectors, and role hints, and prune expired or satisfied intents
+        # instead of only skipping them.
         self.capacity_manager.discover(self.managed_deployments)
         if self.min_total_gpus >= 0:
             self._warn_if_below_floor()
@@ -287,6 +300,10 @@ class Orchestrator:
         # correctly (e.g. component-name role hints for generic workers).
         self.capacity_manager.remember_roles(participant_id, targets)
 
+        # TODO(global-planner): Make the request path scale: avoid full-cluster
+        # observation when budget enforcement is disabled, move synchronous
+        # Kubernetes readback and PATCH work off the event loop, and do not hold
+        # the budget lock through blocking readiness waits.
         # Read ALL known participants' current state once. Cross-participant
         # partner search needs every pool's current replicas and gpu_per_replica;
         # cross-participant budget math also consumes this. Run the synchronous
@@ -313,6 +330,10 @@ class Orchestrator:
                 current_replicas={},
             )
 
+        # TODO(global-planner): Make an approved plan equivalent to execution:
+        # apply same-DGD targets atomically and confirm downscale capacity is
+        # released before dependent upscales (especially with blocking=False),
+        # so intermediate or partial state cannot exceed the hard ceiling.
         # Apply: request + selected partners (may be empty), grouped by
         # participant with at most one scale call per participant.
         # Direction-aware order: scale-down participants first (most negative net
@@ -346,6 +367,10 @@ class Orchestrator:
             grouped_targets.keys(), key=lambda k: net_deltas[k]
         )
 
+        # TODO(global-planner): Give multi-participant apply transaction or
+        # reconciliation semantics: on failure or cancellation, stop subsequent
+        # patches, report a non-success outcome, and persist enough state to
+        # repair or roll back the partially applied transfer.
         applied: list[str] = []
         for i, pid in enumerate(ordered_participants):
             tgts = grouped_targets[pid]
@@ -464,6 +489,11 @@ class Orchestrator:
             total_standalone, internally_paired, standalone_tolerance
         )
 
+        # TODO(global-planner): Rework boundary and partner selection to allow
+        # monotonic recovery from an already-out-of-bounds state, compute
+        # tolerance only from selected pools, continue after an unpartializable
+        # candidate, prefer an already-valid standalone request, and preserve
+        # same-participant priority during sorting.
         # Multi-partner packing: pack as many opposite-direction cached intents
         # as fit within the band, partially consuming one over-sized candidate if
         # needed.

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -207,7 +207,11 @@ class Orchestrator:
         drift toward the floor as load arrives.
         """
         try:
-            total = self.total_gpus(self.capacity_manager.observe())
+            total = self.total_gpus(
+                self.capacity_manager.observe(
+                    require_complete=self.budget_enforcement_enabled()
+                )
+            )
         except Exception as e:
             logger.warning(f"Could not compute initial total GPUs: {e}")
             return
@@ -279,12 +283,19 @@ class Orchestrator:
         caller should read back current replicas. May raise a patch error from
         the first applied participant (propagated to the API layer).
         """
+        # Let the backend record any request context it needs to read pool state
+        # correctly (e.g. component-name role hints for generic workers).
+        self.capacity_manager.remember_roles(participant_id, targets)
+
         # Read ALL known participants' current state once. Cross-participant
         # partner search needs every pool's current replicas and gpu_per_replica;
         # cross-participant budget math also consumes this. Run the synchronous
         # backend reads off-thread so the event loop isn't blocked for the N
-        # round-trips.
-        all_pools = await asyncio.to_thread(self.capacity_manager.observe)
+        # round-trips. When budget is enforced, require a complete snapshot so a
+        # partial read can't under-count cluster usage.
+        all_pools = await asyncio.to_thread(
+            self.capacity_manager.observe, self.budget_enforcement_enabled()
+        )
 
         result = self.mediate(
             participant_id,
@@ -312,6 +323,7 @@ class Orchestrator:
             grouped_targets[partner.participant_id].append(
                 TargetReplica(
                     sub_component_type=SubComponentType(partner.sub_type),
+                    component_name=partner.spec.component_name or None,
                     desired_replicas=partner.applied_desired,
                 )
             )

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -6,7 +6,7 @@
 :class:`Orchestrator` is the application core and a deliberate **no-Kubernetes
 zone**. It owns the participant registry and authorization, the GPU-budget
 arbitration (ceiling/floor bounds, multi-partner pairing, intent cache), and the
-observe -> decide -> actuate loop, delegating the infrastructure reads/writes to
+observe -> decide -> scale loop, delegating the infrastructure reads/writes to
 a :class:`~dynamo.global_planner.capacity_manager.CapacityManager`. Its vocabulary
 is neutral — ``participant_id`` / ``caller_name`` / ``deployment_name`` /
 ``namespace`` — and it imports no Kubernetes SDK and no transport types. The
@@ -38,7 +38,7 @@ from dynamo.planner import SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleStatus
 from dynamo.planner.core import budget
 
-# Planner-level "not ready" signal a backend may raise from ``actuate``; the
+# Planner-level "not ready" signal a backend may raise from ``scale``; the
 # orchestrator treats it as a soft rejection. Not a Kubernetes SDK type.
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 
@@ -54,6 +54,20 @@ class PoolIntent:
 
 
 @dataclass
+class PartnerTransfer:
+    """One pool selected to change alongside a paired transfer.
+
+    Apply ``applied_desired`` replicas to the ``sub_type`` pool of
+    ``participant_id``; ``spec`` is that pool's observed state.
+    """
+
+    participant_id: str
+    sub_type: str
+    applied_desired: int
+    spec: PoolSpec
+
+
+@dataclass
 class MediationResult:
     """Outcome of a budget-arbitration decision.
 
@@ -63,9 +77,9 @@ class MediationResult:
     """
 
     approved: bool
-    # (participant_id, sub_type, applied_desired, spec) — partners to apply
-    # alongside the request. Empty means "standalone / no-budget path".
-    selected_partners: list[tuple[str, str, int, PoolSpec]]
+    # Partners to apply alongside the request. Empty means "standalone /
+    # no-budget path".
+    selected_partners: list[PartnerTransfer]
     reject_message: Optional[str] = None
 
 
@@ -156,7 +170,6 @@ class Orchestrator:
     def register(
         self,
         participant_id: str,
-        *,
         caller_name: str,
         namespace: str,
         deployment_name: str,
@@ -210,21 +223,20 @@ class Orchestrator:
             )
 
     # ------------------------------------------------------------------ #
-    # observe -> decide -> actuate                                       #
+    # observe -> decide -> scale                                       #
     # ------------------------------------------------------------------ #
 
     async def submit(
         self,
         participant_id: str,
         targets: list[TargetReplica],
-        *,
         blocking: bool,
         deployment_name: str,
         caller_name: str,
     ) -> ScaleOutcome:
         """Arbitrate and execute one scale request.
 
-        The observe -> decide -> actuate span is serialized under the scale lock
+        The observe -> decide -> scale span is serialized under the scale lock
         (when enabled) so concurrent requests can't both pass against the same
         pre-scale state. The post-scale replica read-back runs outside the lock,
         matching the original behavior. Patch failures propagate to the caller
@@ -291,16 +303,16 @@ class Orchestrator:
             )
 
         # Apply: request + selected partners (may be empty), grouped by
-        # participant with at most one actuate call per participant.
+        # participant with at most one scale call per participant.
         # Direction-aware order: scale-down participants first (most negative net
         # delta), so GPUs are freed before scale-up participants submit new pods.
         grouped_targets: dict[str, list[TargetReplica]] = defaultdict(list)
         grouped_targets[participant_id].extend(targets)
-        for p_id, p_sub, p_desired, _ in result.selected_partners:
-            grouped_targets[p_id].append(
+        for partner in result.selected_partners:
+            grouped_targets[partner.participant_id].append(
                 TargetReplica(
-                    sub_component_type=SubComponentType(p_sub),
-                    desired_replicas=p_desired,
+                    sub_component_type=SubComponentType(partner.sub_type),
+                    desired_replicas=partner.applied_desired,
                 )
             )
 
@@ -390,7 +402,6 @@ class Orchestrator:
         participant_id: str,
         targets: list[TargetReplica],
         all_pools: PoolSnapshot,
-        *,
         log_deployment_name: str = "",
         log_caller_name: str = "",
     ) -> MediationResult:
@@ -464,11 +475,12 @@ class Orchestrator:
         if selected_partners:
             scope = (
                 "intra-participant"
-                if all(p[0] == participant_id for p in selected_partners)
+                if all(p.participant_id == participant_id for p in selected_partners)
                 else "cross-participant"
             )
             partners_desc = ", ".join(
-                f"{p[0]}/{p[1]}={p[2]}" for p in selected_partners
+                f"{p.participant_id}/{p.sub_type}={p.applied_desired}"
+                for p in selected_partners
             )
             logger.info(
                 f"Paired transfer ({scope}, "
@@ -599,7 +611,7 @@ class Orchestrator:
         request_pool_keys: set[tuple[str, str]],
         all_pools: PoolSnapshot,
         request_net_delta_gpu: int,
-    ) -> Iterator[tuple[str, str, int, PoolSpec]]:
+    ) -> Iterator[PartnerTransfer]:
         """Yield qualifying pair-partner candidates, same-participant first.
 
         A candidate qualifies when it (a) is not in the requesting pool set, (b)
@@ -614,8 +626,8 @@ class Orchestrator:
         if request_net_delta_gpu == 0:
             return
         now = self._now()
-        same: list[tuple[str, str, int, PoolSpec]] = []
-        cross: list[tuple[str, str, int, PoolSpec]] = []
+        same: list[PartnerTransfer] = []
+        cross: list[PartnerTransfer] = []
         for pid, pools in all_pools.items():
             for sub_type, spec in pools.items():
                 if (pid, sub_type) in request_pool_keys:
@@ -638,7 +650,7 @@ class Orchestrator:
                     request_net_delta_gpu < 0 and partner_delta_gpu <= 0
                 ):
                     continue
-                candidate = (pid, sub_type, intent.last_desired, spec)
+                candidate = PartnerTransfer(pid, sub_type, intent.last_desired, spec)
                 if pid == request_participant_id:
                     same.append(candidate)
                 else:
@@ -648,7 +660,7 @@ class Orchestrator:
 
     def _partial_partner(
         self,
-        candidate: tuple[str, str, int, PoolSpec],
+        candidate: PartnerTransfer,
         all_pools: PoolSnapshot,
         current_overrides: dict[tuple[str, str], int],
         tolerance: int,
@@ -663,7 +675,8 @@ class Orchestrator:
         ``min - tolerance`` on the lower side. ``None`` if no feasible partial
         exists.
         """
-        _, _, last_desired, spec = candidate
+        last_desired = candidate.applied_desired
+        spec = candidate.spec
         current = spec.current_replicas
         gpu = spec.gpu_per_replica
         if gpu <= 0 or last_desired == current:
@@ -710,7 +723,7 @@ class Orchestrator:
         request_net_delta_gpu: int,
         standalone_overrides: dict[tuple[str, str], int],
         changing_request_pools: list[PoolSpec],
-    ) -> tuple[list[tuple[str, str, int, PoolSpec]], int, int]:
+    ) -> tuple[list[PartnerTransfer], int, int]:
         """Pack as many opposite-direction cached intents as fit alongside the
         request, partially consuming one over-sized candidate if needed.
 
@@ -740,24 +753,30 @@ class Orchestrator:
             return [], 0, 0
 
         # Tolerance computed once over the universe of changing pools.
-        candidate_specs = [c[3] for c in all_candidates]
+        candidate_specs = [c.spec for c in all_candidates]
         tolerance = budget.compute_tolerance(
             [s.gpu_per_replica for s in changing_request_pools]
             + [s.gpu_per_replica for s in candidate_specs]
         )
 
         # Sort ascending by |delta_gpu| — smaller pieces overshoot less.
-        def cand_delta(c: tuple[str, str, int, PoolSpec]) -> int:
-            _, _, desired, spec = c
-            return (desired - spec.current_replicas) * spec.gpu_per_replica
+        def cand_delta(c: PartnerTransfer) -> int:
+            return (
+                c.applied_desired - c.spec.current_replicas
+            ) * c.spec.gpu_per_replica
 
         all_candidates.sort(key=lambda c: abs(cand_delta(c)))
 
-        selected: list[tuple[str, str, int, PoolSpec]] = []
+        selected: list[PartnerTransfer] = []
         overrides = dict(standalone_overrides)
 
         for cand in all_candidates:
-            cand_pid, cand_sub, cand_desired, cand_spec = cand
+            cand_pid, cand_sub, cand_desired, cand_spec = (
+                cand.participant_id,
+                cand.sub_type,
+                cand.applied_desired,
+                cand.spec,
+            )
 
             # Try full inclusion.
             full_overrides = dict(overrides)
@@ -805,7 +824,7 @@ class Orchestrator:
             # at the appropriate band edge, then stop.
             partial_k = self._partial_partner(cand, all_pools, overrides, tolerance)
             if partial_k is not None and partial_k != cand_spec.current_replicas:
-                partial_cand = (cand_pid, cand_sub, partial_k, cand_spec)
+                partial_cand = PartnerTransfer(cand_pid, cand_sub, partial_k, cand_spec)
                 selected.append(partial_cand)
                 overrides[(cand_pid, cand_sub)] = partial_k
             break
@@ -823,7 +842,11 @@ class Orchestrator:
             )
             if not running_in_band:
                 last = selected[-1]
-                last_pid, last_sub, _, last_spec = last
+                last_pid, last_sub, last_spec = (
+                    last.participant_id,
+                    last.sub_type,
+                    last.spec,
+                )
                 # Roll back the last full inclusion so partial uses the
                 # pre-last-candidate baseline.
                 rollback_overrides = dict(overrides)
@@ -837,7 +860,9 @@ class Orchestrator:
                     last, all_pools, rollback_overrides, tolerance
                 )
                 if partial_k is not None and partial_k != last_spec.current_replicas:
-                    selected[-1] = (last_pid, last_sub, partial_k, last_spec)
+                    selected[-1] = PartnerTransfer(
+                        last_pid, last_sub, partial_k, last_spec
+                    )
                     overrides = dict(rollback_overrides)
                     overrides[(last_pid, last_sub)] = partial_k
 

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -9,7 +9,7 @@ arbitration (ceiling/floor bounds, multi-partner pairing, intent cache), and the
 observe -> decide -> actuate loop, delegating the infrastructure reads/writes to
 a :class:`~dynamo.global_planner.capacity_manager.CapacityManager`. Its vocabulary
 is neutral — ``participant_id`` / ``caller_name`` / ``deployment_name`` /
-``cluster_name`` — and it imports no Kubernetes SDK and no transport types. The
+``namespace`` — and it imports no Kubernetes SDK and no transport types. The
 API layer maps wire fields onto these neutral names; a concrete backend maps them
 back onto its infrastructure.
 
@@ -105,7 +105,7 @@ class Orchestrator:
     def __init__(
         self,
         capacity_manager: CapacityManager,
-        managed_callers: Optional[list],
+        managed_deployments: Optional[list],
         max_total_gpus: int = -1,
         min_total_gpus: int = -1,
         intent_cache_ttl_seconds: float = 360.0,
@@ -126,9 +126,11 @@ class Orchestrator:
         # across requests when one request alone would breach bounds.
         self._intent_cache: dict[str, PoolIntent] = {}
 
-        # Authorization: the set of caller identities allowed to send scale
-        # requests. None/empty accepts all callers.
-        self.managed_callers = set(managed_callers) if managed_callers else None
+        # Authorization: the set of managed deployment identities allowed to send
+        # scale requests. None/empty accepts all callers.
+        self.managed_deployments = (
+            set(managed_deployments) if managed_deployments else None
+        )
 
         # Serializes budget-check + scale-execution so concurrent requests from
         # different pools cannot both pass against the same pre-scale state.
@@ -144,7 +146,10 @@ class Orchestrator:
 
         In implicit mode (no managed callers) every caller is authorized.
         """
-        if self.managed_callers is not None and caller_name not in self.managed_callers:
+        if (
+            self.managed_deployments is not None
+            and caller_name not in self.managed_deployments
+        ):
             return False
         return True
 
@@ -153,18 +158,18 @@ class Orchestrator:
         participant_id: str,
         *,
         caller_name: str,
-        cluster_name: str,
+        namespace: str,
         deployment_name: str,
     ) -> None:
         """Ensure the participant exists in the capacity backend (idempotent).
 
-        ``caller_name`` / ``cluster_name`` / ``deployment_name`` are forwarded
+        ``caller_name`` / ``namespace`` / ``deployment_name`` are forwarded
         opaquely to the backend, which uses them to construct its participant.
         """
         self.capacity_manager.ensure_participant(
             participant_id,
             caller_name=caller_name,
-            cluster_name=cluster_name,
+            namespace=namespace,
             deployment_name=deployment_name,
         )
 
@@ -177,7 +182,7 @@ class Orchestrator:
         below the floor. Only runs when budget enforcement is enabled."""
         if not self.budget_enforcement_enabled():
             return
-        self.capacity_manager.discover(self.managed_callers)
+        self.capacity_manager.discover(self.managed_deployments)
         if self.min_total_gpus >= 0:
             self._warn_if_below_floor()
 
@@ -320,7 +325,7 @@ class Orchestrator:
         applied: list[str] = []
         for i, pid in enumerate(ordered_participants):
             tgts = grouped_targets[pid]
-            if not self.capacity_manager.knows(pid):
+            if not self.capacity_manager.participant_exists(pid):
                 if i == 0:
                     # First patch: missing participant is unrecoverable since
                     # nothing has been applied yet.
@@ -339,7 +344,7 @@ class Orchestrator:
                 )
                 continue
             try:
-                await self.capacity_manager.actuate(pid, tgts, blocking=blocking)
+                await self.capacity_manager.scale(pid, tgts, blocking=blocking)
                 applied.append(pid)
             except DynamoGraphDeploymentNotReadyError as patch_err:
                 if i == 0:

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -1,0 +1,912 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Orchestrator for the GlobalPlanner capacity control loop.
+
+:class:`Orchestrator` is the application core and a deliberate **no-Kubernetes
+zone**. It owns the participant registry and authorization, the GPU-budget
+arbitration (ceiling/floor bounds, multi-partner pairing, intent cache), and the
+observe -> decide -> actuate loop, delegating the infrastructure reads/writes to
+a :class:`~dynamo.global_planner.capacity_manager.CapacityManager`. Its vocabulary
+is neutral — ``participant_id`` / ``caller_name`` / ``deployment_name`` /
+``cluster_name`` — and it imports no Kubernetes SDK and no transport types. The
+API layer maps wire fields onto these neutral names; a concrete backend maps them
+back onto its infrastructure.
+
+Time is injected (``now``) so offline replay can drive the intent-cache TTL on
+sim-time. The serialization lock is toggleable (``use_lock``, default ``True``):
+under the async runtime endpoint it must stay on; a single-threaded replay
+coordinator can disable it, keeping the core free of concurrency assumptions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, Optional
+
+from dynamo.global_planner.capacity_manager import (
+    CapacityManager,
+    PoolSnapshot,
+    PoolSpec,
+)
+from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner.connectors.protocol import ScaleStatus
+from dynamo.planner.core import budget
+
+# Planner-level "not ready" signal a backend may raise from ``actuate``; the
+# orchestrator treats it as a soft rejection. Not a Kubernetes SDK type.
+from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PoolIntent:
+    """Most recently observed desired replica count for a pool."""
+
+    last_desired: int
+    last_seen_at: float
+
+
+@dataclass
+class MediationResult:
+    """Outcome of a budget-arbitration decision.
+
+    ``approved`` requests apply the requesting pool's targets plus any
+    ``selected_partners`` (empty for a standalone apply). A rejected result
+    carries the soft-denial ``reject_message`` the caller returns unchanged.
+    """
+
+    approved: bool
+    # (participant_id, sub_type, applied_desired, spec) — partners to apply
+    # alongside the request. Empty means "standalone / no-budget path".
+    selected_partners: list[tuple[str, str, int, PoolSpec]]
+    reject_message: Optional[str] = None
+
+
+@dataclass
+class ScaleOutcome:
+    """Result of an orchestrated scale request (infra-agnostic).
+
+    The API layer serializes this into the wire ``ScaleResponse``.
+    """
+
+    status: ScaleStatus
+    message: str
+    current_replicas: dict = field(default_factory=dict)
+
+
+class Orchestrator:
+    """Coordinates GPU-budget arbitration and execution across participants.
+
+    Budget enforcement:
+    - ``max_total_gpus`` is a ceiling; scale-ups that would exceed it are
+      rejected unless a cached opposite-direction intent can be paired.
+    - ``min_total_gpus`` is a floor; scale-downs that would drop below it are
+      denied unless a cached opposite-direction intent from another participant
+      can be paired with them (intra- or cross-participant).
+    - Paired transfers may land up to ``tolerance`` GPUs **below** ``min``, where
+      tolerance = max per-replica GPU across the pools actually being paired.
+      ``max`` is a hard cluster-capacity bound and is never relaxed.
+
+    Intent cache semantics:
+    - Every request seeds the per-pool intent cache *before* the budget decision,
+      so a denied request still leaves its desired count behind for a later
+      opposite-direction request to pair against.
+    - Bounded by TTL (``intent_cache_ttl_seconds``) and by the
+      satisfied-vs-pending check (``last_desired != current_replicas``).
+    """
+
+    def __init__(
+        self,
+        capacity_manager: CapacityManager,
+        managed_callers: Optional[list],
+        max_total_gpus: int = -1,
+        min_total_gpus: int = -1,
+        intent_cache_ttl_seconds: float = 360.0,
+        now: Callable[[], float] = time.time,
+        use_lock: bool = True,
+    ):
+        self.capacity_manager = capacity_manager
+
+        # Budget bounds + intent cache.
+        self.max_total_gpus = max_total_gpus
+        self.min_total_gpus = min_total_gpus
+        self.intent_cache_ttl_seconds = intent_cache_ttl_seconds
+        # Injected clock — production uses wall-clock; offline replay passes a
+        # sim-time source so intent-cache TTL is meaningful there too.
+        self._now = now
+        # Per-pool cached desired replicas from recent requests, keyed by
+        # f"{participant_id}/{sub_type}". Used to pair opposite-direction intents
+        # across requests when one request alone would breach bounds.
+        self._intent_cache: dict[str, PoolIntent] = {}
+
+        # Authorization: the set of caller identities allowed to send scale
+        # requests. None/empty accepts all callers.
+        self.managed_callers = set(managed_callers) if managed_callers else None
+
+        # Serializes budget-check + scale-execution so concurrent requests from
+        # different pools cannot both pass against the same pre-scale state.
+        # Toggleable: a single-threaded replay coordinator can disable it.
+        self._scale_lock: Optional[asyncio.Lock] = asyncio.Lock() if use_lock else None
+
+    # ------------------------------------------------------------------ #
+    # Participant registry / authorization                               #
+    # ------------------------------------------------------------------ #
+
+    def is_authorized(self, caller_name: str) -> bool:
+        """Whether ``caller_name`` may send scale requests.
+
+        In implicit mode (no managed callers) every caller is authorized.
+        """
+        if self.managed_callers is not None and caller_name not in self.managed_callers:
+            return False
+        return True
+
+    def register(
+        self,
+        participant_id: str,
+        *,
+        caller_name: str,
+        cluster_name: str,
+        deployment_name: str,
+    ) -> None:
+        """Ensure the participant exists in the capacity backend (idempotent).
+
+        ``caller_name`` / ``cluster_name`` / ``deployment_name`` are forwarded
+        opaquely to the backend, which uses them to construct its participant.
+        """
+        self.capacity_manager.ensure_participant(
+            participant_id,
+            caller_name=caller_name,
+            cluster_name=cluster_name,
+            deployment_name=deployment_name,
+        )
+
+    # ------------------------------------------------------------------ #
+    # Startup                                                            #
+    # ------------------------------------------------------------------ #
+
+    def startup(self) -> None:
+        """Discover existing participants and warn if the initial total GPUs are
+        below the floor. Only runs when budget enforcement is enabled."""
+        if not self.budget_enforcement_enabled():
+            return
+        self.capacity_manager.discover(self.managed_callers)
+        if self.min_total_gpus >= 0:
+            self._warn_if_below_floor()
+
+    def _warn_if_below_floor(self) -> None:
+        """Log a warning if the discovered initial state is below min_total_gpus.
+
+        Soft floor: we do not proactively scale up. The floor prevents
+        scale-downs below it, but initial below-floor state is allowed and will
+        drift toward the floor as load arrives.
+        """
+        try:
+            total = self.total_gpus(self.capacity_manager.observe())
+        except Exception as e:
+            logger.warning(f"Could not compute initial total GPUs: {e}")
+            return
+        if total < self.min_total_gpus:
+            logger.warning(
+                f"Current total GPUs ({total}) is below min_total_gpus "
+                f"({self.min_total_gpus}); scale-up from load scaler will "
+                f"drift toward the floor. No proactive fill is issued."
+            )
+        else:
+            logger.info(
+                f"Initial total GPUs ({total}) meets floor ({self.min_total_gpus})"
+            )
+
+    # ------------------------------------------------------------------ #
+    # observe -> decide -> actuate                                       #
+    # ------------------------------------------------------------------ #
+
+    async def submit(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        *,
+        blocking: bool,
+        deployment_name: str,
+        caller_name: str,
+    ) -> ScaleOutcome:
+        """Arbitrate and execute one scale request.
+
+        The observe -> decide -> actuate span is serialized under the scale lock
+        (when enabled) so concurrent requests can't both pass against the same
+        pre-scale state. The post-scale replica read-back runs outside the lock,
+        matching the original behavior. Patch failures propagate to the caller
+        (the API layer maps them to REJECTED / ERROR).
+        """
+        if self._scale_lock is not None:
+            async with self._scale_lock:
+                terminal = await self._observe_decide_apply(
+                    participant_id, targets, blocking, deployment_name, caller_name
+                )
+        else:
+            terminal = await self._observe_decide_apply(
+                participant_id, targets, blocking, deployment_name, caller_name
+            )
+
+        if terminal is not None:
+            return terminal
+
+        # Read back current replica counts (outside the lock).
+        current_replicas = self.capacity_manager.current_replicas(participant_id)
+        logger.info(f"Successfully scaled {deployment_name}: {current_replicas}")
+        return ScaleOutcome(
+            status=ScaleStatus.SUCCESS,
+            message=f"Scaled {deployment_name} successfully",
+            current_replicas=current_replicas,
+        )
+
+    async def _observe_decide_apply(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        blocking: bool,
+        deployment_name: str,
+        caller_name: str,
+    ) -> Optional[ScaleOutcome]:
+        """Observe all pools, decide the budget outcome, and apply it.
+
+        Returns a terminal ``ScaleOutcome`` for a rejection or an unrecoverable
+        first-patch error; returns ``None`` when the request was applied and the
+        caller should read back current replicas. May raise a patch error from
+        the first applied participant (propagated to the API layer).
+        """
+        # Read ALL known participants' current state once. Cross-participant
+        # partner search needs every pool's current replicas and gpu_per_replica;
+        # cross-participant budget math also consumes this. Run the synchronous
+        # backend reads off-thread so the event loop isn't blocked for the N
+        # round-trips.
+        all_pools = await asyncio.to_thread(self.capacity_manager.observe)
+
+        result = self.mediate(
+            participant_id,
+            targets,
+            all_pools,
+            log_deployment_name=deployment_name,
+            log_caller_name=caller_name,
+        )
+        if not result.approved:
+            # Soft denial: budget breach is an expected operational outcome in
+            # fixed-total mode, not a fault.
+            return ScaleOutcome(
+                status=ScaleStatus.REJECTED,
+                message=result.reject_message or "",
+                current_replicas={},
+            )
+
+        # Apply: request + selected partners (may be empty), grouped by
+        # participant with at most one actuate call per participant.
+        # Direction-aware order: scale-down participants first (most negative net
+        # delta), so GPUs are freed before scale-up participants submit new pods.
+        grouped_targets: dict[str, list[TargetReplica]] = defaultdict(list)
+        grouped_targets[participant_id].extend(targets)
+        for p_id, p_sub, p_desired, _ in result.selected_partners:
+            grouped_targets[p_id].append(
+                TargetReplica(
+                    sub_component_type=SubComponentType(p_sub),
+                    desired_replicas=p_desired,
+                )
+            )
+
+        # Compute net GPU delta per participant for ordering.
+        net_deltas: dict[str, int] = {}
+        for pid, tgts in grouped_targets.items():
+            pools = all_pools.get(pid, {})
+            net = 0
+            for t in tgts:
+                spec = pools.get(t.sub_component_type.value)
+                if spec is not None and spec.gpu_per_replica > 0:
+                    net += (
+                        t.desired_replicas - spec.current_replicas
+                    ) * spec.gpu_per_replica
+            net_deltas[pid] = net
+
+        # Sort: most negative (scale-down) first, most positive (scale-up) last.
+        ordered_participants = sorted(
+            grouped_targets.keys(), key=lambda k: net_deltas[k]
+        )
+
+        applied: list[str] = []
+        for i, pid in enumerate(ordered_participants):
+            tgts = grouped_targets[pid]
+            if not self.capacity_manager.knows(pid):
+                if i == 0:
+                    # First patch: missing participant is unrecoverable since
+                    # nothing has been applied yet.
+                    logger.error(
+                        f"Multi-partner transfer aborted: unknown "
+                        f"first participant ({pid})"
+                    )
+                    return ScaleOutcome(
+                        status=ScaleStatus.ERROR,
+                        message=f"Multi-partner transfer: unknown participant {pid}",
+                        current_replicas={},
+                    )
+                logger.error(
+                    f"Multi-partner transfer: unknown participant {pid} "
+                    f"after applying {applied}; will self-correct on next tick"
+                )
+                continue
+            try:
+                await self.capacity_manager.actuate(pid, tgts, blocking=blocking)
+                applied.append(pid)
+            except DynamoGraphDeploymentNotReadyError as patch_err:
+                if i == 0:
+                    raise
+                logger.warning(
+                    "Multi-partner transfer: patch on %s was skipped "
+                    "after applying %s because the participant is not ready: %s; "
+                    "will self-correct on next tick",
+                    pid,
+                    applied,
+                    patch_err,
+                )
+            except Exception as patch_err:
+                if i == 0:
+                    # First patch failure: nothing applied, propagate to the
+                    # outer handler so the caller sees ERROR.
+                    raise
+                logger.error(
+                    f"Multi-partner transfer: patch on {pid} "
+                    f"failed after applying {applied}: "
+                    f"{patch_err}; will self-correct on next tick"
+                )
+
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Budget arbitration (decision)                                      #
+    # ------------------------------------------------------------------ #
+
+    def budget_enforcement_enabled(self) -> bool:
+        return self.max_total_gpus >= 0 or self.min_total_gpus >= 0
+
+    def total_gpus(
+        self,
+        all_pools: PoolSnapshot,
+        overrides: Optional[dict[tuple[str, str], int]] = None,
+    ) -> int:
+        """Total GPUs across all known participants from a snapshot."""
+        return self._total_gpus_from_snapshot(all_pools, overrides or {})
+
+    def mediate(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        all_pools: PoolSnapshot,
+        *,
+        log_deployment_name: str = "",
+        log_caller_name: str = "",
+    ) -> MediationResult:
+        """Decide whether ``targets`` for ``participant_id`` fit the budget.
+
+        Always updates the intent cache first (so a denied request can still be
+        paired against later). Returns an approved result (standalone or with
+        selected partners) or a soft rejection with a budget-breach message. The
+        ``log_*`` values are used only for parity-identical log lines.
+        """
+        pools = all_pools.get(participant_id, {})
+
+        # Always update the intent cache with this request's targets, regardless
+        # of decision. A later request from a complementary pool may need to pair
+        # with this intent.
+        self.update_intent_cache(participant_id, targets, pools)
+
+        request_pool_keys = {
+            (participant_id, t.sub_component_type.value) for t in targets
+        }
+        standalone_overrides = {
+            (participant_id, t.sub_component_type.value): t.desired_replicas
+            for t in targets
+        }
+
+        if not self.budget_enforcement_enabled():
+            return MediationResult(approved=True, selected_partners=[])
+
+        net_delta = self.net_delta_gpu(targets, pools)
+        internally_paired = self.is_internally_paired(targets, pools)
+
+        total_standalone = self._total_gpus_from_snapshot(
+            all_pools, standalone_overrides
+        )
+
+        # Tolerance depends on which pools are actually changing.
+        changing_request_pools = [
+            pools[t.sub_component_type.value]
+            for t in targets
+            if t.sub_component_type.value in pools
+            and t.desired_replicas != pools[t.sub_component_type.value].current_replicas
+        ]
+        standalone_tolerance = self._internal_pair_tolerance(changing_request_pools)
+
+        # Internally-paired requests get tolerance even without an external
+        # partner.
+        standalone_ok, standalone_reason = self._bounds_for_total(
+            total_standalone, internally_paired, standalone_tolerance
+        )
+
+        # Multi-partner packing: pack as many opposite-direction cached intents
+        # as fit within the band, partially consuming one over-sized candidate if
+        # needed.
+        (
+            selected_partners,
+            total_paired,
+            paired_tolerance,
+        ) = self._find_pair_partner_set(
+            participant_id,
+            request_pool_keys,
+            all_pools,
+            net_delta,
+            standalone_overrides,
+            changing_request_pools,
+        )
+
+        # Decide:
+        # 1. Non-empty pair set → apply request + all partners.
+        # 2. Else if standalone in bounds → apply standalone.
+        # 3. Else deny.
+        if selected_partners:
+            scope = (
+                "intra-participant"
+                if all(p[0] == participant_id for p in selected_partners)
+                else "cross-participant"
+            )
+            partners_desc = ", ".join(
+                f"{p[0]}/{p[1]}={p[2]}" for p in selected_partners
+            )
+            logger.info(
+                f"Paired transfer ({scope}, "
+                f"{len(selected_partners)} partner(s)) for "
+                f"{log_deployment_name}: "
+                f"request {sorted(request_pool_keys)} + "
+                f"[{partners_desc}]; total {total_paired} GPUs "
+                f"(bounds "
+                f"[{self.min_total_gpus if self.min_total_gpus >= 0 else '-inf'} - {paired_tolerance}, "
+                f"{self.max_total_gpus if self.max_total_gpus >= 0 else '+inf'}])"
+            )
+            return MediationResult(approved=True, selected_partners=selected_partners)
+        elif standalone_ok:
+            logger.info(
+                f"Standalone scale request for {log_deployment_name}: "
+                f"total {total_standalone} GPUs "
+                f"(internally_paired={internally_paired})"
+            )
+            return MediationResult(approved=True, selected_partners=[])
+        else:
+            # Budget breach: standalone out-of-bounds and no feasible partner set
+            # found.
+            logger.warning(
+                f"Rejecting scale request from {log_caller_name}: "
+                f"{standalone_reason}; no feasible pair packing"
+            )
+            # Soft denial: budget breach is an expected operational outcome in
+            # fixed-total mode, not a fault. Local planners should treat this as a
+            # no-op for this tick.
+            return MediationResult(
+                approved=False,
+                selected_partners=[],
+                reject_message=(
+                    f"GPU budget breach: {standalone_reason}; no feasible pair packing"
+                ),
+            )
+
+    def _total_gpus_from_snapshot(
+        self,
+        all_pools: PoolSnapshot,
+        overrides: dict[tuple[str, str], int],
+    ) -> int:
+        """Compute total GPUs across all known participants from a snapshot.
+
+        ``overrides`` maps ``(participant_id, sub_type)`` to the replica count to
+        use in place of the current count. Entries not in ``overrides`` use the
+        current replica count.
+        """
+        total_gpus = 0
+        for key, pools in all_pools.items():
+            for sub_type, spec in pools.items():
+                if spec.gpu_per_replica == 0:
+                    continue
+                replicas = overrides.get((key, sub_type), spec.current_replicas)
+                total_gpus += replicas * spec.gpu_per_replica
+        return total_gpus
+
+    # ------------------------------------------------------------------ #
+    # Intent cache helpers                                               #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _pool_cache_key(participant_id: str, sub_type: str) -> str:
+        return f"{participant_id}/{sub_type}"
+
+    @staticmethod
+    def _direction(desired: int, current: int) -> str:
+        if desired > current:
+            return "up"
+        if desired < current:
+            return "down"
+        return "stable"
+
+    def update_intent_cache(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        pools: dict[str, PoolSpec],
+    ):
+        """Record the desired replicas for each pool in this request."""
+        now = self._now()
+        for target in targets:
+            sub_type = target.sub_component_type.value
+            if sub_type not in pools:
+                # Unknown pool (not yet observed); skip — without gpu_per_replica
+                # we can't compute deltas or pair against it.
+                continue
+            key = self._pool_cache_key(participant_id, sub_type)
+            self._intent_cache[key] = PoolIntent(
+                last_desired=target.desired_replicas,
+                last_seen_at=now,
+            )
+
+    # ------------------------------------------------------------------ #
+    # Tolerance                                                          #
+    # ------------------------------------------------------------------ #
+
+    def _pair_tolerance(
+        self,
+        request_pools: list[PoolSpec],
+        partner_spec: PoolSpec,
+    ) -> int:
+        """Tolerance for a specific paired transfer.
+
+        Equal to max per-replica GPU across just the pools actually being changed
+        (request's non-stable pools + partner). Covers step-size asymmetry where a
+        single worker on one side can't exactly cancel a single worker on the
+        other side.
+        """
+        return budget.compute_tolerance(
+            [p.gpu_per_replica for p in request_pools] + [partner_spec.gpu_per_replica]
+        )
+
+    def _internal_pair_tolerance(
+        self,
+        changing_pools: list[PoolSpec],
+    ) -> int:
+        """Tolerance for an internally-paired request (no external partner)."""
+        return budget.compute_tolerance(p.gpu_per_replica for p in changing_pools)
+
+    # ------------------------------------------------------------------ #
+    # Pair-partner search                                                #
+    # ------------------------------------------------------------------ #
+
+    def _iter_pair_partners(
+        self,
+        request_participant_id: str,
+        request_pool_keys: set[tuple[str, str]],
+        all_pools: PoolSnapshot,
+        request_net_delta_gpu: int,
+    ) -> Iterator[tuple[str, str, int, PoolSpec]]:
+        """Yield qualifying pair-partner candidates, same-participant first.
+
+        A candidate qualifies when it (a) is not in the requesting pool set, (b)
+        has a fresh cached intent (within TTL) whose desired differs from current
+        replicas, and (c) the partner delta points opposite to the request's net
+        delta.
+
+        Yields in two passes: same-participant candidates first (atomic-patch
+        preference), then cross-participant candidates. The caller picks the first
+        one whose pair total actually lands in the budget band.
+        """
+        if request_net_delta_gpu == 0:
+            return
+        now = self._now()
+        same: list[tuple[str, str, int, PoolSpec]] = []
+        cross: list[tuple[str, str, int, PoolSpec]] = []
+        for pid, pools in all_pools.items():
+            for sub_type, spec in pools.items():
+                if (pid, sub_type) in request_pool_keys:
+                    continue
+                if spec.gpu_per_replica == 0:
+                    continue
+                cache_key = self._pool_cache_key(pid, sub_type)
+                intent = self._intent_cache.get(cache_key)
+                if intent is None:
+                    continue
+                if now - intent.last_seen_at > self.intent_cache_ttl_seconds:
+                    continue
+                if intent.last_desired == spec.current_replicas:
+                    continue  # Satisfied — nothing to apply.
+                partner_delta_gpu = (
+                    intent.last_desired - spec.current_replicas
+                ) * spec.gpu_per_replica
+                # Must be opposite direction of the request's net delta.
+                if (request_net_delta_gpu > 0 and partner_delta_gpu >= 0) or (
+                    request_net_delta_gpu < 0 and partner_delta_gpu <= 0
+                ):
+                    continue
+                candidate = (pid, sub_type, intent.last_desired, spec)
+                if pid == request_participant_id:
+                    same.append(candidate)
+                else:
+                    cross.append(candidate)
+        yield from same
+        yield from cross
+
+    def _partial_partner(
+        self,
+        candidate: tuple[str, str, int, PoolSpec],
+        all_pools: PoolSnapshot,
+        current_overrides: dict[tuple[str, str], int],
+        tolerance: int,
+    ) -> Optional[int]:
+        """Compute a partial ``applied_desired`` for a candidate whose full
+        consumption would push the combined transfer out of the band.
+
+        Returns an integer ``K`` strictly between ``current_replicas`` and
+        ``last_desired`` (direction-consistent) such that applying ``K`` instead
+        of ``last_desired`` lands the combined transfer at the appropriate band
+        edge — the strict ceiling on the upper side (``max``, no tolerance) or
+        ``min - tolerance`` on the lower side. ``None`` if no feasible partial
+        exists.
+        """
+        _, _, last_desired, spec = candidate
+        current = spec.current_replicas
+        gpu = spec.gpu_per_replica
+        if gpu <= 0 or last_desired == current:
+            return None
+
+        # Combined total assuming this candidate stays at its current count (i.e.,
+        # contributes 0). The candidate is NOT in current_overrides yet, so the
+        # snapshot uses its current_replicas naturally.
+        baseline_total = self._total_gpus_from_snapshot(all_pools, current_overrides)
+
+        if last_desired > current:
+            # Scale-up candidate: pick K in [current+1, last_desired] that keeps
+            # total <= max (strict ceiling — max is a hard hardware bound, see
+            # budget.bounds_for_total).
+            if self.max_total_gpus < 0:
+                return last_desired
+            # K <= current + (max - baseline_total) // gpu
+            headroom = self.max_total_gpus - baseline_total
+            if headroom <= 0:
+                return None
+            max_k = current + headroom // gpu
+            k = min(last_desired, max_k)
+            return k if k > current else None
+        else:
+            # Scale-down candidate: pick K in [last_desired, current-1] that keeps
+            # total >= min - tolerance.
+            if self.min_total_gpus < 0:
+                return last_desired
+            lower = self.min_total_gpus - tolerance
+            # K >= current + ceil((lower - baseline_total) / gpu)
+            diff = lower - baseline_total
+            if diff > 0:
+                # Already below floor; further scale-down impossible.
+                return None
+            min_k = current + math.ceil(diff / gpu)
+            k = max(last_desired, min_k)
+            return k if k < current else None
+
+    def _find_pair_partner_set(
+        self,
+        request_participant_id: str,
+        request_pool_keys: set[tuple[str, str]],
+        all_pools: PoolSnapshot,
+        request_net_delta_gpu: int,
+        standalone_overrides: dict[tuple[str, str], int],
+        changing_request_pools: list[PoolSpec],
+    ) -> tuple[list[tuple[str, str, int, PoolSpec]], int, int]:
+        """Pack as many opposite-direction cached intents as fit alongside the
+        request, partially consuming one over-sized candidate if needed.
+
+        Algorithm: greedy admission, ascending ``abs(delta_gpu)`` order. For each
+        candidate, fully admit if it keeps the combined transfer in
+        ``[min - tolerance, max]``; if full admission would overshoot the strict
+        ceiling, try partial consumption that lands at the band edge and stop.
+
+        Tolerance is computed **once** over the request's changing pools plus all
+        candidates considered for inclusion, not iteratively widened.
+
+        Returns ``(selected_partners, total_after, tolerance)``.
+        ``selected_partners`` is empty when no feasible packing exists.
+        """
+        if request_net_delta_gpu == 0:
+            return [], 0, 0
+
+        all_candidates = list(
+            self._iter_pair_partners(
+                request_participant_id,
+                request_pool_keys,
+                all_pools,
+                request_net_delta_gpu,
+            )
+        )
+        if not all_candidates:
+            return [], 0, 0
+
+        # Tolerance computed once over the universe of changing pools.
+        candidate_specs = [c[3] for c in all_candidates]
+        tolerance = budget.compute_tolerance(
+            [s.gpu_per_replica for s in changing_request_pools]
+            + [s.gpu_per_replica for s in candidate_specs]
+        )
+
+        # Sort ascending by |delta_gpu| — smaller pieces overshoot less.
+        def cand_delta(c: tuple[str, str, int, PoolSpec]) -> int:
+            _, _, desired, spec = c
+            return (desired - spec.current_replicas) * spec.gpu_per_replica
+
+        all_candidates.sort(key=lambda c: abs(cand_delta(c)))
+
+        selected: list[tuple[str, str, int, PoolSpec]] = []
+        overrides = dict(standalone_overrides)
+
+        for cand in all_candidates:
+            cand_pid, cand_sub, cand_desired, cand_spec = cand
+
+            # Try full inclusion.
+            full_overrides = dict(overrides)
+            full_overrides[(cand_pid, cand_sub)] = cand_desired
+            full_total = self._total_gpus_from_snapshot(all_pools, full_overrides)
+            in_band, _ = budget.bounds_for_total(
+                full_total,
+                self.min_total_gpus,
+                self.max_total_gpus,
+                tolerance,
+            )
+            if in_band:
+                # Full inclusion lands in band — accept and continue. Keep
+                # admitting more candidates while feasible.
+                selected.append(cand)
+                overrides = full_overrides
+                continue
+
+            # Out of band. Did this candidate cross the band, or are we still on
+            # the wrong side and need more help?
+            #
+            # Request delta sign indicates which side we started on:
+            #   request_net_delta > 0 → request alone overshoots ceiling
+            #     (approaching from above; candidates pull down).
+            #   request_net_delta < 0 → request alone undershoots floor
+            #     (approaching from below; candidates push up).
+            above_ceiling = (
+                self.max_total_gpus >= 0 and full_total > self.max_total_gpus
+            )
+            below_floor = (
+                self.min_total_gpus >= 0
+                and full_total < self.min_total_gpus - tolerance
+            )
+            still_approaching = (request_net_delta_gpu > 0 and above_ceiling) or (
+                request_net_delta_gpu < 0 and below_floor
+            )
+            if still_approaching:
+                # Candidate moved us toward the band but didn't reach it. Accept
+                # full inclusion and try the next candidate.
+                selected.append(cand)
+                overrides = full_overrides
+                continue
+
+            # Full inclusion crossed the band. Try partial consumption that lands
+            # at the appropriate band edge, then stop.
+            partial_k = self._partial_partner(cand, all_pools, overrides, tolerance)
+            if partial_k is not None and partial_k != cand_spec.current_replicas:
+                partial_cand = (cand_pid, cand_sub, partial_k, cand_spec)
+                selected.append(partial_cand)
+                overrides[(cand_pid, cand_sub)] = partial_k
+            break
+
+        # Loop ended with the running total possibly still on the wrong side (no
+        # candidate fully reached the band, none of them crossed). Try partial of
+        # the last selected candidate to land in band.
+        if selected:
+            running_total = self._total_gpus_from_snapshot(all_pools, overrides)
+            running_in_band, _ = budget.bounds_for_total(
+                running_total,
+                self.min_total_gpus,
+                self.max_total_gpus,
+                tolerance,
+            )
+            if not running_in_band:
+                last = selected[-1]
+                last_pid, last_sub, _, last_spec = last
+                # Roll back the last full inclusion so partial uses the
+                # pre-last-candidate baseline.
+                rollback_overrides = dict(overrides)
+                if (last_pid, last_sub) in standalone_overrides:
+                    rollback_overrides[(last_pid, last_sub)] = standalone_overrides[
+                        (last_pid, last_sub)
+                    ]
+                else:
+                    rollback_overrides.pop((last_pid, last_sub), None)
+                partial_k = self._partial_partner(
+                    last, all_pools, rollback_overrides, tolerance
+                )
+                if partial_k is not None and partial_k != last_spec.current_replicas:
+                    selected[-1] = (last_pid, last_sub, partial_k, last_spec)
+                    overrides = dict(rollback_overrides)
+                    overrides[(last_pid, last_sub)] = partial_k
+
+        if not selected:
+            return [], 0, 0
+
+        final_total = self._total_gpus_from_snapshot(all_pools, overrides)
+        ok, _ = budget.bounds_for_total(
+            final_total,
+            self.min_total_gpus,
+            self.max_total_gpus,
+            tolerance,
+        )
+        if not ok:
+            return [], 0, 0
+
+        return selected, final_total, tolerance
+
+    # ------------------------------------------------------------------ #
+    # Request shape helpers                                              #
+    # ------------------------------------------------------------------ #
+
+    def net_delta_gpu(
+        self,
+        targets: list[TargetReplica],
+        pools: dict[str, PoolSpec],
+    ) -> int:
+        """Sum of (desired - current) * gpu_per_replica across request pools."""
+        net = 0
+        for target in targets:
+            sub_type = target.sub_component_type.value
+            spec = pools.get(sub_type)
+            if spec is None or spec.gpu_per_replica == 0:
+                continue
+            net += (
+                target.desired_replicas - spec.current_replicas
+            ) * spec.gpu_per_replica
+        return net
+
+    def is_internally_paired(
+        self,
+        targets: list[TargetReplica],
+        pools: dict[str, PoolSpec],
+    ) -> bool:
+        """True if the request contains both up and down directions across pools."""
+        has_up = False
+        has_down = False
+        for target in targets:
+            sub_type = target.sub_component_type.value
+            spec = pools.get(sub_type)
+            if spec is None:
+                continue
+            direction = self._direction(target.desired_replicas, spec.current_replicas)
+            if direction == "up":
+                has_up = True
+            elif direction == "down":
+                has_down = True
+        return has_up and has_down
+
+    def _bounds_for_total(
+        self,
+        total: int,
+        paired: bool,
+        tolerance: int,
+    ) -> tuple[bool, str]:
+        """Check whether ``total`` is within the active budget bounds.
+
+        Standalone (non-paired) requests use strict bounds; paired transfers get
+        the tolerance band on the **lower** edge only — ``max_total_gpus`` is a
+        hard cluster-capacity bound (enforced by ``budget.bounds_for_total``).
+        """
+        return budget.bounds_for_total(
+            total,
+            self.min_total_gpus,
+            self.max_total_gpus,
+            tolerance if paired else 0,
+        )

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -70,6 +70,9 @@ class ScaleRequestHandler:
         self.runtime = runtime
         self.no_operation = no_operation
 
+        # TODO(global-planner): Separate the caller authorization allowlist from
+        # the Kubernetes backend's discovery scope instead of deriving both from
+        # managed_namespaces and a namespace-prefix convention.
         # The wire vocabulary (K8s namespace / DGD name) is mapped here onto the
         # orchestrator's neutral vocabulary; the orchestrator is a no-K8s zone.
         capacity_manager = KubernetesCapacityManager(namespace=k8s_namespace)
@@ -116,6 +119,9 @@ class ScaleRequestHandler:
     # Compatibility accessors (handler-level config)                     #
     # ------------------------------------------------------------------ #
 
+    # TODO(global-planner): Preserve the pre-refactor writable handler API
+    # with forwarding setters for max_total_gpus, min_total_gpus, and
+    # managed_namespaces (including its previous shape), or document the break.
     @property
     def max_total_gpus(self) -> int:
         return self.orchestrator.max_total_gpus
@@ -140,6 +146,9 @@ class ScaleRequestHandler:
         """
         try:
             # Validate caller namespace (if authorization is enabled)
+            # TODO(global-planner): Authenticate a trusted runtime principal
+            # instead of relying on payload-claimed caller_namespace, and bind
+            # authorization to the requested Kubernetes namespace and DGD.
             if not self.orchestrator.is_authorized(request.caller_namespace):
                 yield {
                     "status": ScaleStatus.ERROR.value,

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -9,9 +9,9 @@ translation between the wire DTOs (``ScaleRequest`` / ``ScaleResponse``) and the
 orchestrator. All budget arbitration and execution live below it:
 
 - :class:`~dynamo.global_planner.orchestrator.Orchestrator` — participants,
-  authorization, GPU-budget arbitration, and observe -> decide -> actuate
+  authorization, GPU-budget arbitration, and observe -> decide -> scale
 - :class:`~dynamo.global_planner.capacity_manager.CapacityManager` — Kubernetes
-  observe/actuate backend
+  observe/scale backend
 
 Behavior is unchanged from the pre-refactor monolithic handler.
 """
@@ -173,7 +173,7 @@ class ScaleRequestHandler:
             )
 
             # Register the participant (idempotent) so it can be observed and
-            # actuated and counts toward the budget. Map the wire fields onto the
+            # scaled and counts toward the budget. Map the wire fields onto the
             # orchestrator's neutral vocabulary.
             participant_id = f"{request.k8s_namespace}/{request.graph_deployment_name}"
             self.orchestrator.register(

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -1,92 +1,48 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Handler for scale_request endpoint in GlobalPlanner."""
+"""API layer for the GlobalPlanner ``scale_request`` endpoint.
 
-import asyncio
+Thin *driving adapter* over the capacity control loop. It owns the
+dynamo-runtime endpoint contract, caller authorization, no-operation mode, and
+translation between the wire DTOs (``ScaleRequest`` / ``ScaleResponse``) and the
+orchestrator. All budget arbitration and execution live below it:
+
+- :class:`~dynamo.global_planner.orchestrator.Orchestrator` — participants,
+  authorization, GPU-budget arbitration, and observe -> decide -> actuate
+- :class:`~dynamo.global_planner.capacity_manager.CapacityManager` — Kubernetes
+  observe/actuate backend
+
+Behavior is unchanged from the pre-refactor monolithic handler.
+"""
+
 import logging
-import math
-import time
-from collections import defaultdict
-from dataclasses import dataclass
-from typing import Iterator, Optional
 
-from dynamo.planner import KubernetesConnector, SubComponentType, TargetReplica
-from dynamo.planner.connectors.clients.kubernetes_api import KubernetesAPI
+from dynamo.global_planner.capacity_manager import KubernetesCapacityManager
+from dynamo.global_planner.orchestrator import Orchestrator
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
-from dynamo.planner.core import budget
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
-from dynamo.planner.monitoring.dgd_services import (
-    V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
-    Service,
-    get_component_type,
-    get_components_by_name,
-    get_planner_component_role,
-)
 from dynamo.runtime import DistributedRuntime, dynamo_endpoint
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class PoolSpec:
-    """Snapshot of one pool's state read from the DGD spec."""
-
-    sub_type: str
-    component_name: str
-    current_replicas: int
-    gpu_per_replica: int
-
-
-@dataclass
-class PoolIntent:
-    """Most recently observed desired replica count for a pool."""
-
-    last_desired: int
-    last_seen_at: float
-
-
 class ScaleRequestHandler:
-    """Handles incoming scale requests in GlobalPlanner.
+    """Handles incoming scale requests in GlobalPlanner (API layer).
 
-    This handler:
-    1. Receives scale requests from Planners
-    2. Validates caller authorization (optional)
-    3. Caches KubernetesConnector per DGD for efficiency
-    4. Executes scaling via Kubernetes API
-    5. Returns current replica counts
+    Receives scale requests from Planners, validates caller authorization, and
+    delegates budget arbitration and Kubernetes execution to an
+    :class:`Orchestrator`. Returns current replica counts.
 
     Management modes:
-    - **Explicit** (``--managed-namespaces`` set): Only DGDs whose Dynamo
-      namespaces are listed are managed. Authorization rejects requests from
-      unlisted namespaces, and GPU budget only counts these DGDs.
-    - **Implicit** (no ``--managed-namespaces``): All DGDs in the Kubernetes
-      namespace are managed. Any caller is accepted, and GPU budget counts
-      every DGD discovered in the namespace.
+    - **Explicit** (``managed_namespaces`` set): only listed Dynamo namespaces
+      are authorized, and only their DGDs count toward the GPU budget.
+    - **Implicit** (no ``managed_namespaces``): any caller is accepted and every
+      DGD in the namespace counts toward the budget.
 
-    Budget enforcement:
-    - ``max_total_gpus`` is a ceiling; scale-ups that would exceed it are
-      rejected unless a cached opposite-direction intent can be paired.
-    - ``min_total_gpus`` is a floor; scale-downs that would drop below it
-      are denied unless a cached opposite-direction intent from another pool
-      can be paired with them (intra-DGD or cross-DGD).
-    - Paired transfers may land up to ``tolerance`` GPUs **below** ``min``,
-      where tolerance = max per-replica GPU across the pools actually being
-      paired. This exists to handle asymmetric per-replica GPU counts where
-      a single-worker step cannot exactly cancel across pools. ``max`` is
-      a hard cluster-capacity bound and is never relaxed — overshooting it
-      would risk pending pods / over-admission. Asymmetric pairs whose total
-      would land above ``max`` are denied.
-
-    Intent cache semantics:
-    - Every scale request seeds the per-pool intent cache *before* the
-      budget decision, so a request that gets denied this tick still
-      leaves its desired count behind. A subsequent opposite-direction
-      request from another pool can pair against that cached intent and
-      execute the transfer.
-    - Bounded by TTL (``intent_cache_ttl_seconds``) and by the
-      satisfied-vs-pending check (``last_desired != current_replicas``):
-      stale or already-satisfied intents are not eligible partners.
+    Budget enforcement (``max_total_gpus`` ceiling, ``min_total_gpus`` floor with
+    cross-pool pairing) is performed by the :class:`Orchestrator`; see it for the
+    full semantics.
     """
 
     def __init__(
@@ -105,36 +61,28 @@ class ScaleRequestHandler:
             runtime: Dynamo runtime instance
             managed_namespaces: List of authorized namespaces (None = accept all)
             k8s_namespace: Kubernetes namespace where GlobalPlanner is running
-            no_operation: If True, log scale requests without executing K8s scaling
+            no_operation: If True, log scale requests without executing scaling
             max_total_gpus: Maximum total GPUs across all managed pools (-1 = unlimited)
             min_total_gpus: Minimum total GPUs across all managed pools (-1 = no floor)
             intent_cache_ttl_seconds: How long a cached scale intent from a pool
                 is considered fresh for pairing
         """
         self.runtime = runtime
-        # If managed_namespaces is None, accept all namespaces
-        self.managed_namespaces = (
-            set(managed_namespaces) if managed_namespaces else None
-        )
-        self.k8s_namespace = k8s_namespace
         self.no_operation = no_operation
-        self.max_total_gpus = max_total_gpus
-        self.min_total_gpus = min_total_gpus
-        self.intent_cache_ttl_seconds = intent_cache_ttl_seconds
-        self.connectors: dict[str, KubernetesConnector] = {}  # Cache per DGD
-        # Generic v1beta1 ``type: worker`` components need the role supplied by
-        # their Planner's TargetReplica. Specialized prefill/decode components
-        # do not need a hint.
-        self._component_roles: dict[str, dict[str, str]] = {}
-        # Per-pool cached desired replicas from recent ScaleRequests, keyed by
-        # f"{k8s_ns}/{dgd_name}/{sub_type}". Used to pair opposite-direction
-        # intents across requests when one request alone would breach bounds.
-        self._intent_cache: dict[str, PoolIntent] = {}
-        # Serializes budget-check + scale-execution so concurrent requests from
-        # different pools cannot both pass against the same pre-scale state.
-        self._scale_lock = asyncio.Lock()
 
-        if self.managed_namespaces:
+        # The wire vocabulary (K8s namespace / DGD name) is mapped here onto the
+        # orchestrator's neutral vocabulary; the orchestrator is a no-K8s zone.
+        capacity_manager = KubernetesCapacityManager(cluster_name=k8s_namespace)
+        self.orchestrator = Orchestrator(
+            capacity_manager=capacity_manager,
+            managed_callers=managed_namespaces,
+            max_total_gpus=max_total_gpus,
+            min_total_gpus=min_total_gpus,
+            intent_cache_ttl_seconds=intent_cache_ttl_seconds,
+            use_lock=True,
+        )
+
+        if managed_namespaces:
             logger.info(
                 f"ScaleRequestHandler initialized for namespaces: {managed_namespaces}"
             )
@@ -147,678 +95,38 @@ class ScaleRequestHandler:
                 "scale requests will be logged but not executed"
             )
 
-        if self.max_total_gpus >= 0:
-            logger.info(
-                f"GPU budget ceiling ENABLED: max {self.max_total_gpus} total GPUs"
-            )
+        if max_total_gpus >= 0:
+            logger.info(f"GPU budget ceiling ENABLED: max {max_total_gpus} total GPUs")
         else:
             logger.info("GPU budget ceiling DISABLED (unlimited)")
 
-        if self.min_total_gpus >= 0:
+        if min_total_gpus >= 0:
             logger.info(
-                f"GPU budget floor ENABLED: min {self.min_total_gpus} total GPUs, "
-                f"intent cache TTL {self.intent_cache_ttl_seconds}s"
+                f"GPU budget floor ENABLED: min {min_total_gpus} total GPUs, "
+                f"intent cache TTL {intent_cache_ttl_seconds}s"
             )
         else:
             logger.info("GPU budget floor DISABLED")
 
-        if self.max_total_gpus >= 0 or self.min_total_gpus >= 0:
-            self._populate_k8s_connectors()
-            if self.min_total_gpus >= 0:
-                self._warn_if_below_floor()
-
-    def _managed_dgd_names(self) -> set[str] | None:
-        """Derive the DGD names that this GlobalPlanner manages.
-
-        Returns:
-            A set of DGD names when in explicit mode, or None in implicit mode.
-
-        The Dynamo operator convention is:
-            DYN_NAMESPACE = "{k8s_namespace}-{dgd_name}"
-        so the DGD name is the Dynamo namespace with the k8s prefix stripped.
-        """
-        if self.managed_namespaces is None:
-            return None
-
-        prefix = f"{self.k8s_namespace}-"
-        names = set()
-        for ns in self.managed_namespaces:
-            if ns.startswith(prefix):
-                names.add(ns[len(prefix) :])
-            else:
-                logger.warning(
-                    f"Managed namespace '{ns}' does not start with "
-                    f"expected prefix '{prefix}'; cannot derive DGD name"
-                )
-        return names
-
-    def _populate_k8s_connectors(self):
-        """Pre-populate connectors for DGDs managed by this GlobalPlanner.
-
-        This ensures the GPU budget calculation accounts for DGDs that already
-        exist at startup, even if they haven't sent a scale request yet.
-
-        In explicit mode (--managed-namespaces set), only DGDs whose names
-        match the managed Dynamo namespaces are discovered.
-        In implicit mode, all DGDs in the k8s namespace are discovered.
-        """
-        try:
-            kube_api = KubernetesAPI(self.k8s_namespace)
-            managed_names = self._managed_dgd_names()
-            dgds = kube_api.list_graph_deployments()
-            discovered = []
-            for dgd in dgds:
-                name = dgd.get("metadata", {}).get("name", "")
-                if not name:
-                    continue
-                # In explicit mode, skip DGDs not in the managed set
-                if managed_names is not None and name not in managed_names:
-                    continue
-                connector_key = f"{self.k8s_namespace}/{name}"
-                if connector_key not in self.connectors:
-                    connector = KubernetesConnector(
-                        dynamo_namespace="discovered",
-                        k8s_namespace=self.k8s_namespace,
-                        parent_dgd_name=name,
-                        raise_not_ready=True,
-                    )
-                    self.connectors[connector_key] = connector
-                discovered.append(name)
-            logger.info(f"Discovered {len(discovered)} existing DGDs: {discovered}")
-        except Exception as e:
-            logger.warning(f"Failed to discover existing DGDs: {e}")
-
-    def _warn_if_below_floor(self):
-        """Log a warning if the discovered initial state is below min_total_gpus.
-
-        Soft floor: we do not proactively scale up. The floor prevents
-        scale-downs below it, but initial below-floor state is allowed and
-        will drift toward the floor as load arrives.
-        """
-        try:
-            total = self._total_gpus_with_overrides({})
-        except Exception as e:
-            logger.warning(f"Could not compute initial total GPUs: {e}")
-            return
-        if total < self.min_total_gpus:
-            logger.warning(
-                f"Current total GPUs ({total}) is below min_total_gpus "
-                f"({self.min_total_gpus}); scale-up from load scaler will "
-                f"drift toward the floor. No proactive fill is issued."
-            )
-        else:
-            logger.info(
-                f"Initial total GPUs ({total}) meets floor ({self.min_total_gpus})"
-            )
-
-    @staticmethod
-    def _component_role(
-        component_name: str,
-        component: dict,
-        role_hints: dict[str, str],
-    ) -> str:
-        explicit_role = get_planner_component_role(component)
-        if explicit_role:
-            return explicit_role
-        if get_component_type(component) in (
-            "",
-            V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
-        ):
-            return role_hints.get(component_name, "")
-        return ""
-
-    @staticmethod
-    def _gpu_per_replica(component: dict, service: Service) -> int:
-        multinode = component.get("multinode")
-        node_count = 1 if multinode is None else multinode.get("nodeCount", 2)
-        return service.get_gpu_count() * int(node_count)
-
-    @staticmethod
-    def _record_pool_component(
-        components_by_pool: dict[str, str],
-        pool_key: str,
-        component_name: str,
-        dgd_name: str,
-    ) -> None:
-        previous_component = components_by_pool.get(pool_key)
-        if previous_component is not None:
-            raise ValueError(
-                f"DGD {dgd_name!r} components {previous_component!r} and "
-                f"{component_name!r} both resolve to planner pool {pool_key!r}"
-            )
-        components_by_pool[pool_key] = component_name
-
-    def _read_dgd_pools(
-        self,
-        connector: KubernetesConnector,
-        role_hints: Optional[dict[str, str]] = None,
-    ) -> dict[str, PoolSpec]:
-        """Read the current pool state for one DGD.
-
-        Returns a map from sub_component_type to PoolSpec. An unmapped generic
-        worker is keyed by component name so it still contributes to the total.
-        """
-        deployment = connector.kube_api.get_graph_deployment(connector.parent_dgd_name)
-        pools: dict[str, PoolSpec] = {}
-        components_by_pool: dict[str, str] = {}
-        role_hints = role_hints or {}
-        for component_name, component in get_components_by_name(deployment).items():
-            pool_key = self._component_role(component_name, component, role_hints)
-            component_type = get_component_type(component)
-            service = Service(name=component_name, service=component)
-            gpu_per_replica = None
-            if not pool_key and component_type in (
-                "",
-                V1BETA1_GENERIC_WORKER_COMPONENT_TYPE,
-            ):
-                try:
-                    gpu_per_replica = self._gpu_per_replica(component, service)
-                except ValueError:
-                    if component_type == "":
-                        # An untyped non-worker component is not a pool.
-                        continue
-                    raise
-                # Count an as-yet-unmapped worker in the cluster total. Once
-                # its Planner sends a request, the component-name hint replaces
-                # this key with its prefill/decode role.
-                pool_key = component_name
-            if not pool_key:
-                continue
-            self._record_pool_component(
-                components_by_pool,
-                pool_key,
-                component_name,
-                connector.parent_dgd_name,
-            )
-            pools[pool_key] = PoolSpec(
-                sub_type=pool_key,
-                component_name=component_name,
-                current_replicas=service.number_replicas(),
-                gpu_per_replica=(
-                    gpu_per_replica
-                    if gpu_per_replica is not None
-                    else self._gpu_per_replica(component, service)
-                ),
-            )
-        return pools
-
-    def _read_all_pools(
-        self, require_complete: bool = False
-    ) -> dict[str, dict[str, PoolSpec]]:
-        """Read current pool state for every known DGD.
-
-        Returns a map of dgd_key -> (sub_type -> PoolSpec). Each arbitration
-        call reads fresh state once; cross-DGD partner search and budget math
-        both consume this snapshot to avoid re-hitting the K8s API per lookup.
-        When ``require_complete`` is true, any unreadable DGD fails the whole
-        snapshot so budget enforcement cannot under-count cluster usage.
-
-        Snapshots ``self.connectors`` up-front via ``list(...)``: this method
-        runs on a worker thread (see ``asyncio.to_thread`` in scale_request),
-        and a concurrent first-time request for another DGD can insert into
-        the dict before it blocks on ``_scale_lock``. Without the snapshot,
-        that insertion races our iteration and either raises
-        ``RuntimeError: dictionary changed size during iteration`` or yields
-        a snapshot missing the new DGD.
-        """
-        all_pools: dict[str, dict[str, PoolSpec]] = {}
-        for key, connector in list(self.connectors.items()):
-            try:
-                all_pools[key] = self._read_dgd_pools(
-                    connector, self._component_roles.get(key)
-                )
-            except Exception as e:
-                if require_complete:
-                    raise RuntimeError(f"Failed to read DGD for {key}: {e}") from e
-                logger.warning(f"Failed to read DGD for {key}: {e}")
-                all_pools[key] = {}
-        return all_pools
-
-    def _total_gpus_from_snapshot(
-        self,
-        all_pools: dict[str, dict[str, PoolSpec]],
-        overrides: dict[tuple[str, str], int],
-    ) -> int:
-        """Compute total GPUs across all known DGDs from a pre-read snapshot.
-
-        Args:
-            all_pools: pool snapshot as returned by ``_read_all_pools``.
-            overrides: Map from (dgd_key, sub_component_type) to the replica
-                count to use in place of the current K8s replica count. Any
-                entry not in ``overrides`` uses the current K8s replica count.
-        """
-        total_gpus = 0
-        for key, pools in all_pools.items():
-            for sub_type, spec in pools.items():
-                if spec.gpu_per_replica == 0:
-                    continue
-                replicas = overrides.get((key, sub_type), spec.current_replicas)
-                total_gpus += replicas * spec.gpu_per_replica
-        return total_gpus
-
-    def _total_gpus_with_overrides(self, overrides: dict[tuple[str, str], int]) -> int:
-        """Compute total GPUs across all known DGDs (re-reads K8s).
-
-        Kept for backward compatibility (startup warnings, legacy callers).
-        In the hot arbitration path, prefer ``_total_gpus_from_snapshot`` with
-        a pre-read ``_read_all_pools`` result.
-
-        NOTE: GPU count is read from the v1beta1 component's main container,
-        preferring resources.limits.nvidia.com/gpu and falling back to requests.
-        """
-        return self._total_gpus_from_snapshot(
-            self._read_all_pools(require_complete=self._budget_enforcement_enabled()),
-            overrides,
-        )
+        # Discover existing DGDs (and warn if below floor) when a budget is
+        # active, so the initial GPU total accounts for pre-existing pools.
+        self.orchestrator.startup()
 
     # ------------------------------------------------------------------ #
-    # Intent cache helpers                                               #
+    # Compatibility accessors (handler-level config)                     #
     # ------------------------------------------------------------------ #
 
-    @staticmethod
-    def _pool_cache_key(dgd_key: str, sub_type: str) -> str:
-        return f"{dgd_key}/{sub_type}"
+    @property
+    def max_total_gpus(self) -> int:
+        return self.orchestrator.max_total_gpus
 
-    @staticmethod
-    def _direction(desired: int, current: int) -> str:
-        if desired > current:
-            return "up"
-        if desired < current:
-            return "down"
-        return "stable"
+    @property
+    def min_total_gpus(self) -> int:
+        return self.orchestrator.min_total_gpus
 
-    def _update_intent_cache(
-        self, dgd_key: str, request: ScaleRequest, dgd_pools: dict[str, PoolSpec]
-    ):
-        """Record the desired replicas for each pool in this request."""
-        now = time.time()
-        for target in request.target_replicas:
-            sub_type = target.sub_component_type.value
-            if sub_type not in dgd_pools:
-                # Unknown pool (not yet in DGD spec); skip — without
-                # gpu_per_replica we can't compute deltas or pair against it.
-                continue
-            key = self._pool_cache_key(dgd_key, sub_type)
-            self._intent_cache[key] = PoolIntent(
-                last_desired=target.desired_replicas,
-                last_seen_at=now,
-            )
-
-    def _remember_component_roles(self, dgd_key: str, request: ScaleRequest) -> None:
-        role_hints = self._component_roles.setdefault(dgd_key, {})
-        for target in request.target_replicas:
-            if target.component_name:
-                role_hints[target.component_name] = target.sub_component_type.value
-
-    def _pair_tolerance(
-        self,
-        request_pools: list[PoolSpec],
-        partner_spec: PoolSpec,
-    ) -> int:
-        """Tolerance for a specific paired transfer.
-
-        Equal to max per-replica GPU across just the pools actually being
-        changed (request's non-stable pools + partner). Covers step-size
-        asymmetry where a single worker on one side can't exactly cancel
-        a single worker on the other side.
-        """
-        return budget.compute_tolerance(
-            [p.gpu_per_replica for p in request_pools] + [partner_spec.gpu_per_replica]
-        )
-
-    def _internal_pair_tolerance(
-        self,
-        changing_pools: list[PoolSpec],
-    ) -> int:
-        """Tolerance for an internally-paired request (no external partner)."""
-        return budget.compute_tolerance(p.gpu_per_replica for p in changing_pools)
-
-    def _iter_pair_partners(
-        self,
-        request_dgd_key: str,
-        request_pool_keys: set[tuple[str, str]],
-        all_pools: dict[str, dict[str, PoolSpec]],
-        request_net_delta_gpu: int,
-    ) -> Iterator[tuple[str, str, int, PoolSpec]]:
-        """Yield qualifying pair-partner candidates, same-DGD first.
-
-        A candidate qualifies when it (a) is not in the requesting pool set,
-        (b) has a fresh cached intent (within TTL) whose desired differs
-        from current replicas, and (c) the partner delta points opposite
-        to the request's net delta.
-
-        Yields in two passes: same-DGD candidates first (atomic-patch
-        preference), then cross-DGD candidates. The caller picks the first
-        one whose pair total actually lands in the budget band — checking
-        feasibility per-candidate is the caller's job because tolerance and
-        total depend on which partner is chosen, not just which exist.
-
-        Args:
-            request_dgd_key: "k8s_ns/dgd_name" of the requesting DGD.
-            request_pool_keys: (dgd_key, sub_type) tuples already in the
-                incoming request — excluded from partner search.
-            all_pools: snapshot of all DGDs' pool state.
-            request_net_delta_gpu: Net GPU delta of the request standalone.
-                Zero short-circuits (no pairing needed).
-        """
-        if request_net_delta_gpu == 0:
-            return
-        now = time.time()
-        same_dgd: list[tuple[str, str, int, PoolSpec]] = []
-        cross_dgd: list[tuple[str, str, int, PoolSpec]] = []
-        for dgd_key, pools in all_pools.items():
-            for sub_type, spec in pools.items():
-                if (dgd_key, sub_type) in request_pool_keys:
-                    continue
-                if spec.gpu_per_replica == 0:
-                    continue
-                cache_key = self._pool_cache_key(dgd_key, sub_type)
-                intent = self._intent_cache.get(cache_key)
-                if intent is None:
-                    continue
-                if now - intent.last_seen_at > self.intent_cache_ttl_seconds:
-                    continue
-                if intent.last_desired == spec.current_replicas:
-                    continue  # Satisfied — nothing to apply.
-                partner_delta_gpu = (
-                    intent.last_desired - spec.current_replicas
-                ) * spec.gpu_per_replica
-                # Must be opposite direction of the request's net delta.
-                if (request_net_delta_gpu > 0 and partner_delta_gpu >= 0) or (
-                    request_net_delta_gpu < 0 and partner_delta_gpu <= 0
-                ):
-                    continue
-                candidate = (dgd_key, sub_type, intent.last_desired, spec)
-                if dgd_key == request_dgd_key:
-                    same_dgd.append(candidate)
-                else:
-                    cross_dgd.append(candidate)
-        yield from same_dgd
-        yield from cross_dgd
-
-    def _partial_partner(
-        self,
-        candidate: tuple[str, str, int, PoolSpec],
-        all_pools: dict[str, dict[str, PoolSpec]],
-        current_overrides: dict[tuple[str, str], int],
-        tolerance: int,
-    ) -> Optional[int]:
-        """Compute a partial ``applied_desired`` for a candidate whose full
-        consumption would push the combined transfer out of the band.
-
-        Returns an integer ``K`` strictly between ``current_replicas`` and
-        ``last_desired`` (direction-consistent) such that applying ``K``
-        instead of ``last_desired`` lands the combined transfer at the
-        appropriate band edge — the strict ceiling on the upper side
-        (``max``, no tolerance) or ``min - tolerance`` on the lower side.
-        ``None`` if no feasible partial exists (e.g., even one worker's
-        contribution overshoots).
-        """
-        _, _, last_desired, spec = candidate
-        current = spec.current_replicas
-        gpu = spec.gpu_per_replica
-        if gpu <= 0 or last_desired == current:
-            return None
-
-        # Combined total assuming this candidate stays at its current count
-        # (i.e., contributes 0). The candidate is NOT in current_overrides
-        # yet, so the snapshot uses its current_replicas naturally.
-        baseline_total = self._total_gpus_from_snapshot(all_pools, current_overrides)
-
-        if last_desired > current:
-            # Scale-up candidate: pick K in [current+1, last_desired] that
-            # keeps total <= max (strict ceiling — max is a hard hardware
-            # bound, see budget.bounds_for_total).
-            if self.max_total_gpus < 0:
-                return last_desired
-            # K <= current + (max - baseline_total) // gpu
-            headroom = self.max_total_gpus - baseline_total
-            if headroom <= 0:
-                return None
-            max_k = current + headroom // gpu
-            k = min(last_desired, max_k)
-            return k if k > current else None
-        else:
-            # Scale-down candidate: pick K in [last_desired, current-1] that
-            # keeps total >= min - tolerance.
-            if self.min_total_gpus < 0:
-                return last_desired
-            lower = self.min_total_gpus - tolerance
-            # K >= current + ceil((lower - baseline_total) / gpu)
-            diff = lower - baseline_total
-            if diff > 0:
-                # Already below floor; further scale-down impossible.
-                return None
-            min_k = current + math.ceil(diff / gpu)
-            k = max(last_desired, min_k)
-            return k if k < current else None
-
-    def _find_pair_partner_set(
-        self,
-        request_dgd_key: str,
-        request_pool_keys: set[tuple[str, str]],
-        all_pools: dict[str, dict[str, PoolSpec]],
-        request_net_delta_gpu: int,
-        standalone_overrides: dict[tuple[str, str], int],
-        changing_request_pools: list[PoolSpec],
-    ) -> tuple[list[tuple[str, str, int, PoolSpec]], int, int]:
-        """Pack as many opposite-direction cached intents as fit alongside
-        the request, partially consuming one over-sized candidate if needed.
-
-        Algorithm: greedy admission, ascending ``abs(delta_gpu)`` order. For
-        each candidate, fully admit if it keeps the combined transfer in
-        ``[min - tolerance, max]``; if full admission would overshoot the
-        strict ceiling, try partial consumption that lands at the band edge
-        and stop (the band is now tight, larger candidates won't fit either).
-
-        Tolerance is computed **once** over the request's changing pools
-        plus all candidates considered for inclusion, not iteratively
-        widened — this avoids early candidates being admitted under a
-        tighter tolerance that wouldn't admit them after the band widened.
-
-        Returns (selected_partners, total_after, tolerance).
-        ``selected_partners`` is empty when no feasible packing exists.
-        """
-        if request_net_delta_gpu == 0:
-            return [], 0, 0
-
-        all_candidates = list(
-            self._iter_pair_partners(
-                request_dgd_key,
-                request_pool_keys,
-                all_pools,
-                request_net_delta_gpu,
-            )
-        )
-        if not all_candidates:
-            return [], 0, 0
-
-        # Tolerance computed once over the universe of changing pools.
-        candidate_specs = [c[3] for c in all_candidates]
-        tolerance = budget.compute_tolerance(
-            [s.gpu_per_replica for s in changing_request_pools]
-            + [s.gpu_per_replica for s in candidate_specs]
-        )
-
-        # Sort ascending by |delta_gpu| — smaller pieces overshoot less.
-        def cand_delta(c: tuple[str, str, int, PoolSpec]) -> int:
-            _, _, desired, spec = c
-            return (desired - spec.current_replicas) * spec.gpu_per_replica
-
-        all_candidates.sort(key=lambda c: abs(cand_delta(c)))
-
-        selected: list[tuple[str, str, int, PoolSpec]] = []
-        overrides = dict(standalone_overrides)
-
-        for cand in all_candidates:
-            cand_dgd, cand_sub, cand_desired, cand_spec = cand
-
-            # Try full inclusion.
-            full_overrides = dict(overrides)
-            full_overrides[(cand_dgd, cand_sub)] = cand_desired
-            full_total = self._total_gpus_from_snapshot(all_pools, full_overrides)
-            in_band, _ = budget.bounds_for_total(
-                full_total,
-                self.min_total_gpus,
-                self.max_total_gpus,
-                tolerance,
-            )
-            if in_band:
-                # Full inclusion lands in band — accept and continue. The
-                # user's framing is "as long as we stay within the threshold,
-                # do the larger groups of scaling decisions" — so we keep
-                # admitting more candidates while feasible. Subsequent
-                # iterations either continue extending (next full also in
-                # band) or trigger partial-then-break (next full crosses).
-                selected.append(cand)
-                overrides = full_overrides
-                continue
-
-            # Out of band. Did this candidate cross the band, or are we
-            # still on the wrong side and need more help?
-            #
-            # Request delta sign indicates which side we started on:
-            #   request_net_delta > 0 → request alone overshoots ceiling
-            #     (approaching from above; candidates pull down).
-            #   request_net_delta < 0 → request alone undershoots floor
-            #     (approaching from below; candidates push up).
-            above_ceiling = (
-                self.max_total_gpus >= 0 and full_total > self.max_total_gpus
-            )
-            below_floor = (
-                self.min_total_gpus >= 0
-                and full_total < self.min_total_gpus - tolerance
-            )
-            still_approaching = (request_net_delta_gpu > 0 and above_ceiling) or (
-                request_net_delta_gpu < 0 and below_floor
-            )
-            if still_approaching:
-                # Candidate moved us toward the band but didn't reach it.
-                # Accept full inclusion and try the next candidate.
-                selected.append(cand)
-                overrides = full_overrides
-                continue
-
-            # Full inclusion crossed the band. Try partial consumption that
-            # lands at the appropriate band edge, then stop.
-            partial_k = self._partial_partner(cand, all_pools, overrides, tolerance)
-            if partial_k is not None and partial_k != cand_spec.current_replicas:
-                partial_cand = (cand_dgd, cand_sub, partial_k, cand_spec)
-                selected.append(partial_cand)
-                overrides[(cand_dgd, cand_sub)] = partial_k
-            break
-
-        # Loop ended with the running total possibly still on the wrong side
-        # (no candidate fully reached the band, none of them crossed). Try
-        # partial of the last selected candidate to land in band.
-        if selected:
-            running_total = self._total_gpus_from_snapshot(all_pools, overrides)
-            running_in_band, _ = budget.bounds_for_total(
-                running_total,
-                self.min_total_gpus,
-                self.max_total_gpus,
-                tolerance,
-            )
-            if not running_in_band:
-                last = selected[-1]
-                last_dgd, last_sub, _, last_spec = last
-                # Roll back the last full inclusion so partial uses the
-                # pre-last-candidate baseline.
-                rollback_overrides = dict(overrides)
-                if (last_dgd, last_sub) in standalone_overrides:
-                    rollback_overrides[(last_dgd, last_sub)] = standalone_overrides[
-                        (last_dgd, last_sub)
-                    ]
-                else:
-                    rollback_overrides.pop((last_dgd, last_sub), None)
-                partial_k = self._partial_partner(
-                    last, all_pools, rollback_overrides, tolerance
-                )
-                if partial_k is not None and partial_k != last_spec.current_replicas:
-                    selected[-1] = (last_dgd, last_sub, partial_k, last_spec)
-                    overrides = dict(rollback_overrides)
-                    overrides[(last_dgd, last_sub)] = partial_k
-
-        if not selected:
-            return [], 0, 0
-
-        final_total = self._total_gpus_from_snapshot(all_pools, overrides)
-        ok, _ = budget.bounds_for_total(
-            final_total,
-            self.min_total_gpus,
-            self.max_total_gpus,
-            tolerance,
-        )
-        if not ok:
-            return [], 0, 0
-
-        return selected, final_total, tolerance
-
-    # ------------------------------------------------------------------ #
-    # Request handling                                                   #
-    # ------------------------------------------------------------------ #
-
-    def _request_net_delta_gpu(
-        self,
-        request: ScaleRequest,
-        dgd_pools: dict[str, PoolSpec],
-    ) -> int:
-        """Sum of (desired - current) * gpu_per_replica across all pools in the request."""
-        net = 0
-        for target in request.target_replicas:
-            sub_type = target.sub_component_type.value
-            spec = dgd_pools.get(sub_type)
-            if spec is None or spec.gpu_per_replica == 0:
-                continue
-            net += (
-                target.desired_replicas - spec.current_replicas
-            ) * spec.gpu_per_replica
-        return net
-
-    def _request_is_internally_paired(
-        self,
-        request: ScaleRequest,
-        dgd_pools: dict[str, PoolSpec],
-    ) -> bool:
-        """True if the request contains both up and down directions across pools."""
-        has_up = False
-        has_down = False
-        for target in request.target_replicas:
-            sub_type = target.sub_component_type.value
-            spec = dgd_pools.get(sub_type)
-            if spec is None:
-                continue
-            direction = self._direction(target.desired_replicas, spec.current_replicas)
-            if direction == "up":
-                has_up = True
-            elif direction == "down":
-                has_down = True
-        return has_up and has_down
-
-    def _budget_enforcement_enabled(self) -> bool:
-        return self.max_total_gpus >= 0 or self.min_total_gpus >= 0
-
-    def _bounds_for_total(
-        self,
-        total: int,
-        paired: bool,
-        tolerance: int,
-    ) -> tuple[bool, str]:
-        """Check whether ``total`` is within the active budget bounds.
-
-        Returns ``(is_in_bounds, reason_if_out_of_bounds)``.
-
-        Standalone (non-paired) requests use strict bounds; paired transfers
-        get the tolerance band on the **lower** edge only — ``max_total_gpus``
-        is a hard cluster-capacity bound (enforced by
-        ``budget.bounds_for_total``).
-        """
-        return budget.bounds_for_total(
-            total,
-            self.min_total_gpus,
-            self.max_total_gpus,
-            tolerance if paired else 0,
-        )
+    @property
+    def managed_namespaces(self):
+        return self.orchestrator.managed_callers
 
     @dynamo_endpoint(ScaleRequest, ScaleResponse)
     async def scale_request(self, request: ScaleRequest):
@@ -832,10 +140,7 @@ class ScaleRequestHandler:
         """
         try:
             # Validate caller namespace (if authorization is enabled)
-            if (
-                self.managed_namespaces is not None
-                and request.caller_namespace not in self.managed_namespaces
-            ):
+            if not self.orchestrator.is_authorized(request.caller_namespace):
                 yield {
                     "status": ScaleStatus.ERROR.value,
                     "message": f"Namespace {request.caller_namespace} not authorized",
@@ -843,7 +148,7 @@ class ScaleRequestHandler:
                 }
                 return
 
-            # No-operation mode: log and return success without touching K8s
+            # No-operation mode: log and return success without touching the backend
             if self.no_operation:
                 replicas_summary = {
                     r.sub_component_type.value: r.desired_replicas
@@ -867,275 +172,28 @@ class ScaleRequestHandler:
                 f"in K8s namespace {request.k8s_namespace}"
             )
 
-            # Get or create connector for this DGD
-            connector_key = f"{request.k8s_namespace}/{request.graph_deployment_name}"
-            if connector_key not in self.connectors:
-                connector = KubernetesConnector(
-                    dynamo_namespace=request.caller_namespace,
-                    k8s_namespace=request.k8s_namespace,
-                    parent_dgd_name=request.graph_deployment_name,
-                    raise_not_ready=True,
-                )
-                self.connectors[connector_key] = connector
-                logger.debug(f"Created new connector for {connector_key}")
-            else:
-                connector = self.connectors[connector_key]
-                logger.debug(f"Reusing cached connector for {connector_key}")
-
-            # Lock ensures the budget check and scale execution are atomic
-            # so concurrent requests from different pools cannot both pass
-            # against the same pre-scale replica counts.
-            async with self._scale_lock:
-                self._remember_component_roles(connector_key, request)
-                # Read ALL known DGDs' current state once. Cross-DGD partner
-                # search needs to see every pool's current replicas and
-                # gpu_per_replica; cross-DGD budget math also consumes this.
-                # Run the synchronous K8s GETs off-thread so the event loop
-                # (health checks, other endpoints) isn't blocked for the
-                # N round-trips it takes across managed DGDs.
-                all_pools = await asyncio.to_thread(
-                    self._read_all_pools, self._budget_enforcement_enabled()
-                )
-                dgd_pools = all_pools.get(connector_key, {})
-
-                # Always update the intent cache with this request's targets,
-                # regardless of decision. A later request from a complementary
-                # pool may need to pair with this intent.
-                self._update_intent_cache(connector_key, request, dgd_pools)
-
-                # Build standalone overrides (request targets only).
-                request_key = connector_key
-                request_pool_keys = {
-                    (request_key, t.sub_component_type.value)
-                    for t in request.target_replicas
-                }
-                standalone_overrides = {
-                    (request_key, t.sub_component_type.value): t.desired_replicas
-                    for t in request.target_replicas
-                }
-
-                # Selected pair-partners (possibly multiple). Empty list
-                # means "no partners involved" — the standalone or
-                # no-budget path.
-                selected_partners: list[
-                    tuple[str, str, int, PoolSpec]
-                ] = []  # (dgd_key, sub_type, applied_desired, spec)
-
-                if self._budget_enforcement_enabled():
-                    net_delta = self._request_net_delta_gpu(request, dgd_pools)
-                    internally_paired = self._request_is_internally_paired(
-                        request, dgd_pools
-                    )
-
-                    total_standalone = self._total_gpus_from_snapshot(
-                        all_pools, standalone_overrides
-                    )
-
-                    # Tolerance depends on which pools are actually changing.
-                    changing_request_pools = [
-                        dgd_pools[t.sub_component_type.value]
-                        for t in request.target_replicas
-                        if t.sub_component_type.value in dgd_pools
-                        and t.desired_replicas
-                        != dgd_pools[t.sub_component_type.value].current_replicas
-                    ]
-                    standalone_tolerance = self._internal_pair_tolerance(
-                        changing_request_pools
-                    )
-
-                    # Internally-paired requests get tolerance even without an
-                    # external partner.
-                    standalone_ok, standalone_reason = self._bounds_for_total(
-                        total_standalone, internally_paired, standalone_tolerance
-                    )
-
-                    # Multi-partner packing: pack as many opposite-direction
-                    # cached intents as fit within the band, partially
-                    # consuming one over-sized candidate if needed.
-                    (
-                        selected_partners,
-                        total_paired,
-                        paired_tolerance,
-                    ) = self._find_pair_partner_set(
-                        request_key,
-                        request_pool_keys,
-                        all_pools,
-                        net_delta,
-                        standalone_overrides,
-                        changing_request_pools,
-                    )
-
-                    # Decide:
-                    # 1. Non-empty pair set → apply request + all partners.
-                    # 2. Else if standalone in bounds → apply standalone.
-                    # 3. Else deny.
-                    if selected_partners:
-                        scope = (
-                            "intra-DGD"
-                            if all(p[0] == request_key for p in selected_partners)
-                            else "cross-DGD"
-                        )
-                        partners_desc = ", ".join(
-                            f"{p[0]}/{p[1]}={p[2]}" for p in selected_partners
-                        )
-                        logger.info(
-                            f"Paired transfer ({scope}, "
-                            f"{len(selected_partners)} partner(s)) for DGD "
-                            f"{request.graph_deployment_name}: "
-                            f"request {sorted(request_pool_keys)} + "
-                            f"[{partners_desc}]; total {total_paired} GPUs "
-                            f"(bounds "
-                            f"[{self.min_total_gpus if self.min_total_gpus >= 0 else '-inf'} - {paired_tolerance}, "
-                            f"{self.max_total_gpus if self.max_total_gpus >= 0 else '+inf'}])"
-                        )
-                    elif standalone_ok:
-                        logger.info(
-                            f"Standalone scale request for DGD {request.graph_deployment_name}: "
-                            f"total {total_standalone} GPUs "
-                            f"(internally_paired={internally_paired})"
-                        )
-                    else:
-                        # Budget breach: standalone out-of-bounds and no
-                        # feasible partner set found.
-                        logger.warning(
-                            f"Rejecting scale request from {request.caller_namespace}: "
-                            f"{standalone_reason}; no feasible pair packing"
-                        )
-                        # Soft denial: budget breach is an expected operational
-                        # outcome in fixed-total mode, not a fault. Local
-                        # planners should treat this as a no-op for this tick.
-                        yield {
-                            "status": ScaleStatus.REJECTED.value,
-                            "message": (
-                                f"GPU budget breach: {standalone_reason}; "
-                                f"no feasible pair packing"
-                            ),
-                            "current_replicas": {},
-                        }
-                        return
-
-                # Apply: request + selected partners (may be empty), grouped
-                # by DGD with at most one set_component_replicas call per DGD.
-                # Direction-aware order: scale-down DGDs first (most negative
-                # net delta), so that GPUs are freed before scale-up DGDs
-                # submit new pods. Within each DGD, the request's targets and
-                # any same-DGD partners are combined into a single atomic
-                # patch. Cross-DGD partners get separate per-DGD patches.
-                dgd_targets: dict[str, list[TargetReplica]] = defaultdict(list)
-                dgd_targets[request_key].extend(request.target_replicas)
-                for p_dgd, p_sub, p_desired, p_spec in selected_partners:
-                    dgd_targets[p_dgd].append(
-                        TargetReplica(
-                            sub_component_type=SubComponentType(p_sub),
-                            component_name=p_spec.component_name,
-                            desired_replicas=p_desired,
-                        )
-                    )
-
-                # Compute net GPU delta per DGD for ordering.
-                dgd_net_deltas: dict[str, int] = {}
-                for dgd_key_iter, targets in dgd_targets.items():
-                    pools = all_pools.get(dgd_key_iter, {})
-                    net = 0
-                    for t in targets:
-                        spec = pools.get(t.sub_component_type.value)
-                        if spec is not None and spec.gpu_per_replica > 0:
-                            net += (
-                                t.desired_replicas - spec.current_replicas
-                            ) * spec.gpu_per_replica
-                    dgd_net_deltas[dgd_key_iter] = net
-
-                # Sort: most negative (scale-down) first, most positive
-                # (scale-up) last.
-                ordered_dgds = sorted(
-                    dgd_targets.keys(), key=lambda k: dgd_net_deltas[k]
-                )
-
-                applied_dgds: list[str] = []
-                for i, dgd_key_iter in enumerate(ordered_dgds):
-                    targets = dgd_targets[dgd_key_iter]
-                    target_conn = (
-                        connector
-                        if dgd_key_iter == request_key
-                        else self.connectors.get(dgd_key_iter)
-                    )
-                    if target_conn is None:
-                        if i == 0:
-                            # First patch: missing connector is unrecoverable
-                            # since nothing has been applied yet.
-                            logger.error(
-                                f"Multi-partner transfer aborted: missing "
-                                f"connector for first DGD ({dgd_key_iter})"
-                            )
-                            yield {
-                                "status": ScaleStatus.ERROR.value,
-                                "message": (
-                                    f"Multi-partner transfer: missing "
-                                    f"connector for {dgd_key_iter}"
-                                ),
-                                "current_replicas": {},
-                            }
-                            return
-                        logger.error(
-                            f"Multi-partner transfer: missing connector for "
-                            f"{dgd_key_iter} after applying {applied_dgds}; "
-                            f"will self-correct on next tick"
-                        )
-                        continue
-                    try:
-                        await target_conn.set_component_replicas(
-                            targets, blocking=request.blocking
-                        )
-                        applied_dgds.append(dgd_key_iter)
-                    except DynamoGraphDeploymentNotReadyError as patch_err:
-                        if i == 0:
-                            raise
-                        logger.warning(
-                            "Multi-partner transfer: patch on %s was skipped "
-                            "after applying %s because the DGD is not ready: %s; "
-                            "will self-correct on next tick",
-                            dgd_key_iter,
-                            applied_dgds,
-                            patch_err,
-                        )
-                    except Exception as patch_err:
-                        if i == 0:
-                            # First patch failure: nothing applied, propagate
-                            # to the outer try so the caller sees ERROR.
-                            raise
-                        logger.error(
-                            f"Multi-partner transfer: patch on {dgd_key_iter} "
-                            f"failed after applying {applied_dgds}: "
-                            f"{patch_err}; will self-correct on next tick"
-                        )
-
-            # Get current replica counts
-            current_replicas = {}
-            deployment = connector.kube_api.get_graph_deployment(
-                connector.parent_dgd_name
+            # Register the participant (idempotent) so it can be observed and
+            # actuated and counts toward the budget. Map the wire fields onto the
+            # orchestrator's neutral vocabulary.
+            participant_id = f"{request.k8s_namespace}/{request.graph_deployment_name}"
+            self.orchestrator.register(
+                participant_id,
+                caller_name=request.caller_namespace,
+                cluster_name=request.k8s_namespace,
+                deployment_name=request.graph_deployment_name,
             )
-            role_hints = self._component_roles.get(connector_key, {})
-            components_by_pool: dict[str, str] = {}
-            for component_name, component in get_components_by_name(deployment).items():
-                sub_type = self._component_role(component_name, component, role_hints)
-                if sub_type:
-                    self._record_pool_component(
-                        components_by_pool,
-                        sub_type,
-                        component_name,
-                        connector.parent_dgd_name,
-                    )
-                    current_replicas[sub_type] = Service(
-                        name=component_name, service=component
-                    ).number_replicas()
 
-            logger.info(
-                f"Successfully scaled {request.graph_deployment_name}: {current_replicas}"
+            outcome = await self.orchestrator.submit(
+                participant_id,
+                request.target_replicas,
+                blocking=request.blocking,
+                deployment_name=request.graph_deployment_name,
+                caller_name=request.caller_namespace,
             )
             yield {
-                "status": ScaleStatus.SUCCESS.value,
-                "message": f"Scaled {request.graph_deployment_name} successfully",
-                "current_replicas": current_replicas,
+                "status": outcome.status.value,
+                "message": outcome.message,
+                "current_replicas": outcome.current_replicas,
             }
 
         except DynamoGraphDeploymentNotReadyError as e:

--- a/components/src/dynamo/global_planner/scale_handler.py
+++ b/components/src/dynamo/global_planner/scale_handler.py
@@ -18,7 +18,7 @@ Behavior is unchanged from the pre-refactor monolithic handler.
 
 import logging
 
-from dynamo.global_planner.capacity_manager import KubernetesCapacityManager
+from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
 from dynamo.global_planner.orchestrator import Orchestrator
 from dynamo.planner.connectors.protocol import ScaleRequest, ScaleResponse, ScaleStatus
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
@@ -72,10 +72,10 @@ class ScaleRequestHandler:
 
         # The wire vocabulary (K8s namespace / DGD name) is mapped here onto the
         # orchestrator's neutral vocabulary; the orchestrator is a no-K8s zone.
-        capacity_manager = KubernetesCapacityManager(cluster_name=k8s_namespace)
+        capacity_manager = KubernetesCapacityManager(namespace=k8s_namespace)
         self.orchestrator = Orchestrator(
             capacity_manager=capacity_manager,
-            managed_callers=managed_namespaces,
+            managed_deployments=managed_namespaces,
             max_total_gpus=max_total_gpus,
             min_total_gpus=min_total_gpus,
             intent_cache_ttl_seconds=intent_cache_ttl_seconds,
@@ -126,7 +126,7 @@ class ScaleRequestHandler:
 
     @property
     def managed_namespaces(self):
-        return self.orchestrator.managed_callers
+        return self.orchestrator.managed_deployments
 
     @dynamo_endpoint(ScaleRequest, ScaleResponse)
     async def scale_request(self, request: ScaleRequest):
@@ -179,7 +179,7 @@ class ScaleRequestHandler:
             self.orchestrator.register(
                 participant_id,
                 caller_name=request.caller_namespace,
-                cluster_name=request.k8s_namespace,
+                namespace=request.k8s_namespace,
                 deployment_name=request.graph_deployment_name,
             )
 

--- a/components/src/dynamo/global_planner/tests/unit/test_capacity_manager.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_capacity_manager.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for KubernetesCapacityManager — the K8s observe/actuate backend."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dynamo.global_planner.capacity_manager import (
+    KubernetesCapacityManager,
+    PoolSpec,
+)
+from dynamo.planner import SubComponentType, TargetReplica
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
+    return {
+        "spec": {
+            "services": {
+                "prefill": {
+                    "subComponentType": "prefill",
+                    "replicas": prefill_replicas,
+                    "resources": {"limits": {"gpu": prefill_gpu}},
+                },
+                "decode": {
+                    "subComponentType": "decode",
+                    "replicas": decode_replicas,
+                    "resources": {"limits": {"gpu": decode_gpu}},
+                },
+            }
+        }
+    }
+
+
+def _install_connector(cm, key, spec, parent_dgd_name="my-dgd"):
+    connector = MagicMock()
+    connector.parent_dgd_name = parent_dgd_name
+    connector.set_component_replicas = AsyncMock()
+    connector.kube_api = MagicMock()
+    connector.kube_api.get_graph_deployment = MagicMock(return_value=spec)
+    cm.connectors[key] = connector
+    return connector
+
+
+# ---------------------------------------------------------------------------- #
+# Deployment-name derivation (K8s operator convention)                         #
+# ---------------------------------------------------------------------------- #
+
+
+def test_managed_deployment_names_explicit():
+    cm = KubernetesCapacityManager("my-ns")
+    assert cm._managed_deployment_names({"my-ns-model-a", "my-ns-model-b"}) == {
+        "model-a",
+        "model-b",
+    }
+
+
+def test_managed_deployment_names_implicit():
+    cm = KubernetesCapacityManager("my-ns")
+    assert cm._managed_deployment_names(None) is None
+
+
+def test_managed_deployment_names_mismatched_prefix():
+    cm = KubernetesCapacityManager("my-ns")
+    # Only the caller matching the cluster prefix contributes a deployment name.
+    assert cm._managed_deployment_names({"other-ns-model-a", "my-ns-model-b"}) == {
+        "model-b"
+    }
+
+
+# ---------------------------------------------------------------------------- #
+# Discovery                                                                    #
+# ---------------------------------------------------------------------------- #
+
+
+def test_discover_explicit_mode():
+    cm = KubernetesCapacityManager("default")
+    with (
+        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        ) as mock_connector_cls,
+    ):
+        mock_kube = MagicMock()
+        mock_kube_cls.return_value = mock_kube
+        mock_kube.list_graph_deployments.return_value = [
+            {"metadata": {"name": "model-a"}},
+            {"metadata": {"name": "model-b"}},
+            {"metadata": {"name": "gp-ctrl"}},
+        ]
+        mock_connector_cls.return_value = MagicMock()
+
+        # Managed callers are namespaces; the deployment name is derived.
+        discovered = cm.discover({"default-model-a"})
+
+        assert discovered == ["model-a"]
+        assert "default/model-a" in cm.connectors
+        assert "default/model-b" not in cm.connectors
+        assert mock_connector_cls.call_count == 1
+
+
+def test_discover_implicit_mode():
+    cm = KubernetesCapacityManager("default")
+    with (
+        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        ) as mock_connector_cls,
+    ):
+        mock_kube = MagicMock()
+        mock_kube_cls.return_value = mock_kube
+        mock_kube.list_graph_deployments.return_value = [
+            {"metadata": {"name": "model-a"}},
+            {"metadata": {"name": "model-b"}},
+        ]
+        mock_connector_cls.return_value = MagicMock()
+
+        discovered = cm.discover(None)
+
+        assert set(discovered) == {"model-a", "model-b"}
+        assert "default/model-a" in cm.connectors
+        assert "default/model-b" in cm.connectors
+        assert mock_connector_cls.call_count == 2
+
+
+def test_discover_tolerates_api_failure():
+    cm = KubernetesCapacityManager("default")
+    with patch(
+        "dynamo.global_planner.capacity_manager.KubernetesAPI",
+        side_effect=RuntimeError("no cluster"),
+    ):
+        # Best-effort: must not raise, returns nothing discovered.
+        assert cm.discover(None) == []
+    assert cm.connectors == {}
+
+
+# ---------------------------------------------------------------------------- #
+# Registration / observe / actuate                                            #
+# ---------------------------------------------------------------------------- #
+
+
+def test_ensure_participant_idempotent():
+    cm = KubernetesCapacityManager("default")
+    with patch(
+        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+    ) as mock_connector_cls:
+        mock_connector_cls.return_value = MagicMock()
+        cm.ensure_participant(
+            "default/my-dgd",
+            caller_name="app-ns",
+            cluster_name="default",
+            deployment_name="my-dgd",
+        )
+        cm.ensure_participant(
+            "default/my-dgd",
+            caller_name="app-ns",
+            cluster_name="default",
+            deployment_name="my-dgd",
+        )
+        assert mock_connector_cls.call_count == 1
+        assert cm.knows("default/my-dgd")
+        assert not cm.knows("default/other")
+
+
+def test_observe_parses_pools():
+    cm = KubernetesCapacityManager("default")
+    _install_connector(
+        cm,
+        "default/my-dgd",
+        _dgd_spec(prefill_replicas=2, decode_replicas=3, decode_gpu=2),
+    )
+    snapshot = cm.observe()
+    pools = snapshot["default/my-dgd"]
+    assert pools["prefill"] == PoolSpec("prefill", 2, 1)
+    assert pools["decode"] == PoolSpec("decode", 3, 2)
+
+
+def test_observe_tolerates_read_failure():
+    cm = KubernetesCapacityManager("default")
+    good = _install_connector(
+        cm, "default/good", _dgd_spec(1, 1), parent_dgd_name="good"
+    )
+    bad = MagicMock()
+    bad.parent_dgd_name = "bad"
+    bad.kube_api = MagicMock()
+    bad.kube_api.get_graph_deployment = MagicMock(side_effect=RuntimeError("boom"))
+    cm.connectors["default/bad"] = bad
+
+    snapshot = cm.observe()
+    assert snapshot["default/good"]["prefill"] == PoolSpec("prefill", 1, 1)
+    assert snapshot["default/bad"] == {}  # tolerated, empty
+    assert good.kube_api.get_graph_deployment.called
+
+
+def test_current_replicas():
+    cm = KubernetesCapacityManager("default")
+    _install_connector(
+        cm, "default/my-dgd", _dgd_spec(prefill_replicas=2, decode_replicas=5)
+    )
+    assert cm.current_replicas("default/my-dgd") == {"prefill": 2, "decode": 5}
+
+
+@pytest.mark.asyncio
+async def test_actuate_calls_connector():
+    cm = KubernetesCapacityManager("default")
+    connector = _install_connector(cm, "default/my-dgd", _dgd_spec(1, 1))
+    targets = [
+        TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3)
+    ]
+    await cm.actuate("default/my-dgd", targets, blocking=True)
+    connector.set_component_replicas.assert_awaited_once_with(targets, blocking=True)

--- a/components/src/dynamo/global_planner/tests/unit/test_kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_kubernetes_capacity_manager.py
@@ -7,9 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dynamo.global_planner.capacity_manager import (
+from dynamo.global_planner.capacity_manager import PoolSpec
+from dynamo.global_planner.kubernetes_capacity_manager import (
     KubernetesCapacityManager,
-    PoolSpec,
 )
 from dynamo.planner import SubComponentType, TargetReplica
 
@@ -84,9 +84,11 @@ def test_managed_deployment_names_mismatched_prefix():
 def test_discover_explicit_mode():
     cm = KubernetesCapacityManager("default")
     with (
-        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI"
+        ) as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -110,9 +112,11 @@ def test_discover_explicit_mode():
 def test_discover_implicit_mode():
     cm = KubernetesCapacityManager("default")
     with (
-        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI"
+        ) as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -134,7 +138,7 @@ def test_discover_implicit_mode():
 def test_discover_tolerates_api_failure():
     cm = KubernetesCapacityManager("default")
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesAPI",
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI",
         side_effect=RuntimeError("no cluster"),
     ):
         # Best-effort: must not raise, returns nothing discovered.
@@ -150,24 +154,24 @@ def test_discover_tolerates_api_failure():
 def test_ensure_participant_idempotent():
     cm = KubernetesCapacityManager("default")
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector_cls.return_value = MagicMock()
         cm.ensure_participant(
             "default/my-dgd",
             caller_name="app-ns",
-            cluster_name="default",
+            namespace="default",
             deployment_name="my-dgd",
         )
         cm.ensure_participant(
             "default/my-dgd",
             caller_name="app-ns",
-            cluster_name="default",
+            namespace="default",
             deployment_name="my-dgd",
         )
         assert mock_connector_cls.call_count == 1
-        assert cm.knows("default/my-dgd")
-        assert not cm.knows("default/other")
+        assert cm.participant_exists("default/my-dgd")
+        assert not cm.participant_exists("default/other")
 
 
 def test_observe_parses_pools():
@@ -209,11 +213,11 @@ def test_current_replicas():
 
 
 @pytest.mark.asyncio
-async def test_actuate_calls_connector():
+async def test_scale_calls_connector():
     cm = KubernetesCapacityManager("default")
     connector = _install_connector(cm, "default/my-dgd", _dgd_spec(1, 1))
     targets = [
         TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3)
     ]
-    await cm.actuate("default/my-dgd", targets, blocking=True)
+    await cm.scale("default/my-dgd", targets, blocking=True)
     connector.set_component_replicas.assert_awaited_once_with(targets, blocking=True)

--- a/components/src/dynamo/global_planner/tests/unit/test_kubernetes_capacity_manager.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_kubernetes_capacity_manager.py
@@ -1,16 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for KubernetesCapacityManager — the K8s observe/actuate backend."""
+"""Unit tests for KubernetesCapacityManager — the K8s observe/scale backend.
+
+Pool state is read from the v1beta1 DGD component model (``spec.components[]``).
+"""
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from dynamo.global_planner.capacity_manager import PoolSpec
-from dynamo.global_planner.kubernetes_capacity_manager import (
-    KubernetesCapacityManager,
-)
+from dynamo.global_planner.kubernetes_capacity_manager import KubernetesCapacityManager
 from dynamo.planner import SubComponentType, TargetReplica
 
 pytestmark = [
@@ -21,23 +22,54 @@ pytestmark = [
 ]
 
 
-def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
+def _component(name, replicas, gpu=1, ctype=None, node_count=None):
+    component = {
+        "name": name,
+        "replicas": replicas,
+        "podTemplate": {
+            "spec": {
+                "containers": [
+                    {"name": "main", "resources": {"limits": {"nvidia.com/gpu": gpu}}}
+                ]
+            }
+        },
+    }
+    if ctype is not None:
+        component["type"] = ctype
+    if node_count is not None:
+        component["multinode"] = {"nodeCount": node_count}
+    return component
+
+
+def _dgd_spec(
+    prefill_replicas,
+    decode_replicas,
+    prefill_gpu=1,
+    decode_gpu=1,
+    prefill_node_count=None,
+):
+    """A v1beta1 DGD spec with typed prefill and decode components."""
     return {
         "spec": {
-            "services": {
-                "prefill": {
-                    "subComponentType": "prefill",
-                    "replicas": prefill_replicas,
-                    "resources": {"limits": {"gpu": prefill_gpu}},
-                },
-                "decode": {
-                    "subComponentType": "decode",
-                    "replicas": decode_replicas,
-                    "resources": {"limits": {"gpu": decode_gpu}},
-                },
-            }
+            "components": [
+                _component(
+                    "prefill-svc",
+                    prefill_replicas,
+                    gpu=prefill_gpu,
+                    ctype="prefill",
+                    node_count=prefill_node_count,
+                ),
+                _component(
+                    "decode-svc", decode_replicas, gpu=decode_gpu, ctype="decode"
+                ),
+            ]
         }
     }
+
+
+def _worker_dgd_spec(replicas, gpu=1, name="worker-svc", ctype="worker"):
+    """A v1beta1 DGD spec with a single generic worker component."""
+    return {"spec": {"components": [_component(name, replicas, gpu=gpu, ctype=ctype)]}}
 
 
 def _install_connector(cm, key, spec, parent_dgd_name="my-dgd"):
@@ -147,7 +179,7 @@ def test_discover_tolerates_api_failure():
 
 
 # ---------------------------------------------------------------------------- #
-# Registration / observe / actuate                                            #
+# Registration / scale                                                        #
 # ---------------------------------------------------------------------------- #
 
 
@@ -174,17 +206,82 @@ def test_ensure_participant_idempotent():
         assert not cm.participant_exists("default/other")
 
 
-def test_observe_parses_pools():
+@pytest.mark.asyncio
+async def test_scale_calls_connector():
+    cm = KubernetesCapacityManager("default")
+    connector = _install_connector(cm, "default/my-dgd", _dgd_spec(1, 1))
+    targets = [
+        TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3)
+    ]
+    await cm.scale("default/my-dgd", targets, blocking=True)
+    connector.set_component_replicas.assert_awaited_once_with(targets, blocking=True)
+
+
+# ---------------------------------------------------------------------------- #
+# Observe / current_replicas (v1beta1 component reading)                       #
+# ---------------------------------------------------------------------------- #
+
+
+def test_observe_parses_typed_components():
     cm = KubernetesCapacityManager("default")
     _install_connector(
         cm,
         "default/my-dgd",
         _dgd_spec(prefill_replicas=2, decode_replicas=3, decode_gpu=2),
     )
-    snapshot = cm.observe()
-    pools = snapshot["default/my-dgd"]
-    assert pools["prefill"] == PoolSpec("prefill", 2, 1)
-    assert pools["decode"] == PoolSpec("decode", 3, 2)
+    pools = cm.observe()["default/my-dgd"]
+    assert pools["prefill"] == PoolSpec(
+        sub_type="prefill",
+        current_replicas=2,
+        gpu_per_replica=1,
+        component_name="prefill-svc",
+    )
+    assert pools["decode"] == PoolSpec(
+        sub_type="decode",
+        current_replicas=3,
+        gpu_per_replica=2,
+        component_name="decode-svc",
+    )
+
+
+def test_observe_multinode_scales_gpu_count():
+    cm = KubernetesCapacityManager("default")
+    _install_connector(
+        cm, "default/my-dgd", _dgd_spec(1, 1, prefill_gpu=2, prefill_node_count=2)
+    )
+    # gpu_per_replica = main-container GPUs (2) × nodeCount (2) = 4.
+    assert cm.observe()["default/my-dgd"]["prefill"].gpu_per_replica == 4
+
+
+def test_observe_generic_worker_keyed_by_name_then_role_hint():
+    cm = KubernetesCapacityManager("default")
+    _install_connector(cm, "default/w", _worker_dgd_spec(replicas=2, gpu=2))
+
+    # No hint yet: the worker still counts, keyed by its component name.
+    pools = cm.observe()["default/w"]
+    assert "worker-svc" in pools and pools["worker-svc"].gpu_per_replica == 2
+
+    # After its Planner sends a role hint, the worker maps to that pool.
+    cm.remember_roles(
+        "default/w",
+        [
+            TargetReplica(
+                sub_component_type=SubComponentType.DECODE,
+                component_name="worker-svc",
+                desired_replicas=2,
+            )
+        ],
+    )
+    pools = cm.observe()["default/w"]
+    assert "worker-svc" not in pools
+    assert pools["decode"].component_name == "worker-svc"
+
+
+def test_observe_untyped_worker_with_gpu_counts_toward_budget():
+    cm = KubernetesCapacityManager("default")
+    _install_connector(cm, "default/w", _worker_dgd_spec(replicas=2, gpu=2, ctype=None))
+    pools = cm.observe()["default/w"]
+    assert pools["worker-svc"].gpu_per_replica == 2
 
 
 def test_observe_tolerates_read_failure():
@@ -199,9 +296,20 @@ def test_observe_tolerates_read_failure():
     cm.connectors["default/bad"] = bad
 
     snapshot = cm.observe()
-    assert snapshot["default/good"]["prefill"] == PoolSpec("prefill", 1, 1)
+    assert snapshot["default/good"]["prefill"].current_replicas == 1
     assert snapshot["default/bad"] == {}  # tolerated, empty
     assert good.kube_api.get_graph_deployment.called
+
+
+def test_observe_require_complete_raises_on_read_failure():
+    cm = KubernetesCapacityManager("default")
+    bad = MagicMock()
+    bad.parent_dgd_name = "bad"
+    bad.kube_api = MagicMock()
+    bad.kube_api.get_graph_deployment = MagicMock(side_effect=RuntimeError("boom"))
+    cm.connectors["default/bad"] = bad
+    with pytest.raises(RuntimeError):
+        cm.observe(require_complete=True)
 
 
 def test_current_replicas():
@@ -210,14 +318,3 @@ def test_current_replicas():
         cm, "default/my-dgd", _dgd_spec(prefill_replicas=2, decode_replicas=5)
     )
     assert cm.current_replicas("default/my-dgd") == {"prefill": 2, "decode": 5}
-
-
-@pytest.mark.asyncio
-async def test_scale_calls_connector():
-    cm = KubernetesCapacityManager("default")
-    connector = _install_connector(cm, "default/my-dgd", _dgd_spec(1, 1))
-    targets = [
-        TargetReplica(sub_component_type=SubComponentType.PREFILL, desired_replicas=3)
-    ]
-    await cm.scale("default/my-dgd", targets, blocking=True)
-    connector.set_component_replicas.assert_awaited_once_with(targets, blocking=True)

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -190,7 +190,7 @@ class FakeCapacityManager(CapacityManager):
     def participant_exists(self, participant_id):
         return participant_id in self.pools
 
-    def observe(self):
+    def observe(self, require_complete=False):
         return {
             key: {st: PoolSpec(st, r, g) for st, (r, g) in pools.items()}
             for key, pools in self.pools.items()

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -1,0 +1,266 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Orchestrator — GPU-budget arbitration + observe/decide/actuate.
+
+The decision tests exercise ``mediate`` directly (pure, no capacity manager
+needed). The observe/decide/actuate tests drive ``submit`` over an in-memory
+``FakeCapacityManager`` (subclassing the neutral ``CapacityManager`` base) — no
+Kubernetes, no runtime — which previews how offline replay plugs a non-K8s
+backend into the same orchestrator, including the ``use_lock`` toggle.
+"""
+
+import pytest
+
+from dynamo.global_planner.capacity_manager import CapacityManager, PoolSpec
+from dynamo.global_planner.orchestrator import Orchestrator
+from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner.connectors.protocol import ScaleStatus
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _targets(prefill=None, decode=None):
+    out = []
+    if prefill is not None:
+        out.append(
+            TargetReplica(
+                sub_component_type=SubComponentType.PREFILL, desired_replicas=prefill
+            )
+        )
+    if decode is not None:
+        out.append(
+            TargetReplica(
+                sub_component_type=SubComponentType.DECODE, desired_replicas=decode
+            )
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------- #
+# Decision layer (mediate) — pure, no capacity manager needed                  #
+# ---------------------------------------------------------------------------- #
+
+
+def _pools(**participants):
+    """Build a snapshot: participant_id -> {sub_type: PoolSpec}.
+
+    Each participant is ``key=(prefill, decode, gpu)`` where prefill/decode are
+    current replica counts (None to omit the pool) and gpu is per-replica GPUs.
+    ``__`` in the key becomes ``/``.
+    """
+    snapshot = {}
+    for key, (prefill, decode, gpu) in participants.items():
+        key = key.replace("__", "/")
+        pools = {}
+        if prefill is not None:
+            pools["prefill"] = PoolSpec("prefill", prefill, gpu)
+        if decode is not None:
+            pools["decode"] = PoolSpec("decode", decode, gpu)
+        snapshot[key] = pools
+    return snapshot
+
+
+def _decider(**kwargs):
+    kwargs.setdefault("use_lock", False)
+    return Orchestrator(capacity_manager=None, managed_callers=None, **kwargs)
+
+
+def _mediate(orch, key, targets, pools):
+    return orch.mediate(
+        key, targets, pools, log_deployment_name=key, log_caller_name=key
+    )
+
+
+def test_no_budget_approves_standalone():
+    orch = _decider(max_total_gpus=-1, min_total_gpus=-1)
+    pools = _pools(ns__a=(1, 1, 1))
+    res = _mediate(orch, "ns/a", _targets(prefill=5), pools)
+    assert res.approved
+    assert res.selected_partners == []
+    assert res.reject_message is None
+
+
+def test_ceiling_allows_within_cap():
+    orch = _decider(max_total_gpus=4)
+    pools = _pools(ns__a=(1, 1, 1))  # total 2
+    res = _mediate(orch, "ns/a", _targets(prefill=3), pools)  # -> total 4
+    assert res.approved and res.selected_partners == []
+
+
+def test_ceiling_rejects_breach():
+    orch = _decider(max_total_gpus=2)
+    pools = _pools(ns__a=(1, 1, 1))
+    res = _mediate(orch, "ns/a", _targets(prefill=3), pools)  # -> total 4 > 2
+    assert not res.approved
+    assert "budget breach" in (res.reject_message or "").lower()
+    assert "ceiling" in (res.reject_message or "").lower()
+
+
+def test_floor_rejects_unpaired_scale_down():
+    orch = _decider(max_total_gpus=6, min_total_gpus=6)
+    pools = _pools(ns__a=(3, 3, 1))  # total 6
+    res = _mediate(orch, "ns/a", _targets(prefill=2), pools)  # -> 5 < floor, no pair
+    assert not res.approved
+    assert "budget breach" in (res.reject_message or "").lower()
+
+
+def test_floor_pairs_scale_down_across_participants():
+    orch = _decider(max_total_gpus=4, min_total_gpus=4)
+    pools = _pools(nsA__a=(None, 2, 1), nsB__b=(None, 2, 1))  # fixed total 4
+
+    # A wants down to 1 (total 3 < floor): rejected standalone, intent cached.
+    res_a = _mediate(orch, "nsA/a", _targets(decode=1), pools)
+    assert not res_a.approved
+
+    # B wants up to 3: pairs with A's pending scale-down. Combined 1+3 = 4.
+    res_b = _mediate(orch, "nsB/b", _targets(decode=3), pools)
+    assert res_b.approved
+    assert len(res_b.selected_partners) == 1
+    p_id, p_sub, p_desired, _ = res_b.selected_partners[0]
+    assert (p_id, p_sub, p_desired) == ("nsA/a", "decode", 1)
+
+
+def test_intent_cache_ttl_expiry_blocks_pairing():
+    clock = {"t": 1000.0}
+    orch = _decider(
+        max_total_gpus=4,
+        min_total_gpus=4,
+        intent_cache_ttl_seconds=360.0,
+        now=lambda: clock["t"],
+    )
+    pools = _pools(nsA__a=(None, 2, 1), nsB__b=(None, 2, 1))
+
+    _mediate(orch, "nsA/a", _targets(decode=1), pools)  # seed A's intent at t=1000
+
+    clock["t"] = 1000.0 + 361.0  # A's intent now stale
+    res_b = _mediate(orch, "nsB/b", _targets(decode=3), pools)
+    assert not res_b.approved
+    assert res_b.selected_partners == []
+
+
+def test_total_gpus():
+    orch = _decider()
+    pools = _pools(ns__a=(2, 3, 2))  # (2+3) replicas * 2 GPU = 10
+    assert orch.total_gpus(pools) == 10
+    assert orch.total_gpus(pools, {("ns/a", "prefill"): 0}) == 6
+
+
+def test_update_intent_cache_skips_unknown_pool():
+    orch = _decider(max_total_gpus=4)
+    pools = _pools(ns__a=(1, None, 1))  # decode pool absent
+    orch.update_intent_cache("ns/a", _targets(decode=2), pools["ns/a"])
+    assert "ns/a/decode" not in orch._intent_cache
+
+
+# ---------------------------------------------------------------------------- #
+# observe -> decide -> actuate (submit) over an in-memory capacity manager     #
+# ---------------------------------------------------------------------------- #
+
+
+class FakeCapacityManager(CapacityManager):
+    """In-memory backend: pool state is a mutable dict, actuation mutates it."""
+
+    def __init__(self):
+        # participant_id -> {sub_type: [current_replicas, gpu_per_replica]}
+        self.pools: dict[str, dict[str, list]] = {}
+
+    def add(self, key, prefill=None, decode=None, gpu=1):
+        entry = {}
+        if prefill is not None:
+            entry["prefill"] = [prefill, gpu]
+        if decode is not None:
+            entry["decode"] = [decode, gpu]
+        self.pools[key] = entry
+
+    def ensure_participant(
+        self, participant_id, *, caller_name, cluster_name, deployment_name
+    ):
+        self.pools.setdefault(participant_id, {})
+
+    def knows(self, participant_id):
+        return participant_id in self.pools
+
+    def observe(self):
+        return {
+            key: {st: PoolSpec(st, r, g) for st, (r, g) in pools.items()}
+            for key, pools in self.pools.items()
+        }
+
+    async def actuate(self, participant_id, targets, *, blocking):
+        for t in targets:
+            st = t.sub_component_type.value
+            if st in self.pools[participant_id]:
+                self.pools[participant_id][st][0] = t.desired_replicas
+
+    def current_replicas(self, participant_id):
+        return {st: r for st, (r, _g) in self.pools[participant_id].items()}
+
+
+def _orch(capacity_manager, *, max_gpus=-1, min_gpus=-1, managed=None, use_lock=True):
+    return Orchestrator(
+        capacity_manager=capacity_manager,
+        managed_callers=managed,
+        max_total_gpus=max_gpus,
+        min_total_gpus=min_gpus,
+        use_lock=use_lock,
+    )
+
+
+async def _submit(orch, key, targets):
+    return await orch.submit(
+        key, targets, blocking=False, deployment_name=key, caller_name=key
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_lock", [True, False])
+async def test_submit_approves_and_actuates(use_lock):
+    cm = FakeCapacityManager()
+    cm.add("default/a", prefill=1, decode=1)
+    orch = _orch(cm, use_lock=use_lock)
+
+    out = await _submit(orch, "default/a", _targets(prefill=3))
+
+    assert out.status == ScaleStatus.SUCCESS
+    assert cm.pools["default/a"]["prefill"][0] == 3  # actuated
+    assert out.current_replicas == {"prefill": 3, "decode": 1}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_lock", [True, False])
+async def test_submit_ceiling_rejects_without_mutating(use_lock):
+    cm = FakeCapacityManager()
+    cm.add("default/a", prefill=1, decode=1, gpu=1)  # total 2 GPUs
+    orch = _orch(cm, max_gpus=2, use_lock=use_lock)
+
+    out = await _submit(orch, "default/a", _targets(prefill=3))  # would be total 4
+
+    assert out.status == ScaleStatus.REJECTED
+    assert "budget breach" in out.message.lower()
+    assert cm.pools["default/a"]["prefill"][0] == 1  # NOT actuated
+
+
+@pytest.mark.asyncio
+async def test_submit_scale_down_always_allowed_under_ceiling():
+    cm = FakeCapacityManager()
+    cm.add("default/a", prefill=3, decode=3, gpu=1)
+    orch = _orch(cm, max_gpus=6)
+
+    out = await _submit(orch, "default/a", _targets(prefill=1))
+    assert out.status == ScaleStatus.SUCCESS
+    assert cm.pools["default/a"]["prefill"][0] == 1
+
+
+def test_is_authorized_explicit_and_implicit():
+    explicit = _orch(FakeCapacityManager(), managed=["default-a"])
+    assert explicit.is_authorized("default-a")
+    assert not explicit.is_authorized("default-b")
+
+    implicit = _orch(FakeCapacityManager(), managed=None)
+    assert implicit.is_authorized("anything")

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -68,7 +68,7 @@ def _pools(**participants):
 
 def _decider(**kwargs):
     kwargs.setdefault("use_lock", False)
-    return Orchestrator(capacity_manager=None, managed_callers=None, **kwargs)
+    return Orchestrator(capacity_manager=None, managed_deployments=None, **kwargs)
 
 
 def _mediate(orch, key, targets, pools):
@@ -179,11 +179,11 @@ class FakeCapacityManager(CapacityManager):
         self.pools[key] = entry
 
     def ensure_participant(
-        self, participant_id, *, caller_name, cluster_name, deployment_name
+        self, participant_id, *, caller_name, namespace, deployment_name
     ):
         self.pools.setdefault(participant_id, {})
 
-    def knows(self, participant_id):
+    def participant_exists(self, participant_id):
         return participant_id in self.pools
 
     def observe(self):
@@ -192,7 +192,7 @@ class FakeCapacityManager(CapacityManager):
             for key, pools in self.pools.items()
         }
 
-    async def actuate(self, participant_id, targets, *, blocking):
+    async def scale(self, participant_id, targets, *, blocking):
         for t in targets:
             st = t.sub_component_type.value
             if st in self.pools[participant_id]:
@@ -205,7 +205,7 @@ class FakeCapacityManager(CapacityManager):
 def _orch(capacity_manager, *, max_gpus=-1, min_gpus=-1, managed=None, use_lock=True):
     return Orchestrator(
         capacity_manager=capacity_manager,
-        managed_callers=managed,
+        managed_deployments=managed,
         max_total_gpus=max_gpus,
         min_total_gpus=min_gpus,
         use_lock=use_lock,

--- a/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_orchestrator.py
@@ -122,8 +122,12 @@ def test_floor_pairs_scale_down_across_participants():
     res_b = _mediate(orch, "nsB/b", _targets(decode=3), pools)
     assert res_b.approved
     assert len(res_b.selected_partners) == 1
-    p_id, p_sub, p_desired, _ = res_b.selected_partners[0]
-    assert (p_id, p_sub, p_desired) == ("nsA/a", "decode", 1)
+    partner = res_b.selected_partners[0]
+    assert (partner.participant_id, partner.sub_type, partner.applied_desired) == (
+        "nsA/a",
+        "decode",
+        1,
+    )
 
 
 def test_intent_cache_ttl_expiry_blocks_pairing():
@@ -179,7 +183,7 @@ class FakeCapacityManager(CapacityManager):
         self.pools[key] = entry
 
     def ensure_participant(
-        self, participant_id, *, caller_name, namespace, deployment_name
+        self, participant_id, caller_name, namespace, deployment_name
     ):
         self.pools.setdefault(participant_id, {})
 
@@ -192,7 +196,7 @@ class FakeCapacityManager(CapacityManager):
             for key, pools in self.pools.items()
         }
 
-    async def scale(self, participant_id, targets, *, blocking):
+    async def scale(self, participant_id, targets, blocking):
         for t in targets:
             st = t.sub_component_type.value
             if st in self.pools[participant_id]:

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -8,8 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from dynamo.global_planner.scale_handler import PoolIntent, ScaleRequestHandler
-from dynamo.planner import KubernetesConnector, SubComponentType, TargetReplica
+from dynamo.global_planner.orchestrator import PoolIntent
+from dynamo.global_planner.scale_handler import ScaleRequestHandler
+from dynamo.planner import SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleRequest
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 
@@ -48,7 +49,7 @@ async def test_handler_authorization_success(mock_runtime):
 
     # Mock KubernetesConnector
     with patch(
-        "dynamo.global_planner.scale_handler.KubernetesConnector"
+        "dynamo.global_planner.capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -56,7 +57,14 @@ async def test_handler_authorization_success(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value=_dgd_spec(prefill_replicas=3, decode_replicas=5)
+            return_value={
+                "spec": {
+                    "services": {
+                        "prefill-svc": {"subComponentType": "prefill", "replicas": 3},
+                        "decode-svc": {"subComponentType": "decode", "replicas": 5},
+                    }
+                }
+            }
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -134,7 +142,7 @@ async def test_handler_multiple_dgds(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.scale_handler.KubernetesConnector"
+        "dynamo.global_planner.capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -142,7 +150,7 @@ async def test_handler_multiple_dgds(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"components": []}}
+            return_value={"spec": {"services": {}}}
         )
 
         # Process both requests
@@ -152,8 +160,8 @@ async def test_handler_multiple_dgds(mock_runtime):
             pass
 
         # Verify two connectors were created
-        assert "default/dgd-1" in handler.connectors
-        assert "default/dgd-2" in handler.connectors
+        assert "default/dgd-1" in handler.orchestrator.capacity_manager.connectors
+        assert "default/dgd-2" in handler.orchestrator.capacity_manager.connectors
         assert mock_connector_cls.call_count == 2
 
 
@@ -176,7 +184,7 @@ async def test_handler_error_handling(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.scale_handler.KubernetesConnector"
+        "dynamo.global_planner.capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -197,39 +205,6 @@ async def test_handler_error_handling(mock_runtime):
         assert "Scaling failed" in response["message"]
 
 
-def test_managed_dgd_names_explicit(mock_runtime):
-    """Test _managed_dgd_names derives DGD names from Dynamo namespaces."""
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["my-ns-model-a", "my-ns-model-b"],
-        k8s_namespace="my-ns",
-    )
-    names = handler._managed_dgd_names()
-    assert names == {"model-a", "model-b"}
-
-
-def test_managed_dgd_names_implicit(mock_runtime):
-    """Test _managed_dgd_names returns None when no managed namespaces set."""
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=None,
-        k8s_namespace="my-ns",
-    )
-    assert handler._managed_dgd_names() is None
-
-
-def test_managed_dgd_names_mismatched_prefix(mock_runtime):
-    """Test _managed_dgd_names warns for namespaces that don't match the k8s prefix."""
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["other-ns-model-a", "my-ns-model-b"],
-        k8s_namespace="my-ns",
-    )
-    names = handler._managed_dgd_names()
-    # Only the matching namespace is included
-    assert names == {"model-b"}
-
-
 @pytest.mark.asyncio
 async def test_populate_connectors_explicit_mode(mock_runtime):
     """Test _populate_k8s_connectors only creates connectors for managed DGDs."""
@@ -241,9 +216,9 @@ async def test_populate_connectors_explicit_mode(mock_runtime):
     )
 
     with (
-        patch("dynamo.global_planner.scale_handler.KubernetesAPI") as mock_kube_cls,
+        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.scale_handler.KubernetesConnector"
+            "dynamo.global_planner.capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -255,12 +230,14 @@ async def test_populate_connectors_explicit_mode(mock_runtime):
         ]
         mock_connector_cls.return_value = MagicMock()
 
-        handler._populate_k8s_connectors()
+        handler.orchestrator.capacity_manager.discover(
+            handler.orchestrator.managed_callers
+        )
 
         # Only model-a should be discovered
-        assert "default/model-a" in handler.connectors
-        assert "default/model-b" not in handler.connectors
-        assert "default/gp-ctrl" not in handler.connectors
+        assert "default/model-a" in handler.orchestrator.capacity_manager.connectors
+        assert "default/model-b" not in handler.orchestrator.capacity_manager.connectors
+        assert "default/gp-ctrl" not in handler.orchestrator.capacity_manager.connectors
         assert mock_connector_cls.call_count == 1
 
 
@@ -275,9 +252,9 @@ async def test_populate_connectors_implicit_mode(mock_runtime):
     )
 
     with (
-        patch("dynamo.global_planner.scale_handler.KubernetesAPI") as mock_kube_cls,
+        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.scale_handler.KubernetesConnector"
+            "dynamo.global_planner.capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -288,11 +265,13 @@ async def test_populate_connectors_implicit_mode(mock_runtime):
         ]
         mock_connector_cls.return_value = MagicMock()
 
-        handler._populate_k8s_connectors()
+        handler.orchestrator.capacity_manager.discover(
+            handler.orchestrator.managed_callers
+        )
 
         # All DGDs should be discovered
-        assert "default/model-a" in handler.connectors
-        assert "default/model-b" in handler.connectors
+        assert "default/model-a" in handler.orchestrator.capacity_manager.connectors
+        assert "default/model-b" in handler.orchestrator.capacity_manager.connectors
         assert mock_connector_cls.call_count == 2
 
 
@@ -316,7 +295,7 @@ async def test_handler_blocking_mode(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.scale_handler.KubernetesConnector"
+        "dynamo.global_planner.capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -324,7 +303,7 @@ async def test_handler_blocking_mode(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"components": []}}
+            return_value={"spec": {"services": {}}}
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -342,95 +321,24 @@ async def test_handler_blocking_mode(mock_runtime):
 # ---------------------------------------------------------------------------- #
 
 
-def _dgd_spec(
-    prefill_replicas,
-    decode_replicas,
-    prefill_gpu=1,
-    decode_gpu=1,
-    prefill_node_count=None,
-    decode_node_count=None,
-):
-    """Build a v1beta1 DGD spec with prefill and decode components."""
-    deployment = {
+def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
+    """Build a DGD deployment spec with prefill + decode services."""
+    return {
         "spec": {
-            "components": [
-                {
-                    "name": "prefill-svc",
-                    "type": "prefill",
+            "services": {
+                "prefill-svc": {
+                    "subComponentType": "prefill",
                     "replicas": prefill_replicas,
-                    "podTemplate": {
-                        "spec": {
-                            "containers": [
-                                {
-                                    "name": "main",
-                                    "resources": {
-                                        "limits": {"nvidia.com/gpu": prefill_gpu}
-                                    },
-                                }
-                            ]
-                        }
-                    },
+                    "resources": {"limits": {"gpu": prefill_gpu}},
                 },
-                {
-                    "name": "decode-svc",
-                    "type": "decode",
+                "decode-svc": {
+                    "subComponentType": "decode",
                     "replicas": decode_replicas,
-                    "podTemplate": {
-                        "spec": {
-                            "containers": [
-                                {
-                                    "name": "main",
-                                    "resources": {
-                                        "limits": {"nvidia.com/gpu": decode_gpu}
-                                    },
-                                }
-                            ]
-                        }
-                    },
+                    "resources": {"limits": {"gpu": decode_gpu}},
                 },
-            ]
+            }
         }
     }
-    components = deployment["spec"]["components"]
-    if prefill_node_count is not None:
-        components[0]["multinode"] = {"nodeCount": prefill_node_count}
-    if decode_node_count is not None:
-        components[1]["multinode"] = {"nodeCount": decode_node_count}
-    return deployment
-
-
-def _worker_dgd_spec(
-    replicas, gpu=1, component_name="worker-svc", component_type="worker"
-):
-    """Build a v1beta1 DGD spec with one generic worker component."""
-    component = {
-        "name": component_name,
-        "replicas": replicas,
-        "podTemplate": {
-            "spec": {
-                "containers": [
-                    {
-                        "name": "main",
-                        "resources": {"limits": {"nvidia.com/gpu": gpu}},
-                    }
-                ]
-            }
-        },
-    }
-    if component_type is not None:
-        component["type"] = component_type
-    return {"spec": {"components": [component]}}
-
-
-def _two_worker_dgd_spec(replicas=1, gpu=1):
-    """Build a DGD with two generic workers that can resolve to one role."""
-    deployment = _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-a")
-    deployment["spec"]["components"].extend(
-        _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-b")["spec"][
-            "components"
-        ]
-    )
-    return deployment
 
 
 def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
@@ -441,21 +349,7 @@ def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"
     connector.parent_dgd_name = parent_dgd_name
     connector.kube_api = MagicMock()
     connector.kube_api.get_graph_deployment = MagicMock(return_value=dgd_spec_dict)
-    handler.connectors[dgd_key] = connector
-    return connector
-
-
-def _install_real_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
-    """Attach a real KubernetesConnector backed by a mocked Kubernetes API."""
-    connector = KubernetesConnector.__new__(KubernetesConnector)
-    connector.parent_dgd_name = parent_dgd_name
-    connector.graph_deployment_name = parent_dgd_name
-    connector.raise_not_ready = True
-    connector.kube_api = MagicMock()
-    connector.kube_api.get_graph_deployment.return_value = dgd_spec_dict
-    connector.kube_api.is_deployment_ready.return_value = True
-    connector.kube_api.wait_for_graph_deployment_ready = AsyncMock()
-    handler.connectors[dgd_key] = connector
+    handler.orchestrator.capacity_manager.connectors[dgd_key] = connector
     return connector
 
 
@@ -465,8 +359,6 @@ def _scale_req(
     caller_ns="app-ns",
     prefill=None,
     decode=None,
-    prefill_component_name=None,
-    decode_component_name=None,
 ):
     """Build a ScaleRequest with one or both pool targets set."""
     targets = []
@@ -474,7 +366,6 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.PREFILL,
-                component_name=prefill_component_name,
                 desired_replicas=prefill,
             )
         )
@@ -482,7 +373,6 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.DECODE,
-                component_name=decode_component_name,
                 desired_replicas=decode,
             )
         )
@@ -505,248 +395,6 @@ async def _run(handler, request):
 # ---------------------------------------------------------------------------- #
 # min_total_gpus / arbitration tests                                           #
 # ---------------------------------------------------------------------------- #
-
-
-@pytest.mark.asyncio
-async def test_generic_worker_role_used_for_budget_and_readback(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 4
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _worker_dgd_spec(replicas=1, gpu=2),
-    )
-
-    req = _scale_req(
-        caller_ns="default-my-dgd",
-        decode=2,
-        decode_component_name="worker-svc",
-    )
-    results = await _run(handler, req)
-
-    assert results[0]["status"] == "success"
-    assert results[0]["current_replicas"] == {"decode": 1}
-    connector.set_component_replicas.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_generic_worker_scale_rejected_above_budget(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 2
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _worker_dgd_spec(replicas=1, gpu=2),
-    )
-
-    req = _scale_req(
-        caller_ns="default-my-dgd",
-        decode=2,
-        decode_component_name="worker-svc",
-    )
-    results = await _run(handler, req)
-
-    assert results[0]["status"] == "rejected"
-    connector.set_component_replicas.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_generic_worker_partner_keeps_component_name(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-dgd-a", "default-dgd-b"],
-        k8s_namespace="default",
-    )
-    handler.min_total_gpus = 9
-    handler.max_total_gpus = 9
-    connector_a = _install_connector(
-        handler,
-        "default/dgd-a",
-        _dgd_spec(prefill_replicas=3, decode_replicas=3),
-        parent_dgd_name="dgd-a",
-    )
-    connector_b = _install_real_connector(
-        handler,
-        "default/dgd-b",
-        _worker_dgd_spec(replicas=3),
-        parent_dgd_name="dgd-b",
-    )
-    handler._component_roles["default/dgd-b"] = {"worker-svc": "decode"}
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
-        last_desired=4, last_seen_at=time.time()
-    )
-
-    results = await _run(
-        handler,
-        _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2),
-    )
-
-    assert results[0]["status"] == "success"
-    connector_a.set_component_replicas.assert_called_once()
-    connector_b.kube_api.update_graph_replicas.assert_called_once_with(
-        "dgd-b", "worker-svc", 4
-    )
-
-
-@pytest.mark.asyncio
-async def test_duplicate_resolved_pool_rejected_in_budget_snapshot(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 4
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _two_worker_dgd_spec(),
-    )
-    handler._component_roles["default/my-dgd"] = {
-        "worker-a": "decode",
-        "worker-b": "decode",
-    }
-
-    results = await _run(
-        handler,
-        _scale_req(
-            caller_ns="default-my-dgd",
-            decode=2,
-            decode_component_name="worker-a",
-        ),
-    )
-
-    assert results[0]["status"] == "error"
-    assert "'worker-a' and 'worker-b'" in results[0]["message"]
-    assert "planner pool 'decode'" in results[0]["message"]
-    connector.set_component_replicas.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_duplicate_resolved_pool_rejected_during_readback(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _worker_dgd_spec(replicas=1, component_name="worker-a"),
-    )
-    connector.kube_api.get_graph_deployment.side_effect = [
-        _worker_dgd_spec(replicas=1, component_name="worker-a"),
-        _two_worker_dgd_spec(),
-    ]
-    handler._component_roles["default/my-dgd"] = {
-        "worker-a": "decode",
-        "worker-b": "decode",
-    }
-
-    results = await _run(
-        handler,
-        _scale_req(
-            caller_ns="default-my-dgd",
-            decode=2,
-            decode_component_name="worker-a",
-        ),
-    )
-
-    assert results[0]["status"] == "error"
-    assert "'worker-a' and 'worker-b'" in results[0]["message"]
-    assert "planner pool 'decode'" in results[0]["message"]
-    connector.set_component_replicas.assert_called_once()
-
-
-@pytest.mark.asyncio
-async def test_multinode_gpu_count_enforces_budget(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 12
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _dgd_spec(
-            prefill_replicas=1,
-            decode_replicas=0,
-            prefill_gpu=4,
-            prefill_node_count=2,
-        ),
-    )
-
-    results = await _run(
-        handler,
-        _scale_req(caller_ns="default-my-dgd", prefill=2),
-    )
-
-    assert results[0]["status"] == "rejected"
-    connector.set_component_replicas.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_untyped_worker_in_other_dgd_counts_toward_budget(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-dgd-a", "default-dgd-b"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 6
-    connector_a = _install_connector(
-        handler,
-        "default/dgd-a",
-        _dgd_spec(prefill_replicas=1, decode_replicas=1),
-        parent_dgd_name="dgd-a",
-    )
-    connector_b = _install_connector(
-        handler,
-        "default/dgd-b",
-        _worker_dgd_spec(replicas=2, gpu=2, component_type=None),
-        parent_dgd_name="dgd-b",
-    )
-
-    results = await _run(
-        handler,
-        _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2),
-    )
-
-    assert results[0]["status"] == "rejected"
-    connector_a.set_component_replicas.assert_not_called()
-    connector_b.set_component_replicas.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_budget_request_fails_when_dgd_snapshot_is_incomplete(mock_runtime):
-    handler = ScaleRequestHandler(
-        runtime=mock_runtime,
-        managed_namespaces=["default-my-dgd"],
-        k8s_namespace="default",
-    )
-    handler.max_total_gpus = 6
-    connector = _install_connector(
-        handler,
-        "default/my-dgd",
-        _dgd_spec(prefill_replicas=1, decode_replicas=1),
-    )
-    connector.kube_api.get_graph_deployment.side_effect = RuntimeError("API timeout")
-
-    results = await _run(
-        handler,
-        _scale_req(caller_ns="default-my-dgd", prefill=2),
-    )
-
-    assert results[0]["status"] == "error"
-    assert "Failed to read DGD" in results[0]["message"]
-    connector.set_component_replicas.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -807,7 +455,7 @@ async def test_scale_down_paired_with_pending_scale_up_in_same_dgd(mock_runtime)
     )
 
     # Pre-seed cache: decode wants to go to 4 (scale up by 1)
-    handler._intent_cache["default/my-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
 
@@ -848,7 +496,7 @@ async def test_scale_down_paired_across_different_dgd(mock_runtime):
     )
 
     # Decode in DGD-B wants to scale up — should pair across DGDs with DGD-A's scale-down
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
 
@@ -903,10 +551,10 @@ async def test_pair_packs_both_partners_when_both_fit(mock_runtime):
     # Both DGD-A's decode and DGD-B's decode have pending scale-up intents
     # (each +1 GPU). Cluster baseline = 12; standalone request lands at 11
     # (at floor). Pack both partners → 11+1+1 = 13 (at ceiling, strict).
-    handler._intent_cache["default/dgd-a/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-a/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     req = _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2)
@@ -955,7 +603,7 @@ async def test_cross_dgd_pair_second_patch_failure_self_corrects(mock_runtime, c
         parent_dgd_name="dgd-b",
     )
     # DGD-B's decode is a pending partner
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     # DGD-B's K8s patch fails
@@ -1005,7 +653,7 @@ async def test_cross_dgd_pair_second_patch_not_ready_self_corrects(
         _dgd_spec(prefill_replicas=3, decode_replicas=3),
         parent_dgd_name="dgd-b",
     )
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     connector_b.set_component_replicas.side_effect = DynamoGraphDeploymentNotReadyError(
@@ -1051,7 +699,7 @@ async def test_cross_dgd_pair_first_patch_failure_yields_error(mock_runtime):
         _dgd_spec(prefill_replicas=3, decode_replicas=3),
         parent_dgd_name="dgd-b",
     )
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     # Request is DGD-A prefill 3 → 2 (net_delta < 0), so the scale-down
@@ -1084,7 +732,7 @@ async def test_cross_dgd_asymmetric_pair_rejected_above_ceiling(mock_runtime):
         max_total_gpus=10,
     )
     # DGD-A: prefill=4 (1 GPU each) + decode=0 → 4 GPUs.
-    # DGD-B: one agg pool reusing the "decode" component type with 2 GPU/worker,
+    # DGD-B: one agg pool reusing "decode" subComponentType with 2 GPU/worker,
     #   3 workers → 6 GPUs. Total cluster=10.
     _install_connector(
         handler,
@@ -1101,14 +749,18 @@ async def test_cross_dgd_asymmetric_pair_rejected_above_ceiling(mock_runtime):
     # DGD-B decode wants +1 (+2 GPUs); DGD-A prefill request wants -1 (-1 GPU).
     # Paired total = 10 - 1 + 2 = 11 > max=10. Decode's 2 GPU/worker step can't
     # be partially applied to land at exactly 10, so the pair is denied.
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     req = _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=3)
     results = await _run(handler, req)
     assert results[0]["status"] == "rejected"
-    handler.connectors["default/dgd-a"].set_component_replicas.assert_not_called()
-    handler.connectors["default/dgd-b"].set_component_replicas.assert_not_called()
+    handler.orchestrator.capacity_manager.connectors[
+        "default/dgd-a"
+    ].set_component_replicas.assert_not_called()
+    handler.orchestrator.capacity_manager.connectors[
+        "default/dgd-b"
+    ].set_component_replicas.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1126,7 +778,7 @@ async def test_intent_cache_respects_ttl(mock_runtime):
         handler, "default/my-dgd", _dgd_spec(prefill_replicas=3, decode_replicas=3)
     )
     # Cache a decode scale-up intent that is too old
-    handler._intent_cache["default/my-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time() - 60
     )
 
@@ -1152,7 +804,7 @@ async def test_scale_up_paired_with_pending_scale_down_when_ceiling_breached(
         handler, "default/my-dgd", _dgd_spec(prefill_replicas=3, decode_replicas=3)
     )
     # Prefill wants to drop by 1; cache it
-    handler._intent_cache["default/my-dgd/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/prefill"] = PoolIntent(
         last_desired=2, last_seen_at=time.time()
     )
 
@@ -1189,7 +841,7 @@ async def test_asymmetric_per_worker_gpu_pair_rejected_above_ceiling(mock_runtim
     # Paired total = 10 + 2 - 1 = 11 > max=10. No partial works (decode step
     # is 2 GPUs — partial-K can only be 3=current or 4=full, neither lands at
     # 10 with the -1 prefill applied).
-    handler._intent_cache["default/my-dgd/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/prefill"] = PoolIntent(
         last_desired=3, last_seen_at=time.time()
     )
     req = _scale_req(caller_ns="default-my-dgd", decode=4)
@@ -1217,7 +869,7 @@ async def test_asymmetric_pair_denied_if_above_ceiling(mock_runtime):
     )
     # Decode wants +2 (=+4 GPUs), prefill cached intent -1 (=-1 GPU).
     # Paired total = 10 + 4 - 1 = 13 > max=10. Deny.
-    handler._intent_cache["default/my-dgd/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/prefill"] = PoolIntent(
         last_desired=3, last_seen_at=time.time()
     )
     req = _scale_req(caller_ns="default-my-dgd", decode=5)
@@ -1246,7 +898,7 @@ async def test_asymmetric_pair_denied_if_below_tolerance(mock_runtime):
     )
     # Decode wants +1 (+1 GPU); request prefill wants -3 (-3 GPUs). Paired
     # total = 10 - 3 + 1 = 8. min - tolerance = 10 - 1 = 9. 8 < 9 → deny.
-    handler._intent_cache["default/my-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/decode"] = PoolIntent(
         last_desired=6, last_seen_at=time.time()
     )
     req = _scale_req(caller_ns="default-my-dgd", prefill=2)
@@ -1263,9 +915,9 @@ async def test_initial_below_floor_logs_warning(mock_runtime):
     semantics — and the floor only blocks explicit scale-downs going forward
     (covered by the standalone-deny tests above)."""
     with (
-        patch("dynamo.global_planner.scale_handler.KubernetesAPI") as mock_kube_cls,
+        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.scale_handler.KubernetesConnector"
+            "dynamo.global_planner.capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -1281,7 +933,7 @@ async def test_initial_below_floor_logs_warning(mock_runtime):
         )
         mock_connector_cls.return_value = mock_connector
 
-        with patch("dynamo.global_planner.scale_handler.logger") as mock_logger:
+        with patch("dynamo.global_planner.orchestrator.logger") as mock_logger:
             ScaleRequestHandler(
                 runtime=mock_runtime,
                 managed_namespaces=["default-my-dgd"],
@@ -1319,8 +971,10 @@ async def test_out_of_order_requests_pair_via_cache(mock_runtime):
     assert results_1[0]["status"] == "rejected"
     connector.set_component_replicas.assert_not_called()
     # Verify the intent was still cached
-    assert "default/my-dgd/prefill" in handler._intent_cache
-    assert handler._intent_cache["default/my-dgd/prefill"].last_desired == 2
+    assert "default/my-dgd/prefill" in handler.orchestrator._intent_cache
+    assert (
+        handler.orchestrator._intent_cache["default/my-dgd/prefill"].last_desired == 2
+    )
 
     # Second request: decode wants to go up to 4. Now prefill's intent pairs.
     req_decode = _scale_req(caller_ns="default-my-dgd", decode=4)
@@ -1374,7 +1028,7 @@ async def test_pair_preferred_over_standalone_when_both_feasible(mock_runtime):
     )
 
     # Decode has a fresh intent to scale up
-    handler._intent_cache["default/my-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
 
@@ -1407,7 +1061,9 @@ async def test_cache_entry_persists_after_standalone_apply(mock_runtime):
     req = _scale_req(caller_ns="default-my-dgd", prefill=4)
     await _run(handler, req)
 
-    assert handler._intent_cache["default/my-dgd/prefill"].last_desired == 4
+    assert (
+        handler.orchestrator._intent_cache["default/my-dgd/prefill"].last_desired == 4
+    )
 
 
 @pytest.mark.asyncio
@@ -1427,7 +1083,7 @@ async def test_satisfied_cached_intent_does_not_pair(mock_runtime):
     _install_connector(handler, "default/my-dgd", dgd_state)
 
     # Seed prefill's cache entry as satisfied (last_desired == current).
-    handler._intent_cache["default/my-dgd/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/prefill"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
 
@@ -1474,10 +1130,10 @@ async def test_pair_packing_continues_past_too_small_candidate(mock_runtime):
     # decode +4 full would push to 13 — over the strict ceiling (max=12, no
     # upper tolerance). So decode is partially consumed to land at exactly 12.
     # Both partners are applied; decode's cached intent (7) is NOT mutated.
-    handler._intent_cache["default/dgd-b/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/prefill"] = PoolIntent(
         last_desired=2, last_seen_at=time.time()
     )
-    handler._intent_cache["default/dgd-b/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
         last_desired=7, last_seen_at=time.time()
     )
 
@@ -1502,7 +1158,7 @@ async def test_pair_packing_continues_past_too_small_candidate(mock_runtime):
         3 < b_targets["decode"] < 7
     )  # partial: between current(3) and last_desired(7)
     # Cached intent for decode NOT mutated — planner still wants 7.
-    assert handler._intent_cache["default/dgd-b/decode"].last_desired == 7
+    assert handler.orchestrator._intent_cache["default/dgd-b/decode"].last_desired == 7
 
 
 def test_read_all_pools_tolerates_concurrent_connector_insert(mock_runtime):
@@ -1521,7 +1177,7 @@ def test_read_all_pools_tolerates_concurrent_connector_insert(mock_runtime):
 
     # _read_dgd_pools is called per item; mutate self.connectors during
     # the iteration to simulate a concurrent first-time request.
-    original = handler._read_dgd_pools
+    original = handler.orchestrator.capacity_manager._read_pools
 
     def _mutating_read(connector):
         # Inject a new connector mid-iteration. Without the list() snapshot
@@ -1532,13 +1188,15 @@ def test_read_all_pools_tolerates_concurrent_connector_insert(mock_runtime):
         new_conn.kube_api.get_graph_deployment = MagicMock(
             return_value=_dgd_spec(prefill_replicas=1, decode_replicas=1)
         )
-        handler.connectors.setdefault("default/racy-dgd", new_conn)
+        handler.orchestrator.capacity_manager.connectors.setdefault(
+            "default/racy-dgd", new_conn
+        )
         return original(connector)
 
-    handler._read_dgd_pools = _mutating_read  # type: ignore[method-assign]
+    handler.orchestrator.capacity_manager._read_pools = _mutating_read  # type: ignore[method-assign]
 
     # Should not raise.
-    snapshot = handler._read_all_pools()
+    snapshot = handler.orchestrator.capacity_manager.observe()
     # The pre-existing key is in the snapshot; the mid-iteration insert
     # may or may not appear (depends on snapshot timing) but the call
     # must complete cleanly.
@@ -1561,14 +1219,16 @@ async def test_intent_cache_clears_on_stable_signal(mock_runtime):
     )
 
     # Prefill has prior intent to scale down to 2
-    handler._intent_cache["default/my-dgd/prefill"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/prefill"] = PoolIntent(
         last_desired=2, last_seen_at=time.time()
     )
     # Now prefill sends a stable signal (desired == current)
     req_stable = _scale_req(caller_ns="default-my-dgd", prefill=3)
     await _run(handler, req_stable)
     # Prefill's cached intent is now 3 (== current), i.e., satisfied
-    assert handler._intent_cache["default/my-dgd/prefill"].last_desired == 3
+    assert (
+        handler.orchestrator._intent_cache["default/my-dgd/prefill"].last_desired == 3
+    )
 
     # Decode scale-up that would breach ceiling should no longer find a
     # partner (prefill's intent is now stable/satisfied)
@@ -1617,10 +1277,10 @@ async def test_pair_packing_three_pools_full_consumption(mock_runtime):
     )
     # P0 cached: last_desired=1 → delta -2.
     # P1 cached: last_desired=1 → delta -4.
-    handler._intent_cache["default/p0/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p0/decode"] = PoolIntent(
         last_desired=1, last_seen_at=time.time()
     )
-    handler._intent_cache["default/p1/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p1/decode"] = PoolIntent(
         last_desired=1, last_seen_at=time.time()
     )
     # P2 request +6 (decode 2 → 8). Standalone cluster total 3+5+8 = 16.
@@ -1686,10 +1346,10 @@ async def test_pair_packing_partial_consumption_leaves_residual(mock_runtime):
     )
     # P0 cached: last_desired=4 → delta -2.
     # P1 cached: last_desired=2 → delta -8. (Way more than needed.)
-    handler._intent_cache["default/p0/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p0/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
-    handler._intent_cache["default/p1/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p1/decode"] = PoolIntent(
         last_desired=2, last_seen_at=time.time()
     )
     # Cluster total = 6+10+2 = 18. P2 request +4 → standalone total = 22.
@@ -1716,7 +1376,7 @@ async def test_pair_packing_partial_consumption_leaves_residual(mock_runtime):
     # P1 was partially consumed — applied K is between current(10) and last_desired(2)
     assert 2 < p1_targets["decode"] < 10
     # The cached intent must NOT have been mutated — planner still wants 2.
-    assert handler._intent_cache["default/p1/decode"].last_desired == 2
+    assert handler.orchestrator._intent_cache["default/p1/decode"].last_desired == 2
 
 
 @pytest.mark.asyncio
@@ -1734,7 +1394,7 @@ async def test_pair_packing_single_partner_regression(mock_runtime):
     connector = _install_connector(
         handler, "default/my-dgd", _dgd_spec(prefill_replicas=3, decode_replicas=3)
     )
-    handler._intent_cache["default/my-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/my-dgd/decode"] = PoolIntent(
         last_desired=4, last_seen_at=time.time()
     )
     req = _scale_req(caller_ns="default-my-dgd", prefill=2)
@@ -1785,10 +1445,10 @@ async def test_pair_packing_overshooting_partner_is_partially_consumed(mock_runt
     # Pack P1 (-1) → total 12 (in band [11, 13]). Continue.
     # Try P2 full (-4) → would push to 8 (below floor-tol=11). Crosses band.
     # Partial of P2: K=3 lands at total 11 (lower band edge). Apply partial.
-    handler._intent_cache["default/p1/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p1/decode"] = PoolIntent(
         last_desired=3, last_seen_at=time.time()
     )
-    handler._intent_cache["default/p2/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/p2/decode"] = PoolIntent(
         last_desired=0, last_seen_at=time.time()
     )
     req = _scale_req(dgd="p0", caller_ns="default-p0", decode=5)
@@ -1810,7 +1470,7 @@ async def test_pair_packing_overshooting_partner_is_partially_consumed(mock_runt
     }
     assert 0 < p2_targets["decode"] < 4
     # Cached intent for P2 is NOT mutated — planner still wants 0.
-    assert handler._intent_cache["default/p2/decode"].last_desired == 0
+    assert handler.orchestrator._intent_cache["default/p2/decode"].last_desired == 0
 
 
 @pytest.mark.asyncio
@@ -1836,7 +1496,7 @@ async def test_pair_packing_direction_aware_order_multi_dgd(mock_runtime):
         _dgd_spec(prefill_replicas=0, decode_replicas=5),
         parent_dgd_name="down-dgd",
     )
-    handler._intent_cache["default/down-dgd/decode"] = PoolIntent(
+    handler.orchestrator._intent_cache["default/down-dgd/decode"] = PoolIntent(
         last_desired=3, last_seen_at=time.time()
     )
     # Track call order

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -10,7 +10,7 @@ import pytest
 
 from dynamo.global_planner.orchestrator import PoolIntent
 from dynamo.global_planner.scale_handler import ScaleRequestHandler
-from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner import KubernetesConnector, SubComponentType, TargetReplica
 from dynamo.planner.connectors.protocol import ScaleRequest
 from dynamo.planner.errors import DynamoGraphDeploymentNotReadyError
 
@@ -57,14 +57,7 @@ async def test_handler_authorization_success(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={
-                "spec": {
-                    "services": {
-                        "prefill-svc": {"subComponentType": "prefill", "replicas": 3},
-                        "decode-svc": {"subComponentType": "decode", "replicas": 5},
-                    }
-                }
-            }
+            return_value=_dgd_spec(prefill_replicas=3, decode_replicas=5)
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -150,7 +143,7 @@ async def test_handler_multiple_dgds(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"services": {}}}
+            return_value={"spec": {"components": []}}
         )
 
         # Process both requests
@@ -307,7 +300,7 @@ async def test_handler_blocking_mode(mock_runtime):
         mock_connector.set_component_replicas = AsyncMock()
         mock_connector.kube_api = MagicMock()
         mock_connector.kube_api.get_graph_deployment = MagicMock(
-            return_value={"spec": {"services": {}}}
+            return_value={"spec": {"components": []}}
         )
 
         # Process request (pass as dict to match endpoint behavior)
@@ -325,24 +318,84 @@ async def test_handler_blocking_mode(mock_runtime):
 # ---------------------------------------------------------------------------- #
 
 
-def _dgd_spec(prefill_replicas, decode_replicas, prefill_gpu=1, decode_gpu=1):
-    """Build a DGD deployment spec with prefill + decode services."""
+def _component(name, replicas, gpu, ctype, node_count=None):
+    component = {
+        "name": name,
+        "type": ctype,
+        "replicas": replicas,
+        "podTemplate": {
+            "spec": {
+                "containers": [
+                    {"name": "main", "resources": {"limits": {"nvidia.com/gpu": gpu}}}
+                ]
+            }
+        },
+    }
+    if node_count is not None:
+        component["multinode"] = {"nodeCount": node_count}
+    return component
+
+
+def _dgd_spec(
+    prefill_replicas,
+    decode_replicas,
+    prefill_gpu=1,
+    decode_gpu=1,
+    prefill_node_count=None,
+    decode_node_count=None,
+):
+    """Build a v1beta1 DGD spec with prefill and decode components."""
     return {
         "spec": {
-            "services": {
-                "prefill-svc": {
-                    "subComponentType": "prefill",
-                    "replicas": prefill_replicas,
-                    "resources": {"limits": {"gpu": prefill_gpu}},
-                },
-                "decode-svc": {
-                    "subComponentType": "decode",
-                    "replicas": decode_replicas,
-                    "resources": {"limits": {"gpu": decode_gpu}},
-                },
-            }
+            "components": [
+                _component(
+                    "prefill-svc",
+                    prefill_replicas,
+                    prefill_gpu,
+                    "prefill",
+                    prefill_node_count,
+                ),
+                _component(
+                    "decode-svc",
+                    decode_replicas,
+                    decode_gpu,
+                    "decode",
+                    decode_node_count,
+                ),
+            ]
         }
     }
+
+
+def _worker_dgd_spec(
+    replicas, gpu=1, component_name="worker-svc", component_type="worker"
+):
+    """Build a v1beta1 DGD spec with one generic worker component."""
+    component = {
+        "name": component_name,
+        "replicas": replicas,
+        "podTemplate": {
+            "spec": {
+                "containers": [
+                    {"name": "main", "resources": {"limits": {"nvidia.com/gpu": gpu}}}
+                ]
+            }
+        },
+    }
+    if component_type is not None:
+        component["type"] = component_type
+    return {"spec": {"components": [component]}}
+
+
+def _two_worker_dgd_spec(replicas=1, gpu=1):
+    """Build a DGD with two generic workers that can resolve to one role."""
+    deployment = _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-a")
+    deployment["spec"]["components"].extend(
+        _worker_dgd_spec(replicas=replicas, gpu=gpu, component_name="worker-b")["spec"][
+            "components"
+        ]
+    )
+    return deployment
 
 
 def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
@@ -357,12 +410,28 @@ def _install_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"
     return connector
 
 
+def _install_real_connector(handler, dgd_key, dgd_spec_dict, parent_dgd_name="my-dgd"):
+    """Attach a real KubernetesConnector backed by a mocked Kubernetes API."""
+    connector = KubernetesConnector.__new__(KubernetesConnector)
+    connector.parent_dgd_name = parent_dgd_name
+    connector.graph_deployment_name = parent_dgd_name
+    connector.raise_not_ready = True
+    connector.kube_api = MagicMock()
+    connector.kube_api.get_graph_deployment.return_value = dgd_spec_dict
+    connector.kube_api.is_deployment_ready.return_value = True
+    connector.kube_api.wait_for_graph_deployment_ready = AsyncMock()
+    handler.orchestrator.capacity_manager.connectors[dgd_key] = connector
+    return connector
+
+
 def _scale_req(
     dgd="my-dgd",
     k8s_ns="default",
     caller_ns="app-ns",
     prefill=None,
     decode=None,
+    prefill_component_name=None,
+    decode_component_name=None,
 ):
     """Build a ScaleRequest with one or both pool targets set."""
     targets = []
@@ -370,6 +439,7 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.PREFILL,
+                component_name=prefill_component_name,
                 desired_replicas=prefill,
             )
         )
@@ -377,6 +447,7 @@ def _scale_req(
         targets.append(
             TargetReplica(
                 sub_component_type=SubComponentType.DECODE,
+                component_name=decode_component_name,
                 desired_replicas=decode,
             )
         )
@@ -1516,3 +1587,198 @@ async def test_pair_packing_direction_aware_order_multi_dgd(mock_runtime):
     assert results[0]["status"] == "success"
     # Down DGD must apply before up DGD.
     assert call_order == ["down", "up"]
+
+
+# ---------------------------------------------------------------------------- #
+# v1beta1 component reading + generic-worker role hints (ported from #11990)   #
+# ---------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_role_used_for_budget_and_readback(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+        max_total_gpus=4,
+    )
+    connector = _install_connector(
+        handler, "default/my-dgd", _worker_dgd_spec(replicas=1, gpu=2)
+    )
+    req = _scale_req(
+        caller_ns="default-my-dgd", decode=2, decode_component_name="worker-svc"
+    )
+    results = await _run(handler, req)
+    assert results[0]["status"] == "success"
+    assert results[0]["current_replicas"] == {"decode": 1}
+    connector.set_component_replicas.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_scale_rejected_above_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+        max_total_gpus=2,
+    )
+    connector = _install_connector(
+        handler, "default/my-dgd", _worker_dgd_spec(replicas=1, gpu=2)
+    )
+    req = _scale_req(
+        caller_ns="default-my-dgd", decode=2, decode_component_name="worker-svc"
+    )
+    results = await _run(handler, req)
+    assert results[0]["status"] == "rejected"
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generic_worker_partner_keeps_component_name(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-dgd-a", "default-dgd-b"],
+        k8s_namespace="default",
+        min_total_gpus=9,
+        max_total_gpus=9,
+    )
+    connector_a = _install_connector(
+        handler,
+        "default/dgd-a",
+        _dgd_spec(prefill_replicas=3, decode_replicas=3),
+        parent_dgd_name="dgd-a",
+    )
+    connector_b = _install_real_connector(
+        handler,
+        "default/dgd-b",
+        _worker_dgd_spec(replicas=3),
+        parent_dgd_name="dgd-b",
+    )
+    cm = handler.orchestrator.capacity_manager
+    cm._component_roles["default/dgd-b"] = {"worker-svc": "decode"}
+    handler.orchestrator._intent_cache["default/dgd-b/decode"] = PoolIntent(
+        last_desired=4, last_seen_at=time.time()
+    )
+
+    results = await _run(
+        handler, _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2)
+    )
+
+    assert results[0]["status"] == "success"
+    connector_a.set_component_replicas.assert_called_once()
+    # The partner's component name rides through to the actual scale call.
+    connector_b.kube_api.update_graph_replicas.assert_called_once_with(
+        "dgd-b", "worker-svc", 4
+    )
+
+
+@pytest.mark.asyncio
+async def test_duplicate_resolved_pool_rejected_in_budget_snapshot(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+        max_total_gpus=4,
+    )
+    connector = _install_connector(handler, "default/my-dgd", _two_worker_dgd_spec())
+    handler.orchestrator.capacity_manager._component_roles["default/my-dgd"] = {
+        "worker-a": "decode",
+        "worker-b": "decode",
+    }
+
+    results = await _run(
+        handler,
+        _scale_req(
+            caller_ns="default-my-dgd", decode=2, decode_component_name="worker-a"
+        ),
+    )
+
+    assert results[0]["status"] == "error"
+    assert "'worker-a' and 'worker-b'" in results[0]["message"]
+    assert "planner pool 'decode'" in results[0]["message"]
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_resolved_pool_rejected_during_readback(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+    )
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _worker_dgd_spec(replicas=1, component_name="worker-a"),
+    )
+    # Clean read for the budget snapshot, duplicate roles for the read-back.
+    connector.kube_api.get_graph_deployment.side_effect = [
+        _worker_dgd_spec(replicas=1, component_name="worker-a"),
+        _two_worker_dgd_spec(),
+    ]
+    handler.orchestrator.capacity_manager._component_roles["default/my-dgd"] = {
+        "worker-a": "decode",
+        "worker-b": "decode",
+    }
+
+    results = await _run(
+        handler,
+        _scale_req(
+            caller_ns="default-my-dgd", decode=2, decode_component_name="worker-a"
+        ),
+    )
+
+    assert results[0]["status"] == "error"
+    assert "'worker-a' and 'worker-b'" in results[0]["message"]
+    assert "planner pool 'decode'" in results[0]["message"]
+    connector.set_component_replicas.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_multinode_gpu_count_enforces_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-my-dgd"],
+        k8s_namespace="default",
+        max_total_gpus=12,
+    )
+    connector = _install_connector(
+        handler,
+        "default/my-dgd",
+        _dgd_spec(
+            prefill_replicas=1,
+            decode_replicas=0,
+            prefill_gpu=4,
+            prefill_node_count=2,
+        ),
+    )
+    results = await _run(handler, _scale_req(caller_ns="default-my-dgd", prefill=2))
+    assert results[0]["status"] == "rejected"
+    connector.set_component_replicas.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_untyped_worker_in_other_dgd_counts_toward_budget(mock_runtime):
+    handler = ScaleRequestHandler(
+        runtime=mock_runtime,
+        managed_namespaces=["default-dgd-a", "default-dgd-b"],
+        k8s_namespace="default",
+        max_total_gpus=6,
+    )
+    connector_a = _install_connector(
+        handler,
+        "default/dgd-a",
+        _dgd_spec(prefill_replicas=1, decode_replicas=1),
+        parent_dgd_name="dgd-a",
+    )
+    _install_connector(
+        handler,
+        "default/dgd-b",
+        _worker_dgd_spec(replicas=2, gpu=2, component_type=None),
+        parent_dgd_name="dgd-b",
+    )
+    results = await _run(
+        handler, _scale_req(dgd="dgd-a", caller_ns="default-dgd-a", prefill=2)
+    )
+    assert results[0]["status"] == "rejected"
+    connector_a.set_component_replicas.assert_not_called()

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -49,7 +49,7 @@ async def test_handler_authorization_success(mock_runtime):
 
     # Mock KubernetesConnector
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -142,7 +142,7 @@ async def test_handler_multiple_dgds(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -184,7 +184,7 @@ async def test_handler_error_handling(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -216,9 +216,11 @@ async def test_populate_connectors_explicit_mode(mock_runtime):
     )
 
     with (
-        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI"
+        ) as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -231,7 +233,7 @@ async def test_populate_connectors_explicit_mode(mock_runtime):
         mock_connector_cls.return_value = MagicMock()
 
         handler.orchestrator.capacity_manager.discover(
-            handler.orchestrator.managed_callers
+            handler.orchestrator.managed_deployments
         )
 
         # Only model-a should be discovered
@@ -252,9 +254,11 @@ async def test_populate_connectors_implicit_mode(mock_runtime):
     )
 
     with (
-        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI"
+        ) as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()
@@ -266,7 +270,7 @@ async def test_populate_connectors_implicit_mode(mock_runtime):
         mock_connector_cls.return_value = MagicMock()
 
         handler.orchestrator.capacity_manager.discover(
-            handler.orchestrator.managed_callers
+            handler.orchestrator.managed_deployments
         )
 
         # All DGDs should be discovered
@@ -295,7 +299,7 @@ async def test_handler_blocking_mode(mock_runtime):
     )
 
     with patch(
-        "dynamo.global_planner.capacity_manager.KubernetesConnector"
+        "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
     ) as mock_connector_cls:
         mock_connector = AsyncMock()
         mock_connector_cls.return_value = mock_connector
@@ -915,9 +919,11 @@ async def test_initial_below_floor_logs_warning(mock_runtime):
     semantics — and the floor only blocks explicit scale-downs going forward
     (covered by the standalone-deny tests above)."""
     with (
-        patch("dynamo.global_planner.capacity_manager.KubernetesAPI") as mock_kube_cls,
         patch(
-            "dynamo.global_planner.capacity_manager.KubernetesConnector"
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesAPI"
+        ) as mock_kube_cls,
+        patch(
+            "dynamo.global_planner.kubernetes_capacity_manager.KubernetesConnector"
         ) as mock_connector_cls,
     ):
         mock_kube = MagicMock()

--- a/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_scale_request_handler.py
@@ -22,6 +22,12 @@ pytestmark = [
     pytest.mark.filterwarnings("ignore::pydantic.warnings.PydanticDeprecatedSince20"),
 ]
 
+# TODO(global-planner): Add invariant coverage for HA/shared state, cancellation
+# and intermediate PATCH failure, out-of-bound recovery, selected-only tolerance,
+# and duplicate-target execution; patch discovery by default in handler unit
+# tests and repair the concurrent-insert test so its _read_pools monkeypatch
+# accepts role_hints and actually runs instead of having TypeError swallowed.
+
 
 @pytest.fixture
 def mock_runtime():


### PR DESCRIPTION
## Overview:

Create a boundary between Dynamo Runtime based API (scale_handler.py), core Global Planner decision logic (now in orchestrator.py) and kubernetes scaling (now in CapacityManager)

## Details:

Create a boundary between Dynamo Runtime based API (scale_handler.py), core Global Planner decision logic (now in orchestrator.py) and kubernetes scaling (now in CapacityManager).
This is the first step towards creating a Global Planner 

## Where should the reviewer start?

orchestrator.py
capacity_manager.py

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes-backed capacity discovery, monitoring, and replica scaling.
  * Added global planning for GPU budgets, authorization, participant registration, and coordinated scale requests.
  * Added support for pairing scale operations across pools while respecting minimum and maximum GPU limits.
  * Added current replica reporting and handling for generic worker roles.

* **Bug Fixes**
  * Improved resilience when Kubernetes discovery or capacity observations fail.

* **Tests**
  * Added comprehensive coverage for capacity management, orchestration, budgeting, authorization, and scaling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->