### PR TITLE
fix(operator): preserve DGDSA-owned replica counts

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -2568,47 +2568,68 @@ func (r *DynamoGraphDeploymentReconciler) buildCheckpointJobPodTemplate(
 func (r *DynamoGraphDeploymentReconciler) reconcileScalingAdapters(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment) error {
 	logger := log.FromContext(ctx)
 
-	// Process each component - SyncResource handles create, update, and delete via toDelete flag.
+	// Process each component. The DGD controller owns the adapter lifecycle and
+	// identity, while the adapter owns its replica count after creation.
 	for i := range dynamoDeployment.Spec.Components {
 		component := &dynamoDeployment.Spec.Components[i]
 		componentName := component.ComponentName
-		// Check if scaling adapter is enabled for this component (disabled by default).
-		scalingAdapterEnabled := component.ScalingAdapter != nil
-
-		// Get current replicas (default to 1 if not set)
-		currentReplicas := int32(1)
-		if component.Replicas != nil {
-			currentReplicas = *component.Replicas
+		adapterName := generateAdapterName(dynamoDeployment.Name, componentName)
+		adapter := &nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapter{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      adapterName,
+				Namespace: dynamoDeployment.Namespace,
+			},
 		}
 
-		// Use SyncResource to handle creation/updates/deletion
-		// When toDelete=true, SyncResource will delete the existing resource if it exists
-		_, _, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapter, bool, error) {
-			adapterName := generateAdapterName(dynamoDeployment.Name, componentName)
-			adapter := &nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapter{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      adapterName,
-					Namespace: dynamoDeployment.Namespace,
-					Labels: map[string]string{
-						consts.KubeLabelDynamoGraphDeploymentName: dynamoDeployment.Name,
-						consts.KubeLabelDynamoComponent:           componentName,
-					},
-				},
-				Spec: nvidiacomv1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
-					Replicas: currentReplicas,
-					DGDRef: nvidiacomv1alpha1.DynamoGraphDeploymentServiceRef{
-						Name:        dynamoDeployment.Name,
-						ServiceName: componentName,
-					},
-				},
+		if component.ScalingAdapter == nil {
+			if err := r.Delete(ctx, adapter); err != nil {
+				if errors.IsNotFound(err) {
+					continue
+				}
+				logger.Error(err, "Failed to delete DynamoGraphDeploymentScalingAdapter", "component", componentName)
+				return err
 			}
-			// Return toDelete=true if scaling adapter is not enabled
-			return adapter, !scalingAdapterEnabled, nil
+			logger.Info("Deleted DynamoGraphDeploymentScalingAdapter", "adapter", adapterName, "component", componentName)
+			r.Recorder.Eventf(dynamoDeployment, corev1.EventTypeNormal, "AdapterDeleted",
+				"Deleted scaling adapter %s for component %s", adapterName, componentName)
+			continue
+		}
+
+		initialReplicas := ptr.Deref(component.Replicas, int32(1))
+		operation, err := controllerutil.CreateOrPatch(ctx, r.Client, adapter, func() error {
+			if adapter.Labels == nil {
+				adapter.Labels = map[string]string{}
+			}
+			adapter.Labels[consts.KubeLabelDynamoGraphDeploymentName] = dynamoDeployment.Name
+			adapter.Labels[consts.KubeLabelDynamoComponent] = componentName
+			adapter.Spec.DGDRef = nvidiacomv1alpha1.DynamoGraphDeploymentServiceRef{
+				Name:        dynamoDeployment.Name,
+				ServiceName: componentName,
+			}
+
+			// The DGD replica count seeds a new adapter. Once created, the
+			// adapter is the sole source of truth for desired replicas.
+			if adapter.GetResourceVersion() == "" {
+				adapter.Spec.Replicas = initialReplicas
+			}
+
+			return controllerutil.SetControllerReference(dynamoDeployment, adapter, r.Scheme())
 		})
 
 		if err != nil {
-			logger.Error(err, "Failed to sync DynamoGraphDeploymentScalingAdapter", "component", componentName)
+			logger.Error(err, "Failed to reconcile DynamoGraphDeploymentScalingAdapter", "component", componentName)
 			return err
+		}
+
+		switch operation {
+		case controllerutil.OperationResultCreated:
+			logger.Info("Created DynamoGraphDeploymentScalingAdapter", "adapter", adapterName, "component", componentName)
+			r.Recorder.Eventf(dynamoDeployment, corev1.EventTypeNormal, "AdapterCreated",
+				"Created scaling adapter %s for component %s", adapterName, componentName)
+		case controllerutil.OperationResultUpdated:
+			logger.Info("Updated DynamoGraphDeploymentScalingAdapter", "adapter", adapterName, "component", componentName)
+			r.Recorder.Eventf(dynamoDeployment, corev1.EventTypeNormal, "AdapterUpdated",
+				"Updated scaling adapter %s for component %s", adapterName, componentName)
 		}
 	}
 

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -440,6 +440,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 				WithScheme(testScheme).
 				WithObjects(initObjs...)
 			if tt.assertNoReplicaPatch {
+				t.Log("Intercept adapter patches and verify they exclude replicas")
 				clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
 					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 						data, err := patch.Data(obj)

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -138,6 +138,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 		expectedAdapterCount int
 		expectedAdapters     map[string]int32 // map of adapter name to expected replicas
 		expectDeleted        []string         // adapter names that should be deleted
+		assertNoReplicaPatch bool
 	}{
 		{
 			name: "creates adapters for services with scalingAdapter.enabled=true",
@@ -190,6 +191,66 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 			expectedAdapters: map[string]int32{
 				"test-dgd-worker": 1, // default replicas
 			},
+		},
+		{
+			name: "preserves existing adapter replicas across components",
+			dgd: betaDGD(t, &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd",
+					Namespace: "default",
+					UID:       "test-uid",
+				},
+				Spec: v1alpha1.DynamoGraphDeploymentSpec{
+					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+						"Frontend": {
+							Replicas: ptr.To(int32(2)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
+						},
+						"decode": {
+							Replicas: ptr.To(int32(3)),
+							ScalingAdapter: &v1alpha1.ScalingAdapter{
+								Enabled: true,
+							},
+						},
+					},
+				},
+			}),
+			existingAdapters: []v1alpha1.DynamoGraphDeploymentScalingAdapter{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dgd-frontend",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+						Replicas: 5,
+						DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
+							Name:        "test-dgd",
+							ServiceName: "Frontend",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-dgd-decode",
+						Namespace: "default",
+					},
+					Spec: v1alpha1.DynamoGraphDeploymentScalingAdapterSpec{
+						Replicas: 0,
+						DGDRef: v1alpha1.DynamoGraphDeploymentServiceRef{
+							Name:        "test-dgd",
+							ServiceName: "decode",
+						},
+					},
+				},
+			},
+			expectedAdapterCount: 2,
+			expectedAdapters: map[string]int32{
+				"test-dgd-frontend": 5,
+				"test-dgd-decode":   0,
+			},
+			assertNoReplicaPatch: true,
 		},
 		{
 			name: "skips adapter creation when not enabled",
@@ -375,10 +436,21 @@ func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) 
 			}
 
 			// Create fake client
