### PR TITLE
feat(replay): Add global planner + multi-model sim support

### DIFF
--- a/components/src/dynamo/global_planner/capacity_manager.py
+++ b/components/src/dynamo/global_planner/capacity_manager.py
@@ -6,10 +6,10 @@
 :class:`CapacityManager` is the infrastructure-facing base class the
 :class:`~dynamo.global_planner.orchestrator.Orchestrator` drives to **observe**
 current pool state and **scale** replicas. It defines a neutral,
-infrastructure-agnostic surface (``observe`` / ``scale`` / ``discover`` /
-``ensure_participant`` / ``participant_exists`` / ``remember_roles`` /
-``current_replicas``) keyed by opaque ``participant_id``; the orchestrator never
-sees Kubernetes concepts.
+infrastructure-agnostic surface (``observe`` / ``observe_async`` / ``scale`` /
+``discover`` / ``ensure_participant`` / ``participant_exists`` /
+``remember_roles`` / ``current_replicas``) keyed by opaque
+``participant_id``; the orchestrator never sees Kubernetes concepts.
 
 The concrete Kubernetes backend is
 :class:`~dynamo.global_planner.kubernetes_capacity_manager.KubernetesCapacityManager`.
@@ -17,6 +17,7 @@ The concrete Kubernetes backend is
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from typing import Optional
 
@@ -92,6 +93,16 @@ class CapacityManager:
         under-count usage from a partially-read snapshot.
         """
         raise NotImplementedError
+
+    async def observe_async(self, require_complete: bool = False) -> PoolSnapshot:
+        """Read pool state without blocking the caller's event loop.
+
+        Infrastructure backends generally implement :meth:`observe` with
+        synchronous client libraries, so the default runs that method on a worker
+        thread. Pure in-memory backends may override this method and return their
+        snapshot directly.
+        """
+        return await asyncio.to_thread(self.observe, require_complete)
 
     async def scale(
         self,

--- a/components/src/dynamo/global_planner/orchestrator.py
+++ b/components/src/dynamo/global_planner/orchestrator.py
@@ -306,12 +306,13 @@ class Orchestrator:
         # the budget lock through blocking readiness waits.
         # Read ALL known participants' current state once. Cross-participant
         # partner search needs every pool's current replicas and gpu_per_replica;
-        # cross-participant budget math also consumes this. Run the synchronous
-        # backend reads off-thread so the event loop isn't blocked for the N
-        # round-trips. When budget is enforced, require a complete snapshot so a
-        # partial read can't under-count cluster usage.
-        all_pools = await asyncio.to_thread(
-            self.capacity_manager.observe, self.budget_enforcement_enabled()
+        # cross-participant budget math also consumes this. The backend owns the
+        # sync/async boundary: production offloads synchronous infrastructure
+        # reads, while in-memory replay can return directly. When budget is
+        # enforced, require a complete snapshot so a partial read can't
+        # under-count cluster usage.
+        all_pools = await self.capacity_manager.observe_async(
+            self.budget_enforcement_enabled()
         )
 
         result = self.mediate(

--- a/components/src/dynamo/global_planner/tests/unit/test_replay_capacity_manager.py
+++ b/components/src/dynamo/global_planner/tests/unit/test_replay_capacity_manager.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Replay's in-memory Global Planner capacity backend."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from dynamo.global_planner.capacity_manager import CapacityManager, PoolSpec
+from dynamo.global_planner.orchestrator import Orchestrator
+from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner.connectors.protocol import ScaleStatus
+from dynamo.replay.global_planner import (
+    ReplayCapacityManager,
+    ReplayParticipantSpec,
+    ReplayScaleAction,
+    ReplayScaleTarget,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _participant(
+    participant_id: str, *pools: tuple[str, int, int]
+) -> ReplayParticipantSpec:
+    return ReplayParticipantSpec(
+        participant_id=participant_id,
+        pools=tuple(
+            PoolSpec(
+                sub_type=role,
+                current_replicas=replicas,
+                gpu_per_replica=gpu,
+                component_name=f"{participant_id}-{role}",
+            )
+            for role, replicas, gpu in pools
+        ),
+    )
+
+
+def _target(role: SubComponentType, replicas: int) -> TargetReplica:
+    return TargetReplica(sub_component_type=role, desired_replicas=replicas)
+
+
+@pytest.mark.asyncio
+async def test_capacity_manager_observe_async_offloads_sync_backend():
+    manager = CapacityManager()
+    expected = {"deployment": {}}
+
+    with patch(
+        "dynamo.global_planner.capacity_manager.asyncio.to_thread",
+        new=AsyncMock(return_value=expected),
+    ) as to_thread:
+        result = await manager.observe_async(require_complete=True)
+
+    assert result == expected
+    to_thread.assert_awaited_once_with(manager.observe, True)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_and_actions_are_deterministic_and_overlay_aware():
+    manager = ReplayCapacityManager(
+        [
+            _participant("z-deployment", ("decode", 1, 2)),
+            _participant(
+                "a-deployment",
+                ("prefill", 2, 1),
+                ("decode", 3, 1),
+            ),
+        ]
+    )
+
+    snapshot = await manager.observe_async(require_complete=True)
+    assert list(snapshot) == ["a-deployment", "z-deployment"]
+    assert list(snapshot["a-deployment"]) == ["decode", "prefill"]
+
+    manager.begin_batch()
+    await manager.scale(
+        "a-deployment",
+        [
+            _target(SubComponentType.PREFILL, 4),
+            _target(SubComponentType.DECODE, 5),
+        ],
+        blocking=False,
+    )
+
+    assert manager.current_replicas("a-deployment") == {
+        "decode": 5,
+        "prefill": 4,
+    }
+    assert manager.observe()["a-deployment"]["decode"].current_replicas == 5
+
+    actions = manager.finish_batch()
+    assert actions == (
+        ReplayScaleAction(
+            participant_id="a-deployment",
+            targets=(
+                ReplayScaleTarget("prefill", 4),
+                ReplayScaleTarget("decode", 5),
+            ),
+            blocking=False,
+        ),
+    )
+    assert manager.current_replicas("a-deployment") == {
+        "decode": 5,
+        "prefill": 4,
+    }
+
+
+@pytest.mark.asyncio
+async def test_abort_batch_discards_overlay_and_actions():
+    manager = ReplayCapacityManager([_participant("deployment", ("decode", 2, 1))])
+
+    manager.begin_batch()
+    await manager.scale(
+        "deployment",
+        [_target(SubComponentType.DECODE, 7)],
+        blocking=True,
+    )
+    assert manager.current_replicas("deployment") == {"decode": 7}
+
+    manager.abort_batch()
+
+    assert not manager.batch_active
+    assert manager.current_replicas("deployment") == {"decode": 2}
+    manager.begin_batch()
+    assert manager.finish_batch() == ()
+
+
+@pytest.mark.asyncio
+async def test_invalid_action_is_atomic():
+    manager = ReplayCapacityManager([_participant("deployment", ("decode", 2, 1))])
+    manager.begin_batch()
+
+    with pytest.raises(ValueError, match="unknown pool role 'prefill'"):
+        await manager.scale(
+            "deployment",
+            [
+                _target(SubComponentType.DECODE, 4),
+                _target(SubComponentType.PREFILL, 1),
+            ],
+            blocking=False,
+        )
+
+    assert manager.current_replicas("deployment") == {"decode": 2}
+    assert manager.finish_batch() == ()
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_stages_cross_participant_pair_in_apply_order():
+    manager = ReplayCapacityManager(
+        [
+            _participant("a", ("decode", 2, 1)),
+            _participant("b", ("decode", 2, 1)),
+        ]
+    )
+    orchestrator = Orchestrator(
+        capacity_manager=manager,
+        managed_deployments=None,
+        min_total_gpus=4,
+        max_total_gpus=4,
+        now=lambda: 10.0,
+        use_lock=False,
+    )
+
+    # A's standalone scale-down is denied but seeds the Global Planner intent.
+    manager.begin_batch()
+    first = await orchestrator.submit(
+        "a",
+        [_target(SubComponentType.DECODE, 1)],
+        blocking=False,
+        deployment_name="a",
+        caller_name="a",
+    )
+    assert first.status == ScaleStatus.REJECTED
+    assert manager.finish_batch() == ()
+
+    # B's scale-up pairs with A's cached intent. Down is staged before up.
+    manager.begin_batch()
+    second = await orchestrator.submit(
+        "b",
+        [_target(SubComponentType.DECODE, 3)],
+        blocking=False,
+        deployment_name="b",
+        caller_name="b",
+    )
+    actions = manager.finish_batch()
+
+    assert second.status == ScaleStatus.SUCCESS
+    assert second.current_replicas == {"decode": 3}
+    assert [action.participant_id for action in actions] == ["a", "b"]
+    assert [action.targets[0].desired_replicas for action in actions] == [1, 3]
+    assert manager.current_replicas("a") == {"decode": 1}
+    assert manager.current_replicas("b") == {"decode": 3}
+
+
+@pytest.mark.parametrize(
+    ("participants", "message"),
+    [
+        (
+            [
+                _participant("duplicate", ("decode", 1, 1)),
+                _participant("duplicate", ("decode", 1, 1)),
+            ],
+            "duplicate replay participant",
+        ),
+        (
+            [
+                _participant(
+                    "deployment",
+                    ("decode", 1, 1),
+                    ("decode", 2, 1),
+                )
+            ],
+            "duplicate pool role",
+        ),
+        (
+            [_participant("deployment", ("aggregate", 1, 1))],
+            "pool role.*must be one of",
+        ),
+        (
+            [_participant("deployment", ("decode", -1, 1))],
+            "initial replicas.*must be non-negative",
+        ),
+        (
+            [_participant("deployment", ("decode", 1, -1))],
+            "gpu_per_replica.*must be non-negative",
+        ),
+    ],
+)
+def test_setup_validation(participants, message):
+    with pytest.raises(ValueError, match=message):
+        ReplayCapacityManager(participants)
+
+
+@pytest.mark.asyncio
+async def test_action_boundary_validation():
+    manager = ReplayCapacityManager([_participant("deployment", ("decode", 2, 1))])
+
+    with pytest.raises(RuntimeError, match="no replay capacity batch"):
+        await manager.scale(
+            "deployment",
+            [_target(SubComponentType.DECODE, 3)],
+            blocking=False,
+        )
+
+    manager.begin_batch()
+    with pytest.raises(ValueError, match="desired replicas.*must be non-negative"):
+        await manager.scale(
+            "deployment",
+            [_target(SubComponentType.DECODE, -1)],
+            blocking=False,
+        )
+    with pytest.raises(ValueError, match="duplicate target role"):
+        await manager.scale(
+            "deployment",
+            [
+                _target(SubComponentType.DECODE, 3),
+                _target(SubComponentType.DECODE, 4),
+            ],
+            blocking=False,
+        )
+    with pytest.raises(KeyError, match="was not pre-registered"):
+        await manager.scale(
+            "unknown",
+            [_target(SubComponentType.DECODE, 3)],
+            blocking=False,
+        )
+    assert manager.finish_batch() == ()
+
+
+def test_batch_lifecycle_is_strict():
+    manager = ReplayCapacityManager([_participant("deployment", ("decode", 2, 1))])
+
+    with pytest.raises(RuntimeError, match="no replay capacity batch"):
+        manager.finish_batch()
+    with pytest.raises(RuntimeError, match="no replay capacity batch"):
+        manager.abort_batch()
+
+    manager.begin_batch()
+    with pytest.raises(RuntimeError, match="already active"):
+        manager.begin_batch()
+    manager.abort_batch()

--- a/components/src/dynamo/mocker/__init__.py
+++ b/components/src/dynamo/mocker/__init__.py
@@ -21,6 +21,7 @@ try:
     from dynamo._core import MockEngineArgs as MockEngineArgs
     from dynamo._core import PlannerReplayBridge as PlannerReplayBridge
     from dynamo._core import ReasoningConfig as ReasoningConfig
+    from dynamo._core import ReplayWorldBridge as ReplayWorldBridge
     from dynamo._core import SglangArgs as SglangArgs
     from dynamo._core import TrtllmArgs as TrtllmArgs
     from dynamo._core import run_mocker_trace_replay as _run_mocker_trace_replay
@@ -33,6 +34,7 @@ else:
         [
             "MockEngineArgs",
             "PlannerReplayBridge",
+            "ReplayWorldBridge",
             "ReasoningConfig",
             "SglangArgs",
             "TrtllmArgs",

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -56,7 +56,7 @@ from dynamo.planner.core.types import (
 )
 from dynamo.planner.monitoring.diagnostics_recorder import DiagnosticsRecorder
 from dynamo.planner.monitoring.traffic_metrics import Metrics
-from dynamo.planner.plugins.clock import VirtualClock
+from dynamo.planner.plugins.clock import Clock, VirtualClock
 from dynamo.planner.plugins.orchestrator.engine_adapter import OrchestratorEngineAdapter
 
 logger = logging.getLogger(__name__)
@@ -64,13 +64,54 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class ScalingEvent:
-    """Record of a single scaling decision."""
+    """Record of a committed scaling action."""
 
     at_s: float
     component: str  # "agg", "prefill", or "decode"
     from_count: int
     to_count: int
     reason: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ScalingProposal:
+    """One local-planner proposal awaiting mediation and actuation.
+
+    ``None`` retains the planner's component mask: it means the local planner
+    expressed no opinion about that component. ``current_*`` is the ready count
+    observed by the local planner when it produced the proposal and is used only
+    as the legacy direct-path actuation baseline.
+    """
+
+    at_s: float
+    current_prefill: int
+    current_decode: int
+    target_prefill: Optional[int] = None
+    target_decode: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class ScaleMediationEvent:
+    """Mediation outcome for a local proposal.
+
+    Mediation and actuation are deliberately separate: an approved proposal may
+    be partially applied, while an adapter may receive a committed partner action
+    even when it did not produce a proposal on that tick.
+    """
+
+    at_s: float
+    status: str
+    target_prefill: Optional[int] = None
+    target_decode: Optional[int] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PlannerTickResult:
+    """Result of one local planner tick before any scaling is committed."""
+
+    proposal: Optional[ScalingProposal]
+    next_tick_ms: Optional[float]
 
 
 @dataclass
@@ -82,6 +123,8 @@ class ReplayPlannerReport:
     diagnostics_log: list[TickDiagnostics] = field(default_factory=list)
     total_ticks: int = 0
     html_report_path: Optional[str] = None
+    # Appended to preserve the legacy positional constructor order above.
+    mediation_events: list[ScaleMediationEvent] = field(default_factory=list)
 
 
 def _build_fpm_from_dict(d: dict[str, Any]) -> ForwardPassMetrics:
@@ -204,10 +247,13 @@ class ReplayPlannerAdapter:
         bridge: Any,  # PlannerReplayBridge (Rust pyclass)
         capabilities: Optional[WorkerCapabilities] = None,
         warmup_observations: Optional[list[TrafficObservation]] = None,
+        *,
+        clock: Optional[Clock] = None,
+        event_loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         self._config = planner_config
         self._bridge = bridge
-        self._capabilities = capabilities
+        self._capabilities = capabilities or WorkerCapabilities()
         self._is_disagg = planner_config.mode == "disagg"
 
         self._engine: EngineProtocol
@@ -217,13 +263,18 @@ class ReplayPlannerAdapter:
         # HOLD_LAST cache see trace time, not real wall-clock.
         self._engine = OrchestratorEngineAdapter(
             planner_config,
-            capabilities or WorkerCapabilities(),
-            clock=VirtualClock(),
+            self._capabilities,
+            clock=clock or VirtualClock(),
         )
         # Replay's ``run()`` is synchronous; we own a scoped event loop to
         # drive the async engine calls without forcing callers to use
-        # ``asyncio.run``.
-        self._loop: Optional[asyncio.AbstractEventLoop] = asyncio.new_event_loop()
+        # ``asyncio.run``. A multi-deployment world injects its shared loop and
+        # drives ``start_async`` / ``propose_tick_async`` directly.
+        self._owns_loop = event_loop is None
+        self._loop: Optional[asyncio.AbstractEventLoop] = (
+            event_loop if event_loop is not None else asyncio.new_event_loop()
+        )
+        self._engine_shutdown = False
 
         # Last-seen FPM caches (separate for prefill/decode)
         self._prefill_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
@@ -235,6 +286,18 @@ class ReplayPlannerAdapter:
         # Scaling targets -- used as `expected` in WorkerCounts
         self._scaling_target_prefill: Optional[int] = None
         self._scaling_target_decode: Optional[int] = None
+        # Last runtime inventory observed by a tick. Total counts include workers
+        # that are starting or draining when the bridge exposes them.
+        self._last_ready_prefill: Optional[int] = None
+        self._last_ready_decode: Optional[int] = None
+        self._last_total_prefill: Optional[int] = None
+        self._last_total_decode: Optional[int] = None
+        self._has_total_prefill = False
+        self._has_total_decode = False
+        self._scaling_events: list[ScalingEvent] = []
+        self._mediation_events: list[ScaleMediationEvent] = []
+        self._diagnostics_log: list[TickDiagnostics] = []
+        self._total_ticks = 0
 
         # Diagnostics recorder for HTML report generation
         decode_max_kv = (
@@ -263,15 +326,16 @@ class ReplayPlannerAdapter:
         assert self._loop is not None, "sync bridge only available on orchestrator path"
         return self._loop.run_until_complete(coro)
 
-    def _bootstrap_orchestrator_if_needed(self) -> None:
+    async def _bootstrap_orchestrator_if_needed_async(self) -> None:
         if self._orchestrator_bootstrapped:
             return
-        self._run_sync(
-            self._engine.bootstrap_plugins(  # type: ignore[attr-defined]
-                historical_traffic=self._warmup_observations or None
-            )
+        await self._engine.bootstrap_plugins(  # type: ignore[attr-defined]
+            historical_traffic=self._warmup_observations or None
         )
         self._orchestrator_bootstrapped = True
+
+    def _bootstrap_orchestrator_if_needed(self) -> None:
+        self._run_sync(self._bootstrap_orchestrator_if_needed_async())
 
     def install_benchmark_fpms(
         self,
@@ -301,79 +365,122 @@ class ReplayPlannerAdapter:
     # Python while-loop that drove ``bridge.advance_to`` + ``bridge.apply_scaling``.)
     # ------------------------------------------------------------------
 
+    def _initialize_run_state(self) -> None:
+        self._pending_tick: ScheduledTick = self._engine.initial_tick(0.0)
+        self._scaling_events = []
+        self._mediation_events = []
+        self._diagnostics_log = []
+        self._total_ticks = 0
+
+    async def start_async(self) -> None:
+        """Bootstrap on the caller's running loop and compute the first tick."""
+        await self._bootstrap_orchestrator_if_needed_async()
+        self._initialize_run_state()
+
     def start(self) -> None:
         """Bootstrap the orchestrator and compute the first tick. Idempotent."""
-        self._bootstrap_orchestrator_if_needed()
-        self._pending_tick: ScheduledTick = self._engine.initial_tick(0.0)
-        self._scaling_events: list[ScalingEvent] = []
-        self._diagnostics_log: list[TickDiagnostics] = []
-        self._total_ticks = 0
+        self._run_sync(self.start_async())
 
     def initial_tick_ms(self) -> float:
         """First tick time in milliseconds (called by the Rust PlannerHook)."""
+        return self._run_sync(self.initial_tick_ms_async())
+
+    async def initial_tick_ms_async(self) -> float:
+        """First tick time for a controller that owns the running event loop."""
         if not self._orchestrator_bootstrapped or not hasattr(self, "_pending_tick"):
-            self.start()
+            await self.start_async()
         return self._pending_tick.at_s * 1000.0
 
-    def on_tick(self, result: dict[str, Any]) -> dict[str, Any]:
-        """Drive one planner tick from the bridge's metrics dict. Returns the scaling
-        decision (absolute targets, ``None`` = unchanged) + the next tick time in ms
-        (``None`` = stop) for the Rust loop to apply and re-arm."""
+    async def propose_tick_async(self, result: dict[str, Any]) -> PlannerTickResult:
+        """Run one local planner tick without committing its scale proposal.
+
+        The caller owns mediation. It may reject the proposal, commit a partial
+        target, or commit an action to a different adapter selected as a Global
+        Planner partner. Planner cadence and diagnostics still advance normally.
+        """
         tick = self._pending_tick
         tick_input = self._build_tick_input(tick, result)
-        effects: PlannerEffects = self._run_sync(self._engine.tick(tick, tick_input))
+        effects: PlannerEffects = await self._engine.tick(tick, tick_input)
         emit_diagnostics = self._should_emit_tick_diagnostics(tick, effects)
         if emit_diagnostics:
             self._diagnostics_log.append(effects.diagnostics)
         self._total_ticks += 1
         self._record_diagnostics(tick_input, effects, result, emit_diagnostics)
 
-        # Clear scaling targets once active counts match.
-        active_p = result["active_prefill_count"]
-        active_d = result["active_decode_count"]
-        if (
-            self._scaling_target_prefill is not None
-            and active_p == self._scaling_target_prefill
-        ):
-            self._scaling_target_prefill = None
-        if (
-            self._scaling_target_decode is not None
-            and active_d == self._scaling_target_decode
-        ):
-            self._scaling_target_decode = None
-
-        target_prefill: Optional[int] = None
-        target_decode: Optional[int] = None
+        proposal: Optional[ScalingProposal] = None
         if effects.scale_to is not None:
-            target_prefill, target_decode = self._compute_scale_decision(
-                effects, result, tick_input.now_s
-            )
+            proposal = self._build_scale_proposal(effects, result, tick_input.now_s)
 
         next_tick_ms: Optional[float] = None
         if effects.next_tick is not None:
             self._pending_tick = effects.next_tick
             next_tick_ms = effects.next_tick.at_s * 1000.0
 
+        return PlannerTickResult(proposal=proposal, next_tick_ms=next_tick_ms)
+
+    def propose_tick(self, result: dict[str, Any]) -> PlannerTickResult:
+        """Synchronous wrapper used by the legacy single-deployment bridge."""
+        return self._run_sync(self.propose_tick_async(result))
+
+    def on_tick(self, result: dict[str, Any]) -> dict[str, Any]:
+        """Legacy direct bridge path: propose, then immediately commit.
+
+        ``PlannerReplayBridge`` historically treats every local proposal as an
+        accepted action. Preserve that API while the multi-deployment world uses
+        :meth:`propose_tick` plus explicit mediation/commit methods.
+        """
+        tick_result = self.propose_tick(result)
+        proposal = tick_result.proposal
+        if proposal is not None:
+            self.observe_mediation(proposal, status="approved")
+            self.observe_committed_scale(
+                at_s=proposal.at_s,
+                target_prefill=proposal.target_prefill,
+                target_decode=proposal.target_decode,
+                from_prefill=proposal.current_prefill,
+                from_decode=proposal.current_decode,
+            )
+
         return {
-            "target_prefill": target_prefill,
-            "target_decode": target_decode,
-            "next_tick_ms": next_tick_ms,
+            "target_prefill": (
+                proposal.target_prefill if proposal is not None else None
+            ),
+            "target_decode": proposal.target_decode if proposal is not None else None,
+            "next_tick_ms": tick_result.next_tick_ms,
         }
 
+    def build_report(self, trace_report: dict[str, Any]) -> ReplayPlannerReport:
+        """Assemble a report without shutting down an injected shared loop."""
+        html_report_path = self._recorder.finalize()
+        return ReplayPlannerReport(
+            trace_report=trace_report,
+            scaling_events=self._scaling_events,
+            mediation_events=self._mediation_events,
+            diagnostics_log=self._diagnostics_log,
+            total_ticks=self._total_ticks,
+            html_report_path=html_report_path,
+        )
+
     def finalize(self, trace_report: dict[str, Any]) -> ReplayPlannerReport:
-        """Assemble the enriched report from accumulated planner state. Called by the
-        entrypoint after the Rust ``run()`` returns the trace_report dict."""
+        """Build the legacy report and close this adapter's planner resources."""
         try:
-            html_report_path = self._recorder.finalize()
-            return ReplayPlannerReport(
-                trace_report=trace_report,
-                scaling_events=self._scaling_events,
-                diagnostics_log=self._diagnostics_log,
-                total_ticks=self._total_ticks,
-                html_report_path=html_report_path,
-            )
-        finally:
+            report = self.build_report(trace_report)
+        except BaseException as exc:
+            try:
+                self.close()
+            except BaseException as cleanup_exc:
+                exc.add_note(f"Replay planner cleanup also failed: {cleanup_exc}")
+            raise
+        else:
             self.close()
