### PR TITLE
feat(frontend): add image-token count metrics

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -120,6 +120,8 @@ class frontend_service:
     VIDEOS_PER_REQUEST = "videos_per_request"
     # Number of `audio_url` content parts per request (histogram)
     AUDIO_PER_REQUEST = "audio_per_request"
+    # SMG-derived image-placeholder token estimate per image-bearing request (histogram)
+    IMAGE_TOKENS_PER_REQUEST = "image_tokens_per_request"
     # Model configuration metrics
     # Runtime config metrics (from ModelRuntimeConfig):
     # Total KV blocks available for a worker serving the model

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -120,7 +120,7 @@ class frontend_service:
     VIDEOS_PER_REQUEST = "videos_per_request"
     # Number of `audio_url` content parts per request (histogram)
     AUDIO_PER_REQUEST = "audio_per_request"
-    # SMG-derived image-placeholder token estimate per image-bearing request (histogram)
+    # Image token estimate per image-bearing request (histogram)
     IMAGE_TOKENS_PER_REQUEST = "image_tokens_per_request"
     # Model configuration metrics
     # Runtime config metrics (from ModelRuntimeConfig):

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -120,7 +120,7 @@ class frontend_service:
     VIDEOS_PER_REQUEST = "videos_per_request"
     # Number of `audio_url` content parts per request (histogram)
     AUDIO_PER_REQUEST = "audio_per_request"
