### PR TITLE
fix(ext-proc): support IPv6 EPP endpoints

### DIFF
--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -872,19 +872,11 @@ fn pod_endpoint_address(pod: &k8s_openapi::api::core::v1::Pod) -> Option<String>
     Some(SocketAddr::new(ip, port).to_string())
 }
 
-/// An externally supplied [`Endpoint`] rendered the way [`WorkerEndpointIndex`]
-/// stores addresses, so the two can be compared.
+/// Formats an external IP endpoint the same way as [`WorkerEndpointIndex`].
 ///
-/// [`Endpoint::address_port`] builds its string with `format!("{ip}:{port}")`,
-/// which leaves an IPv6 literal unbracketed (`fd00::2:8000`), while the index
-/// stores `SocketAddr`-rendered addresses (`[fd00::2]:8000`). Comparing the two
-/// forms directly matches on IPv4 and silently never matches on IPv6, so both
-/// sides go through `SocketAddr` here. Returns `None` for an address or port
-/// that does not parse, which is not a routable endpoint either way.
+/// Hostnames and invalid values return `None`; the index only stores pod IPs.
 fn indexed_endpoint_address(endpoint: &Endpoint) -> Option<String> {
-    let ip: IpAddr = endpoint.address.parse().ok()?;
-    let port: u16 = endpoint.port.parse().ok()?;
-    Some(SocketAddr::new(ip, port).to_string())
+    endpoint.socket_addr().map(|address| address.to_string())
 }
 
 /// The worker instance IDs `pod` is currently known under, per discovery mode:
@@ -1283,11 +1275,24 @@ fn apply_subset_filter<'a>(
     }
 
     let candidates: HashSet<&str> = candidate_subset.iter().map(|s| s.as_str()).collect();
+    let candidate_ips: HashSet<IpAddr> = candidate_subset
+        .iter()
+        .filter_map(|candidate| candidate.parse().ok())
+        .collect();
     endpoints
         .iter()
         .filter(|ep| {
-            candidates.contains(ep.address_port().as_str())
-                || candidates.contains(ep.address.as_str())
+            if candidates.contains(ep.address.as_str()) {
+                return true;
+            }
+
+            match ep.socket_addr() {
+                Some(address) => {
+                    candidate_ips.contains(&address.ip())
+                        || candidates.contains(address.to_string().as_str())
+                }
+                None => candidates.contains(format!("{}:{}", ep.address, ep.port).as_str()),
+            }
         })
         .collect()
 }
@@ -2466,12 +2471,8 @@ mod tests {
         );
     }
 
-    /// `Endpoint::address_port` does not bracket IPv6, while the index stores
-    /// `SocketAddr`-rendered addresses. Comparing the raw forms matches on
-    /// IPv4 and silently never matches on IPv6, so the normalization has to
-    /// agree with what the index stores.
     #[test]