+            return report
+
+    async def shutdown_async(self) -> None:
+        """Shut down this planner engine on the caller's running event loop."""
+        if self._engine_shutdown:
+            return
+        await self._engine.shutdown()
+        self._engine_shutdown = True
 
     def close(self) -> None:
         """Shut down the engine and the replay-scoped event loop. Idempotent so it
@@ -382,11 +489,21 @@ class ReplayPlannerAdapter:
         loop = self._loop
         if loop is None:
             return
-        self._loop = None
+        if loop.is_running():
+            raise RuntimeError(
+                "ReplayPlannerAdapter.close() cannot run on an active event loop; "
+                "await shutdown_async() from the shared-loop controller"
+            )
         try:
-            loop.run_until_complete(self._engine.shutdown())
+            loop.run_until_complete(self.shutdown_async())
         finally:
-            loop.close()
+            if self._owns_loop:
+                try:
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                    loop.run_until_complete(loop.shutdown_default_executor())
+                finally:
+                    loop.close()
+                    self._loop = None
 
     def _record_diagnostics(
         self,
@@ -404,8 +521,18 @@ class ReplayPlannerAdapter:
             dt_h = (now_s - self._last_tick_s) / 3600.0
             num_p = result["active_prefill_count"]
             num_d = result["active_decode_count"]
-            gpu_p = self._config.prefill_engine_num_gpu or 0
-            gpu_d = self._config.decode_engine_num_gpu or 0
+            gpu_p = (
+                self._capabilities.prefill.num_gpu
+                if self._capabilities.prefill is not None
+                and self._capabilities.prefill.num_gpu is not None
+                else 0
+            )
+            gpu_d = (
+                self._capabilities.decode.num_gpu
+                if self._capabilities.decode is not None
+                and self._capabilities.decode.num_gpu is not None
+                else 0
+            )
             self._cumulative_gpu_hours += (num_p * gpu_p + num_d * gpu_d) * dt_h
         self._last_tick_s = now_s
 
@@ -432,92 +559,213 @@ class ReplayPlannerAdapter:
             or bool(diag.short_circuit_reason)
         )
 
-    def _compute_scale_decision(
+    def _build_scale_proposal(
         self,
         effects: PlannerEffects,
         result: dict[str, Any],
         now_s: float,
-    ) -> tuple[Optional[int], Optional[int]]:
-        """Compute the (prefill, decode) absolute scale targets and record the scaling
-        event. Returns ``(None, None)`` for a no-op. The Rust loop applies the targets,
-        so this no longer calls ``bridge.apply_scaling``."""
+    ) -> Optional[ScalingProposal]:
+        """Build a masked local proposal without mutating actuation state."""
         scale = effects.scale_to
         if scale is None:
             raise ValueError(
-                "_compute_scale_decision requires effects.scale_to to be set"
+                "_build_scale_proposal requires effects.scale_to to be set"
             )
         current_p = result["active_prefill_count"]
         current_d = result["active_decode_count"]
-        target_p = scale.num_prefill if scale.num_prefill is not None else current_p
-        target_d = scale.num_decode if scale.num_decode is not None else current_d
+        target_p = scale.num_prefill if self._is_disagg else None
+        target_d = scale.num_decode
 
-        if target_p == current_p and target_d == current_d:
-            return (None, None)
+        changed_p = target_p is not None and target_p != current_p
+        changed_d = target_d is not None and target_d != current_d
+        if not changed_p and not changed_d:
+            return None
 
-        if self._is_disagg:
-            if scale.num_prefill is not None and target_p != current_p:
-                direction = "scale_up" if target_p > current_p else "scale_down"
-                logger.info(
-                    "Planner scaling prefill: %d -> %d at t=%.1fs (%s)",
-                    current_p,
-                    target_p,
-                    now_s,
-                    direction,
-                )
-                self._scaling_target_prefill = target_p
-                self._scaling_events.append(
-                    ScalingEvent(
-                        at_s=now_s,
-                        component="prefill",
-                        from_count=current_p,
-                        to_count=target_p,
-                        reason=direction,
-                    )
-                )
-            if scale.num_decode is not None and target_d != current_d:
-                direction = "scale_up" if target_d > current_d else "scale_down"
-                logger.info(
-                    "Planner scaling decode: %d -> %d at t=%.1fs (%s)",
-                    current_d,
-                    target_d,
-                    now_s,
-                    direction,
-                )
-                self._scaling_target_decode = target_d
-                self._scaling_events.append(
-                    ScalingEvent(
-                        at_s=now_s,
-                        component="decode",
-                        from_count=current_d,
-                        to_count=target_d,
-                        reason=direction,
-                    )
-                )
-        else:
-            direction = "scale_up" if target_d > current_d else "scale_down"
-            logger.info(
-                "Planner scaling: %d -> %d workers at t=%.1fs (%s)",
-                current_d,
-                target_d,
-                now_s,
-                direction,
+        return ScalingProposal(
+            at_s=now_s,
+            current_prefill=current_p,
+            current_decode=current_d,
+            target_prefill=target_p,
+            target_decode=target_d,
+        )
+
+    def observe_mediation(
+        self,
+        proposal: ScalingProposal,
+        *,
+        status: str,
+        message: Optional[str] = None,
+    ) -> None:
+        """Record mediation without implying that any target was committed."""
+        if status not in {"approved", "rejected", "error"}:
+            raise ValueError(
+                "mediation status must be 'approved', 'rejected', or 'error'"
             )
-            self._scaling_target_decode = target_d
-            self._scaling_events.append(
-                ScalingEvent(
-                    at_s=now_s,
-                    component="agg",
-                    from_count=current_d,
-                    to_count=target_d,
-                    reason=direction,
+        self._mediation_events.append(
+            ScaleMediationEvent(
+                at_s=proposal.at_s,
+                status=status,
+                target_prefill=proposal.target_prefill,
+                target_decode=proposal.target_decode,
+                message=message,
+            )
+        )
+
+    def observe_rejection(
+        self, proposal: ScalingProposal, *, message: Optional[str] = None
+    ) -> None:
+        """Record a soft denial. Expected targets and scaling events stay unchanged."""
+        self.observe_mediation(proposal, status="rejected", message=message)
+
+    def observe_committed_scale(
+        self,
+        *,
+        at_s: float,
+        target_prefill: Optional[int] = None,
+        target_decode: Optional[int] = None,
+        from_prefill: Optional[int] = None,
+        from_decode: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Observe targets actually committed to this deployment.
+
+        This method is intentionally independent of :meth:`propose_tick`: a
+        Global Planner may apply a cached or partially-consumed partner intent to
+        an adapter that did not tick at ``at_s``. When no explicit ``from_*``
+        baseline is supplied, a superseded committed target is more authoritative
+        than the adapter's potentially stale last-ready observation.
+        """
+        if target_prefill is None and target_decode is None:
+            raise ValueError(
+                "a committed scale action must target at least one component"
+            )
+        if not self._is_disagg and target_prefill is not None:
+            raise ValueError("aggregated replay cannot commit a prefill target")
+        for name, target in (
+            ("prefill", target_prefill),
+            ("decode", target_decode),
+        ):
+            if target is not None and target < 0:
+                raise ValueError(f"{name} target must be non-negative, got {target}")
+
+        if target_prefill is not None:
+            previous_target = self._scaling_target_prefill
+            baseline = (
+                from_prefill
+                if from_prefill is not None
+                else (
+                    previous_target
+                    if previous_target is not None
+                    else self._last_ready_prefill
                 )
             )
-        return (target_p, target_d)
+            self._scaling_target_prefill = target_prefill
+            self._append_committed_event(
+                at_s=at_s,
+                component="prefill",
+                baseline=baseline,
+                target=target_prefill,
+                reason=reason,
+            )
+
+        if target_decode is not None:
+            previous_target = self._scaling_target_decode
+            baseline = (
+                from_decode
+                if from_decode is not None
+                else (
+                    previous_target
+                    if previous_target is not None
+                    else self._last_ready_decode
+                )
+            )
+            self._scaling_target_decode = target_decode
+            self._append_committed_event(
+                at_s=at_s,
+                component="decode" if self._is_disagg else "agg",
+                baseline=baseline,
+                target=target_decode,
+                reason=reason,
+            )
+
+        # A partner action may arrive without a local tick, so the cached
+        # inventory can predate this commit even when its counts happen to match
+        # the new target. Only _observe_runtime_inventory may settle it.
+
+    def _append_committed_event(
+        self,
+        *,
+        at_s: float,
+        component: str,
+        baseline: Optional[int],
+        target: int,
+        reason: Optional[str],
+    ) -> None:
+        if baseline is None or baseline == target:
+            return
+        direction = "scale_up" if target > baseline else "scale_down"
+        logger.info(
+            "Planner scaling %s: %d -> %d at t=%.1fs (%s)",
+            component,
+            baseline,
+            target,
+            at_s,
+            reason or direction,
+        )
+        self._scaling_events.append(
+            ScalingEvent(
+                at_s=at_s,
+                component=component,
+                from_count=baseline,
+                to_count=target,
+                reason=reason or direction,
+            )
+        )
 
     def _is_easy_mode(self) -> bool:
         """Easy-mode check routed via config — both paths honour this
         the same way (no regression in non-SLA modes)."""
         return self._config.optimization_target != "sla"
