### PR TITLE
feat(power-agent): support affinity-based dev pod placement

### DIFF
--- a/deploy/helm/charts/power-agent/templates/NOTES.txt
+++ b/deploy/helm/charts/power-agent/templates/NOTES.txt
@@ -29,7 +29,7 @@ RBAC scope: {{ if eq (include "power-agent.effectiveNamespaceRestricted" .) "tru
 
 {{- if .Values.dev.enabled }}
 
-DEV MODE: a single Pod (not a DaemonSet) was created, pinned to node "{{ .Values.dev.nodeName }}".
+DEV MODE: a single Pod (not a DaemonSet) was created, {{ if .Values.dev.nodeName }}pinned to node "{{ .Values.dev.nodeName }}"{{ else }}scheduled via the affinity rules in dev.affinity{{ end }}.
 
 ╭─ PREREQUISITE — the script ConfigMap MUST exist before this Pod can start ─╮
 │                                                                            │

--- a/deploy/helm/charts/power-agent/templates/_helpers.tpl
+++ b/deploy/helm/charts/power-agent/templates/_helpers.tpl
@@ -216,7 +216,7 @@ pinned nodeName or scheduler affinity. Surfaces at `helm install` /
 {{- fail "daemonset.enabled and dev.enabled are mutually exclusive. Set exactly one." -}}
 {{- end -}}
 {{- if and .Values.dev.enabled (not .Values.dev.nodeName) (not .Values.dev.affinity) -}}
-{{- fail "dev.enabled requires a placement target: set dev.nodeName to pin the dev pod to a GPU node, or dev.affinity to let the scheduler place it. Set exactly one (nodeName wins if both are set)." -}}
+{{- fail "dev.enabled requires a placement target: set dev.nodeName to pin the dev pod to a GPU node, or dev.affinity to let the scheduler place it. Set at least one; nodeName takes precedence if both are set." -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/charts/power-agent/templates/_helpers.tpl
+++ b/deploy/helm/charts/power-agent/templates/_helpers.tpl
@@ -207,15 +207,16 @@ would mask validator regressions.
 
 {{/*
 Validate that production DaemonSet mode and in-cluster dev-pod mode are
-not both enabled, and that dev mode has a pinned nodeName. Surfaces at
-`helm install` / `helm template` time, not as two competing Pods at runtime.
+not both enabled, and that dev mode has a placement target — either a
+pinned nodeName or scheduler affinity. Surfaces at `helm install` /
+`helm template` time, not as two competing Pods at runtime.
 */}}
 {{- define "power-agent.validateMutex" -}}
 {{- if and .Values.daemonset.enabled .Values.dev.enabled -}}
 {{- fail "daemonset.enabled and dev.enabled are mutually exclusive. Set exactly one." -}}
 {{- end -}}
-{{- if and .Values.dev.enabled (not .Values.dev.nodeName) -}}
-{{- fail "dev.enabled requires dev.nodeName (the GPU node to pin the dev pod to)." -}}
+{{- if and .Values.dev.enabled (not .Values.dev.nodeName) (not .Values.dev.affinity) -}}
+{{- fail "dev.enabled requires a placement target: set dev.nodeName to pin the dev pod to a GPU node, or dev.affinity to let the scheduler place it. Set exactly one (nodeName wins if both are set)." -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/charts/power-agent/templates/dev-pod.yaml
+++ b/deploy/helm/charts/power-agent/templates/dev-pod.yaml
@@ -46,7 +46,18 @@ spec:
   restartPolicy: Never                   # let it stay Failed if it crashes so we can read logs
   terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}  # graceful shutdown restores TGP
   runtimeClassName: {{ .Values.runtimeClassName | quote }}
+  {{- if .Values.dev.nodeName }}
+  # Explicit pin: bypasses the scheduler entirely, so dev.affinity (if any)
+  # is intentionally not rendered here — Kubernetes would ignore it anyway.
   nodeName: {{ .Values.dev.nodeName | quote }}
+  {{- else }}
+  {{- with .Values.dev.affinity }}
+  # No nodeName: let the scheduler place the dev pod using these affinity
+  # rules. validateMutex guarantees one of nodeName/affinity is set.
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   {{- with .Values.tolerations }}
   tolerations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/helm/charts/power-agent/templates/dev-pod.yaml
+++ b/deploy/helm/charts/power-agent/templates/dev-pod.yaml
@@ -6,8 +6,9 @@
 #
 # In-cluster dev-iteration harness. Renders a single Pod that mounts
 # power_agent.py, actuator.py, and managed_state.py from an
-# externally-created ConfigMap, pinned to one GPU node (dev.nodeName)
-# and one namespace (Release.Namespace).
+# externally-created ConfigMap, placed on one GPU node via
+# dev.nodeName (pinned) or dev.affinity (scheduler), and scoped to
+# one namespace (Release.Namespace).
 #
 # PREREQUISITE (NOT validated by Helm — validateMutex only checks
 # daemonset/dev exclusivity, not this ConfigMap's existence. If it is

--- a/deploy/helm/charts/power-agent/tests/dev_placement_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/dev_placement_test.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Dev-pod placement contract. The dev pod supports two mutually exclusive
+# placement targets, guarded by validateMutex in templates/_helpers.tpl:
+#   - dev.nodeName  → pin directly to a node (scheduler bypassed)
+#   - dev.affinity  → let the scheduler place the pod (only when nodeName empty)
+# validateMutex fails at `helm template` time when dev.enabled=true but
+# neither is provided. nodeName wins when both are set, and dev.affinity is
+# then intentionally not rendered (Kubernetes ignores affinity once nodeName
+# is set, so emitting it would be misleading dead config).
+
+suite: dev-pod placement (nodeName / affinity)
+templates:
+  - templates/dev-pod.yaml
+release:
+  name: power-agent
+  namespace: dynamo-system
+
+tests:
+  - it: pins the dev pod via nodeName when dev.nodeName is set
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: gpu-node-0
+    asserts:
+      - notFailedTemplate: {}
+      - equal:
+          path: spec.nodeName
+          value: gpu-node-0
+      # nodeName wins: no affinity block even if the default {} were populated
+      - notExists:
+          path: spec.affinity
+
+  - it: renders affinity and omits nodeName when only dev.affinity is set
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: ""
+      dev.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+    asserts:
+      - notFailedTemplate: {}
+      - notExists:
+          path: spec.nodeName
+      - equal:
+          path: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: nvidia.com/gpu.present
+
+  - it: nodeName takes precedence when both nodeName and affinity are set
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: gpu-node-0
+      dev.affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: nvidia.com/gpu.present
+                    operator: In
+                    values:
+                      - "true"
+    asserts:
+      - notFailedTemplate: {}
+      - equal:
+          path: spec.nodeName
+          value: gpu-node-0
+      - notExists:
+          path: spec.affinity
+
+  - it: fails to render when dev.enabled but neither nodeName nor affinity is set
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "dev.enabled requires a placement target"

--- a/deploy/helm/charts/power-agent/tests/dev_placement_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/dev_placement_test.yaml
@@ -1,14 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Dev-pod placement contract. The dev pod supports two mutually exclusive
-# placement targets, guarded by validateMutex in templates/_helpers.tpl:
+# Dev-pod placement contract. The dev pod supports two placement targets,
+# guarded by validateMutex in templates/_helpers.tpl:
 #   - dev.nodeName  → pin directly to a node (scheduler bypassed)
 #   - dev.affinity  → let the scheduler place the pod (only when nodeName empty)
-# validateMutex fails at `helm template` time when dev.enabled=true but
-# neither is provided. nodeName wins when both are set, and dev.affinity is
-# then intentionally not rendered (Kubernetes ignores affinity once nodeName
-# is set, so emitting it would be misleading dead config).
+# At least one is required; nodeName takes precedence if both are set, and
+# dev.affinity is then intentionally not rendered (Kubernetes ignores affinity
+# once nodeName is set, so emitting it would be misleading dead config).
+# validateMutex also rejects daemonset.enabled + dev.enabled together.
 
 suite: dev-pod placement (nodeName / affinity)
 templates:
@@ -50,6 +50,10 @@ tests:
       - notFailedTemplate: {}
       - notExists:
           path: spec.nodeName
+      # Stable top-level check: affinity block rendered.
+      - isNotNull:
+          path: spec.affinity.nodeAffinity
+      # Secondary: confirm the operator-supplied rule survived toYaml.
       - equal:
           path: spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
           value: nvidia.com/gpu.present
@@ -84,3 +88,14 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: "dev.enabled requires a placement target"
+
+  - it: fails when both daemonset.enabled and dev.enabled are set
+    set:
+      daemonset.enabled: true
+      dev.enabled: true
+      # placement target present so the failure is specifically the mutex,
+      # not the "requires a placement target" branch.
+      dev.nodeName: gpu-node-0
+    asserts:
+      - failedTemplate:
+          errorPattern: "mutually exclusive"

--- a/deploy/helm/charts/power-agent/values.yaml
+++ b/deploy/helm/charts/power-agent/values.yaml
@@ -244,14 +244,29 @@ daemonset:
 # ConfigMap will start the pod but ImportError immediately.
 #
 # Mutually exclusive with daemonset.enabled (chart fails to render if both
-# are true). dev.nodeName is required when dev.enabled=true.
+# are true). When dev.enabled=true you must provide a placement target:
+# either dev.nodeName (pin) or dev.affinity (scheduler). The chart fails to
+# render if neither is set.
 dev:
   enabled: false
-  # Required when enabled=true. Pin to the GPU node hosting the workload pod
-  # being annotated. Find a candidate with:
+  # Placement option 1 — pin the dev pod directly to a GPU node. Takes
+  # precedence over dev.affinity: when set, the scheduler is bypassed and
+  # dev.affinity is not rendered. Find a candidate with:
   #   kubectl get pods -n $NAMESPACE -l nvidia.com/dynamo-component-type=worker \
   #     -o jsonpath='{.items[*].spec.nodeName}'
   nodeName: ""
+  # Placement option 2 — let the scheduler place the dev pod using standard
+  # Pod affinity rules (nodeAffinity/podAffinity/podAntiAffinity). Only
+  # rendered when dev.nodeName is empty. Example:
+  #   affinity:
+  #     nodeAffinity:
+  #       requiredDuringSchedulingIgnoredDuringExecution:
+  #         nodeSelectorTerms:
+  #           - matchExpressions:
+  #               - key: nvidia.com/gpu.present
+  #                 operator: In
+  #                 values: ["true"]
+  affinity: {}
   # Name of an externally-created ConfigMap holding power_agent.py,
   # actuator.py AND managed_state.py at the matching key names (all three
   # are required; see top-of-section recipe).

--- a/deploy/helm/charts/power-agent/values.yaml
+++ b/deploy/helm/charts/power-agent/values.yaml
@@ -266,6 +266,7 @@ dev:
   #               - key: nvidia.com/gpu.present
   #                 operator: In
   #                 values: ["true"]
+  # Empty ({}) means "not set" — Helm treats empty maps as false.
   affinity: {}
   # Name of an externally-created ConfigMap holding power_agent.py,
   # actuator.py AND managed_state.py at the matching key names (all three


### PR DESCRIPTION
## Summary

Adds affinity-based placement for the power-agent in-cluster dev pod, reworking the
intent of #11885 into a complete, validated contract.

Previously the dev pod hard-required `dev.nodeName` and unconditionally rendered
`spec.nodeName`, so it could only ever be pinned to one node. This PR introduces
`dev.affinity` as an alternative placement target:

- `dev.nodeName` set → render `spec.nodeName` (scheduler bypassed).
- `dev.nodeName` empty + `dev.affinity` set → render `spec.affinity`.
- neither set → `validateMutex` fails at `helm template` time with an actionable message.

`nodeName` takes precedence when both are set, and `dev.affinity` is then intentionally
**not** rendered — Kubernetes ignores affinity once `spec.nodeName` is set, so emitting
it would be misleading dead config.

### What this fixes relative to #11885

That PR added the `affinity` block but left the contract incomplete. The review found:

- `validateMutex` still hard-required `dev.nodeName`, so an affinity-only config failed
  during rendering before the new block could ever be used. **Fixed** — validation now
  requires `nodeName` *or* `affinity`.
- With both set, both `nodeName` and `affinity` were emitted despite the value doc saying
  affinity is "only effective when nodeName is empty." **Fixed** — affinity renders only
  when `nodeName` is empty.
- `NOTES.txt` still claimed every dev pod was pinned via `nodeName`. **Fixed** — the
  post-install note now reflects the active placement mode.
- No test covered the placement contract. **Fixed** — added a `helm-unittest` suite.

### Files

- `templates/dev-pod.yaml` — conditional `nodeName` / `affinity` placement.
- `templates/_helpers.tpl` — `validateMutex` now requires a placement target (nodeName or affinity).
- `templates/NOTES.txt` — reports pin vs. scheduler placement.
- `values.yaml` — documents both placement options; adds `dev.affinity: {}`.
- `tests/dev_placement_test.yaml` — new suite covering all four branches.

## Validation

Run from `deploy/helm/charts/power-agent`:

- `helm lint . --set image.tag=ci-test` → passes.
- `helm template` for the pinned path (`--set dev.enabled=true --set dev.nodeName=ci-node`) → renders.
- `helm template` for the affinity-only path (`--set dev.enabled=true --set dev.affinity...`) → renders.
- `helm unittest .` → **52 passed** (5 suites), including the 4 new placement tests:
  - pins via `nodeName` when set (and no `affinity` block),
  - renders `affinity` and omits `nodeName` when only affinity is set,
  - `nodeName` wins when both are set,
  - fails to render when neither is set.

## Related Issues

- Relates to #11885

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12074" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible development Pod placement using either a specific node or affinity-based scheduling.
  * Specific node placement takes precedence when both options are configured.

* **Bug Fixes**
  * Improved validation and error messaging when development mode lacks a placement target.

* **Tests**
  * Added coverage for node pinning, affinity scheduling, precedence, and invalid configurations.

* **Documentation**
  * Updated Helm value guidance to explain development Pod placement options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->