### PR TITLE
fix(chart): allow podmonitor labels

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
@@ -27,6 +27,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-frontend
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -57,6 +61,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-worker
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -132,6 +140,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-planner
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -160,6 +172,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-router
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:

--- a/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
@@ -182,6 +182,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-epp
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:

--- a/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/prometheus.yaml
@@ -27,6 +27,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-frontend
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -57,6 +61,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-worker
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -148,6 +156,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-planner
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
@@ -200,6 +212,10 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: dynamo-router
+  {{- with .Values.dynamo.metrics.podMonitors.labels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if .Values.namespaceRestriction.enabled }}
   namespaceSelector:

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -121,6 +121,8 @@ dynamo:
       # true=always create (use for helm template / GitOps workflows),
       # false=never create
       enabled: null
+      # -- Extra labels to add to every PodMonitor resource.
+      labels: {}
       # -- Enable the NIXL telemetry metrics collection on workers.
       # Requires workers with NIXL_TELEMETRY_ENABLE=y in their environment
       nixlTelemetry: false

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -138,6 +138,8 @@ dynamo:
       # series goes missing. Applies only to the endpoints that scrape a frontend
       # HTTP service; the system port always serves /metrics.
       frontendPath: /metrics
+      # -- Extra labels to add to every PodMonitor resource.
+      labels: {}
       # -- Enable the NIXL telemetry metrics collection on workers.
       # Requires workers with NIXL_TELEMETRY_ENABLE=y in their environment
       nixlTelemetry: false

--- a/deploy/helm/charts/platform/tests/podmonitor_labels_test.yaml
+++ b/deploy/helm/charts/platform/tests/podmonitor_labels_test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: PodMonitor labels
+templates:
+  - charts/dynamo-operator/templates/prometheus.yaml
+tests:
+  - it: adds configured labels to every PodMonitor
+    set:
+      dynamo-operator.dynamo.metrics.podMonitors.enabled: true
+      dynamo-operator.dynamo.metrics.podMonitors.labels.release: kube-prometheus-stack
+    asserts:
+      - hasDocuments:
+          count: 4
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+        documentIndex: 0
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+        documentIndex: 1
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+        documentIndex: 2
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+        documentIndex: 3

--- a/deploy/helm/charts/platform/tests/podmonitor_labels_test.yaml
+++ b/deploy/helm/charts/platform/tests/podmonitor_labels_test.yaml
@@ -11,20 +11,34 @@ tests:
       dynamo-operator.dynamo.metrics.podMonitors.labels.release: kube-prometheus-stack
     asserts:
       - hasDocuments:
-          count: 4
+          count: 5
       - equal:
           path: metadata.labels.release
           value: kube-prometheus-stack
-        documentIndex: 0
+        documentSelector:
+          path: metadata.name
+          value: dynamo-frontend
       - equal:
           path: metadata.labels.release
           value: kube-prometheus-stack
-        documentIndex: 1
+        documentSelector:
+          path: metadata.name
+          value: dynamo-worker
       - equal:
           path: metadata.labels.release
           value: kube-prometheus-stack
-        documentIndex: 2
+        documentSelector:
+          path: metadata.name
+          value: dynamo-planner
       - equal:
           path: metadata.labels.release
           value: kube-prometheus-stack
-        documentIndex: 3
+        documentSelector:
+          path: metadata.name
+          value: dynamo-epp
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack
+        documentSelector:
+          path: metadata.name
+          value: dynamo-router


### PR DESCRIPTION
## summary

prometheus installations that select monitors by a release label cannot discover dynamo’s generated `PodMonitor` resources. those resources currently render without metadata labels.

## details

adds `dynamo.metrics.podMonitors.labels` to the operator chart. every generated `PodMonitor` receives the configured map. the default is empty, so existing rendered manifests do not change.

adds a helm unit test that sets `release: kube-prometheus-stack` and checks the frontend, worker, planner, and router monitors.

## where should the reviewer start?

`deploy/helm/charts/platform/components/operator/templates/prometheus.yaml` contains the behavior change. the values file and unit test cover its configuration and all four rendered resources.

## validation

- `make test`
- `make lint`
- applicable pre commit hooks on all three changed files
- direct helm renders with and without the custom label

## related issues

fixes #12003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for applying custom labels to all generated Prometheus PodMonitor resources.
  * Added a configurable `dynamo.metrics.podMonitors.labels` setting, defaulting to no additional labels.

* **Tests**
  * Added validation to ensure configured labels appear on all four PodMonitor resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->