+
+    def _observe_runtime_inventory(self, result: dict[str, Any]) -> None:
+        """Remember ready/total lifecycle counts and retire settled targets."""
+        ready_p = int(result["active_prefill_count"])
+        ready_d = int(result["active_decode_count"])
+        self._last_ready_prefill = ready_p
+        self._last_ready_decode = ready_d
+        self._has_total_prefill = "total_prefill_count" in result
+        self._has_total_decode = "total_decode_count" in result
+        self._last_total_prefill = int(result.get("total_prefill_count", ready_p))
+        self._last_total_decode = int(result.get("total_decode_count", ready_d))
+        self._clear_settled_scaling_targets()
+
+    def _clear_settled_scaling_targets(self) -> None:
+        """Clear accepted targets only after ready and provisioned state settle."""
+
+        def settled(
+            target: Optional[int],
+            ready: Optional[int],
+            total: Optional[int],
+            has_total: bool,
+        ) -> bool:
+            if target is None or ready is None or ready != target:
+                return False
+            return not has_total or total == target
+
+        if settled(
+            getattr(self, "_scaling_target_prefill", None),
+            getattr(self, "_last_ready_prefill", None),
+            getattr(self, "_last_total_prefill", None),
+            getattr(self, "_has_total_prefill", False),
+        ):
+            self._scaling_target_prefill = None
+        if settled(
+            getattr(self, "_scaling_target_decode", None),
+            getattr(self, "_last_ready_decode", None),
+            getattr(self, "_last_total_decode", None),
+            getattr(self, "_has_total_decode", False),
+        ):
+            self._scaling_target_decode = None
 
     def _build_tick_input(
         self, tick: ScheduledTick, result: dict[str, Any]
@@ -527,20 +775,25 @@ class ReplayPlannerAdapter:
         # also advances idle gaps to this timestamp so traffic windows drain
         # with the same duration the planner sees.
         now_s = tick.at_s
+        self._observe_runtime_inventory(result)
 
         worker_counts = None
         if tick.need_worker_states:
-            active_p = result["active_prefill_count"]
-            active_d = result["active_decode_count"]
+            active_p = self._last_ready_prefill
+            active_d = self._last_ready_decode
+            total_p = self._last_total_prefill
+            total_d = self._last_total_decode
+            assert active_p is not None and active_d is not None
+            assert total_p is not None and total_d is not None
             expected_p = (
                 self._scaling_target_prefill
                 if self._scaling_target_prefill is not None
-                else active_p
+                else total_p
             )
             expected_d = (
                 self._scaling_target_decode
                 if self._scaling_target_decode is not None
-                else active_d
+                else total_d
             )
             worker_counts = WorkerCounts(
                 ready_num_prefill=active_p if self._is_disagg else None,
@@ -549,12 +802,40 @@ class ReplayPlannerAdapter:
                 expected_num_decode=expected_d,
                 prefill_scaling_in_progress=(
                     self._is_disagg
-                    and self._scaling_target_prefill is not None
-                    and self._scaling_target_prefill != active_p
+                    and (
+                        (
+                            self._scaling_target_prefill is not None
+                            and (
+                                self._scaling_target_prefill != active_p
+                                or (
+                                    self._has_total_prefill
+                                    and self._scaling_target_prefill != total_p
+                                )
+                            )
+                        )
+                        or (
+                            self._scaling_target_prefill is None
+                            and self._has_total_prefill
+                            and total_p != active_p
+                        )
+                    )
                 ),
                 decode_scaling_in_progress=(
-                    self._scaling_target_decode is not None
-                    and self._scaling_target_decode != active_d
+                    (
+                        self._scaling_target_decode is not None
+                        and (
+                            self._scaling_target_decode != active_d
+                            or (
+                                self._has_total_decode
+                                and self._scaling_target_decode != total_d
+                            )
+                        )
+                    )
+                    or (
+                        self._scaling_target_decode is None
+                        and self._has_total_decode
+                        and total_d != active_d
+                    )
                 ),
             )
 

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -237,7 +237,7 @@ def test_replay_engine_caps_aggregates_attention_dp_capacity_and_gpu_width():
         MockEngineArgs(
             num_gpu_blocks=100,
             block_size=16,
-            dp_size=4,
+            aic_attention_dp_size=4,
             aic_tp_size=2,
         )
     )

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_scaling.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_scaling.py
@@ -1,0 +1,402 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+
+import pytest
+
+from dynamo.planner.config.planner_config import PlannerConfig
+from dynamo.planner.core.types import (
+    EngineCapabilities,
+    PlannerEffects,
+    ScalingDecision,
+    ScheduledTick,
+    TickDiagnostics,
+    TickInput,
+    WorkerCapabilities,
+)
+from dynamo.planner.monitoring.traffic_metrics import Metrics
+from dynamo.planner.offline.replay_adapter import (
+    ReplayPlannerAdapter,
+    ReplayPlannerReport,
+    ScalingEvent,
+    ScalingProposal,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+class _FakeEngine:
+    def __init__(self, effects: list[PlannerEffects]):
+        self._effects = list(effects)
+        self.inputs = []
+        self.shutdown_calls = 0
+
+    async def tick(self, tick, tick_input):
+        self.inputs.append((tick, tick_input))
+        return self._effects.pop(0)
+
+    async def shutdown(self):
+        self.shutdown_calls += 1
+
+
+class _DisabledRecorder:
+    enabled = False
+
+    def finalize(self):
+        return None
+
+
+class _RecordingRecorder:
+    enabled = True
+
+    def __init__(self):
+        self.records = []
+
+    def record(self, *args):
+        self.records.append(args)
+
+    def finalize(self):
+        return None
+
+
+def _adapter(mode: str, *effects: PlannerEffects) -> ReplayPlannerAdapter:
+    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+    adapter._config = PlannerConfig(mode=mode, optimization_target="throughput")
+    adapter._is_disagg = mode == "disagg"
+    adapter._capabilities = WorkerCapabilities(
+        prefill=EngineCapabilities(num_gpu=2) if mode == "disagg" else None,
+        decode=EngineCapabilities(num_gpu=4),
+    )
+    adapter._engine = _FakeEngine(list(effects))
+    adapter._loop = asyncio.new_event_loop()
+    adapter._owns_loop = True
+    adapter._engine_shutdown = False
+    adapter._orchestrator_bootstrapped = True
+    adapter._pending_tick = ScheduledTick(at_s=5.0, need_worker_states=True)
+    adapter._prefill_fpm_cache = {}
+    adapter._decode_fpm_cache = {}
+    adapter._pending_traffic = None
+    adapter._scaling_target_prefill = None
+    adapter._scaling_target_decode = None
+    adapter._last_ready_prefill = None
+    adapter._last_ready_decode = None
+    adapter._last_total_prefill = None
+    adapter._last_total_decode = None
+    adapter._has_total_prefill = False
+    adapter._has_total_decode = False
+    adapter._scaling_events = []
+    adapter._mediation_events = []
+    adapter._diagnostics_log = []
+    adapter._total_ticks = 0
+    adapter._recorder = _DisabledRecorder()
+    adapter._cumulative_gpu_hours = 0.0
+    adapter._last_tick_s = 0.0
+    adapter._last_traffic = Metrics()
+    return adapter
+
+
+def _result(
+    *,
+    ready_prefill: int,
+    ready_decode: int,
+    total_prefill: int | None = None,
+    total_decode: int | None = None,
+):
+    result = {
+        "now_ms": 5_000.0,
+        "active_prefill_count": ready_prefill,
+        "active_decode_count": ready_decode,
+        "active_prefill_ids": list(range(ready_prefill)),
+        "active_decode_ids": list(range(ready_decode)),
+        "prefill_fpm_snapshots": [],
+        "decode_fpm_snapshots": [],
+    }
+    if total_prefill is not None:
+        result["total_prefill_count"] = total_prefill
+    if total_decode is not None:
+        result["total_decode_count"] = total_decode
+    return result
+
+
+def _effects(
+    *,
+    prefill: int | None = None,
+    decode: int | None = None,
+    next_at_s: float | None = 10.0,
+) -> PlannerEffects:
+    return PlannerEffects(
+        scale_to=(
+            ScalingDecision(num_prefill=prefill, num_decode=decode)
+            if prefill is not None or decode is not None
+            else None
+        ),
+        next_tick=(
+            ScheduledTick(at_s=next_at_s, need_worker_states=True)
+            if next_at_s is not None
+            else None
+        ),
+        diagnostics=TickDiagnostics(),
+    )
+
+
+def test_rejected_proposal_does_not_mutate_expected_or_applied_events():
+    adapter = _adapter("disagg", _effects(prefill=3))
+    try:
+        tick_result = adapter.propose_tick(_result(ready_prefill=1, ready_decode=2))
+        proposal = tick_result.proposal
+
+        assert proposal is not None
+        assert proposal.target_prefill == 3
+        assert proposal.target_decode is None
+        assert adapter._scaling_target_prefill is None
+        assert adapter._scaling_target_decode is None
+        assert adapter._scaling_events == []
+
+        adapter.observe_rejection(proposal, message="GPU budget breach")
+
+        assert adapter._scaling_target_prefill is None
+        assert adapter._scaling_target_decode is None
+        assert adapter._scaling_events == []
+        assert adapter._mediation_events[-1].status == "rejected"
+    finally:
+        adapter.close()
+
+
+def test_report_keeps_legacy_positional_constructor_order():
+    scaling_event = ScalingEvent(
+        at_s=5.0,
+        component="agg",
+        from_count=1,
+        to_count=2,
+    )
+    diagnostics = [TickDiagnostics()]
+
+    report = ReplayPlannerReport(
+        {"request_count": 1},
+        [scaling_event],
+        diagnostics,
+        3,
+        "planner.html",
+    )
+
+    assert report.scaling_events == [scaling_event]
+    assert report.diagnostics_log is diagnostics
+    assert report.total_ticks == 3
+    assert report.html_report_path == "planner.html"
+    assert report.mediation_events == []
+
+
+def test_finalize_preserves_report_error_when_cleanup_also_fails():
+    class ReportError(RuntimeError):
+        pass
+
+    class _FailingAdapter:
+        def build_report(self, _trace_report):
+            raise ReportError("report generation failed")
+
+        def close(self):
+            raise RuntimeError("engine shutdown failed")
+
+    adapter = _FailingAdapter()
+    with pytest.raises(ReportError, match="report generation failed") as exc_info:
+        ReplayPlannerAdapter.finalize(adapter, {})  # type: ignore[arg-type]
+
+    assert exc_info.value.__notes__ == [
+        "Replay planner cleanup also failed: engine shutdown failed"
+    ]
+
+
+def test_partner_partial_commit_updates_adapter_that_did_not_tick():
+    adapter = _adapter("disagg")
+    try:
+        rejected = ScalingProposal(
+            at_s=5.0,
+            current_prefill=1,
+            current_decode=2,
+            target_decode=5,
+        )
+        adapter.observe_rejection(rejected, message="waiting for a partner")
+
+        # A later request selects only part of this cached intent. This adapter
+        # did not run a local tick at the actuation timestamp.
+        adapter.observe_committed_scale(
+            at_s=7.0,
+            target_decode=3,
+            from_decode=2,
+            reason="global_planner_partner",
+        )
+
+        assert adapter._scaling_target_decode == 3
+        assert adapter._scaling_events[-1].component == "decode"
+        assert adapter._scaling_events[-1].from_count == 2
+        assert adapter._scaling_events[-1].to_count == 3
+        assert adapter._scaling_events[-1].reason == "global_planner_partner"
+    finally:
+        adapter.close()
+
+
+def test_partner_commit_stays_pending_until_a_later_inventory_observation():
+    adapter = _adapter("agg")
+    adapter._last_ready_decode = 2
+    adapter._last_total_decode = 2
+    adapter._has_total_decode = True
+    adapter._scaling_target_decode = 3
+    try:
+        # This partner did not tick at t=7. Its last snapshot happens to match
+        # the new target, but that stale snapshot cannot settle a new action.
+        adapter.observe_committed_scale(
+            at_s=7.0,
+            target_decode=2,
+            reason="global_planner_partner",
+        )
+
+        assert adapter._scaling_target_decode == 2
+        assert adapter._scaling_events[-1].from_count == 3
+        assert adapter._scaling_events[-1].to_count == 2
+
+        # The first post-commit observation still sees a draining worker.
+        adapter._observe_runtime_inventory(
+            _result(
+                ready_prefill=0,
+                ready_decode=2,
+                total_prefill=0,
+                total_decode=3,
+            )
+        )
+        assert adapter._scaling_target_decode == 2
+
+        # Only a subsequent settled runtime snapshot retires the target.
+        adapter._observe_runtime_inventory(
+            _result(
+                ready_prefill=0,
+                ready_decode=2,
+                total_prefill=0,
+                total_decode=2,
+            )
+        )
+        assert adapter._scaling_target_decode is None
+    finally:
+        adapter.close()
+
+
+def test_proposal_preserves_component_mask():
+    adapter = _adapter("disagg", _effects(prefill=3, decode=None))
+    try:
+        proposal = adapter.propose_tick(
+            _result(ready_prefill=1, ready_decode=2)
+        ).proposal
+
+        assert proposal is not None
+        assert proposal.target_prefill == 3
+        assert proposal.target_decode is None
+    finally:
+        adapter.close()
+
+
+def test_legacy_on_tick_immediately_commits_and_keeps_bridge_shape():
+    adapter = _adapter("agg", _effects(decode=3, next_at_s=12.0))
+    try:
+        decision = adapter.on_tick(_result(ready_prefill=0, ready_decode=1))
+
+        assert decision == {
+            "target_prefill": None,
+            "target_decode": 3,
+            "next_tick_ms": 12_000.0,
+        }
+        assert adapter._scaling_target_decode == 3
+        assert adapter._scaling_events[-1].component == "agg"
+        assert adapter._scaling_events[-1].from_count == 1
+        assert adapter._scaling_events[-1].to_count == 3
+        assert adapter._mediation_events[-1].status == "approved"
+    finally:
+        adapter.close()
+
+
+def test_total_lifecycle_count_keeps_target_in_progress_until_drained():
+    adapter = _adapter("agg", _effects(), _effects())
+    adapter._scaling_target_decode = 1
+    try:
+        adapter.propose_tick(
+            _result(
+                ready_prefill=0,
+                ready_decode=1,
+                total_prefill=0,
+                total_decode=2,
+            )
+        )
+        first_counts = adapter._engine.inputs[-1][1].worker_counts
+
+        assert first_counts is not None
+        assert first_counts.expected_num_decode == 1
+        assert first_counts.decode_scaling_in_progress
+        assert adapter._scaling_target_decode == 1
+
+        adapter.propose_tick(
+            _result(
+                ready_prefill=0,
+                ready_decode=1,
+                total_prefill=0,
+                total_decode=1,
+            )
+        )
+        settled_counts = adapter._engine.inputs[-1][1].worker_counts
+
+        assert settled_counts is not None
+        assert settled_counts.expected_num_decode == 1
+        assert not settled_counts.decode_scaling_in_progress
+        assert adapter._scaling_target_decode is None
+    finally:
+        adapter.close()
+
+
+def test_async_controller_surface_exposes_initial_tick_and_proposal():
+    adapter = _adapter("agg", _effects(decode=2))
+
+    async def drive():
+        assert await adapter.initial_tick_ms_async() == 5_000.0
+
+        tick_result = await adapter.propose_tick_async(
+            _result(ready_prefill=0, ready_decode=1)
+        )
+
+        assert tick_result.proposal is not None
+        assert tick_result.proposal.target_decode == 2
+        assert adapter._scaling_target_decode is None
+        await adapter.shutdown_async()
+
+    try:
+        asyncio.run(drive())
+        assert adapter._engine.shutdown_calls == 1
+    finally:
+        adapter.close()
+
+
+def test_gpu_hours_use_runtime_capabilities_not_planner_config_hints():
+    adapter = _adapter("disagg")
+    recorder = _RecordingRecorder()
+    adapter._recorder = recorder
+    adapter._config.prefill_engine_num_gpu = 100
+    adapter._config.decode_engine_num_gpu = 100
+    adapter._last_tick_s = 5.0
+    try:
+        adapter._record_diagnostics(
+            TickInput(now_s=3_605.0),
+            _effects(),
+            {
+                "active_prefill_count": 1,
+                "active_decode_count": 2,
+            },
+            emit_diagnostics=True,
+        )
+
+        # One simulated hour at 1x2-GPU prefill + 2x4-GPU decode.
+        assert adapter._cumulative_gpu_hours == 10.0
+        assert len(recorder.records) == 1
+    finally:
+        adapter.close()

--- a/components/src/dynamo/replay/__init__.py
+++ b/components/src/dynamo/replay/__init__.py
@@ -3,4 +3,25 @@
 
 from dynamo.replay.api import run_synthetic_trace_replay, run_trace_replay
 
-__all__ = ["run_synthetic_trace_replay", "run_trace_replay"]
+__all__ = [
+    "ReplayDeploymentConfig",
+    "ReplayGlobalPlannerConfig",
+    "ReplaySyntheticWorkload",
+    "ReplayTraceWorkload",
+    "ReplayWorldReport",
+    "run_replay_world",
+    "run_synthetic_trace_replay",
+    "run_trace_replay",
+]
+
+_WORLD_EXPORTS = frozenset(__all__[:-2])
+
+
+def __getattr__(name: str):
+    # Preserve the existing cheap `dynamo.replay` import path. The world API
+    # pulls in the planner and Global Planner stacks only when requested.
+    if name in _WORLD_EXPORTS:
+        from dynamo.replay import world
+
+        return getattr(world, name)
+    raise AttributeError(name)

--- a/components/src/dynamo/replay/global_planner.py
+++ b/components/src/dynamo/replay/global_planner.py
@@ -1,0 +1,321 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory Global Planner capacity backend for offline Replay.
+
+The production Global Planner observes and patches Kubernetes through a
+``CapacityManager``. Offline Replay uses the same orchestrator with this backend:
+configured participants are pre-registered, desired replica counts are mirrored
+in memory, and approved scale calls are staged as ordered actions for the Rust
+simulation world to apply after the Python callback returns.
+
+One orchestrator submission may scale several participants. ``begin_batch`` /
+``finish_batch`` make those calls visible to the orchestrator as one overlay while
+keeping the committed mirror unchanged until the controller accepts the complete
+batch. ``abort_batch`` discards both the overlay and its actions.
+"""
+
+from __future__ import annotations
+
+import operator
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Optional
+
+from dynamo.global_planner.capacity_manager import (
+    CapacityManager,
+    PoolSnapshot,
+    PoolSpec,
+)
+from dynamo.planner import SubComponentType, TargetReplica
+
+__all__ = [
+    "ReplayCapacityManager",
+    "ReplayParticipantSpec",
+    "ReplayScaleAction",
+    "ReplayScaleTarget",
+]
+
+
+@dataclass(frozen=True)
+class ReplayParticipantSpec:
+    """Pre-registered Global Planner participant and its capacity pools."""
+
+    participant_id: str
+    pools: tuple[PoolSpec, ...]
+
+
+@dataclass(frozen=True)
+class ReplayScaleTarget:
+    """One immutable pool target staged for the simulation world."""
+
+    sub_type: str
+    desired_replicas: int
+    component_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ReplayScaleAction:
+    """One ordered backend ``scale`` call staged during an active batch."""
+
+    participant_id: str
+    targets: tuple[ReplayScaleTarget, ...]
+    blocking: bool
+
+
+_PoolKey = tuple[str, str]
+_VALID_ROLES = frozenset(role.value for role in SubComponentType)
+
+
+def _non_negative_int(value: object, *, field: str) -> int:
+    """Normalize an integer-like value and reject bools and negative values."""
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a non-negative integer, got {value!r}")
+    try:
+        normalized = operator.index(value)
+    except TypeError as exc:
+        raise ValueError(
+            f"{field} must be a non-negative integer, got {value!r}"
+        ) from exc
+    if normalized < 0:
+        raise ValueError(f"{field} must be non-negative, got {normalized}")
+    return normalized
+
+
+def _normalize_role(value: object, *, field: str) -> str:
+    """Normalize a planner role to its string value."""
+    raw = value.value if isinstance(value, SubComponentType) else value
+    if not isinstance(raw, str) or raw not in _VALID_ROLES:
+        valid = ", ".join(sorted(_VALID_ROLES))
+        raise ValueError(f"{field} must be one of [{valid}], got {raw!r}")
+    return raw
+
+
+class ReplayCapacityManager(CapacityManager):
+    """Transactional in-memory capacity backend for a Replay world.
+
+    ``scale`` never mutates a Rust runtime. It updates the active batch overlay
+    and records an immutable action. The world controller obtains those actions
+    from :meth:`finish_batch` and applies them after the planner callback returns.
+    """
+
+    def __init__(self, participants: Iterable[ReplayParticipantSpec]):
+        self._participant_ids: tuple[str, ...]
+        self._pool_specs: dict[_PoolKey, PoolSpec] = {}
+        self._roles_by_participant: dict[str, tuple[str, ...]] = {}
+        self._desired_replicas: dict[_PoolKey, int] = {}
+        self._batch_overlay: Optional[dict[_PoolKey, int]] = None
+        self._batch_actions: Optional[list[ReplayScaleAction]] = None
+
+        participant_ids: set[str] = set()
+        for participant in participants:
+            participant_id = participant.participant_id
+            if not isinstance(participant_id, str) or not participant_id:
+                raise ValueError("participant_id must be a non-empty string")
+            if participant_id in participant_ids:
+                raise ValueError(f"duplicate replay participant {participant_id!r}")
+            participant_ids.add(participant_id)
+
+            pools = tuple(participant.pools)
+            if not pools:
+                raise ValueError(
+                    f"replay participant {participant_id!r} must define at least "
+                    "one pool"
+                )
+
+            roles: set[str] = set()
+            for pool in pools:
+                role = _normalize_role(
+                    pool.sub_type,
+                    field=f"pool role for participant {participant_id!r}",
+                )
+                if role in roles:
+                    raise ValueError(
+                        f"duplicate pool role {role!r} for participant "
+                        f"{participant_id!r}"
+                    )
+                roles.add(role)
+
+                replicas = _non_negative_int(
+                    pool.current_replicas,
+                    field=f"initial replicas for {participant_id!r}/{role}",
+                )
+                gpu_per_replica = _non_negative_int(
+                    pool.gpu_per_replica,
+                    field=f"gpu_per_replica for {participant_id!r}/{role}",
+                )
+                key = (participant_id, role)
+                self._pool_specs[key] = PoolSpec(
+                    sub_type=role,
+                    current_replicas=replicas,
+                    gpu_per_replica=gpu_per_replica,
+                    component_name=pool.component_name,
+                )
+                self._desired_replicas[key] = replicas
+
+            self._roles_by_participant[participant_id] = tuple(sorted(roles))
+
+        self._participant_ids = tuple(sorted(participant_ids))
+
+    @property
+    def batch_active(self) -> bool:
+        """Whether a scale-action batch is currently being staged."""
+        return self._batch_overlay is not None
+
+    def begin_batch(self) -> None:
+        """Start a new desired-state overlay and ordered action batch."""
+        if self.batch_active:
+            raise RuntimeError("a replay capacity batch is already active")
+        self._batch_overlay = {}
+        self._batch_actions = []
+
+    def finish_batch(self) -> tuple[ReplayScaleAction, ...]:
+        """Commit the active overlay and return its actions in apply order."""
+        overlay, actions = self._require_batch()
+        self._desired_replicas.update(overlay)
+        result = tuple(actions)
+        self._batch_overlay = None
+        self._batch_actions = None
+        return result
+
+    def abort_batch(self) -> None:
+        """Discard the active overlay and every action staged in it."""
+        self._require_batch()
+        self._batch_overlay = None
+        self._batch_actions = None
+
+    def discover(self, managed_deployments: Optional[set[str]]) -> list[str]:
+        """Return pre-registered participant IDs in deterministic order."""
+        if managed_deployments is None:
+            return list(self._participant_ids)
+        return [
+            participant_id
+            for participant_id in self._participant_ids
+            if participant_id in managed_deployments
+        ]
+
+    def ensure_participant(
+        self,
+        participant_id: str,
+        caller_name: str,
+        namespace: str,
+        deployment_name: str,
+    ) -> None:
+        """Validate that a participant was declared by the Replay scenario."""
+        del caller_name, namespace, deployment_name
+        self._require_participant(participant_id)
+
+    def participant_exists(self, participant_id: str) -> bool:
+        return participant_id in self._roles_by_participant
+
+    def remember_roles(self, participant_id: str, targets: list[TargetReplica]) -> None:
+        """Replay pool roles are explicit; validate identity and otherwise no-op."""
+        del targets
+        self._require_participant(participant_id)
+
+    def observe(self, require_complete: bool = False) -> PoolSnapshot:
+        """Return a complete, deterministic snapshot of the current overlay."""
+        del require_complete
+        snapshot: PoolSnapshot = {}
+        for participant_id in self._participant_ids:
+            pools: dict[str, PoolSpec] = {}
+            for role in self._roles_by_participant[participant_id]:
+                key = (participant_id, role)
+                registered = self._pool_specs[key]
+                pools[role] = PoolSpec(
+                    sub_type=role,
+                    current_replicas=self._desired_for(key),
+                    gpu_per_replica=registered.gpu_per_replica,
+                    component_name=registered.component_name,
+                )
+            snapshot[participant_id] = pools
+        return snapshot
+
+    async def observe_async(self, require_complete: bool = False) -> PoolSnapshot:
+        """Return in-memory state directly; no thread or infrastructure I/O."""
+        return self.observe(require_complete)
+
+    async def scale(
+        self,
+        participant_id: str,
+        targets: list[TargetReplica],
+        blocking: bool,
+    ) -> None:
+        """Stage one ordered participant action in the active batch.
+
+        Every target is validated before the overlay or action list is mutated, so
+        a malformed call cannot leave a partially staged participant update.
+        """
+        self._require_participant(participant_id)
+        overlay, actions = self._require_batch()
+        if not targets:
+            raise ValueError("replay scale action must include at least one target")
+
+        seen_roles: set[str] = set()
+        normalized_targets: list[ReplayScaleTarget] = []
+        updates: list[tuple[_PoolKey, int]] = []
+        for target in targets:
+            role = _normalize_role(
+                target.sub_component_type,
+                field=f"target role for participant {participant_id!r}",
+            )
+            if role in seen_roles:
+                raise ValueError(
+                    f"duplicate target role {role!r} for participant {participant_id!r}"
+                )
+            seen_roles.add(role)
+
+            key = (participant_id, role)
+            if key not in self._pool_specs:
+                raise ValueError(
+                    f"unknown pool role {role!r} for participant {participant_id!r}"
+                )
+            desired = _non_negative_int(
+                target.desired_replicas,
+                field=f"desired replicas for {participant_id!r}/{role}",
+            )
+            normalized_targets.append(
+                ReplayScaleTarget(
+                    sub_type=role,
+                    desired_replicas=desired,
+                    component_name=target.component_name,
+                )
+            )
+            updates.append((key, desired))
+
+        for key, desired in updates:
+            overlay[key] = desired
+        actions.append(
+            ReplayScaleAction(
+                participant_id=participant_id,
+                targets=tuple(normalized_targets),
+                blocking=bool(blocking),
+            )
+        )
+
+    def current_replicas(self, participant_id: str) -> dict[str, int]:
+        """Read desired counts, including changes in the active batch overlay."""
+        self._require_participant(participant_id)
+        return {
+            role: self._desired_for((participant_id, role))
+            for role in self._roles_by_participant[participant_id]
+        }
+
+    def _desired_for(self, key: _PoolKey) -> int:
+        overlay = self._batch_overlay
+        if overlay is not None and key in overlay:
+            return overlay[key]
+        return self._desired_replicas[key]
+
+    def _require_participant(self, participant_id: str) -> None:
+        if not self.participant_exists(participant_id):
+            raise KeyError(
+                f"replay participant {participant_id!r} was not pre-registered"
+            )
+
+    def _require_batch(
+        self,
+    ) -> tuple[dict[_PoolKey, int], list[ReplayScaleAction]]:
+        if self._batch_overlay is None or self._batch_actions is None:
+            raise RuntimeError("no replay capacity batch is active")
+        return self._batch_overlay, self._batch_actions

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import importlib
 import json
 import os
+import re
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -301,7 +303,17 @@ def _engine_caps(args: MockEngineArgs) -> EngineCapabilities:
     """Derive EngineCapabilities from MockEngineArgs."""
     from dynamo.planner.core.types import EngineCapabilities
 
-    dp_size = max(args.dp_size, 1)
+    # Match the Rust replay materialization exactly: an explicit attention-DP
+    # size becomes the scheduler topology even when the Python object's raw
+    # `dp_size` is still its default. GP budgets, local planner capabilities,
+    # and Mocker GPU-hours must all use the same per-worker width.
+    attention_dp = args.aic_attention_dp_size
+    dp_size = max(attention_dp if attention_dp is not None else args.dp_size, 1)
+    if attention_dp is not None and args.dp_size > 1 and args.dp_size != dp_size:
+        raise ValueError(
+            "dp_size must match aic_attention_dp_size for AIC-backed replay "
+            f"(got dp_size={args.dp_size}, aic_attention_dp_size={dp_size})"
+        )
     max_kv_tokens = args.num_gpu_blocks * args.block_size * dp_size
     return EngineCapabilities(
         num_gpu=(args.aic_tp_size or 1) * dp_size,
@@ -402,7 +414,18 @@ class SyntheticWorkload:
     inter_turn_delay_ms: float = 0.0
 
 
-def _run_planner_replay(
+def _report_namespace_component(report_namespace: str | None) -> str | None:
+    """Return a filesystem-safe, collision-resistant report directory name."""
+    if report_namespace is None:
+        return None
+
+    safe_prefix = re.sub(r"[^A-Za-z0-9_.-]+", "_", report_namespace).strip("._")
+    safe_prefix = safe_prefix[:64] or "deployment"
+    namespace_hash = hashlib.sha256(report_namespace.encode("utf-8")).hexdigest()
+    return f"{safe_prefix}-{namespace_hash}"
+
+
+def _build_planner_replay(
     trace_file: str | None,
     extra_engine_args: MockEngineArgs | None,
     prefill_engine_args: MockEngineArgs | None,
@@ -422,8 +445,11 @@ def _run_planner_replay(
     sla_e2e_ms: float | None = None,
     replay_concurrency: int | None = None,
     synthetic: SyntheticWorkload | None = None,
+    event_loop=None,
+    clock=None,
+    report_namespace: str | None = None,
 ):
-    """Run an offline replay with planner-in-the-loop (agg or disagg).
+    """Build an offline planner bridge and adapter without starting the replay.
 
     ``sla_ttft_ms`` / ``sla_itl_ms`` / ``sla_e2e_ms`` are the **goodput** SLA used
     to classify SLA-satisfying requests in the report. They are independent of
@@ -445,6 +471,11 @@ def _run_planner_replay(
 
     planner_config = PlannerConfig.from_config_arg(planner_config_arg)
     planner_config.advisory = True
+    safe_namespace = _report_namespace_component(report_namespace)
+    if safe_namespace is not None:
+        planner_config.report_output_dir = os.path.join(
+            planner_config.report_output_dir, safe_namespace
+        )
 
     if (trace_file is None) == (synthetic is None):
         raise ValueError(
@@ -555,18 +586,13 @@ def _run_planner_replay(
             f"planner-in-the-loop replay supports mode='agg' or 'disagg', got '{planner_config.mode}'"
         )
 
-    adapter = ReplayPlannerAdapter(
-        planner_config=planner_config,
-        bridge=bridge,
-        capabilities=capabilities,
-    )
-
     # Bootstrap regression models from mocker's perf model.
     # AIC provides accurate batch-size-aware timing that works with the
     # planner's linear regression. The default polynomial model cannot
     # feed the throughput regression (its decode formula is quadratic in
     # utilization ratio, causing negative regression coefficients).
-    if not adapter._is_easy_mode():
+    benchmark_fpms: dict[str, list[ForwardPassMetrics]] = {}
+    if planner_config.optimization_target == "sla":
         ref_args = (
             extra_engine_args
             or (
@@ -679,21 +705,47 @@ def _run_planner_replay(
                     # have variance.
                     agg_fpms = prefill_fpms + decode_fpms
                     if agg_fpms:
-                        adapter.install_benchmark_fpms(agg_fpms=agg_fpms)
+                        benchmark_fpms["agg_fpms"] = agg_fpms
                     else:
                         sys.stderr.write(
                             "Warning: AIC produced no agg benchmark FPMs\n"
                         )
                 else:
                     if prefill_fpms and decode_fpms:
-                        adapter.install_benchmark_fpms(
-                            prefill_fpms=prefill_fpms, decode_fpms=decode_fpms
-                        )
+                        benchmark_fpms["prefill_fpms"] = prefill_fpms
+                        benchmark_fpms["decode_fpms"] = decode_fpms
                     else:
                         sys.stderr.write(
                             f"Warning: AIC produced empty benchmark FPMs "
                             f"(prefill={len(prefill_fpms)}, decode={len(decode_fpms)})\n"
                         )
+
+    adapter = ReplayPlannerAdapter(
+        planner_config=planner_config,
+        bridge=bridge,
+        capabilities=capabilities,
+        event_loop=event_loop,
+        clock=clock,
+    )
+    try:
+        if benchmark_fpms:
+            adapter.install_benchmark_fpms(**benchmark_fpms)
+    except BaseException as exc:
+        try:
+            adapter.close()
+        except BaseException as cleanup_exc:
+            exc.add_note(
+                "Replay planner adapter cleanup after build failure also failed: "
+                f"{cleanup_exc}"
+            )
+        raise
+
+    return bridge, adapter
+
+
+def _run_planner_replay(*args, **kwargs):
+    """Build and run the legacy single-deployment planner Replay path."""
+    bridge, adapter = _build_planner_replay(*args, **kwargs)
 
     # gpu_hours (and prefill/decode_gpus_per_worker) are computed in the mocker
     # from its own worker parallelism (aic_tp x aic_attention_dp) and ride the
@@ -704,11 +756,14 @@ def _run_planner_replay(
     # trace_report with the adapter's accumulated scaling events / diagnostics.
     try:
         trace_report = bridge.run(adapter)
-    except BaseException:
+    except BaseException as exc:
         # `finalize` (which closes the engine + replay-scoped event loop) is only
         # reached on success; ensure cleanup also runs when the Rust loop or a
         # planner callback raises. `close()` is idempotent.
-        adapter.close()
+        try:
+            adapter.close()
+        except BaseException as cleanup_exc:
+            exc.add_note(f"Replay planner cleanup also failed: {cleanup_exc}")
         raise
     return adapter.finalize(trace_report)
 

--- a/components/src/dynamo/replay/tests/test_main_planner_lifecycle.py
+++ b/components/src/dynamo/replay/tests/test_main_planner_lifecycle.py
@@ -1,0 +1,208 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused ownership tests for Replay planner construction and teardown."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import ANY
+
+import pytest
+
+import dynamo.replay.main as replay_main
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def test_report_namespace_component_is_stable_and_collision_resistant() -> None:
+    slash = replay_main._report_namespace_component("model/a")
+    question = replay_main._report_namespace_component("model?a")
+    upper = replay_main._report_namespace_component("Deployment")
+    lower = replay_main._report_namespace_component("deployment")
+    unicode_only = replay_main._report_namespace_component("模型")
+
+    assert replay_main._report_namespace_component(None) is None
+    assert slash == replay_main._report_namespace_component("model/a")
+    assert slash is not None and slash.startswith("model_a-")
+    assert question is not None and question.startswith("model_a-")
+    assert slash != question
+    assert upper is not None and lower is not None
+    assert upper.casefold() != lower.casefold()
+    assert unicode_only is not None
+    assert unicode_only.startswith("deployment-")
+
+
+class _FakePlannerConfig:
+    mode = "agg"
+    optimization_target = "sla"
+
+    def __init__(self, report_output_dir: Path) -> None:
+        self.advisory = False
+        self.report_output_dir = str(report_output_dir)
+
+
+class _FakePlannerReplayBridge:
+    @classmethod
+    def from_synthetic(cls, **_kwargs: Any) -> _FakePlannerReplayBridge:
+        return cls()
+
+
+class _FakeWorkerCapabilities:
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+
+def _patch_builder_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    adapter_type: type,
+) -> None:
+    import dynamo._internal.aic as aic_module
+    import dynamo.mocker as mocker_module
+    import dynamo.planner.config.planner_config as config_module
+    import dynamo.planner.core.types as types_module
+    import dynamo.planner.offline.replay_adapter as adapter_module
+
+    config = _FakePlannerConfig(tmp_path)
+
+    class _ConfigFactory:
+        @staticmethod
+        def from_config_arg(_config_arg: str) -> _FakePlannerConfig:
+            return config
+
+    monkeypatch.setattr(config_module, "PlannerConfig", _ConfigFactory)
+    monkeypatch.setattr(
+        mocker_module,
+        "PlannerReplayBridge",
+        _FakePlannerReplayBridge,
+        raising=False,
+    )
+    monkeypatch.setattr(types_module, "WorkerCapabilities", _FakeWorkerCapabilities)
+    monkeypatch.setattr(adapter_module, "ReplayPlannerAdapter", adapter_type)
+    monkeypatch.setattr(replay_main, "_engine_caps", lambda _args: object())
+    monkeypatch.setattr(aic_module, "create_session", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        replay_main,
+        "_generate_aic_prefill_fpms",
+        lambda *_args, **_kwargs: [object()],
+    )
+    monkeypatch.setattr(
+        replay_main,
+        "_generate_aic_decode_fpms",
+        lambda *_args, **_kwargs: [object()],
+    )
+
+
+def _aic_engine_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        aic_backend="test",
+        aic_system="test-system",
+        aic_model_path="test-model",
+        aic_tp_size=1,
+        aic_backend_version=None,
+        aic_moe_tp_size=None,
+        aic_moe_ep_size=None,
+        aic_attention_dp_size=None,
+        aic_gemm_dtype=None,
+        aic_moe_dtype=None,
+        aic_fmha_dtype=None,
+        aic_kv_cache_dtype=None,
+        aic_comm_dtype=None,
+        aic_nextn=None,
+    )
+
+
+def test_builder_closes_adapter_after_regression_install_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class RegressionInstallError(RuntimeError):
+        pass
+
+    class _FailingAdapter:
+        instances: list[_FailingAdapter] = []
+
+        def __init__(self, **kwargs: Any) -> None:
+            self.event_loop = kwargs["event_loop"]
+            self.close_calls = 0
+            self.installed: dict[str, Any] | None = None
+            self.instances.append(self)
+
+        def install_benchmark_fpms(self, **kwargs: Any) -> None:
+            self.installed = kwargs
+            raise RegressionInstallError("regression install failed")
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    _patch_builder_dependencies(monkeypatch, tmp_path, _FailingAdapter)
+    shared_loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(RegressionInstallError, match="regression install failed"):
+            replay_main._build_planner_replay(
+                trace_file=None,
+                extra_engine_args=_aic_engine_args(),
+                prefill_engine_args=None,
+                decode_engine_args=None,
+                router_config=None,
+                num_workers=1,
+                num_prefill_workers=0,
+                num_decode_workers=0,
+                router_mode="round_robin",
+                arrival_speedup_ratio=1.0,
+                trace_block_size=512,
+                planner_config_arg="ignored",
+                synthetic=replay_main.SyntheticWorkload(
+                    input_tokens=1,
+                    output_tokens=1,
+                    request_count=1,
+                ),
+                event_loop=shared_loop,
+            )
+
+        adapter = _FailingAdapter.instances[-1]
+        assert adapter.event_loop is shared_loop
+        assert adapter.close_calls == 1
+        assert adapter.installed == {
+            "agg_fpms": [ANY, ANY],
+        }
+        assert not shared_loop.is_closed()
+    finally:
+        shared_loop.close()
+
+
+def test_legacy_run_preserves_run_error_when_cleanup_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class RunError(RuntimeError):
+        pass
+
+    class _Bridge:
+        def run(self, _adapter: object) -> None:
+            raise RunError("planner callback failed")
+
+    class _Adapter:
+        def close(self) -> None:
+            raise RuntimeError("transport shutdown failed")
+
+    monkeypatch.setattr(
+        replay_main,
+        "_build_planner_replay",
+        lambda *_args, **_kwargs: (_Bridge(), _Adapter()),
+    )
+
+    with pytest.raises(RunError, match="planner callback failed") as exc_info:
+        replay_main._run_planner_replay()
+
+    assert exc_info.value.__notes__ == [
+        "Replay planner cleanup also failed: transport shutdown failed"
+    ]

--- a/components/src/dynamo/replay/tests/test_world_config.py
+++ b/components/src/dynamo/replay/tests/test_world_config.py
@@ -1,0 +1,386 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation tests for the public multi-deployment Replay configuration."""
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+import dynamo.replay.world as world_module
+from dynamo.replay.world import (
+    ReplayDeploymentConfig,
+    ReplayGlobalPlannerConfig,
+    ReplaySyntheticWorkload,
+    ReplayTraceWorkload,
+    _resolved_synthetic_arrival_interval_ms,
+    _validate_deployment_engine_args,
+    run_replay_world,
+)
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def _deployment(**overrides) -> ReplayDeploymentConfig:
+    deployment = ReplayDeploymentConfig(
+        deployment_id="deployment",
+        planner_config={},
+        workload=ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+        ),
+    )
+    return replace(deployment, **overrides)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("max_total_gpus", True),
+        ("max_total_gpus", 2.0),
+        ("max_total_gpus", float("nan")),
+        ("min_total_gpus", False),
+        ("min_total_gpus", float("inf")),
+    ],
+)
+def test_global_gpu_limits_require_integers(field, value):
+    with pytest.raises(ValueError, match=rf"{field} must be an integer"):
+        ReplayGlobalPlannerConfig(**{field: value})
+
+
+@pytest.mark.parametrize("value", [0, -1, True, 512.0, float("nan")])
+def test_trace_block_size_requires_a_positive_integer(value):
+    with pytest.raises(ValueError, match="trace_block_size"):
+        ReplayTraceWorkload("trace.jsonl", trace_block_size=value)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("input_tokens", True),
+        ("output_tokens", 32.0),
+        ("request_count", float("inf")),
+        ("turns_per_session", 0),
+        ("num_prefix_groups", -1),
+        ("num_prefix_groups", False),
+        ("arrival_seed", -1),
+        ("arrival_seed", True),
+        ("arrival_seed", 1.0),
+    ],
+)
+def test_synthetic_workload_count_fields_require_integers(field, value):
+    workload = ReplaySyntheticWorkload(
+        input_tokens=128,
+        output_tokens=32,
+        request_count=10,
+    )
+    with pytest.raises(ValueError, match=field):
+        replace(workload, **{field: value})
+
+
+def test_synthetic_arrival_seed_must_fit_u64():
+    with pytest.raises(ValueError, match="unsigned 64-bit"):
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            arrival_seed=1 << 64,
+        )
+
+
+@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "1"])
+def test_synthetic_request_rate_must_be_finite_and_positive(value):
+    with pytest.raises(ValueError, match="request_rate"):
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            request_rate=value,
+        )
+
+
+@pytest.mark.parametrize("value", [-1, float("nan"), float("inf"), True, "1"])
+def test_synthetic_arrival_interval_must_be_finite_and_non_negative(value):
+    with pytest.raises(ValueError, match="arrival_interval_ms"):
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            arrival_interval_ms=value,
+        )
+
+
+def test_synthetic_open_loop_controls_are_mutually_exclusive():
+    with pytest.raises(ValueError, match="at most one"):
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            request_rate=5.0,
+            arrival_interval_ms=1.0,
+        )
+
+
+@pytest.mark.parametrize(
+    "workload",
+    [
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            request_rate=5.0,
+        ),
+        ReplaySyntheticWorkload(
+            input_tokens=128,
+            output_tokens=32,
+            request_count=10,
+            arrival_interval_ms=1.0,
+        ),
+    ],
+)
+def test_synthetic_closed_loop_rejects_an_open_loop_controller(workload):
+    with pytest.raises(ValueError, match="at most one"):
+        _deployment(workload=workload, replay_concurrency=2)
+
+
+def test_synthetic_arrival_interval_resolution_preserves_legacy_default():
+    workload = ReplaySyntheticWorkload(
+        input_tokens=128,
+        output_tokens=32,
+        request_count=10,
+    )
+
+    assert _resolved_synthetic_arrival_interval_ms(workload, None) == 1.0
+    assert _resolved_synthetic_arrival_interval_ms(workload, 2) is None
+    assert (
+        _resolved_synthetic_arrival_interval_ms(
+            replace(workload, request_rate=5.0), None
+        )
+        is None
+    )
+    assert (
+        _resolved_synthetic_arrival_interval_ms(
+            replace(workload, arrival_interval_ms=0.0), None
+        )
+        == 0.0
+    )
+
+
+def test_trace_workload_accepts_replay_concurrency():
+    deployment = ReplayDeploymentConfig(
+        deployment_id="trace",
+        planner_config={},
+        workload=ReplayTraceWorkload("trace.jsonl"),
+        replay_concurrency=2,
+    )
+
+    assert deployment.replay_concurrency == 2
+
+
+@pytest.mark.parametrize(
+    (
+        "workload",
+        "replay_concurrency",
+        "expected_request_rate",
+        "expected_arrival_interval_ms",
+        "expected_arrival_seed",
+    ),
+    [
+        pytest.param(
+            ReplaySyntheticWorkload(128, 32, 10),
+            None,
+            None,
+            1.0,
+            42,
+            id="legacy-fixed-interval",
+        ),
+        pytest.param(
+            ReplaySyntheticWorkload(
+                128,
+                32,
+                10,
+                request_rate=7.5,
+                arrival_seed=99,
+            ),
+            None,
+            7.5,
+            None,
+            99,
+            id="poisson-rate-and-seed",
+        ),
+        pytest.param(
+            ReplaySyntheticWorkload(128, 32, 10, arrival_interval_ms=17.5),
+            None,
+            None,
+            17.5,
+            42,
+            id="explicit-fixed-interval",
+        ),
+        pytest.param(
+            ReplaySyntheticWorkload(128, 32, 10),
+            3,
+            None,
+            None,
+            42,
+            id="closed-loop-concurrency",
+        ),
+    ],
+)
+def test_world_forwards_synthetic_load_controller_to_planner_bridge(
+    monkeypatch: pytest.MonkeyPatch,
+    workload: ReplaySyntheticWorkload,
+    replay_concurrency: int | None,
+    expected_request_rate: float | None,
+    expected_arrival_interval_ms: float | None,
+    expected_arrival_seed: int,
+):
+    pytest.importorskip("dynamo._core")
+    import dynamo.replay.main as replay_main
+
+    captured: dict = {}
+
+    class _CapturedBridgeArguments(Exception):
+        pass
+
+    def capture_bridge_arguments(**kwargs):
+        captured.update(kwargs)
+        raise _CapturedBridgeArguments
+
+    monkeypatch.setattr(
+        replay_main,
+        "_build_planner_replay",
+        capture_bridge_arguments,
+    )
+
+    deployment = _deployment(
+        planner_config={"mode": "agg"},
+        workload=workload,
+        replay_concurrency=replay_concurrency,
+    )
+    with pytest.raises(_CapturedBridgeArguments):
+        run_replay_world([deployment])
+
+    synthetic = captured["synthetic"]
+    assert (
+        synthetic.request_rate,
+        synthetic.arrival_interval_ms,
+        synthetic.arrival_seed,
+        captured["replay_concurrency"],
+    ) == (
+        expected_request_rate,
+        expected_arrival_interval_ms,
+        expected_arrival_seed,
+        replay_concurrency,
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("num_workers", -1),
+        ("num_prefill_workers", True),
+        ("num_decode_workers", 1.0),
+        ("replay_concurrency", 0),
+        ("replay_concurrency", False),
+        ("benchmark_granularity", 0),
+        ("benchmark_granularity", -1),
+        ("benchmark_granularity", True),
+        ("benchmark_granularity", 8.0),
+        ("benchmark_granularity", float("nan")),
+    ],
+)
+def test_deployment_count_fields_require_valid_integers(field, value):
+    with pytest.raises(ValueError, match=field):
+        _deployment(**{field: value})
+
+
+@pytest.mark.parametrize("deployment_id", ["", "   ", "\t\n"])
+def test_deployment_id_rejects_empty_or_whitespace_only_values(deployment_id):
+    with pytest.raises(ValueError, match="deployment_id must be non-empty"):
+        _deployment(deployment_id=deployment_id)
+
+
+@pytest.mark.parametrize("deployment_id", ["model/a?", "部署-A"])
+def test_deployment_id_accepts_punctuation_and_unicode(deployment_id):
+    assert _deployment(deployment_id=deployment_id).deployment_id == deployment_id
+
+
+def test_aggregated_mode_rejects_role_specific_engine_args():
+    for field in ("prefill_engine_args", "decode_engine_args"):
+        deployment = _deployment(**{field: object()})
+        with pytest.raises(ValueError, match="accepts only extra_engine_args"):
+            _validate_deployment_engine_args(deployment, "agg")
+
+
+def test_disaggregated_mode_rejects_aggregate_engine_args():
+    deployment = _deployment(
+        extra_engine_args=object(),
+        prefill_engine_args=object(),
+        decode_engine_args=object(),
+    )
+
+    with pytest.raises(ValueError, match="does not accept extra_engine_args"):
+        _validate_deployment_engine_args(deployment, "disagg")
+
+
+@pytest.mark.parametrize(
+    ("prefill_engine_args", "decode_engine_args"),
+    [(None, object()), (object(), None), (None, None)],
+)
+def test_disaggregated_mode_requires_both_role_engine_args(
+    prefill_engine_args,
+    decode_engine_args,
+):
+    deployment = _deployment(
+        prefill_engine_args=prefill_engine_args,
+        decode_engine_args=decode_engine_args,
+    )
+
+    with pytest.raises(
+        ValueError, match="requires prefill_engine_args and decode_engine_args"
+    ):
+        _validate_deployment_engine_args(deployment, "disagg")
+
+
+def test_valid_engine_argument_shapes_are_accepted():
+    _validate_deployment_engine_args(_deployment(), "agg")
+    _validate_deployment_engine_args(
+        _deployment(
+            prefill_engine_args=object(),
+            decode_engine_args=object(),
+        ),
+        "disagg",
+    )
+
+
+def test_synchronous_world_api_rejects_a_running_event_loop():
+    async def invoke() -> None:
+        with pytest.raises(RuntimeError, match="active asyncio event loop"):
+            run_replay_world([_deployment()])
+
+    asyncio.run(invoke())
+
+
+def test_setup_failure_closes_the_world_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    pytest.importorskip("dynamo._core")
+    loop = asyncio.new_event_loop()
+
+    def fail_clock():
+        raise RuntimeError("clock construction failed")
+
+    monkeypatch.setattr(asyncio, "new_event_loop", lambda: loop)
+    monkeypatch.setattr(world_module, "VirtualClock", fail_clock)
+
+    with pytest.raises(RuntimeError, match="clock construction failed"):
+        run_replay_world([_deployment()])
+
+    assert loop.is_closed()

