### PR TITLE
feat(router): add parent-aware placement for subagent sessions

### DIFF
--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -30,6 +30,7 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "active_prefill_tokens_threshold",
     "active_prefill_tokens_threshold_frac",
     "session_affinity_ttl_secs",
+    "session_affinity_grouping",
 )
 
 _ENFORCE_DISAGG_DEPRECATION = (
@@ -70,6 +71,7 @@ class RouterConfigBase(ConfigBase):
     min_initial_workers: int
     enforce_disagg: bool
     session_affinity_ttl_secs: Optional[int]
+    session_affinity_grouping: Optional[str]
     active_decode_blocks_threshold: Optional[float]
     active_prefill_tokens_threshold: Optional[int]
     active_prefill_tokens_threshold_frac: Optional[float]
@@ -203,6 +205,18 @@ class RouterArgGroup(ArgGroup):
             ),
             arg_type=int,
             dest="session_affinity_ttl_secs",
+        )
+        add_argument(
+            g,
+            flag_name="--router-session-affinity-grouping",
+            env_var="DYN_ROUTER_SESSION_AFFINITY_GROUPING",
+            default=None,
+            help=(
+                "Prefer the parent or lineage-root affinity target for a child session's "
+                "first placement. Requires --router-session-affinity-ttl-secs."
+            ),
+            choices=("parent", "root"),
+            dest="session_affinity_grouping",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -20,7 +20,12 @@ from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import add_argument, nullable_float, nullable_int
+from dynamo.common.configuration.utils import (
+    add_argument,
+    add_negatable_bool_argument,
+    nullable_float,
+    nullable_int,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +35,7 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "active_prefill_tokens_threshold",
     "active_prefill_tokens_threshold_frac",
     "session_affinity_ttl_secs",
-    "session_affinity_grouping",
+    "parent_affinity",
 )
 
 _ENFORCE_DISAGG_DEPRECATION = (
@@ -71,7 +76,7 @@ class RouterConfigBase(ConfigBase):
     min_initial_workers: int
     enforce_disagg: bool
     session_affinity_ttl_secs: Optional[int]
-    session_affinity_grouping: Optional[str]
+    parent_affinity: bool
     active_decode_blocks_threshold: Optional[float]
     active_prefill_tokens_threshold: Optional[int]
     active_prefill_tokens_threshold_frac: Optional[float]
@@ -206,17 +211,16 @@ class RouterArgGroup(ArgGroup):
             arg_type=int,
             dest="session_affinity_ttl_secs",
         )
-        add_argument(
+        add_negatable_bool_argument(
             g,
-            flag_name="--router-session-affinity-grouping",
-            env_var="DYN_ROUTER_SESSION_AFFINITY_GROUPING",
-            default=None,
+            flag_name="--router-parent-affinity",
+            env_var="DYN_ROUTER_PARENT_AFFINITY",
+            default=False,
             help=(
-                "Prefer the parent or lineage-root affinity target for a child session's "
-                "first placement. Requires --router-session-affinity-ttl-secs."
+                "Prefer the parent's affinity target for a child session's first "
+                "placement. Requires --router-session-affinity-ttl-secs."
             ),
-            choices=("parent", "root"),
-            dest="session_affinity_grouping",
+            dest="parent_affinity",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -378,6 +378,7 @@ def test_frontend_rejection_thresholds_default_to_none(
         "active_prefill_tokens_threshold": None,
         "active_prefill_tokens_threshold_frac": None,
         "session_affinity_ttl_secs": None,
+        "session_affinity_grouping": None,
     }
     assert "busy-worker rejection disabled" in caplog.text
 
@@ -506,6 +507,7 @@ def test_all_rejection_thresholds_and_queue_override_are_forwarded(
         "active_prefill_tokens_threshold": 1000,
         "active_prefill_tokens_threshold_frac": 2.0,
         "session_affinity_ttl_secs": None,
+        "session_affinity_grouping": None,
     }
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
@@ -650,11 +652,13 @@ def test_rejection_threshold_validation_rejects_invalid_values(
 
 def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", raising=False)
+    monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", raising=False)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
     config = FrontendConfig.from_cli_args(parser.parse_args([]))
     config.validate()
     assert config.session_affinity_ttl_secs is None
+    assert config.session_affinity_grouping is None
     assert config.router_kwargs()["session_affinity_ttl_secs"] is None
 
     monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", "600")
@@ -672,6 +676,40 @@ def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     )
     config.validate()
     assert config.session_affinity_ttl_secs == 900
+
+
+def test_session_affinity_grouping_cli_and_environment(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", raising=False)
+    monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(
+            [
+                "--router-session-affinity-ttl-secs",
+                "600",
+                "--router-session-affinity-grouping",
+                "parent",
+            ]
+        )
+    )
+    config.validate()
+    assert config.router_kwargs()["session_affinity_grouping"] == "parent"
+
+    monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", "root")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(["--router-session-affinity-ttl-secs", "600"])
+    )
+    config.validate()
+    assert config.session_affinity_grouping == "root"
+
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    with pytest.raises(ValueError, match="router-session-affinity-grouping"):
+        config.validate()
 
 
 @pytest.mark.parametrize("ttl", [0, 31_536_001])

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -378,7 +378,7 @@ def test_frontend_rejection_thresholds_default_to_none(
         "active_prefill_tokens_threshold": None,
         "active_prefill_tokens_threshold_frac": None,
         "session_affinity_ttl_secs": None,
-        "session_affinity_grouping": None,
+        "parent_affinity": False,
     }
     assert "busy-worker rejection disabled" in caplog.text
 
@@ -507,7 +507,7 @@ def test_all_rejection_thresholds_and_queue_override_are_forwarded(
         "active_prefill_tokens_threshold": 1000,
         "active_prefill_tokens_threshold_frac": 2.0,
         "session_affinity_ttl_secs": None,
-        "session_affinity_grouping": None,
+        "parent_affinity": False,
     }
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
@@ -652,13 +652,13 @@ def test_rejection_threshold_validation_rejects_invalid_values(
 
 def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", raising=False)
-    monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", raising=False)
+    monkeypatch.delenv("DYN_ROUTER_PARENT_AFFINITY", raising=False)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
     config = FrontendConfig.from_cli_args(parser.parse_args([]))
     config.validate()
     assert config.session_affinity_ttl_secs is None
-    assert config.session_affinity_grouping is None
+    assert config.parent_affinity is False
     assert config.router_kwargs()["session_affinity_ttl_secs"] is None
 
     monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", "600")
@@ -678,9 +678,9 @@ def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     assert config.session_affinity_ttl_secs == 900
 
 
-def test_session_affinity_grouping_cli_and_environment(monkeypatch) -> None:
+def test_parent_affinity_cli_and_environment(monkeypatch) -> None:
     monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", raising=False)
-    monkeypatch.delenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", raising=False)
+    monkeypatch.delenv("DYN_ROUTER_PARENT_AFFINITY", raising=False)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
     config = FrontendConfig.from_cli_args(
@@ -688,27 +688,26 @@ def test_session_affinity_grouping_cli_and_environment(monkeypatch) -> None:
             [
                 "--router-session-affinity-ttl-secs",
                 "600",
-                "--router-session-affinity-grouping",
-                "parent",
+                "--router-parent-affinity",
             ]
         )
     )
     config.validate()
-    assert config.router_kwargs()["session_affinity_grouping"] == "parent"
+    assert config.router_kwargs()["parent_affinity"] is True
 
-    monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_GROUPING", "root")
+    monkeypatch.setenv("DYN_ROUTER_PARENT_AFFINITY", "1")
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
     config = FrontendConfig.from_cli_args(
         parser.parse_args(["--router-session-affinity-ttl-secs", "600"])
     )
     config.validate()
-    assert config.session_affinity_grouping == "root"
+    assert config.parent_affinity is True
 
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
     config = FrontendConfig.from_cli_args(parser.parse_args([]))
-    with pytest.raises(ValueError, match="router-session-affinity-grouping"):
+    with pytest.raises(ValueError, match="router-parent-affinity"):
         config.validate()
 
 

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -118,13 +118,9 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
                 "--router-session-affinity-ttl-secs must be between 1 and "
                 f"{_MAX_SESSION_AFFINITY_TTL_SECS}"
             )
-        if (
-            self.session_affinity_grouping is not None
-            and self.session_affinity_ttl_secs is None
-        ):
+        if self.parent_affinity and self.session_affinity_ttl_secs is None:
             raise ValueError(
-                "--router-session-affinity-grouping requires "
-                "--router-session-affinity-ttl-secs"
+                "--router-parent-affinity requires --router-session-affinity-ttl-secs"
             )
         if self.tokenizer_backend not in self._VALID_TOKENIZER_BACKENDS:
             raise ValueError(

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -118,6 +118,14 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
                 "--router-session-affinity-ttl-secs must be between 1 and "
                 f"{_MAX_SESSION_AFFINITY_TTL_SECS}"
             )
+        if (
+            self.session_affinity_grouping is not None
+            and self.session_affinity_ttl_secs is None
+        ):
+            raise ValueError(
+                "--router-session-affinity-grouping requires "
+                "--router-session-affinity-ttl-secs"
+            )
         if self.tokenizer_backend not in self._VALID_TOKENIZER_BACKENDS:
             raise ValueError(
                 f"--tokenizer: invalid value '{self.tokenizer_backend}' "

--- a/docs/agents/session-ids.md
+++ b/docs/agents/session-ids.md
@@ -7,7 +7,7 @@ subtitle: Identify agent sessions from supported coding agents and custom client
 
 A session ID is the stable identifier Dynamo uses for one agent reasoning/tool chain. A root agent, planner, researcher subagent, or OpenCode subtask can each have its own session. Every LLM request in that chain should carry the same `session_id`; child sessions can also carry a `parent_session_id` so traces and replay tools can rebuild the tree. Some academic papers also call this a `program_id`.
 
-Session identity is passive metadata. Sending `X-Dynamo-Session-ID` does not enable sticky sessions or change request placement. Tracing records the identity when `DYN_REQUEST_TRACE` is enabled, and a session-aware routing policy can consume it only when that policy is configured separately.
+Session identity is passive metadata. Sending `X-Dynamo-Session-ID` does not enable sticky sessions or change request placement. Tracing records the identity when `DYN_REQUEST_TRACE` is enabled, and a session-aware routing policy can consume it only when that policy is configured separately. For example, the router's experimental [parent-aware session affinity](../components/router/router-configuration.md#session-affinity) can use `parent_session_id` to seed a child's first placement.
 
 ## Session ID Inputs
 

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -39,7 +39,7 @@ explains when to adjust these settings.
 | `--router-mode` | `DYN_ROUTER_MODE` | `round-robin` | Routing strategy: `round-robin`, `random`, `power-of-two`, `kv`, `direct`, `least-loaded`, or `device-aware-weighted`. `power-of-two` samples two workers and selects the one with fewer in-flight requests |
 | `--router-min-initial-workers` | `DYN_ROUTER_MIN_INITIAL_WORKERS` | `0` | Minimum workers required before router startup continues. `0` disables the startup wait |
 | `--router-session-affinity-ttl-secs` | `DYN_ROUTER_SESSION_AFFINITY_TTL_SECS` | unset | Enable session affinity and best-effort binding sync with this router-local idle TTL |
-| `--router-session-affinity-grouping` | `DYN_ROUTER_SESSION_AFFINITY_GROUPING` | unset | Experimental first-placement preference for child sessions: `parent` prefers the immediate parent's binding; `root` prefers the lineage root. Requires session affinity |
+| `--router-parent-affinity` / `--no-router-parent-affinity` | `DYN_ROUTER_PARENT_AFFINITY` | `false` | Experimental preference for the immediate parent's binding when placing a child session for the first time. Requires session affinity |
 | `--decode-fallback` / `--no-decode-fallback` | `DYN_DECODE_FALLBACK` | `false` | Fall back to aggregated mode when prefill workers are unavailable |
 
 ### KV Scoring and Cache Locality

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -39,6 +39,7 @@ explains when to adjust these settings.
 | `--router-mode` | `DYN_ROUTER_MODE` | `round-robin` | Routing strategy: `round-robin`, `random`, `power-of-two`, `kv`, `direct`, `least-loaded`, or `device-aware-weighted`. `power-of-two` samples two workers and selects the one with fewer in-flight requests |
 | `--router-min-initial-workers` | `DYN_ROUTER_MIN_INITIAL_WORKERS` | `0` | Minimum workers required before router startup continues. `0` disables the startup wait |
 | `--router-session-affinity-ttl-secs` | `DYN_ROUTER_SESSION_AFFINITY_TTL_SECS` | unset | Enable session affinity and best-effort binding sync with this router-local idle TTL |
+| `--router-session-affinity-grouping` | `DYN_ROUTER_SESSION_AFFINITY_GROUPING` | unset | Experimental first-placement preference for child sessions: `parent` prefers the immediate parent's binding; `root` prefers the lineage root. Requires session affinity |
 | `--decode-fallback` / `--no-decode-fallback` | `DYN_DECODE_FALLBACK` | `false` | Fall back to aggregated mode when prefill workers are unavailable |
 
 ### KV Scoring and Cache Locality

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -125,6 +125,19 @@ error, or cancellation, the idle timer restarts. A missing bound worker or a
 non-cancellation selection, setup, dispatch, or target-validation failure invalidates
 the binding.
 
+**Experimental.** Set `--router-session-affinity-grouping parent` (or
+`DYN_ROUTER_SESSION_AFFINITY_GROUPING=parent`) to prefer the immediate parent's
+worker and data-parallel rank when placing an unbound child session for the first
+time. Use `root` to prefer the root session's binding for every descendant. This
+option requires `--router-session-affinity-ttl-secs`.
+
+Parent-aware placement is a soft initialization preference, not a group pin. An
+explicit worker target takes precedence for an unbound child; after binding, normal
+affinity target validation applies. If the preferred target is unavailable or rejected
+by the normal load and eligibility checks, the router falls back to ordinary selection
+and binds the child there. Later child requests use that child's own binding even if
+the parent moves.
+
 The configured value is the idle timeout. It is independent of
 `--router-ttl-secs` and `--router-predicted-ttl-secs`. Omit the session-affinity
 option to keep affinity disabled.
@@ -133,7 +146,8 @@ When session affinity is enabled, routers synchronize affinity bindings through 
 Runtime event plane. The origin publishes a binding after successful dispatch so
 concurrent requests can observe it, then publishes it again when the request lease
 ends so peer idle timers restart when the request becomes idle. The extra event
-fanout is an intentional tradeoff.
+fanout is an intentional tradeoff. Root grouping also carries the derived lineage
+root with these best-effort updates.
 
 Synchronization is advisory. Each replica owns its local idle TTL and uses the
 first live binding it observes. A matching update refreshes that local deadline,

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -125,10 +125,9 @@ error, or cancellation, the idle timer restarts. A missing bound worker or a
 non-cancellation selection, setup, dispatch, or target-validation failure invalidates
 the binding.
 
-**Experimental.** Set `--router-session-affinity-grouping parent` (or
-`DYN_ROUTER_SESSION_AFFINITY_GROUPING=parent`) to prefer the immediate parent's
-worker and data-parallel rank when placing an unbound child session for the first
-time. Use `root` to prefer the root session's binding for every descendant. This
+**Experimental.** Set `--router-parent-affinity` (or
+`DYN_ROUTER_PARENT_AFFINITY=1`) to prefer the immediate parent's worker and
+data-parallel rank when placing an unbound child session for the first time. This
 option requires `--router-session-affinity-ttl-secs`.
 
 Parent-aware placement is a soft initialization preference, not a group pin. An
@@ -146,8 +145,7 @@ When session affinity is enabled, routers synchronize affinity bindings through 
 Runtime event plane. The origin publishes a binding after successful dispatch so
 concurrent requests can observe it, then publishes it again when the request lease
 ends so peer idle timers restart when the request becomes idle. The extra event
-fanout is an intentional tradeoff. Root grouping also carries the derived lineage
-root with these best-effort updates.
+fanout is an intentional tradeoff.
 
 Synchronization is advisory. Each replica owns its local idle TTL and uses the
 first live binding it observes. A matching update refreshes that local deadline,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -851,6 +851,7 @@ pub unsafe extern "C" fn create_routers(
             Some(prefill_config),
             None,
             None,
+            None,
             model_name.clone(),
             actual_namespace.clone(),
             enable_eagle,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -851,7 +851,7 @@ pub unsafe extern "C" fn create_routers(
             Some(prefill_config),
             None,
             None,
-            None,
+            false,
             model_name.clone(),
             actual_namespace.clone(),
             enable_eagle,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -427,13 +427,13 @@ pub struct RouterConfig {
     /// Threshold for active prefill tokens as fraction of max_num_batched_tokens
     active_prefill_tokens_threshold_frac: Option<f64>,
     session_affinity_ttl_secs: Option<u64>,
-    session_affinity_grouping: Option<dynamo_llm::session_affinity::SessionAffinityGrouping>,
+    parent_affinity: bool,
 }
 
 #[pymethods]
 impl RouterConfig {
     #[new]
-    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None, session_affinity_grouping=None))]
+    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None, parent_affinity=false))]
     pub fn new(
         mode: RouterMode,
         config: Option<KvRouterConfig>,
@@ -442,7 +442,7 @@ impl RouterConfig {
         active_prefill_tokens_threshold_frac: Option<f64>,
         enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
-        session_affinity_grouping: Option<&str>,
+        parent_affinity: bool,
     ) -> PyResult<Self> {
         if enforce_disagg {
             static WARN_ONCE: std::sync::Once = std::sync::Once::new();
@@ -457,15 +457,11 @@ impl RouterConfig {
                 "session_affinity_ttl_secs must be between 1 and 31536000",
             ));
         }
-        if session_affinity_grouping.is_some() && session_affinity_ttl_secs.is_none() {
+        if parent_affinity && session_affinity_ttl_secs.is_none() {
             return Err(PyValueError::new_err(
-                "session_affinity_grouping requires session_affinity_ttl_secs",
+                "parent_affinity requires session_affinity_ttl_secs",
             ));
         }
-        let session_affinity_grouping = session_affinity_grouping
-            .map(str::parse)
-            .transpose()
-            .map_err(PyValueError::new_err)?;
         RsLoadThresholdConfig {
             active_decode_blocks_threshold,
             active_prefill_tokens_threshold,
@@ -480,7 +476,7 @@ impl RouterConfig {
             active_prefill_tokens_threshold,
             active_prefill_tokens_threshold_frac,
             session_affinity_ttl_secs,
-            session_affinity_grouping,
+            parent_affinity,
         })
     }
 }
