### PR TITLE
chore(sglang): bump to 0.5.16

### DIFF
--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -66,7 +66,7 @@ ensure_sglang_top_level_exports()
 def ensure_sglang_tensor_image_size() -> None:
     """Allow SGLang's image-token resolver to handle decoded image tensors.
 
-    SGLang 0.5.13 through 0.5.15 assume every decoded image exposes the PIL
+    SGLang 0.5.13 through 0.5.16 assume every decoded image exposes the PIL
     ``height``/``width`` attributes. Its CUDA JPEG decoder instead returns a
     CHW tensor, causing multimodal requests to fall back to retokenization.
 
@@ -173,49 +173,6 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
     return kwargs
 
 
-@lru_cache(maxsize=32)
-def _start_profile_accepts_request_object(start_profile: Any) -> bool:
-    """Return whether TokenizerManager.start_profile expects a ProfileReq."""
-    try:
-        signature = inspect.signature(start_profile)
-    except (TypeError, ValueError):
-        logger.debug(
-            "Could not inspect SGLang TokenizerManager.start_profile signature; "
-            "using the legacy keyword-argument API"
-        )
-        return False
-
-    return "req" in signature.parameters
-
-
-def _build_profile_request(body: dict[str, Any]) -> Any:
-    from sglang.srt.managers.io_struct import ProfileReq
-
-    return ProfileReq(**body)
-
-
-async def start_profile_compat(tokenizer_manager: Any, body: dict[str, Any]) -> None:
-    """Start profiling across SGLang's old and new control APIs.
-
-    SGLang 0.5.14 accepts profiling fields as keyword arguments. SGLang 0.5.15
-    accepts one ``ProfileReq`` object instead.
-    """
-    start_profile = tokenizer_manager.start_profile
-    signature_source = getattr(start_profile, "__func__", start_profile)
-
-    try:
-        accepts_request_object = _start_profile_accepts_request_object(signature_source)
-    except TypeError:
-        accepts_request_object = _start_profile_accepts_request_object.__wrapped__(
-            signature_source
-        )
-
-    if accepts_request_object:
-        await start_profile(_build_profile_request(body))
-    else:
-        await start_profile(**body)
-
-
 def enable_disjoint_streaming_output(server_args: Any) -> None:
     """Enable SGLang's disjoint streaming output.
 
@@ -232,5 +189,4 @@ __all__ = [
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",
     "require_reasoning_kwargs",
-    "start_profile_compat",
 ]