--- a/components/src/dynamo/replay/tests/test_world_controller.py
+++ b/components/src/dynamo/replay/tests/test_world_controller.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for the multi-deployment Replay planner controller."""
+
+import asyncio
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from dynamo.global_planner.capacity_manager import PoolSpec
+from dynamo.planner.offline.replay_adapter import PlannerTickResult, ScalingProposal
+from dynamo.planner.plugins.clock import VirtualClock
+from dynamo.replay.global_planner import ReplayParticipantSpec
+from dynamo.replay.world import ReplayGlobalPlannerConfig, ReplayWorldPlannerController
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+class _FakePlannerSession:
+    def __init__(
+        self,
+        participant_id: str,
+        results: list[PlannerTickResult],
+        events: list[tuple[str, str]],
+        *,
+        fail_on_mediation: bool = False,
+    ) -> None:
+        self.participant_id = participant_id
+        self._results = list(results)
+        self._events = events
+        self._fail_on_mediation = fail_on_mediation
+        self.propose_ticks: list[dict[str, Any]] = []
+        self.rejections: list[tuple[ScalingProposal, str | None]] = []
+        self.mediations: list[tuple[ScalingProposal, str, str | None]] = []
+        self.commits: list[dict[str, Any]] = []
+        self.shutdown_calls = 0
+
+    async def propose_tick_async(self, tick: dict[str, Any]) -> PlannerTickResult:
+        self._events.append(("propose", self.participant_id))
+        self.propose_ticks.append(tick)
+        if not self._results:
+            raise AssertionError(f"unexpected planner tick for {self.participant_id!r}")
+        return self._results.pop(0)
+
+    def observe_rejection(
+        self,
+        proposal: ScalingProposal,
+        *,
+        message: str | None = None,
+    ) -> None:
+        self._events.append(("reject", self.participant_id))
+        self.rejections.append((proposal, message))
+
+    def observe_mediation(
+        self,
+        proposal: ScalingProposal,
+        *,
+        status: str,
+        message: str | None = None,
+    ) -> None:
+        self._events.append(("mediate", self.participant_id))
+        self.mediations.append((proposal, status, message))
+        if self._fail_on_mediation:
+            raise RuntimeError(f"mediation callback failed for {self.participant_id}")
+
+    def observe_committed_scale(self, **kwargs: Any) -> None:
+        self._events.append(("commit", self.participant_id))
+        self.commits.append(kwargs)
+
+    async def shutdown_async(self) -> None:
+        self.shutdown_calls += 1
+
+
+@pytest.fixture
+def controller_factory() -> Iterator[Any]:
+    controllers: list[ReplayWorldPlannerController] = []
+
+    def build(
+        sessions: dict[str, _FakePlannerSession],
+        *,
+        initial_replicas: dict[str, int] | None = None,
+        config: ReplayGlobalPlannerConfig = ReplayGlobalPlannerConfig(),
+    ) -> ReplayWorldPlannerController:
+        replicas = initial_replicas or {}
+        participants = [
+            ReplayParticipantSpec(
+                participant_id=participant_id,
+                pools=(
+                    PoolSpec(
+                        sub_type="decode",
+                        current_replicas=replicas.get(participant_id, 1),
+                        gpu_per_replica=1,
+                    ),
+                ),
+            )
+            for participant_id in sessions
+        ]
+        controller = ReplayWorldPlannerController(
+            sessions,  # type: ignore[arg-type]
+            participants,
+            config=config,
+            event_loop=asyncio.new_event_loop(),
+            clock=VirtualClock(),
+        )
+        controllers.append(controller)
+        return controller
+
+    yield build
+
+    for controller in reversed(controllers):
+        controller.close()
+
+
+def _proposal(
+    *,
+    at_s: float,
+    current_decode: int,
+    target_decode: int,
+    next_tick_ms: float | None = None,
+) -> PlannerTickResult:
+    return PlannerTickResult(
+        proposal=ScalingProposal(
+            at_s=at_s,
+            current_prefill=0,
+            current_decode=current_decode,
+            target_decode=target_decode,
+        ),
+        next_tick_ms=next_tick_ms,
+    )
+
+
+def _tick(participant_id: str, now_ms: float) -> dict[str, Any]:
+    return {"deployment_id": participant_id, "now_ms": now_ms}
+
+
+def test_all_due_proposals_run_before_any_commit_notification(
+    controller_factory,
+):
+    events: list[tuple[str, str]] = []
+    sessions = {
+        "b": _FakePlannerSession(
+            "b",
+            [_proposal(at_s=1.0, current_decode=1, target_decode=2)],
+            events,
+        ),
+        "a": _FakePlannerSession(
+            "a",
+            [_proposal(at_s=1.0, current_decode=1, target_decode=2)],
+            events,
+        ),
+    }
+    controller = controller_factory(sessions)
+
+    result = controller.on_ticks([_tick("b", 1_000.0), _tick("a", 1_000.0)])
+
+    assert result["actions"] == [
+        {
+            "deployment_id": "a",
+            "target_prefill": None,
+            "target_decode": 2,
+        },
+        {
+            "deployment_id": "b",
+            "target_prefill": None,
+            "target_decode": 2,
+        },
+    ]
+    assert events == [
+        ("propose", "a"),
+        ("propose", "b"),
+        ("mediate", "a"),
+        ("mediate", "b"),
+        ("commit", "a"),
+        ("commit", "b"),
+    ]
+
+
+def test_rejected_request_stages_no_action(controller_factory):
+    events: list[tuple[str, str]] = []
+    session = _FakePlannerSession(
+        "deployment",
+        [_proposal(at_s=1.0, current_decode=2, target_decode=3)],
+        events,
+    )
+    controller = controller_factory(
+        {"deployment": session},
+        initial_replicas={"deployment": 2},
+        config=ReplayGlobalPlannerConfig(max_total_gpus=2),
+    )
+
+    result = controller.on_ticks([_tick("deployment", 1_000.0)])
+
+    assert result["actions"] == []
+    assert len(session.rejections) == 1
+    assert session.commits == []
+    assert controller._capacity_manager.current_replicas("deployment") == {"decode": 2}
+
+
+def test_fixed_budget_cached_partner_is_applied_down_then_up(
+    controller_factory,
+):
+    events: list[tuple[str, str]] = []
+    sessions = {
+        "a": _FakePlannerSession(
+            "a",
+            [_proposal(at_s=1.0, current_decode=2, target_decode=1)],
+            events,
+        ),
+        "b": _FakePlannerSession(
+            "b",
+            [_proposal(at_s=2.0, current_decode=2, target_decode=3)],
+            events,
+        ),
+    }
+    controller = controller_factory(
+        sessions,
+        initial_replicas={"a": 2, "b": 2},
+        config=ReplayGlobalPlannerConfig(
+            min_total_gpus=4,
+            max_total_gpus=4,
+        ),
+    )
+
+    first = controller.on_ticks([_tick("a", 1_000.0)])
+    assert first["actions"] == []
+    assert len(sessions["a"].rejections) == 1
+    assert sessions["a"].commits == []
+
+    events.clear()
+    second = controller.on_ticks([_tick("b", 2_000.0)])
+
+    assert second["actions"] == [
+        {
+            "deployment_id": "a",
+            "target_prefill": None,
+            "target_decode": 1,
+        },
+        {
+            "deployment_id": "b",
+            "target_prefill": None,
+            "target_decode": 3,
+        },
+    ]
+    assert events == [
+        ("propose", "b"),
+        ("mediate", "b"),
+        ("commit", "a"),
+        ("commit", "b"),
+    ]
+    assert len(sessions["a"].propose_ticks) == 1
+    assert sessions["a"].commits == [
+        {
+            "at_s": 2.0,
+            "target_prefill": None,
+            "target_decode": 1,
+            "reason": "global_planner",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("ticks", "message"),
+    [
+        (
+            [_tick("a", 1_000.0), _tick("a", 1_000.0)],
+            "fired twice at one timestamp",
+        ),
+        (
+            [_tick("a", 1_000.0), _tick("b", 1_001.0)],
+            "exactly one timestamp",
+        ),
+    ],
+)
+def test_duplicate_or_mismatched_tick_barriers_are_rejected(
+    controller_factory,
+    ticks,
+    message,
+):
+    events: list[tuple[str, str]] = []
+    sessions = {
+        "a": _FakePlannerSession("a", [], events),
+        "b": _FakePlannerSession("b", [], events),
+    }
+    controller = controller_factory(sessions)
+
+    with pytest.raises(ValueError, match=message):
+        controller.on_ticks(ticks)
+
+    assert events == []
+    assert not controller._capacity_manager.batch_active
+
+
+def test_callback_exception_aborts_capacity_batch(controller_factory):
+    events: list[tuple[str, str]] = []
+    sessions = {
+        "a": _FakePlannerSession(
+            "a",
+            [_proposal(at_s=1.0, current_decode=1, target_decode=2)],
+            events,
+        ),
+        "b": _FakePlannerSession(
+            "b",
+            [_proposal(at_s=1.0, current_decode=1, target_decode=2)],
+            events,
+            fail_on_mediation=True,
+        ),
+    }
+    controller = controller_factory(sessions)
+    manager = controller._capacity_manager
+
+    with pytest.raises(RuntimeError, match="mediation callback failed for b"):
+        controller.on_ticks([_tick("a", 1_000.0), _tick("b", 1_000.0)])
+
+    assert not manager.batch_active
+    assert manager.current_replicas("a") == {"decode": 1}
+    assert manager.current_replicas("b") == {"decode": 1}
+    assert sessions["a"].commits == []
+    assert sessions["b"].commits == []
+    manager.begin_batch()
+    assert manager.finish_batch() == ()

--- a/components/src/dynamo/replay/tests/test_world_e2e.py
+++ b/components/src/dynamo/replay/tests/test_world_e2e.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public-API smoke tests for the PyO3 multi-deployment Replay world."""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.e2e,
+    pytest.mark.planner,
+]
+
+
+def _load_planner_config(
+    report_dir: Path,
+    *,
+    scale_up_percent: float,
+    scale_down_percent: float,
+) -> dict:
+    return {
+        "mode": "agg",
+        "backend": "mocker",
+        "environment": "virtual",
+        "optimization_target": "load",
+        "enable_throughput_scaling": False,
+        "decode_scale_up_kv_rate": scale_up_percent,
+        "decode_scale_down_kv_rate": scale_down_percent,
+        "load_adjustment_interval_seconds": 1,
+        "scheduling": {"scale_interval_seconds": 0.25},
+        "report_interval_hours": None,
+        "report_output_dir": str(report_dir),
+        "live_dashboard_port": 0,
+    }
+
+
+@pytest.mark.parametrize(
+    "model_names",
+    [
+        pytest.param(("model-alpha", "model-beta"), id="different-models"),
+        pytest.param(("shared-model", "shared-model"), id="same-model"),
+    ],
+)
+def test_public_api_runs_two_deployments_with_shared_global_planner(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    model_names: tuple[str, str],
+) -> None:
+    """Run independent deployment workloads through local planners and shared GP."""
+    pytest.importorskip("dynamo._core")
+    monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "matplotlib"))
+
+    from dynamo.mocker import MockEngineArgs
+    from dynamo.replay import (
+        ReplayDeploymentConfig,
+        ReplayGlobalPlannerConfig,
+        ReplaySyntheticWorkload,
+        run_replay_world,
+    )
+
+    engine = MockEngineArgs(
+        num_gpu_blocks=64,
+        block_size=16,
+        max_num_seqs=32,
+        max_num_batched_tokens=512,
+        startup_time=0.0,
+    )
+    report_dir = tmp_path / "planner-reports"
+
+    report = run_replay_world(
+        [
+            ReplayDeploymentConfig(
+                deployment_id="alpha",
+                model_name=model_names[0],
+                planner_config=_load_planner_config(
+                    report_dir,
+                    scale_up_percent=100.0,
+                    scale_down_percent=99.0,
+                ),
+                workload=ReplaySyntheticWorkload(
+                    input_tokens=16,
+                    output_tokens=128,
+                    request_count=1,
+                    arrival_interval_ms=0.0,
+                ),
+                extra_engine_args=engine,
+                num_workers=2,
+            ),
+            ReplayDeploymentConfig(
+                deployment_id="beta",
+                model_name=model_names[1],
+                planner_config=_load_planner_config(
+                    report_dir,
+                    scale_up_percent=0.01,
+                    scale_down_percent=0.0,
+                ),
+                workload=ReplaySyntheticWorkload(
+                    input_tokens=16,
+                    output_tokens=128,
+                    request_count=4,
+                    arrival_interval_ms=0.0,
+                ),
+                extra_engine_args=engine,
+                num_workers=1,
+            ),
+        ],
+        global_planner=ReplayGlobalPlannerConfig(
+            min_total_gpus=3,
+            max_total_gpus=3,
+        ),
+    )
+
+    assert list(report.deployments) == ["alpha", "beta"]
+    assert report.deployments["alpha"].trace_report["completed_requests"] == 1
+    assert report.deployments["beta"].trace_report["completed_requests"] == 4
+
+    # Alpha's standalone scale-down cannot cross the fixed budget, but its
+    # cached intent pairs with beta's scale-up in the same timestamp barrier.
+    assert [
+        (
+            event.at_s,
+            event.participant_id,
+            event.status,
+            event.target_decode,
+        )
+        for event in report.global_planner_events[:2]
+    ] == [
+        (1.0, "alpha", "rejected", 1),
+        (1.0, "beta", "success", 2),
+    ]
+
+    alpha_scales = report.deployments["alpha"].scaling_events
+    beta_scales = report.deployments["beta"].scaling_events
+    assert [
+        (event.at_s, event.from_count, event.to_count, event.reason)
+        for event in alpha_scales
+    ] == [(1.0, 2, 1, "global_planner")]
+    assert [
+        (event.at_s, event.from_count, event.to_count, event.reason)
+        for event in beta_scales
+    ] == [(1.0, 1, 2, "global_planner")]
+
+
+@pytest.mark.parametrize(
+    ("workload_kwargs", "replay_concurrency"),
+    [
+        pytest.param({}, None, id="legacy-implicit-interval"),
+        pytest.param(
+            {"request_rate": 1_000.0, "arrival_seed": 17},
+            None,
+            id="poisson-rate",
+        ),
+        pytest.param({}, 1, id="closed-loop"),
+    ],
+)
+def test_public_api_runs_each_synthetic_load_controller(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    workload_kwargs: dict,
+    replay_concurrency: int | None,
+) -> None:
+    pytest.importorskip("dynamo._core")
+    monkeypatch.setenv("MPLCONFIGDIR", str(tmp_path / "matplotlib"))
+
+    from dynamo.mocker import MockEngineArgs
+    from dynamo.replay import (
+        ReplayDeploymentConfig,
+        ReplaySyntheticWorkload,
+        run_replay_world,
+    )
+
+    report = run_replay_world(
+        [
+            ReplayDeploymentConfig(
+                deployment_id="deployment",
+                model_name="model",
+                planner_config=_load_planner_config(
+                    tmp_path / "planner-reports",
+                    scale_up_percent=100.0,
+                    scale_down_percent=0.0,
+                ),
+                workload=ReplaySyntheticWorkload(
+                    input_tokens=16,
+                    output_tokens=8,
+                    request_count=3,
+                    **workload_kwargs,
+                ),
+                extra_engine_args=MockEngineArgs(
+                    num_gpu_blocks=64,
+                    block_size=16,
+                    max_num_seqs=32,
+                    max_num_batched_tokens=512,
+                    startup_time=0.0,
+                ),
+                num_workers=1,
+                replay_concurrency=replay_concurrency,
+            )
+        ]
+    )
+
+    assert report.deployments["deployment"].trace_report["completed_requests"] == 3

