### PR TITLE
chore(vllm): remove deprecated worker role flags

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -131,7 +131,7 @@ def test_build_dgd_config_vllm_disagg_preserves_explicit_kv_config() -> None:
 
 
 def test_build_dgd_config_vllm_disagg_removes_legacy_role_flags() -> None:
-    """Canonical worker roles must replace deprecated vLLM role flags."""
+    """AIC legacy role flags must not reach the vLLM backend CLI."""
     modifier = CONFIG_MODIFIERS["vllm"]
     dgd_config = modifier.build_dgd_config(
         mode="disagg",

--- a/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/vllm.py
@@ -72,6 +72,8 @@ def _set_valued_arg(args: list[str], key: str, value: str) -> list[str]:
 def _finalize_disagg_cli_args(args: list[str], role: SubComponentType) -> list[str]:
     """Restore the Dynamo runtime arguments omitted by AIC engine tuning."""
     tokens = break_arguments(args)
+    # AIC may still emit the removed vLLM role flags. Normalize them at this
+    # ingestion boundary so they never reach the backend CLI.
     cleaned_args = [
         arg
         for arg in tokens
@@ -184,8 +186,9 @@ class VllmV1ConfigModifier(BaseConfigModifier):
             args = validate_and_get_worker_args(worker_service, backend="vllm")
             args = break_arguments(args)
 
-            # remove --disaggregation-mode and its value (or legacy --is-prefill-worker)
+            # Remove role selection when converting the prefill worker to aggregated.
             args = remove_valued_arguments(args, "--disaggregation-mode")
+            # AIC may still emit this removed vLLM role flag.
             if "--is-prefill-worker" in args:
                 args.remove("--is-prefill-worker")
 

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -72,24 +72,6 @@ class DynamoVllmArgGroup(ArgGroup):
 
         add_negatable_bool_argument(
             g,
-            flag_name="--is-prefill-worker",
-            env_var="DYN_VLLM_IS_PREFILL_WORKER",
-            default=False,
-            help="DEPRECATED: use --disaggregation-mode=prefill. "
-            "Enable prefill functionality for this worker.",
-        )
-
-        add_negatable_bool_argument(
-            g,
-            flag_name="--is-decode-worker",
-            env_var="DYN_VLLM_IS_DECODE_WORKER",
-            default=False,
-            help="DEPRECATED: use --disaggregation-mode=decode. "
-            "Mark this as a decode worker.",
-        )
-
-        add_negatable_bool_argument(
-            g,
             flag_name="--use-vllm-tokenizer",
             env_var="DYN_VLLM_USE_TOKENIZER",
             default=False,
@@ -437,8 +419,6 @@ class DynamoVllmConfig(ConfigBase):
     disaggregation_mode: Union[
         None, str, DisaggregationMode
     ]  # None when not provided; resolved to enum in validate()
-    is_prefill_worker: bool
-    is_decode_worker: bool
     use_vllm_tokenizer: bool
 
     # Multimodal
@@ -612,55 +592,20 @@ class DynamoVllmConfig(ConfigBase):
             )
 
     def _resolve_disaggregation_mode(self) -> None:
-        """Resolve disaggregation_mode from new enum or legacy boolean flags.
+        """Resolve disaggregation_mode from its CLI value and legacy multimodal flags.
 
         Priority:
         1. If --disaggregation-mode was explicitly provided, use it.
-           Raise if legacy booleans are also set.
-        2. If legacy --is-prefill-worker or --is-decode-worker is set,
-           emit DeprecationWarning and translate to enum.
-        3. If legacy multimodal flags are set, translate to enum,
-           emit DeprecationWarning and translate to enum, raise if conflicting
-           with --disaggregation-mode.
+        2. If legacy multimodal flags are set, emit DeprecationWarning and
+           translate to enum, raising if they conflict with --disaggregation-mode.
         3. Apply default (AGGREGATED) if nothing was provided.
-        4. Sync boolean fields from the resolved enum value.
         """
-        # Convert string to enum (non-None means explicitly provided)
-        explicit_mode = self.disaggregation_mode is not None
+        # Convert string to enum
         if isinstance(self.disaggregation_mode, str):
             if self.disaggregation_mode == PREFILL_DECODE_DISAGGREGATION_MODE:
                 self.disaggregation_mode = DisaggregationMode.AGGREGATED
             else:
                 self.disaggregation_mode = DisaggregationMode(self.disaggregation_mode)
-
-        # Check for legacy boolean flags
-        has_legacy = self.is_prefill_worker or self.is_decode_worker
-
-        if has_legacy and explicit_mode:
-            raise ValueError(
-                "Cannot combine --is-prefill-worker/--is-decode-worker with "
-                "--disaggregation-mode. Use only --disaggregation-mode."
-            )
-
-        if has_legacy:
-            if self.is_prefill_worker and self.is_decode_worker:
-                raise ValueError(
-                    "Cannot set both --is-prefill-worker and --is-decode-worker"
-                )
-            if self.is_prefill_worker:
-                warnings.warn(
-                    "--is-prefill-worker is deprecated, use --disaggregation-mode=prefill",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                self.disaggregation_mode = DisaggregationMode.PREFILL
-            elif self.is_decode_worker:
-                warnings.warn(
-                    "--is-decode-worker is deprecated, use --disaggregation-mode=decode",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                self.disaggregation_mode = DisaggregationMode.DECODE
 
         # Porting multimodal legacy flags
         if (
@@ -673,10 +618,6 @@ class DynamoVllmConfig(ConfigBase):
         # Apply default if neither new flag nor legacy flags were provided
         if self.disaggregation_mode is None:
             self.disaggregation_mode = DisaggregationMode.AGGREGATED
-
-        # Sync booleans from enum (canonical source of truth)
-        self.is_prefill_worker = self.disaggregation_mode == DisaggregationMode.PREFILL
-        self.is_decode_worker = self.disaggregation_mode == DisaggregationMode.DECODE
 
     def _resolve_disaggregation_model_from_legacy_multimodal_flags(self) -> None:
         """

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -109,8 +109,6 @@ class TestResolveDisaggregationModeFromLegacyMultimodalFlags:
     def test_pd_alias_resolves_to_aggregated(self):
         config = create_config()
         config.disaggregation_mode = "pd"
-        config.is_prefill_worker = False
-        config.is_decode_worker = False
 
         config._resolve_disaggregation_mode()
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -10,7 +10,6 @@ import os
 import re
 import socket
 import sys
-import warnings
 from contextlib import asynccontextmanager
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -546,8 +545,6 @@ def test_disaggregation_mode_default(mock_vllm_cli):
     mock_vllm_cli("--model", "Qwen/Qwen3-0.6B")
     config = parse_args()
     assert config.disaggregation_mode == DisaggregationMode.AGGREGATED
-    assert config.is_prefill_worker is False
-    assert config.is_decode_worker is False
 
 
 def test_kv_events_disabled_by_default_without_explicit_config(mock_vllm_cli):
@@ -570,8 +567,6 @@ def test_disaggregation_mode_prefill(mock_vllm_cli):
     )
     config = parse_args()
     assert config.disaggregation_mode == DisaggregationMode.PREFILL
-    assert config.is_prefill_worker is True
-    assert config.is_decode_worker is False
     assert config.component == "prefill"
 
 
@@ -580,66 +575,6 @@ def test_disaggregation_mode_decode(mock_vllm_cli):
     mock_vllm_cli("--model", "Qwen/Qwen3-0.6B", "--disaggregation-mode", "decode")
     config = parse_args()
     assert config.disaggregation_mode == DisaggregationMode.DECODE
-    assert config.is_prefill_worker is False
-    assert config.is_decode_worker is True
-
-
-def test_legacy_is_prefill_worker_emits_deprecation(mock_vllm_cli):
-    """Test that --is-prefill-worker still works but emits DeprecationWarning."""
-    mock_vllm_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--is-prefill-worker",
-        "--kv-transfer-config",
-        '{"kv_connector":"NixlConnector","kv_role":"kv_both"}',
-    )
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        config = parse_args()
-    deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-    assert len(deprecation_warnings) >= 1
-    assert "deprecated" in str(deprecation_warnings[0].message).lower()
-    assert config.disaggregation_mode == DisaggregationMode.PREFILL
-    assert config.is_prefill_worker is True
-
-
-def test_legacy_is_decode_worker_emits_deprecation(mock_vllm_cli):
-    """Test that --is-decode-worker still works but emits DeprecationWarning."""
-    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B", "--is-decode-worker")
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        config = parse_args()
-    deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
-    assert len(deprecation_warnings) >= 1
-    assert "deprecated" in str(deprecation_warnings[0].message).lower()
-    assert config.disaggregation_mode == DisaggregationMode.DECODE
-    assert config.is_decode_worker is True
-
-
-def test_conflicting_legacy_and_new_flags_raises(mock_vllm_cli):
-    """Test that combining legacy flags with explicit --disaggregation-mode raises ValueError."""
-    mock_vllm_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--disaggregation-mode",
-        "prefill",
-        "--is-decode-worker",
-    )
-    with pytest.raises(ValueError, match="Cannot combine"):
-        parse_args()
-
-
-def test_explicit_default_mode_with_legacy_flag_raises(mock_vllm_cli):
-    """Test that --disaggregation-mode agg --is-decode-worker raises ValueError."""
-    mock_vllm_cli(
-        "--model",
-        "Qwen/Qwen3-0.6B",
-        "--disaggregation-mode",
-        "agg",
-        "--is-decode-worker",
-    )
-    with pytest.raises(ValueError, match="Cannot combine"):
-        parse_args()
 
 
 # --- _is_routable tests (pure logic, no mocking) ---

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -44,7 +44,6 @@ pytestmark = [
 
 def _make_config(
     model: str = "test-model",
-    is_prefill_worker: bool = False,
     enable_multimodal: bool = True,
     multimodal_embedding_cache_capacity_gb: float = 0,
     disaggregation_mode: str | None = None,
@@ -54,11 +53,8 @@ def _make_config(
 
     config = MagicMock()
     config.model = model
-    config.is_prefill_worker = is_prefill_worker
     if disaggregation_mode is not None:
         config.disaggregation_mode = getattr(DisaggregationMode, disaggregation_mode)
-    elif is_prefill_worker:
-        config.disaggregation_mode = DisaggregationMode.PREFILL
     else:
         config.disaggregation_mode = DisaggregationMode.AGGREGATED
     # NIXL_WRITE / NIXL_READ modes require GPU, the tests may run in CPU-only environments,
@@ -564,7 +560,7 @@ class TestGenerateDisagg:
     @pytest.mark.asyncio
     async def test_prefills_then_forwards_to_decode(self):
         """_generate_disagg prefills locally, then round-robins to decode worker."""
-        config = _make_config(model="test-model", is_prefill_worker=True)
+        config = _make_config(model="test-model", disaggregation_mode="PREFILL")
         decode_client = MagicMock()
         handler = _make_handler(config=config, decode_worker_client=decode_client)
         handler.engine_client = MagicMock()

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -4707,7 +4707,7 @@ func TestGeneratePodSpecForComponent_VLLM(t *testing.T) {
 				ComponentType: commonconsts.ComponentTypeWorker,
 				ExtraPodSpec: &v1alpha1.ExtraPodSpec{
 					MainContainer: &corev1.Container{
-						Args: []string{"python3", "-m", "dynamo.vllm", "--is-prefill-worker"},
+						Args: []string{"python3", "-m", "dynamo.vllm", "--disaggregation-mode", "prefill"},
 					},
 				},
 			},
@@ -4715,7 +4715,7 @@ func TestGeneratePodSpecForComponent_VLLM(t *testing.T) {
 			role:              RoleMain,
 			numberOfNodes:     1,
 			expectError:       false,
-			expectContains:    []string{"python3", "-m", "dynamo.vllm", "--is-prefill-worker"},
+			expectContains:    []string{"python3", "-m", "dynamo.vllm", "--disaggregation-mode", "prefill"},
 			expectNotContains: []string{"ray start"},
 		},
 	}

--- a/docs/integrations/flexkv-integration.md
+++ b/docs/integrations/flexkv-integration.md
@@ -121,7 +121,7 @@ FLEXKV_CPU_CACHE_GB=32 \
 CUDA_VISIBLE_DEVICES=1 \
   python -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
-  --is-prefill-worker \
+  --disaggregation-mode prefill \
   --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}'
 ```

--- a/examples/backends/vllm/deploy/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/disagg-multinode.yaml
@@ -43,7 +43,8 @@ spec:
           - Qwen/Qwen3-0.6B
           - --tensor-parallel-size
           - "2"
-          - --is-decode-worker
+          - --disaggregation-mode
+          - decode
           - --kv-transfer-config
           - '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "engine_id":
             "vllm-disagg-decode-engine-0abc123"}'

--- a/examples/backends/vllm/deploy/v1beta1/disagg-multinode.yaml
+++ b/examples/backends/vllm/deploy/v1beta1/disagg-multinode.yaml
@@ -34,7 +34,8 @@ spec:
           - Qwen/Qwen3-0.6B
           - --tensor-parallel-size
           - "2"
-          - --is-decode-worker
+          - --disaggregation-mode
+          - decode
           - --kv-transfer-config
           - '{"kv_connector": "NixlConnector", "kv_role": "kv_both", "engine_id":
             "vllm-disagg-decode-engine-0abc123"}'

--- a/examples/backends/vllm/launch/disagg_flexkv.sh
+++ b/examples/backends/vllm/launch/disagg_flexkv.sh
@@ -27,7 +27,7 @@ FLEXKV_CPU_CACHE_GB=32 \
 CUDA_VISIBLE_DEVICES=1 \
   python -m dynamo.vllm \
   --model $MODEL \
-  --is-prefill-worker \
+  --disaggregation-mode prefill \
   --kv-transfer-config '{"kv_connector":"PdConnector","kv_role":"kv_both","kv_connector_extra_config":{"connectors":[{"kv_connector":"FlexKVConnectorV1","kv_role":"kv_both"},{"kv_connector":"NixlConnector","kv_role":"kv_both"}]},"kv_connector_module_path":"kvbm.vllm_integration.connector"}' \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
 

--- a/examples/backends/vllm/launch/xpu/disagg_router_xpu_gdr.sh
+++ b/examples/backends/vllm/launch/xpu/disagg_router_xpu_gdr.sh
@@ -45,14 +45,15 @@ ZE_AFFINITY_MASK=1 python3 -m dynamo.vllm \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557", "enable_kv_cache_events":true}' &
 
 # two prefill workers
-# When registered with --is-prefill-worker, these workers are automatically detected
-# by the frontend, which activates an internal prefill router for KV-aware prefill routing
+# When registered with --disaggregation-mode prefill, these workers are
+# automatically detected by the frontend, which activates an internal prefill
+# router for KV-aware prefill routing.
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
 ZE_AFFINITY_MASK=2 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --is-prefill-worker \
+    --disaggregation-mode prefill \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5558", "enable_kv_cache_events":true}' &
 
 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
@@ -60,7 +61,7 @@ ZE_AFFINITY_MASK=3 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
     --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\", \"kv_buffer_device\": \"${NIXL_BUFFER_DEVICE}\", \"kv_connector_extra_config\": {\"backends\": [\"${VLLM_NIXL_BACKEND}\"]}}" \
-    --is-prefill-worker \
+    --disaggregation-mode prefill \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5559", "enable_kv_cache_events":true}' &
 
 wait_any_exit

--- a/examples/global_planner/global-planner-gpu-budget.yaml
+++ b/examples/global_planner/global-planner-gpu-budget.yaml
@@ -122,7 +122,8 @@ spec:
             - ${MODEL_A}
             - --tensor-parallel-size
             - "1"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
           volumeMounts:
             - name: hf-model-cache
               mountPath: /home/dynamo/.cache/huggingface/hub
@@ -217,7 +218,8 @@ spec:
             - ${MODEL_B}
             - --tensor-parallel-size
             - "1"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
           volumeMounts:
             - name: hf-model-cache
               mountPath: /home/dynamo/.cache/huggingface/hub

--- a/examples/global_planner/global-planner-vllm-test.yaml
+++ b/examples/global_planner/global-planner-vllm-test.yaml
@@ -214,7 +214,8 @@ spec:
             - ${MODEL_NAME}
             - --tensor-parallel-size
             - "1"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
           volumeMounts:
             - name: hf-model-cache
               mountPath: /home/dynamo/.cache/huggingface/hub
@@ -289,7 +290,8 @@ spec:
             - ${MODEL_NAME}
             - --tensor-parallel-size
             - "2"
-            - --is-prefill-worker
+            - --disaggregation-mode
+            - prefill
           volumeMounts:
             - name: hf-model-cache
               mountPath: /home/dynamo/.cache/huggingface/hub

--- a/examples/global_planner/v1beta1/global-planner-gpu-budget.yaml
+++ b/examples/global_planner/v1beta1/global-planner-gpu-budget.yaml
@@ -154,7 +154,8 @@ spec:
           - ${MODEL_A}
           - --tensor-parallel-size
           - "1"
-          - --is-prefill-worker
+          - --disaggregation-mode
+          - prefill
           command:
           - python3
           - -m
@@ -255,7 +256,8 @@ spec:
           - ${MODEL_B}
           - --tensor-parallel-size
           - "1"
-          - --is-prefill-worker
+          - --disaggregation-mode
+          - prefill
           command:
           - python3
           - -m

--- a/examples/global_planner/v1beta1/global-planner-vllm-test.yaml
+++ b/examples/global_planner/v1beta1/global-planner-vllm-test.yaml
@@ -220,7 +220,8 @@ spec:
           - ${MODEL_NAME}
           - --tensor-parallel-size
           - "1"
-          - --is-prefill-worker
+          - --disaggregation-mode
+          - prefill
           command:
           - python3
           - -m
@@ -301,7 +302,8 @@ spec:
           - ${MODEL_NAME}
           - --tensor-parallel-size
           - "2"
-          - --is-prefill-worker
+          - --disaggregation-mode
+          - prefill
           command:
           - python3
           - -m


### PR DESCRIPTION
## Summary

- Remove the deprecated vLLM `--is-prefill-worker` and `--is-decode-worker` CLI flags and their `DYN_VLLM_IS_PREFILL_WORKER` / `DYN_VLLM_IS_DECODE_WORKER` environment variables.
- Remove the unused derived `is_prefill_worker` and `is_decode_worker` config fields so `--disaggregation-mode` is the single source of truth.
- Migrate vLLM documentation, launch scripts, deployment examples, global-planner examples, and the operator fixture to `--disaggregation-mode prefill|decode`.
- Retain the profiler's AIC-ingestion normalization for legacy role flags because AIC may still emit them; those values are removed before reaching the vLLM backend CLI.
- Leave the mock backend's separate compatibility flags unchanged.

This follows #12084, whose KV-event behavior fix is now included in `main`.

## User impact

Existing vLLM deployments must replace:

- `--is-prefill-worker` with `--disaggregation-mode prefill`
- `--is-decode-worker` with `--disaggregation-mode decode`
- `DYN_VLLM_IS_PREFILL_WORKER=true` with `DYN_VLLM_DISAGGREGATION_MODE=prefill`
- `DYN_VLLM_IS_DECODE_WORKER=true` with `DYN_VLLM_DISAGGREGATION_MODE=decode`

## Validation

- 37 vLLM backend-argument unit tests passed in the local Dynamo vLLM runtime image.
- Direct parser-surface validation confirmed only canonical disaggregation role selection remains.
- Focused operator test `TestGeneratePodSpecForComponent_VLLM` passed with Go 1.26.3.
- Shell syntax checks passed for the migrated launch scripts.
- `isort`, `black`, `flake8`, `codespell`, `ruff`, YAML validation, and `pytest-marker-report` passed.
- `gofmt -d` and `git diff --check` passed.
- No replacement tests were added for removed compatibility inputs; existing canonical `--disaggregation-mode` coverage remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Replaced legacy vLLM worker-role flags with the explicit `--disaggregation-mode` option for prefill and decode workers.
  * Updated deployment examples, launch scripts, and integration guidance to use the new configuration format.
  * Simplified disaggregation mode handling and removed deprecated worker-role settings.

* **Bug Fixes**
  * Prevented legacy role flags from being passed to the vLLM backend CLI.

* **Tests**
  * Updated unit and deployment tests to validate the new disaggregation-mode configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->