@@ -497,7 +493,7 @@ impl From<RouterConfig> for RsRouterConfig {
             },
             enforce_disagg: false,
             session_affinity_ttl_secs: rc.session_affinity_ttl_secs,
-            session_affinity_grouping: rc.session_affinity_grouping,
+            parent_affinity: rc.parent_affinity,
         }
     }
 }

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -427,12 +427,13 @@ pub struct RouterConfig {
     /// Threshold for active prefill tokens as fraction of max_num_batched_tokens
     active_prefill_tokens_threshold_frac: Option<f64>,
     session_affinity_ttl_secs: Option<u64>,
+    session_affinity_grouping: Option<dynamo_llm::session_affinity::SessionAffinityGrouping>,
 }
 
 #[pymethods]
 impl RouterConfig {
     #[new]
-    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None))]
+    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None, session_affinity_grouping=None))]
     pub fn new(
         mode: RouterMode,
         config: Option<KvRouterConfig>,
@@ -441,6 +442,7 @@ impl RouterConfig {
         active_prefill_tokens_threshold_frac: Option<f64>,
         enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
+        session_affinity_grouping: Option<&str>,
     ) -> PyResult<Self> {
         if enforce_disagg {
             static WARN_ONCE: std::sync::Once = std::sync::Once::new();
@@ -455,6 +457,15 @@ impl RouterConfig {
                 "session_affinity_ttl_secs must be between 1 and 31536000",
             ));
         }
+        if session_affinity_grouping.is_some() && session_affinity_ttl_secs.is_none() {
+            return Err(PyValueError::new_err(
+                "session_affinity_grouping requires session_affinity_ttl_secs",
+            ));
+        }
+        let session_affinity_grouping = session_affinity_grouping
+            .map(str::parse)
+            .transpose()
+            .map_err(PyValueError::new_err)?;
         RsLoadThresholdConfig {
             active_decode_blocks_threshold,
             active_prefill_tokens_threshold,
@@ -469,6 +480,7 @@ impl RouterConfig {
             active_prefill_tokens_threshold,
             active_prefill_tokens_threshold_frac,
             session_affinity_ttl_secs,
+            session_affinity_grouping,
         })
     }
 }
@@ -485,6 +497,7 @@ impl From<RouterConfig> for RsRouterConfig {
             },
             enforce_disagg: false,
             session_affinity_ttl_secs: rc.session_affinity_ttl_secs,