--- a/components/src/dynamo/replay/world.py
+++ b/components/src/dynamo/replay/world.py
@@ -1,0 +1,827 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Multi-deployment offline Replay control plane.
+
+The Rust Replay world owns virtual-time data-plane progress.  This module owns
+the Python planner state for that world: one local planner session per
+deployment, one shared Global Planner orchestrator, and an in-memory capacity
+backend that stages approved actions for Rust to apply after the callback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import operator
+from dataclasses import dataclass, field
+from os import PathLike
+from typing import Any, Mapping, Optional
+
+from dynamo.global_planner.capacity_manager import PoolSpec
+from dynamo.global_planner.orchestrator import Orchestrator
+from dynamo.planner import SubComponentType, TargetReplica
+from dynamo.planner.connectors.protocol import ScaleStatus
+from dynamo.planner.offline.replay_adapter import (
+    ReplayPlannerAdapter,
+    ReplayPlannerReport,
+    ScalingProposal,
+)
+from dynamo.planner.plugins.clock import VirtualClock
+from dynamo.replay.global_planner import (
+    ReplayCapacityManager,
+    ReplayParticipantSpec,
+    ReplayScaleAction,
+)
+
+
+def _require_integer(value: object, *, name: str, minimum: int) -> int:
+    """Validate an integer-valued public configuration field.
+
+    ``bool`` is intentionally rejected even though it subclasses ``int``:
+    accepting ``True`` as one worker is almost always a configuration typo.
+    """
+
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    try:
+        normalized = operator.index(value)
+    except TypeError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if normalized < minimum:
+        qualifier = "positive" if minimum == 1 else f"at least {minimum}"
+        raise ValueError(f"{name} must be {qualifier}")
+    return normalized
+
+
+@dataclass(frozen=True)
+class ReplayGlobalPlannerConfig:
+    """Global Planner policy for one Replay world."""
+
+    max_total_gpus: int = -1
+    min_total_gpus: int = -1
+    intent_cache_ttl_seconds: float = 360.0
+
+    def __post_init__(self) -> None:
+        max_total_gpus = _require_integer(
+            self.max_total_gpus, name="max_total_gpus", minimum=-1
+        )
+        min_total_gpus = _require_integer(
+            self.min_total_gpus, name="min_total_gpus", minimum=-1
+        )
+        if (
+            max_total_gpus >= 0
+            and min_total_gpus >= 0
+            and min_total_gpus > max_total_gpus
+        ):
+            raise ValueError("min_total_gpus cannot exceed max_total_gpus")
+        if (
+            not math.isfinite(self.intent_cache_ttl_seconds)
+            or self.intent_cache_ttl_seconds < 0
+        ):
+            raise ValueError("intent_cache_ttl_seconds must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class ReplayTraceWorkload:
+    """One deployment-local Mooncake trace workload."""
+
+    trace_file: str | PathLike[str]
+    arrival_speedup_ratio: float = 1.0
+    trace_block_size: int = 512
+
+    def __post_init__(self) -> None:
+        if (
+            not math.isfinite(self.arrival_speedup_ratio)
+            or self.arrival_speedup_ratio <= 0
+        ):
+            raise ValueError("arrival_speedup_ratio must be finite and positive")
+        _require_integer(self.trace_block_size, name="trace_block_size", minimum=1)
+
+
+@dataclass(frozen=True)
+class ReplaySyntheticWorkload:
+    """One deployment-local deterministic synthetic workload distribution.
+
+    ``request_rate`` selects Poisson open-loop arrivals and
+    ``arrival_interval_ms`` selects fixed open-loop arrivals. A deployment-level
+    ``replay_concurrency`` instead selects closed-loop admission. When none is
+    specified, Replay preserves its original fixed 1 ms arrival interval.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    request_count: int
+    arrival_interval_ms: Optional[float] = None
+    turns_per_session: int = 1
+    shared_prefix_ratio: float = 0.0
+    num_prefix_groups: int = 0
+    inter_turn_delay_ms: float = 0.0
+    arrival_speedup_ratio: float = 1.0
+    request_rate: Optional[float] = None
+    arrival_seed: int = 42
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("input_tokens", self.input_tokens),
+            ("output_tokens", self.output_tokens),
+            ("request_count", self.request_count),
+            ("turns_per_session", self.turns_per_session),
+        ):
+            _require_integer(value, name=name, minimum=1)
+        _require_integer(self.num_prefix_groups, name="num_prefix_groups", minimum=0)
+        arrival_seed = _require_integer(
+            self.arrival_seed, name="arrival_seed", minimum=0
+        )
+        if arrival_seed > (1 << 64) - 1:
+            raise ValueError("arrival_seed must fit in an unsigned 64-bit integer")
+        if self.arrival_interval_ms is not None:
+            try:
+                valid_interval = (
+                    not isinstance(self.arrival_interval_ms, bool)
+                    and math.isfinite(self.arrival_interval_ms)
+                    and self.arrival_interval_ms >= 0
+                )
+            except TypeError:
+                valid_interval = False
+            if not valid_interval:
+                raise ValueError("arrival_interval_ms must be finite and non-negative")
+        if self.request_rate is not None:
+            try:
+                valid_rate = (
+                    not isinstance(self.request_rate, bool)
+                    and math.isfinite(self.request_rate)
+                    and self.request_rate > 0
+                )
+            except TypeError:
+                valid_rate = False
+            if not valid_rate:
+                raise ValueError("request_rate must be finite and positive")
+        if self.request_rate is not None and self.arrival_interval_ms is not None:
+            raise ValueError(
+                "synthetic Replay accepts at most one of request_rate or "
+                "arrival_interval_ms"
+            )
+        if (
+            not math.isfinite(self.arrival_speedup_ratio)
+            or self.arrival_speedup_ratio <= 0
+        ):
+            raise ValueError("arrival_speedup_ratio must be finite and positive")
+
+
+@dataclass(frozen=True)
+class ReplayDeploymentConfig:
+    """Configuration for one independent serving deployment in a Replay world.
+
+    ``planner_config`` accepts the same inline JSON dictionary, JSON string, or
+    file path as the existing single-deployment Replay API.  Engine/router
+    objects are the existing Python binding types.
+    """
+
+    deployment_id: str
+    planner_config: dict[str, Any] | str
+    workload: ReplayTraceWorkload | ReplaySyntheticWorkload
+    model_name: Optional[str] = None
+    extra_engine_args: Any = None
+    prefill_engine_args: Any = None
+    decode_engine_args: Any = None
+    router_config: Any = None
+    num_workers: int = 1
+    num_prefill_workers: int = 1
+    num_decode_workers: int = 1
+    replay_concurrency: Optional[int] = None
+    router_mode: str = "round_robin"
+    benchmark_granularity: int = 8
+    sla_ttft_ms: Optional[float] = None
+    sla_itl_ms: Optional[float] = None
+    sla_e2e_ms: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.deployment_id, str) or not self.deployment_id.strip():
+            raise ValueError("deployment_id must be non-empty")
+        for name, value in (
+            ("num_workers", self.num_workers),
+            ("num_prefill_workers", self.num_prefill_workers),
+            ("num_decode_workers", self.num_decode_workers),
+        ):
+            _require_integer(value, name=name, minimum=0)
+        if self.replay_concurrency is not None:
+            _require_integer(
+                self.replay_concurrency, name="replay_concurrency", minimum=1
+            )
+        if isinstance(self.workload, ReplaySyntheticWorkload):
+            controller_count = (
+                int(self.replay_concurrency is not None)
+                + int(self.workload.request_rate is not None)
+                + int(self.workload.arrival_interval_ms is not None)
+            )
+            if controller_count > 1:
+                raise ValueError(
+                    "synthetic Replay accepts at most one of replay_concurrency, "
+                    "request_rate, or arrival_interval_ms"
+                )
+        _require_integer(
+            self.benchmark_granularity,
+            name="benchmark_granularity",
+            minimum=1,
+        )
+
+
+def _resolved_synthetic_arrival_interval_ms(
+    workload: ReplaySyntheticWorkload,
+    replay_concurrency: Optional[int],
+) -> Optional[float]:
+    """Apply the legacy fixed-1 ms default after explicit controllers are known."""
+
+    if (
+        replay_concurrency is None
+        and workload.request_rate is None
+        and workload.arrival_interval_ms is None
+    ):
+        return 1.0
+    return workload.arrival_interval_ms
+
+
+def _validate_deployment_engine_args(
+    deployment: ReplayDeploymentConfig,
+    planner_mode: str,
+) -> None:
+    """Reject engine arguments that would otherwise be silently ignored."""
+
+    if planner_mode == "agg":
+        if (
+            deployment.prefill_engine_args is not None
+            or deployment.decode_engine_args is not None
+        ):
+            raise ValueError(
+                f"aggregated deployment {deployment.deployment_id!r} accepts only "
+                "extra_engine_args"
+            )
+        return
+    if planner_mode == "disagg":
+        if deployment.extra_engine_args is not None:
+            raise ValueError(
+                f"disaggregated deployment {deployment.deployment_id!r} does not "
+                "accept extra_engine_args"
+            )
+        if (
+            deployment.prefill_engine_args is None
+            or deployment.decode_engine_args is None
+        ):
+            raise ValueError(
+                f"disaggregated deployment {deployment.deployment_id!r} requires "
+                "prefill_engine_args and decode_engine_args"
+            )
+        return
+    raise ValueError(f"unsupported planner mode {planner_mode!r}")
+
+
+@dataclass(frozen=True)
+class GlobalPlannerReplayEvent:
+    """One local proposal's Global Planner outcome."""
+
+    at_s: float
+    participant_id: str
+    status: str
+    target_prefill: Optional[int]
+    target_decode: Optional[int]
+    message: str = ""
+
+
+@dataclass
+class ReplayWorldReport:
+    """Planner-enriched reports and allocation decisions for a Replay world."""
+
+    deployments: dict[str, ReplayPlannerReport]
+    global_planner_events: list[GlobalPlannerReplayEvent] = field(default_factory=list)
+    duration_ms: float = 0.0
+    wall_time_ms: float = 0.0
+
+
+class ReplayWorldPlannerController:
+    """Python callback used by the Rust multi-deployment Replay world.
+
+    The callback is intentionally timestamp-batched.  Every due local planner
+    first produces a proposal from its frozen metrics; only then are proposals
+    serialized through the shared Global Planner.  Approved capacity writes are
+    staged in :class:`ReplayCapacityManager` and returned as owned values, so
+    Python never re-enters a mutably borrowed Rust world.
+    """
+
+    def __init__(
+        self,
+        sessions: Mapping[str, ReplayPlannerAdapter],
+        participants: list[ReplayParticipantSpec],
+        *,
+        config: ReplayGlobalPlannerConfig = ReplayGlobalPlannerConfig(),
+        event_loop: asyncio.AbstractEventLoop,
+        clock: VirtualClock,
+    ) -> None:
+        if not sessions:
+            raise ValueError("a Replay world requires at least one deployment")
+        if event_loop.is_running():
+            raise ValueError("Replay world event loop must not already be running")
+
+        self._sessions = dict(sessions)
+        if any(not participant_id for participant_id in self._sessions):
+            raise ValueError("deployment IDs must be non-empty")
+
+        participant_ids = {spec.participant_id for spec in participants}
+        session_ids = set(self._sessions)
+        if participant_ids != session_ids:
+            missing_sessions = sorted(participant_ids - session_ids)
+            missing_participants = sorted(session_ids - participant_ids)
+            raise ValueError(
+                "planner sessions and capacity participants must match exactly "
+                f"(missing_sessions={missing_sessions}, "
+                f"missing_participants={missing_participants})"
+            )
+
+        self._loop: Optional[asyncio.AbstractEventLoop] = event_loop
+        self._clock = clock
+        self._capacity_manager = ReplayCapacityManager(participants)
+        self._orchestrator = Orchestrator(
+            self._capacity_manager,
+            managed_deployments=sorted(session_ids),
+            max_total_gpus=config.max_total_gpus,
+            min_total_gpus=config.min_total_gpus,
+            intent_cache_ttl_seconds=config.intent_cache_ttl_seconds,
+            now=self._clock.now,
+            use_lock=False,
+        )
+        for participant_id in sorted(session_ids):
+            self._orchestrator.register(
+                participant_id,
+                caller_name=participant_id,
+                namespace="",
+                deployment_name=participant_id,
+            )
+        self._orchestrator.startup()
+
+        self._started: set[str] = set()
+        self._global_planner_events: list[GlobalPlannerReplayEvent] = []
+        self._closed = False
+
+    def _run_sync(self, coro):
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("Replay world planner controller is closed")
+        return loop.run_until_complete(coro)
+
+    def initial_tick_ms(self, deployment_id: str) -> float:
+        """Return one deployment's first local-planner deadline."""
+        if deployment_id not in self._sessions:
+            raise KeyError(f"unknown Replay deployment {deployment_id!r}")
+        if deployment_id in self._started:
+            raise RuntimeError(
+                f"initial planner tick requested twice for {deployment_id!r}"
+            )
+        first_tick_ms = self._run_sync(
+            self._sessions[deployment_id].initial_tick_ms_async()
+        )
+        self._started.add(deployment_id)
+        return first_tick_ms
+
+    def on_ticks(self, ticks: list[dict[str, Any]]) -> dict[str, Any]:
+        """Process one complete world planner barrier."""
+        return self._run_sync(self._on_ticks_async(ticks))
+
+    async def _on_ticks_async(self, ticks: list[dict[str, Any]]) -> dict[str, Any]:
+        if not ticks:
+            raise ValueError("world planner callback requires at least one due tick")
+
+        by_id: dict[str, dict[str, Any]] = {}
+        now_ms: Optional[float] = None
+        for tick in ticks:
+            participant_id = str(tick["deployment_id"])
+            if participant_id not in self._sessions:
+                raise KeyError(f"unknown Replay deployment {participant_id!r}")
+            if participant_id in by_id:
+                raise ValueError(
+                    f"deployment {participant_id!r} fired twice at one timestamp"
+                )
+            tick_now_ms = float(tick["now_ms"])
+            if not math.isfinite(tick_now_ms):
+                raise ValueError(f"planner timestamp must be finite, got {tick_now_ms}")
+            if now_ms is None:
+                now_ms = tick_now_ms
+            elif tick_now_ms != now_ms:
+                raise ValueError(
+                    "one world callback must contain exactly one timestamp "
+                    f"(saw {now_ms} and {tick_now_ms})"
+                )
+            by_id[participant_id] = tick
+
+        assert now_ms is not None
+        now_s = now_ms / 1000.0
+        delta_s = now_s - self._clock.monotonic()
+        if delta_s < 0:
+            raise ValueError(
+                f"Replay world clock cannot move backwards "
+                f"({self._clock.monotonic()} -> {now_s})"
+            )
+        if delta_s > 0:
+            self._clock.advance(delta_s)
+
+        # Freeze the local control-plane phase: every due session proposes before
+        # any Global Planner action changes another session's expected state.
+        proposals: dict[str, Optional[ScalingProposal]] = {}
+        next_ticks: dict[str, Optional[float]] = {}
+        for participant_id in sorted(by_id):
+            result = await self._sessions[participant_id].propose_tick_async(
+                by_id[participant_id]
+            )
+            proposals[participant_id] = result.proposal
+            next_ticks[participant_id] = result.next_tick_ms
+
+        self._capacity_manager.begin_batch()
+        actions: tuple[ReplayScaleAction, ...]
+        try:
+            for participant_id in sorted(proposals):
+                proposal = proposals[participant_id]
+                if proposal is None:
+                    continue
+                if not self._orchestrator.is_authorized(participant_id):
+                    raise PermissionError(
+                        f"Replay participant {participant_id!r} is not authorized"
+                    )
+
+                outcome = await self._orchestrator.submit(
+                    participant_id,
+                    self._targets_for(proposal),
+                    blocking=False,
+                    deployment_name=participant_id,
+                    caller_name=participant_id,
+                )
+                self._global_planner_events.append(
+                    GlobalPlannerReplayEvent(
+                        at_s=now_s,
+                        participant_id=participant_id,
+                        status=outcome.status.value,
+                        target_prefill=proposal.target_prefill,
+                        target_decode=proposal.target_decode,
+                        message=outcome.message,
+                    )
+                )
+                if outcome.status == ScaleStatus.REJECTED:
+                    self._sessions[participant_id].observe_rejection(
+                        proposal, message=outcome.message
+                    )
+                elif outcome.status == ScaleStatus.SUCCESS:
+                    self._sessions[participant_id].observe_mediation(
+                        proposal, status="approved", message=outcome.message
+                    )
+                else:
+                    self._sessions[participant_id].observe_mediation(
+                        proposal, status="error", message=outcome.message
+                    )
+                    raise RuntimeError(
+                        f"Global Planner returned {outcome.status.value} for "
+                        f"{participant_id!r}: {outcome.message}"
+                    )
+
+            actions = self._capacity_manager.finish_batch()
+        except BaseException:
+            if self._capacity_manager.batch_active:
+                self._capacity_manager.abort_batch()
+            raise
+
+        # Outcome notifications are delayed until every same-time local planner
+        # has run.  An action may target a cached partner that did not tick.
+        action_dicts: list[dict[str, Any]] = []
+        for action in actions:
+            target_prefill: Optional[int] = None
+            target_decode: Optional[int] = None
+            for target in action.targets:
+                if target.sub_type == SubComponentType.PREFILL.value:
+                    target_prefill = target.desired_replicas
+                elif target.sub_type == SubComponentType.DECODE.value:
+                    target_decode = target.desired_replicas
+                else:  # Defensive: ReplayCapacityManager validates known roles.
+                    raise ValueError(
+                        f"unsupported Replay pool role {target.sub_type!r}"
+                    )
+
+            self._sessions[action.participant_id].observe_committed_scale(
+                at_s=now_s,
+                target_prefill=target_prefill,
+                target_decode=target_decode,
+                reason="global_planner",
+            )
+            action_dicts.append(
+                {
+                    "deployment_id": action.participant_id,
+                    "target_prefill": target_prefill,
+                    "target_decode": target_decode,
+                }
+            )
+
+        return {"next_ticks": next_ticks, "actions": action_dicts}
+
+    @staticmethod
+    def _targets_for(proposal: ScalingProposal) -> list[TargetReplica]:
+        targets: list[TargetReplica] = []
+        if proposal.target_prefill is not None:
+            targets.append(
+                TargetReplica(
+                    sub_component_type=SubComponentType.PREFILL,
+                    desired_replicas=proposal.target_prefill,
+                )
+            )
+        if proposal.target_decode is not None:
+            targets.append(
+                TargetReplica(
+                    sub_component_type=SubComponentType.DECODE,
+                    desired_replicas=proposal.target_decode,
+                )
+            )
+        if not targets:
+            raise ValueError("a planner proposal must target at least one component")
+        return targets
+
+    def finalize(self, raw_report: Mapping[str, Any]) -> ReplayWorldReport:
+        """Build per-deployment planner reports and close all planner resources."""
+        try:
+            raw_deployments = raw_report.get("deployments", [])
+            if isinstance(raw_deployments, Mapping):
+                report_items = raw_deployments.items()
+            else:
+                report_items = raw_deployments
+            trace_reports = {
+                str(participant_id): report for participant_id, report in report_items
+            }
+            if set(trace_reports) != set(self._sessions):
+                raise ValueError(
+                    "Rust world report deployment IDs do not match planner sessions"
+                )
+            result = ReplayWorldReport(
+                deployments={
+                    participant_id: self._sessions[participant_id].build_report(
+                        trace_reports[participant_id]
+                    )
+                    for participant_id in sorted(self._sessions)
+                },
+                global_planner_events=list(self._global_planner_events),
+                duration_ms=float(raw_report.get("duration_ms", 0.0)),
+                wall_time_ms=float(raw_report.get("wall_time_ms", 0.0)),
+            )
+        except BaseException as exc:
+            try:
+                self.close()
+            except BaseException as cleanup_exc:
+                exc.add_note(f"Replay world cleanup also failed: {cleanup_exc}")
+            raise
+        else:
+            self.close()
+            return result
+
+    def close(self) -> None:
+        """Shut down every local planner and the shared event loop."""
+        if self._closed:
+            return
+        self._closed = True
+        loop = self._loop
+        self._loop = None
+        if loop is None:
+            return
+
+        async def shutdown_sessions() -> list[BaseException]:
+            errors: list[BaseException] = []
+            for participant_id in sorted(self._sessions):
+                try:
+                    await self._sessions[participant_id].shutdown_async()
+                except BaseException as exc:  # Continue closing sibling engines.
+                    errors.append(exc)
+            return errors
+
+        errors: list[BaseException] = []
+        try:
+            errors.extend(loop.run_until_complete(shutdown_sessions()))
+            loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.run_until_complete(loop.shutdown_default_executor())
+        finally:
+            loop.close()
+        if errors:
+            raise RuntimeError(
+                f"{len(errors)} Replay planner session(s) failed to shut down"
+            ) from errors[0]
+
+
+def _planner_config_arg(config: dict[str, Any] | str) -> str:
+    return json.dumps(config) if isinstance(config, dict) else config
+
+
+def run_replay_world(
+    deployments: list[ReplayDeploymentConfig],
+    *,
+    global_planner: ReplayGlobalPlannerConfig = ReplayGlobalPlannerConfig(),
+) -> ReplayWorldReport:
+    """Run a multi-deployment offline simulation with shared GP arbitration.
+
+    Every deployment owns its trace or synthetic distribution.  Deployments may
+    share ``model_name``; request assignment remains explicit and no Global
+    Router is simulated. This synchronous API owns a private event loop and must
+    not run on a thread that already has an active asyncio loop; async callers
+    can offload it with :func:`asyncio.to_thread`.
+    """
+
+    if not deployments:
+        raise ValueError("run_replay_world requires at least one deployment")
+    by_id = {deployment.deployment_id: deployment for deployment in deployments}
+    if len(by_id) != len(deployments):
+        raise ValueError("Replay world deployment IDs must be unique")
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError(
+            "run_replay_world is synchronous and cannot run on a thread with an "
+            "active asyncio event loop"
+        )
+
+    # Imports are intentionally local: the legacy Replay API remains importable
+    # in static environments where the Rust extension is not installed.
+    from dynamo.mocker import MockEngineArgs, ReplayWorldBridge
+    from dynamo.planner.config.planner_config import PlannerConfig
+    from dynamo.planner.core.types import WorkerCapabilities
+    from dynamo.replay.main import (
+        SyntheticWorkload,
+        _build_planner_replay,
+        _engine_caps,
+    )
+
+    loop = asyncio.new_event_loop()
+    sessions: dict[str, ReplayPlannerAdapter] = {}
+    controller: Optional[ReplayWorldPlannerController] = None
+
+    try:
+        clock = VirtualClock()
+        participants: list[ReplayParticipantSpec] = []
+        world_bridge = ReplayWorldBridge()
+        for participant_id in sorted(by_id):
+            deployment = by_id[participant_id]
+            planner_config_arg = _planner_config_arg(deployment.planner_config)
+            parsed_planner_config = PlannerConfig.from_config_arg(planner_config_arg)
+            _validate_deployment_engine_args(deployment, parsed_planner_config.mode)
+
+            extra_engine_args = deployment.extra_engine_args
+            if parsed_planner_config.mode == "agg" and extra_engine_args is None:
+                extra_engine_args = MockEngineArgs()
+
+            workload = deployment.workload
+            if isinstance(workload, ReplayTraceWorkload):
+                trace_file: Optional[str] = str(workload.trace_file)
+                synthetic = None
+                arrival_speedup_ratio = workload.arrival_speedup_ratio
+                trace_block_size = workload.trace_block_size
+            else:
+                trace_file = None
+                synthetic = SyntheticWorkload(
+                    input_tokens=workload.input_tokens,
+                    output_tokens=workload.output_tokens,
+                    request_count=workload.request_count,
+                    request_rate=workload.request_rate,
+                    arrival_interval_ms=_resolved_synthetic_arrival_interval_ms(
+                        workload, deployment.replay_concurrency
+                    ),
+                    arrival_seed=workload.arrival_seed,
+                    turns_per_session=workload.turns_per_session,
+                    shared_prefix_ratio=workload.shared_prefix_ratio,
+                    num_prefix_groups=workload.num_prefix_groups,
+                    inter_turn_delay_ms=workload.inter_turn_delay_ms,
+                )
+                arrival_speedup_ratio = workload.arrival_speedup_ratio
+                trace_block_size = 512
+
+            bridge, adapter = _build_planner_replay(
+                trace_file=trace_file,
+                extra_engine_args=extra_engine_args,
+                prefill_engine_args=deployment.prefill_engine_args,
+                decode_engine_args=deployment.decode_engine_args,
+                router_config=deployment.router_config,
+                num_workers=deployment.num_workers,
+                num_prefill_workers=deployment.num_prefill_workers,
+                num_decode_workers=deployment.num_decode_workers,
+                router_mode=deployment.router_mode,
+                arrival_speedup_ratio=arrival_speedup_ratio,
+                trace_block_size=trace_block_size,
+                planner_config_arg=planner_config_arg,
+                model_name=deployment.model_name,
+                benchmark_granularity=deployment.benchmark_granularity,
+                sla_ttft_ms=deployment.sla_ttft_ms,
+                sla_itl_ms=deployment.sla_itl_ms,
+                sla_e2e_ms=deployment.sla_e2e_ms,
+                replay_concurrency=deployment.replay_concurrency,
+                synthetic=synthetic,
+                event_loop=loop,
+                clock=clock,
+                report_namespace=participant_id,
+            )
+            sessions[participant_id] = adapter
+            world_bridge.add_deployment(participant_id, bridge)
+
+            if parsed_planner_config.mode == "agg":
+                assert extra_engine_args is not None
+                capabilities = WorkerCapabilities(
+                    decode=_engine_caps(extra_engine_args)
+                )
+                gpu_per_replica = capabilities.decode.num_gpu
+                if gpu_per_replica is None or gpu_per_replica <= 0:
+                    raise ValueError(
+                        f"deployment {participant_id!r} has invalid GPU width "
+                        f"{gpu_per_replica!r}"
+                    )
+                pools = (
+                    PoolSpec(
+                        sub_type=SubComponentType.DECODE.value,
+                        current_replicas=deployment.num_workers,
+                        gpu_per_replica=gpu_per_replica,
+                    ),
+                )
+            elif parsed_planner_config.mode == "disagg":
+                assert deployment.prefill_engine_args is not None
+                assert deployment.decode_engine_args is not None
+                prefill_gpu = _engine_caps(deployment.prefill_engine_args).num_gpu
+                decode_gpu = _engine_caps(deployment.decode_engine_args).num_gpu
+                if (
+                    prefill_gpu is None
+                    or prefill_gpu <= 0
+                    or decode_gpu is None
+                    or decode_gpu <= 0
+                ):
+                    raise ValueError(
+                        f"deployment {participant_id!r} has invalid GPU widths "
+                        f"(prefill={prefill_gpu!r}, decode={decode_gpu!r})"
+                    )
+                pools = (
+                    PoolSpec(
+                        sub_type=SubComponentType.PREFILL.value,
+                        current_replicas=deployment.num_prefill_workers,
+                        gpu_per_replica=prefill_gpu,
+                    ),
+                    PoolSpec(
+                        sub_type=SubComponentType.DECODE.value,
+                        current_replicas=deployment.num_decode_workers,
+                        gpu_per_replica=decode_gpu,
+                    ),
+                )
+            else:  # Validated before constructing the deployment adapter.
+                raise AssertionError(
+                    f"unexpected planner mode {parsed_planner_config.mode!r}"
+                )
+            participants.append(
+                ReplayParticipantSpec(participant_id=participant_id, pools=pools)
+            )
+
+        controller = ReplayWorldPlannerController(
+            sessions,
+            participants,
+            config=global_planner,
+            event_loop=loop,
+            clock=clock,
+        )
+        raw_report = world_bridge.run(controller)
+        return controller.finalize(raw_report)
+    except BaseException as exc:
+        try:
+            if controller is not None:
+                controller.close()
+            else:
+
+                async def shutdown_built_sessions() -> list[BaseException]:
+                    errors: list[BaseException] = []
+                    for participant_id in sorted(sessions):
+                        try:
+                            await sessions[participant_id].shutdown_async()
+                        except BaseException as shutdown_exc:
+                            errors.append(shutdown_exc)
+                    return errors
+
+                try:
+                    shutdown_errors = loop.run_until_complete(shutdown_built_sessions())
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                    loop.run_until_complete(loop.shutdown_default_executor())
+                finally:
+                    loop.close()
+                if shutdown_errors:
+                    raise RuntimeError(
+                        f"{len(shutdown_errors)} Replay planner session(s) "
+                        "failed to shut down"
+                    ) from shutdown_errors[0]
+        except BaseException as cleanup_exc:
+            exc.add_note(f"Replay world cleanup also failed: {cleanup_exc}")
+        raise
+
+
+__all__ = [
+    "GlobalPlannerReplayEvent",
+    "ReplayDeploymentConfig",
+    "ReplayGlobalPlannerConfig",
+    "ReplaySyntheticWorkload",
+    "ReplayTraceWorkload",
+    "ReplayWorldPlannerController",
+    "ReplayWorldReport",
+    "run_replay_world",
+]

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -216,6 +216,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         m.add_class::<llm::engine_perf::RustEnginePerfOptions>()?;
     }
     m.add_class::<llm::replay::PlannerReplayBridge>()?;
