### PR TITLE
fix(vllm): publish configured KV events from decode workers

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -303,7 +303,7 @@ def update_engine_config_with_dynamo(
     if hasattr(engine_config, "runner"):
         logger.debug(f"Using runner={engine_config.runner} from engine args")
 
-    kv_cfg = create_kv_events_config(dynamo_config, engine_config)
+    kv_cfg = create_kv_events_config(engine_config)
     defaults["kv_events_config"] = kv_cfg
     dynamo_config.use_kv_events = kv_cfg is not None and kv_cfg.enable_kv_cache_events
 
@@ -407,16 +407,9 @@ def update_engine_config_with_dynamo(
 
 
 def create_kv_events_config(
-    dynamo_config: Config, engine_config: AsyncEngineArgs
+    engine_config: AsyncEngineArgs,
 ) -> Optional[KVEventsConfig]:
     """Create KVEventsConfig for prefix caching if needed."""
-    if dynamo_config.disaggregation_mode == DisaggregationMode.DECODE:
-        logger.info(
-            "Decode worker detected (disaggregation_mode=decode): "
-            "kv_events_config disabled (decode workers don't publish KV events)"
-        )
-        return None
-
     # If prefix caching is not enabled, no events config needed
     if not engine_config.enable_prefix_caching:
         logger.info("No kv_events_config required: prefix caching is disabled")

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -85,7 +85,7 @@ class DynamoVllmArgGroup(ArgGroup):
             env_var="DYN_VLLM_IS_DECODE_WORKER",
             default=False,
             help="DEPRECATED: use --disaggregation-mode=decode. "
-            "Mark this as a decode worker which does not publish KV events.",
+            "Mark this as a decode worker.",
         )
 
         add_negatable_bool_argument(

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -56,7 +56,6 @@ from .capacity import (
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
 )
-from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
@@ -691,11 +690,7 @@ async def register_vllm_model(
     runtime_config.total_kv_blocks = per_rank_kv_blocks(num_gpu_blocks, dp_range[1])
     runtime_config.max_num_seqs = runtime_values["max_num_seqs"]
     runtime_config.max_num_batched_tokens = runtime_values["max_num_batched_tokens"]
-    # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
-    runtime_config.enable_local_indexer = (
-        config.enable_local_indexer
-        and config.disaggregation_mode != DisaggregationMode.DECODE
-    )
+    runtime_config.enable_local_indexer = config.enable_local_indexer
     runtime_config.kv_state_endpoint = config.kv_state_endpoint
 
     # Add tool/reasoning parsers for decode/aggregated workers. Prefill

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -367,11 +367,6 @@ def setup_kv_event_publisher(
     if not config.engine_args.enable_prefix_caching:
         return None
 
-    # Skip KV event publishing for decode workers
-    if config.disaggregation_mode == DisaggregationMode.DECODE:
-        logger.info("Skipping KV event publisher setup for decode worker")
-        return None
-
     if config.engine_args.kv_events_config is None:
         return None
 

--- a/recipes/nemotron-3-super-fp8/README.md
+++ b/recipes/nemotron-3-super-fp8/README.md
@@ -117,7 +117,7 @@ Approximate (hash-based) routing is used for the vLLM and SGLang variants becaus
 
 ### vLLM
 - No connector flags needed in 1.0 (default is no connector)
-- Requires `--is-decode-worker` to skip KV event publisher setup
+- Omits `--kv-events-config` to keep KV event publishing disabled for approximate routing
 - Requires `--mamba-cache-mode align` to work around [vllm#34865](https://github.com/vllm-project/vllm/issues/34865): prefix caching with the default `mamba_cache_mode="all"` produces NaN logprobs and garbage tokens for Nemotron-H. Fixed in vLLM 0.17.0 ([vllm#34874](https://github.com/vllm-project/vllm/pull/34874)); the 1.0 container ships vLLM 0.16.0, so the workaround is needed.
 - **Attention backend**: On Hopper the default (`FLASH_ATTN`) is safe. On Blackwell, vLLM defaults to FlashInfer, which has a [stale NaN bug](https://github.com/vllm-project/vllm/issues/35138) with hybrid Mamba models ([vllm#35219](https://github.com/vllm-project/vllm/pull/35219)). For Blackwell, specify `--attention-backend FLASH_ATTN` or `--attention-backend TRITON_ATTN` to avoid the issue.
 - Sets `VLLM_FLASHINFER_ALLREDUCE_BACKEND=trtllm` to avoid a [hang during CUDA graph capture](https://github.com/vllm-project/vllm/issues/35772) with TP>1. This is the [new default](https://github.com/vllm-project/vllm/pull/35793) in later vLLM versions but must be set explicitly in 0.16.0.

--- a/recipes/nemotron-3-super-fp8/vllm/agg/deploy.yaml
+++ b/recipes/nemotron-3-super-fp8/vllm/agg/deploy.yaml
@@ -105,9 +105,8 @@ spec:
             # --connector none is no longer needed in 1.0 (default is no connector).
             # In 0.9.1, you must add: --connector none
             #
-            # --is-decode-worker also automatically disables KV event publishing,
-            # which pairs with --no-kv-events on the frontend for approximate routing.
-            - --is-decode-worker
+            # Omit --kv-events-config to pair with --no-kv-events on the frontend
+            # for approximate routing.
             - --dyn-tool-call-parser
             - nemotron_nano
             # nemotron_nano reasoning parser handles both enable_thinking: true and false.


### PR DESCRIPTION
## Summary

- Preserve an explicitly supplied vLLM `kv_events_config` for disaggregated decode workers.
- Set up Dynamo's KV-event relay for decode workers when prefix caching and KV-cache events are enabled.
- Remove the Nemotron recipe workaround that selected decode mode solely to suppress KV-event publishing.

Decode mode previously had two independent guards: one discarded the engine's KV-event configuration, and the other skipped relay setup. That made decode-worker KV events impossible even when operators explicitly configured them. Router support can evolve independently; the backend should not suppress the engine's event stream.

The default remains unchanged when no `--kv-events-config` is supplied, prefix caching is disabled, or `enable_kv_cache_events` is false.

## Validation

- An ephemeral local Dynamo vLLM runtime smoke check verified that decode-worker KV-event configuration is retained and the relay is constructed.
- `isort`, `black`, `flake8`, `codespell`, `ruff`, YAML validation, and `pytest-marker-report` passed for the changed files.
- Python compile checks and `git diff --check` passed.
- No new automated test is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Behavior Changes**
  - KV event publishing now depends on whether prefix caching is enabled.
  - Decode-worker configuration no longer controls KV event publisher setup directly.
  - Deprecated worker configuration guidance has been simplified.

- **Documentation**
  - Updated vLLM guidance for approximate KV-aware routing.
  - Deployment examples now recommend omitting KV event configuration when publishing should remain disabled.
  - Removed outdated decode-worker configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->