-			fakeClient := fake.NewClientBuilder().
+			clientBuilder := fake.NewClientBuilder().
 				WithScheme(testScheme).
-				WithObjects(initObjs...).
-				Build()
+				WithObjects(initObjs...)
+			if tt.assertNoReplicaPatch {
+				clientBuilder = clientBuilder.WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						data, err := patch.Data(obj)
+						require.NoError(t, err)
+						assert.NotContains(t, string(data), `"replicas"`,
+							"existing adapter patches must never include spec.replicas")
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				})
+			}
+			fakeClient := clientBuilder.Build()
 
 			// Create reconciler
 			r := &DynamoGraphDeploymentReconciler{

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller.go
@@ -97,6 +97,12 @@ func (r *DynamoGraphDeploymentScalingAdapterReconciler) Reconcile(ctx context.Co
 			"availableComponents", getComponentNames(dgd.Spec.Components))
 		return ctrl.Result{}, nil
 	}
+	if component.ScalingAdapter == nil {
+		logger.V(1).Info("Component no longer uses a scaling adapter; skipping replica propagation",
+			"component", componentName,
+			"dgd", dgd.Name)
+		return ctrl.Result{}, nil
+	}
 
 	// Get current replicas from DGD (default to 1 if not set)
 	currentReplicas := int32(1)

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -48,6 +48,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 		expectedStatusReplicas int32
 		expectError            bool
 		expectMissingComponent bool
+		expectSkipped          bool
 		expectRequeue          bool
 	}{
 		{
@@ -73,8 +74,9 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 				Spec: v1beta1.DynamoGraphDeploymentSpec{
 					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
 						{
-							ComponentName: "Frontend",
-							Replicas:      ptr.To(int32(2)),
+							ComponentName:  "Frontend",
+							Replicas:       ptr.To(int32(2)),
+							ScalingAdapter: &v1beta1.ScalingAdapter{},
 						},
 					},
 				},
@@ -106,8 +108,9 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 				Spec: v1beta1.DynamoGraphDeploymentSpec{
 					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
 						{
-							ComponentName: "Frontend",
-							Replicas:      ptr.To(int32(3)),
+							ComponentName:  "Frontend",
+							Replicas:       ptr.To(int32(3)),
+							ScalingAdapter: &v1beta1.ScalingAdapter{},
 						},
 					},
 				},