+    m.add_class::<llm::replay::ReplayWorldBridge>()?;
     #[cfg(feature = "select-service")]
     m.add_class::<llm::kv::SelectionService>()?;
     #[cfg(feature = "select-service")]

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -13,10 +14,14 @@ use dynamo_mocker::common::protocols::{
 use dynamo_mocker::loadgen::{
     ArrivalSpec, DelaySpec, DynamoRequestTrace, LengthSpec, SyntheticTraceSpec, Trace as RsTrace,
 };
-use dynamo_mocker::replay::{PlannerHook, PlannerTickDecision, PlannerTickMetrics, ReplayArgsMode};
+use dynamo_mocker::replay::{
+    PlannerHook, PlannerReplayHandle, PlannerTickDecision, PlannerTickMetrics, ReplayArgsMode,
+    ReplayWorldHandle, WorldPlannerDecision, WorldPlannerHook, WorldScalingAction,
+};
 use pyo3::{
     exceptions::{PyException, PyValueError},
     prelude::*,
+    types::PyDict,
 };
 use pythonize::pythonize;
 use serde_json::json;
@@ -2233,6 +2238,45 @@ fn fpm_snapshots_to_json(
         .collect()
 }
 
+/// Convert one deployment-local planner snapshot into the Python callback
+/// contract shared by the legacy and multi-deployment bridges.
+fn planner_tick_metrics_to_json(metrics: PlannerTickMetrics) -> serde_json::Value {
+    let PlannerTickMetrics {
+        now_ms,
+        prefill_fpm,
+        decode_fpm,
+        traffic,
+        active_prefill_ids,
+        active_decode_ids,
+        total_prefill,
+        total_decode,
+    } = metrics;
+    json!({
+        "now_ms": now_ms,
+        "prefill_fpm_snapshots": fpm_snapshots_to_json(prefill_fpm),
+        "decode_fpm_snapshots": fpm_snapshots_to_json(decode_fpm),
+        "active_prefill_count": active_prefill_ids.len(),
+        "active_decode_count": active_decode_ids.len(),
+        "active_prefill_ids": active_prefill_ids,
+        "active_decode_ids": active_decode_ids,
+        "total_prefill_count": total_prefill,
+        "total_decode_count": total_decode,
+        "traffic": {
+            "duration_s": traffic.duration_s,
+            "num_req": traffic.num_req,
+            "avg_isl": traffic.avg_isl,
+            "avg_osl": traffic.avg_osl,
+            "avg_ttft_ms": traffic.avg_ttft_ms,
+            "avg_itl_ms": traffic.avg_itl_ms,
+            "avg_accept_length": traffic.avg_accept_length,
+            "avg_kv_hit_rate": traffic.avg_kv_hit_rate,
+            // Native denominators let Python merge partial windows exactly.
+            "hit_rate_count": traffic.hit_rate_count,
+            "accept_length_forward_count": traffic.accept_length_forward_count,
+        },
+    })
+}
+
 /// Reject a goodput SLA threshold that is not a finite, non-negative value;
 /// `None` (unset) is allowed and means "do not gate on this dimension".
 fn validate_sla_threshold(name: &str, value: Option<f64>) -> PyResult<()> {
@@ -2567,6 +2611,71 @@ impl PlannerReplayBridge {
     }
 }
 
+/// Builder/runner for a coordinated multi-deployment planner Replay.
+///
+/// Existing `PlannerReplayBridge` constructors remain the source of deployment
+/// runtimes. `add_deployment` consumes each bridge handle; `run` then invokes one
+/// timestamp-batched Python controller for the whole world.
+#[pyclass(unsendable)]
+pub struct ReplayWorldBridge {
+    deployments: Option<Vec<(String, PlannerReplayHandle)>>,
+    deployment_ids: BTreeSet<String>,
+}
+
+#[pymethods]
+impl ReplayWorldBridge {
+    #[new]
+    fn new() -> Self {
+        Self {
+            deployments: Some(Vec::new()),
+            deployment_ids: BTreeSet::new(),
+        }
+    }
+
+    fn add_deployment(
+        &mut self,
+        deployment_id: String,
+        mut bridge: PyRefMut<'_, PlannerReplayBridge>,
+    ) -> PyResult<()> {
+        if deployment_id.trim().is_empty() {
+            return Err(PyValueError::new_err(
+                "Replay world deployment_id must be non-empty",
+            ));
+        }
+        let deployments = self
+            .deployments
+            .as_mut()
+            .ok_or_else(|| PyException::new_err("Replay world bridge has been finalized"))?;
+        if self.deployment_ids.contains(&deployment_id) {
+            return Err(PyValueError::new_err(format!(
+                "duplicate Replay world deployment_id {deployment_id:?}"
+            )));
+        }
+        let handle = bridge.handle.take().ok_or_else(|| {
+            PyException::new_err(format!(
+                "planner bridge for deployment {deployment_id:?} has been finalized"
+            ))
+        })?;
+        self.deployment_ids.insert(deployment_id.clone());
+        deployments.push((deployment_id, handle));
+        Ok(())
+    }
+
+    fn run(&mut self, py: Python<'_>, planner: Py<PyAny>) -> PyResult<PyObject> {
+        let deployments = self
+            .deployments
+            .take()
+            .ok_or_else(|| PyException::new_err("Replay world bridge has been finalized"))?;
+        let handle =
+            ReplayWorldHandle::from_deployments(deployments).map_err(planner_run_err_to_pyerr)?;
+        let hook: Box<dyn WorldPlannerHook> = Box::new(PyWorldPlannerHook { callback: planner });
+        let report = handle.run(hook).map_err(planner_run_err_to_pyerr)?;
+        pythonize(py, &report)
+            .map_err(to_pyerr)
+            .map(|obj| obj.unbind())
+    }
+}
+
 /// Convert a planner-run error back into a `PyErr`, preserving the original
 /// Python exception (its type and traceback) when the failure originated in a
 /// planner callback (`initial_tick_ms` / `on_tick` stash the `PyErr` via
@@ -2600,45 +2709,10 @@ impl PlannerHook for PyPlannerHook {
     }
 
     fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
-        let PlannerTickMetrics {
-            now_ms,
-            prefill_fpm,
-            decode_fpm,
-            traffic,
-            active_prefill_ids,
-            active_decode_ids,
-            total_prefill,
-            total_decode,
-        } = metrics;
         Python::with_gil(|py| -> PyResult<PlannerTickDecision> {
             // The metrics dict mirrors the old `advance_to` + `drain_traffic` dicts so
             // the Python adapter's `_build_tick_input` consumes it unchanged.
-            let metrics_json = json!({
-                "now_ms": now_ms,
-                "prefill_fpm_snapshots": fpm_snapshots_to_json(prefill_fpm),
-                "decode_fpm_snapshots": fpm_snapshots_to_json(decode_fpm),
-                "active_prefill_count": active_prefill_ids.len(),
-                "active_decode_count": active_decode_ids.len(),
-                "active_prefill_ids": active_prefill_ids,
-                "active_decode_ids": active_decode_ids,
-                "total_prefill_count": total_prefill,
-                "total_decode_count": total_decode,
-                "traffic": {
-                    "duration_s": traffic.duration_s,
-                    "num_req": traffic.num_req,
-                    "avg_isl": traffic.avg_isl,
-                    "avg_osl": traffic.avg_osl,
-                    "avg_ttft_ms": traffic.avg_ttft_ms,
-                    "avg_itl_ms": traffic.avg_itl_ms,
-                    "avg_accept_length": traffic.avg_accept_length,
-                    "avg_kv_hit_rate": traffic.avg_kv_hit_rate,
-                    // Denominators behind the two ratio averages, so the Python
-                    // adapter can merge partial windows with exact count weights
-                    // instead of approximating with num_req.
-                    "hit_rate_count": traffic.hit_rate_count,
-                    "accept_length_forward_count": traffic.accept_length_forward_count,
-                },
-            });
+            let metrics_json = planner_tick_metrics_to_json(metrics);
             let metrics_obj = pythonize(py, &metrics_json).map_err(to_pyerr)?;
             let decision = self
                 .callback
@@ -2653,6 +2727,75 @@ impl PlannerHook for PyPlannerHook {
         })
         // Preserve the original `PyErr` (type + traceback) through the anyhow
         // boundary so `PlannerReplayBridge::run` can re-raise it unchanged.
+        .map_err(anyhow::Error::new)
+    }
+}
+
+/// Python adapter for the timestamp-batched [`WorldPlannerHook`] contract.
+struct PyWorldPlannerHook {
+    callback: Py<PyAny>,
+}
+
+impl WorldPlannerHook for PyWorldPlannerHook {
+    fn initial_tick_ms(&mut self, deployment_id: &str) -> anyhow::Result<f64> {
+        Python::with_gil(|py| {
+            self.callback
+                .bind(py)
+                .call_method1("initial_tick_ms", (deployment_id,))?
+                .extract::<f64>()
+        })
+        .map_err(anyhow::Error::new)
+    }
+
+    fn on_ticks(
+        &mut self,
+        ticks: Vec<(String, PlannerTickMetrics)>,
+    ) -> anyhow::Result<WorldPlannerDecision> {
+        Python::with_gil(|py| -> PyResult<WorldPlannerDecision> {
+            let ticks_json = ticks
+                .into_iter()
+                .map(|(deployment_id, metrics)| {
+                    let mut value = planner_tick_metrics_to_json(metrics);
+                    value
+                        .as_object_mut()
+                        .expect("planner metrics serialize as an object")
+                        .insert("deployment_id".to_string(), json!(deployment_id));
+                    value
+                })
+                .collect::<Vec<_>>();
+            let ticks_obj = pythonize(py, &ticks_json).map_err(to_pyerr)?;
+            let decision = self
+                .callback
+                .bind(py)
+                .call_method1("on_ticks", (ticks_obj,))?;
+
+            let next_ticks_dict = decision.get_item("next_ticks")?.downcast_into::<PyDict>()?;
+            let mut next_ticks = BTreeMap::new();
+            for (deployment_id, next_ms) in next_ticks_dict.iter() {
+                let deployment_id = deployment_id.extract::<String>()?;
+                let next_ms = next_ms.extract::<Option<f64>>()?;
+                if next_ticks.insert(deployment_id.clone(), next_ms).is_some() {
+                    return Err(PyValueError::new_err(format!(
+                        "duplicate next tick for deployment {deployment_id:?}"
+                    )));
+                }
+            }
+
+            let mut actions = Vec::new();
+            for action in decision.get_item("actions")?.try_iter()? {
+                let action = action?;
+                actions.push(WorldScalingAction {
+                    deployment_id: action.get_item("deployment_id")?.extract()?,
+                    target_prefill: action.get_item("target_prefill")?.extract()?,
+                    target_decode: action.get_item("target_decode")?.extract()?,
+                });
+            }
+
+            Ok(WorldPlannerDecision {
+                next_ticks: next_ticks.into_iter().collect(),
+                actions,
+            })
+        })
         .map_err(anyhow::Error::new)
     }
 }

--- a/lib/mocker/src/replay/mod.rs
+++ b/lib/mocker/src/replay/mod.rs
@@ -7,6 +7,7 @@ mod entrypoints;
 pub(crate) mod offline;
 mod online;
 mod planner_handle;
+mod planner_world;
 mod router_shared;
 mod validate;
 
@@ -99,6 +100,10 @@ pub use offline::planner_hook::{
 #[doc(hidden)]
 pub use offline::run_offline_handoff_conformance;
 pub use planner_handle::PlannerReplayHandle;
+pub use planner_world::{
+    ReplayWorldHandle, ReplayWorldReport, WorldPlannerDecision, WorldPlannerHook,
+    WorldScalingAction,
+};
 pub use validate::validate_replay_args_mode;
 
 pub(crate) fn normalize_trace_requests(

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -11,7 +11,7 @@ use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationEventKind, SimulationWorkerStage};
 #[cfg(test)]
 use super::extensions::kv_router::AggRuntime;
 use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
@@ -279,6 +279,30 @@ where
         }
         self.planner_hook = Some(hook);
         self
+    }
+
+    /// Prepare this runtime for a world-owned planner. The world coordinator owns
+    /// planner deadlines and callbacks, so no `PlannerTick` events or local hook
+    /// are installed here; the runtime only retains the FPM/traffic state needed
+    /// to freeze a [`PlannerTickMetrics`] snapshot at a control-time barrier.
+    pub(in crate::replay) fn enable_world_planner(&mut self) -> anyhow::Result<()> {
+        if self.planner_hook.is_some()
+            || self
+                .events
+                .iter()
+                .any(|event| matches!(&event.kind, SimulationEventKind::PlannerTick))
+        {
+            bail!("aggregated replay runtime already has a local planner attached");
+        }
+        if self.max_sim_time_ms.is_some() {
+            bail!("max_sim_time_ms is not supported by multi-deployment replay");
+        }
+        self.collect_fpm = true;
+        for worker_id in self.engine.active_group_ids() {
+            self.fpm_buffer
+                .activate_worker(worker_id, self.dp_size, self.now_ms);
+        }
+        Ok(())
     }
 
     #[cfg(test)]
@@ -815,19 +839,7 @@ where
             if self.is_workload_done() {
                 continue;
             }
-            let active_decode_ids = self.engine.active_group_ids();
-            self.fpm_buffer
-                .emit_idle_due(&active_decode_ids, self.dp_size, self.now_ms);
-            let metrics = PlannerTickMetrics {
-                now_ms: self.now_ms,
-                prefill_fpm: Vec::new(),
-                decode_fpm: self.fpm_buffer.take(),
-                traffic: self.traffic.drain(self.now_ms),
-                active_prefill_ids: Vec::new(),
-                active_decode_ids,
-                total_prefill: 0,
-                total_decode: self.total_worker_count(),
-            };
+            let metrics = self.take_planner_metrics();
             let mut hook = self
                 .planner_hook
                 .take()
@@ -861,6 +873,22 @@ where
         Ok(changed)
     }
 
+    fn take_planner_metrics(&mut self) -> PlannerTickMetrics {
+        let active_decode_ids = self.engine.active_group_ids();
+        self.fpm_buffer
+            .emit_idle_due(&active_decode_ids, self.dp_size, self.now_ms);
+        PlannerTickMetrics {
+            now_ms: self.now_ms,
+            prefill_fpm: Vec::new(),
+            decode_fpm: self.fpm_buffer.take(),
+            traffic: self.traffic.drain(self.now_ms),
+            active_prefill_ids: Vec::new(),
+            active_decode_ids,
+            total_prefill: 0,
+            total_decode: self.total_worker_count(),
+        }
+    }
+
     // ------------------------------------------------------------------
     // Planner integration: scaling + worker-count accessors used by the
     // in-loop `PlannerTick` handler (apply_planner_ticks).
@@ -890,6 +918,91 @@ where
     /// Total worker count including pending-removal.
     pub(in crate::replay) fn total_worker_count(&self) -> usize {
         self.engine.worker_count()
+    }
+
+    /// Current logical time for a world-owned deployment runtime.
+    pub(in crate::replay) fn world_now_ms(&self) -> f64 {
+        self.now_ms
+    }
+
+    /// Earliest data-plane timestamp. Planner deadlines live in the world
+    /// coordinator and are intentionally absent from this runtime's event heap.
+    pub(in crate::replay) fn world_next_data_timestamp(&mut self) -> Option<f64> {
+        self.next_timestamp()
+    }
+
+    /// Advance through every data-plane timestamp up to `control_ms`, settling
+    /// each timestamp to the runtime's existing fixed point. When no local event
+    /// is due, the clock still advances so provisioned worker-time stays aligned
+    /// with the authoritative world clock.
+    pub(in crate::replay) fn world_settle_data_plane_to(
+        &mut self,
+        control_ms: f64,
+    ) -> anyhow::Result<()> {
+        if !control_ms.is_finite() || control_ms < self.now_ms {
+            bail!(
+                "aggregated deployment cannot advance from {}ms to {control_ms}ms",
+                self.now_ms
+            );
+        }
+
+        self.drain_current_timestamp()?;
+        while let Some(next_ms) = self.next_timestamp() {
+            if next_ms > control_ms {
+                break;
+            }
+            if next_ms < self.now_ms {
+                bail!(
+                    "aggregated deployment produced a past event at {next_ms}ms while at {}ms",
+                    self.now_ms
+                );
+            }
+            self.advance_now_ms(next_ms);
+            self.drain_current_timestamp()?;
+        }
+        if control_ms > self.now_ms {
+            self.advance_now_ms(control_ms);
+        }
+        self.drain_current_timestamp()
+    }
+
+    /// Freeze planner-visible state after the world has settled every deployment
+    /// at the current control timestamp.
+    pub(in crate::replay) fn world_take_planner_metrics(&mut self) -> PlannerTickMetrics {
+        self.take_planner_metrics()
+    }
+
+    /// Apply a world-mediated target using the same lifecycle path as the legacy
+    /// local planner. Aggregated replay reports its sole pool as decode.
+    pub(in crate::replay) fn world_apply_targets(
+        &mut self,
+        _target_prefill: Option<usize>,
+        target_decode: Option<usize>,
+    ) -> anyhow::Result<()> {
+        if let Some(target_decode) = target_decode {
+            self.apply_scaling(target_decode)?;
+        }
+        Ok(())
+    }
+
+    pub(in crate::replay) fn world_has_request_work(&self) -> bool {
+        !self.is_workload_done()
+    }
+
+    pub(in crate::replay) fn world_has_lifecycle_work(&self) -> bool {
+        self.events
+            .iter()
+            .any(|event| matches!(&event.kind, SimulationEventKind::WorkerReady { .. }))
+    }
+
+    pub(in crate::replay) fn world_stop_planner(&mut self) {
+        self.collect_fpm = false;
+        self.fpm_buffer.take();
+    }
+
+    pub(in crate::replay) fn world_finish(self) -> TraceCollector {
+        self.progress.finish();
+        self.collector
     }
 
     /// Apply a scaling decision: set the target number of workers.

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -19,7 +19,7 @@ use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationEventKind, SimulationWorkerStage};
 #[cfg(test)]
 use super::extensions::kv_router::{
     DisaggRuntime, ReplayKvRouterConfig, derive_decode_router_config, derive_prefill_router_config,
@@ -1104,6 +1104,35 @@ where
         }
         self.planner_hook = Some(hook);
         self
