### PR TITLE
fix(mocker): restore KVBM test imports

### DIFF
--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -4,6 +4,8 @@
 use std::time::Instant;
 
 #[cfg(all(test, feature = "kvbm-offload"))]
+use std::sync::{Arc, Mutex};
+#[cfg(all(test, feature = "kvbm-offload"))]
 use std::time::Duration;
 
 use tokio::sync::mpsc;


### PR DESCRIPTION
## Overview:

CI fix for KVBM test imports

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved conditional compilation for internal test utilities when KV cache offloading is enabled.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->