@@ -138,7 +141,10 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 				},
 				Spec: v1beta1.DynamoGraphDeploymentSpec{
 					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
-						{ComponentName: "worker"}, // no replicas set
+						{
+							ComponentName:  "worker",
+							ScalingAdapter: &v1beta1.ScalingAdapter{},
+						}, // no replicas set
 					},
 				},
 			},
@@ -177,6 +183,38 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			},
 			expectError:            false,
 			expectMissingComponent: true,
+		},
+		{
+			name: "does not propagate replicas after component opts out",
+			adapter: &v1beta1.DynamoGraphDeploymentScalingAdapter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd-frontend",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DynamoGraphDeploymentScalingAdapterSpec{
+					Replicas: 5,
+					DGDRef: v1beta1.DynamoGraphDeploymentComponentRef{
+						Name:          "test-dgd",
+						ComponentName: "Frontend",
+					},
+				},
+			},
+			dgd: &v1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-dgd",
+					Namespace: "default",
+				},
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+						{
+							ComponentName: "Frontend",
+							Replicas:      ptr.To(int32(2)),
+						},
+					},
+				},
+			},
+			expectedDGDReplicas: 2,
+			expectSkipped:       true,
 		},
 	}
 
@@ -264,6 +302,13 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			updatedAdapter := &v1beta1.DynamoGraphDeploymentScalingAdapter{}
 			if err := fakeClient.Get(ctx, types.NamespacedName{Name: tt.adapter.Name, Namespace: tt.adapter.Namespace}, updatedAdapter); err != nil {
 				t.Fatalf("Failed to get updated adapter: %v", err)
+			}
+
+			if tt.expectSkipped {
+				if updatedAdapter.Status.Selector != "" || updatedAdapter.Status.Replicas != 0 {
+					t.Errorf("Adapter status was updated after opt-out: %+v", updatedAdapter.Status)
+				}
+				return
 			}
 
 			if updatedAdapter.Status.Replicas != tt.expectedStatusReplicas {

--- a/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentscalingadapter_controller_test.go
@@ -305,6 +305,7 @@ func TestDynamoGraphDeploymentScalingAdapterReconciler_Reconcile(t *testing.T) {
 			}
 
 			if tt.expectSkipped {
+				t.Log("Verify adapter status remains unchanged after component opt-out")
 				if updatedAdapter.Status.Selector != "" || updatedAdapter.Status.Replicas != 0 {
 					t.Errorf("Adapter status was updated after opt-out: %+v", updatedAdapter.Status)
 				}


### PR DESCRIPTION
## Summary

Fix the replica ownership race between the DynamoGraphDeployment (DGD) and DynamoGraphDeploymentScalingAdapter (DGDSA) controllers.

When a component uses a scaling adapter, DGDSA is the source of truth for its desired replica count. Previously, the DGD controller reconciled DGDSA through the generic full-spec synchronization helper, allowing stale DGD replica values to overwrite `DGDSA.spec.replicas`. The DGDSA controller could then write the value back to the DGD, creating a bidirectional reconciliation loop during serve/unserve and scaling operations.

This change:

- Replaces full-spec DGDSA synchronization with `CreateOrPatch`.
- Seeds `spec.replicas` from the DGD only when creating a DGDSA.
- Preserves `spec.replicas` on every subsequent DGD reconciliation.
- Continues reconciling DGD-owned adapter metadata, references, and lifecycle.
- Explicitly deletes the adapter when scaling-adapter support is disabled.
- Prevents the DGDSA controller from propagating replicas after a component opts out.
- Adds regression coverage for stale multi-component values, scale-to-zero, replica-free patches, and opt-out behavior.

The resulting ownership flow is unidirectional after adapter creation:

`DGDSA.spec.replicas → DGD component replicas`

No CRD, schema, status, or public API changes are included.

Closes #12080

## Validation

- `go test ./internal/controller -run 'TestDynamoGraphDeployment(Reconciler_reconcileScalingAdapters|ScalingAdapterReconciler_Reconcile)' -count=1`
- `go test ./internal/controller -count=1`
- `go test ./api/... ./internal/... -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scaling adapters are now automatically created, updated, or removed as component scaling settings change.
  * Existing scaling adapter replica counts are preserved during reconciliation, including explicitly configured zero replicas.
  * Replica propagation and status updates are skipped when scaling is disabled for a component.
* **Reliability**
  * Scaling adapter ownership, labels, and lifecycle events are now maintained consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->