+    }
+
+    /// Prepare this runtime for a world-owned planner. The world coordinator owns
+    /// planner deadlines and callbacks, so no `PlannerTick` event or local hook is
+    /// installed here.
+    pub(in crate::replay) fn enable_world_planner(&mut self) -> Result<()> {
+        if self.planner_hook.is_some()
+            || self
+                .events
+                .iter()
+                .any(|event| matches!(&event.kind, SimulationEventKind::PlannerTick))
+        {
+            bail!("disaggregated replay runtime already has a local planner attached");
+        }
+        if self.max_sim_time_ms.is_some() {
+            bail!("max_sim_time_ms is not supported by multi-deployment replay");
+        }
+        self.collect_fpm = true;
+        let prefill_dp_size = self.prefill_engine.dp_size();
+        for worker_id in self.prefill_engine.active_group_ids() {
+            self.prefill_fpm_buffer
+                .activate_worker(worker_id, prefill_dp_size, self.now_ms);
+        }
+        let decode_dp_size = self.decode_engine.dp_size();
+        for worker_id in self.decode_engine.active_group_ids() {
+            self.decode_fpm_buffer
+                .activate_worker(worker_id, decode_dp_size, self.now_ms);
+        }
+        Ok(())
     }
 
     #[cfg(test)]
@@ -2225,28 +2254,7 @@ where
             if self.is_workload_done() {
                 continue;
             }
-            let active_prefill_ids = self.prefill_engine.active_group_ids();
-            let active_decode_ids = self.decode_engine.active_group_ids();
-            self.prefill_fpm_buffer.emit_idle_due(
-                &active_prefill_ids,
-                self.prefill_engine.dp_size(),
-                self.now_ms,
-            );
-            self.decode_fpm_buffer.emit_idle_due(
-                &active_decode_ids,
-                self.decode_engine.dp_size(),
-                self.now_ms,
-            );
-            let metrics = PlannerTickMetrics {
-                now_ms: self.now_ms,
-                prefill_fpm: self.prefill_fpm_buffer.take(),
-                decode_fpm: self.decode_fpm_buffer.take(),
-                traffic: self.traffic.drain(self.now_ms),
-                active_prefill_ids,
-                active_decode_ids,
-                total_prefill: self.total_prefill_count(),
-                total_decode: self.total_decode_count(),
-            };
+            let metrics = self.take_planner_metrics();
             // Borrow the hook out so the runtime stays mutably available for
             // apply_scaling; restore it before propagating any error.
             let mut hook = self
@@ -2258,13 +2266,7 @@ where
             let decision = decision?;
 
             if decision.target_prefill.is_some() || decision.target_decode.is_some() {
-                let target_prefill = decision
-                    .target_prefill
-                    .unwrap_or_else(|| self.total_prefill_count());
-                let target_decode = decision
-                    .target_decode
-                    .unwrap_or_else(|| self.total_decode_count());
-                self.apply_scaling(target_prefill, target_decode)?;
+                self.apply_scaling_targets(decision.target_prefill, decision.target_decode)?;
             }
 
             // Re-arm only into the strict, finite future and only while work
@@ -2285,6 +2287,31 @@ where
             changed = true;
         }
         Ok(changed)
+    }
+
+    fn take_planner_metrics(&mut self) -> PlannerTickMetrics {
+        let active_prefill_ids = self.prefill_engine.active_group_ids();
+        let active_decode_ids = self.decode_engine.active_group_ids();
+        self.prefill_fpm_buffer.emit_idle_due(
+            &active_prefill_ids,
+            self.prefill_engine.dp_size(),
+            self.now_ms,
+        );
+        self.decode_fpm_buffer.emit_idle_due(
+            &active_decode_ids,
+            self.decode_engine.dp_size(),
+            self.now_ms,
+        );
+        PlannerTickMetrics {
+            now_ms: self.now_ms,
+            prefill_fpm: self.prefill_fpm_buffer.take(),
+            decode_fpm: self.decode_fpm_buffer.take(),
+            traffic: self.traffic.drain(self.now_ms),
+            active_prefill_ids,
+            active_decode_ids,
+            total_prefill: self.total_prefill_count(),
+            total_decode: self.total_decode_count(),
+        }
     }
 
     /// Finalize test-only request snapshots before returning.
@@ -2346,6 +2373,85 @@ where
         self.decode_engine.worker_count()
     }
 
+    /// Current logical time for a world-owned deployment runtime.
+    pub(in crate::replay) fn world_now_ms(&self) -> f64 {
+        self.now_ms
+    }
+
+    /// Earliest data-plane timestamp. Planner deadlines live in the world
+    /// coordinator and are intentionally absent from this runtime's event heap.
+    pub(in crate::replay) fn world_next_data_timestamp(&mut self) -> Option<f64> {
+        self.next_timestamp()
+    }
+
+    /// Advance through every data-plane timestamp up to `control_ms`, settling
+    /// each timestamp to the runtime's existing fixed point.
+    pub(in crate::replay) fn world_settle_data_plane_to(&mut self, control_ms: f64) -> Result<()> {
+        if !control_ms.is_finite() || control_ms < self.now_ms {
+            bail!(
+                "disaggregated deployment cannot advance from {}ms to {control_ms}ms",
+                self.now_ms
+            );
+        }
+
+        self.drain_current_timestamp()?;
+        while let Some(next_ms) = self.next_timestamp() {
+            if next_ms > control_ms {
+                break;
+            }
+            if next_ms < self.now_ms {
+                bail!(
+                    "disaggregated deployment produced a past event at {next_ms}ms while at {}ms",
+                    self.now_ms
+                );
+            }
+            self.advance_now_ms(next_ms);
+            self.drain_current_timestamp()?;
+        }
+        if control_ms > self.now_ms {
+            self.advance_now_ms(control_ms);
+        }
+        self.drain_current_timestamp()
+    }
+
+    /// Freeze planner-visible state after the world has settled every deployment
+    /// at the current control timestamp.
+    pub(in crate::replay) fn world_take_planner_metrics(&mut self) -> PlannerTickMetrics {
+        self.take_planner_metrics()
+    }
+
+    /// Apply a world-mediated target using the same lifecycle path as the legacy
+    /// local planner.
+    pub(in crate::replay) fn world_apply_targets(
+        &mut self,
+        target_prefill: Option<usize>,
+        target_decode: Option<usize>,
+    ) -> Result<()> {
+        self.apply_scaling_targets(target_prefill, target_decode)
+    }
+
+    pub(in crate::replay) fn world_has_request_work(&self) -> bool {
+        !self.is_workload_done()
+    }
+
+    pub(in crate::replay) fn world_has_lifecycle_work(&self) -> bool {
+        self.events
+            .iter()
+            .any(|event| matches!(&event.kind, SimulationEventKind::WorkerReady { .. }))
+    }
+
+    pub(in crate::replay) fn world_stop_planner(&mut self) {
+        self.collect_fpm = false;
+        self.prefill_fpm_buffer.take();
+        self.decode_fpm_buffer.take();
+    }
+
+    pub(in crate::replay) fn world_finish(mut self) -> TraceCollector {
+        self.progress.finish();
+        self.finish_test_stats();
+        self.collector
+    }
+
     /// Apply a scaling decision with separate prefill and decode targets.
     ///
     /// Scale-up: if `startup_time` is configured on the respective engine args,
@@ -2355,12 +2461,34 @@ where
     ///
     /// Scale-down: the worker is removed from the router immediately so no
     /// new requests land on it while it drains in-flight work.
+    #[cfg(test)]
     pub(in crate::replay) fn apply_scaling(
         &mut self,
         target_prefill: usize,
         target_decode: usize,
     ) -> Result<()> {
-        // -- prefill --
+        self.apply_scaling_targets(Some(target_prefill), Some(target_decode))
+    }
+
+    /// Apply only the explicitly targeted pools. An omitted role must not be
+    /// replaced with `worker_count()`: that count includes draining workers and
+    /// would create a replacement while the prior scale-down is still pending.
+    fn apply_scaling_targets(
+        &mut self,
+        target_prefill: Option<usize>,
+        target_decode: Option<usize>,
+    ) -> Result<()> {
+        if let Some(target_prefill) = target_prefill {
+            self.apply_prefill_scaling(target_prefill)?;
+        }
+        if let Some(target_decode) = target_decode {
+            self.apply_decode_scaling(target_decode)?;
+        }
+        self.record_router_pending();
+        Ok(())
+    }
+
+    fn apply_prefill_scaling(&mut self, target_prefill: usize) -> Result<()> {
         let (added, newly_marked, removed) = self.prefill_engine.apply_target_count(target_prefill);
         let prefill_delay = self.prefill_engine.startup_time_ms();
         for &id in &added {
@@ -2419,8 +2547,10 @@ where
         if !added.is_empty() && prefill_delay.is_none() {
             self.wake_worker_waiters(SimulationWorkerStage::Prefill);
         }
+        Ok(())
+    }
 
-        // -- decode --
+    fn apply_decode_scaling(&mut self, target_decode: usize) -> Result<()> {
         let (added, newly_marked, removed) = self.decode_engine.apply_target_count(target_decode);
         let decode_delay = self.decode_engine.startup_time_ms();
         for &id in &added {
@@ -2479,7 +2609,6 @@ where
         if !added.is_empty() && decode_delay.is_none() {
             self.wake_worker_waiters(SimulationWorkerStage::Decode);
         }
-        self.record_router_pending();
         Ok(())
     }
 

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -34,6 +34,27 @@ impl PlannerHook for CaptureOnceHook {
     }
 }
 
+struct DecodeOnlyScaleHook {
+    calls: Rc<RefCell<usize>>,
+}
+
+impl PlannerHook for DecodeOnlyScaleHook {
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+        Ok(0.0)
+    }
+
+    fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
+        assert_eq!(metrics.active_prefill_ids.len(), 1);
+        assert_eq!(metrics.total_prefill, 2);
+        *self.calls.borrow_mut() += 1;
+        Ok(PlannerTickDecision {
+            target_prefill: None,
+            target_decode: Some(2),
+            next_tick_ms: None,
+        })
+    }
+}
+
 fn staged_args(worker_type: WorkerType, speedup_ratio: f64) -> MockEngineArgs {
     MockEngineArgs::builder()
         .block_size(64)
@@ -1528,6 +1549,88 @@ fn prefill_router_pending_workload_keeps_prompt_compact() {
             .unwrap()
             .is_some()
     );
+}
+
+#[test]
+fn world_partial_decode_target_does_not_recreate_draining_prefill() {
+    let mut config = scaling_test_disagg_config();
+    config.num_prefill_workers = 2;
+    let mut runtime = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        VecDeque::from([request(1, 64, 8, 0.0), request(2, 64, 8, 0.0)]),
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap();
+
+    runtime.drain_current_timestamp().unwrap();
+    assert_eq!(runtime.prefill_engine.active_group_ids().len(), 2);
+    runtime.apply_scaling(1, 1).unwrap();
+    assert_eq!(runtime.prefill_engine.active_group_ids().len(), 1);
+    assert_eq!(
+        runtime.total_prefill_count(),
+        2,
+        "one busy prefill worker should remain provisioned while draining"
+    );
+
+    runtime.world_apply_targets(None, Some(2)).unwrap();
+
+    assert_eq!(
+        runtime.prefill_engine.active_group_ids().len(),
+        1,
+        "an omitted prefill target must preserve its effective desired count"
+    );
+    assert_eq!(
+        runtime.total_prefill_count(),
+        2,
+        "an omitted prefill target must not recreate its draining worker"
+    );
+    assert_eq!(runtime.decode_engine.active_group_ids().len(), 2);
+    assert_eq!(runtime.total_decode_count(), 2);
+}
+
+#[test]
+fn legacy_planner_decode_only_target_does_not_recreate_draining_prefill() {
+    let mut config = scaling_test_disagg_config();
+    config.num_prefill_workers = 2;
+    let calls = Rc::new(RefCell::new(0));
+    let mut runtime = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        VecDeque::from([request(1, 64, 8, 0.0), request(2, 64, 8, 0.0)]),
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap();
+
+    runtime.drain_current_timestamp().unwrap();
+    assert_eq!(runtime.prefill_engine.active_group_ids().len(), 2);
+    runtime.apply_scaling(1, 1).unwrap();
+    assert_eq!(runtime.prefill_engine.active_group_ids().len(), 1);
+    assert_eq!(runtime.total_prefill_count(), 2);
+
+    let mut runtime = runtime.with_planner_hook(Box::new(DecodeOnlyScaleHook {
+        calls: Rc::clone(&calls),
+    }));
+    runtime.seed_first_planner_tick().unwrap();
+    runtime.drain_current_timestamp().unwrap();
+
+    assert_eq!(*calls.borrow(), 1);
+    assert_eq!(
+        runtime.prefill_engine.active_group_ids().len(),
+        1,
+        "a masked legacy planner decision must preserve the prefill drain"
+    );
+    assert_eq!(
+        runtime.total_prefill_count(),
+        2,
+        "a masked legacy planner decision must not recreate a prefill worker"
+    );
+    assert_eq!(runtime.decode_engine.active_group_ids().len(), 2);
+    assert_eq!(runtime.total_decode_count(), 2);
 }
 
 #[test]

--- a/lib/mocker/src/replay/planner_handle.rs
+++ b/lib/mocker/src/replay/planner_handle.rs
@@ -26,7 +26,7 @@ use crate::loadgen::{Trace, WorkloadDriver};
 use anyhow::Result;
 
 #[allow(clippy::large_enum_variant)]