-    # Image token estimate per image-bearing request (histogram)
+    # Calculated image-placeholder token count per image-bearing request (histogram)
     IMAGE_TOKENS_PER_REQUEST = "image_tokens_per_request"
     # Model configuration metrics
     # Runtime config metrics (from ModelRuntimeConfig):

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -400,6 +400,7 @@ pub struct Metrics {
     images_per_request: HistogramVec,
     videos_per_request: HistogramVec,
     audio_per_request: HistogramVec,
+    image_tokens_per_request: HistogramVec,
 
     // Runtime configuration metrics. Note: Some of these metrics represent counter-like values from
     // source systems, but are implemented as gauges because they are copied/synchronized from upstream
@@ -544,6 +545,7 @@ pub struct ResponseMetricCollector {
     images_per_request: prometheus::Histogram,
     videos_per_request: prometheus::Histogram,
     audio_per_request: prometheus::Histogram,
+    image_tokens_per_request: prometheus::Histogram,
     // Latched per-request counts (for the tracing span fields recorded in `Drop`).
     image_count_val: usize,
     video_count_val: usize,
@@ -851,6 +853,24 @@ impl Metrics {
         )
         .unwrap();
 
+        // Image placeholder-token buckets: powers of two cover the common
+        // single-image range and multi-image request totals.
+        let image_token_buckets = vec![
+            4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0, 8192.0,
+            16384.0, 32768.0, 65536.0,
+        ];
+        let image_tokens_per_request = HistogramVec::new(
+            HistogramOpts::new(
+                frontend_metric_name(frontend_service::IMAGE_TOKENS_PER_REQUEST),
+                "SMG-derived image-placeholder token estimate per image-bearing request; \
+                 recorded from the response path only when every image resolves and \
+                 processor overrides are absent",
+            )
+            .buckets(image_token_buckets),
+            &["model"],
+        )
+        .unwrap();
+
         let cached_tokens = HistogramVec::new(
             HistogramOpts::new(
                 frontend_metric_name(frontend_service::CACHED_TOKENS),
@@ -986,6 +1006,7 @@ impl Metrics {
             images_per_request,
             videos_per_request,
             audio_per_request,
+            image_tokens_per_request,
             model_total_kv_blocks,
             model_max_num_seqs,
             model_max_num_batched_tokens,
@@ -1143,6 +1164,7 @@ impl Metrics {
         registry.register(Box::new(self.images_per_request.clone()))?;
         registry.register(Box::new(self.videos_per_request.clone()))?;
         registry.register(Box::new(self.audio_per_request.clone()))?;
+        registry.register(Box::new(self.image_tokens_per_request.clone()))?;
 
         // Register runtime configuration metrics
         registry.register(Box::new(self.model_total_kv_blocks.clone()))?;
@@ -1561,6 +1583,9 @@ impl ResponseMetricCollector {
         let images_per_request = metrics.images_per_request.with_label_values(&[&model]);
         let videos_per_request = metrics.videos_per_request.with_label_values(&[&model]);
         let audio_per_request = metrics.audio_per_request.with_label_values(&[&model]);
+        let image_tokens_per_request = metrics
+            .image_tokens_per_request
+            .with_label_values(&[&model]);
         ResponseMetricCollector {
             metrics,
             model,
@@ -1573,6 +1598,7 @@ impl ResponseMetricCollector {
             images_per_request,
             videos_per_request,
             audio_per_request,
+            image_tokens_per_request,
             image_count_val: 0,
             video_count_val: 0,
             audio_count_val: 0,
@@ -1684,13 +1710,23 @@ impl ResponseMetricCollector {
         }
     }
 
-    /// Observe per-request multimodal content-part counts, latched to run exactly
-    /// once per request (the counts are constant across a request's chunks).
+    /// Observe per-request multimodal content-part counts, latched to run
+    /// exactly once per request (the counts are constant across chunks).
     pub fn observe_multimodal_counts(
         &mut self,
         image_count: usize,
         video_count: usize,
         audio_count: usize,
+    ) {
+        self.observe_multimodal_metrics(image_count, video_count, audio_count, None);
+    }
+
+    fn observe_multimodal_metrics(
+        &mut self,
+        image_count: usize,
+        video_count: usize,
+        audio_count: usize,
+        image_tokens: Option<usize>,
     ) {
         if self.multimodal_counts_observed {
             return;
@@ -1704,6 +1740,9 @@ impl ResponseMetricCollector {
         self.images_per_request.observe(image_count as f64);
         self.videos_per_request.observe(video_count as f64);
         self.audio_per_request.observe(audio_count as f64);
+        if let Some(image_tokens) = image_tokens {
+            self.image_tokens_per_request.observe(image_tokens as f64);
+        }
     }
 
     /// Observe tokenize/detokenize latencies in milliseconds.
@@ -1954,10 +1993,11 @@ fn observe_llm_metrics(
 ) {
     response_collector.observe_current_osl(metrics.output_tokens);
     response_collector.observe_cached_tokens(metrics.cached_tokens);
-    response_collector.observe_multimodal_counts(
+    response_collector.observe_multimodal_metrics(
         metrics.image_count,
         metrics.video_count,
         metrics.audio_count,
+        metrics.image_tokens,
     );
     response_collector.observe_tokenize_latencies(
         metrics.tokenize_latency,
@@ -2569,10 +2609,10 @@ mod tests {
 
         let mut collector = metrics.clone().create_response_collector(model);
         // Repeated calls simulate the same counts arriving on each streamed chunk.
-        collector.observe_multimodal_counts(2, 1, 0);
-        collector.observe_multimodal_counts(2, 1, 0);
+        collector.observe_multimodal_metrics(2, 1, 0, Some(1290));
+        collector.observe_multimodal_metrics(2, 1, 0, Some(1290));
         // A later, differing value must not override the latched counts.
-        collector.observe_multimodal_counts(99, 99, 99);
+        collector.observe_multimodal_metrics(99, 99, 99, Some(9999));
 
         let img = metrics.images_per_request.with_label_values(&[model]);
         assert_eq!(img.get_sample_count(), 1, "image histogram observed once");
@@ -2587,6 +2627,13 @@ mod tests {
             "audio histogram observes even a 0 (text-only distribution)"
         );
         assert_eq!(aud.get_sample_sum(), 0.0);
+        let image_tokens = metrics.image_tokens_per_request.with_label_values(&[model]);
+        assert_eq!(
+            image_tokens.get_sample_count(),
+            1,
+            "image-token histogram observed once"
+        );
+        assert_eq!(image_tokens.get_sample_sum(), 1290.0);
     }
 
     #[test]
@@ -2604,6 +2651,12 @@ mod tests {
         let img = metrics.images_per_request.with_label_values(&[model]);
         assert_eq!(img.get_sample_count(), 1);
         assert_eq!(img.get_sample_sum(), 0.0);
+        let image_tokens = metrics.image_tokens_per_request.with_label_values(&[model]);
+        assert_eq!(
+            image_tokens.get_sample_count(),
+            0,
+            "unavailable image-token count must not emit a sample"
+        );
     }
 
     #[test]
@@ -3119,6 +3172,7 @@ mod tests {
             output_tokens: 2,
             chunk_tokens: 1,
             cached_tokens: Some(1),
+            image_tokens: Some(300),
             prefill_worker_id: None,
             prefill_dp_rank: None,
             prefill_worker_type: None,

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -862,7 +862,7 @@ impl Metrics {
         let image_tokens_per_request = HistogramVec::new(
             HistogramOpts::new(
                 frontend_metric_name(frontend_service::IMAGE_TOKENS_PER_REQUEST),
-                "Image token estimate per image-bearing request; \
+                "Calculated image-placeholder token count per image-bearing request; \
                  recorded from the response path only when every image resolves and \
                  processor overrides are absent",
             )

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -862,7 +862,7 @@ impl Metrics {
         let image_tokens_per_request = HistogramVec::new(
             HistogramOpts::new(
                 frontend_metric_name(frontend_service::IMAGE_TOKENS_PER_REQUEST),
-                "SMG-derived image-placeholder token estimate per image-bearing request; \
+                "Image token estimate per image-bearing request; \
                  recorded from the response path only when every image resolves and \
                  processor overrides are absent",
             )

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -230,6 +230,37 @@ impl MultimodalCounts {
     }
 }
 
+#[cfg(feature = "mm-routing")]
+fn checked_add_image_tokens(total: Option<usize>, next: usize) -> Option<usize> {
+    total?.checked_add(next)
+}
+
+#[cfg(feature = "mm-routing")]
+fn has_image_token_processor_override(value: Option<&serde_json::Value>) -> bool {
+    value.is_some_and(|value| match value {
+        serde_json::Value::Null => false,
+        serde_json::Value::Object(map) => !map.is_empty(),
+        // The schema expects an object. Fail closed for every other JSON shape
+        // because its processor semantics are unknown here.
+        _ => true,
+    })
+}
+
+#[cfg(feature = "mm-routing")]
+fn aggregate_image_tokens(
+    image_tokens: Option<usize>,
+    resolved_image_count: usize,
+    total_image_count: usize,
+    has_processor_override: bool,
+) -> Option<usize> {
+    if total_image_count == 0 || has_processor_override || resolved_image_count != total_image_count
+    {
+        return None;
+    }
+
+    image_tokens
+}
+
 /// Derive the model's local directory from the MDC. The directory is the
 /// parent of `config.json` (which lives in `mdc.model_info` as `HfConfigJson`)
 /// and contains the other artifacts MM-aware routing reads at startup
@@ -242,12 +273,13 @@ fn mdc_model_dir(mdc: &ModelDeploymentCard) -> Option<std::path::PathBuf> {
 }
 
 /// Shared SSRF-aware `MediaFetcher` + `reqwest::Client` for the dim-fetch
-/// path used by MM-aware routing. Inherits the same policy contract as the
-/// frontend-decode path (`MediaLoader`): blocklist DNS resolver, redirect
-/// revalidation, hostname/IP blocklist, `DYN_MM_ALLOW_INTERNAL` opt-in.
+/// path used by MM-aware routing and image-token metrics. Inherits the same
+/// policy contract as the frontend-decode path (`MediaLoader`): blocklist DNS
+/// resolver, redirect revalidation, hostname/IP blocklist,
+/// `DYN_MM_ALLOW_INTERNAL` opt-in.
 ///
 /// **Lifecycle:** `LazyLock` so the closure runs on first access. For MM-
-/// routable preprocessors, `OpenAIPreprocessor::new_with_parts` calls
+/// countable or routable preprocessors, `OpenAIPreprocessor::new_with_parts` calls
 /// `LazyLock::force(...)` at startup — that surfaces TLS-root / reqwest-
 /// init / env-misconfig failures at deployment time, not on the first MM
 /// request 20 minutes in. Text-only deployments skip the force, leaving
@@ -641,29 +673,30 @@ impl OpenAIPreprocessor {
         // custom-named directories where the family substring isn't in the path.
         #[cfg(feature = "mm-routing")]
         let model_dir_for_routing: Option<std::path::PathBuf> = mdc_model_dir(&mdc);
+        #[cfg(feature = "mm-routing")]
+        let fastokens_active = runtime_config.effective_tokenizer_backend().is_fastokens();
         // TODO(mm-routing): fastokens lacks a special-token mutator, so it
         // can't merge tokenizer_config.json specials and would BPE-shatter
         // placeholders (e.g. Qwen2-VL `<|image_pad|>`). Disable MM-routing
-        // here; remove once fastokens upstream exposes the mutator.
+        // token resolution here, but keep SMG image-token counting enabled.
+        // Remove this split once fastokens upstream exposes the mutator.
+        #[cfg(feature = "mm-routing")]
+        if fastokens_active && model_dir_for_routing.is_some() {
+            tracing::warn!(
+                target: "mm_routing",
+                "fastokens tokenizer backend is active; MM-aware KV routing disabled. \
+                 Image-token metrics remain enabled when SMG supports the model."
+            );
+        }
         #[cfg(feature = "mm-routing")]
         let image_token_inputs: Option<(String, String, std::path::PathBuf)> = {
-            let fastokens_active = runtime_config.effective_tokenizer_backend().is_fastokens();
-            if fastokens_active && model_dir_for_routing.is_some() {
-                tracing::warn!(
-                    target: "mm_routing",
-                    "fastokens tokenizer backend is active; MM-aware KV routing disabled. \
-                     Use the default tokenizer backend to re-enable."
-                );
-                None
-            } else {
-                model_dir_for_routing.as_ref().map(|p| {
-                    (
-                        mdc.source_path().to_string(),
-                        model_info.model_type(),
-                        p.clone(),
-                    )
-                })
-            }
+            model_dir_for_routing.as_ref().map(|p| {
+                (
+                    mdc.source_path().to_string(),
+                    model_info.model_type(),
+                    p.clone(),
+                )
+            })
         };
 
         let context_length = mdc.effective_context_length();
@@ -690,17 +723,23 @@ impl OpenAIPreprocessor {
                         Ok(c) => (Some(c), None),
                         Err(e) => (None, Some(e.to_string())),
                     };
-                    // One-shot config/tokenizer_config read for all
-                    // routing-side token info. Parsing lives next to the
-                    // spec resolution in the MM-routing module.
-                    let routing_tokens =
-                        lightseek_mm::resolve_routing_tokens(&model_id, &model_dir);
-                    // `chat_placeholder_token_id` already prefers config.json's
-                    // explicit field and falls back to the spec value, so it's
-                    // the single id used both for the engagement gate and the
-                    // routing-fill below.
-                    let img_tok = routing_tokens.chat_placeholder_token_id;
-                    let bos_tok_string = routing_tokens.bos_token_string;
+                    let (img_tok, bos_tok_string) = if fastokens_active {
+                        (None, None)
+                    } else {
+                        // One-shot config/tokenizer_config read for all
+                        // routing-side token info. Parsing lives next to the
+                        // spec resolution in the MM-routing module.
+                        let routing_tokens =
+                            lightseek_mm::resolve_routing_tokens(&model_id, &model_dir);
+                        // `chat_placeholder_token_id` already prefers
+                        // config.json's explicit field and falls back to the
+                        // spec value, so it is used for both the engagement
+                        // gate and the routing fill.
+                        (
+                            routing_tokens.chat_placeholder_token_id,
+                            routing_tokens.bos_token_string,
+                        )
+                    };
 
                     match (counter.is_some(), img_tok.is_some()) {
                         (true, true) => tracing::info!(
@@ -709,6 +748,7 @@ impl OpenAIPreprocessor {
                             model_dir = %model_dir.display(),
                             "MM-aware KV routing enabled"
                         ),
+                        _ if fastokens_active => {}
                         (counter_ok, img_ok) => {
                             let mut reasons: Vec<String> = Vec::new();
                             if !counter_ok {
@@ -720,8 +760,8 @@ impl OpenAIPreprocessor {
                             if !img_ok {
                                 reasons.push(
                                     "image-placeholder token unresolvable from \
-                                 config.json / processor_config.json / \
-                                 tokenizer_config.json / vocab probe"
+                                     config.json / processor_config.json / \
+                                     tokenizer_config.json / vocab probe"
                                         .to_string(),
                                 );
                             }
@@ -750,7 +790,7 @@ impl OpenAIPreprocessor {
             };
 
         // Force the dim-fetch HTTP client to build at startup for any
-        // MM-routable preprocessor, so TLS / env-var / reqwest-init
+        // MM-countable or routable preprocessor, so TLS / env-var / reqwest-init
         // failures fail the deployment instead of crashing the first
         // MM request 20 minutes in. Text-only preprocessors skip the
         // force (both MM-routing hooks resolved to `None`) — no point
@@ -847,8 +887,10 @@ impl OpenAIPreprocessor {
         request: &R,
         tracker: Option<&RequestTracker>,
     ) -> Result<(PreprocessedRequest, HashMap<String, String>, bool)> {
-        self.preprocess_request_with_options(request, tracker, PreprocessRequestOptions::default())
-            .await
+        let (request, annotations, prompt_injected_reasoning, _image_tokens) = self
+            .preprocess_request_with_options(request, tracker, PreprocessRequestOptions::default())
+            .await?;
+        Ok((request, annotations, prompt_injected_reasoning))
     }
 
     async fn preprocess_request_with_options<
@@ -864,7 +906,12 @@ impl OpenAIPreprocessor {
         request: &R,
         tracker: Option<&RequestTracker>,
         options: PreprocessRequestOptions,
-    ) -> Result<(PreprocessedRequest, HashMap<String, String>, bool)> {
+    ) -> Result<(
+        PreprocessedRequest,
+        HashMap<String, String>,
+        bool,
+        Option<usize>,
+    )> {
         let _stage_guard = StageGuard::new(STAGE_PREPROCESS, "");
         let preprocess_start = Instant::now();
         let mut builder = self.builder(request)?;
@@ -894,8 +941,8 @@ impl OpenAIPreprocessor {
         };
         TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
 
-        let _mm_image_entries = self
-            .gather_multi_modal_data(
+        let (_mm_image_entries, image_tokens) = self
+            .gather_multi_modal_data_with_image_tokens(
                 request,
                 &mut builder,
                 formatted_prompt.as_deref(),
@@ -967,7 +1014,12 @@ impl OpenAIPreprocessor {
             preprocessed.stop_conditions.max_tokens = Some(max_tokens);
         }
 
-        Ok((preprocessed, annotations, prompt_injected_reasoning))
+        Ok((
+            preprocessed,
+            annotations,
+            prompt_injected_reasoning,
+            image_tokens,
+        ))
     }
 
     pub fn builder<
@@ -1290,6 +1342,26 @@ impl OpenAIPreprocessor {
         // `gather_mm_exact_routing_info`, so the two never diverge.
         token_ids: &[crate::protocols::TokenIdType],
     ) -> Result<Vec<MmImageEntry>> {
+        let (entries, _image_tokens) = self
+            .gather_multi_modal_data_with_image_tokens(
+                request,
+                builder,
+                formatted_prompt,
+                token_ids,
+            )
+            .await?;
+        Ok(entries)
+    }
+
+    async fn gather_multi_modal_data_with_image_tokens<
+        R: OAIChatLikeRequest + MediaRequestExt + NvExtProvider,
+    >(
+        &self,
+        request: &R,
+        builder: &mut PreprocessedRequestBuilder,
+        formatted_prompt: Option<&str>,
+        token_ids: &[crate::protocols::TokenIdType],
+    ) -> Result<(Vec<MmImageEntry>, Option<usize>)> {
         // `token_ids` is only consumed by the mm-routing `mm_hashes` gate below.
         #[cfg(not(feature = "mm-routing"))]
         let _ = token_ids;
@@ -1305,6 +1377,10 @@ impl OpenAIPreprocessor {
         // Cleared and returned to the caller; empty for non-image / text-only requests.
         #[cfg(feature = "mm-routing")]
         let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        // Private per-request total for frontend metrics. `None` means the SMG
+        // counter is unavailable or checked addition overflowed.
+        #[cfg(feature = "mm-routing")]
+        let mut image_tokens = self.image_token_counter.as_ref().map(|_| 0usize);
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
         // `mm_hashes` forwarding time: if `mm_image_entries.len()` is
@@ -1326,7 +1402,7 @@ impl OpenAIPreprocessor {
         let mut url_passthrough_images: Vec<(u64, &str)> = Vec::new();
 
         let Some(messages) = request.typed_messages() else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), None));
         };
         let has_media_loader = self.media_loader.is_some();
 
@@ -1469,6 +1545,7 @@ impl OpenAIPreprocessor {
                                 source = hash_source,
                                 "image-token count"
                             );
+                            image_tokens = checked_add_image_tokens(image_tokens, n);
                         }
                         mm_image_entries.push(MmImageEntry {
                             mm_hash,
@@ -1514,6 +1591,7 @@ impl OpenAIPreprocessor {
                                 source = "url_passthrough_header_fetch",
                                 "image-token count"
                             );
+                            image_tokens = checked_add_image_tokens(image_tokens, n);
                         }
                         mm_image_entries.push(MmImageEntry {
                             mm_hash,
@@ -1640,9 +1718,19 @@ impl OpenAIPreprocessor {
         }
 
         #[cfg(feature = "mm-routing")]
-        return Ok(mm_image_entries);
+        let has_processor_override =
+            has_image_token_processor_override(request.mm_processor_kwargs());
+        #[cfg(feature = "mm-routing")]
+        let image_tokens = aggregate_image_tokens(
+            image_tokens,
+            mm_image_entries.len(),
+            total_image_count,
+            has_processor_override,
+        );
+        #[cfg(feature = "mm-routing")]
+        return Ok((mm_image_entries, image_tokens));
         #[cfg(not(feature = "mm-routing"))]
-        Ok(Vec::new())
+        Ok((Vec::new(), None))
     }
 
     /// Build `MmRoutingInfo` for exact MM-aware KV routing. The worker-bound
@@ -2358,6 +2446,33 @@ impl OpenAIPreprocessor {
         S: Stream<Item = Annotated<BackendOutput>> + Send + 'static,
         Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
     {
+        Self::transform_postprocessor_stream_with_image_tokens(
+            stream,
+            generator,
+            context,
+            emit_payload_usage_chunk,
+            trace_tokens_enabled,
+            trace_finish_reason_metadata,
+            mm_counts,
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn transform_postprocessor_stream_with_image_tokens<S, Resp>(
+        stream: S,
+        generator: Box<dyn DeltaGeneratorExt<Resp>>,
+        context: Arc<dyn AsyncEngineContext>,
+        emit_payload_usage_chunk: bool,
+        trace_tokens_enabled: bool,
+        trace_finish_reason_metadata: Option<crate::request_trace::SharedFinishReasonMetadata>,
+        mm_counts: MultimodalCounts,
+        image_tokens: Option<usize>,
+    ) -> impl Stream<Item = Annotated<Resp>> + Send
+    where
+        S: Stream<Item = Annotated<BackendOutput>> + Send + 'static,
+        Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
+    {
         struct State<Resp>
         where
             Resp: Send + Sync + Clone + 'static + std::fmt::Debug,
@@ -2377,6 +2492,7 @@ impl OpenAIPreprocessor {
             trace_tokens_enabled: bool,
             trace_finish_reason_metadata: Option<crate::request_trace::SharedFinishReasonMetadata>,
             mm_counts: MultimodalCounts,
+            image_tokens: Option<usize>,
         }
 
         let state = State {
@@ -2393,6 +2509,7 @@ impl OpenAIPreprocessor {
             trace_tokens_enabled,
             trace_finish_reason_metadata,
             mm_counts,
+            image_tokens,
         };
 
         // transform the common response stream into a chat response stream
@@ -2507,6 +2624,7 @@ impl OpenAIPreprocessor {
                         image_count: inner.mm_counts.image,
                         video_count: inner.mm_counts.video,
                         audio_count: inner.mm_counts.audio,
+                        image_tokens: inner.image_tokens,
                         prefill_worker_id,
                         prefill_dp_rank,
                         prefill_worker_type,
@@ -2587,6 +2705,7 @@ impl OpenAIPreprocessor {
                             image_count: inner.mm_counts.image,
                             video_count: inner.mm_counts.video,
                             audio_count: inner.mm_counts.audio,
+                            image_tokens: inner.image_tokens,
                             prefill_worker_id,
                             prefill_dp_rank,
                             prefill_worker_type,
@@ -3444,7 +3563,7 @@ impl
         };
 
         // convert the chat completion request to a common completion request
-        let (mut common_request, annotations, prompt_injected_reasoning) = self
+        let (mut common_request, annotations, prompt_injected_reasoning, image_tokens) = self
             .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
             .await?;
         attach_agent_context_from_context(&mut common_request, &context);
@@ -3496,7 +3615,7 @@ impl
         let context = response_stream.context();
 
         // transform the postprocessor stream (no boxing yet) - detokenize
-        let stream = Self::transform_postprocessor_stream(
+        let stream = Self::transform_postprocessor_stream_with_image_tokens(
             response_stream,
             response_generator,
             context.clone(),
@@ -3504,6 +3623,7 @@ impl
             trace_tokens_enabled,
             trace_finish_reason_metadata,
             mm_counts,
+            image_tokens,
         );
 
         let transformed_stream = self.postprocessor_parsing_stream(
@@ -3861,6 +3981,39 @@ mod tests {
         assert_eq!(counts.audio, 0);
     }
 
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn image_token_aggregate_requires_complete_trustworthy_counts() {
+        assert_eq!(aggregate_image_tokens(Some(300), 2, 2, false), Some(300));
+        assert_eq!(aggregate_image_tokens(Some(300), 2, 3, false), None);
+        assert_eq!(aggregate_image_tokens(Some(300), 2, 2, true), None);
+        assert_eq!(aggregate_image_tokens(None, 2, 2, false), None);
+        assert_eq!(aggregate_image_tokens(Some(0), 0, 0, false), None);
+        assert_eq!(
+            checked_add_image_tokens(Some(usize::MAX), 1),
+            None,
+            "overflow must omit the aggregate rather than wrap"
+        );
+    }
+
+    #[cfg(feature = "mm-routing")]
+    #[test]
+    fn image_token_processor_override_is_conservative() {
+        assert!(!has_image_token_processor_override(None));
+        assert!(!has_image_token_processor_override(Some(
+            &serde_json::Value::Null
+        )));
+        assert!(!has_image_token_processor_override(Some(
+            &serde_json::json!({})
+        )));
+        assert!(has_image_token_processor_override(Some(
+            &serde_json::json!([])
+        )));
+        assert!(has_image_token_processor_override(Some(
+            &serde_json::json!({"min_pixels": 64})
+        )));
+    }
+
     #[test]
     fn replace_reserved_media_slot_preserves_alignment_and_returns_errors() {
         let mut map = HashMap::from([(
@@ -3922,6 +4075,7 @@ mod tests {
             output_tokens: 20,
             chunk_tokens: 3,
             cached_tokens: Some(4),
+            image_tokens: Some(512),
             prefill_worker_id: Some(1),
             prefill_dp_rank: Some(2),
             prefill_worker_type: Some("prefill".to_string()),
@@ -3956,6 +4110,7 @@ mod tests {
                 .unwrap_or_else(|| panic!("metrics recognized for tag {tag}"));
             assert_eq!(metrics.input_tokens, 10);
             assert_eq!(metrics.output_tokens, 20);
+            assert_eq!(metrics.image_tokens, Some(512));
             assert_eq!(metrics.detokenize_count, Some(6));
         }
     }

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -359,6 +359,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn counter_loads_hf_config_and_counts_known_qwen3_vl_dimensions() {
+        let model_dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            model_dir.path().join("preprocessor_config.json"),
+            serde_json::json!({
+                "patch_size": 16,
+                "merge_size": 2,
+                "min_pixels": 3136,
+                "max_pixels": 12_845_056,
+                "temporal_patch_size": 2
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let counter = LightseekMmCounter::try_new(
+            "Qwen/Qwen3-VL-2B-Instruct",
+            Some("qwen3_vl"),
+            model_dir.path(),
+        )
+        .unwrap();
+
+        // 640x480 is already aligned to patch_size * merge_size (32).
+        // (640 / 16) * (480 / 16) / merge_size² = 300.
+        assert_eq!(counter.count_tokens(640, 480), 300);
+    }
+
     /// Coverage table for the VLM families we claim to support. Each row is
     /// a `(family_label, hf_id, model_type)` triple. A row "passes" when the
     /// upstream registry can match it via either the HF id substring OR the
@@ -383,6 +411,11 @@ mod tests {
             ),
             ("LLaVA-1.5", "llava-hf/llava-1.5-7b-hf", "llava"),
             ("Llama-4", "meta-llama/Llama-4-Scout-17B-16E", "llama4"),
+            (
+                "Phi-3 Vision",
+                "microsoft/Phi-3-vision-128k-instruct",
+                "phi3_v",
+            ),
             ("Kimi-K2.5", "moonshotai/Kimi-K2.5-Instruct", "kimi_k2_5"),
             ("Kimi-K2.6", "moonshotai/Kimi-K2.6-Instruct", "kimi_k2_6"),
             ("Qwen3.5", "Qwen/Qwen3.5-0.8B", "qwen3_5"),

--- a/lib/llm/src/protocols/common/metrics.rs
+++ b/lib/llm/src/protocols/common/metrics.rs
@@ -33,6 +33,11 @@ pub struct LLMMetricAnnotation {
     /// Number of `audio_url` content parts in the request (0 for text-only).
     #[serde(default, skip_serializing_if = "is_zero")]
     pub audio_count: usize,
+    /// SMG-derived image-placeholder token estimate summed across the request.
+    /// `None` when the model is unsupported, media dimensions are incomplete,
+    /// or request-level processor overrides make the static count unreliable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_tokens: Option<usize>,
     /// Prefill worker ID (for TTFT attribution in disaggregated mode)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prefill_worker_id: Option<u64>,

--- a/lib/llm/src/protocols/common/metrics.rs
+++ b/lib/llm/src/protocols/common/metrics.rs
@@ -33,7 +33,7 @@ pub struct LLMMetricAnnotation {
     /// Number of `audio_url` content parts in the request (0 for text-only).
     #[serde(default, skip_serializing_if = "is_zero")]
     pub audio_count: usize,
-    /// Image token estimate summed across the request.
+    /// Calculated image-placeholder token count summed across the request.
     /// `None` when the model is unsupported, media dimensions are incomplete,
     /// or request-level processor overrides make the static count unreliable.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lib/llm/src/protocols/common/metrics.rs
+++ b/lib/llm/src/protocols/common/metrics.rs
@@ -33,7 +33,7 @@ pub struct LLMMetricAnnotation {
     /// Number of `audio_url` content parts in the request (0 for text-only).
     #[serde(default, skip_serializing_if = "is_zero")]
     pub audio_count: usize,
-    /// SMG-derived image-placeholder token estimate summed across the request.
+    /// Image token estimate summed across the request.
     /// `None` when the model is unsupported, media dimensions are incomplete,
     /// or request-level processor overrides make the static count unreliable.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -457,18 +457,7 @@ mod tests {
             output_tokens: 5,
             chunk_tokens: 0,
             cached_tokens: None,
-            image_count: 0,
-            video_count: 0,
-            audio_count: 0,
-            prefill_worker_id: None,
-            prefill_dp_rank: None,
-            prefill_worker_type: None,
-            decode_worker_id: None,
-            decode_dp_rank: None,
-            decode_worker_type: None,
-            tokenize_latency: None,
-            detokenize_total_latency: None,
-            detokenize_count: None,
+            ..Default::default()
         });
         chunk
     }

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -143,6 +143,7 @@ impl
                     image_count,
                     video_count,
                     audio_count,
+                    image_tokens: Some(1290),
                     ..Default::default()
                 };
                 if let Ok(ann) = metrics.to_annotation::<NvCreateChatCompletionStreamResponse>() {
@@ -477,6 +478,16 @@ async fn test_multimodal_count_metrics_exposed() {
         assert!(
             metrics_body.contains("dynamo_frontend_audio_per_request_sum{model=\"mmmodel\"} 0\n"),
             "audio_per_request_sum should be 0; got:\n{metrics_body}"
+        );
+        assert!(
+            metrics_body
+                .contains("dynamo_frontend_image_tokens_per_request_count{model=\"mmmodel\"} 1\n"),
+            "image_tokens_per_request_count should be 1; got:\n{metrics_body}"
+        );
+        assert!(
+            metrics_body
+                .contains("dynamo_frontend_image_tokens_per_request_sum{model=\"mmmodel\"} 1290\n"),
+            "image_tokens_per_request_sum should be 1290; got:\n{metrics_body}"
         );
 
         cancel_token.cancel();

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -241,6 +241,9 @@ pub mod frontend_service {
     /// Number of `audio_url` content parts per request (histogram)
     pub const AUDIO_PER_REQUEST: &str = "audio_per_request";
 
+    /// SMG-derived image-placeholder token estimate per image-bearing request (histogram)
+    pub const IMAGE_TOKENS_PER_REQUEST: &str = "image_tokens_per_request";
+
     /// Model configuration metrics
     ///
     /// Runtime config metrics (from ModelRuntimeConfig):

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -241,7 +241,7 @@ pub mod frontend_service {
     /// Number of `audio_url` content parts per request (histogram)
     pub const AUDIO_PER_REQUEST: &str = "audio_per_request";
 
-    /// Image token estimate per image-bearing request (histogram)
+    /// Calculated image-placeholder token count per image-bearing request (histogram)
     pub const IMAGE_TOKENS_PER_REQUEST: &str = "image_tokens_per_request";
 
     /// Model configuration metrics

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -241,7 +241,7 @@ pub mod frontend_service {
     /// Number of `audio_url` content parts per request (histogram)
     pub const AUDIO_PER_REQUEST: &str = "audio_per_request";
 
-    /// SMG-derived image-placeholder token estimate per image-bearing request (histogram)
+    /// Image token estimate per image-bearing request (histogram)
     pub const IMAGE_TOKENS_PER_REQUEST: &str = "image_tokens_per_request";
 
     /// Model configuration metrics

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -318,10 +318,13 @@ def run_serve_deployment(
                 if hasattr(payload, "with_model"):
                     payload = payload.with_model(config.model)
 
-                # Default behavior: requests go to the frontend port, except metrics which target
-                # worker system ports (mapped from DefaultPort -> per-test ports).
+                # Default behavior: requests go to the frontend port. Metrics
+                # may target either the frontend or worker system ports; map
+                # each DefaultPort placeholder to its per-test allocation.
                 if getattr(payload, "endpoint", "") == "/metrics":
-                    if payload.port == DefaultPort.SYSTEM1.value:
+                    if payload.port == DefaultPort.FRONTEND.value:
+                        payload.port = dynamic_frontend_port
+                    elif payload.port == DefaultPort.SYSTEM1.value:
                         if len(dynamic_system_ports) < 1:
                             raise RuntimeError(
                                 "Payload targets SYSTEM_PORT1 but no system ports were provided "

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -18,7 +18,11 @@ from tests.utils.multimodal import (
     make_image_payload_uuid_passthrough,
     make_video_payload,
 )
-from tests.utils.payload_builder import chat_payload, chat_payload_default
+from tests.utils.payload_builder import (
+    chat_payload,
+    chat_payload_default,
+    image_token_metrics_payload,
+)
 
 # LLaVA 1.5 color-identification reference set: the model legitimately
 # emits these colors (though the order/subset varies across CUDA backends
@@ -269,7 +273,10 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 requested_vllm_kv_cache_bytes=920_126_000,  # 2x safety over min=460_062_720
                 tests=[
                     # HTTP-URL color test on hybrid Mamba/full-attention VL.
-                    MmCase(payload=make_image_payload(["green"])),
+                    MmCase(
+                        payload=make_image_payload(["green"]),
+                        followup_payloads=[image_token_metrics_payload()],
+                    ),
                     # Inline-base64 + --frontend-decoding (NIXL RDMA path).
                     # post_merge for the NIXL-stub reason — local pre-merge
                     # builds outside Docker ship a NIXL stub that errors on

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -32,6 +32,7 @@ from tests.utils.payload_builder import (
     embedding_payload,
     embedding_payload_default,
     guided_decoding_chat_payload_default,
+    image_token_metrics_payload,
     kv_events_metrics_payload,
     metric_payload_default,
     responses_payload_default,
@@ -450,6 +451,7 @@ sglang_configs = {
             # Rust frontend + NIXL RDMA transfer of decoded pixels — the
             # path that distinguishes FD from the plain URL path.
             make_image_payload_b64(["green"]),
+            image_token_metrics_payload(),
         ],
     ),
     "multimodal_agg_qwen": SGLangConfig(

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -23,6 +23,7 @@ from tests.utils.payload_builder import (
     chat_payload_default,
     completion_payload,
     completion_payload_default,
+    image_token_metrics_payload,
     metric_payload_default,
     multimodal_payload_default,
     router_selection_chat_payload_default,
@@ -595,7 +596,8 @@ trtllm_configs = {
             multimodal_payload_default(
                 text="Describe what you see in this image.",
                 expected_response=["mountain", "rock", "trees", "road"],
-            )
+            ),
+            image_token_metrics_payload(),
         ],
         env={
             "AGG_ENGINE_ARGS": "/workspace/examples/backends/trtllm/engine_configs/qwen3-vl-2b-instruct/agg.yaml",

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -419,15 +419,18 @@ class MmCase:
 
     Each :class:`MmCase` produces exactly one ``EngineConfig`` keyed
     ``mm_{topology}_{short_name}[_{suffix}]``. The case carries its own
-    payload (HTTP-URL, base64-inline, video, audio) and any per-case
-    overrides on top of the parent :class:`TopologyConfig`.
+    inference payload (HTTP-URL, base64-inline, video, audio), optional
+    follow-up payloads such as metrics checks, and any per-case overrides
+    on top of the parent :class:`TopologyConfig`.
 
-    ``payload`` is the only required field; everything else either inherits
-    from the parent ``TopologyConfig`` (marks, timeout) or extends it
-    (extra script args, env overlay).
+    ``payload`` is the only required field; follow-up payloads run in order
+    after it. Everything else either inherits from the parent
+    ``TopologyConfig`` (marks, timeout) or extends it (extra script args,
+    env overlay).
     """
 
     payload: BasePayload  # required — fully formed test payload
+    followup_payloads: list[BasePayload] = field(default_factory=list)
     suffix: str = ""  # appended to config key; "" yields the bare topology key
     extra_script_args: list[str] = field(default_factory=list)
     marks: list[Any] = field(default_factory=list)  # if empty, inherit topology marks
@@ -565,7 +568,7 @@ def make_multimodal_configs(
                 script_args=list(base_script_args) + list(case.extra_script_args),
                 marks=marks,
                 delayed_start=topo_cfg.delayed_start,
-                request_payloads=[case.payload],
+                request_payloads=[case.payload, *case.followup_payloads],
                 env={**topo_env, **case.env},
             )
 

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -18,6 +18,7 @@ from tests.utils.payloads import (
     EmbeddingPayload,
     GuidedDecodingChatPayload,
     ImagesPayload,
+    ImageTokenMetricsPayload,
     KvEventMetricsPayload,
     LMCacheMetricsPayload,
     MetricsPayload,
@@ -346,6 +347,20 @@ def metric_payload_default(
     else:
         # Default to base MetricsPayload for unknown backends
         return MetricsPayload(**common_args)
+
+
+def image_token_metrics_payload(
+    min_num_requests: int = 1,
+    expected_log: Optional[List[str]] = None,
+) -> ImageTokenMetricsPayload:
+    """Create a frontend image-token aggregate metrics check."""
+    return ImageTokenMetricsPayload(
+        body={},
+        repeat_count=1,
+        expected_log=expected_log or [],
+        expected_response=[],
+        min_num_requests=min_num_requests,
+    )
 
 
 def kv_events_metrics_payload(

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1712,6 +1712,62 @@ class MetricsPayload(BasePayload):
 
 
 @dataclass
+class ImageTokenMetricsPayload(MetricsPayload):
+    """Validate frontend image-token usage aggregates for one model."""
+
+    model: Optional[str] = None
+    port: int = DefaultPort.FRONTEND.value
+
+    def with_model(self, model: str) -> "ImageTokenMetricsPayload":
+        payload = deepcopy(self)
+        payload.model = model
+        return payload
+
+    def _get_common_metric_checks(self) -> list[MetricCheck]:
+        if self.model is None:
+            raise ValueError("ImageTokenMetricsPayload requires a model")
+
+        prefix = prometheus_names.name_prefix.FRONTEND
+        metric = prometheus_names.frontend_service.IMAGE_TOKENS_PER_REQUEST
+        count_name = f"{prefix}_{metric}_count"
+        sum_name = f"{prefix}_{metric}_sum"
+        escaped_model = re.escape(self.model)
+
+        def model_metric_pattern(name: str) -> str:
+            return (
+                rf'{re.escape(name)}\{{(?:[^}}]*,)?model="{escaped_model}"'
+                r"(?:,[^}]*)?\}"
+                r"\s+([\d.eE+-]+)"
+            )
+
+        return [
+            MetricCheck(
+                name=count_name,
+                pattern=model_metric_pattern,
+                validator=lambda value: int(float(value)) >= self.min_num_requests,
+                error_msg=lambda name, value: (
+                    f"{name} has count {value}, expected at least "
+                    f"{self.min_num_requests}"
+                ),
+                success_msg=lambda name, value: (
+                    f"SUCCESS: Found {name} with count: {value}"
+                ),
+            ),
+            MetricCheck(
+                name=sum_name,
+                pattern=model_metric_pattern,
+                validator=lambda value: float(value) > 0,
+                error_msg=lambda name, value: (
+                    f"{name} should contain positive image-token usage, got {value}"
+                ),
+                success_msg=lambda name, value: (
+                    f"SUCCESS: Found {name} with aggregate image-token usage: {value}"
+                ),
+            ),
+        ]
+
+
+@dataclass
 class VLLMMetricsPayload(MetricsPayload):
     """Metrics validation for vLLM backend with auto-label checks"""
 


### PR DESCRIPTION
#### Summary

This PR exposes `dynamo_frontend_image_tokens_per_request`, a frontend Prometheus histogram of calculated image-placeholder token counts for image-bearing requests. It adds no client response field or worker/backend logic; a sample is recorded only when every image dimension resolves and request-level processor overrides do not make the calculation unreliable.

**Repro**

Against a running Qwen3-VL deployment:

```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model": "Qwen/Qwen3-VL-2B-Instruct",
    "messages": [{
      "role": "user",
      "content": [
        {
          "type": "image_url",
          "image_url": {
            "url": "http://images.cocodataset.org/test2017/000000155781.jpg"
          }
        },
        {
          "type": "text",
          "text": "Describe this image."
        }
      ]
    }],
    "max_tokens": 8,
    "temperature": 0
  }' >/dev/null

curl -sS http://localhost:8000/metrics \
  | grep 'dynamo_frontend_image_tokens_per_request_\(count\|sum\)'
```

New behavior: the scrape includes `_count` and `_sum` series labeled by model. Unsupported models, incomplete image resolution, processor overrides, overflow, and text-only requests omit the image-token observation rather than reporting an unreliable value.

#### Details

`OpenAIPreprocessor` reuses the existing `MmCounter` while resolving image dimensions, safely sums counts in private request state, and carries the optional total through the frontend postprocessor metrics path. The pinned registry covers Qwen2-VL, Qwen2.5-VL, Qwen3-VL, Qwen3.5/3.6, LLaVA-1.5/NeXT, Llama 4 Vision, Phi-3 Vision, and Kimi-K2.5/2.6.

`LLMMetricAnnotation` carries the optional internal value, and `ResponseMetricCollector` latches it once into a model-labeled, power-of-two-bucketed histogram. The typed metrics field remains `serde(skip)`, so the value is absent from OpenAI-compatible client JSON. Existing public preprocessor, multimodal-count, and collector APIs remain intact.

Fastokens continues to disable MM-aware KV routing, but counting remains available. Because counting requires dimensions, supported Fastokens VLMs now initialize the existing SSRF-aware dimension-fetch client at startup, surfacing TLS/config initialization failures at deployment time instead of the first request.

#### Validation

- `cargo check -p dynamo-llm --no-default-features`
- `cargo check -p dynamo-llm --no-default-features --features mm-routing`
- `cargo test -p dynamo-llm --no-default-features --features mm-routing --lib image_token_` (2 passed)
- vLLM: `python -m pytest --models-dir=/root/.cache/huggingface -xvv 'tests/serve/test_vllm.py::test_serve_deployment[mm_agg_qwen3.5-0.8b-2]'` (1 passed; count 1, sum 256)
- SGLang: `python -m pytest --models-dir=/root/.cache/huggingface -xvv 'tests/serve/test_sglang.py::test_sglang_deployment[multimodal_agg_fd_qwen-4]'` (1 passed; count 1, sum 256)
- TensorRT-LLM: `python -m pytest --models-dir=/root/.cache/huggingface -xvv 'tests/serve/test_trtllm.py::test_deployment[aggregated_multimodal_frontend_decoding-2]'` (1 passed; count 1, sum 256; local dev-image NIXL package paths exposed)
- `pre-commit run --files <touched Python files>`

#### Related Issues

- Resolves DIS-2313


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for estimated image-placeholder tokens per multimodal request.
  * Image token estimates are now calculated during preprocessing and included in request metrics.
  * Added support for image-token tracking across streaming and final usage metrics.

* **Bug Fixes**
  * Improved conservative handling of image-token estimates when image data is incomplete or overridden.
  * Disabled multimodal KV routing for fast tokenizer backends while retaining image-token counting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