--- a/components/src/dynamo/sglang/_compat.py
+++ b/components/src/dynamo/sglang/_compat.py
@@ -173,18 +173,7 @@ def require_reasoning_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[st
     return kwargs
 
 
-def enable_disjoint_streaming_output(server_args: Any) -> None:
-    """Enable SGLang's disjoint streaming output.
-
-    Diffusion workers pass a ``SimpleNamespace`` stub that does not carry the
-    field, so this is a no-op when the attribute is absent.
-    """
-    if hasattr(server_args, "incremental_streaming_output"):
-        server_args.incremental_streaming_output = True
-
-
 __all__ = [
-    "enable_disjoint_streaming_output",
     "ensure_sglang_tensor_image_size",
     "ensure_sglang_top_level_exports",
     "filter_supported_async_generate_kwargs",

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -29,10 +29,7 @@ from dynamo.common.snapshot.lifecycle import (
 )
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.runtime.logging import configure_dynamo_logging
-from dynamo.sglang._compat import (
-    enable_disjoint_streaming_output,
-    ensure_sglang_tensor_image_size,
-)
+from dynamo.sglang._compat import ensure_sglang_tensor_image_size
 from dynamo.sglang.backend_args import DynamoSGLangArgGroup, DynamoSGLangConfig
 
 configure_dynamo_logging()
@@ -549,6 +546,8 @@ async def parse_args(
             f"Created stub ServerArgs for {worker_type}: model_path={server_args.model_path}"
         )
     else:
+        # Dynamo expects disjoint output_ids; ServerArgs is read-only after resolution.
+        parsed_args.incremental_streaming_output = True
         server_args = ServerArgs.from_cli_args(parsed_args)
         if server_args.get_model_config().is_multimodal:
             ensure_sglang_tensor_image_size()
@@ -559,12 +558,6 @@ async def parse_args(
             "SGLang integration. Dynamo normalizes request priority so higher "
             "values are always higher priority at the API layer."
         )
-
-    # Dynamo's streaming handlers expect disjoint output_ids from SGLang (only new
-    # tokens since last output), not cumulative tokens. Modern SGLang gates this
-    # behavior behind incremental_streaming_output, while older releases used
-    # stream_output.
-    enable_disjoint_streaming_output(server_args)
 
     if dynamo_config.use_sglang_tokenizer:
         warnings.warn(

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -517,6 +517,22 @@ async def parse_args(
     image_diffusion_worker = dynamo_config.image_diffusion_worker
     video_generation_worker = dynamo_config.video_generation_worker
 
+    # ServerArgs is read-only after resolution, so apply Dynamo defaults first.
+    fpm_source = _forward_pass_metrics_source(
+        dynamo_config,
+        fpm_trace_relay_supported=fpm_trace_relay_supported,
+    )
+    if fpm_source and not getattr(parsed_args, "enable_forward_pass_metrics", False):
+        parsed_args.enable_forward_pass_metrics = True
+        logging.info("Enabled forward_pass_metrics from %s", fpm_source)
+
+    if (
+        parsed_args.dllm_algorithm
+        and getattr(parsed_args, "max_running_requests", None) is None
+    ):
+        parsed_args.max_running_requests = 8
+        logging.info("Defaulting max_running_requests to 8 for diffusion worker")
+
     if image_diffusion_worker or video_generation_worker:
         worker_type = (
             "image diffusion" if image_diffusion_worker else "video generation"
@@ -542,6 +558,9 @@ async def parse_args(
         server_args.dllm_algorithm = False
         server_args.load_format = None
         server_args.enable_trace = getattr(parsed_args, "enable_trace", False)
+        server_args.enable_forward_pass_metrics = getattr(
+            parsed_args, "enable_forward_pass_metrics", False
+        )
         logging.info(
             f"Created stub ServerArgs for {worker_type}: model_path={server_args.model_path}"
         )
@@ -587,30 +606,8 @@ async def parse_args(
         f"Derived use_kv_events={use_kv_events} from kv_events_config={server_args.kv_events_config}"
     )
 
-    # Enable forward pass metrics from dynamo env var if configured
-    fpm_source = _forward_pass_metrics_source(
-        dynamo_config,
-        fpm_trace_relay_supported=fpm_trace_relay_supported,
-    )
-    if fpm_source and not getattr(server_args, "enable_forward_pass_metrics", False):
-        server_args.enable_forward_pass_metrics = True
-        logging.info("Enabled forward_pass_metrics from %s", fpm_source)
-
     # Auto-detect diffusion worker mode if dllm_algorithm
     diffusion_worker = server_args.dllm_algorithm is not None
-
-    # SGLang's DLLM scheduler reads server_args.max_running_requests directly
-    # but the field stays None until the normal scheduler init sets it from
-    # tp_worker.get_worker_info(). Set a safe default so the DLLM mixin
-    # doesn't crash on `None - int`.
-    # Only applies to real DLLM workers (truthy algorithm string), not
-    # video/image diffusion stubs where dllm_algorithm=False.
-    if (
-        server_args.dllm_algorithm
-        and getattr(server_args, "max_running_requests", None) is None
-    ):
-        server_args.max_running_requests = 8
-        logging.info("Defaulting max_running_requests to 8 for diffusion worker")
 
     dynamo_config.namespace = parsed_namespace
     dynamo_config.component = parsed_component_name

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -23,6 +23,7 @@ from typing import (
 )
 
 import sglang as sgl
+from sglang.srt.managers.io_struct import ProfileReq
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 from dynamo._core import Context
@@ -43,7 +44,6 @@ from dynamo.llm import (
 )
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
-from dynamo.sglang._compat import start_profile_compat
 from dynamo.sglang.args import Config
 from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import DynamoSglangPublisher
@@ -876,7 +876,7 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
         Args:
             body: Dict with profiling parameters passed to start_profile.
         """
-        await start_profile_compat(self.engine.tokenizer_manager, body)
+        await self.engine.tokenizer_manager.start_profile(ProfileReq(**body))
         return {"status": "ok", "message": "Profiling started"}
 
     async def stop_profile(self, body: dict) -> dict:

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -23,7 +23,6 @@ from dynamo.sglang._compat import (
     ensure_sglang_top_level_exports,
     filter_supported_async_generate_kwargs,
     require_reasoning_kwargs,
-    start_profile_compat,
 )
 from dynamo.sglang.args import (
     _forward_pass_metrics_source,
@@ -148,6 +147,7 @@ def test_compat_supports_tensor_image_sizes_and_is_idempotent(caplog, monkeypatc
 
         processor = object.__new__(ConcreteMultimodalProcessor)
         processor._processor = Processor()
+        processor.use_cuda_ipc = False
         image_token_id = 99
         processor._process_and_collect_mm_items = lambda **kwargs: (
             [],
@@ -386,46 +386,6 @@ def test_compat_caches_async_generate_signature_inspection(monkeypatch):
     assert calls == 1
 
     sglang_compat._get_async_generate_supported_kwarg_names.cache_clear()
-
-
-@pytest.mark.asyncio
-async def test_compat_starts_profile_with_legacy_kwargs():
-    class LegacyTokenizerManager:
-        received = None
-
-        async def start_profile(self, output_dir=None, start_step=None, num_steps=None):
-            self.received = {
-                "output_dir": output_dir,
-                "start_step": start_step,
-                "num_steps": num_steps,
-            }
-
-    manager = LegacyTokenizerManager()
-    body = {"output_dir": "/tmp/profile", "start_step": 10, "num_steps": 5}
-
-    await start_profile_compat(manager, body)
-
-    assert manager.received == body
-
-
-@pytest.mark.asyncio
-async def test_compat_starts_profile_with_request_object(monkeypatch):
-    class RequestTokenizerManager:
-        received = None
-
-        async def start_profile(self, req=None):
-            self.received = req
-
-    request = SimpleNamespace(output_dir="/tmp/profile", start_step=10, num_steps=5)
-    monkeypatch.setattr(sglang_compat, "_build_profile_request", lambda body: request)
-    manager = RequestTokenizerManager()
-
-    await start_profile_compat(
-        manager,
-        {"output_dir": "/tmp/profile", "start_step": 10, "num_steps": 5},
-    )
-
-    assert manager.received is request
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -246,6 +246,31 @@ async def test_parse_args_enables_incremental_streaming_before_resolution(
     assert config.server_args.incremental_streaming_output is True
 
 
+@pytest.mark.asyncio
+async def test_parse_args_applies_dynamo_defaults_before_resolution(
+    monkeypatch, mock_sglang_cli
+):
+    monkeypatch.setenv("DYN_FORWARDPASS_METRIC_PORT", "23456")
+    server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        dllm_algorithm="dream",
+        enable_forward_pass_metrics=True,
+        kv_events_config=None,
+        max_running_requests=8,
+        get_model_config=lambda: SimpleNamespace(is_multimodal=False),
+    )
+
+    def resolve(parsed_args):
+        assert parsed_args.enable_forward_pass_metrics is True
+        assert parsed_args.max_running_requests == 8
+        return server_args
+
+    monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
+    mock_sglang_cli("--model", "/tmp", "--dllm-algorithm", "dream")
+
+    await parse_args(sys.argv[1:])
+
+
 def test_compat_filters_async_generate_kwargs_for_older_engines():
     class OldEngine:
         async def async_generate(self, input_ids=None, sampling_params=None):

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -14,6 +14,7 @@ import pytest
 import torch
 import yaml
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.managers.io_struct import ProfileReq
 
 import dynamo.sglang._compat as sglang_compat
 from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
@@ -36,6 +37,7 @@ from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
+from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
@@ -218,6 +220,32 @@ async def test_tensor_image_size_compat_uses_resolved_model_capability(
     assert install_calls == ([True] if is_multimodal else [])
 
 
+@pytest.mark.asyncio
+async def test_parse_args_enables_incremental_streaming_before_resolution(
+    monkeypatch, mock_sglang_cli
+):
+    server_args = SimpleNamespace(
+        disaggregation_mode="null",
+        dllm_algorithm=None,
+        kv_events_config=None,
+        get_model_config=lambda: SimpleNamespace(is_multimodal=False),
+    )
+
+    def resolve(parsed_args):
+        assert parsed_args.incremental_streaming_output is True
+        server_args.incremental_streaming_output = (
+            parsed_args.incremental_streaming_output
+        )
+        return server_args
+
+    monkeypatch.setattr("dynamo.sglang.args.ServerArgs.from_cli_args", resolve)
+    mock_sglang_cli(model="/tmp")
+
+    config = await parse_args(sys.argv[1:])
+
+    assert config.server_args.incremental_streaming_output is True
+
+
 def test_compat_filters_async_generate_kwargs_for_older_engines():
     class OldEngine:
         async def async_generate(self, input_ids=None, sampling_params=None):
@@ -386,6 +414,29 @@ def test_compat_caches_async_generate_signature_inspection(monkeypatch):
     assert calls == 1
 
     sglang_compat._get_async_generate_supported_kwarg_names.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_start_profile_forwards_profile_request():
+    class TokenizerManager:
+        request = None
+
+        async def start_profile(self, request):
+            self.request = request
+
+    tokenizer_manager = TokenizerManager()
+    handler = SimpleNamespace(
+        engine=SimpleNamespace(tokenizer_manager=tokenizer_manager)
+    )
+    body = {"output_dir": "/tmp/profile", "start_step": 10, "num_steps": 5}
+
+    response = await BaseWorkerHandler.start_profile(handler, body)
+
+    assert isinstance(tokenizer_manager.request, ProfileReq)
+    assert tokenizer_manager.request.output_dir == body["output_dir"]
+    assert tokenizer_manager.request.start_step == body["start_step"]
+    assert tokenizer_manager.request.num_steps == body["num_steps"]
+    assert response == {"status": "ok", "message": "Profiling started"}
 
 
 @pytest.mark.asyncio

--- a/container/compliance/license_overrides.yaml
+++ b/container/compliance/license_overrides.yaml
@@ -356,6 +356,8 @@ overrides:
   - { ecosystem: python, name: deep-ep,                   license: "MIT",       source: "deep-ep upstream — https://github.com/deepseek-ai/DeepEP/blob/main/LICENSE" }
   - { ecosystem: python, name: gguf,                      license: "MIT",       source: "gguf (llama.cpp Python binding) — https://github.com/ggerganov/llama.cpp/blob/master/LICENSE" }
   - { ecosystem: python, name: google-crc32c,             license: "Apache-2.0",  source: "google-crc32c upstream — https://github.com/googleapis/python-crc32c/blob/main/LICENSE" }
+  - { ecosystem: python, name: helion,                    license: "BSD-3-Clause",  source: "PyTorch Helion — https://github.com/pytorch/helion/blob/main/LICENSE" }
+  - { ecosystem: python, name: hpc-ops,                   license: "MIT AND BSD-3-Clause",  source: "Tencent HPC-Ops and bundled CUTLASS — https://github.com/Tencent/hpc-ops/blob/main/LICENSE.txt" }
   - { ecosystem: python, name: icdiff,                    license: "BSD-3-Clause",  source: "icdiff upstream — https://github.com/jeffkaufman/icdiff/blob/master/LICENSE" }
   - { ecosystem: python, name: jinja2,                    license: "BSD-3-Clause",  source: "Jinja upstream — https://github.com/pallets/jinja/blob/main/LICENSE.rst" }
   - { ecosystem: python, name: jiter,                     license: "MIT",       source: "jiter upstream — https://github.com/pydantic/jiter/blob/main/LICENSE" }

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -102,7 +102,7 @@ sglang:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.5.15-cu130-runtime
+    runtime_image_tag: v0.5.16-cu130-runtime
     # Baseline is the TRUE base of the third-party lmsysorg/sglang image,
     # nvidia/cuda:13.0.1-cudnn-devel-ubuntu24.04 (Docker Hub; CUDA_VERSION=13.0.1,
     # cuDNN 9.13.0.50, ubuntu24.04), NOT a self-baseline of lmsysorg/sglang.

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -13,16 +13,6 @@ FROM framework AS runtime
 FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 {% endif %}
 
-{% if device != "xpu" %}
-# SGLang 0.5.15 JIT-compiles its native HiCache hash extension, which includes
-# OpenSSL headers and links libcrypto.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libssl-dev
-{% endif %}
-
 ARG MODELEXPRESS_VERSION
 
 WORKDIR /workspace

--- a/docs/fern/assets/releases.json
+++ b/docs/fern/assets/releases.json
@@ -10,7 +10,7 @@
     "wheel": "1.3.0.post1"
   },
   "mainTot": {
-    "sglang": "0.5.15",
+    "sglang": "0.5.16",
     "trtllm": "1.3.0rc22",
     "vllm": "0.26.0",
     "nixlSglang": "1.3.0",

--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -68,7 +68,7 @@ export const CURRENT_TAG = "1.3.0";
 export const CURRENT_WHEEL = "1.3.0.post1";
 
 export const MAIN_TOT: BackendPins = {
-  sglang: "0.5.15",
+  sglang: "0.5.16",
   trtllm: "1.3.0rc22",
   vllm: "0.26.0",
   nixlSglang: "1.3.0",

--- a/docs/fern/reference/compatibility.mdx
+++ b/docs/fern/reference/compatibility.mdx
@@ -204,7 +204,7 @@ Current stable release: v1.3.0 (container tag `1.3.0`, wheel version `1.3.0.post
 
 | Dynamo | Type | SGLang | TensorRT-LLM | vLLM | NIXL (SGL / TRT / vLLM) | UCX |
 | --- | --- | --- | --- | --- | --- | --- |
-| main (ToT) | development head | 0.5.15 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.1 | - |
+| main (ToT) | development head | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.1 | - |
 | v1.3.0 | stable | 0.5.14 | 1.3.0rc19 | 0.23.0 | 1.3.0 / 1.0.1 / 1.1.0 | 1.20.x |
 | v1.3.0-dev.1 | platform-preview | 0.5.12.post1 | 1.3.0rc17 | 0.22.0 | 1.0.1 / 0.10.1 / 1.1.0 | - |
 | v1.2.1 | patch | 0.5.11 | 1.3.0rc14 | 0.20.1 | 1.0.1 / 0.10.1 / 0.10.1 | - |

--- a/docs/fern/reference/releases-data.mdx
+++ b/docs/fern/reference/releases-data.mdx
@@ -15,7 +15,7 @@ Current stable release: v1.3.0 (Jul 20, 2026; container tag `1.3.0`, wheel versi
 
 | Version | Kind | Date | SGLang | TensorRT-LLM | vLLM | NIXL (SGL / TRT / vLLM) | UCX | Notes | Delta |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| main (ToT) | development head | - | 0.5.15 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.1.0 | - | - | - |
+| main (ToT) | development head | - | 0.5.16 | 1.3.0rc22 | 0.26.0 | 1.3.0 / 1.0.1 / 1.3.1 | - | - | - |
 | v1.3.0 | stable | Jul 20, 2026 | 0.5.14 | 1.3.0rc19 | 0.23.0 | 1.3.0 / 1.0.1 / 1.1.0 | 1.20.x | [release notes](https://docs.nvidia.com/dynamo/dev/reference/releases/v1-3-0) | CUDA 12 container images discontinued; EFA variants go multi-arch as -efa; GA wheels published as 1.3.0.post1 (containers stay :1.3.0); UCX 1.20.x. |
 | v1.3.0-dev.1 | platform-preview | Jun 9, 2026 | 0.5.12.post1 | 1.3.0rc17 | 0.22.0 | 1.0.1 / 0.10.1 / 1.1.0 | - | [release notes](https://github.com/ai-dynamo/dynamo/releases/tag/v1.3.0-dev.1) | Full-platform preview of v1.3.0: complete runtime matrix, wheels on pypi.nvidia.com, crates, and Helm charts. Superseded by v1.3.0 GA. |
 | v1.2.1 | patch | Jun 13, 2026 | 0.5.11 | 1.3.0rc14 | 0.20.1 | 1.0.1 / 0.10.1 / 0.10.1 | - | [release notes](https://docs.nvidia.com/dynamo/dev/reference/releases/v1-2-0) | Patch release. Same backend pins as v1.2.0. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ vllm = [
 
 sglang = [
     "uvloop",
-    "sglang[diffusion]==0.5.15",
+    "sglang[diffusion]==0.5.16",
     # sglang[diffusion] dropped accelerate in 0.5.12; diffusers still needs it.
     "accelerate>=0.17.0",
     "blake3>=1.0.0,<2.0.0",


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This PR bumps Dynamo's SGLang backend and supported-version window to 0.5.16. It now also uses the published 0.5.16 runtime image and configures disjoint streaming before `ServerArgs` becomes read-only, keeping both release and post-#31811 source builds usable.

### How This Was Implemented
- Pin SGLang and the support matrix to 0.5.16, removing the expired 0.5.14 profiling compatibility path.
- Set `incremental_streaming_output` on parsed CLI arguments before `ServerArgs.from_cli_args()` resolves the immutable startup record.
- Use `lmsysorg/sglang:v0.5.16-cu130-runtime` and delete Dynamo's redundant `libssl-dev` apt layer because upstream now includes it.

<details>
<summary>Walkthrough</summary>

#### Mental model

Dynamo supplies its required streaming mode as an input to SGLang configuration resolution instead of mutating the resolved object.

```mermaid
flowchart LR
    CLI[Parsed CLI arguments] -->|incremental_streaming_output=true| Resolve[ServerArgs.from_cli_args]
    Resolve --> Engine[Read-only ServerArgs used by SGLang]
```

#### Boundaries and limitations

The official 0.5.16 runtime image is built from release commit `fdebc938f7` with FlashInfer `0.6.14`; the read-only compatibility was separately validated against SGLang main `69a3c54c70` with FlashInfer `0.6.15.post1`.

</details>

### Validation
- `pytest -q components/src/dynamo/sglang/tests tests/serve/test_sglang_mm_hashes_protocol.py` (`287 passed, 1 skipped`) against the 0.5.16 release branch.
- Focused read-only parse regression and live `agg.sh` SSE request against SGLang main `69a3c54c70`; five disjoint chunks joined to the expected response.
- `docker buildx imagetools inspect lmsysorg/sglang:v0.5.16-cu130-runtime` confirmed amd64 and arm64 manifests.
- Rendered runtime Dockerfile check passed on amd64; arm64 reached the existing local-driver wheel-builder platform warning.
- `uvx pre-commit run --all-files`.
<!-- codex-pr-description:end -->

## Summary

- Pin the SGLang backend dependency and support matrix to `0.5.16`.
- Remove the SGLang `0.5.14` profiling compatibility path now that the supported window is `0.5.15`/`0.5.16`.
- Update the multimodal processor unit fixture for SGLang's new `use_cuda_ipc` instance attribute.
- Defer the SGLang runtime-container bump until upstream publishes `0.5.16` image tags.

## Validation

- Validated against `sgl-project/sglang` `release/v0.5.16` at `49e709eafb`.
- `pytest -q components/src/dynamo/sglang/tests tests/serve/test_sglang_mm_hashes_protocol.py` (`287 passed, 1 skipped`).
- Real-request smoke tests passed for 14 launchers: aggregated, agent, embedding, KV-routed, multimodal-routed, vision/frontend-decoding, disaggregated, same-GPU disaggregated, multimodal E/P/D and E/PD, native-gRPC aggregated/disaggregated sidecars, full-observability aggregated, and LoRA.
- Environment skips: `disagg_router.sh` requires four GPUs; `diffusion_llada.sh`, `image_diffusion.sh`, and `text-to-video-diffusion.sh` require uncached large diffusion checkpoints, with LLaDA also exceeding the available 46 GiB L40S memory.
- `uvx pre-commit run --all-files`.
- `fern check`.
- `fern docs broken-links`.
- `uv pip check --python .venv/bin/python`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added compatibility support for SGLang 0.5.16.
  - Image processing now remains compatible across the expanded SGLang version range.

- **Bug Fixes**
  - Improved profiling initialization by using the current request format.
  - Updated multimodal processing behavior for more reliable image handling.

- **Documentation**
  - Updated the backend support matrix to reflect SGLang 0.5.16 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