-    fn indexed_endpoint_address_brackets_ipv6_to_match_the_index() {
+    fn external_ipv6_endpoint_matches_subset_and_index() {
         let endpoint = Endpoint {
             pod_name: "worker-0".to_string(),
             address: "fd00::2".to_string(),
@@ -2479,15 +2480,20 @@ mod tests {
             labels: HashMap::new(),
         };
 
+        let expected = "[fd00::2]:8000";
+        assert_eq!(endpoint.address_port(), expected);
         assert_eq!(
             indexed_endpoint_address(&endpoint).as_deref(),
-            Some("[fd00::2]:8000")
+            Some(expected)
         );
-        assert_ne!(
-            endpoint.address_port(),
-            "[fd00::2]:8000",
-            "guards the reason this helper exists: the raw form is unbracketed"
-        );
+
+        for candidate in ["fd00::2", "FD00:0:0:0:0:0:0:2", expected] {
+            let subset = [candidate.to_string()];
+            assert_eq!(
+                apply_subset_filter(std::slice::from_ref(&endpoint), &subset).len(),
+                1
+            );
+        }
 
         let mut index = WorkerEndpointIndex::default();
         index.upsert(&simple_pod("worker-0", "fd00::2"));
@@ -2496,6 +2502,24 @@ mod tests {
             indexed_endpoint_address(&endpoint),
             "normalized endpoint must equal what the index stored"
         );
+    }
+
+    #[test]
+    fn external_hostname_endpoint_matches_bare_or_full_subset() {
+        let endpoint = Endpoint {
+            pod_name: "worker-0".to_string(),
+            address: "worker.example".to_string(),
+            port: "8000".to_string(),
+            labels: HashMap::new(),
+        };
+
+        for candidate in ["worker.example", "worker.example:8000"] {
+            let subset = [candidate.to_string()];
+            assert_eq!(
+                apply_subset_filter(std::slice::from_ref(&endpoint), &subset).len(),
+                1
+            );
+        }
     }
 
     /// A minimal pod exposing an `http`-named port, for

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -26,7 +26,9 @@ use dynamo_runtime::pipeline::RouterMode;
 use dynamo_runtime::{DistributedRuntime, Runtime};
 
 use crate::envoy_helpers::find_header;
-use crate::picker::{Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage};
+use crate::picker::{
+    Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage, format_address_port,
+};
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);
 const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
@@ -248,7 +250,7 @@ impl Router {
         ))
     }
 
-    /// Resolve a worker_id to a pod endpoint address (ip:port).
+    /// Resolve a worker_id to a pod endpoint socket address.
     /// Lock-free read from the in-memory reflector store — no K8s API calls.
     /// Port is read from the pod's Dynamo HTTP container port.
     pub fn resolve_worker_endpoint(&self, worker_id: u64) -> Option<String> {
@@ -263,7 +265,7 @@ impl Router {
         None
     }
 
-    /// Resolve any available worker to its endpoint address (ip:port).
+    /// Resolve any available worker to its endpoint socket address.
     /// Used for body-less requests (GET /v1/models) where we just need any backend.
     pub fn resolve_any_worker_endpoint(&self) -> Option<String> {
         self.pod_store
@@ -289,8 +291,8 @@ impl Router {
         None
     }
 
-    /// Map an Envoy `candidate_subset` (endpoint addresses, "ip:port" or bare
-    /// "ip") onto the worker IDs of the reflected pods that match it.
+    /// Map an Envoy `candidate_subset` (endpoint socket addresses or bare IPs)
+    /// onto the worker IDs of the reflected pods that match it.
     ///
     /// This is how the InferencePool subset hint is honored on the hot path:
     /// the ext_proc server always calls `pick()` with an empty external
@@ -307,8 +309,11 @@ impl Router {
             let Some(addr_port) = pod_endpoint_address(&pod) else {
                 continue;
             };
-            let ip = addr_port.split(':').next().unwrap_or("");
-            if candidates.contains(addr_port.as_str()) || candidates.contains(ip) {
+            let ip = addr_port
+                .parse::<std::net::SocketAddr>()
+                .map(|address| address.ip().to_string())
+                .unwrap_or_default();
+            if candidates.contains(addr_port.as_str()) || candidates.contains(ip.as_str()) {
                 ids.insert(hash_pod_name(pod_name));
             }
         }
@@ -653,7 +658,7 @@ async fn fetch_preprocessor_from_discovery(
     })
 }
 
-/// Extract "ip:port" from a pod by reading its IP from status and the
+/// Extract a socket address from a pod by reading its IP from status and the
 /// container port named `http` (the Dynamo HTTP inference port) from the
 /// container spec.
 ///
@@ -681,7 +686,7 @@ fn pod_endpoint_address(pod: &k8s_openapi::api::core::v1::Pod) -> Option<String>
         .flatten()
         .find(|p| p.name.as_deref() == Some(DYNAMO_CONTAINER_PORT_NAME))
         .map(|p| p.container_port)?;
-    Some(format!("{ip}:{port}"))
+    Some(format_address_port(ip, &port.to_string()))
 }
 
 /// Start a background pod reflector that watches worker pods matching the