-enum RuntimeKind {
+pub(in crate::replay) enum RuntimeKind {
     AggRoundRobin(RoundRobinAggRuntime),
     AggKv(AggRuntime),
     DisaggRoundRobin(RoundRobinDisaggRuntime),
@@ -80,6 +80,13 @@ fn prepare_mooncake_trace(
 }
 
 impl PlannerReplayHandle {
+    /// Consume this single-deployment handle into the runtime facade used by
+    /// [`super::planner_world::ReplayWorldHandle`]. The construction paths stay
+    /// shared with the legacy bridge while the world owns control-plane stepping.
+    pub(in crate::replay) fn into_runtime_kind(self) -> RuntimeKind {
+        self.runtime
+    }
+
     /// Build an aggregated handle from an **already-prepared** workload trace.
     ///
     /// Trace preparation is the caller's job: Mooncake callers normalize session

--- a/lib/mocker/src/replay/planner_world.rs
+++ b/lib/mocker/src/replay/planner_world.rs
@@ -1,0 +1,1094 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Multi-deployment offline replay coordinator.
+//!
+//! Each deployment retains its existing aggregated or disaggregated DES. This
+//! module adds a control-plane barrier around those runtimes: one authoritative
+//! clock settles every data plane before freezing all same-time planner metrics,
+//! invokes one world callback, applies its ordered cross-deployment actions, and
+//! then re-settles same-time work.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Instant;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Serialize;
+
+use super::offline::planner_hook::PlannerTickMetrics;
+use super::planner_handle::{PlannerReplayHandle, RuntimeKind};
+use super::{TraceCollector, TraceSimulationReport};
+
+/// One ordered replica-target mutation returned by the world planner.
+///
+/// Actions may target any deployment, including one whose local planner did not
+/// tick at the current control timestamp. Vector order is application order.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorldScalingAction {
+    pub deployment_id: String,
+    pub target_prefill: Option<usize>,
+    pub target_decode: Option<usize>,
+}
+
+/// Result of one batched world-planner callback.
+///
+/// `next_ticks` must contain exactly one entry for every deployment present in
+/// the callback batch. `None` stops that deployment's local planner; `Some(t)`
+/// must be a finite absolute simulated timestamp strictly greater than the
+/// current world time.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct WorldPlannerDecision {
+    pub next_ticks: Vec<(String, Option<f64>)>,
+    pub actions: Vec<WorldScalingAction>,
+}
+
+/// Planner callback driven once for all deployments due at the same timestamp.
+///
+/// The metrics vector is sorted by deployment ID and frozen only after every
+/// deployment data plane has settled at the callback timestamp.
+pub trait WorldPlannerHook {
+    /// Initial absolute simulated tick time for one deployment. A non-finite
+    /// value disables that deployment's planner. Finite times before the current
+    /// world time are clamped to the current time, matching legacy replay.
+    fn initial_tick_ms(&mut self, deployment_id: &str) -> Result<f64>;
+
+    /// Evaluate all local planners due at the same exact simulated timestamp.
+    fn on_ticks(
+        &mut self,
+        ticks: Vec<(String, PlannerTickMetrics)>,
+    ) -> Result<WorldPlannerDecision>;
+}
+
+/// Final report for a multi-deployment replay.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplayWorldReport {
+    /// Authoritative world control time when request work became quiescent.
+    pub duration_ms: f64,
+    /// Real execution time for the whole coordinated run.
+    pub wall_time_ms: f64,
+    /// Per-deployment reports in canonical deployment-ID order.
+    pub deployments: Vec<(String, TraceSimulationReport)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::replay) struct DeploymentRuntimeState {
+    pub request_work_pending: bool,
+    pub lifecycle_work_pending: bool,
+}
+
+/// Internal facade over the four existing agg/disagg + routing compositions.
+///
+/// This deliberately contains no scheduling logic of its own: all work is
+/// delegated to the runtime variants' existing fixed-point settlement and
+/// scaling paths.
+#[allow(clippy::large_enum_variant)]
+pub(in crate::replay) struct DeploymentRuntime {
+    inner: RuntimeKind,
+}
+
+impl DeploymentRuntime {
+    fn new(inner: RuntimeKind) -> Result<Self> {
+        let mut runtime = Self { inner };
+        match &mut runtime.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.enable_world_planner()?,
+            RuntimeKind::AggKv(runtime) => runtime.enable_world_planner()?,
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.enable_world_planner()?,
+            RuntimeKind::DisaggKv(runtime) => runtime.enable_world_planner()?,
+        }
+        Ok(runtime)
+    }
+
+    fn now_ms(&self) -> f64 {
+        match &self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_now_ms(),
+            RuntimeKind::AggKv(runtime) => runtime.world_now_ms(),
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.world_now_ms(),
+            RuntimeKind::DisaggKv(runtime) => runtime.world_now_ms(),
+        }
+    }
+
+    fn next_data_timestamp(&mut self) -> Option<f64> {
+        match &mut self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_next_data_timestamp(),
+            RuntimeKind::AggKv(runtime) => runtime.world_next_data_timestamp(),
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.world_next_data_timestamp(),
+            RuntimeKind::DisaggKv(runtime) => runtime.world_next_data_timestamp(),
+        }
+    }
+
+    fn settle_data_plane_to(&mut self, control_ms: f64) -> Result<()> {
+        match &mut self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_settle_data_plane_to(control_ms),
+            RuntimeKind::AggKv(runtime) => runtime.world_settle_data_plane_to(control_ms),
+            RuntimeKind::DisaggRoundRobin(runtime) => {
+                runtime.world_settle_data_plane_to(control_ms)
+            }
+            RuntimeKind::DisaggKv(runtime) => runtime.world_settle_data_plane_to(control_ms),
+        }
+    }
+
+    fn take_planner_metrics(&mut self) -> PlannerTickMetrics {
+        match &mut self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_take_planner_metrics(),
+            RuntimeKind::AggKv(runtime) => runtime.world_take_planner_metrics(),
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.world_take_planner_metrics(),
+            RuntimeKind::DisaggKv(runtime) => runtime.world_take_planner_metrics(),
+        }
+    }
+
+    fn apply_targets(
+        &mut self,
+        target_prefill: Option<usize>,
+        target_decode: Option<usize>,
+    ) -> Result<()> {
+        match &mut self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => {
+                if target_prefill.is_some() {
+                    bail!("aggregated deployment does not have a prefill pool");
+                }
+                runtime.world_apply_targets(None, target_decode)
+            }
+            RuntimeKind::AggKv(runtime) => {
+                if target_prefill.is_some() {
+                    bail!("aggregated deployment does not have a prefill pool");
+                }
+                runtime.world_apply_targets(None, target_decode)
+            }
+            RuntimeKind::DisaggRoundRobin(runtime) => {
+                runtime.world_apply_targets(target_prefill, target_decode)
+            }
+            RuntimeKind::DisaggKv(runtime) => {
+                runtime.world_apply_targets(target_prefill, target_decode)
+            }
+        }
+    }
+
+    fn state(&self) -> DeploymentRuntimeState {
+        let (request_work_pending, lifecycle_work_pending) = match &self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => (
+                runtime.world_has_request_work(),
+                runtime.world_has_lifecycle_work(),
+            ),
+            RuntimeKind::AggKv(runtime) => (
+                runtime.world_has_request_work(),
+                runtime.world_has_lifecycle_work(),
+            ),
+            RuntimeKind::DisaggRoundRobin(runtime) => (
+                runtime.world_has_request_work(),
+                runtime.world_has_lifecycle_work(),
+            ),
+            RuntimeKind::DisaggKv(runtime) => (
+                runtime.world_has_request_work(),
+                runtime.world_has_lifecycle_work(),
+            ),
+        };
+        DeploymentRuntimeState {
+            request_work_pending,
+            lifecycle_work_pending,
+        }
+    }
+
+    fn stop_planner(&mut self) {
+        match &mut self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_stop_planner(),
+            RuntimeKind::AggKv(runtime) => runtime.world_stop_planner(),
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.world_stop_planner(),
+            RuntimeKind::DisaggKv(runtime) => runtime.world_stop_planner(),
+        }
+    }
+
+    fn finish(self) -> TraceCollector {
+        match self.inner {
+            RuntimeKind::AggRoundRobin(runtime) => runtime.world_finish(),
+            RuntimeKind::AggKv(runtime) => runtime.world_finish(),
+            RuntimeKind::DisaggRoundRobin(runtime) => runtime.world_finish(),
+            RuntimeKind::DisaggKv(runtime) => runtime.world_finish(),
+        }
+    }
+}
+
+struct WorldDeployment {
+    id: String,
+    runtime: DeploymentRuntime,
+    next_planner_tick_ms: Option<f64>,
+}
+
+/// Owns multiple existing replay runtimes under one logical control clock.
+pub struct ReplayWorldHandle {
+    deployments: Vec<WorldDeployment>,
+    now_ms: f64,
+    started_at: Instant,
+}
+
+impl ReplayWorldHandle {
+    /// Consume existing single-deployment handles into one coordinated world.
+    ///
+    /// Deployment IDs must be non-empty and unique. The world canonicalizes
+    /// deployment order lexicographically, independent of caller insertion order.
+    pub fn from_deployments(deployments: Vec<(String, PlannerReplayHandle)>) -> Result<Self> {
+        if deployments.is_empty() {
+            bail!("multi-deployment replay requires at least one deployment");
+        }
+
+        let mut seen = BTreeSet::new();
+        let mut world_deployments = Vec::with_capacity(deployments.len());
+        for (id, handle) in deployments {
+            if id.trim().is_empty() {
+                bail!("multi-deployment replay requires non-empty deployment IDs");
+            }
+            if !seen.insert(id.clone()) {
+                bail!("duplicate replay deployment ID {id:?}");
+            }
+            world_deployments.push(WorldDeployment {
+                id,
+                runtime: DeploymentRuntime::new(handle.into_runtime_kind())?,
+                next_planner_tick_ms: None,
+            });
+        }
+        world_deployments.sort_by(|left, right| left.id.cmp(&right.id));
+
+        Ok(Self {
+            deployments: world_deployments,
+            now_ms: 0.0,
+            started_at: Instant::now(),
+        })
+    }
+
+    /// Run until request work is quiescent across the whole world.
+    ///
+    /// A locally idle deployment continues receiving its scheduled planner ticks
+    /// while any other deployment still has request work. Once world request work
+    /// is quiescent, planner deadlines and startup-only lifecycle events no longer
+    /// keep the run alive.
+    pub fn run(mut self, mut hook: Box<dyn WorldPlannerHook>) -> Result<ReplayWorldReport> {
+        self.settle_all_data_planes(0.0)?;
+        self.seed_initial_ticks(hook.as_mut())?;
+
+        while self.has_request_work() {
+            let next_ms = self.next_control_timestamp()?.ok_or_else(|| {
+                let blocked = self
+                    .deployments
+                    .iter()
+                    .filter(|deployment| deployment.runtime.state().request_work_pending)
+                    .map(|deployment| deployment.id.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                anyhow!(
+                    "multi-deployment replay reached a dead end at {}ms with request work in: {blocked}",
+                    self.now_ms
+                )
+            })?;
+            if next_ms < self.now_ms {
+                bail!(
+                    "multi-deployment replay produced a past control timestamp {next_ms}ms while at {}ms",
+                    self.now_ms
+                );
+            }
+
+            self.settle_all_data_planes(next_ms)?;
+            self.now_ms = next_ms;
+
+            // Match legacy replay: once request work is globally quiescent, a
+            // same-time planner heartbeat is dropped rather than keeping the run
+            // alive. Startup-only lifecycle events are intentionally ignored here.
+            if !self.has_request_work() {
+                break;
+            }
+
+            let due_indices = self.due_planner_indices();
+            if due_indices.is_empty() {
+                continue;
+            }
+
+            let ticks = due_indices
+                .iter()
+                .map(|&index| {
+                    let deployment = &mut self.deployments[index];
+                    (
+                        deployment.id.clone(),
+                        deployment.runtime.take_planner_metrics(),
+                    )
+                })
+                .collect();
+            let decision = hook.on_ticks(ticks)?;
+
+            let scheduled = self.validate_next_ticks(&due_indices, &decision.next_ticks)?;
+            self.validate_actions(&decision.actions)?;
+            self.install_next_ticks(&due_indices, scheduled);
+            self.apply_actions(decision.actions)?;
+
+            // Zero-startup scaling and router changes can make more data-plane
+            // work possible without advancing logical time.
+            self.settle_all_data_planes(self.now_ms)?;
+        }
+
+        self.finish()
+    }
+
+    fn seed_initial_ticks(&mut self, hook: &mut dyn WorldPlannerHook) -> Result<()> {
+        for deployment in &mut self.deployments {
+            let first_ms = hook.initial_tick_ms(&deployment.id).with_context(|| {
+                format!(
+                    "failed to obtain initial planner tick for deployment {:?}",
+                    deployment.id
+                )
+            })?;
+            if first_ms.is_finite() {
+                deployment.next_planner_tick_ms = Some(first_ms.max(self.now_ms));
+            } else {
+                deployment.next_planner_tick_ms = None;
+                deployment.runtime.stop_planner();
+            }
+        }
+        Ok(())
+    }
+
+    fn has_request_work(&self) -> bool {
+        self.deployments
+            .iter()
+            .any(|deployment| deployment.runtime.state().request_work_pending)
+    }
+
+    fn settle_all_data_planes(&mut self, control_ms: f64) -> Result<()> {
+        for deployment in &mut self.deployments {
+            deployment
+                .runtime
+                .settle_data_plane_to(control_ms)
+                .with_context(|| {
+                    format!(
+                        "failed to settle deployment {:?} at {control_ms}ms",
+                        deployment.id
+                    )
+                })?;
+            if deployment.runtime.now_ms() != control_ms {
+                bail!(
+                    "deployment {:?} settled at {}ms instead of authoritative world time {control_ms}ms",
+                    deployment.id,
+                    deployment.runtime.now_ms()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn next_control_timestamp(&mut self) -> Result<Option<f64>> {
+        let mut next = None;
+        for deployment in &mut self.deployments {
+            let state = deployment.runtime.state();
+            let next_data_timestamp = (state.request_work_pending || state.lifecycle_work_pending)
+                .then(|| deployment.runtime.next_data_timestamp())
+                .flatten();
+            for candidate in [next_data_timestamp, deployment.next_planner_tick_ms]
+                .into_iter()
+                .flatten()
+            {
+                if !candidate.is_finite() {
+                    bail!(
+                        "deployment {:?} produced a non-finite control timestamp {candidate}",
+                        deployment.id
+                    );
+                }
+                next = Some(match next {
+                    Some(current) if current <= candidate => current,
+                    _ => candidate,
+                });
+            }
+        }
+        Ok(next)
+    }
+
+    fn due_planner_indices(&self) -> Vec<usize> {
+        self.deployments
+            .iter()
+            .enumerate()
+            .filter_map(|(index, deployment)| {
+                (deployment.next_planner_tick_ms == Some(self.now_ms)).then_some(index)
+            })
+            .collect()
+    }
+
+    fn validate_next_ticks(
+        &self,
+        due_indices: &[usize],
+        next_ticks: &[(String, Option<f64>)],
+    ) -> Result<BTreeMap<String, Option<f64>>> {
+        let due_ids = due_indices
+            .iter()
+            .map(|&index| self.deployments[index].id.as_str())
+            .collect::<BTreeSet<_>>();
+        let mut scheduled = BTreeMap::new();
+
+        for (id, next_ms) in next_ticks {
+            if !due_ids.contains(id.as_str()) {
+                bail!(
+                    "world planner returned a next tick for non-due deployment {id:?} at {}ms",
+                    self.now_ms
+                );
+            }
+            if scheduled.insert(id.clone(), *next_ms).is_some() {
+                bail!("world planner returned duplicate next ticks for deployment {id:?}");
+            }
+            if let Some(next_ms) = next_ms
+                && (!next_ms.is_finite() || *next_ms <= self.now_ms)
+            {
+                bail!(
+                    "world planner next tick for deployment {id:?} must be finite and strictly greater than {}ms, got {next_ms}",
+                    self.now_ms
+                );
+            }
+        }
+
+        if scheduled.len() != due_ids.len() {
+            let missing = due_ids
+                .into_iter()
+                .filter(|id| !scheduled.contains_key(*id))
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!("world planner omitted next ticks for due deployments: {missing}");
+        }
+        Ok(scheduled)
+    }
+
+    fn validate_actions(&self, actions: &[WorldScalingAction]) -> Result<()> {
+        let deployment_ids = self
+            .deployments
+            .iter()
+            .map(|deployment| deployment.id.as_str())
+            .collect::<BTreeSet<_>>();
+        for action in actions {
+            if !deployment_ids.contains(action.deployment_id.as_str()) {
+                bail!(
+                    "world planner action targets unknown deployment {:?}",
+                    action.deployment_id
+                );
+            }
+            if action.target_prefill.is_none() && action.target_decode.is_none() {
+                bail!(
+                    "world planner action for deployment {:?} has no replica target",
+                    action.deployment_id
+                );
+            }
+            let deployment = self
+                .deployments
+                .iter()
+                .find(|deployment| deployment.id == action.deployment_id)
+                .expect("validated deployment must exist");
+            if action.target_prefill.is_some()
+                && matches!(
+                    &deployment.runtime.inner,
+                    RuntimeKind::AggRoundRobin(_) | RuntimeKind::AggKv(_)
+                )
+            {
+                bail!(
+                    "world planner action targets nonexistent prefill pool on aggregated deployment {:?}",
+                    action.deployment_id
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn install_next_ticks(
+        &mut self,
+        due_indices: &[usize],
+        mut scheduled: BTreeMap<String, Option<f64>>,
+    ) {
+        for &index in due_indices {
+            let deployment = &mut self.deployments[index];
+            deployment.next_planner_tick_ms = scheduled
+                .remove(&deployment.id)
+                .expect("validated next tick must exist");
+            if deployment.next_planner_tick_ms.is_none() {
+                deployment.runtime.stop_planner();
+            }
+        }
+    }
+
+    fn apply_actions(&mut self, actions: Vec<WorldScalingAction>) -> Result<()> {
+        for action in actions {
+            let deployment = self
+                .deployments
+                .iter_mut()
+                .find(|deployment| deployment.id == action.deployment_id)
+                .expect("validated deployment action target must exist");
+            deployment
+                .runtime
+                .apply_targets(action.target_prefill, action.target_decode)
+                .with_context(|| {
+                    format!(
+                        "failed to apply world planner action to deployment {:?} at {}ms",
+                        action.deployment_id, self.now_ms
+                    )
+                })?;
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Result<ReplayWorldReport> {
+        let wall_time_ms = self.started_at.elapsed().as_secs_f64() * 1000.0;
+        let deployments = self
+            .deployments
+            .into_iter()
+            .map(|deployment| {
+                (
+                    deployment.id,
+                    deployment
+                        .runtime
+                        .finish()
+                        .finish()
+                        .with_wall_time_ms(wall_time_ms),
+                )
+            })
+            .collect();
+        Ok(ReplayWorldReport {
+            duration_ms: self.now_ms,
+            wall_time_ms,
+            deployments,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use super::{ReplayWorldHandle, WorldPlannerDecision, WorldPlannerHook, WorldScalingAction};
+    use crate::common::protocols::{MockEngineArgs, WorkerType};
+    use crate::loadgen::{ArrivalSpec, DelaySpec, LengthSpec, SyntheticTraceSpec, Trace};
+    use crate::replay::offline::extensions::kv_router::ReplayKvRouterConfig;
+    use crate::replay::offline::planner_hook::PlannerTickMetrics;
+    use crate::replay::{
+        OfflineDisaggReplayConfig, PlannerReplayHandle, ReplayRouterMode, SlaThresholds,
+    };
+
+    fn small_args() -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(128)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1_000_000.0)
+            .build()
+            .unwrap()
+    }
+
+    fn one_request_trace(arrival_ms: f64) -> Trace {
+        let mut trace = Trace::synthetic(SyntheticTraceSpec {
+            block_size: 4,
+            num_sessions: 1,
+            turns_per_session: 1,
+            input_tokens: LengthSpec {
+                mean: 8,
+                stddev: 0.0,
+            },
+            output_tokens: LengthSpec {
+                mean: 1,
+                stddev: 0.0,
+            },
+            shared_prefix_ratio: 0.0,
+            num_prefix_groups: 0,
+            first_turn_arrivals: ArrivalSpec::Burst,
+            inter_turn_delays: DelaySpec::None,
+            seed: 42,
+            arrival_seed: 42,
+        })
+        .unwrap();
+        trace.sessions[0].first_arrival_timestamp_ms = Some(arrival_ms);
+        trace
+    }
+
+    fn handle_with_workers(arrival_ms: f64, num_workers: usize) -> PlannerReplayHandle {
+        PlannerReplayHandle::from_trace(
+            small_args(),
+            None,
+            None,
+            one_request_trace(arrival_ms),
+            num_workers,
+            None,
+            ReplayRouterMode::RoundRobin,
+            SlaThresholds::default(),
+        )
+        .unwrap()
+    }
+
+    fn handle(arrival_ms: f64) -> PlannerReplayHandle {
+        handle_with_workers(arrival_ms, 1)
+    }
+
+    fn queueing_handle_with_no_workers(arrival_ms: f64) -> PlannerReplayHandle {
+        PlannerReplayHandle::from_trace(
+            small_args(),
+            Some(ReplayKvRouterConfig {
+                router_queue_threshold: Some(0.5),
+                ..ReplayKvRouterConfig::default()
+            }),
+            None,
+            one_request_trace(arrival_ms),
+            0,
+            None,
+            ReplayRouterMode::KvRouter,
+            SlaThresholds::default(),
+        )
+        .unwrap()
+    }
+
+    fn disagg_handle(arrival_ms: f64) -> PlannerReplayHandle {
+        PlannerReplayHandle::from_trace_disagg(
+            OfflineDisaggReplayConfig {
+                prefill_args: MockEngineArgs {
+                    worker_type: WorkerType::Prefill,
+                    ..small_args()
+                },
+                decode_args: MockEngineArgs {
+                    worker_type: WorkerType::Decode,
+                    ..small_args()
+                },
+                num_prefill_workers: 1,
+                num_decode_workers: 1,
+            },
+            None,
+            None,
+            one_request_trace(arrival_ms),
+            None,
+            ReplayRouterMode::RoundRobin,
+            SlaThresholds::default(),
+        )
+        .unwrap()
+    }
+
+    fn startup_handle(arrival_ms: f64) -> PlannerReplayHandle {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(128)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1_000_000.0)
+            .startup_time(Some(1.0))
+            .build()
+            .unwrap();
+        PlannerReplayHandle::from_trace(
+            args,
+            None,
+            None,
+            one_request_trace(arrival_ms),
+            1,
+            None,
+            ReplayRouterMode::RoundRobin,
+            SlaThresholds::default(),
+        )
+        .unwrap()
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct TickObservation {
+        deployment_id: String,
+        now_ms: f64,
+        num_req: usize,
+        active_decode: usize,
+    }
+
+    struct OneBatchHook {
+        initial_tick_ms: f64,
+        observations: Rc<RefCell<Vec<Vec<TickObservation>>>>,
+    }
+
+    impl WorldPlannerHook for OneBatchHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(self.initial_tick_ms)
+        }
+
+        fn on_ticks(
+            &mut self,
+            ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            let observations = ticks
+                .iter()
+                .map(|(deployment_id, metrics)| TickObservation {
+                    deployment_id: deployment_id.clone(),
+                    now_ms: metrics.now_ms,
+                    num_req: metrics.traffic.num_req,
+                    active_decode: metrics.active_decode_ids.len(),
+                })
+                .collect();
+            let next_ticks = ticks
+                .into_iter()
+                .map(|(deployment_id, _)| (deployment_id, None))
+                .collect();
+            self.observations.borrow_mut().push(observations);
+            Ok(WorldPlannerDecision {
+                next_ticks,
+                actions: Vec::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn batches_same_time_ticks_after_every_deployment_settles() {
+        let observations = Rc::new(RefCell::new(Vec::new()));
+        let report = ReplayWorldHandle::from_deployments(vec![
+            ("zeta".to_string(), handle(2_000.0)),
+            ("alpha".to_string(), handle(0.0)),
+        ])
+        .unwrap()
+        .run(Box::new(OneBatchHook {
+            initial_tick_ms: 500.0,
+            observations: Rc::clone(&observations),
+        }))
+        .unwrap();
+
+        let observations = observations.borrow();
+        assert_eq!(observations.len(), 1);
+        assert_eq!(
+            observations[0]
+                .iter()
+                .map(|observation| observation.deployment_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "zeta"]
+        );
+        assert!(
+            observations[0]
+                .iter()
+                .all(|observation| observation.now_ms == 500.0)
+        );
+        assert_eq!(observations[0][0].num_req, 1);
+        assert_eq!(observations[0][1].num_req, 0);
+        assert_eq!(
+            report
+                .deployments
+                .iter()
+                .map(|(id, _)| id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["alpha", "zeta"]
+        );
+        assert!(
+            report
+                .deployments
+                .iter()
+                .all(|(_, report)| report.request_counts.completed_requests == 1)
+        );
+    }
+
+    #[test]
+    fn mixed_aggregated_and_disaggregated_deployments_share_a_barrier() {
+        let observations = Rc::new(RefCell::new(Vec::new()));
+        let report = ReplayWorldHandle::from_deployments(vec![
+            ("disagg".to_string(), disagg_handle(100.0)),
+            ("agg".to_string(), handle(100.0)),
+        ])
+        .unwrap()
+        .run(Box::new(OneBatchHook {
+            initial_tick_ms: 0.0,
+            observations: Rc::clone(&observations),
+        }))
+        .unwrap();
+
+        let observations = observations.borrow();
+        assert_eq!(observations.len(), 1);
+        assert_eq!(
+            observations[0]
+                .iter()
+                .map(|observation| observation.deployment_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["agg", "disagg"]
+        );
+        assert!(
+            report
+                .deployments
+                .iter()
+                .all(|(_, report)| report.request_counts.completed_requests == 1)
+        );
+    }
+
+    struct CrossDeploymentScaleHook {
+        observations: Rc<RefCell<Vec<Vec<TickObservation>>>>,
+        calls: usize,
+    }
+
+    impl WorldPlannerHook for CrossDeploymentScaleHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(0.0)
+        }
+
+        fn on_ticks(
+            &mut self,
+            ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            let observations = ticks
+                .iter()
+                .map(|(deployment_id, metrics)| TickObservation {
+                    deployment_id: deployment_id.clone(),
+                    now_ms: metrics.now_ms,
+                    num_req: metrics.traffic.num_req,
+                    active_decode: metrics.active_decode_ids.len(),
+                })
+                .collect();
+            let next_ticks = ticks
+                .iter()
+                .map(|(deployment_id, _)| (deployment_id.clone(), (self.calls == 0).then_some(1.0)))
+                .collect();
+            let actions = if self.calls == 0 {
+                vec![WorldScalingAction {
+                    deployment_id: "beta".to_string(),
+                    target_prefill: None,
+                    target_decode: Some(2),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            self.calls += 1;
+            self.observations.borrow_mut().push(observations);
+            Ok(WorldPlannerDecision {
+                next_ticks,
+                actions,
+            })
+        }
+    }
+
+    #[test]
+    fn applies_cross_deployment_action_before_the_next_barrier() {
+        let observations = Rc::new(RefCell::new(Vec::new()));
+        let report = ReplayWorldHandle::from_deployments(vec![
+            ("alpha".to_string(), handle(1_000.0)),
+            ("beta".to_string(), handle(1_000.0)),
+        ])
+        .unwrap()
+        .run(Box::new(CrossDeploymentScaleHook {
+            observations: Rc::clone(&observations),
+            calls: 0,
+        }))
+        .unwrap();
+
+        let observations = observations.borrow();
+        assert_eq!(observations.len(), 2);
+        assert!(observations.iter().all(|batch| {
+            batch
+                .iter()
+                .map(|tick| tick.deployment_id.as_str())
+                .eq(["alpha", "beta"])
+        }));
+        assert!(
+            observations[0]
+                .iter()
+                .all(|observation| observation.active_decode == 1)
+        );
+        assert_eq!(
+            observations[1]
+                .iter()
+                .find(|observation| observation.deployment_id == "beta")
+                .unwrap()
+                .active_decode,
+            2
+        );
+        assert!(
+            report
+                .deployments
+                .iter()
+                .all(|(_, report)| report.request_counts.completed_requests == 1)
+        );
+    }
+
+    struct WakeQueuedDeploymentHook {
+        observation: Rc<RefCell<Option<TickObservation>>>,
+    }
+
+    impl WorldPlannerHook for WakeQueuedDeploymentHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(10.0)
+        }
+
+        fn on_ticks(
+            &mut self,
+            mut ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            assert_eq!(ticks.len(), 1);
+            let (deployment_id, metrics) = ticks.pop().unwrap();
+            self.observation.replace(Some(TickObservation {
+                deployment_id: deployment_id.clone(),
+                now_ms: metrics.now_ms,
+                num_req: metrics.traffic.num_req,
+                active_decode: metrics.active_decode_ids.len(),
+            }));
+            Ok(WorldPlannerDecision {
+                next_ticks: vec![(deployment_id.clone(), None)],
+                actions: vec![WorldScalingAction {
+                    deployment_id,
+                    target_prefill: None,
+                    target_decode: Some(1),
+                }],
+            })
+        }
+    }
+
+    #[test]
+    fn planner_barrier_wakes_queued_deployment_with_no_local_event() {
+        let observation = Rc::new(RefCell::new(None));
+        let report = ReplayWorldHandle::from_deployments(vec![(
+            "sleeping".to_string(),
+            queueing_handle_with_no_workers(0.0),
+        )])
+        .unwrap()
+        .run(Box::new(WakeQueuedDeploymentHook {
+            observation: Rc::clone(&observation),
+        }))
+        .unwrap();
+
+        assert_eq!(
+            observation.borrow().as_ref(),
+            Some(&TickObservation {
+                deployment_id: "sleeping".to_string(),
+                now_ms: 10.0,
+                num_req: 0,
+                active_decode: 0,
+            })
+        );
+        assert_eq!(report.deployments[0].1.request_counts.completed_requests, 1);
+    }
+
+    struct ScaleAndStopHook;
+
+    impl WorldPlannerHook for ScaleAndStopHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(0.0)
+        }
+
+        fn on_ticks(
+            &mut self,
+            ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            assert_eq!(ticks.len(), 1);
+            let deployment_id = ticks[0].0.clone();
+            Ok(WorldPlannerDecision {
+                next_ticks: vec![(deployment_id.clone(), None)],
+                actions: vec![WorldScalingAction {
+                    deployment_id,
+                    target_prefill: None,
+                    target_decode: Some(2),
+                }],
+            })
+        }
+    }
+
+    #[test]
+    fn pending_worker_startup_does_not_extend_world_past_request_quiescence() {
+        let report =
+            ReplayWorldHandle::from_deployments(vec![("startup".to_string(), startup_handle(0.0))])
+                .unwrap()
+                .run(Box::new(ScaleAndStopHook))
+                .unwrap();
+
+        assert_eq!(report.deployments[0].1.request_counts.completed_requests, 1);
+        assert!(
+            report.duration_ms < 1_000.0,
+            "a startup-only lifecycle event must not keep the world alive: {}ms",
+            report.duration_ms
+        );
+    }
+
+    type RecordedTickBatches = Rc<RefCell<Vec<(f64, Vec<String>)>>>;
+
+    struct RecurringHook {
+        tick_ms: RecordedTickBatches,
+        interval_ms: f64,
+    }
+
+    impl WorldPlannerHook for RecurringHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(0.0)
+        }
+
+        fn on_ticks(
+            &mut self,
+            ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            let now_ms = ticks[0].1.now_ms;
+            let deployment_ids = ticks
+                .iter()
+                .map(|(deployment_id, _)| deployment_id.clone())
+                .collect::<Vec<_>>();
+            let next_ticks = deployment_ids
+                .iter()
+                .cloned()
+                .map(|deployment_id| (deployment_id, Some(now_ms + self.interval_ms)))
+                .collect();
+            self.tick_ms.borrow_mut().push((now_ms, deployment_ids));
+            Ok(WorldPlannerDecision {
+                next_ticks,
+                actions: Vec::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn idle_deployment_keeps_ticking_until_world_request_work_is_quiescent() {
+        let tick_ms = Rc::new(RefCell::new(Vec::new()));
+        let report = ReplayWorldHandle::from_deployments(vec![
+            ("alpha".to_string(), handle(0.0)),
+            ("beta".to_string(), handle(100.0)),
+        ])
+        .unwrap()
+        .run(Box::new(RecurringHook {
+            tick_ms: Rc::clone(&tick_ms),
+            interval_ms: 10.0,
+        }))
+        .unwrap();
+
+        let tick_ms = tick_ms.borrow();
+        assert!(tick_ms.iter().any(|(now_ms, ids)| *now_ms > 10.0
+            && *now_ms < 100.0
+            && ids == &["alpha".to_string(), "beta".to_string()]));
+        assert!(report.duration_ms >= 100.0);
+        let (last_tick_ms, last_ids) = tick_ms.last().unwrap();
+        assert_eq!(last_ids, &["alpha".to_string(), "beta".to_string()]);
+        assert!(*last_tick_ms <= report.duration_ms);
+        assert!(
+            *last_tick_ms + 10.0 > report.duration_ms,
+            "the world should terminate before the already-scheduled next heartbeat"
+        );
+        assert!(
+            report
+                .deployments
+                .iter()
+                .all(|(_, report)| report.request_counts.completed_requests == 1)
+        );
+    }
+
+    struct InvalidNextTickHook;
+
+    impl WorldPlannerHook for InvalidNextTickHook {
+        fn initial_tick_ms(&mut self, _deployment_id: &str) -> anyhow::Result<f64> {
+            Ok(0.0)
+        }
+
+        fn on_ticks(
+            &mut self,
+            ticks: Vec<(String, PlannerTickMetrics)>,
+        ) -> anyhow::Result<WorldPlannerDecision> {
+            Ok(WorldPlannerDecision {
+                next_ticks: ticks
+                    .into_iter()
+                    .map(|(deployment_id, metrics)| (deployment_id, Some(metrics.now_ms)))
+                    .collect(),
+                actions: Vec::new(),
+            })
+        }
+    }
+
+    #[test]
+    fn rejects_non_future_next_tick() {
+        let error = ReplayWorldHandle::from_deployments(vec![("alpha".to_string(), handle(100.0))])
+            .unwrap()
+            .run(Box::new(InvalidNextTickHook))
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("strictly greater"),
+            "unexpected error: {error:#}"
+        );
+    }
+}


### PR DESCRIPTION
## Overview:

In this PR we add support for supporting multi-model / multi-deployments in Replay where scaling decisions are mediated by Global Planner.  This is a step towards being able to do comprehensive Inference Provider simulation with offline replay.  Inference Providers like Baseten, DeepInfra, Together, Firework, etc and even frontier labs like Anthropic and OpenAI are responsible for serving multiple models using the capacity they have available.  With this PR we can simulate how Global Planner would resolve competing scaling requests from different models / deployments with shared gpu budgets.

## Details:

TLDR, we introduce a world controller that is playing out all of the deployments "simultaneously" - still through a single thread.  It does this by finding the next valid timestamp barrier which is the min of every deployments next "data-plane" event and ever deployments next local planner deadline. Then advances all the deployments up until that timestamp.  Then finds the subsets that have planner ticks due.  Process them in a batch, takes their scaling proposals, runs them all through GlobalPlanner for mediation.

## Where should the reviewer start?

Definitely read `planner_world.rs` starting from `run` also read `world.py` and `global_planner.py`

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [X] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-deployment offline replay with shared global planning and coordinated scaling.
  * Added support for aggregated and disaggregated deployments, trace workloads, and configurable synthetic workloads.
  * Added structured replay reports with per-deployment results, scaling events, mediation outcomes, and planner events.
  * Added public replay-world APIs and configuration options, including workload controls and planner resource limits.
  * Added asynchronous planner operation for responsive replay execution.

* **Bug Fixes**
  * Improved scaling-state tracking, including partial targets and draining workers.
  * Strengthened validation and cleanup behavior for invalid inputs and replay failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->