### PR TITLE
fix: count only generate workers in kv router bench

### DIFF
--- a/lib/llm/benches/kv_router_bench.rs
+++ b/lib/llm/benches/kv_router_bench.rs
@@ -625,9 +625,7 @@ async fn discover_worker_ids(
     let worker_ids: Vec<WorkerId> = health
         .instances
         .iter()
-        .filter(|i| {
-            i.namespace == namespace && i.component == component && i.endpoint == endpoint
-        })
+        .filter(|i| i.namespace == namespace && i.component == component && i.endpoint == endpoint)
         .map(|i| i.instance_id)
         .collect();
 

--- a/lib/llm/benches/kv_router_bench.rs
+++ b/lib/llm/benches/kv_router_bench.rs
@@ -612,9 +612,14 @@ async fn discover_worker_ids(frontend_url: &str) -> Result<Vec<WorkerId>> {
         .await
         .context("Failed to parse health response")?;
 
-    let worker_ids: Vec<WorkerId> = health.instances.iter().map(|i| i.instance_id).collect();
+    let worker_ids: Vec<WorkerId> = health
+        .instances
+        .iter()
+        .filter(|i| i.endpoint == "generate")
+        .map(|i| i.instance_id)
+        .collect();
 
-    // Deduplicate (in case of multiple endpoints per worker)
+    // Deduplicate (in case of multiple generate endpoints per worker)
     let mut unique_ids: Vec<WorkerId> = worker_ids.clone();
     unique_ids.sort_unstable();
     unique_ids.dedup();

--- a/lib/llm/benches/kv_router_bench.rs
+++ b/lib/llm/benches/kv_router_bench.rs
@@ -144,6 +144,10 @@ struct Args {
     #[arg(long, default_value = "backend")]
     component: String,
 
+    /// Endpoint name used to discover routable workers
+    #[arg(long, default_value = "generate")]
+    endpoint: String,
+
     // Output
     /// Write results to JSON file
     #[arg(long)]
@@ -584,14 +588,20 @@ struct HealthResponse {
 #[derive(Debug, Deserialize)]
 struct HealthInstance {
     instance_id: u64,
-    #[allow(dead_code)]
+    namespace: String,
+    component: String,
     endpoint: String,
 }
 
 /// Discover worker IDs from the frontend's /health endpoint.
 ///
 /// Returns a list of instance_ids (worker_ids) that are currently registered.
-async fn discover_worker_ids(frontend_url: &str) -> Result<Vec<WorkerId>> {
+async fn discover_worker_ids(
+    frontend_url: &str,
+    namespace: &str,
+    component: &str,
+    endpoint: &str,
+) -> Result<Vec<WorkerId>> {
     let client = reqwest::Client::new();
     let url = format!("{}/health", frontend_url);
 
@@ -615,19 +625,32 @@ async fn discover_worker_ids(frontend_url: &str) -> Result<Vec<WorkerId>> {
     let worker_ids: Vec<WorkerId> = health
         .instances
         .iter()
-        .filter(|i| i.endpoint == "generate")
+        .filter(|i| {
+            i.namespace == namespace && i.component == component && i.endpoint == endpoint
+        })
         .map(|i| i.instance_id)
         .collect();
 
-    // Deduplicate (in case of multiple generate endpoints per worker)
+    // Deduplicate in case discovery reports the same endpoint instance more than once.
     let mut unique_ids: Vec<WorkerId> = worker_ids.clone();
     unique_ids.sort_unstable();
     unique_ids.dedup();
 
-    println!("  Discovered {} workers", unique_ids.len());
+    println!(
+        "  Discovered {} workers for {}.{}.{}",
+        unique_ids.len(),
+        namespace,
+        component,
+        endpoint
+    );
 
     if unique_ids.is_empty() {
-        anyhow::bail!("No workers discovered from frontend. Are kv_stress_workers running?");
+        anyhow::bail!(
+            "No workers discovered from frontend for {}.{}.{}. Are kv_stress_workers running?",
+            namespace,
+            component,
+            endpoint
+        );
     }
 
     Ok(unique_ids)
@@ -1347,6 +1370,7 @@ async fn main() -> Result<()> {
     println!("  Tokenizer: {}", tokenizer_path);
     println!("  Namespace: {}", args.namespace);
     println!("  Component: {}", args.component);
+    println!("  Endpoint: {}", args.endpoint);
     println!(
         "  NATS subject: namespace.{}.component.{}.kv-events",
         args.namespace, args.component
@@ -1511,7 +1535,13 @@ async fn main() -> Result<()> {
     println!("\nPhase 2: Discover Workers & Generate Sequences");
 
     // Discover actual worker IDs from the frontend
-    let discovered_worker_ids = discover_worker_ids(&args.frontend_url).await?;
+    let discovered_worker_ids = discover_worker_ids(
+        &args.frontend_url,
+        &args.namespace,
+        &args.component,
+        &args.endpoint,
+    )
+    .await?;
 
     if discovered_worker_ids.len() != args.num_workers {
         println!(


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Fixes KV router benchmark worker discovery so the benchmark only uses backend workers that can serve generation requests

## Details:

<!-- Describe the changes made in this PR. -->

`/health` reports all discovered component endpoints, not only generation workers. `kv_router_bench` was collecting every `instance_id`, which could make the benchmark count non-generation endpoints as workers and build synthetic KV state for IDs that are not valid generation targets.

This change filters discovered instances to `endpoint == "generate"` before deduplicating worker IDs.

 Validation:

 ```bash
  cargo bench --package dynamo-llm --bench kv_router_bench --features kv-router-stress --no-run
```

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `--endpoint` option for selecting benchmark workers.
  * Worker discovery now filters by namespace, component, and endpoint.
  * Configuration output now displays the selected endpoint.

* **Bug Fixes**
  * Prevented duplicate workers from appearing in discovery results.
  * Improved messages and errors when matching workers are found or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->