@@ -841,7 +846,7 @@ fn spawn_prefill_discovery_watcher(
 // EndpointPicker trait implementation (mirrors Go LW-EPP from GAIE #2834)
 // ---------------------------------------------------------------------------
 
-/// Narrow `endpoints` down to only those whose address (or address:port)
+/// Narrow `endpoints` down to only those whose address (or socket address)
 /// appears in the `candidate_subset` sent via `envoy.lb.subset_hint`.
 /// If `candidate_subset` is empty, returns the full list unchanged.
 fn apply_subset_filter<'a>(
@@ -1133,6 +1138,7 @@ impl EndpointPicker for Router {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn tenant_header_overrides_body_cache_namespace() {
@@ -1159,6 +1165,66 @@ mod tests {
     #[test]
     fn absent_cache_namespace_stays_absent() {
         assert_eq!(cache_namespace_with_header_override(&[], None), None);
+    }
+
+    #[test]
+    fn pod_endpoint_address_brackets_ipv6() {
+        use k8s_openapi::api::core::v1::{Container, ContainerPort, Pod, PodSpec, PodStatus};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+        let pod = Pod {
+            metadata: ObjectMeta::default(),
+            spec: Some(PodSpec {
+                containers: vec![Container {
+                    name: "worker".to_string(),
+                    ports: Some(vec![ContainerPort {
+                        container_port: 8000,
+                        name: Some("http".to_string()),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            status: Some(PodStatus {
+                pod_ip: Some("fd00::10".to_string()),
+                ..Default::default()
+            }),
+        };
+
+        assert_eq!(
+            pod_endpoint_address(&pod).as_deref(),
+            Some("[fd00::10]:8000")
+        );
+    }
+
+    #[test]
+    fn endpoint_format_preserves_ipv4_hostname_and_ipv6() {
+        assert_eq!(format_address_port("10.0.0.1", "8000"), "10.0.0.1:8000");
+        assert_eq!(
+            format_address_port("worker.example", "8000"),
+            "worker.example:8000"
+        );
+        assert_eq!(format_address_port("fd00::10", "8000"), "[fd00::10]:8000");
+    }
+
+    #[test]
+    fn ipv6_pod_endpoint_and_subset_filter_match() {
+        let endpoints = [Endpoint {
+            pod_name: "worker-0".to_string(),
+            address: "fd00::10".to_string(),
+            port: "8000".to_string(),
+            labels: HashMap::new(),
+        }];
+
+        assert_eq!(
+            apply_subset_filter(&endpoints, &["fd00::10".to_string()]).len(),
+            1
+        );
+        assert_eq!(
+            apply_subset_filter(&endpoints, &["[fd00::10]:8000".to_string()]).len(),
+            1
+        );
     }
 
     /// Proves the core feature: `nvext.agent_hints.priority` lifts into a

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -27,7 +27,8 @@ use dynamo_runtime::{DistributedRuntime, Runtime};
 
 use crate::envoy_helpers::find_header;
 use crate::picker::{
-    Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage, format_address_port,
+    Endpoint, EndpointPicker, PickError, PickResult, RequestInfo, ResponseUsage,
+    format_address_port,
 };
 
 const BOOKKEEPING_TIMEOUT: Duration = Duration::from_secs(5);

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -8,6 +8,26 @@
 //! routing decision.
 
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
+
+/// Format an endpoint without losing the delimiters required by IPv6.
+///
+/// Kubernetes pod IPs are IP literals, while external endpoint lists may also
+/// contain hostnames. Keep the existing hostname behavior and use
+/// `SocketAddr` whenever both fields are valid socket-address components.
+pub(crate) fn format_address_port(address: &str, port: &str) -> String {
+    let parsed_ip = address
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(address)
+        .parse::<IpAddr>();
+    let parsed_port = port.parse::<u16>();
+
+    match (parsed_ip, parsed_port) {
+        (Ok(ip), Ok(port)) => SocketAddr::new(ip, port).to_string(),
+        _ => format!("{address}:{port}"),
+    }
+}
 
 use bytes::Bytes;
 
@@ -26,9 +46,9 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Returns the endpoint in "ip:port" format.
+    /// Returns the endpoint in socket-address format.
     pub fn address_port(&self) -> String {
-        format!("{}:{}", self.address, self.port)
+        format_address_port(&self.address, &self.port)
     }
 }
 

--- a/deploy/inference-gateway/ext-proc/src/picker.rs
+++ b/deploy/inference-gateway/ext-proc/src/picker.rs
@@ -7,6 +7,7 @@
 //! routing decision.
 
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 
 use bytes::Bytes;
 
@@ -24,9 +25,23 @@ pub struct Endpoint {
 }
 
 impl Endpoint {
-    /// Returns the endpoint in "ip:port" format.
+    /// Parses a numeric IP and port. IPv6 may be bracketed or bare.
+    pub(crate) fn socket_addr(&self) -> Option<SocketAddr> {
+        let address = self
+            .address
+            .strip_prefix('[')
+            .and_then(|value| value.strip_suffix(']'))
+            .unwrap_or(&self.address);
+        let ip: IpAddr = address.parse().ok()?;
+        let port: u16 = self.port.parse().ok()?;
+        Some(SocketAddr::new(ip, port))
+    }
+
+    /// Returns `host:port`, adding brackets around IPv6 addresses.
     pub fn address_port(&self) -> String {
-        format!("{}:{}", self.address, self.port)
+        self.socket_addr()
+            .map(|address| address.to_string())
+            .unwrap_or_else(|| format!("{}:{}", self.address, self.port))
     }
 }
 
@@ -145,4 +160,28 @@ pub enum PickError {
     /// multiplexing means the connection cap does not bound concurrent requests.
     #[error("endpoint picker overloaded")]
     Overloaded,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_address_port_formats_ipv4_ipv6_and_hostname() {
+        for (address, expected) in [
+            ("10.0.0.1", "10.0.0.1:8000"),
+            ("fd00::10", "[fd00::10]:8000"),
+            ("[fd00::10]", "[fd00::10]:8000"),
+            ("worker.example", "worker.example:8000"),
+        ] {
+            let endpoint = Endpoint {
+                pod_name: "worker-0".to_string(),
+                address: address.to_string(),
+                port: "8000".to_string(),
+                labels: HashMap::new(),
+            };
+
+            assert_eq!(endpoint.address_port(), expected);
+        }
+    }
 }

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -4,6 +4,8 @@
 use std::time::Instant;
 
 #[cfg(all(test, feature = "kvbm-offload"))]
+use std::sync::{Arc, Mutex};
+#[cfg(all(test, feature = "kvbm-offload"))]
 use std::time::Duration;
 
 use tokio::sync::mpsc;


### PR DESCRIPTION
## Overview:

Fix IPv6 endpoint formatting in the Rust EPP router.

## Details:

- Format IPv6 endpoints as `[IPv6]:port`.
- Fix IPv6 subset matching.
- Preserve IPv4 and hostname behavior.
- Add focused unit tests.

## Where should the reviewer start?

- `deploy/inference-gateway/ext-proc/src/picker.rs`
- `deploy/inference-gateway/ext-proc/src/epp.rs`

## Related Issues

- Closes #12063
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12064" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inference gateway endpoint handling for IPv6 addresses, including consistent bracketed socket formatting.
  * Fixed subset-based endpoint matching so IPv4 and IPv6 candidates can be matched reliably by full address or IP.
  * Improved routing consistency when resolving worker endpoints with valid address and port combinations.

* **Tests**
  * Added coverage for IPv6 address formatting and endpoint subset matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->