+            session_affinity_grouping: rc.session_affinity_grouping,
         }
     }
 }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1676,29 +1676,25 @@ impl KvRouter {
     /// Note: Worker type for Prometheus metrics is inferred from the endpoint name/component
     /// (contains "prefill") or by `router_track_active_blocks` being disabled.
     #[new]
-    #[pyo3(signature = (endpoint, block_size, kv_router_config, aic_perf_config=None, session_affinity_ttl_secs=None, session_affinity_grouping=None))]
+    #[pyo3(signature = (endpoint, block_size, kv_router_config, aic_perf_config=None, session_affinity_ttl_secs=None, parent_affinity=false))]
     fn new(
         endpoint: &Endpoint,
         block_size: usize,
         kv_router_config: &super::entrypoint::KvRouterConfig,
         aic_perf_config: Option<&AicPerfConfig>,
         session_affinity_ttl_secs: Option<u64>,
-        session_affinity_grouping: Option<&str>,
+        parent_affinity: bool,
     ) -> PyResult<Self> {
         if session_affinity_ttl_secs.is_some_and(|ttl| !(1..=31_536_000).contains(&ttl)) {
             return Err(PyValueError::new_err(
                 "session_affinity_ttl_secs must be between 1 and 31536000",
             ));
         }
-        if session_affinity_grouping.is_some() && session_affinity_ttl_secs.is_none() {
+        if parent_affinity && session_affinity_ttl_secs.is_none() {
             return Err(PyValueError::new_err(
-                "session_affinity_grouping requires session_affinity_ttl_secs",
+                "parent_affinity requires session_affinity_ttl_secs",
             ));
         }
-        let session_affinity_grouping = session_affinity_grouping
-            .map(str::parse)
-            .transpose()
-            .map_err(PyValueError::new_err)?;
         let prefill_load_estimator = aic_perf_config
             .map(|config| {
                 Python::with_gil(|py| {
@@ -1755,7 +1751,7 @@ impl KvRouter {
                 push_router,
                 kv_router,
                 session_affinity_ttl_secs.map(Duration::from_secs),
-                session_affinity_grouping,
+                parent_affinity,
             )
             .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1676,19 +1676,29 @@ impl KvRouter {
     /// Note: Worker type for Prometheus metrics is inferred from the endpoint name/component
     /// (contains "prefill") or by `router_track_active_blocks` being disabled.
     #[new]
-    #[pyo3(signature = (endpoint, block_size, kv_router_config, aic_perf_config=None, session_affinity_ttl_secs=None))]
+    #[pyo3(signature = (endpoint, block_size, kv_router_config, aic_perf_config=None, session_affinity_ttl_secs=None, session_affinity_grouping=None))]
     fn new(
         endpoint: &Endpoint,
         block_size: usize,
         kv_router_config: &super::entrypoint::KvRouterConfig,
         aic_perf_config: Option<&AicPerfConfig>,
         session_affinity_ttl_secs: Option<u64>,
+        session_affinity_grouping: Option<&str>,
     ) -> PyResult<Self> {
         if session_affinity_ttl_secs.is_some_and(|ttl| !(1..=31_536_000).contains(&ttl)) {
             return Err(PyValueError::new_err(
                 "session_affinity_ttl_secs must be between 1 and 31536000",
             ));
         }
+        if session_affinity_grouping.is_some() && session_affinity_ttl_secs.is_none() {
+            return Err(PyValueError::new_err(
+                "session_affinity_grouping requires session_affinity_ttl_secs",
+            ));
+        }
+        let session_affinity_grouping = session_affinity_grouping
+            .map(str::parse)
+            .transpose()
+            .map_err(PyValueError::new_err)?;
         let prefill_load_estimator = aic_perf_config
             .map(|config| {
                 Python::with_gil(|py| {
@@ -1745,6 +1755,7 @@ impl KvRouter {
                 push_router,
                 kv_router,
                 session_affinity_ttl_secs.map(Duration::from_secs),
+                session_affinity_grouping,
             )
             .map_err(to_pyerr)?;
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1646,6 +1646,7 @@ class RouterConfig:
         active_prefill_tokens_threshold_frac: Optional[float] = None,
         enforce_disagg: bool = False,
         session_affinity_ttl_secs: Optional[int] = None,
+        session_affinity_grouping: Optional[str] = None,
     ) -> None:
         """
         Create a RouterConfig.
@@ -1658,6 +1659,7 @@ class RouterConfig:
             active_prefill_tokens_threshold_frac: Fraction of max_num_batched_tokens for busy detection
             enforce_disagg: Deprecated and ignored. Routing topology and readiness come from registered worker types.
             session_affinity_ttl_secs: Router-local session-affinity idle TTL in seconds.
+            session_affinity_grouping: Initial child placement grouping, either ``parent`` or ``root``.
         """
         ...
 
@@ -2920,6 +2922,8 @@ class KvRouter:
         block_size: int,
         kv_router_config: KvRouterConfig,
         aic_perf_config: Optional[AicPerfConfig] = None,
+        session_affinity_ttl_secs: Optional[int] = None,
+        session_affinity_grouping: Optional[str] = None,
     ) -> None:
         """
         Create a new KvRouter instance.
@@ -2929,6 +2933,8 @@ class KvRouter:
             block_size: The KV cache block size
             kv_router_config: Configuration for the KV router
             aic_perf_config: Optional AIC perf-model config for effective prefill load tracking
+            session_affinity_ttl_secs: Router-local session-affinity idle TTL in seconds
+            session_affinity_grouping: Initial child placement grouping, either ``parent`` or ``root``
         """
         ...
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1646,7 +1646,7 @@ class RouterConfig:
         active_prefill_tokens_threshold_frac: Optional[float] = None,
         enforce_disagg: bool = False,
         session_affinity_ttl_secs: Optional[int] = None,
-        session_affinity_grouping: Optional[str] = None,
+        parent_affinity: bool = False,
     ) -> None:
         """
         Create a RouterConfig.
@@ -1659,7 +1659,7 @@ class RouterConfig:
             active_prefill_tokens_threshold_frac: Fraction of max_num_batched_tokens for busy detection
             enforce_disagg: Deprecated and ignored. Routing topology and readiness come from registered worker types.
             session_affinity_ttl_secs: Router-local session-affinity idle TTL in seconds.
-            session_affinity_grouping: Initial child placement grouping, either ``parent`` or ``root``.
+            parent_affinity: Prefer the parent's target for a child's initial placement.
         """
         ...
 
@@ -2923,7 +2923,7 @@ class KvRouter:
         kv_router_config: KvRouterConfig,
         aic_perf_config: Optional[AicPerfConfig] = None,
         session_affinity_ttl_secs: Optional[int] = None,
-        session_affinity_grouping: Optional[str] = None,
+        parent_affinity: bool = False,
     ) -> None:
         """
         Create a new KvRouter instance.
@@ -2934,7 +2934,7 @@ class KvRouter:
             kv_router_config: Configuration for the KV router
             aic_perf_config: Optional AIC perf-model config for effective prefill load tracking
             session_affinity_ttl_secs: Router-local session-affinity idle TTL in seconds
-            session_affinity_grouping: Initial child placement grouping, either ``parent`` or ``root``
+            parent_affinity: Prefer the parent's target for a child's initial placement
         """
         ...
 

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -1174,7 +1174,7 @@ mod tests {
             std::sync::Arc::new(crate::discovery::ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
             None,
-            None,
+            false,
         );
         pr.mark_active_for_test();
         pr.deactivate();
@@ -1214,7 +1214,7 @@ mod tests {
                 Arc::new(crate::discovery::ModelManager::new()),
                 dynamo_runtime::pipeline::RouterMode::RoundRobin,
                 None,
-                None,
+                false,
             );
             router.mark_active_for_test();
             worker_set.prefill_router = Some(router);

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -1174,6 +1174,7 @@ mod tests {
             std::sync::Arc::new(crate::discovery::ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
             None,
+            None,
         );
         pr.mark_active_for_test();
         pr.deactivate();
@@ -1212,6 +1213,7 @@ mod tests {
             let router = PrefillRouter::disabled(
                 Arc::new(crate::discovery::ModelManager::new()),
                 dynamo_runtime::pipeline::RouterMode::RoundRobin,
+                None,
                 None,
             );
             router.mark_active_for_test();

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -2952,7 +2952,7 @@ mod tests {
             std::sync::Arc::new(ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
             None,
-            None,
+            false,
         );
         pr.mark_active_for_test();
         ws.prefill_router = Some(pr);

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -2952,6 +2952,7 @@ mod tests {
             std::sync::Arc::new(ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
             None,
+            None,
         );
         pr.mark_active_for_test();
         ws.prefill_router = Some(pr);

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1673,7 +1673,7 @@ impl ModelWatcher {
                     Some(prefill_config),
                     self.prefill_load_estimator.clone(),
                     router_config.session_affinity_ttl_secs,
-                    router_config.session_affinity_grouping,
+                    router_config.parent_affinity,
                     model_name.clone(),
                     namespace.clone(),
                     prefill_enable_eagle,
@@ -1714,7 +1714,7 @@ impl ModelWatcher {
                         encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
-                        router_config.session_affinity_grouping,
+                        router_config.parent_affinity,
                     )
                     .await
                     .context("build_preprocessed_routing")?,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1673,6 +1673,7 @@ impl ModelWatcher {
                     Some(prefill_config),
                     self.prefill_load_estimator.clone(),
                     router_config.session_affinity_ttl_secs,
+                    router_config.session_affinity_grouping,
                     model_name.clone(),
                     namespace.clone(),
                     prefill_enable_eagle,
@@ -1713,6 +1714,7 @@ impl ModelWatcher {
                         encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
+                        router_config.session_affinity_grouping,
                     )
                     .await
                     .context("build_preprocessed_routing")?,

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backend::ExecutionContext, discovery::LoadThresholdConfig, engines::StreamingEngine,
     local_model::LocalModel, model_card::ModelDeploymentCard,
+    session_affinity::SessionAffinityGrouping,
     types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine,
 };
 
@@ -52,6 +53,8 @@ pub struct RouterConfig {
     pub enforce_disagg: bool,
     #[serde(default)]
     pub session_affinity_ttl_secs: Option<u64>,
+    #[serde(default)]
+    pub session_affinity_grouping: Option<SessionAffinityGrouping>,
 }
 
 impl RouterConfig {
@@ -62,6 +65,7 @@ impl RouterConfig {
             load_threshold_config: LoadThresholdConfig::default(),
             enforce_disagg: false,
             session_affinity_ttl_secs: None,
+            session_affinity_grouping: None,
         }
     }
 
@@ -80,6 +84,11 @@ impl RouterConfig {
 
     pub fn with_session_affinity_ttl_secs(mut self, ttl_secs: u64) -> Self {
         self.session_affinity_ttl_secs = Some(ttl_secs);
+        self
+    }
+
+    pub fn with_session_affinity_grouping(mut self, grouping: SessionAffinityGrouping) -> Self {
+        self.session_affinity_grouping = Some(grouping);
         self
     }
 }

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -19,7 +19,6 @@ use serde::{Deserialize, Serialize};
 use crate::{
     backend::ExecutionContext, discovery::LoadThresholdConfig, engines::StreamingEngine,
     local_model::LocalModel, model_card::ModelDeploymentCard,
-    session_affinity::SessionAffinityGrouping,
     types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine,
 };
 
@@ -54,7 +53,7 @@ pub struct RouterConfig {
     #[serde(default)]
     pub session_affinity_ttl_secs: Option<u64>,
     #[serde(default)]
-    pub session_affinity_grouping: Option<SessionAffinityGrouping>,
+    pub parent_affinity: bool,
 }
 
 impl RouterConfig {
@@ -65,7 +64,7 @@ impl RouterConfig {
             load_threshold_config: LoadThresholdConfig::default(),
             enforce_disagg: false,
             session_affinity_ttl_secs: None,
-            session_affinity_grouping: None,
+            parent_affinity: false,
         }
     }
 
@@ -87,8 +86,8 @@ impl RouterConfig {
         self
     }
 
-    pub fn with_session_affinity_grouping(mut self, grouping: SessionAffinityGrouping) -> Self {
-        self.session_affinity_grouping = Some(grouping);
+    pub fn with_parent_affinity(mut self) -> Self {
+        self.parent_affinity = true;
         self
     }
 }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -252,7 +252,7 @@ pub async fn build_preprocessed_routing(
     encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
-    session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
+    parent_affinity: bool,
 ) -> anyhow::Result<PreprocessedRouting> {
     // Fail fast on an unsupported LoRA + router-mode combination BEFORE waiting for the initial
     // worker set, so a misconfiguration surfaces immediately at startup rather than after the
@@ -270,7 +270,7 @@ pub async fn build_preprocessed_routing(
 
     let affinity = create_affinity_coordinator(
         session_affinity_ttl_secs.map(Duration::from_secs),
-        session_affinity_grouping,
+        parent_affinity,
         router_client.clone(),
     )
     .await?;
@@ -310,7 +310,7 @@ pub async fn build_preprocessed_routing(
             model_manager.clone(),
             router_mode,
             session_affinity_ttl_secs,
-            session_affinity_grouping,
+            parent_affinity,
         )
     });
     let encoder_router = encoder_chooser.unwrap_or_else(EncoderRouter::disabled);

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -252,6 +252,7 @@ pub async fn build_preprocessed_routing(
     encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
+    session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
 ) -> anyhow::Result<PreprocessedRouting> {
     // Fail fast on an unsupported LoRA + router-mode combination BEFORE waiting for the initial
     // worker set, so a misconfiguration surfaces immediately at startup rather than after the
@@ -269,6 +270,7 @@ pub async fn build_preprocessed_routing(
 
     let affinity = create_affinity_coordinator(
         session_affinity_ttl_secs.map(Duration::from_secs),
+        session_affinity_grouping,
         router_client.clone(),
     )
     .await?;
@@ -308,6 +310,7 @@ pub async fn build_preprocessed_routing(
             model_manager.clone(),
             router_mode,
             session_affinity_ttl_secs,
+            session_affinity_grouping,
         )
     });
     let encoder_router = encoder_chooser.unwrap_or_else(EncoderRouter::disabled);

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -34,7 +34,7 @@ impl PrefillRouter {
         model_manager: Arc<ModelManager>,
         router_mode: RouterMode,
         session_affinity_ttl_secs: Option<u64>,
-        session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
+        parent_affinity: bool,
     ) -> Arc<Self> {
         Arc::new(Self {
             prefill_router: std::sync::OnceLock::new(),
@@ -43,7 +43,7 @@ impl PrefillRouter {
             cancel_token: tokio_util::sync::CancellationToken::new(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
-            session_affinity_grouping,
+            parent_affinity,
             prefill_load_estimator: None,
             model_name: String::new(), // Not used for disabled router
             namespace: String::new(),  // Not used for disabled router
@@ -61,7 +61,7 @@ impl PrefillRouter {
         kv_router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         session_affinity_ttl_secs: Option<u64>,
-        session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
+        parent_affinity: bool,
         model_name: String,
         namespace: String,
         is_eagle: bool,
@@ -77,7 +77,7 @@ impl PrefillRouter {
             cancel_token: cancel_token.clone(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
-            session_affinity_grouping,
+            parent_affinity,
             prefill_load_estimator,
             model_name,
             namespace,
@@ -180,7 +180,7 @@ impl PrefillRouter {
             Self::attach_prefill_client(worker_monitor, &client);
             let affinity = create_affinity_coordinator(
                 self.session_affinity_ttl,
-                self.session_affinity_grouping,
+                self.parent_affinity,
                 client.clone(),
             )
             .await?;
@@ -205,7 +205,7 @@ impl PrefillRouter {
             Self::attach_prefill_client(worker_monitor, &client);
             let affinity = create_affinity_coordinator(
                 self.session_affinity_ttl,
-                self.session_affinity_grouping,
+                self.parent_affinity,
                 client.clone(),
             )
             .await?;

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -34,6 +34,7 @@ impl PrefillRouter {
         model_manager: Arc<ModelManager>,
         router_mode: RouterMode,
         session_affinity_ttl_secs: Option<u64>,
+        session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
     ) -> Arc<Self> {
         Arc::new(Self {
             prefill_router: std::sync::OnceLock::new(),
@@ -42,6 +43,7 @@ impl PrefillRouter {
             cancel_token: tokio_util::sync::CancellationToken::new(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
+            session_affinity_grouping,
             prefill_load_estimator: None,
             model_name: String::new(), // Not used for disabled router
             namespace: String::new(),  // Not used for disabled router
@@ -59,6 +61,7 @@ impl PrefillRouter {
         kv_router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         session_affinity_ttl_secs: Option<u64>,
+        session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
         model_name: String,
         namespace: String,
         is_eagle: bool,
@@ -74,6 +77,7 @@ impl PrefillRouter {
             cancel_token: cancel_token.clone(),
             router_mode,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
+            session_affinity_grouping,
             prefill_load_estimator,
             model_name,
             namespace,
@@ -174,8 +178,12 @@ impl PrefillRouter {
             // Extract client from kv_chooser to ensure shared state
             let client = kv_chooser.client().clone();
             Self::attach_prefill_client(worker_monitor, &client);
-            let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+            let affinity = create_affinity_coordinator(
+                self.session_affinity_ttl,
+                self.session_affinity_grouping,
+                client.clone(),
+            )
+            .await?;
 
             // Build the PushRouter for prefill with KV mode using the shared client
             let push_router = PushRouter::<PreprocessedRequest, Annotated<LLMEngineOutput>>::from_client_with_monitor(
@@ -195,8 +203,12 @@ impl PrefillRouter {
             // Create client for simple router
             let client = endpoint.client().await?;
             Self::attach_prefill_client(worker_monitor, &client);
-            let affinity =
-                create_affinity_coordinator(self.session_affinity_ttl, client.clone()).await?;
+            let affinity = create_affinity_coordinator(
+                self.session_affinity_ttl,
+                self.session_affinity_grouping,
+                client.clone(),
+            )
+            .await?;
 
             // Create simple push router with the frontend's router mode
             // Note: Per-worker metrics (active_prefill_tokens, active_decode_blocks) are only

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -141,6 +141,7 @@ pub struct PrefillRouter {
     cancel_token: CancellationToken,
     router_mode: RouterMode,
     session_affinity_ttl: Option<std::time::Duration>,
+    session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     /// Model name (used for logging / lifecycle messages).
     model_name: String,
@@ -561,6 +562,7 @@ mod tests {
         PrefillRouter::disabled(
             Arc::new(crate::discovery::ModelManager::new()),
             RouterMode::RoundRobin,
+            None,
             None,
         )
     }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -141,7 +141,7 @@ pub struct PrefillRouter {
     cancel_token: CancellationToken,
     router_mode: RouterMode,
     session_affinity_ttl: Option<std::time::Duration>,
-    session_affinity_grouping: Option<crate::session_affinity::SessionAffinityGrouping>,
+    parent_affinity: bool,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     /// Model name (used for logging / lifecycle messages).
     model_name: String,
@@ -563,7 +563,7 @@ mod tests {
             Arc::new(crate::discovery::ModelManager::new()),
             RouterMode::RoundRobin,
             None,
-            None,
+            false,
         )
     }
 

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -25,7 +25,8 @@ use crate::{
         timing::{RequestPhase, RoutingData},
     },
     session_affinity::{
-        AffinityAcquire, AffinityCoordinator, AffinityTarget, affinity_id, explicit_target,
+        AffinityAcquire, AffinityCoordinator, AffinityTarget, SessionAffinityGrouping, affinity_id,
+        explicit_target,
     },
 };
 
@@ -115,9 +116,10 @@ impl KvPushRouter {
         inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
         chooser: Arc<KvRouter>,
         session_affinity_ttl: Option<Duration>,
+        session_affinity_grouping: Option<SessionAffinityGrouping>,
     ) -> Result<Self, Error> {
         let affinity = session_affinity_ttl
-            .map(AffinityCoordinator::new)
+            .map(|ttl| AffinityCoordinator::new_with_grouping(ttl, session_affinity_grouping))
             .transpose()?;
 
         Ok(Self::new_with_coordinator(inner, chooser, affinity))
@@ -196,8 +198,13 @@ impl KvPushRouter {
             ));
         };
         let explicit = explicit_target(request, phase)?;
+        let parent_session_id = request
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.parent_session_id.as_deref());
         if is_query_only {
-            let target = affinity.query_target(&session_id, explicit)?;
+            let target =
+                affinity.query_target_with_lineage(&session_id, parent_session_id, explicit)?;
             let worker = target.and_then(affinity_worker);
             return Ok((
                 self.select_request(request, phase, true, worker).await?,
@@ -207,7 +214,12 @@ impl KvPushRouter {
 
         let request_context = request.context();
         let operation = affinity
-            .acquire_with_context(&session_id, explicit, request_context.as_ref())
+            .acquire_with_lineage(
+                &session_id,
+                parent_session_id,
+                explicit,
+                request_context.as_ref(),
+            )
             .await?;
         let worker = operation.target().and_then(affinity_worker);
         match self.select_request(request, phase, false, worker).await {
@@ -686,7 +698,9 @@ mod tests {
     use super::*;
     use crate::{
         local_model::runtime_config::ModelRuntimeConfig,
-        protocols::common::extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
+        protocols::common::extensions::{
+            AgentContext, SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
+        },
     };
 
     fn request() -> PreprocessedRequest {
@@ -912,7 +926,10 @@ mod tests {
         runtime.shutdown();
     }
 
-    async fn router(session_affinity_ttl: Option<Duration>) -> (KvPushRouter, Runtime) {
+    async fn router_with_grouping(
+        session_affinity_ttl: Option<Duration>,
+        session_affinity_grouping: Option<SessionAffinityGrouping>,
+    ) -> (KvPushRouter, Runtime) {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
             DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
@@ -953,8 +970,18 @@ mod tests {
         let inner = PushRouter::from_client(client, RouterMode::KV)
             .await
             .unwrap();
-        let router = KvPushRouter::new(inner, Arc::new(chooser), session_affinity_ttl).unwrap();
+        let router = KvPushRouter::new(
+            inner,
+            Arc::new(chooser),
+            session_affinity_ttl,
+            session_affinity_grouping,
+        )
+        .unwrap();
         (router, runtime)
+    }
+
+    async fn router(session_affinity_ttl: Option<Duration>) -> (KvPushRouter, Runtime) {
+        router_with_grouping(session_affinity_ttl, None).await
     }
 
     async fn track_request(
@@ -977,6 +1004,58 @@ mod tests {
     async fn session_affinity_disabled_does_not_create_coordinator() {
         let (router, runtime) = router(None).await;
         assert!(router.affinity.is_none());
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn parent_affinity_falls_back_when_the_parent_target_is_ineligible() {
+        let (router, runtime) = router_with_grouping(
+            Some(Duration::from_secs(10)),
+            Some(SessionAffinityGrouping::Parent),
+        )
+        .await;
+        let affinity = router.affinity.as_ref().unwrap();
+        let parent_id = SessionAffinityId::new("parent");
+        let AffinityAcquire::Initialize(parent) = affinity.acquire(&parent_id, None).await.unwrap()
+        else {
+            panic!("parent must initialize");
+        };
+        drop(
+            parent
+                .commit(AffinityTarget {
+                    worker_id: 99,
+                    dp_rank: Some(0),
+                })
+                .unwrap(),
+        );
+
+        let child_id = SessionAffinityId::new("child");
+        let mut content = request();
+        content.agent_context = Some(AgentContext {
+            session_id: child_id.as_str().to_string(),
+            parent_session_id: Some(parent_id.as_str().to_string()),
+            session_final: None,
+            kv_hints: None,
+        });
+        let mut child = Context::new(content);
+        child.insert(SESSION_AFFINITY_CONTEXT_KEY, child_id);
+
+        let (selection, operation) = router
+            .select_with_affinity(&child, RequestPhase::Aggregated, false)
+            .await
+            .unwrap();
+        assert_eq!(selection.instance_id, 7);
+        assert_eq!(operation.as_ref().unwrap().target(), None);
+        operation.unwrap().invalidate();
+        assert_eq!(
+            affinity.query_target(&parent_id, None).unwrap(),
+            Some(AffinityTarget {
+                worker_id: 99,
+                dp_rank: Some(0),
+            })
+        );
 
         drop(router);
         runtime.shutdown();

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -25,8 +25,7 @@ use crate::{
         timing::{RequestPhase, RoutingData},
     },
     session_affinity::{
-        AffinityAcquire, AffinityCoordinator, AffinityTarget, SessionAffinityGrouping, affinity_id,
-        explicit_target,
+        AffinityAcquire, AffinityCoordinator, AffinityTarget, affinity_id, explicit_target,
     },
 };
 
@@ -116,10 +115,10 @@ impl KvPushRouter {
         inner: PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>,
         chooser: Arc<KvRouter>,
         session_affinity_ttl: Option<Duration>,
-        session_affinity_grouping: Option<SessionAffinityGrouping>,
+        parent_affinity: bool,
     ) -> Result<Self, Error> {
         let affinity = session_affinity_ttl
-            .map(|ttl| AffinityCoordinator::new_with_grouping(ttl, session_affinity_grouping))
+            .map(|ttl| AffinityCoordinator::new_with_parent_affinity(ttl, parent_affinity))
             .transpose()?;
 
         Ok(Self::new_with_coordinator(inner, chooser, affinity))
@@ -204,7 +203,7 @@ impl KvPushRouter {
             .and_then(|context| context.parent_session_id.as_deref());
         if is_query_only {
             let target =
-                affinity.query_target_with_lineage(&session_id, parent_session_id, explicit)?;
+                affinity.query_target_with_parent(&session_id, parent_session_id, explicit)?;
             let worker = target.and_then(affinity_worker);
             return Ok((
                 self.select_request(request, phase, true, worker).await?,
@@ -214,7 +213,7 @@ impl KvPushRouter {
 
         let request_context = request.context();
         let operation = affinity
-            .acquire_with_lineage(
+            .acquire_with_parent(
                 &session_id,
                 parent_session_id,
                 explicit,
@@ -926,9 +925,9 @@ mod tests {
         runtime.shutdown();
     }
 
-    async fn router_with_grouping(
+    async fn router_with_parent_affinity(
         session_affinity_ttl: Option<Duration>,
-        session_affinity_grouping: Option<SessionAffinityGrouping>,
+        parent_affinity: bool,
     ) -> (KvPushRouter, Runtime) {
         let runtime = Runtime::from_current().unwrap();
         let distributed =
@@ -974,14 +973,14 @@ mod tests {
             inner,
             Arc::new(chooser),
             session_affinity_ttl,
-            session_affinity_grouping,
+            parent_affinity,
         )
         .unwrap();
         (router, runtime)
     }
 
     async fn router(session_affinity_ttl: Option<Duration>) -> (KvPushRouter, Runtime) {
-        router_with_grouping(session_affinity_ttl, None).await
+        router_with_parent_affinity(session_affinity_ttl, false).await
     }
 
     async fn track_request(
@@ -1011,11 +1010,8 @@ mod tests {
 
     #[tokio::test]
     async fn parent_affinity_falls_back_when_the_parent_target_is_ineligible() {
-        let (router, runtime) = router_with_grouping(
-            Some(Duration::from_secs(10)),
-            Some(SessionAffinityGrouping::Parent),
-        )
-        .await;
+        let (router, runtime) =
+            router_with_parent_affinity(Some(Duration::from_secs(10)), true).await;
         let affinity = router.affinity.as_ref().unwrap();
         let parent_id = SessionAffinityId::new("parent");
         let AffinityAcquire::Initialize(parent) = affinity.acquire(&parent_id, None).await.unwrap()

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use super::replica_sync::SessionAffinityUpdate;
 use super::{
     LlmResponse, MAX_SESSION_AFFINITY_ENTRIES, MAX_SESSION_AFFINITY_ID_BYTES,
-    MAX_SESSION_AFFINITY_TTL_SECS, replica_sync::ReplicaSyncRuntime,
+    MAX_SESSION_AFFINITY_TTL_SECS, SessionAffinityGrouping, replica_sync::ReplicaSyncRuntime,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -45,12 +45,14 @@ enum AffinityEntry {
     Initializing {
         revision: u64,
         notify: Arc<Notify>,
+        root_session_id: Option<String>,
     },
     Bound {
         target: AffinityTarget,
         revision: u64,
         active_leases: usize,
         idle_deadline: Instant,
+        root_session_id: Option<String>,
     },
 }
 
@@ -59,6 +61,7 @@ pub(super) struct AffinityCoordinatorInner {
     ttl: Duration,
     max_entries: usize,
     max_session_id_bytes: usize,
+    grouping: Option<SessionAffinityGrouping>,
     entry_count: AtomicUsize,
     next_revision: AtomicU64,
     cancel: CancellationToken,
@@ -96,10 +99,18 @@ pub struct AffinityCoordinator {
 
 impl AffinityCoordinator {
     pub fn new(ttl: Duration) -> Result<Self, Error> {
+        Self::new_with_grouping(ttl, None)
+    }
+
+    pub fn new_with_grouping(
+        ttl: Duration,
+        grouping: Option<SessionAffinityGrouping>,
+    ) -> Result<Self, Error> {
         Self::new_with_limits(
             ttl,
             MAX_SESSION_AFFINITY_ENTRIES,
             MAX_SESSION_AFFINITY_ID_BYTES,
+            grouping,
         )
     }
 
@@ -107,6 +118,7 @@ impl AffinityCoordinator {
         ttl: Duration,
         max_entries: usize,
         max_session_id_bytes: usize,
+        grouping: Option<SessionAffinityGrouping>,
     ) -> Result<Self, Error> {
         if !(Duration::from_secs(1)..=Duration::from_secs(MAX_SESSION_AFFINITY_TTL_SECS))
             .contains(&ttl)
@@ -120,6 +132,7 @@ impl AffinityCoordinator {
             ttl,
             max_entries,
             max_session_id_bytes,
+            grouping,
             entry_count: AtomicUsize::new(0),
             next_revision: AtomicU64::new(1),
             cancel: CancellationToken::new(),
@@ -133,6 +146,7 @@ impl AffinityCoordinator {
         tracing::info!(
             ttl_secs = ttl.as_secs(),
             max_entries,
+            ?grouping,
             "session affinity enabled"
         );
         Ok(Self { inner })
@@ -193,7 +207,8 @@ impl AffinityCoordinator {
         session_id: &SessionAffinityId,
         requested_target: Option<AffinityTarget>,
     ) -> Result<AffinityAcquire, Error> {
-        self.acquire_inner(session_id, requested_target, None).await
+        self.acquire_inner(session_id, requested_target, None, None, None)
+            .await
     }
 
     pub(crate) async fn acquire_with_context(
@@ -202,14 +217,52 @@ impl AffinityCoordinator {
         requested_target: Option<AffinityTarget>,
         request_context: &dyn AsyncEngineContext,
     ) -> Result<AffinityAcquire, Error> {
-        self.acquire_inner(session_id, requested_target, Some(request_context))
-            .await
+        self.acquire_inner(
+            session_id,
+            requested_target,
+            None,
+            None,
+            Some(request_context),
+        )
+        .await
+    }
+
+    pub(crate) async fn acquire_with_lineage(
+        &self,
+        session_id: &SessionAffinityId,
+        parent_session_id: Option<&str>,
+        requested_target: Option<AffinityTarget>,
+        request_context: &dyn AsyncEngineContext,
+    ) -> Result<AffinityAcquire, Error> {
+        if self.query_target(session_id, None)?.is_some() {
+            return self
+                .acquire_inner(
+                    session_id,
+                    requested_target,
+                    None,
+                    None,
+                    Some(request_context),
+                )
+                .await;
+        }
+        let (root_session_id, preferred_target) =
+            self.lineage_preference(parent_session_id, requested_target)?;
+        self.acquire_inner(
+            session_id,
+            requested_target,
+            preferred_target,
+            root_session_id,
+            Some(request_context),
+        )
+        .await
     }
 
     async fn acquire_inner(
         &self,
         session_id: &SessionAffinityId,
         requested_target: Option<AffinityTarget>,
+        preferred_target: Option<AffinityTarget>,
+        root_session_id: Option<String>,
         request_context: Option<&dyn AsyncEngineContext>,
     ) -> Result<AffinityAcquire, Error> {
         self.validate_session_id(session_id)?;
@@ -228,6 +281,8 @@ impl AffinityCoordinator {
                         &self.inner,
                         session_id,
                         requested_target,
+                        preferred_target,
+                        root_session_id,
                     )));
                 }
                 Entry::Occupied(mut entry) => match entry.get_mut() {
@@ -258,6 +313,7 @@ impl AffinityCoordinator {
                         revision,
                         active_leases,
                         idle_deadline,
+                        ..
                     } if *active_leases == 0 && *idle_deadline <= now => {
                         tracing::debug!(
                             session_id = %session_id,
@@ -268,6 +324,7 @@ impl AffinityCoordinator {
                         *entry.get_mut() = AffinityEntry::Initializing {
                             revision,
                             notify: notify.clone(),
+                            root_session_id: root_session_id.clone(),
                         };
                         drop(entry);
                         return Ok(AffinityAcquire::Initialize(AffinityInitialization {
@@ -276,6 +333,8 @@ impl AffinityCoordinator {
                             revision,
                             notify,
                             requested_target,
+                            preferred_target,
+                            root_session_id,
                             active: true,
                         }));
                     }
@@ -283,9 +342,13 @@ impl AffinityCoordinator {
                         target,
                         revision,
                         active_leases,
+                        root_session_id: stored_root_session_id,
                         ..
                     } => {
                         validate_bound_target(&session_id, *target, requested_target)?;
+                        if stored_root_session_id.is_none() {
+                            stored_root_session_id.clone_from(&root_session_id);
+                        }
                         tracing::debug!(
                             session_id = %session_id,
                             worker_id = target.worker_id,
@@ -298,6 +361,7 @@ impl AffinityCoordinator {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
                             revision: *revision,
+                            root_session_id: stored_root_session_id.clone(),
                             active: true,
                         };
                         return Ok(AffinityAcquire::Bound {
@@ -342,6 +406,59 @@ impl AffinityCoordinator {
         Ok(Some(*target))
     }
 
+    pub(crate) fn query_target_with_lineage(
+        &self,
+        session_id: &SessionAffinityId,
+        parent_session_id: Option<&str>,
+        requested_target: Option<AffinityTarget>,
+    ) -> Result<Option<AffinityTarget>, Error> {
+        if let Some(target) = self.query_target(session_id, requested_target)? {
+            return Ok(Some(target));
+        }
+        if requested_target.is_some() {
+            return Ok(requested_target);
+        }
+        let (_, preferred_target) = self.lineage_preference(parent_session_id, requested_target)?;
+        Ok(preferred_target)
+    }
+
+    fn lineage_preference(
+        &self,
+        parent_session_id: Option<&str>,
+        requested_target: Option<AffinityTarget>,
+    ) -> Result<(Option<String>, Option<AffinityTarget>), Error> {
+        let (Some(grouping), Some(parent_session_id)) = (self.inner.grouping, parent_session_id)
+        else {
+            return Ok((None, None));
+        };
+        self.validate_session_id(&SessionAffinityId::new(parent_session_id))?;
+
+        let root_session_id = self
+            .inner
+            .entries
+            .get(parent_session_id)
+            .and_then(|entry| match entry.value() {
+                AffinityEntry::Initializing {
+                    root_session_id, ..
+                }
+                | AffinityEntry::Bound {
+                    root_session_id, ..
+                } => root_session_id.clone(),
+            })
+            .unwrap_or_else(|| parent_session_id.to_string());
+        let preference_session_id = match grouping {
+            SessionAffinityGrouping::Parent => parent_session_id,
+            SessionAffinityGrouping::Root => root_session_id.as_str(),
+        };
+        let preferred_target = requested_target
+            .is_none()
+            .then(|| self.query_target(&SessionAffinityId::new(preference_session_id), None))
+            .transpose()?
+            .flatten();
+
+        Ok((Some(root_session_id), preferred_target))
+    }
+
     #[cfg(test)]
     pub(super) fn entry_count(&self) -> usize {
         self.inner.entry_count.load(Ordering::Relaxed)
@@ -381,7 +498,13 @@ impl AffinityCoordinator {
 
     #[cfg(test)]
     pub(super) fn with_test_limits(max_entries: usize, max_session_id_bytes: usize) -> Self {
-        Self::new_with_limits(Duration::from_secs(10), max_entries, max_session_id_bytes).unwrap()
+        Self::new_with_limits(
+            Duration::from_secs(10),
+            max_entries,
+            max_session_id_bytes,
+            None,
+        )
+        .unwrap()
     }
 
     #[cfg(test)]
@@ -404,7 +527,8 @@ impl AffinityCoordinator {
         session_id: impl Into<String>,
         target: AffinityTarget,
     ) -> ReplicaApplyOutcome {
-        self.inner.apply_replica_update(session_id.into(), target)
+        self.inner
+            .apply_replica_update(session_id.into(), target, None)
     }
 
     fn validate_session_id(&self, session_id: &SessionAffinityId) -> Result<(), Error> {
@@ -434,9 +558,14 @@ impl AffinityCoordinatorInner {
             .is_ok()
     }
 
-    fn publish_replica_update(&self, session_id: &str, target: AffinityTarget) {
+    fn publish_replica_update(
+        &self,
+        session_id: &str,
+        target: AffinityTarget,
+        root_session_id: Option<&str>,
+    ) {
         if let Some(replica) = self.replica.get() {
-            replica.publish(session_id, target);
+            replica.publish(session_id, target, root_session_id);
         }
     }
 
@@ -444,8 +573,13 @@ impl AffinityCoordinatorInner {
         &self,
         session_id: String,
         target: AffinityTarget,
+        root_session_id: Option<String>,
     ) -> ReplicaApplyOutcome {
-        if session_id.len() > self.max_session_id_bytes {
+        if session_id.len() > self.max_session_id_bytes
+            || root_session_id
+                .as_ref()
+                .is_some_and(|id| id.len() > self.max_session_id_bytes)
+        {
             return ReplicaApplyOutcome::RejectedSessionId;
         }
 
@@ -461,6 +595,7 @@ impl AffinityCoordinatorInner {
                     revision,
                     active_leases: 0,
                     idle_deadline: now + self.ttl,
+                    root_session_id,
                 });
                 ReplicaApplyOutcome::Inserted
             }
@@ -477,15 +612,20 @@ impl AffinityCoordinatorInner {
                         revision,
                         active_leases: 0,
                         idle_deadline: now + self.ttl,
+                        root_session_id,
                     };
                     ReplicaApplyOutcome::ReplacedExpired
                 }
                 AffinityEntry::Bound {
                     target: existing,
                     idle_deadline,
+                    root_session_id: existing_root_session_id,
                     ..
                 } if *existing == target => {
                     *idle_deadline = now + self.ttl;
+                    if existing_root_session_id.is_none() {
+                        existing_root_session_id.clone_from(&root_session_id);
+                    }
                     ReplicaApplyOutcome::Refreshed
                 }
                 AffinityEntry::Bound { .. } => ReplicaApplyOutcome::IgnoredConflict,
@@ -500,6 +640,8 @@ trait VacantEntryExt {
         inner: &Arc<AffinityCoordinatorInner>,
         session_id: String,
         requested_target: Option<AffinityTarget>,
+        preferred_target: Option<AffinityTarget>,
+        root_session_id: Option<String>,
     ) -> AffinityInitialization;
 }
 
@@ -509,12 +651,15 @@ impl<'a> VacantEntryExt for dashmap::mapref::entry::VacantEntry<'a, String, Affi
         inner: &Arc<AffinityCoordinatorInner>,
         session_id: String,
         requested_target: Option<AffinityTarget>,
+        preferred_target: Option<AffinityTarget>,
+        root_session_id: Option<String>,
     ) -> AffinityInitialization {
         let revision = inner.next_revision.fetch_add(1, Ordering::Relaxed);
         let notify = Arc::new(Notify::new());
         self.insert(AffinityEntry::Initializing {
             revision,
             notify: notify.clone(),
+            root_session_id: root_session_id.clone(),
         });
         AffinityInitialization {
             coordinator: Arc::downgrade(inner),
@@ -522,6 +667,8 @@ impl<'a> VacantEntryExt for dashmap::mapref::entry::VacantEntry<'a, String, Affi
             revision,
             notify,
             requested_target,
+            preferred_target,
+            root_session_id,
             active: true,
         }
     }
@@ -538,7 +685,9 @@ pub(crate) enum AffinityAcquire {
 impl AffinityAcquire {
     pub(crate) fn target(&self) -> Option<AffinityTarget> {
         match self {
-            Self::Initialize(_) => None,
+            Self::Initialize(initialization) => initialization
+                .requested_target
+                .or(initialization.preferred_target),
             Self::Bound { target, .. } => Some(*target),
         }
     }
@@ -579,6 +728,8 @@ pub(crate) struct AffinityInitialization {
     revision: u64,
     notify: Arc<Notify>,
     requested_target: Option<AffinityTarget>,
+    preferred_target: Option<AffinityTarget>,
+    root_session_id: Option<String>,
     active: bool,
 }
 
@@ -599,11 +750,13 @@ impl AffinityInitialization {
         ) {
             return Err(invalid_argument("session affinity initialization changed"));
         }
+        let root_session_id = self.root_session_id.take();
         *entry = AffinityEntry::Bound {
             target,
             revision: self.revision,
             active_leases: 1,
             idle_deadline: Instant::now() + inner.ttl,
+            root_session_id: root_session_id.clone(),
         };
         drop(entry);
         self.active = false;
@@ -612,6 +765,7 @@ impl AffinityInitialization {
             coordinator: Arc::downgrade(&inner),
             session_id: self.session_id.clone(),
             revision: self.revision,
+            root_session_id,
             active: true,
         })
     }
@@ -642,13 +796,14 @@ pub(crate) struct AffinityLease {
     coordinator: Weak<AffinityCoordinatorInner>,
     session_id: String,
     revision: u64,
+    root_session_id: Option<String>,
     active: bool,
 }
 
 impl AffinityLease {
     fn publish(&self, target: AffinityTarget) {
         if let Some(inner) = self.coordinator.upgrade() {
-            inner.publish_replica_update(&self.session_id, target);
+            inner.publish_replica_update(&self.session_id, target, self.root_session_id.as_deref());
         }
     }
 
@@ -680,6 +835,7 @@ impl AffinityLease {
                 revision,
                 active_leases,
                 idle_deadline,
+                ..
             } = entry.value_mut()
             else {
                 return;
@@ -691,7 +847,7 @@ impl AffinityLease {
             *idle_deadline = Instant::now() + inner.ttl;
             *target
         };
-        inner.publish_replica_update(&self.session_id, target);
+        inner.publish_replica_update(&self.session_id, target, self.root_session_id.as_deref());
     }
 
     fn invalidate(&mut self) {

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use super::replica_sync::SessionAffinityUpdate;
 use super::{
     LlmResponse, MAX_SESSION_AFFINITY_ENTRIES, MAX_SESSION_AFFINITY_ID_BYTES,
-    MAX_SESSION_AFFINITY_TTL_SECS, SessionAffinityGrouping, replica_sync::ReplicaSyncRuntime,
+    MAX_SESSION_AFFINITY_TTL_SECS, replica_sync::ReplicaSyncRuntime,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -45,14 +45,12 @@ enum AffinityEntry {
     Initializing {
         revision: u64,
         notify: Arc<Notify>,
-        root_session_id: Option<String>,
     },
     Bound {
         target: AffinityTarget,
         revision: u64,
         active_leases: usize,
         idle_deadline: Instant,
-        root_session_id: Option<String>,
     },
 }
 
@@ -61,7 +59,7 @@ pub(super) struct AffinityCoordinatorInner {
     ttl: Duration,
     max_entries: usize,
     max_session_id_bytes: usize,
-    grouping: Option<SessionAffinityGrouping>,
+    parent_affinity: bool,
     entry_count: AtomicUsize,
     next_revision: AtomicU64,
     cancel: CancellationToken,
@@ -99,18 +97,15 @@ pub struct AffinityCoordinator {
 
 impl AffinityCoordinator {
     pub fn new(ttl: Duration) -> Result<Self, Error> {
-        Self::new_with_grouping(ttl, None)
+        Self::new_with_parent_affinity(ttl, false)
     }
 
-    pub fn new_with_grouping(
-        ttl: Duration,
-        grouping: Option<SessionAffinityGrouping>,
-    ) -> Result<Self, Error> {
+    pub fn new_with_parent_affinity(ttl: Duration, parent_affinity: bool) -> Result<Self, Error> {
         Self::new_with_limits(
             ttl,
             MAX_SESSION_AFFINITY_ENTRIES,
             MAX_SESSION_AFFINITY_ID_BYTES,
-            grouping,
+            parent_affinity,
         )
     }
 
@@ -118,7 +113,7 @@ impl AffinityCoordinator {
         ttl: Duration,
         max_entries: usize,
         max_session_id_bytes: usize,
-        grouping: Option<SessionAffinityGrouping>,
+        parent_affinity: bool,
     ) -> Result<Self, Error> {
         if !(Duration::from_secs(1)..=Duration::from_secs(MAX_SESSION_AFFINITY_TTL_SECS))
             .contains(&ttl)
@@ -132,7 +127,7 @@ impl AffinityCoordinator {
             ttl,
             max_entries,
             max_session_id_bytes,
-            grouping,
+            parent_affinity,
             entry_count: AtomicUsize::new(0),
             next_revision: AtomicU64::new(1),
             cancel: CancellationToken::new(),
@@ -146,7 +141,7 @@ impl AffinityCoordinator {
         tracing::info!(
             ttl_secs = ttl.as_secs(),
             max_entries,
-            ?grouping,
+            parent_affinity,
             "session affinity enabled"
         );
         Ok(Self { inner })
@@ -207,7 +202,7 @@ impl AffinityCoordinator {
         session_id: &SessionAffinityId,
         requested_target: Option<AffinityTarget>,
     ) -> Result<AffinityAcquire, Error> {
-        self.acquire_inner(session_id, requested_target, None, None, None)
+        self.acquire_inner(session_id, requested_target, None, None)
             .await
     }
 
@@ -217,17 +212,11 @@ impl AffinityCoordinator {
         requested_target: Option<AffinityTarget>,
         request_context: &dyn AsyncEngineContext,
     ) -> Result<AffinityAcquire, Error> {
-        self.acquire_inner(
-            session_id,
-            requested_target,
-            None,
-            None,
-            Some(request_context),
-        )
-        .await
+        self.acquire_inner(session_id, requested_target, None, Some(request_context))
+            .await
     }
 
-    pub(crate) async fn acquire_with_lineage(
+    pub(crate) async fn acquire_with_parent(
         &self,
         session_id: &SessionAffinityId,
         parent_session_id: Option<&str>,
@@ -236,22 +225,14 @@ impl AffinityCoordinator {
     ) -> Result<AffinityAcquire, Error> {
         if self.query_target(session_id, None)?.is_some() {
             return self
-                .acquire_inner(
-                    session_id,
-                    requested_target,
-                    None,
-                    None,
-                    Some(request_context),
-                )
+                .acquire_inner(session_id, requested_target, None, Some(request_context))
                 .await;
         }
-        let (root_session_id, preferred_target) =
-            self.lineage_preference(parent_session_id, requested_target)?;
+        let preferred_target = self.parent_preference(parent_session_id, requested_target)?;
         self.acquire_inner(
             session_id,
             requested_target,
             preferred_target,
-            root_session_id,
             Some(request_context),
         )
         .await
@@ -262,7 +243,6 @@ impl AffinityCoordinator {
         session_id: &SessionAffinityId,
         requested_target: Option<AffinityTarget>,
         preferred_target: Option<AffinityTarget>,
-        root_session_id: Option<String>,
         request_context: Option<&dyn AsyncEngineContext>,
     ) -> Result<AffinityAcquire, Error> {
         self.validate_session_id(session_id)?;
@@ -282,7 +262,6 @@ impl AffinityCoordinator {
                         session_id,
                         requested_target,
                         preferred_target,
-                        root_session_id,
                     )));
                 }
                 Entry::Occupied(mut entry) => match entry.get_mut() {
@@ -324,7 +303,6 @@ impl AffinityCoordinator {
                         *entry.get_mut() = AffinityEntry::Initializing {
                             revision,
                             notify: notify.clone(),
-                            root_session_id: root_session_id.clone(),
                         };
                         drop(entry);
                         return Ok(AffinityAcquire::Initialize(AffinityInitialization {
@@ -334,7 +312,6 @@ impl AffinityCoordinator {
                             notify,
                             requested_target,
                             preferred_target,
-                            root_session_id,
                             active: true,
                         }));
                     }
@@ -342,13 +319,9 @@ impl AffinityCoordinator {
                         target,
                         revision,
                         active_leases,
-                        root_session_id: stored_root_session_id,
                         ..
                     } => {
                         validate_bound_target(&session_id, *target, requested_target)?;
-                        if stored_root_session_id.is_none() {
-                            stored_root_session_id.clone_from(&root_session_id);
-                        }
                         tracing::debug!(
                             session_id = %session_id,
                             worker_id = target.worker_id,
@@ -361,7 +334,6 @@ impl AffinityCoordinator {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
                             revision: *revision,
-                            root_session_id: stored_root_session_id.clone(),
                             active: true,
                         };
                         return Ok(AffinityAcquire::Bound {
@@ -406,7 +378,7 @@ impl AffinityCoordinator {
         Ok(Some(*target))
     }
 
-    pub(crate) fn query_target_with_lineage(
+    pub(crate) fn query_target_with_parent(
         &self,
         session_id: &SessionAffinityId,
         parent_session_id: Option<&str>,
@@ -418,45 +390,28 @@ impl AffinityCoordinator {
         if requested_target.is_some() {
             return Ok(requested_target);
         }
-        let (_, preferred_target) = self.lineage_preference(parent_session_id, requested_target)?;
-        Ok(preferred_target)
+        self.parent_preference(parent_session_id, requested_target)
     }
 
-    fn lineage_preference(
+    fn parent_preference(
         &self,
         parent_session_id: Option<&str>,
         requested_target: Option<AffinityTarget>,
-    ) -> Result<(Option<String>, Option<AffinityTarget>), Error> {
-        let (Some(grouping), Some(parent_session_id)) = (self.inner.grouping, parent_session_id)
-        else {
-            return Ok((None, None));
+    ) -> Result<Option<AffinityTarget>, Error> {
+        if !self.inner.parent_affinity {
+            return Ok(None);
+        }
+        let Some(parent_session_id) = parent_session_id else {
+            return Ok(None);
         };
         self.validate_session_id(&SessionAffinityId::new(parent_session_id))?;
 
-        let root_session_id = self
-            .inner
-            .entries
-            .get(parent_session_id)
-            .and_then(|entry| match entry.value() {
-                AffinityEntry::Initializing {
-                    root_session_id, ..
-                }
-                | AffinityEntry::Bound {
-                    root_session_id, ..
-                } => root_session_id.clone(),
-            })
-            .unwrap_or_else(|| parent_session_id.to_string());
-        let preference_session_id = match grouping {
-            SessionAffinityGrouping::Parent => parent_session_id,
-            SessionAffinityGrouping::Root => root_session_id.as_str(),
-        };
         let preferred_target = requested_target
             .is_none()
-            .then(|| self.query_target(&SessionAffinityId::new(preference_session_id), None))
+            .then(|| self.query_target(&SessionAffinityId::new(parent_session_id), None))
             .transpose()?
             .flatten();
-
-        Ok((Some(root_session_id), preferred_target))
+        Ok(preferred_target)
     }
 
     #[cfg(test)]
@@ -502,7 +457,7 @@ impl AffinityCoordinator {
             Duration::from_secs(10),
             max_entries,
             max_session_id_bytes,
-            None,
+            false,
         )
         .unwrap()
     }
@@ -527,8 +482,7 @@ impl AffinityCoordinator {
         session_id: impl Into<String>,
         target: AffinityTarget,
     ) -> ReplicaApplyOutcome {
-        self.inner
-            .apply_replica_update(session_id.into(), target, None)
+        self.inner.apply_replica_update(session_id.into(), target)
     }
 
     fn validate_session_id(&self, session_id: &SessionAffinityId) -> Result<(), Error> {
@@ -558,14 +512,9 @@ impl AffinityCoordinatorInner {
             .is_ok()
     }
 
-    fn publish_replica_update(
-        &self,
-        session_id: &str,
-        target: AffinityTarget,
-        root_session_id: Option<&str>,
-    ) {
+    fn publish_replica_update(&self, session_id: &str, target: AffinityTarget) {
         if let Some(replica) = self.replica.get() {
-            replica.publish(session_id, target, root_session_id);
+            replica.publish(session_id, target);
         }
     }
 
@@ -573,13 +522,8 @@ impl AffinityCoordinatorInner {
         &self,
         session_id: String,
         target: AffinityTarget,
-        root_session_id: Option<String>,
     ) -> ReplicaApplyOutcome {
-        if session_id.len() > self.max_session_id_bytes
-            || root_session_id
-                .as_ref()
-                .is_some_and(|id| id.len() > self.max_session_id_bytes)
-        {
+        if session_id.len() > self.max_session_id_bytes {
             return ReplicaApplyOutcome::RejectedSessionId;
         }
 
@@ -595,7 +539,6 @@ impl AffinityCoordinatorInner {
                     revision,
                     active_leases: 0,
                     idle_deadline: now + self.ttl,
-                    root_session_id,
                 });
                 ReplicaApplyOutcome::Inserted
             }
@@ -612,20 +555,15 @@ impl AffinityCoordinatorInner {
                         revision,
                         active_leases: 0,
                         idle_deadline: now + self.ttl,
-                        root_session_id,
                     };
                     ReplicaApplyOutcome::ReplacedExpired
                 }
                 AffinityEntry::Bound {
                     target: existing,
                     idle_deadline,
-                    root_session_id: existing_root_session_id,
                     ..
                 } if *existing == target => {
                     *idle_deadline = now + self.ttl;
-                    if existing_root_session_id.is_none() {
-                        existing_root_session_id.clone_from(&root_session_id);
-                    }
                     ReplicaApplyOutcome::Refreshed
                 }
                 AffinityEntry::Bound { .. } => ReplicaApplyOutcome::IgnoredConflict,
@@ -641,7 +579,6 @@ trait VacantEntryExt {
         session_id: String,
         requested_target: Option<AffinityTarget>,
         preferred_target: Option<AffinityTarget>,
-        root_session_id: Option<String>,
     ) -> AffinityInitialization;
 }
 
@@ -652,14 +589,12 @@ impl<'a> VacantEntryExt for dashmap::mapref::entry::VacantEntry<'a, String, Affi
         session_id: String,
         requested_target: Option<AffinityTarget>,
         preferred_target: Option<AffinityTarget>,
-        root_session_id: Option<String>,
     ) -> AffinityInitialization {
         let revision = inner.next_revision.fetch_add(1, Ordering::Relaxed);
         let notify = Arc::new(Notify::new());
         self.insert(AffinityEntry::Initializing {
             revision,
             notify: notify.clone(),
-            root_session_id: root_session_id.clone(),
         });
         AffinityInitialization {
             coordinator: Arc::downgrade(inner),
@@ -668,7 +603,6 @@ impl<'a> VacantEntryExt for dashmap::mapref::entry::VacantEntry<'a, String, Affi
             notify,
             requested_target,
             preferred_target,
-            root_session_id,
             active: true,
         }
     }
@@ -729,7 +663,6 @@ pub(crate) struct AffinityInitialization {
     notify: Arc<Notify>,
     requested_target: Option<AffinityTarget>,
     preferred_target: Option<AffinityTarget>,
-    root_session_id: Option<String>,
     active: bool,
 }
 
@@ -750,13 +683,11 @@ impl AffinityInitialization {
         ) {
             return Err(invalid_argument("session affinity initialization changed"));
         }
-        let root_session_id = self.root_session_id.take();
         *entry = AffinityEntry::Bound {
             target,
             revision: self.revision,
             active_leases: 1,
             idle_deadline: Instant::now() + inner.ttl,
-            root_session_id: root_session_id.clone(),
         };
         drop(entry);
         self.active = false;
@@ -765,7 +696,6 @@ impl AffinityInitialization {
             coordinator: Arc::downgrade(&inner),
             session_id: self.session_id.clone(),
             revision: self.revision,
-            root_session_id,
             active: true,
         })
     }
@@ -796,14 +726,13 @@ pub(crate) struct AffinityLease {
     coordinator: Weak<AffinityCoordinatorInner>,
     session_id: String,
     revision: u64,
-    root_session_id: Option<String>,
     active: bool,
 }
 
 impl AffinityLease {
     fn publish(&self, target: AffinityTarget) {
         if let Some(inner) = self.coordinator.upgrade() {
-            inner.publish_replica_update(&self.session_id, target, self.root_session_id.as_deref());
+            inner.publish_replica_update(&self.session_id, target);
         }
     }
 
@@ -847,7 +776,7 @@ impl AffinityLease {
             *idle_deadline = Instant::now() + inner.ttl;
             *target
         };
-        inner.publish_replica_update(&self.session_id, target, self.root_session_id.as_deref());
+        inner.publish_replica_update(&self.session_id, target);
     }
 
     fn invalidate(&mut self) {

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -8,7 +8,6 @@ mod replica_sync;
 use std::time::Duration;
 
 use dynamo_runtime::{component::Client, pipeline::Error};
-use serde::{Deserialize, Serialize};
 
 pub(crate) use coordinator::{AffinityAcquire, affinity_id};
 pub use coordinator::{AffinityCoordinator, AffinityTarget, explicit_target};
@@ -18,42 +17,23 @@ pub const MAX_SESSION_AFFINITY_TTL_SECS: u64 = 31_536_000;
 pub const MAX_SESSION_AFFINITY_ENTRIES: usize = 65_536;
 pub const MAX_SESSION_AFFINITY_ID_BYTES: usize = 256;
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SessionAffinityGrouping {
-    Parent,
-    Root,
-}
-
-impl std::str::FromStr for SessionAffinityGrouping {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "parent" => Ok(Self::Parent),
-            "root" => Ok(Self::Root),
-            _ => Err("session affinity grouping must be 'parent' or 'root'".to_string()),
-        }
-    }
-}
-
 pub type LlmResponse =
     crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>;
 
 pub(crate) async fn create_affinity_coordinator(
     ttl: Option<Duration>,
-    grouping: Option<SessionAffinityGrouping>,
+    parent_affinity: bool,
     client: Client,
 ) -> Result<Option<AffinityCoordinator>, Error> {
     let Some(ttl) = ttl else {
-        if grouping.is_some() {
+        if parent_affinity {
             return Err(coordinator::invalid_argument(
-                "session affinity grouping requires session affinity TTL",
+                "parent affinity requires session affinity TTL",
             ));
         }
         return Ok(None);
     };
-    let coordinator = AffinityCoordinator::new_with_grouping(ttl, grouping)?;
+    let coordinator = AffinityCoordinator::new_with_parent_affinity(ttl, parent_affinity)?;
     coordinator.enable_replica_sync(client).await?;
     Ok(Some(coordinator))
 }

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -8,6 +8,7 @@ mod replica_sync;
 use std::time::Duration;
 
 use dynamo_runtime::{component::Client, pipeline::Error};
+use serde::{Deserialize, Serialize};
 
 pub(crate) use coordinator::{AffinityAcquire, affinity_id};
 pub use coordinator::{AffinityCoordinator, AffinityTarget, explicit_target};
@@ -17,17 +18,42 @@ pub const MAX_SESSION_AFFINITY_TTL_SECS: u64 = 31_536_000;
 pub const MAX_SESSION_AFFINITY_ENTRIES: usize = 65_536;
 pub const MAX_SESSION_AFFINITY_ID_BYTES: usize = 256;
 
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionAffinityGrouping {
+    Parent,
+    Root,
+}
+
+impl std::str::FromStr for SessionAffinityGrouping {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "parent" => Ok(Self::Parent),
+            "root" => Ok(Self::Root),
+            _ => Err("session affinity grouping must be 'parent' or 'root'".to_string()),
+        }
+    }
+}
+
 pub type LlmResponse =
     crate::types::Annotated<crate::protocols::common::llm_backend::LLMEngineOutput>;
 
 pub(crate) async fn create_affinity_coordinator(
     ttl: Option<Duration>,
+    grouping: Option<SessionAffinityGrouping>,
     client: Client,
 ) -> Result<Option<AffinityCoordinator>, Error> {
     let Some(ttl) = ttl else {
+        if grouping.is_some() {
+            return Err(coordinator::invalid_argument(
+                "session affinity grouping requires session affinity TTL",
+            ));
+        }
         return Ok(None);
     };
-    let coordinator = AffinityCoordinator::new(ttl)?;
+    let coordinator = AffinityCoordinator::new_with_grouping(ttl, grouping)?;
     coordinator.enable_replica_sync(client).await?;
     Ok(Some(coordinator))
 }

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -9,7 +9,7 @@ use dynamo_runtime::pipeline::{
 };
 
 use super::{
-    AffinityCoordinator, AffinityTarget, LlmResponse,
+    AffinityCoordinator, AffinityTarget, LlmResponse, SessionAffinityGrouping,
     coordinator::{affinity_id, invalid_argument},
     explicit_target,
 };
@@ -30,9 +30,12 @@ impl SessionAffinityPushRouter {
     pub fn new(
         inner: PushRouter<PreprocessedRequest, LlmResponse>,
         ttl: Option<Duration>,
+        grouping: Option<SessionAffinityGrouping>,
         direct: bool,
     ) -> Result<Self, Error> {
-        let affinity = ttl.map(AffinityCoordinator::new).transpose()?;
+        let affinity = ttl
+            .map(|ttl| AffinityCoordinator::new_with_grouping(ttl, grouping))
+            .transpose()?;
         Ok(Self::new_with_coordinator(inner, affinity, direct))
     }
 
@@ -105,6 +108,7 @@ impl SessionAffinityPushRouter {
     async fn acquire_routable(
         &self,
         session_id: &crate::protocols::common::extensions::SessionAffinityId,
+        parent_session_id: Option<&str>,
         explicit: Option<AffinityTarget>,
         request_context: &dyn AsyncEngineContext,
     ) -> Result<super::AffinityAcquire, Error> {
@@ -113,7 +117,7 @@ impl SessionAffinityPushRouter {
             .as_ref()
             .expect("affinity acquisition requires an enabled coordinator");
         let operation = affinity
-            .acquire_with_context(session_id, explicit, request_context)
+            .acquire_with_lineage(session_id, parent_session_id, explicit, request_context)
             .await?;
         let Some(target) = operation.target() else {
             return Ok(operation);
@@ -187,6 +191,10 @@ impl SessionAffinityPushRouter {
             explicit_target(&request, RequestPhase::Prefill)?,
             RequestPhase::Prefill,
         )?;
+        let parent_session_id = request
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.parent_session_id.as_deref());
         let Some(session_id) = session_id else {
             let Some(target) = explicit else {
                 return Err(invalid_argument(
@@ -203,8 +211,7 @@ impl SessionAffinityPushRouter {
                 .affinity
                 .as_ref()
                 .expect("affinity query requires an enabled coordinator")
-                .query_target(&session_id, explicit)?
-                .or(explicit);
+                .query_target_with_lineage(&session_id, parent_session_id, explicit)?;
             return self
                 .select_and_dispatch_exact_target(request, selected, prepare)
                 .await;
@@ -212,7 +219,12 @@ impl SessionAffinityPushRouter {
 
         let request_context = request.context();
         let operation = self
-            .acquire_routable(&session_id, explicit, request_context.as_ref())
+            .acquire_routable(
+                &session_id,
+                parent_session_id,
+                explicit,
+                request_context.as_ref(),
+            )
             .await?;
         let selected = operation.target().or(explicit);
         let rank = selected.and_then(|target| target.dp_rank);
@@ -275,6 +287,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
             return Ok(stream);
         }
         let explicit = self.direct_target(explicit_target(&request, phase)?, phase)?;
+        let parent_session_id = request
+            .agent_context
+            .as_ref()
+            .and_then(|context| context.parent_session_id.as_deref());
         let Some(session_id) = session_id else {
             let Some(target) = explicit else {
                 return Err(invalid_argument(format!(
@@ -302,8 +318,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 .affinity
                 .as_ref()
                 .expect("affinity query requires an enabled coordinator")
-                .query_target(&session_id, explicit)?
-                .or(explicit);
+                .query_target_with_lineage(&session_id, parent_session_id, explicit)?;
             let rank = target.and_then(|target| target.dp_rank);
             let ((tracker, target), stream) = self
                 .inner
@@ -330,7 +345,12 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
 
         let request_context = request.context();
         let operation = self
-            .acquire_routable(&session_id, explicit, request_context.as_ref())
+            .acquire_routable(
+                &session_id,
+                parent_session_id,
+                explicit,
+                request_context.as_ref(),
+            )
             .await?;
         let selected = operation.target().or(explicit);
         let rank = selected.and_then(|target| target.dp_rank);
@@ -459,7 +479,7 @@ mod tests {
         let inner = PushRouter::from_client(client, RouterMode::RoundRobin)
             .await
             .unwrap();
-        let router = SessionAffinityPushRouter::new(inner, None, false).unwrap();
+        let router = SessionAffinityPushRouter::new(inner, None, None, false).unwrap();
 
         assert!(router.affinity.is_none());
 
@@ -497,7 +517,8 @@ mod tests {
             let worker_id = client.wait_for_instances().await.unwrap()[0].id();
             let inner = PushRouter::from_client(client, mode).await.unwrap();
             let router =
-                SessionAffinityPushRouter::new(inner, None, mode.is_direct_routing()).unwrap();
+                SessionAffinityPushRouter::new(inner, None, None, mode.is_direct_routing())
+                    .unwrap();
             let tracker = Arc::new(RequestTracker::new());
             let mut content = request(mode.is_direct_routing().then_some(worker_id), false);
             content.tracker = Some(tracker.clone());
@@ -552,6 +573,7 @@ mod tests {
             let router = SessionAffinityPushRouter::new(
                 inner,
                 Some(Duration::from_secs(10)),
+                None,
                 mode.is_direct_routing(),
             )
             .unwrap();
@@ -594,7 +616,8 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), false).unwrap();
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, false)
+                .unwrap();
         assert!(router.generate(affinity_request(None, true)).await.is_err());
         assert_eq!(affinity(&router).entry_count(), 0);
         assert!(
@@ -614,7 +637,8 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), true).unwrap();
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, true)
+                .unwrap();
         let error = router
             .generate(affinity_request(None, false))
             .await
@@ -668,7 +692,7 @@ mod tests {
 
         for (mode, direct) in [(RouterMode::Direct, true), (RouterMode::RoundRobin, false)] {
             let inner = PushRouter::from_client(client.clone(), mode).await.unwrap();
-            let router = SessionAffinityPushRouter::new(inner, None, direct).unwrap();
+            let router = SessionAffinityPushRouter::new(inner, None, None, direct).unwrap();
             let mut content = request(None, false);
             content.routing_mut().prefill_worker_id = Some(worker_id);
             content.routing_mut().prefill_dp_rank = Some(0);
@@ -712,7 +736,8 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), false).unwrap();
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, false)
+                .unwrap();
         let session_id = SessionAffinityId::new("adapter-session");
         let AffinityAcquire::Initialize(initializer) =
             affinity(&router).acquire(&session_id, None).await.unwrap()

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -9,7 +9,7 @@ use dynamo_runtime::pipeline::{
 };
 
 use super::{
-    AffinityCoordinator, AffinityTarget, LlmResponse, SessionAffinityGrouping,
+    AffinityCoordinator, AffinityTarget, LlmResponse,
     coordinator::{affinity_id, invalid_argument},
     explicit_target,
 };
@@ -30,11 +30,11 @@ impl SessionAffinityPushRouter {
     pub fn new(
         inner: PushRouter<PreprocessedRequest, LlmResponse>,
         ttl: Option<Duration>,
-        grouping: Option<SessionAffinityGrouping>,
+        parent_affinity: bool,
         direct: bool,
     ) -> Result<Self, Error> {
         let affinity = ttl
-            .map(|ttl| AffinityCoordinator::new_with_grouping(ttl, grouping))
+            .map(|ttl| AffinityCoordinator::new_with_parent_affinity(ttl, parent_affinity))
             .transpose()?;
         Ok(Self::new_with_coordinator(inner, affinity, direct))
     }
@@ -117,7 +117,7 @@ impl SessionAffinityPushRouter {
             .as_ref()
             .expect("affinity acquisition requires an enabled coordinator");
         let operation = affinity
-            .acquire_with_lineage(session_id, parent_session_id, explicit, request_context)
+            .acquire_with_parent(session_id, parent_session_id, explicit, request_context)
             .await?;
         let Some(target) = operation.target() else {
             return Ok(operation);
@@ -211,7 +211,7 @@ impl SessionAffinityPushRouter {
                 .affinity
                 .as_ref()
                 .expect("affinity query requires an enabled coordinator")
-                .query_target_with_lineage(&session_id, parent_session_id, explicit)?;
+                .query_target_with_parent(&session_id, parent_session_id, explicit)?;
             return self
                 .select_and_dispatch_exact_target(request, selected, prepare)
                 .await;
@@ -318,7 +318,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 .affinity
                 .as_ref()
                 .expect("affinity query requires an enabled coordinator")
-                .query_target_with_lineage(&session_id, parent_session_id, explicit)?;
+                .query_target_with_parent(&session_id, parent_session_id, explicit)?;
             let rank = target.and_then(|target| target.dp_rank);
             let ((tracker, target), stream) = self
                 .inner
@@ -479,7 +479,7 @@ mod tests {
         let inner = PushRouter::from_client(client, RouterMode::RoundRobin)
             .await
             .unwrap();
-        let router = SessionAffinityPushRouter::new(inner, None, None, false).unwrap();
+        let router = SessionAffinityPushRouter::new(inner, None, false, false).unwrap();
 
         assert!(router.affinity.is_none());
 
@@ -517,7 +517,7 @@ mod tests {
             let worker_id = client.wait_for_instances().await.unwrap()[0].id();
             let inner = PushRouter::from_client(client, mode).await.unwrap();
             let router =
-                SessionAffinityPushRouter::new(inner, None, None, mode.is_direct_routing())
+                SessionAffinityPushRouter::new(inner, None, false, mode.is_direct_routing())
                     .unwrap();
             let tracker = Arc::new(RequestTracker::new());
             let mut content = request(mode.is_direct_routing().then_some(worker_id), false);
@@ -573,7 +573,7 @@ mod tests {
             let router = SessionAffinityPushRouter::new(
                 inner,
                 Some(Duration::from_secs(10)),
-                None,
+                false,
                 mode.is_direct_routing(),
             )
             .unwrap();
@@ -616,7 +616,7 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, false)
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), false, false)
                 .unwrap();
         assert!(router.generate(affinity_request(None, true)).await.is_err());
         assert_eq!(affinity(&router).entry_count(), 0);
@@ -637,7 +637,7 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, true)
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), false, true)
                 .unwrap();
         let error = router
             .generate(affinity_request(None, false))
@@ -692,7 +692,7 @@ mod tests {
 
         for (mode, direct) in [(RouterMode::Direct, true), (RouterMode::RoundRobin, false)] {
             let inner = PushRouter::from_client(client.clone(), mode).await.unwrap();
-            let router = SessionAffinityPushRouter::new(inner, None, None, direct).unwrap();
+            let router = SessionAffinityPushRouter::new(inner, None, false, direct).unwrap();
             let mut content = request(None, false);
             content.routing_mut().prefill_worker_id = Some(worker_id);
             content.routing_mut().prefill_dp_rank = Some(0);
@@ -736,7 +736,7 @@ mod tests {
             .await
             .unwrap();
         let router =
-            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), None, false)
+            SessionAffinityPushRouter::new(inner, Some(Duration::from_secs(10)), false, false)
                 .unwrap();
         let session_id = SessionAffinityId::new("adapter-session");
         let AffinityAcquire::Initialize(initializer) =

--- a/lib/llm/src/session_affinity/replica_sync.rs
+++ b/lib/llm/src/session_affinity/replica_sync.rs
@@ -33,6 +33,8 @@ pub(super) struct SessionAffinityUpdate {
     pub session_id: String,
     pub worker_id: u64,
     pub dp_rank: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub root_session_id: Option<String>,
     pub router_id: u64,
 }
 
@@ -43,11 +45,12 @@ struct ReplicaUpdateSender {
 }
 
 impl ReplicaUpdateSender {
-    fn publish(&self, session_id: &str, target: AffinityTarget) {
+    fn publish(&self, session_id: &str, target: AffinityTarget, root_session_id: Option<&str>) {
         let update = SessionAffinityUpdate {
             session_id: session_id.to_string(),
             worker_id: target.worker_id,
             dp_rank: target.dp_rank,
+            root_session_id: root_session_id.map(str::to_string),
             router_id: self.router_id,
         };
         if let Err(error) = self.tx.try_send(update) {
@@ -83,7 +86,8 @@ impl ReplicaUpdateApplier {
             worker_id: update.worker_id,
             dp_rank: update.dp_rank,
         };
-        let outcome = coordinator.apply_replica_update(update.session_id, target);
+        let outcome =
+            coordinator.apply_replica_update(update.session_id, target, update.root_session_id);
         drop(coordinator);
         tracing::trace!(
             worker_id = target.worker_id,
@@ -231,8 +235,13 @@ impl ReplicaSyncRuntime {
         })
     }
 
-    pub(super) fn publish(&self, session_id: &str, target: AffinityTarget) {
-        self.sender.publish(session_id, target);
+    pub(super) fn publish(
+        &self,
+        session_id: &str,
+        target: AffinityTarget,
+        root_session_id: Option<&str>,
+    ) {
+        self.sender.publish(session_id, target, root_session_id);
     }
 
     pub(super) fn shutdown_now(&mut self) {
@@ -295,6 +304,7 @@ mod tests {
             session_id: "session".to_string(),
             worker_id,
             dp_rank: Some(0),
+            root_session_id: None,
             router_id,
         }
     }
@@ -322,6 +332,7 @@ mod tests {
                 worker_id: 10,
                 dp_rank: Some(0),
             },
+            Some("root"),
         );
         runtime.publish(
             "second",
@@ -329,9 +340,12 @@ mod tests {
                 worker_id: 11,
                 dp_rank: Some(0),
             },
+            None,
         );
 
-        assert_eq!(rx.recv().await.unwrap().session_id, "first");
+        let update = rx.recv().await.unwrap();
+        assert_eq!(update.session_id, "first");
+        assert_eq!(update.root_session_id.as_deref(), Some("root"));
         assert!(rx.try_recv().is_err());
     }
 

--- a/lib/llm/src/session_affinity/replica_sync.rs
+++ b/lib/llm/src/session_affinity/replica_sync.rs
@@ -33,8 +33,6 @@ pub(super) struct SessionAffinityUpdate {
     pub session_id: String,
     pub worker_id: u64,
     pub dp_rank: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub root_session_id: Option<String>,
     pub router_id: u64,
 }
 
@@ -45,12 +43,11 @@ struct ReplicaUpdateSender {
 }
 
 impl ReplicaUpdateSender {
-    fn publish(&self, session_id: &str, target: AffinityTarget, root_session_id: Option<&str>) {
+    fn publish(&self, session_id: &str, target: AffinityTarget) {
         let update = SessionAffinityUpdate {
             session_id: session_id.to_string(),
             worker_id: target.worker_id,
             dp_rank: target.dp_rank,
-            root_session_id: root_session_id.map(str::to_string),
             router_id: self.router_id,
         };
         if let Err(error) = self.tx.try_send(update) {
@@ -86,8 +83,7 @@ impl ReplicaUpdateApplier {
             worker_id: update.worker_id,
             dp_rank: update.dp_rank,
         };
-        let outcome =
-            coordinator.apply_replica_update(update.session_id, target, update.root_session_id);
+        let outcome = coordinator.apply_replica_update(update.session_id, target);
         drop(coordinator);
         tracing::trace!(
             worker_id = target.worker_id,
@@ -235,13 +231,8 @@ impl ReplicaSyncRuntime {
         })
     }
 
-    pub(super) fn publish(
-        &self,
-        session_id: &str,
-        target: AffinityTarget,
-        root_session_id: Option<&str>,
-    ) {
-        self.sender.publish(session_id, target, root_session_id);
+    pub(super) fn publish(&self, session_id: &str, target: AffinityTarget) {
+        self.sender.publish(session_id, target);
     }
 
     pub(super) fn shutdown_now(&mut self) {
@@ -304,7 +295,6 @@ mod tests {
             session_id: "session".to_string(),
             worker_id,
             dp_rank: Some(0),
-            root_session_id: None,
             router_id,
         }
     }
@@ -332,7 +322,6 @@ mod tests {
                 worker_id: 10,
                 dp_rank: Some(0),
             },
-            Some("root"),
         );
         runtime.publish(
             "second",
@@ -340,12 +329,9 @@ mod tests {
                 worker_id: 11,
                 dp_rank: Some(0),
             },
-            None,
         );
 
-        let update = rx.recv().await.unwrap();
-        assert_eq!(update.session_id, "first");
-        assert_eq!(update.root_session_id.as_deref(), Some("root"));
+        assert_eq!(rx.recv().await.unwrap().session_id, "first");
         assert!(rx.try_recv().is_err());
     }
 

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -12,8 +12,8 @@ use dynamo_runtime::{
 use futures::{StreamExt, stream};
 
 use super::{
-    AffinityAcquire, AffinityCoordinator, AffinityTarget, LlmResponse, SessionAffinityGrouping,
-    affinity_id, coordinator::ReplicaApplyOutcome, explicit_target,
+    AffinityAcquire, AffinityCoordinator, AffinityTarget, LlmResponse, affinity_id,
+    coordinator::ReplicaApplyOutcome, explicit_target,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -162,56 +162,36 @@ async fn session_affinity_initialization_is_atomic() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn child_affinity_uses_configured_parent_or_root_only_for_initial_placement() {
-    for (grouping, expected) in [
-        (SessionAffinityGrouping::Parent, target(8, Some(1))),
-        (SessionAffinityGrouping::Root, target(7, Some(0))),
-    ] {
-        let coordinator =
-            AffinityCoordinator::new_with_grouping(Duration::from_secs(10), Some(grouping))
-                .unwrap();
-        let context = Controller::default();
-        let root_id = SessionAffinityId::new("root");
-        let parent_id = SessionAffinityId::new("parent");
-        let child_id = SessionAffinityId::new("child");
+async fn child_affinity_uses_parent_only_for_initial_placement() {
+    let coordinator =
+        AffinityCoordinator::new_with_parent_affinity(Duration::from_secs(10), true).unwrap();
+    let context = Controller::default();
+    let parent_id = SessionAffinityId::new("parent");
+    let child_id = SessionAffinityId::new("child");
+    let parent_target = target(8, Some(1));
 
-        let AffinityAcquire::Initialize(root) = coordinator.acquire(&root_id, None).await.unwrap()
-        else {
-            panic!("root must initialize");
-        };
-        drop(root.commit(target(7, Some(0))).unwrap());
+    let AffinityAcquire::Initialize(parent) = coordinator.acquire(&parent_id, None).await.unwrap()
+    else {
+        panic!("parent must initialize");
+    };
+    drop(parent.commit(parent_target).unwrap());
 
-        let AffinityAcquire::Initialize(parent) = coordinator
-            .acquire_with_lineage(
-                &parent_id,
-                Some(root_id.as_str()),
-                Some(target(8, Some(1))),
-                &context,
-            )
-            .await
-            .unwrap()
-        else {
-            panic!("parent must initialize");
-        };
-        drop(parent.commit(target(8, Some(1))).unwrap());
+    let child = coordinator
+        .acquire_with_parent(&child_id, Some(parent_id.as_str()), None, &context)
+        .await
+        .unwrap();
+    assert_eq!(child.target(), Some(parent_target));
+    let AffinityAcquire::Initialize(child) = child else {
+        panic!("child must initialize");
+    };
+    let fallback = target(9, Some(2));
+    drop(child.commit(fallback).unwrap());
 
-        let child = coordinator
-            .acquire_with_lineage(&child_id, Some(parent_id.as_str()), None, &context)
-            .await
-            .unwrap();
-        assert_eq!(child.target(), Some(expected));
-        let AffinityAcquire::Initialize(child) = child else {
-            panic!("child must initialize");
-        };
-        let fallback = target(9, Some(2));
-        drop(child.commit(fallback).unwrap());
-
-        let child = coordinator
-            .acquire_with_lineage(&child_id, Some(parent_id.as_str()), None, &context)
-            .await
-            .unwrap();
-        assert_eq!(child.target(), Some(fallback));
-    }
+    let child = coordinator
+        .acquire_with_parent(&child_id, Some(parent_id.as_str()), None, &context)
+        .await
+        .unwrap();
+    assert_eq!(child.target(), Some(fallback));
 }
 
 #[tokio::test(start_paused = true)]

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -12,8 +12,8 @@ use dynamo_runtime::{
 use futures::{StreamExt, stream};
 
 use super::{
-    AffinityAcquire, AffinityCoordinator, AffinityTarget, LlmResponse, affinity_id,
-    coordinator::ReplicaApplyOutcome, explicit_target,
+    AffinityAcquire, AffinityCoordinator, AffinityTarget, LlmResponse, SessionAffinityGrouping,
+    affinity_id, coordinator::ReplicaApplyOutcome, explicit_target,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -159,6 +159,59 @@ async fn session_affinity_initialization_is_atomic() {
     assert_eq!(second_target, target(7, Some(0)));
     drop(first_lease);
     drop(second_lease);
+}
+
+#[tokio::test(start_paused = true)]
+async fn child_affinity_uses_configured_parent_or_root_only_for_initial_placement() {
+    for (grouping, expected) in [
+        (SessionAffinityGrouping::Parent, target(8, Some(1))),
+        (SessionAffinityGrouping::Root, target(7, Some(0))),
+    ] {
+        let coordinator =
+            AffinityCoordinator::new_with_grouping(Duration::from_secs(10), Some(grouping))
+                .unwrap();
+        let context = Controller::default();
+        let root_id = SessionAffinityId::new("root");
+        let parent_id = SessionAffinityId::new("parent");
+        let child_id = SessionAffinityId::new("child");
+
+        let AffinityAcquire::Initialize(root) = coordinator.acquire(&root_id, None).await.unwrap()
+        else {
+            panic!("root must initialize");
+        };
+        drop(root.commit(target(7, Some(0))).unwrap());
+
+        let AffinityAcquire::Initialize(parent) = coordinator
+            .acquire_with_lineage(
+                &parent_id,
+                Some(root_id.as_str()),
+                Some(target(8, Some(1))),
+                &context,
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("parent must initialize");
+        };
+        drop(parent.commit(target(8, Some(1))).unwrap());
+
+        let child = coordinator
+            .acquire_with_lineage(&child_id, Some(parent_id.as_str()), None, &context)
+            .await
+            .unwrap();
+        assert_eq!(child.target(), Some(expected));
+        let AffinityAcquire::Initialize(child) = child else {
+            panic!("child must initialize");
+        };
+        let fallback = target(9, Some(2));
+        drop(child.commit(fallback).unwrap());
+
+        let child = coordinator
+            .acquire_with_lineage(&child_id, Some(parent_id.as_str()), None, &context)
+            .await
+            .unwrap();
+        assert_eq!(child.target(), Some(fallback));
+    }
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
## Summary

Adds opt-in parent-aware first placement for unbound child sessions using `--router-parent-affinity` or `DYN_ROUTER_PARENT_AFFINITY=1`. This lets a child reuse the immediate parent's worker and DP-rank locality without hard-pinning the session tree.

Closes #11343

### How This Was Implemented

- Reuses the existing session-affinity coordinator and treats the parent's live binding as a soft first-placement preference.
- Preserves routing precedence: an explicit target wins, an existing child binding wins on later requests, and an unavailable or ineligible parent target falls back to normal selection.
- Commits the child affinity to the worker and DP rank actually selected after successful dispatch.
- Wires the disabled-by-default boolean through Rust routing config, Python bindings, frontend CLI/environment parsing, and router documentation; enabling it requires a session-affinity TTL.

<details>
<summary>Walkthrough</summary>

#### Mental model

The parent and child keep independent affinity entries. The parent only seeds the child's first placement; after that request succeeds, the child follows its own binding.

```mermaid
flowchart LR
    A["Request metadata<br/>parent_session_id"] --> B["Affinity coordinator<br/>look up parent binding"]
    B --> C["Router selection<br/>soft preferred target"]
    C --> D["Successful dispatch<br/>bind child to actual target"]
```

#### State and ordering

For an unbound child, an explicit target takes precedence over the parent's binding. Without an explicit target, the parent's current `(worker_id, dp_rank)` becomes the preferred target; if normal load or eligibility checks reject it, ordinary routing selects a fallback and that fallback becomes the child's binding.

Once the child is bound, later requests validate and reuse the child's binding rather than consulting the parent again. Existing best-effort affinity synchronization continues to replicate the resulting child binding without adding lineage state to the replica protocol.

#### Request lifecycle

The router reads `parent_session_id` from the existing agent context and asks the affinity coordinator for an acquisition. A new child acquisition exposes the parent target as a preference, selection runs normally, and the initializer commits only the target that was successfully dispatched; cancellation and selection failures retain the existing affinity invalidation behavior.

#### Boundaries and limitations

This is disabled by default and only considers the immediate parent. It does not add root-lineage grouping, hard group pinning, backend scheduler gating, or a performance claim.

</details>

### Validation

- `cargo check -p dynamo-llm`
- `cargo test -p dynamo-llm session_affinity --lib` (44 passed)
- `cargo test -p dynamo-llm parent_affinity_falls_back --lib`
- Python frontend configuration tests (48 passed) and Python binding `cargo check`
- `cargo fmt --all --check`, Ruff check/format, `fern check`, `fern docs broken-links`, and `git diff --check`
<!-- codex-pr-description:end -->
