### PR TITLE
feat(router): warn on missing KV event publishers [DYN-3849]

### DIFF
--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -377,6 +377,9 @@ def build_runtime_config(
     rc.enable_local_indexer = (
         engine_args.enable_local_indexer and not engine_args.is_decode()
     )
+    rc.kv_event_publishing_enabled = (
+        engine_args.enable_prefix_caching and not engine_args.is_decode()
+    )
     rc.data_parallel_size = engine_args.dp_size
     rc.set_engine_specific("output_replay_consumer", "true")
 

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -171,6 +171,7 @@ class DynamoSglangPublisher:
 
         self._running = True
         self.kv_publishers: List[KvEventPublisher] = []
+        self.kv_publisher: Optional[KvEventPublisher] = None
         self.fpm_relays: list = []
 
         # ZMQ setup for receiving scheduler metrics (leader node only)
@@ -292,10 +293,10 @@ class DynamoSglangPublisher:
         - NATS handles cross-node event distribution
 
         Returns:
-            List of KvEventPublisher instances if kv_events_config is set,
+            List of KvEventPublisher instances if KV event publishing is enabled,
             empty list otherwise.
         """
-        if self.server_args.kv_events_config:
+        if self.dynamo_args.use_kv_events:
             kv_events = json.loads(self.server_args.kv_events_config)
             base_ep = kv_events.get("endpoint")
             if not base_ep:
@@ -535,7 +536,7 @@ async def setup_sgl_metrics(
 
     publisher.init_engine_metrics_publish()
     node_rank = getattr(config.server_args, "node_rank", 0) or 0
-    if node_rank <= 0:
+    if node_rank <= 0 and config.dynamo_args.use_kv_events:
         publisher.init_kv_event_publish()
     publisher.init_fpm_relay()
 
@@ -564,7 +565,7 @@ async def handle_non_leader_node(
     )
 
     try:
-        if publisher.server_args.kv_events_config:
+        if publisher.dynamo_args.use_kv_events:
             kv_worker_id = await _resolve_multinode_leader_worker_id(
                 publisher.generate_endpoint,
                 publisher.server_args,

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -376,6 +376,7 @@ async def _get_runtime_config(
     runtime_config.enable_local_indexer = (
         dynamo_args.enable_local_indexer and not is_decode_worker
     )
+    runtime_config.kv_event_publishing_enabled = dynamo_args.use_kv_events
 
     start_dp_rank, end_dp_rank = model_card_dp_rank_bounds(server_args)
     registered_dp_size = end_dp_rank - start_dp_rank

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -256,6 +256,7 @@ async def test_handle_non_leader_node_resolves_worker_before_kv_publish(monkeypa
         def __init__(self):
             self.generate_endpoint = FakeEndpoint()
             self.server_args = server_args
+            self.dynamo_args = SimpleNamespace(use_kv_events=True)
             self.kv_worker_id = None
 
         def init_kv_event_publish(self):
@@ -303,6 +304,7 @@ async def test_handle_non_leader_node_skips_kv_publish_without_resolved_worker(
     class FakePublisher:
         generate_endpoint = object()
         server_args = SimpleNamespace(kv_events_config='{"endpoint": "tcp://*:5557"}')
+        dynamo_args = SimpleNamespace(use_kv_events=True)
         kv_worker_id = None
 
         def init_kv_event_publish(self):
@@ -348,6 +350,7 @@ async def test_handle_non_leader_node_cleans_up_when_resolution_fails(monkeypatc
     class FakePublisher:
         generate_endpoint = object()
         server_args = SimpleNamespace(kv_events_config='{"endpoint": "tcp://*:5557"}')
+        dynamo_args = SimpleNamespace(use_kv_events=True)
 
         def cleanup(self):
             cleanup_called.set()
@@ -404,7 +407,11 @@ def test_init_kv_event_publish_uses_worker_id_override(monkeypatch):
     )
     config = SimpleNamespace(
         server_args=server_args,
-        dynamo_args=SimpleNamespace(enable_local_indexer=True, kv_state_endpoint=None),
+        dynamo_args=SimpleNamespace(
+            enable_local_indexer=True,
+            kv_state_endpoint=None,
+            use_kv_events=True,
+        ),
     )
     publisher = DynamoSglangPublisher(
         engine=SimpleNamespace(),
@@ -419,6 +426,25 @@ def test_init_kv_event_publish_uses_worker_id_override(monkeypatch):
     assert len(publishers) == 4
     assert [call["dp_rank"] for call in calls] == [4, 5, 6, 7]
     assert {call["worker_id"] for call in calls} == {1234}
+
+
+def test_init_kv_event_publish_uses_effective_kv_event_setting():
+    server_args = SimpleNamespace(
+        kv_events_config='{"publisher": "null", "endpoint": "tcp://*:5557"}',
+        node_rank=1,
+    )
+    config = SimpleNamespace(
+        server_args=server_args,
+        dynamo_args=SimpleNamespace(use_kv_events=False),
+    )
+    publisher = DynamoSglangPublisher(
+        engine=SimpleNamespace(),
+        config=config,
+        generate_endpoint=SimpleNamespace(),
+        component_gauges=SimpleNamespace(),
+    )
+
+    assert publisher.init_kv_event_publish() == []
 
 
 def test_init_kv_event_publish_allows_zero_worker_id_override(monkeypatch):
@@ -461,7 +487,11 @@ def test_init_kv_event_publish_allows_zero_worker_id_override(monkeypatch):
     )
     config = SimpleNamespace(
         server_args=server_args,
-        dynamo_args=SimpleNamespace(enable_local_indexer=True, kv_state_endpoint=None),
+        dynamo_args=SimpleNamespace(
+            enable_local_indexer=True,
+            kv_state_endpoint=None,
+            use_kv_events=True,
+        ),
     )
     publisher = DynamoSglangPublisher(
         engine=SimpleNamespace(
@@ -618,6 +648,7 @@ async def test_setup_sgl_metrics_returns_publisher_for_chat_worker(monkeypatch):
         dynamo_args=SimpleNamespace(
             embedding_worker=False,
             component="sglang-decode",
+            use_kv_events=False,
         ),
         server_args=engine.server_args,
     )

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -664,6 +664,7 @@ async def init_llm_worker(
             config.enable_local_indexer
             and config.disaggregation_mode != DisaggregationMode.DECODE
         )
+        runtime_config.kv_event_publishing_enabled = config.use_kv_events
         # Set data_parallel_size for attention DP mode
         # This enables the router's scheduler to correctly iterate over all dp_ranks
         # Need to name ADP as `data_parallel_size` for parity with other frameworks

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -664,7 +664,7 @@ async def init_llm_worker(
             config.enable_local_indexer
             and config.disaggregation_mode != DisaggregationMode.DECODE
         )
-        runtime_config.kv_event_publishing_enabled = config.use_kv_events
+        runtime_config.kv_event_publishing_enabled = config.publish_events_and_metrics
         # Set data_parallel_size for attention DP mode
         # This enables the router's scheduler to correctly iterate over all dp_ranks
         # Need to name ADP as `data_parallel_size` for parity with other frameworks

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2240,6 +2240,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                             runtime_config = ModelRuntimeConfig()
                             runtime_config.context_length = self.model_max_len
+                            runtime_config.kv_event_publishing_enabled = (
+                                self.config.use_kv_events
+                            )
                             runtime_config.tool_call_parser = (
                                 self.config.dyn_tool_call_parser
                             )

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -691,6 +691,7 @@ async def register_vllm_model(
     runtime_config.max_num_seqs = runtime_values["max_num_seqs"]
     runtime_config.max_num_batched_tokens = runtime_values["max_num_batched_tokens"]
     runtime_config.enable_local_indexer = config.enable_local_indexer
+    runtime_config.kv_event_publishing_enabled = config.use_kv_events
     runtime_config.kv_state_endpoint = config.kv_state_endpoint
 
     # Add tool/reasoning parsers for decode/aggregated workers. Prefill

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -39,6 +39,7 @@ def _make_prefill_handler():
         model="/models/base",
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
+        use_kv_events=True,
         engine_args=SimpleNamespace(block_size=16, max_loras=4),
     )
     handler.engine_client = SimpleNamespace(
@@ -94,6 +95,7 @@ async def test_prefill_load_records_and_publishes_without_eager_engine_add(
     assert str(kwargs["model_type"]) == str(ModelType.Prefill)
     assert kwargs["worker_type"] == WorkerType.Prefill
     assert kwargs["needs"] == [[WorkerType.Decode]]
+    assert kwargs["runtime_config"].kv_event_publishing_enabled is True
     # The adapter card must carry the engine-actual main-attention block size,
     # not engine_args.block_size (16) — see #11866.
     assert kwargs["kv_cache_block_size"] == 1056

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -133,11 +133,12 @@ impl Router {
         let model_manager = Arc::new(ModelManager::new());
 
         let decode_router = model_manager
-            .kv_chooser_for(
+            .kv_chooser_for_with_worker_role(
                 &endpoint,
                 block_size,
                 Some(kv_router_config.clone()),
                 None,
+                bootstrap.card.worker_type,
                 WORKER_TYPE_DECODE,
                 Some(model_name.clone()),
                 enable_eagle,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -785,11 +785,12 @@ pub unsafe extern "C" fn create_routers(
 
         // Create decode router
         let decode_router = match model_manager
-            .kv_chooser_for(
+            .kv_chooser_for_with_worker_role(
                 &endpoint,
                 block_size,
                 Some(kv_router_config.clone()),
                 None,
+                card.worker_type,
                 WORKER_TYPE_DECODE,
                 Some(model_name.clone()),
                 enable_eagle,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1636,7 +1636,7 @@ async fn create_kv_router_from_endpoint(
         .as_ref()
         .map(|cfg| cfg.use_remote_indexer || cfg.serve_indexer)
         .unwrap_or(false);
-    let (model_name, enable_eagle) = {
+    let (model_name, enable_eagle, worker_role) = {
         let maybe_card = if needs_model_name {
             let wait_secs: u64 = std::env::var("DYN_ROUTER_MODEL_CARD_WAIT_SECS")
                 .ok()
@@ -1677,7 +1677,11 @@ async fn create_kv_router_from_endpoint(
         match maybe_card {
             Some(card) => {
                 let model_name = needs_model_name.then(|| card.display_name.clone());
-                (model_name, card.runtime_config.enable_eagle)
+                (
+                    model_name,
+                    card.runtime_config.enable_eagle,
+                    card.worker_type,
+                )
             }
             None => {
                 tracing::warn!(
@@ -1686,17 +1690,18 @@ async fn create_kv_router_from_endpoint(
                     endpoint = %endpoint_id.name,
                     "No model card found in discovery; defaulting to non-Eagle routing semantics"
                 );
-                (None, false)
+                (None, false, None)
             }
         }
     };
 
     let kv_router = model_manager
-        .kv_chooser_for(
+        .kv_chooser_for_with_worker_role(
             &endpoint.inner,
             block_size as u32,
             kv_router_config,
             prefill_load_estimator,
+            worker_role,
             worker_type,
             model_name,
             enable_eagle,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -158,6 +158,11 @@ impl ModelRuntimeConfig {
     }
 
     #[setter]
+    fn set_kv_event_publishing_enabled(&mut self, enabled: Option<bool>) {
+        self.inner.kv_event_publishing_enabled = enabled;
+    }
+
+    #[setter]
     fn set_kv_state_endpoint(&mut self, kv_state_endpoint: Option<String>) {
         self.inner.kv_state_endpoint = kv_state_endpoint.as_deref().map(EndpointId::from);
     }
@@ -238,6 +243,11 @@ impl ModelRuntimeConfig {
     #[getter]
     fn enable_local_indexer(&self) -> bool {
         self.inner.enable_local_indexer
+    }
+
+    #[getter]
+    fn kv_event_publishing_enabled(&self) -> Option<bool> {
+        self.inner.kv_event_publishing_enabled
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -867,6 +867,7 @@ class ModelRuntimeConfig:
     data_parallel_start_rank: int
     data_parallel_size: int
     enable_local_indexer: bool
+    kv_event_publishing_enabled: bool | None
     kv_state_endpoint: str | None
     enable_eagle: bool
     taints: Set[str]

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -7,9 +7,8 @@ pub use model::Model;
 pub mod kv_source_membership;
 pub use kv_source_membership::{
     KvEventSource, KvSourceAdvertisement, KvSourceAmbiguity, KvSourceId, KvSourceKey,
-    KvSourceMembership, KvSourceMembershipError, KvSourceMembershipView, KvSourceObservationState,
-    KvSourceStatus, KvSourceTransition, KvStateEndpointResolution, PublisherId,
-    resolve_kv_state_endpoint,
+    KvSourceMembership, KvSourceMembershipError, KvSourceMembershipView, KvSourceStatus,
+    KvSourceTransition, KvStateEndpointResolution, PublisherId, resolve_kv_state_endpoint,
 };
 
 mod kv_source_watch;

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -7,8 +7,9 @@ pub use model::Model;
 pub mod kv_source_membership;
 pub use kv_source_membership::{
     KvEventSource, KvSourceAdvertisement, KvSourceAmbiguity, KvSourceId, KvSourceKey,
-    KvSourceMembership, KvSourceMembershipError, KvSourceMembershipView, KvSourceStatus,
-    KvSourceTransition, KvStateEndpointResolution, PublisherId, resolve_kv_state_endpoint,
+    KvSourceMembership, KvSourceMembershipError, KvSourceMembershipView, KvSourceObservationState,
+    KvSourceStatus, KvSourceTransition, KvStateEndpointResolution, PublisherId,
+    resolve_kv_state_endpoint,
 };
 
 mod kv_source_watch;

--- a/lib/llm/src/discovery/kv_source_membership.rs
+++ b/lib/llm/src/discovery/kv_source_membership.rs
@@ -131,14 +131,37 @@ pub enum KvStateEndpointResolution {
     Ambiguous { endpoints: Vec<EndpointId> },
 }
 
+/// Whether the coordinator currently has an exact KV event-source discovery watch.
+///
+/// Consumers must not interpret `Missing` as an observed publisher absence while the
+/// coordinator is rebinding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvSourceObservationState {
+    Rebinding,
+    Bound,
+}
+
+impl KvSourceObservationState {
+    pub fn is_bound(self) -> bool {
+        matches!(self, Self::Bound)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvSourceMembershipView<S = KvEventSource> {
     /// The exact serving endpoint whose workers this view describes.
     pub serving_endpoint: EndpointId,
     pub endpoint_resolution: KvStateEndpointResolution,
+    /// Whether `sources` is backed by a currently bound exact discovery watch.
+    pub observation_state: KvSourceObservationState,
     /// Membership remains indexed by logical worker and global DP rank. Publisher incarnation is
     /// deliberately absent from this routing/index identity.
     pub sources: HashMap<WorkerWithDpRank, KvSourceStatus<S>>,
+    /// Runtime-declared KV event publication capability, stored once per logical worker.
+    ///
+    /// `Some(true)` and `Some(false)` are explicit declarations. `None` is a legacy or otherwise
+    /// unknown declaration.
+    pub kv_event_publishing_enabled: HashMap<WorkerId, Option<bool>>,
     /// Monotonic cold-reset fence for each logical source in `sources`.
     ///
     /// A consumer must cold-reset a logical rank before accepting a source when this value
@@ -162,6 +185,13 @@ impl<S> KvSourceMembershipView<S> {
 
     pub fn recovery_expected(&self, worker: &WorkerWithDpRank) -> Option<bool> {
         self.recovery_expected.get(worker).copied()
+    }
+
+    pub fn kv_event_publishing_enabled(&self, worker_id: WorkerId) -> Option<bool> {
+        self.kv_event_publishing_enabled
+            .get(&worker_id)
+            .copied()
+            .flatten()
     }
 
     pub fn resolved_kv_state_endpoint(&self) -> Option<&EndpointId> {
@@ -342,6 +372,19 @@ where
         serving_endpoint: &EndpointId,
         runtime_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
     ) -> KvSourceMembershipView<S> {
+        self.view_with_observation_state(
+            serving_endpoint,
+            runtime_configs,
+            KvSourceObservationState::Rebinding,
+        )
+    }
+
+    pub(crate) fn view_with_observation_state(
+        &self,
+        serving_endpoint: &EndpointId,
+        runtime_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
+        observation_state: KvSourceObservationState,
+    ) -> KvSourceMembershipView<S> {
         let endpoint_resolution =
             resolve_kv_state_endpoint(serving_endpoint, runtime_configs.values());
         let workers: Vec<_> = runtime_configs
@@ -384,12 +427,18 @@ where
         let recovery_expected = workers
             .into_iter()
             .collect::<HashMap<WorkerWithDpRank, bool>>();
+        let kv_event_publishing_enabled = runtime_configs
+            .iter()
+            .map(|(&worker_id, config)| (worker_id, config.kv_event_publishing_enabled))
+            .collect();
 
         KvSourceMembershipView {
             serving_endpoint: serving_endpoint.clone(),
             endpoint_resolution,
+            observation_state,
             lifecycle_generations: sources.keys().map(|worker| (*worker, 0)).collect(),
             recovery_expected,
+            kv_event_publishing_enabled,
             sources,
         }
     }
@@ -574,6 +623,7 @@ mod tests {
                 data_parallel_start_rank: 2,
                 data_parallel_size: 2,
                 kv_state_endpoint: Some(kv_endpoint.clone()),
+                kv_event_publishing_enabled: Some(true),
                 ..Default::default()
             },
         )]);
@@ -594,5 +644,19 @@ mod tests {
             Some(&KvSourceStatus::Missing)
         );
         assert!(view.status(&WorkerWithDpRank::new(99, 0)).is_none());
+        assert_eq!(view.kv_event_publishing_enabled.len(), 1);
+        assert_eq!(view.kv_event_publishing_enabled(7), Some(true));
+        assert_eq!(view.kv_event_publishing_enabled(99), None);
+        assert_eq!(view.observation_state, KvSourceObservationState::Rebinding);
+    }
+
+    #[test]
+    fn view_preserves_legacy_unknown_capability_for_expected_worker() {
+        let serving = endpoint("generate");
+        let configs = HashMap::from([(7, ModelRuntimeConfig::default())]);
+        let view = KvSourceMembership::<KvEventSource>::new().view(&serving, &configs);
+
+        assert_eq!(view.kv_event_publishing_enabled, HashMap::from([(7, None)]));
+        assert_eq!(view.kv_event_publishing_enabled(7), None);
     }
 }

--- a/lib/llm/src/discovery/kv_source_membership.rs
+++ b/lib/llm/src/discovery/kv_source_membership.rs
@@ -131,29 +131,11 @@ pub enum KvStateEndpointResolution {
     Ambiguous { endpoints: Vec<EndpointId> },
 }
 
-/// Whether the coordinator currently has an exact KV event-source discovery watch.
-///
-/// Consumers must not interpret `Missing` as an observed publisher absence while the
-/// coordinator is rebinding.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum KvSourceObservationState {
-    Rebinding,
-    Bound,
-}
-
-impl KvSourceObservationState {
-    pub fn is_bound(self) -> bool {
-        matches!(self, Self::Bound)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KvSourceMembershipView<S = KvEventSource> {
     /// The exact serving endpoint whose workers this view describes.
     pub serving_endpoint: EndpointId,
     pub endpoint_resolution: KvStateEndpointResolution,
-    /// Whether `sources` is backed by a currently bound exact discovery watch.
-    pub observation_state: KvSourceObservationState,
     /// Membership remains indexed by logical worker and global DP rank. Publisher incarnation is
     /// deliberately absent from this routing/index identity.
     pub sources: HashMap<WorkerWithDpRank, KvSourceStatus<S>>,
@@ -372,19 +354,6 @@ where
         serving_endpoint: &EndpointId,
         runtime_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
     ) -> KvSourceMembershipView<S> {
-        self.view_with_observation_state(
-            serving_endpoint,
-            runtime_configs,
-            KvSourceObservationState::Rebinding,
-        )
-    }
-
-    pub(crate) fn view_with_observation_state(
-        &self,
-        serving_endpoint: &EndpointId,
-        runtime_configs: &HashMap<WorkerId, ModelRuntimeConfig>,
-        observation_state: KvSourceObservationState,
-    ) -> KvSourceMembershipView<S> {
         let endpoint_resolution =
             resolve_kv_state_endpoint(serving_endpoint, runtime_configs.values());
         let workers: Vec<_> = runtime_configs
@@ -435,7 +404,6 @@ where
         KvSourceMembershipView {
             serving_endpoint: serving_endpoint.clone(),
             endpoint_resolution,
-            observation_state,
             lifecycle_generations: sources.keys().map(|worker| (*worker, 0)).collect(),
             recovery_expected,
             kv_event_publishing_enabled,
@@ -647,7 +615,6 @@ mod tests {
         assert_eq!(view.kv_event_publishing_enabled.len(), 1);
         assert_eq!(view.kv_event_publishing_enabled(7), Some(true));
         assert_eq!(view.kv_event_publishing_enabled(99), None);
-        assert_eq!(view.observation_state, KvSourceObservationState::Rebinding);
     }
 
     #[test]

--- a/lib/llm/src/discovery/kv_source_watch.rs
+++ b/lib/llm/src/discovery/kv_source_watch.rs
@@ -21,6 +21,7 @@ use futures::StreamExt;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use super::kv_source_membership::KvSourceObservationState;
 use super::{
     KvEventSource, KvSourceMembership, KvSourceMembershipView, KvSourceStatus,
     KvStateEndpointResolution, RuntimeConfigWatch, resolve_kv_state_endpoint,
@@ -158,7 +159,7 @@ impl LifecycleTracker {
             if expected.contains(worker) {
                 continue;
             }
-            if lifecycle.ever_active && lifecycle.previous.is_some() {
+            if lifecycle.previous.is_some() {
                 lifecycle.generation = lifecycle.generation.saturating_add(1);
             }
             lifecycle.previous = None;
@@ -197,13 +198,22 @@ async fn run_membership_coordinator(
     let mut resolution = resolve_kv_state_endpoint(&serving_endpoint, configs.values());
     let mut membership = KvSourceMembership::new();
     let mut lifecycle = LifecycleTracker::default();
-    let mut source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
+    let mut observation_state = KvSourceObservationState::Rebinding;
     let mut retry_delay = Duration::from_millis(100);
     publish_view(
         &sender,
         &mut lifecycle,
-        membership.view(&serving_endpoint, &configs),
+        membership.view_with_observation_state(&serving_endpoint, &configs, observation_state),
     );
+    let mut source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
+    if source_stream.is_some() {
+        observation_state = KvSourceObservationState::Bound;
+        publish_view(
+            &sender,
+            &mut lifecycle,
+            membership.view_with_observation_state(&serving_endpoint, &configs, observation_state),
+        );
+    }
 
     loop {
         enum CoordinatorInput {
@@ -237,48 +247,97 @@ async fn run_membership_coordinator(
                     resolution = next_resolution;
                     membership = KvSourceMembership::new();
                     drop(source_stream.take());
+                    observation_state = KvSourceObservationState::Rebinding;
                     publish_view(
                         &sender,
                         &mut lifecycle,
-                        membership.view(&serving_endpoint, &configs),
+                        membership.view_with_observation_state(
+                            &serving_endpoint,
+                            &configs,
+                            observation_state,
+                        ),
                     );
                     source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
                     if source_stream.is_some() {
+                        observation_state = KvSourceObservationState::Bound;
                         retry_delay = Duration::from_millis(100);
+                        publish_view(
+                            &sender,
+                            &mut lifecycle,
+                            membership.view_with_observation_state(
+                                &serving_endpoint,
+                                &configs,
+                                observation_state,
+                            ),
+                        );
                     }
                 } else {
                     publish_view(
                         &sender,
                         &mut lifecycle,
-                        membership.view(&serving_endpoint, &configs),
+                        membership.view_with_observation_state(
+                            &serving_endpoint,
+                            &configs,
+                            observation_state,
+                        ),
                     );
                 }
             }
             CoordinatorInput::Source(Some(event)) => {
                 let stream_is_healthy =
                     reconcile_discovery_event(event, &resolution, &mut membership);
+                if !stream_is_healthy {
+                    drop(source_stream.take());
+                    observation_state = KvSourceObservationState::Rebinding;
+                }
                 publish_view(
                     &sender,
                     &mut lifecycle,
-                    membership.view(&serving_endpoint, &configs),
+                    membership.view_with_observation_state(
+                        &serving_endpoint,
+                        &configs,
+                        observation_state,
+                    ),
                 );
-                if !stream_is_healthy {
-                    drop(source_stream.take());
-                }
             }
             CoordinatorInput::Source(None) => {
                 membership = KvSourceMembership::new();
+                source_stream = None;
+                observation_state = KvSourceObservationState::Rebinding;
                 publish_view(
                     &sender,
                     &mut lifecycle,
-                    membership.view(&serving_endpoint, &configs),
+                    membership.view_with_observation_state(
+                        &serving_endpoint,
+                        &configs,
+                        observation_state,
+                    ),
                 );
-                source_stream = None;
             }
             CoordinatorInput::Retry => {
+                observation_state = KvSourceObservationState::Rebinding;
+                publish_view(
+                    &sender,
+                    &mut lifecycle,
+                    membership.view_with_observation_state(
+                        &serving_endpoint,
+                        &configs,
+                        observation_state,
+                    ),
+                );
                 source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
                 if source_stream.is_some() {
+                    observation_state = KvSourceObservationState::Bound;
                     retry_delay = Duration::from_millis(100);
+                    publish_view(
+                        &sender,
+                        &mut lifecycle,
+                        membership.view_with_observation_state(
+                            &serving_endpoint,
+                            &configs,
+                            observation_state,
+                        ),
+                    );
                 } else {
                     retry_delay = (retry_delay * 2).min(Duration::from_secs(5));
                 }
@@ -396,13 +455,24 @@ fn publish_view(
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Duration};
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use dynamo_kv_router::protocols::WorkerWithDpRank;
     use dynamo_runtime::{
         component::{Instance, TransportType},
-        discovery::{Discovery, DiscoverySpec, MockDiscovery, SharedMockRegistry},
+        discovery::{
+            Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, DiscoveryStream,
+            MockDiscovery, SharedMockRegistry,
+        },
     };
+    use tokio::sync::{Notify, Semaphore};
 
     use super::*;
     use crate::discovery::{KvSourceAmbiguity, KvSourceId, KvSourceKey};
@@ -449,6 +519,58 @@ mod tests {
                 device_type: None,
             }),
             ..source(endpoint, worker_id, publisher_id)
+        }
+    }
+
+    struct BlockingSecondBindDiscovery {
+        inner: MockDiscovery,
+        bind_count: AtomicUsize,
+        second_bind_started: Notify,
+        allow_second_bind: Semaphore,
+    }
+
+    impl BlockingSecondBindDiscovery {
+        fn new() -> Self {
+            Self {
+                inner: MockDiscovery::new(Some(1), SharedMockRegistry::new()),
+                bind_count: AtomicUsize::new(0),
+                second_bind_started: Notify::new(),
+                allow_second_bind: Semaphore::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Discovery for BlockingSecondBindDiscovery {
+        fn instance_id(&self) -> u64 {
+            self.inner.instance_id()
+        }
+
+        async fn register_internal(
+            &self,
+            spec: DiscoverySpec,
+        ) -> anyhow::Result<DiscoveryInstance> {
+            self.inner.register_internal(spec).await
+        }
+
+        async fn unregister(&self, instance: DiscoveryInstance) -> anyhow::Result<()> {
+            self.inner.unregister(instance).await
+        }
+
+        async fn list(&self, query: DiscoveryQuery) -> anyhow::Result<Vec<DiscoveryInstance>> {
+            self.inner.list(query).await
+        }
+
+        async fn list_and_watch(
+            &self,
+            query: DiscoveryQuery,
+            cancel_token: Option<CancellationToken>,
+        ) -> anyhow::Result<DiscoveryStream> {
+            if self.bind_count.fetch_add(1, Ordering::SeqCst) == 1 {
+                self.second_bind_started.notify_waiters();
+                self.allow_second_bind.acquire().await?.forget();
+            }
+            self.inner.list_and_watch(query, cancel_token).await
         }
     }
 
@@ -502,6 +624,7 @@ mod tests {
             watch.borrow().status(&worker),
             Some(&KvSourceStatus::Missing)
         );
+        wait_for(&mut watch, |view| view.observation_state.is_bound()).await;
 
         register_source(discovery.as_ref(), &source(&other, 42, 900)).await;
         register_source(discovery.as_ref(), &source(&kv, 99, 901)).await;
@@ -557,8 +680,8 @@ mod tests {
         let kv_b = endpoint("kv-b");
         let (configs_tx, configs_rx) =
             watch::channel(HashMap::from([(42, runtime_config(Some(kv_a.clone())))]));
-        let discovery: Arc<dyn Discovery> =
-            Arc::new(MockDiscovery::new(Some(1), SharedMockRegistry::new()));
+        let controlled_discovery = Arc::new(BlockingSecondBindDiscovery::new());
+        let discovery: Arc<dyn Discovery> = controlled_discovery.clone();
         let coordinator =
             KvSourceMembershipCoordinator::start(serving.clone(), configs_rx, discovery.clone());
         let mut slow_consumer = coordinator.subscribe();
@@ -576,13 +699,26 @@ mod tests {
             .lifecycle_generation(&worker)
             .unwrap();
 
+        let second_bind_started = controlled_discovery.second_bind_started.notified();
         configs_tx
             .send(HashMap::from([(42, runtime_config(Some(kv_b.clone())))]))
             .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), second_bind_started)
+            .await
+            .unwrap();
+        wait_for(&mut slow_consumer, |view| {
+            view.resolved_kv_state_endpoint() == Some(&kv_b)
+                && view.observation_state == KvSourceObservationState::Rebinding
+                && view.status(&worker) == Some(&KvSourceStatus::Missing)
+        })
+        .await;
+
         register_source(discovery.as_ref(), &source_b).await;
+        controlled_discovery.allow_second_bind.add_permits(1);
         discovery.unregister(instance_a).await.unwrap();
         wait_for(&mut slow_consumer, |view| {
             view.resolved_kv_state_endpoint() == Some(&kv_b)
+                && view.observation_state == KvSourceObservationState::Bound
                 && view.status(&worker)
                     == Some(&KvSourceStatus::ActiveRecoverable(source_b.clone()))
         })
@@ -622,6 +758,63 @@ mod tests {
         assert!(
             active_b.lifecycle_generation(&worker).unwrap()
                 > active_a.lifecycle_generation(&worker).unwrap()
+        );
+    }
+
+    #[test]
+    fn observation_binding_changes_do_not_advance_the_reset_fence() {
+        let serving = endpoint("generate");
+        let kv = endpoint("kv");
+        let configs = HashMap::from([(42, runtime_config(Some(kv.clone())))]);
+        let worker = WorkerWithDpRank::new(42, 4);
+        let mut membership = KvSourceMembership::new();
+        let mut lifecycle = LifecycleTracker::default();
+        membership.add(source(&kv, 42, 100)).unwrap();
+
+        let rebinding = lifecycle.apply(membership.view_with_observation_state(
+            &serving,
+            &configs,
+            KvSourceObservationState::Rebinding,
+        ));
+        let bound = lifecycle.apply(membership.view_with_observation_state(
+            &serving,
+            &configs,
+            KvSourceObservationState::Bound,
+        ));
+
+        assert_eq!(
+            bound.lifecycle_generation(&worker),
+            rebinding.lifecycle_generation(&worker)
+        );
+    }
+
+    #[test]
+    fn missing_worker_remove_rejoin_advances_the_reset_fence() {
+        let serving = endpoint("generate");
+        let kv = endpoint("kv");
+        let configs = HashMap::from([(42, runtime_config(Some(kv)))]);
+        let worker = WorkerWithDpRank::new(42, 4);
+        let mut lifecycle = LifecycleTracker::default();
+
+        let initial = lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
+            &serving,
+            &configs,
+            KvSourceObservationState::Bound,
+        ));
+        lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
+            &serving,
+            &HashMap::new(),
+            KvSourceObservationState::Bound,
+        ));
+        let rejoined = lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
+            &serving,
+            &configs,
+            KvSourceObservationState::Bound,
+        ));
+
+        assert!(
+            rejoined.lifecycle_generation(&worker) > initial.lifecycle_generation(&worker),
+            "a coalesced remove/rejoin must invalidate the old missing-source deadline"
         );
     }
 

--- a/lib/llm/src/discovery/kv_source_watch.rs
+++ b/lib/llm/src/discovery/kv_source_watch.rs
@@ -21,7 +21,6 @@ use futures::StreamExt;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
-use super::kv_source_membership::KvSourceObservationState;
 use super::{
     KvEventSource, KvSourceMembership, KvSourceMembershipView, KvSourceStatus,
     KvStateEndpointResolution, RuntimeConfigWatch, resolve_kv_state_endpoint,
@@ -159,7 +158,7 @@ impl LifecycleTracker {
             if expected.contains(worker) {
                 continue;
             }
-            if lifecycle.previous.is_some() {
+            if lifecycle.ever_active && lifecycle.previous.is_some() {
                 lifecycle.generation = lifecycle.generation.saturating_add(1);
             }
             lifecycle.previous = None;
@@ -198,22 +197,13 @@ async fn run_membership_coordinator(
     let mut resolution = resolve_kv_state_endpoint(&serving_endpoint, configs.values());
     let mut membership = KvSourceMembership::new();
     let mut lifecycle = LifecycleTracker::default();
-    let mut observation_state = KvSourceObservationState::Rebinding;
+    let mut source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
     let mut retry_delay = Duration::from_millis(100);
     publish_view(
         &sender,
         &mut lifecycle,
-        membership.view_with_observation_state(&serving_endpoint, &configs, observation_state),
+        membership.view(&serving_endpoint, &configs),
     );
-    let mut source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
-    if source_stream.is_some() {
-        observation_state = KvSourceObservationState::Bound;
-        publish_view(
-            &sender,
-            &mut lifecycle,
-            membership.view_with_observation_state(&serving_endpoint, &configs, observation_state),
-        );
-    }
 
     loop {
         enum CoordinatorInput {
@@ -247,97 +237,48 @@ async fn run_membership_coordinator(
                     resolution = next_resolution;
                     membership = KvSourceMembership::new();
                     drop(source_stream.take());
-                    observation_state = KvSourceObservationState::Rebinding;
                     publish_view(
                         &sender,
                         &mut lifecycle,
-                        membership.view_with_observation_state(
-                            &serving_endpoint,
-                            &configs,
-                            observation_state,
-                        ),
+                        membership.view(&serving_endpoint, &configs),
                     );
                     source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
                     if source_stream.is_some() {
-                        observation_state = KvSourceObservationState::Bound;
                         retry_delay = Duration::from_millis(100);
-                        publish_view(
-                            &sender,
-                            &mut lifecycle,
-                            membership.view_with_observation_state(
-                                &serving_endpoint,
-                                &configs,
-                                observation_state,
-                            ),
-                        );
                     }
                 } else {
                     publish_view(
                         &sender,
                         &mut lifecycle,
-                        membership.view_with_observation_state(
-                            &serving_endpoint,
-                            &configs,
-                            observation_state,
-                        ),
+                        membership.view(&serving_endpoint, &configs),
                     );
                 }
             }
             CoordinatorInput::Source(Some(event)) => {
                 let stream_is_healthy =
                     reconcile_discovery_event(event, &resolution, &mut membership);
-                if !stream_is_healthy {
-                    drop(source_stream.take());
-                    observation_state = KvSourceObservationState::Rebinding;
-                }
                 publish_view(
                     &sender,
                     &mut lifecycle,
-                    membership.view_with_observation_state(
-                        &serving_endpoint,
-                        &configs,
-                        observation_state,
-                    ),
+                    membership.view(&serving_endpoint, &configs),
                 );
+                if !stream_is_healthy {
+                    drop(source_stream.take());
+                }
             }
             CoordinatorInput::Source(None) => {
                 membership = KvSourceMembership::new();
-                source_stream = None;
-                observation_state = KvSourceObservationState::Rebinding;
                 publish_view(
                     &sender,
                     &mut lifecycle,
-                    membership.view_with_observation_state(
-                        &serving_endpoint,
-                        &configs,
-                        observation_state,
-                    ),
+                    membership.view(&serving_endpoint, &configs),
                 );
+                source_stream = None;
             }
             CoordinatorInput::Retry => {
-                observation_state = KvSourceObservationState::Rebinding;
-                publish_view(
-                    &sender,
-                    &mut lifecycle,
-                    membership.view_with_observation_state(
-                        &serving_endpoint,
-                        &configs,
-                        observation_state,
-                    ),
-                );
                 source_stream = bind_source_stream(&discovery, &resolution, &cancel).await;
                 if source_stream.is_some() {
-                    observation_state = KvSourceObservationState::Bound;
                     retry_delay = Duration::from_millis(100);
-                    publish_view(
-                        &sender,
-                        &mut lifecycle,
-                        membership.view_with_observation_state(
-                            &serving_endpoint,
-                            &configs,
-                            observation_state,
-                        ),
-                    );
                 } else {
                     retry_delay = (retry_delay * 2).min(Duration::from_secs(5));
                 }
@@ -455,24 +396,13 @@ fn publish_view(
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        time::Duration,
-    };
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use dynamo_kv_router::protocols::WorkerWithDpRank;
     use dynamo_runtime::{
         component::{Instance, TransportType},
-        discovery::{
-            Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, DiscoveryStream,
-            MockDiscovery, SharedMockRegistry,
-        },
+        discovery::{Discovery, DiscoverySpec, MockDiscovery, SharedMockRegistry},
     };
-    use tokio::sync::{Notify, Semaphore};
 
     use super::*;
     use crate::discovery::{KvSourceAmbiguity, KvSourceId, KvSourceKey};
@@ -519,58 +449,6 @@ mod tests {
                 device_type: None,
             }),
             ..source(endpoint, worker_id, publisher_id)
-        }
-    }
-
-    struct BlockingSecondBindDiscovery {
-        inner: MockDiscovery,
-        bind_count: AtomicUsize,
-        second_bind_started: Notify,
-        allow_second_bind: Semaphore,
-    }
-
-    impl BlockingSecondBindDiscovery {
-        fn new() -> Self {
-            Self {
-                inner: MockDiscovery::new(Some(1), SharedMockRegistry::new()),
-                bind_count: AtomicUsize::new(0),
-                second_bind_started: Notify::new(),
-                allow_second_bind: Semaphore::new(0),
-            }
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl Discovery for BlockingSecondBindDiscovery {
-        fn instance_id(&self) -> u64 {
-            self.inner.instance_id()
-        }
-
-        async fn register_internal(
-            &self,
-            spec: DiscoverySpec,
-        ) -> anyhow::Result<DiscoveryInstance> {
-            self.inner.register_internal(spec).await
-        }
-
-        async fn unregister(&self, instance: DiscoveryInstance) -> anyhow::Result<()> {
-            self.inner.unregister(instance).await
-        }
-
-        async fn list(&self, query: DiscoveryQuery) -> anyhow::Result<Vec<DiscoveryInstance>> {
-            self.inner.list(query).await
-        }
-
-        async fn list_and_watch(
-            &self,
-            query: DiscoveryQuery,
-            cancel_token: Option<CancellationToken>,
-        ) -> anyhow::Result<DiscoveryStream> {
-            if self.bind_count.fetch_add(1, Ordering::SeqCst) == 1 {
-                self.second_bind_started.notify_waiters();
-                self.allow_second_bind.acquire().await?.forget();
-            }
-            self.inner.list_and_watch(query, cancel_token).await
         }
     }
 
@@ -624,7 +502,6 @@ mod tests {
             watch.borrow().status(&worker),
             Some(&KvSourceStatus::Missing)
         );
-        wait_for(&mut watch, |view| view.observation_state.is_bound()).await;
 
         register_source(discovery.as_ref(), &source(&other, 42, 900)).await;
         register_source(discovery.as_ref(), &source(&kv, 99, 901)).await;
@@ -680,8 +557,8 @@ mod tests {
         let kv_b = endpoint("kv-b");
         let (configs_tx, configs_rx) =
             watch::channel(HashMap::from([(42, runtime_config(Some(kv_a.clone())))]));
-        let controlled_discovery = Arc::new(BlockingSecondBindDiscovery::new());
-        let discovery: Arc<dyn Discovery> = controlled_discovery.clone();
+        let discovery: Arc<dyn Discovery> =
+            Arc::new(MockDiscovery::new(Some(1), SharedMockRegistry::new()));
         let coordinator =
             KvSourceMembershipCoordinator::start(serving.clone(), configs_rx, discovery.clone());
         let mut slow_consumer = coordinator.subscribe();
@@ -699,26 +576,13 @@ mod tests {
             .lifecycle_generation(&worker)
             .unwrap();
 
-        let second_bind_started = controlled_discovery.second_bind_started.notified();
         configs_tx
             .send(HashMap::from([(42, runtime_config(Some(kv_b.clone())))]))
             .unwrap();
-        tokio::time::timeout(Duration::from_secs(2), second_bind_started)
-            .await
-            .unwrap();
-        wait_for(&mut slow_consumer, |view| {
-            view.resolved_kv_state_endpoint() == Some(&kv_b)
-                && view.observation_state == KvSourceObservationState::Rebinding
-                && view.status(&worker) == Some(&KvSourceStatus::Missing)
-        })
-        .await;
-
         register_source(discovery.as_ref(), &source_b).await;
-        controlled_discovery.allow_second_bind.add_permits(1);
         discovery.unregister(instance_a).await.unwrap();
         wait_for(&mut slow_consumer, |view| {
             view.resolved_kv_state_endpoint() == Some(&kv_b)
-                && view.observation_state == KvSourceObservationState::Bound
                 && view.status(&worker)
                     == Some(&KvSourceStatus::ActiveRecoverable(source_b.clone()))
         })
@@ -758,63 +622,6 @@ mod tests {
         assert!(
             active_b.lifecycle_generation(&worker).unwrap()
                 > active_a.lifecycle_generation(&worker).unwrap()
-        );
-    }
-
-    #[test]
-    fn observation_binding_changes_do_not_advance_the_reset_fence() {
-        let serving = endpoint("generate");
-        let kv = endpoint("kv");
-        let configs = HashMap::from([(42, runtime_config(Some(kv.clone())))]);
-        let worker = WorkerWithDpRank::new(42, 4);
-        let mut membership = KvSourceMembership::new();
-        let mut lifecycle = LifecycleTracker::default();
-        membership.add(source(&kv, 42, 100)).unwrap();
-
-        let rebinding = lifecycle.apply(membership.view_with_observation_state(
-            &serving,
-            &configs,
-            KvSourceObservationState::Rebinding,
-        ));
-        let bound = lifecycle.apply(membership.view_with_observation_state(
-            &serving,
-            &configs,
-            KvSourceObservationState::Bound,
-        ));
-
-        assert_eq!(
-            bound.lifecycle_generation(&worker),
-            rebinding.lifecycle_generation(&worker)
-        );
-    }
-
-    #[test]
-    fn missing_worker_remove_rejoin_advances_the_reset_fence() {
-        let serving = endpoint("generate");
-        let kv = endpoint("kv");
-        let configs = HashMap::from([(42, runtime_config(Some(kv)))]);
-        let worker = WorkerWithDpRank::new(42, 4);
-        let mut lifecycle = LifecycleTracker::default();
-
-        let initial = lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
-            &serving,
-            &configs,
-            KvSourceObservationState::Bound,
-        ));
-        lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
-            &serving,
-            &HashMap::new(),
-            KvSourceObservationState::Bound,
-        ));
-        let rejoined = lifecycle.apply(KvSourceMembership::new().view_with_observation_state(
-            &serving,
-            &configs,
-            KvSourceObservationState::Bound,
-        ));
-
-        assert!(
-            rejoined.lifecycle_generation(&worker) > initial.lifecycle_generation(&worker),
-            "a coalesced remove/rejoin must invalidate the old missing-source deadline"
         );
     }
 

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -32,7 +32,7 @@ use dynamo_runtime::{
 
 use crate::{
     kv_router::{
-        KvRouter, router_endpoint_id, scheduler::DefaultWorkerSelector,
+        KvEventSourceRequirement, KvRouter, router_endpoint_id, scheduler::DefaultWorkerSelector,
         shared_cache::HicacheSharedKvCache,
     },
     local_model::runtime_config::{DisaggregatedEndpoint, ModelRuntimeConfig, topology_taint},
@@ -49,6 +49,7 @@ use crate::{
             images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
     },
+    worker_type::WorkerType,
 };
 
 /// State for prefill router activation rendezvous.
@@ -1037,7 +1038,7 @@ impl ModelManager {
 
     // -- KV Router creation --
 
-    /// Whether to start the LoRA load-estimator feed for a KV router being built for `worker_type`.
+    /// Whether to start the LoRA load-estimator feed for a KV router's metric worker type.
     ///
     /// The feed must run for the worker mode that carries the routable request load. In dynamo's
     /// KV path that is `WORKER_TYPE_DECODE`, which the binding assigns to BOTH aggregated and
@@ -1056,7 +1057,32 @@ impl ModelManager {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        worker_type: &'static str,
+        metric_worker_type: &'static str,
+        model_name: Option<String>,
+        is_eagle: bool,
+    ) -> anyhow::Result<Arc<KvRouter>> {
+        self.kv_chooser_for_with_worker_role(
+            endpoint,
+            kv_cache_block_size,
+            kv_router_config,
+            prefill_load_estimator,
+            None,
+            metric_worker_type,
+            model_name,
+            is_eagle,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn kv_chooser_for_with_worker_role(
+        &self,
+        endpoint: &Endpoint,
+        kv_cache_block_size: u32,
+        kv_router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        worker_role: Option<WorkerType>,
+        metric_worker_type: &'static str,
         model_name: Option<String>,
         is_eagle: bool,
     ) -> anyhow::Result<Arc<KvRouter>> {
@@ -1086,7 +1112,7 @@ impl ModelManager {
         // Get of create runtime config watcher for this endpoint
         let workers_with_configs = self.get_or_create_runtime_config_watcher(endpoint).await?;
 
-        let selector = DefaultWorkerSelector::new(kv_router_config.clone(), worker_type);
+        let selector = DefaultWorkerSelector::new(kv_router_config.clone(), metric_worker_type);
 
         // Build shared cache client based on shared_cache_type.
         let shared_cache: Option<Box<dyn dynamo_kv_router::SharedKvCache>> = match kv_router_config
@@ -1108,18 +1134,19 @@ impl ModelManager {
         };
 
         let effective_kv_router_config = kv_router_config.clone().unwrap_or_default();
-        let kv_source_membership = if !effective_kv_router_config.use_remote_indexer
-            && effective_kv_router_config.should_subscribe_to_kv_events()
-        {
-            Some(
-                self.get_or_create_kv_source_membership_watch(endpoint)
-                    .await?,
-            )
-        } else {
-            None
-        };
+        let kv_event_source_requirement =
+            KvEventSourceRequirement::derive(worker_role, &effective_kv_router_config);
+        let kv_source_membership =
+            if kv_event_source_requirement.should_subscribe(&effective_kv_router_config) {
+                Some(
+                    self.get_or_create_kv_source_membership_watch(endpoint)
+                        .await?,
+                )
+            } else {
+                None
+            };
 
-        let chooser = KvRouter::new(
+        let chooser = KvRouter::new_with_worker_role(
             endpoint.clone(),
             client,
             workers_with_configs,
@@ -1128,7 +1155,8 @@ impl ModelManager {
             selector,
             kv_router_config,
             prefill_load_estimator,
-            worker_type,
+            worker_role,
+            metric_worker_type,
             model_name,
             is_eagle,
             shared_cache,
@@ -1149,7 +1177,7 @@ impl ModelManager {
         // routing is not load-aware — dynamic LoRA allocation then degrades to cold-start pins while
         // the filter still routes by loaded worker. Constructors that pass WORKER_TYPE_DECODE
         // directly, e.g. the watcher / C bindings, are unaffected.)
-        if Self::should_start_lora_load_feed(self.lora_enabled, worker_type) {
+        if Self::should_start_lora_load_feed(self.lora_enabled, metric_worker_type) {
             let feed_key = endpoint.id().to_string();
             // Start a feed if none runs for this endpoint yet, or restart it if the previous
             // one exited (so a dead subscription does not permanently disable load tracking).

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1094,11 +1094,7 @@ impl ModelWatcher {
         if !component_has_instances {
             // No more workers of this component in this namespace — remove its WorkerSet
             let removed = self.manager.remove_worker_set(&model_name, &ws_key);
-            if let Some(worker_set) = &removed {
-                // Active requests can retain a retired router after discovery removes its
-                // WorkerSet. Stop only its diagnostic monitor so a replacement router becomes
-                // the sole reporter without disrupting in-flight request cleanup.
-                worker_set.stop_kv_source_health_monitor();
+            if removed.is_some() {
                 tracing::info!(
                     model_name,
                     namespace = %worker_namespace,

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1094,7 +1094,11 @@ impl ModelWatcher {
         if !component_has_instances {
             // No more workers of this component in this namespace — remove its WorkerSet
             let removed = self.manager.remove_worker_set(&model_name, &ws_key);
-            if removed.is_some() {
+            if let Some(worker_set) = &removed {
+                // Active requests can retain a retired router after discovery removes its
+                // WorkerSet. Stop only its diagnostic monitor so a replacement router becomes
+                // the sole reporter without disrupting in-flight request cleanup.
+                worker_set.stop_kv_source_health_monitor();
                 tracing::info!(
                     model_name,
                     namespace = %worker_namespace,
@@ -1591,11 +1595,12 @@ impl ModelWatcher {
                 if router_config.router_mode == RouterMode::KV && needs_preprocessed_routing {
                     Some(
                         self.manager
-                            .kv_chooser_for(
+                            .kv_chooser_for_with_worker_role(
                                 &endpoint,
                                 card.kv_cache_block_size,
                                 Some(router_config.kv_router_config.clone()),
                                 self.prefill_load_estimator.clone(),
+                                card.worker_type,
                                 WORKER_TYPE_DECODE, // This is the decode router
                                 Some(card.display_name.clone()),
                                 card.runtime_config.enable_eagle,

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -223,6 +223,12 @@ impl WorkerSet {
     pub fn set_instance_watcher(&mut self, rx: watch::Receiver<Vec<u64>>) {
         self.instance_count_rx = Some(rx);
     }
+
+    pub(crate) fn stop_kv_source_health_monitor(&self) {
+        if let Some(router) = &self.kv_router {
+            router.stop_source_health_monitor();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -223,12 +223,6 @@ impl WorkerSet {
     pub fn set_instance_watcher(&mut self, rx: watch::Receiver<Vec<u64>>) {
         self.instance_count_rx = Some(rx);
     }
-
-    pub(crate) fn stop_kv_source_health_monitor(&self) {
-        if let Some(router) = &self.kv_router {
-            router.stop_source_health_monitor();
-        }
-    }
 }
 
 #[cfg(test)]

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -506,12 +506,6 @@ where
         }
     }
 
-    pub(crate) fn stop_source_health_monitor(&self) {
-        if let Some(subscription) = &self.kv_event_subscription {
-            subscription.stop_source_health_monitor();
-        }
-    }
-
     pub fn is_eagle(&self) -> bool {
         self.is_eagle
     }
@@ -1448,49 +1442,57 @@ mod tests {
     }
 
     #[test]
-    fn kv_event_source_requirement_is_role_and_config_aware() {
-        let config = KvRouterConfig::default();
-        assert_eq!(
-            KvEventSourceRequirement::derive(Some(WorkerType::Prefill), &config),
-            KvEventSourceRequirement::CacheAwareRouting
-        );
-        assert_eq!(
-            KvEventSourceRequirement::derive(Some(WorkerType::Aggregated), &config),
-            KvEventSourceRequirement::CacheAwareRouting
-        );
-        assert_eq!(
-            KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config),
-            KvEventSourceRequirement::NotRequired
-        );
-        assert_eq!(
-            KvEventSourceRequirement::derive(Some(WorkerType::Encode), &config),
-            KvEventSourceRequirement::NotRequired
-        );
-        assert_eq!(
-            KvEventSourceRequirement::derive(None, &config),
-            KvEventSourceRequirement::Unknown
-        );
-
+    fn kv_event_source_requirement_matrix() {
+        let default = KvRouterConfig::default();
+        let mut cases = vec![
+            (
+                Some(WorkerType::Prefill),
+                default.clone(),
+                KvEventSourceRequirement::CacheAwareRouting,
+                true,
+            ),
+            (
+                Some(WorkerType::Aggregated),
+                default.clone(),
+                KvEventSourceRequirement::CacheAwareRouting,
+                true,
+            ),
+            (
+                Some(WorkerType::Decode),
+                default.clone(),
+                KvEventSourceRequirement::NotRequired,
+                false,
+            ),
+            (
+                Some(WorkerType::Encode),
+                default.clone(),
+                KvEventSourceRequirement::NotRequired,
+                false,
+            ),
+            (
+                None,
+                default.clone(),
+                KvEventSourceRequirement::Unknown,
+                true,
+            ),
+        ];
         for policy in [
             dynamo_kv_router::ConditionalDisaggPolicyKind::IslBounding,
             dynamo_kv_router::ConditionalDisaggPolicyKind::PrefillLoad,
             dynamo_kv_router::ConditionalDisaggPolicyKind::IslOrLoad,
         ] {
-            let conditional = KvRouterConfig {
-                conditional_disagg_enabled: true,
-                conditional_disagg_policy: policy,
-                ..config.clone()
-            };
-            assert_eq!(
-                KvEventSourceRequirement::derive(Some(WorkerType::Decode), &conditional),
-                KvEventSourceRequirement::ConditionalDisaggDecodeCache
-            );
+            cases.push((
+                Some(WorkerType::Decode),
+                KvRouterConfig {
+                    conditional_disagg_enabled: true,
+                    conditional_disagg_policy: policy,
+                    ..default.clone()
+                },
+                KvEventSourceRequirement::ConditionalDisaggDecodeCache,
+                true,
+            ));
         }
-    }
-
-    #[test]
-    fn non_local_indexers_never_require_kv_event_sources() {
-        let configurations = [
+        for config in [
             KvRouterConfig {
                 use_remote_indexer: true,
                 ..Default::default()
@@ -1503,32 +1505,34 @@ mod tests {
                 overlap_score_credit: 0.0,
                 ..Default::default()
             },
-        ];
-
-        for config in configurations {
-            assert_eq!(
-                KvEventSourceRequirement::derive(None, &config),
-                KvEventSourceRequirement::Unknown
-            );
-            assert_eq!(
-                KvEventSourceRequirement::derive(Some(WorkerType::Aggregated), &config),
-                KvEventSourceRequirement::NotRequired
-            );
-            assert_eq!(
-                KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config),
-                KvEventSourceRequirement::NotRequired
-            );
+        ] {
+            cases.extend([
+                (
+                    None,
+                    config.clone(),
+                    KvEventSourceRequirement::Unknown,
+                    false,
+                ),
+                (
+                    Some(WorkerType::Aggregated),
+                    config.clone(),
+                    KvEventSourceRequirement::NotRequired,
+                    false,
+                ),
+                (
+                    Some(WorkerType::Decode),
+                    config,
+                    KvEventSourceRequirement::NotRequired,
+                    false,
+                ),
+            ]);
         }
-    }
 
-    #[test]
-    fn unknown_role_preserves_configured_subscription_behavior() {
-        let config = KvRouterConfig::default();
-        assert!(KvEventSourceRequirement::Unknown.should_subscribe(&config));
-
-        let decode_requirement =
-            KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config);
-        assert!(!decode_requirement.should_subscribe(&config));
+        for (role, config, expected, should_subscribe) in cases {
+            let requirement = KvEventSourceRequirement::derive(role, &config);
+            assert_eq!(requirement, expected);
+            assert_eq!(requirement.should_subscribe(&config), should_subscribe);
+        }
     }
 
     #[test]

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashSet, sync::Arc, time::Instant};
+use std::{collections::HashSet, fmt, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use dynamo_kv_router::{
@@ -69,8 +69,65 @@ use crate::{
         sequence::{SequenceError, SequenceRequest},
     },
     local_model::runtime_config::ModelRuntimeConfig,
+    worker_type::WorkerType,
 };
 use route_lookup::{TieredLookupResult, query_tiered_matches, split_retained_block_hashes};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum KvEventSourceRequirement {
+    NotRequired,
+    CacheAwareRouting,
+    ConditionalDisaggDecodeCache,
+    Unknown,
+}
+
+impl KvEventSourceRequirement {
+    pub(crate) fn derive(worker_role: Option<WorkerType>, config: &KvRouterConfig) -> Self {
+        let Some(worker_role) = worker_role else {
+            return Self::Unknown;
+        };
+        if config.use_remote_indexer || !config.should_subscribe_to_kv_events() {
+            return Self::NotRequired;
+        }
+
+        match worker_role {
+            WorkerType::Prefill | WorkerType::Aggregated => Self::CacheAwareRouting,
+            WorkerType::Decode if config.conditional_disagg_enabled => {
+                Self::ConditionalDisaggDecodeCache
+            }
+            WorkerType::Decode | WorkerType::Encode => Self::NotRequired,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NotRequired => "not_required",
+            Self::CacheAwareRouting => "cache_aware_routing",
+            Self::ConditionalDisaggDecodeCache => "conditional_disagg_decode_cache",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub(crate) fn requires_source(self) -> bool {
+        matches!(
+            self,
+            Self::CacheAwareRouting | Self::ConditionalDisaggDecodeCache
+        )
+    }
+
+    pub(crate) fn should_subscribe(self, config: &KvRouterConfig) -> bool {
+        match self {
+            Self::Unknown => !config.use_remote_indexer && config.should_subscribe_to_kv_events(),
+            requirement => requirement.requires_source(),
+        }
+    }
+}
+
+impl fmt::Display for KvEventSourceRequirement {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
 
 pub enum FindBestMatchOutcome {
     Routed {
@@ -253,7 +310,43 @@ where
         selector: Sel,
         kv_router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        worker_type: &'static str,
+        metric_worker_type: &'static str,
+        model_name: Option<String>,
+        is_eagle: bool,
+        shared_cache: Option<Box<dyn SharedKvCache>>,
+        lora_filter: Option<Arc<crate::lora::LoraFilter>>,
+    ) -> Result<Self> {
+        Self::new_with_worker_role(
+            endpoint,
+            client,
+            workers_with_configs,
+            kv_source_membership,
+            block_size,
+            selector,
+            kv_router_config,
+            prefill_load_estimator,
+            None,
+            metric_worker_type,
+            model_name,
+            is_eagle,
+            shared_cache,
+            lora_filter,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_with_worker_role(
+        endpoint: Endpoint,
+        client: Client,
+        workers_with_configs: RuntimeConfigWatch,
+        kv_source_membership: Option<KvSourceMembershipWatch>,
+        block_size: u32,
+        selector: Sel,
+        kv_router_config: Option<KvRouterConfig>,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        worker_role: Option<WorkerType>,
+        metric_worker_type: &'static str,
         model_name: Option<String>,
         is_eagle: bool,
         shared_cache: Option<Box<dyn SharedKvCache>>,
@@ -264,6 +357,8 @@ where
         let tracking_hash = TrackingHashContext::from_config(&kv_router_config)?;
         let tracking_model_name =
             resolve_tracking_model_name(tracking_hash.algorithm(), model_name.as_deref())?;
+        let kv_event_source_requirement =
+            KvEventSourceRequirement::derive(worker_role, &kv_router_config);
         let component = endpoint.component();
         // Router-owned tasks derive from this token so a rebuild cannot cancel the runtime.
         let cancellation_token = component.drt().child_token();
@@ -313,17 +408,16 @@ where
             overlap_scores_refresh,
             Some(overloaded_worker_provider),
             model_name.as_deref(),
-            worker_type,
+            metric_worker_type,
             cancellation_token.child_token(),
             Default::default(),
         )
         .await?;
 
         // Start KV event subscription if needed — skip when using a remote indexer.
-        let kv_event_subscription = if kv_router_config.use_remote_indexer {
-            tracing::info!("Skipping KV event subscription (using remote indexer)");
-            None
-        } else if kv_router_config.should_subscribe_to_kv_events() {
+        let kv_event_subscription = if kv_event_source_requirement
+            .should_subscribe(&kv_router_config)
+        {
             let membership_watch = kv_source_membership.ok_or_else(|| {
                 anyhow::anyhow!(
                     "KV source membership watch is required when local KV event subscription is enabled"
@@ -335,16 +429,20 @@ where
                     indexer.clone(),
                     membership_watch,
                     model_name.clone().unwrap_or_else(|| "unknown".to_string()),
-                    worker_type,
+                    worker_role,
+                    kv_event_source_requirement,
+                    metric_worker_type,
                     cancellation_token.child_token(),
                 )
                 .await?,
             )
         } else {
             tracing::info!(
-                "Skipping KV event subscription (use_kv_events={}, overlap_score_credit={})",
+                requirement = %kv_event_source_requirement,
+                "Skipping KV event subscription (use_kv_events={}, overlap_score_credit={}, use_remote_indexer={})",
                 kv_router_config.use_kv_events,
                 kv_router_config.overlap_score_credit,
+                kv_router_config.use_remote_indexer,
             );
             None
         };
@@ -405,6 +503,12 @@ where
         self.cancellation_token.cancel();
         if let Some(subscription) = self.kv_event_subscription.take() {
             subscription.shutdown().await;
+        }
+    }
+
+    pub(crate) fn stop_source_health_monitor(&self) {
+        if let Some(subscription) = &self.kv_event_subscription {
+            subscription.stop_source_health_monitor();
         }
     }
 
@@ -1344,6 +1448,90 @@ mod tests {
     }
 
     #[test]
+    fn kv_event_source_requirement_is_role_and_config_aware() {
+        let config = KvRouterConfig::default();
+        assert_eq!(
+            KvEventSourceRequirement::derive(Some(WorkerType::Prefill), &config),
+            KvEventSourceRequirement::CacheAwareRouting
+        );
+        assert_eq!(
+            KvEventSourceRequirement::derive(Some(WorkerType::Aggregated), &config),
+            KvEventSourceRequirement::CacheAwareRouting
+        );
+        assert_eq!(
+            KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config),
+            KvEventSourceRequirement::NotRequired
+        );
+        assert_eq!(
+            KvEventSourceRequirement::derive(Some(WorkerType::Encode), &config),
+            KvEventSourceRequirement::NotRequired
+        );
+        assert_eq!(
+            KvEventSourceRequirement::derive(None, &config),
+            KvEventSourceRequirement::Unknown
+        );
+
+        for policy in [
+            dynamo_kv_router::ConditionalDisaggPolicyKind::IslBounding,
+            dynamo_kv_router::ConditionalDisaggPolicyKind::PrefillLoad,
+            dynamo_kv_router::ConditionalDisaggPolicyKind::IslOrLoad,
+        ] {
+            let conditional = KvRouterConfig {
+                conditional_disagg_enabled: true,
+                conditional_disagg_policy: policy,
+                ..config.clone()
+            };
+            assert_eq!(
+                KvEventSourceRequirement::derive(Some(WorkerType::Decode), &conditional),
+                KvEventSourceRequirement::ConditionalDisaggDecodeCache
+            );
+        }
+    }
+
+    #[test]
+    fn non_local_indexers_never_require_kv_event_sources() {
+        let configurations = [
+            KvRouterConfig {
+                use_remote_indexer: true,
+                ..Default::default()
+            },
+            KvRouterConfig {
+                use_kv_events: false,
+                ..Default::default()
+            },
+            KvRouterConfig {
+                overlap_score_credit: 0.0,
+                ..Default::default()
+            },
+        ];
+
+        for config in configurations {
+            assert_eq!(
+                KvEventSourceRequirement::derive(None, &config),
+                KvEventSourceRequirement::Unknown
+            );
+            assert_eq!(
+                KvEventSourceRequirement::derive(Some(WorkerType::Aggregated), &config),
+                KvEventSourceRequirement::NotRequired
+            );
+            assert_eq!(
+                KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config),
+                KvEventSourceRequirement::NotRequired
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_role_preserves_configured_subscription_behavior() {
+        let config = KvRouterConfig::default();
+        assert!(KvEventSourceRequirement::Unknown.should_subscribe(&config));
+
+        let decode_requirement =
+            KvEventSourceRequirement::derive(Some(WorkerType::Decode), &config);
+        assert!(!decode_requirement.should_subscribe(&config));
+    }
+
+    #[test]
     fn weighted_cache_hit_estimates_include_lower_tiers() {
         let worker_1 = WorkerWithDpRank::new(1, 0);
         let worker_2 = WorkerWithDpRank::new(2, 0);
@@ -1458,6 +1646,54 @@ mod tests {
             .unwrap()
     }
 
+    async fn make_router_without_membership(worker_role: Option<WorkerType>) -> Result<KvRouter> {
+        let component = make_test_component("role-aware-subscription").await;
+        let endpoint = component.endpoint("backend");
+        let client = endpoint.client().await?;
+        let (_tx, workers) = watch::channel(HashMap::from([(7, ModelRuntimeConfig::default())]));
+        let config = KvRouterConfig {
+            skip_initial_worker_wait: true,
+            router_event_threads: 1,
+            ..Default::default()
+        };
+
+        KvRouter::new_with_worker_role(
+            endpoint,
+            client,
+            workers,
+            None,
+            16,
+            DefaultWorkerSelector::new(Some(config.clone()), "decode"),
+            Some(config),
+            None,
+            worker_role,
+            "decode",
+            None,
+            false,
+            None,
+            None,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn constructor_skips_sources_for_decode_but_preserves_unknown_behavior() {
+        let router = make_router_without_membership(Some(WorkerType::Decode))
+            .await
+            .expect("ordinary decode must not require KV source membership");
+        assert!(router.kv_event_subscription.is_none());
+
+        let error = make_router_without_membership(None)
+            .await
+            .err()
+            .expect("unknown role must preserve config-driven subscription");
+        assert!(
+            error
+                .to_string()
+                .contains("KV source membership watch is required")
+        );
+    }
+
     async fn make_test_router(
         selector: impl dynamo_kv_router::selector::WorkerSelector<ModelRuntimeConfig>
         + Send
@@ -1486,7 +1722,7 @@ mod tests {
             ..Default::default()
         };
 
-        KvRouter::new(
+        KvRouter::new_with_worker_role(
             endpoint,
             client,
             rx,
@@ -1494,6 +1730,7 @@ mod tests {
             2,
             selector,
             Some(config),
+            None,
             None,
             "decode",
             None,

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -29,7 +29,7 @@ use tokio_util::sync::CancellationToken;
 use super::{
     IndexerRecoveryTarget,
     subscriber::{
-        clear_mismatch_metric_on_cancellation, update_mismatch_metric,
+        MismatchMetricScope, clear_mismatch_metric_on_cancellation, update_mismatch_metric,
         update_subscription_failure_metric,
     },
     worker_query::{ReadyKvSource, WorkerQueryClient},
@@ -98,6 +98,7 @@ pub(super) async fn run_direct_zmq_supervisor(
     mut membership_watch: KvSourceMembershipWatch,
     model: String,
     worker_type: &'static str,
+    metric_scope: MismatchMetricScope,
     cancellation_token: CancellationToken,
     mut startup_ready: Option<oneshot::Sender<Result<(), String>>>,
 ) {
@@ -113,6 +114,7 @@ pub(super) async fn run_direct_zmq_supervisor(
             &model,
             worker_type,
             &serving_endpoint,
+            metric_scope,
         );
 
         let Some(kv_state_endpoint) = view.resolved_kv_state_endpoint().cloned() else {
@@ -153,6 +155,7 @@ pub(super) async fn run_direct_zmq_supervisor(
                     &model,
                     worker_type,
                     &serving_endpoint,
+                    metric_scope,
                 );
                 client
                     .sync_membership_with_ready_sources(&HashSet::new())
@@ -185,6 +188,7 @@ pub(super) async fn run_direct_zmq_supervisor(
             &model,
             worker_type,
             &serving_endpoint,
+            metric_scope,
             &cancellation_token,
         )
         .await;
@@ -200,6 +204,7 @@ pub(super) async fn run_direct_zmq_supervisor(
                     &model,
                     worker_type,
                     &serving_endpoint,
+                    metric_scope,
                 );
                 if !wait_for_retry(retry_delay, &mut membership_watch, &cancellation_token).await {
                     break;
@@ -231,6 +236,7 @@ async fn consume_scope(
     model: &str,
     worker_type: &str,
     serving_endpoint: &EndpointId,
+    metric_scope: MismatchMetricScope,
     cancellation_token: &CancellationToken,
 ) -> ScopeExit {
     let expected_scope = EventScope::Endpoint {
@@ -275,6 +281,7 @@ async fn consume_scope(
                     model,
                     worker_type,
                     serving_endpoint,
+                    metric_scope,
                 );
             }
             signal = signal_rx.recv() => {

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod direct_zmq;
+mod source_health;
 mod subscriber;
 mod target;
 mod worker_query;

--- a/lib/llm/src/kv_router/indexer/recovery/source_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/source_health.rs
@@ -1,0 +1,754 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    time::Duration,
+};
+
+use dynamo_kv_router::protocols::{WorkerId, WorkerWithDpRank};
+use dynamo_runtime::protocols::EndpointId;
+use tokio::{sync::oneshot, time::Instant};
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    discovery::{
+        KvSourceAmbiguity, KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus,
+    },
+    kv_router::KvEventSourceRequirement,
+    worker_type::WorkerType,
+};
+
+const SOURCE_JOIN_GRACE: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+enum DiagnosticCode {
+    PublisherDisabled,
+    SourceNotObserved,
+    SourceAmbiguous,
+    SourceRecovered,
+}
+
+impl DiagnosticCode {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::PublisherDisabled => "kv_event_publisher_disabled",
+            Self::SourceNotObserved => "kv_event_source_not_observed",
+            Self::SourceAmbiguous => "kv_event_source_ambiguous",
+            Self::SourceRecovered => "kv_event_source_recovered",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RankDiagnostic {
+    code: DiagnosticCode,
+    worker: WorkerWithDpRank,
+    kv_event_publishing_enabled: bool,
+    waited: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DeadlineToken {
+    worker: WorkerWithDpRank,
+    epoch: u64,
+    deadline: Instant,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum RankIssue {
+    Idle,
+    Pending {
+        code: DiagnosticCode,
+        since: Instant,
+        deadline: Instant,
+    },
+    Warned {
+        code: DiagnosticCode,
+        since: Instant,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RankHealth {
+    epoch: u64,
+    lifecycle_generation: u64,
+    issue: RankIssue,
+}
+
+impl RankHealth {
+    fn new(epoch: u64, lifecycle_generation: u64) -> Self {
+        Self {
+            epoch,
+            lifecycle_generation,
+            issue: RankIssue::Idle,
+        }
+    }
+}
+
+struct SourceHealthState {
+    requirement: KvEventSourceRequirement,
+    ranks: HashMap<WorkerWithDpRank, RankHealth>,
+    next_epoch: u64,
+}
+
+impl SourceHealthState {
+    fn new(requirement: KvEventSourceRequirement) -> Self {
+        Self {
+            requirement,
+            ranks: HashMap::new(),
+            next_epoch: 1,
+        }
+    }
+
+    fn reconcile(&mut self, view: &KvSourceMembershipView, now: Instant) -> Vec<RankDiagnostic> {
+        if !self.requirement.requires_source() {
+            self.ranks.clear();
+            return Vec::new();
+        }
+
+        let present: HashSet<_> = view.sources.keys().copied().collect();
+        self.ranks.retain(|worker, _| present.contains(worker));
+
+        let mut diagnostics = Vec::new();
+        for (&worker, status) in &view.sources {
+            let capability = view.kv_event_publishing_enabled(worker.worker_id);
+            let generation = view.lifecycle_generation(&worker).unwrap_or(0);
+            self.reconcile_rank(
+                worker,
+                status,
+                capability,
+                view.observation_state.is_bound(),
+                generation,
+                now,
+                &mut diagnostics,
+            );
+        }
+        diagnostics
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn reconcile_rank(
+        &mut self,
+        worker: WorkerWithDpRank,
+        status: &KvSourceStatus,
+        capability: Option<bool>,
+        observation_bound: bool,
+        lifecycle_generation: u64,
+        now: Instant,
+        diagnostics: &mut Vec<RankDiagnostic>,
+    ) {
+        let Some(capability) = capability else {
+            self.ranks.remove(&worker);
+            return;
+        };
+
+        let mut state = self
+            .ranks
+            .remove(&worker)
+            .unwrap_or_else(|| RankHealth::new(self.take_epoch(), lifecycle_generation));
+        let generation_changed = state.lifecycle_generation != lifecycle_generation;
+        state.lifecycle_generation = lifecycle_generation;
+
+        if !capability {
+            self.set_immediate_issue(
+                worker,
+                &mut state,
+                DiagnosticCode::PublisherDisabled,
+                false,
+                now,
+                diagnostics,
+            );
+            self.ranks.insert(worker, state);
+            return;
+        }
+
+        match status {
+            KvSourceStatus::ActiveRecoverable(_) | KvSourceStatus::ActiveLiveOnly(_) => {
+                if let RankIssue::Warned { since, .. } = state.issue {
+                    diagnostics.push(RankDiagnostic {
+                        code: DiagnosticCode::SourceRecovered,
+                        worker,
+                        kv_event_publishing_enabled: true,
+                        waited: now.saturating_duration_since(since),
+                    });
+                }
+                self.set_issue(&mut state, RankIssue::Idle);
+            }
+            KvSourceStatus::Missing if observation_bound => {
+                let keep_existing = matches!(
+                    state.issue,
+                    RankIssue::Pending {
+                        code: DiagnosticCode::SourceNotObserved,
+                        ..
+                    } | RankIssue::Warned {
+                        code: DiagnosticCode::SourceNotObserved,
+                        ..
+                    }
+                ) && !generation_changed;
+                if !keep_existing {
+                    self.set_issue(
+                        &mut state,
+                        RankIssue::Pending {
+                            code: DiagnosticCode::SourceNotObserved,
+                            since: now,
+                            deadline: now + SOURCE_JOIN_GRACE,
+                        },
+                    );
+                }
+            }
+            KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping { .. }) => {
+                self.set_immediate_issue(
+                    worker,
+                    &mut state,
+                    DiagnosticCode::SourceAmbiguous,
+                    true,
+                    now,
+                    diagnostics,
+                );
+            }
+            KvSourceStatus::Ambiguous(_) if observation_bound => {
+                self.set_immediate_issue(
+                    worker,
+                    &mut state,
+                    DiagnosticCode::SourceAmbiguous,
+                    true,
+                    now,
+                    diagnostics,
+                );
+            }
+            KvSourceStatus::Missing | KvSourceStatus::Ambiguous(_) => {
+                if matches!(state.issue, RankIssue::Pending { .. }) {
+                    self.set_issue(&mut state, RankIssue::Idle);
+                }
+            }
+        }
+
+        self.ranks.insert(worker, state);
+    }
+
+    fn set_immediate_issue(
+        &mut self,
+        worker: WorkerWithDpRank,
+        state: &mut RankHealth,
+        code: DiagnosticCode,
+        capability: bool,
+        now: Instant,
+        diagnostics: &mut Vec<RankDiagnostic>,
+    ) {
+        if matches!(state.issue, RankIssue::Warned { code: current, .. } if current == code) {
+            return;
+        }
+        diagnostics.push(RankDiagnostic {
+            code,
+            worker,
+            kv_event_publishing_enabled: capability,
+            waited: Duration::ZERO,
+        });
+        self.set_issue(state, RankIssue::Warned { code, since: now });
+    }
+
+    fn set_issue(&mut self, state: &mut RankHealth, issue: RankIssue) {
+        state.epoch = self.take_epoch();
+        state.issue = issue;
+    }
+
+    fn take_epoch(&mut self) -> u64 {
+        let epoch = self.next_epoch;
+        self.next_epoch = self.next_epoch.wrapping_add(1);
+        epoch
+    }
+
+    fn next_deadline(&self) -> Option<DeadlineToken> {
+        self.ranks
+            .iter()
+            .filter_map(|(&worker, state)| {
+                let RankIssue::Pending { deadline, .. } = state.issue else {
+                    return None;
+                };
+                Some(DeadlineToken {
+                    worker,
+                    epoch: state.epoch,
+                    deadline,
+                })
+            })
+            .min_by_key(|token| token.deadline)
+    }
+
+    fn fire_deadline(&mut self, token: DeadlineToken, now: Instant) -> Vec<RankDiagnostic> {
+        let Some(state) = self.ranks.get(&token.worker) else {
+            return Vec::new();
+        };
+        if state.epoch != token.epoch {
+            return Vec::new();
+        }
+        let RankIssue::Pending { deadline, .. } = state.issue else {
+            return Vec::new();
+        };
+        if deadline != token.deadline || deadline > now {
+            return Vec::new();
+        }
+
+        let due: Vec<_> = self
+            .ranks
+            .iter()
+            .filter_map(|(&worker, state)| {
+                let RankIssue::Pending {
+                    code,
+                    since,
+                    deadline,
+                } = state.issue
+                else {
+                    return None;
+                };
+                (deadline <= now).then_some((worker, code, since))
+            })
+            .collect();
+        let mut diagnostics = Vec::with_capacity(due.len());
+        for (worker, code, since) in due {
+            let epoch = self.take_epoch();
+            let state = self
+                .ranks
+                .get_mut(&worker)
+                .expect("due rank came from health map");
+            state.epoch = epoch;
+            state.issue = RankIssue::Warned { code, since };
+            diagnostics.push(RankDiagnostic {
+                code,
+                worker,
+                kv_event_publishing_enabled: true,
+                waited: now.saturating_duration_since(since),
+            });
+        }
+        diagnostics
+    }
+}
+
+#[derive(Debug)]
+struct AggregatedDiagnostic {
+    code: DiagnosticCode,
+    worker_id: WorkerId,
+    kv_event_publishing_enabled: bool,
+    waited_ms: u64,
+    dp_ranks: Vec<u32>,
+}
+
+fn aggregate_diagnostics(diagnostics: Vec<RankDiagnostic>) -> Vec<AggregatedDiagnostic> {
+    let mut grouped = BTreeMap::<(DiagnosticCode, WorkerId, bool), (u64, Vec<u32>)>::new();
+    for diagnostic in diagnostics {
+        let waited_ms = diagnostic.waited.as_millis().min(u128::from(u64::MAX)) as u64;
+        let entry = grouped
+            .entry((
+                diagnostic.code,
+                diagnostic.worker.worker_id,
+                diagnostic.kv_event_publishing_enabled,
+            ))
+            .or_default();
+        entry.0 = entry.0.max(waited_ms);
+        entry.1.push(diagnostic.worker.dp_rank);
+    }
+    grouped
+        .into_iter()
+        .map(
+            |((code, worker_id, kv_event_publishing_enabled), (waited_ms, mut dp_ranks))| {
+                dp_ranks.sort_unstable();
+                AggregatedDiagnostic {
+                    code,
+                    worker_id,
+                    kv_event_publishing_enabled,
+                    waited_ms,
+                    dp_ranks,
+                }
+            },
+        )
+        .collect()
+}
+
+struct DiagnosticContext<'a> {
+    model: &'a str,
+    worker_role: Option<WorkerType>,
+    requirement: KvEventSourceRequirement,
+    serving_endpoint: &'a EndpointId,
+}
+
+fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<RankDiagnostic>) {
+    let worker_role = context
+        .worker_role
+        .map(|role| role.as_str())
+        .unwrap_or("unknown");
+    for diagnostic in aggregate_diagnostics(diagnostics) {
+        let diagnostic_code = diagnostic.code.as_str();
+        let requirement = context.requirement.as_str();
+        let rank_count = diagnostic.dp_ranks.len();
+        let dp_ranks = diagnostic
+            .dp_ranks
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        if diagnostic.code == DiagnosticCode::SourceRecovered {
+            tracing::info!(
+                diagnostic_code,
+                model = context.model,
+                worker_role,
+                requirement,
+                worker_id = diagnostic.worker_id,
+                serving_endpoint = %context.serving_endpoint,
+                kv_event_publishing_enabled = diagnostic.kv_event_publishing_enabled,
+                waited_ms = diagnostic.waited_ms,
+                rank_count,
+                dp_ranks = %dp_ranks,
+                "KV event source recovered"
+            );
+        } else {
+            tracing::warn!(
+                diagnostic_code,
+                model = context.model,
+                worker_role,
+                requirement,
+                worker_id = diagnostic.worker_id,
+                serving_endpoint = %context.serving_endpoint,
+                kv_event_publishing_enabled = diagnostic.kv_event_publishing_enabled,
+                waited_ms = diagnostic.waited_ms,
+                rank_count,
+                dp_ranks = %dp_ranks,
+                "KV event source health warning"
+            );
+        }
+    }
+}
+
+pub(super) fn spawn(
+    mut membership_watch: KvSourceMembershipWatch,
+    model: String,
+    worker_role: Option<WorkerType>,
+    requirement: KvEventSourceRequirement,
+    serving_endpoint: EndpointId,
+    cancellation_token: CancellationToken,
+) -> oneshot::Receiver<()> {
+    let (completion_tx, completion_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let mut state = SourceHealthState::new(requirement);
+        let context = DiagnosticContext {
+            model: &model,
+            worker_role,
+            requirement,
+            serving_endpoint: &serving_endpoint,
+        };
+        let initial = membership_watch.borrow_and_update().clone();
+        emit_diagnostics(&context, state.reconcile(&initial, Instant::now()));
+
+        loop {
+            let Some(deadline) = state.next_deadline() else {
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => break,
+                    changed = membership_watch.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                        let view = membership_watch.borrow_and_update().clone();
+                        emit_diagnostics(&context, state.reconcile(&view, Instant::now()));
+                    }
+                }
+                continue;
+            };
+
+            tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => break,
+                changed = membership_watch.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    let now = Instant::now();
+                    let view = membership_watch.borrow_and_update().clone();
+                    let mut diagnostics = state.reconcile(&view, now);
+                    if let Some(current) = state.next_deadline()
+                        && current.deadline <= now
+                    {
+                        diagnostics.extend(state.fire_deadline(current, now));
+                    }
+                    emit_diagnostics(&context, diagnostics);
+                }
+                _ = tokio::time::sleep_until(deadline.deadline) => {
+                    // Re-read membership before using the wake-up token. A removal, rejoin, or
+                    // source arrival invalidates the per-rank epoch and suppresses the stale alarm.
+                    let now = Instant::now();
+                    let view = membership_watch.borrow_and_update().clone();
+                    let mut diagnostics = state.reconcile(&view, now);
+                    diagnostics.extend(state.fire_deadline(deadline, now));
+                    emit_diagnostics(&context, diagnostics);
+                }
+            }
+        }
+        let _ = completion_tx.send(());
+    });
+    completion_rx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::{KvEventSource, KvSourceObservationState, KvStateEndpointResolution};
+
+    fn endpoint() -> EndpointId {
+        EndpointId {
+            namespace: "ns".to_string(),
+            component: "worker".to_string(),
+            name: "generate".to_string(),
+        }
+    }
+
+    fn view(
+        observation_state: KvSourceObservationState,
+        capabilities: impl IntoIterator<Item = (WorkerId, Option<bool>)>,
+        statuses: impl IntoIterator<Item = (WorkerWithDpRank, KvSourceStatus)>,
+    ) -> KvSourceMembershipView {
+        let endpoint = endpoint();
+        let sources: HashMap<_, _> = statuses.into_iter().collect();
+        KvSourceMembershipView {
+            serving_endpoint: endpoint.clone(),
+            endpoint_resolution: KvStateEndpointResolution::Resolved(endpoint),
+            observation_state,
+            lifecycle_generations: sources.keys().map(|worker| (*worker, 0)).collect(),
+            recovery_expected: HashMap::new(),
+            kv_event_publishing_enabled: capabilities.into_iter().collect(),
+            sources,
+        }
+    }
+
+    fn active(worker: WorkerWithDpRank) -> KvSourceStatus {
+        KvSourceStatus::ActiveLiveOnly(KvEventSource {
+            kv_state_endpoint: endpoint(),
+            worker,
+            publisher_id: 17,
+            recovery_target: None,
+        })
+    }
+
+    fn required_state() -> SourceHealthState {
+        SourceHealthState::new(KvEventSourceRequirement::CacheAwareRouting)
+    }
+
+    #[test]
+    fn disabled_capability_warns_immediately_and_once() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let view = view(
+            KvSourceObservationState::Rebinding,
+            [(7, Some(false))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        let diagnostics = state.reconcile(&view, now);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::PublisherDisabled);
+        assert!(!diagnostics[0].kv_event_publishing_enabled);
+        assert!(state.reconcile(&view, now).is_empty());
+    }
+
+    #[test]
+    fn missing_source_waits_full_grace_and_active_source_recovers_once() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let missing = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        assert!(state.reconcile(&missing, now).is_empty());
+        let deadline = state.next_deadline().expect("missing source has deadline");
+        assert!(
+            state
+                .fire_deadline(deadline, deadline.deadline - Duration::from_nanos(1))
+                .is_empty()
+        );
+        let diagnostics = state.fire_deadline(deadline, deadline.deadline);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceNotObserved);
+        assert_eq!(diagnostics[0].waited, SOURCE_JOIN_GRACE);
+
+        let active = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, active(worker))],
+        );
+        let recovered = state.reconcile(&active, deadline.deadline + Duration::from_secs(1));
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].code, DiagnosticCode::SourceRecovered);
+        assert!(
+            state
+                .reconcile(&active, deadline.deadline + Duration::from_secs(32))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn rebinding_resets_pending_grace_and_fences_old_deadline() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let bound_missing = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let rebinding = view(
+            KvSourceObservationState::Rebinding,
+            [(7, Some(true))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        state.reconcile(&bound_missing, now);
+        let stale = state.next_deadline().unwrap();
+        state.reconcile(&rebinding, now + Duration::from_secs(20));
+        assert!(state.next_deadline().is_none());
+        state.reconcile(&bound_missing, now + Duration::from_secs(25));
+        let fresh = state.next_deadline().unwrap();
+        assert_ne!(fresh.epoch, stale.epoch);
+        assert!(
+            state
+                .fire_deadline(stale, now + SOURCE_JOIN_GRACE)
+                .is_empty()
+        );
+        assert_eq!(
+            state.fire_deadline(fresh, fresh.deadline)[0].code,
+            DiagnosticCode::SourceNotObserved
+        );
+    }
+
+    #[test]
+    fn remove_and_rejoin_fences_old_deadline() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let missing = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let removed = view(
+            KvSourceObservationState::Bound,
+            std::iter::empty(),
+            std::iter::empty(),
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        state.reconcile(&missing, now);
+        let stale = state.next_deadline().unwrap();
+        state.reconcile(&removed, now + Duration::from_secs(1));
+        state.reconcile(&missing, now + Duration::from_secs(2));
+        let fresh = state.next_deadline().unwrap();
+        assert_ne!(fresh.epoch, stale.epoch);
+        assert!(state.fire_deadline(stale, stale.deadline).is_empty());
+        assert_eq!(
+            state.fire_deadline(fresh, fresh.deadline)[0].code,
+            DiagnosticCode::SourceNotObserved
+        );
+    }
+
+    #[test]
+    fn ambiguity_warns_once_then_active_emits_one_recovery() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let ambiguity = crate::discovery::KvSourceAmbiguity::Incarnations {
+            publisher_ids: vec![1, 2],
+        };
+        let ambiguous = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, KvSourceStatus::Ambiguous(ambiguity))],
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        let diagnostics = state.reconcile(&ambiguous, now);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceAmbiguous);
+        assert!(state.reconcile(&ambiguous, now).is_empty());
+
+        let active = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(true))],
+            [(worker, active(worker))],
+        );
+        assert_eq!(
+            state.reconcile(&active, now + Duration::from_secs(1))[0].code,
+            DiagnosticCode::SourceRecovered
+        );
+        assert!(
+            state
+                .reconcile(&active, now + Duration::from_secs(2))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn endpoint_mapping_ambiguity_warns_while_source_watch_is_unbound() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let ambiguous = view(
+            KvSourceObservationState::Rebinding,
+            [(7, Some(true))],
+            [(
+                worker,
+                KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping {
+                    endpoints: vec![endpoint()],
+                }),
+            )],
+        );
+        let now = Instant::now();
+        let mut state = required_state();
+
+        let diagnostics = state.reconcile(&ambiguous, now);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceAmbiguous);
+        assert!(state.reconcile(&ambiguous, now).is_empty());
+    }
+
+    #[test]
+    fn unknown_capability_and_unknown_requirement_are_silent() {
+        let worker = WorkerWithDpRank::new(7, 0);
+        let unknown_capability = view(
+            KvSourceObservationState::Bound,
+            [(7, None)],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let now = Instant::now();
+        let mut required = required_state();
+        assert!(required.reconcile(&unknown_capability, now).is_empty());
+        assert!(required.next_deadline().is_none());
+
+        let disabled = view(
+            KvSourceObservationState::Bound,
+            [(7, Some(false))],
+            [(worker, KvSourceStatus::Missing)],
+        );
+        let mut unknown = SourceHealthState::new(KvEventSourceRequirement::Unknown);
+        assert!(unknown.reconcile(&disabled, now).is_empty());
+        assert!(unknown.next_deadline().is_none());
+    }
+
+    #[test]
+    fn diagnostics_aggregate_by_worker_and_code() {
+        let diagnostics = aggregate_diagnostics(vec![
+            RankDiagnostic {
+                code: DiagnosticCode::SourceNotObserved,
+                worker: WorkerWithDpRank::new(7, 3),
+                kv_event_publishing_enabled: true,
+                waited: Duration::from_secs(30),
+            },
+            RankDiagnostic {
+                code: DiagnosticCode::SourceNotObserved,
+                worker: WorkerWithDpRank::new(7, 1),
+                kv_event_publishing_enabled: true,
+                waited: Duration::from_secs(31),
+            },
+        ]);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].worker_id, 7);
+        assert_eq!(diagnostics[0].waited_ms, 31_000);
+        assert_eq!(diagnostics[0].dp_ranks, vec![1, 3]);
+    }
+}

--- a/lib/llm/src/kv_router/indexer/recovery/source_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/source_health.rs
@@ -2,26 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{BTreeMap, HashMap},
     time::Duration,
 };
 
-use dynamo_kv_router::protocols::{WorkerId, WorkerWithDpRank};
+use dynamo_kv_router::protocols::WorkerId;
 use dynamo_runtime::protocols::EndpointId;
 use tokio::{sync::oneshot, time::Instant};
 use tokio_util::sync::CancellationToken;
 
 use crate::{
-    discovery::{
-        KvSourceAmbiguity, KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus,
-    },
+    discovery::{KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus},
     kv_router::KvEventSourceRequirement,
     worker_type::WorkerType,
 };
 
 const SOURCE_JOIN_GRACE: Duration = Duration::from_secs(30);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DiagnosticCode {
     PublisherDisabled,
     SourceNotObserved,
@@ -41,327 +39,215 @@ impl DiagnosticCode {
 }
 
 #[derive(Debug, Clone)]
-struct RankDiagnostic {
+struct Diagnostic {
     code: DiagnosticCode,
-    worker: WorkerWithDpRank,
+    worker_id: WorkerId,
     kv_event_publishing_enabled: bool,
     waited: Duration,
+    dp_ranks: Vec<u32>,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DeadlineToken {
-    worker: WorkerWithDpRank,
-    epoch: u64,
-    deadline: Instant,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum RankIssue {
-    Idle,
-    Pending {
-        code: DiagnosticCode,
-        since: Instant,
-        deadline: Instant,
-    },
+#[derive(Debug, Clone)]
+enum WorkerIssue {
+    MissingSince(Instant),
     Warned {
         code: DiagnosticCode,
         since: Instant,
+        dp_ranks: Vec<u32>,
     },
-}
-
-#[derive(Debug, Clone, Copy)]
-struct RankHealth {
-    epoch: u64,
-    lifecycle_generation: u64,
-    issue: RankIssue,
-}
-
-impl RankHealth {
-    fn new(epoch: u64, lifecycle_generation: u64) -> Self {
-        Self {
-            epoch,
-            lifecycle_generation,
-            issue: RankIssue::Idle,
-        }
-    }
 }
 
 struct SourceHealthState {
     requirement: KvEventSourceRequirement,
-    ranks: HashMap<WorkerWithDpRank, RankHealth>,
-    next_epoch: u64,
+    issues: HashMap<WorkerId, WorkerIssue>,
 }
 
 impl SourceHealthState {
     fn new(requirement: KvEventSourceRequirement) -> Self {
         Self {
             requirement,
-            ranks: HashMap::new(),
-            next_epoch: 1,
+            issues: HashMap::new(),
         }
     }
 
-    fn reconcile(&mut self, view: &KvSourceMembershipView, now: Instant) -> Vec<RankDiagnostic> {
+    fn reconcile(&mut self, view: &KvSourceMembershipView, now: Instant) -> Vec<Diagnostic> {
         if !self.requirement.requires_source() {
-            self.ranks.clear();
+            self.issues.clear();
             return Vec::new();
         }
 
-        let present: HashSet<_> = view.sources.keys().copied().collect();
-        self.ranks.retain(|worker, _| present.contains(worker));
+        let mut workers = BTreeMap::<WorkerId, Vec<(u32, &KvSourceStatus)>>::new();
+        for (worker, status) in &view.sources {
+            workers
+                .entry(worker.worker_id)
+                .or_default()
+                .push((worker.dp_rank, status));
+        }
+        self.issues
+            .retain(|worker_id, _| workers.contains_key(worker_id));
 
         let mut diagnostics = Vec::new();
-        for (&worker, status) in &view.sources {
-            let capability = view.kv_event_publishing_enabled(worker.worker_id);
-            let generation = view.lifecycle_generation(&worker).unwrap_or(0);
-            self.reconcile_rank(
-                worker,
-                status,
-                capability,
-                view.observation_state.is_bound(),
-                generation,
-                now,
-                &mut diagnostics,
-            );
+        for (worker_id, statuses) in workers {
+            let previous = self.issues.remove(&worker_id);
+            let capability = view.kv_event_publishing_enabled(worker_id);
+            let (next, diagnostic) =
+                reconcile_worker(worker_id, statuses, capability, previous, now);
+            if let Some(next) = next {
+                self.issues.insert(worker_id, next);
+            }
+            if let Some(diagnostic) = diagnostic {
+                diagnostics.push(diagnostic);
+            }
         }
         diagnostics
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn reconcile_rank(
-        &mut self,
-        worker: WorkerWithDpRank,
-        status: &KvSourceStatus,
-        capability: Option<bool>,
-        observation_bound: bool,
-        lifecycle_generation: u64,
-        now: Instant,
-        diagnostics: &mut Vec<RankDiagnostic>,
-    ) {
-        let Some(capability) = capability else {
-            self.ranks.remove(&worker);
-            return;
-        };
-
-        let mut state = self
-            .ranks
-            .remove(&worker)
-            .unwrap_or_else(|| RankHealth::new(self.take_epoch(), lifecycle_generation));
-        let generation_changed = state.lifecycle_generation != lifecycle_generation;
-        state.lifecycle_generation = lifecycle_generation;
-
-        if !capability {
-            self.set_immediate_issue(
-                worker,
-                &mut state,
-                DiagnosticCode::PublisherDisabled,
-                false,
-                now,
-                diagnostics,
-            );
-            self.ranks.insert(worker, state);
-            return;
-        }
-
-        match status {
-            KvSourceStatus::ActiveRecoverable(_) | KvSourceStatus::ActiveLiveOnly(_) => {
-                if let RankIssue::Warned { since, .. } = state.issue {
-                    diagnostics.push(RankDiagnostic {
-                        code: DiagnosticCode::SourceRecovered,
-                        worker,
-                        kv_event_publishing_enabled: true,
-                        waited: now.saturating_duration_since(since),
-                    });
-                }
-                self.set_issue(&mut state, RankIssue::Idle);
-            }
-            KvSourceStatus::Missing if observation_bound => {
-                let keep_existing = matches!(
-                    state.issue,
-                    RankIssue::Pending {
-                        code: DiagnosticCode::SourceNotObserved,
-                        ..
-                    } | RankIssue::Warned {
-                        code: DiagnosticCode::SourceNotObserved,
-                        ..
-                    }
-                ) && !generation_changed;
-                if !keep_existing {
-                    self.set_issue(
-                        &mut state,
-                        RankIssue::Pending {
-                            code: DiagnosticCode::SourceNotObserved,
-                            since: now,
-                            deadline: now + SOURCE_JOIN_GRACE,
-                        },
-                    );
-                }
-            }
-            KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping { .. }) => {
-                self.set_immediate_issue(
-                    worker,
-                    &mut state,
-                    DiagnosticCode::SourceAmbiguous,
-                    true,
-                    now,
-                    diagnostics,
-                );
-            }
-            KvSourceStatus::Ambiguous(_) if observation_bound => {
-                self.set_immediate_issue(
-                    worker,
-                    &mut state,
-                    DiagnosticCode::SourceAmbiguous,
-                    true,
-                    now,
-                    diagnostics,
-                );
-            }
-            KvSourceStatus::Missing | KvSourceStatus::Ambiguous(_) => {
-                if matches!(state.issue, RankIssue::Pending { .. }) {
-                    self.set_issue(&mut state, RankIssue::Idle);
-                }
-            }
-        }
-
-        self.ranks.insert(worker, state);
-    }
-
-    fn set_immediate_issue(
-        &mut self,
-        worker: WorkerWithDpRank,
-        state: &mut RankHealth,
-        code: DiagnosticCode,
-        capability: bool,
-        now: Instant,
-        diagnostics: &mut Vec<RankDiagnostic>,
-    ) {
-        if matches!(state.issue, RankIssue::Warned { code: current, .. } if current == code) {
-            return;
-        }
-        diagnostics.push(RankDiagnostic {
-            code,
-            worker,
-            kv_event_publishing_enabled: capability,
-            waited: Duration::ZERO,
-        });
-        self.set_issue(state, RankIssue::Warned { code, since: now });
-    }
-
-    fn set_issue(&mut self, state: &mut RankHealth, issue: RankIssue) {
-        state.epoch = self.take_epoch();
-        state.issue = issue;
-    }
-
-    fn take_epoch(&mut self) -> u64 {
-        let epoch = self.next_epoch;
-        self.next_epoch = self.next_epoch.wrapping_add(1);
-        epoch
-    }
-
-    fn next_deadline(&self) -> Option<DeadlineToken> {
-        self.ranks
-            .iter()
-            .filter_map(|(&worker, state)| {
-                let RankIssue::Pending { deadline, .. } = state.issue else {
-                    return None;
-                };
-                Some(DeadlineToken {
-                    worker,
-                    epoch: state.epoch,
-                    deadline,
-                })
+    fn next_deadline(&self) -> Option<Instant> {
+        self.issues
+            .values()
+            .filter_map(|issue| match issue {
+                WorkerIssue::MissingSince(since) => Some(*since + SOURCE_JOIN_GRACE),
+                WorkerIssue::Warned { .. } => None,
             })
-            .min_by_key(|token| token.deadline)
+            .min()
+    }
+}
+
+fn reconcile_worker(
+    worker_id: WorkerId,
+    mut statuses: Vec<(u32, &KvSourceStatus)>,
+    capability: Option<bool>,
+    previous: Option<WorkerIssue>,
+    now: Instant,
+) -> (Option<WorkerIssue>, Option<Diagnostic>) {
+    let Some(capability) = capability else {
+        return (None, None);
+    };
+
+    statuses.sort_unstable_by_key(|(rank, _)| *rank);
+    let all_ranks = || statuses.iter().map(|(rank, _)| *rank).collect::<Vec<_>>();
+
+    if !capability {
+        return immediate_warning(
+            worker_id,
+            DiagnosticCode::PublisherDisabled,
+            false,
+            all_ranks(),
+            previous,
+            now,
+        );
     }
 
-    fn fire_deadline(&mut self, token: DeadlineToken, now: Instant) -> Vec<RankDiagnostic> {
-        let Some(state) = self.ranks.get(&token.worker) else {
-            return Vec::new();
-        };
-        if state.epoch != token.epoch {
-            return Vec::new();
-        }
-        let RankIssue::Pending { deadline, .. } = state.issue else {
-            return Vec::new();
-        };
-        if deadline != token.deadline || deadline > now {
-            return Vec::new();
-        }
+    let ambiguous_ranks = statuses
+        .iter()
+        .filter_map(|(rank, status)| {
+            matches!(status, KvSourceStatus::Ambiguous(_)).then_some(*rank)
+        })
+        .collect::<Vec<_>>();
+    if !ambiguous_ranks.is_empty() {
+        return immediate_warning(
+            worker_id,
+            DiagnosticCode::SourceAmbiguous,
+            true,
+            ambiguous_ranks,
+            previous,
+            now,
+        );
+    }
 
-        let due: Vec<_> = self
-            .ranks
-            .iter()
-            .filter_map(|(&worker, state)| {
-                let RankIssue::Pending {
-                    code,
-                    since,
-                    deadline,
-                } = state.issue
-                else {
-                    return None;
-                };
-                (deadline <= now).then_some((worker, code, since))
-            })
-            .collect();
-        let mut diagnostics = Vec::with_capacity(due.len());
-        for (worker, code, since) in due {
-            let epoch = self.take_epoch();
-            let state = self
-                .ranks
-                .get_mut(&worker)
-                .expect("due rank came from health map");
-            state.epoch = epoch;
-            state.issue = RankIssue::Warned { code, since };
-            diagnostics.push(RankDiagnostic {
-                code,
-                worker,
+    let missing_ranks = statuses
+        .iter()
+        .filter_map(|(rank, status)| matches!(status, KvSourceStatus::Missing).then_some(*rank))
+        .collect::<Vec<_>>();
+    if !missing_ranks.is_empty() {
+        return missing_source(worker_id, missing_ranks, previous, now);
+    }
+
+    match previous {
+        Some(WorkerIssue::Warned {
+            since, dp_ranks, ..
+        }) => (
+            None,
+            Some(Diagnostic {
+                code: DiagnosticCode::SourceRecovered,
+                worker_id,
                 kv_event_publishing_enabled: true,
                 waited: now.saturating_duration_since(since),
-            });
-        }
-        diagnostics
+                dp_ranks,
+            }),
+        ),
+        Some(WorkerIssue::MissingSince(_)) | None => (None, None),
     }
 }
 
-#[derive(Debug)]
-struct AggregatedDiagnostic {
-    code: DiagnosticCode,
+fn immediate_warning(
     worker_id: WorkerId,
-    kv_event_publishing_enabled: bool,
-    waited_ms: u64,
+    code: DiagnosticCode,
+    capability: bool,
     dp_ranks: Vec<u32>,
+    previous: Option<WorkerIssue>,
+    now: Instant,
+) -> (Option<WorkerIssue>, Option<Diagnostic>) {
+    if matches!(
+        previous,
+        Some(WorkerIssue::Warned {
+            code: current,
+            ..
+        }) if current == code
+    ) {
+        return (previous, None);
+    }
+
+    (
+        Some(WorkerIssue::Warned {
+            code,
+            since: now,
+            dp_ranks: dp_ranks.clone(),
+        }),
+        Some(Diagnostic {
+            code,
+            worker_id,
+            kv_event_publishing_enabled: capability,
+            waited: Duration::ZERO,
+            dp_ranks,
+        }),
+    )
 }
 
-fn aggregate_diagnostics(diagnostics: Vec<RankDiagnostic>) -> Vec<AggregatedDiagnostic> {
-    let mut grouped = BTreeMap::<(DiagnosticCode, WorkerId, bool), (u64, Vec<u32>)>::new();
-    for diagnostic in diagnostics {
-        let waited_ms = diagnostic.waited.as_millis().min(u128::from(u64::MAX)) as u64;
-        let entry = grouped
-            .entry((
-                diagnostic.code,
-                diagnostic.worker.worker_id,
-                diagnostic.kv_event_publishing_enabled,
-            ))
-            .or_default();
-        entry.0 = entry.0.max(waited_ms);
-        entry.1.push(diagnostic.worker.dp_rank);
-    }
-    grouped
-        .into_iter()
-        .map(
-            |((code, worker_id, kv_event_publishing_enabled), (waited_ms, mut dp_ranks))| {
-                dp_ranks.sort_unstable();
-                AggregatedDiagnostic {
-                    code,
-                    worker_id,
-                    kv_event_publishing_enabled,
-                    waited_ms,
-                    dp_ranks,
-                }
+fn missing_source(
+    worker_id: WorkerId,
+    dp_ranks: Vec<u32>,
+    previous: Option<WorkerIssue>,
+    now: Instant,
+) -> (Option<WorkerIssue>, Option<Diagnostic>) {
+    match previous {
+        Some(
+            issue @ WorkerIssue::Warned {
+                code: DiagnosticCode::SourceNotObserved,
+                ..
             },
-        )
-        .collect()
+        ) => (Some(issue), None),
+        Some(WorkerIssue::MissingSince(since))
+            if now.saturating_duration_since(since) >= SOURCE_JOIN_GRACE =>
+        {
+            (
+                Some(WorkerIssue::Warned {
+                    code: DiagnosticCode::SourceNotObserved,
+                    since,
+                    dp_ranks: dp_ranks.clone(),
+                }),
+                Some(Diagnostic {
+                    code: DiagnosticCode::SourceNotObserved,
+                    worker_id,
+                    kv_event_publishing_enabled: true,
+                    waited: now.saturating_duration_since(since),
+                    dp_ranks,
+                }),
+            )
+        }
+        Some(WorkerIssue::MissingSince(since)) => (Some(WorkerIssue::MissingSince(since)), None),
+        Some(WorkerIssue::Warned { .. }) | None => (Some(WorkerIssue::MissingSince(now)), None),
+    }
 }
 
 struct DiagnosticContext<'a> {
@@ -371,14 +257,15 @@ struct DiagnosticContext<'a> {
     serving_endpoint: &'a EndpointId,
 }
 
-fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<RankDiagnostic>) {
+fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<Diagnostic>) {
     let worker_role = context
         .worker_role
         .map(|role| role.as_str())
         .unwrap_or("unknown");
-    for diagnostic in aggregate_diagnostics(diagnostics) {
+    for diagnostic in diagnostics {
         let diagnostic_code = diagnostic.code.as_str();
         let requirement = context.requirement.as_str();
+        let waited_ms = diagnostic.waited.as_millis().min(u128::from(u64::MAX)) as u64;
         let rank_count = diagnostic.dp_ranks.len();
         let dp_ranks = diagnostic
             .dp_ranks
@@ -395,7 +282,7 @@ fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<RankDiagno
                 worker_id = diagnostic.worker_id,
                 serving_endpoint = %context.serving_endpoint,
                 kv_event_publishing_enabled = diagnostic.kv_event_publishing_enabled,
-                waited_ms = diagnostic.waited_ms,
+                waited_ms,
                 rank_count,
                 dp_ranks = %dp_ranks,
                 "KV event source recovered"
@@ -409,7 +296,7 @@ fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<RankDiagno
                 worker_id = diagnostic.worker_id,
                 serving_endpoint = %context.serving_endpoint,
                 kv_event_publishing_enabled = diagnostic.kv_event_publishing_enabled,
-                waited_ms = diagnostic.waited_ms,
+                waited_ms,
                 rank_count,
                 dp_ranks = %dp_ranks,
                 "KV event source health warning"
@@ -439,48 +326,26 @@ pub(super) fn spawn(
         emit_diagnostics(&context, state.reconcile(&initial, Instant::now()));
 
         loop {
-            let Some(deadline) = state.next_deadline() else {
+            let changed = if let Some(deadline) = state.next_deadline() {
                 tokio::select! {
                     biased;
                     _ = cancellation_token.cancelled() => break,
-                    changed = membership_watch.changed() => {
-                        if changed.is_err() {
-                            break;
-                        }
-                        let view = membership_watch.borrow_and_update().clone();
-                        emit_diagnostics(&context, state.reconcile(&view, Instant::now()));
-                    }
+                    changed = membership_watch.changed() => Some(changed),
+                    _ = tokio::time::sleep_until(deadline) => None,
                 }
-                continue;
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancellation_token.cancelled() => break,
+                    changed = membership_watch.changed() => Some(changed),
+                }
             };
-
-            tokio::select! {
-                biased;
-                _ = cancellation_token.cancelled() => break,
-                changed = membership_watch.changed() => {
-                    if changed.is_err() {
-                        break;
-                    }
-                    let now = Instant::now();
-                    let view = membership_watch.borrow_and_update().clone();
-                    let mut diagnostics = state.reconcile(&view, now);
-                    if let Some(current) = state.next_deadline()
-                        && current.deadline <= now
-                    {
-                        diagnostics.extend(state.fire_deadline(current, now));
-                    }
-                    emit_diagnostics(&context, diagnostics);
-                }
-                _ = tokio::time::sleep_until(deadline.deadline) => {
-                    // Re-read membership before using the wake-up token. A removal, rejoin, or
-                    // source arrival invalidates the per-rank epoch and suppresses the stale alarm.
-                    let now = Instant::now();
-                    let view = membership_watch.borrow_and_update().clone();
-                    let mut diagnostics = state.reconcile(&view, now);
-                    diagnostics.extend(state.fire_deadline(deadline, now));
-                    emit_diagnostics(&context, diagnostics);
-                }
+            if changed.is_some_and(|result| result.is_err()) {
+                break;
             }
+
+            let view = membership_watch.borrow_and_update().clone();
+            emit_diagnostics(&context, state.reconcile(&view, Instant::now()));
         }
         let _ = completion_tx.send(());
     });
@@ -489,8 +354,10 @@ pub(super) fn spawn(
 
 #[cfg(test)]
 mod tests {
+    use dynamo_kv_router::protocols::WorkerWithDpRank;
+
     use super::*;
-    use crate::discovery::{KvEventSource, KvSourceObservationState, KvStateEndpointResolution};
+    use crate::discovery::{KvEventSource, KvStateEndpointResolution};
 
     fn endpoint() -> EndpointId {
         EndpointId {
@@ -501,7 +368,6 @@ mod tests {
     }
 
     fn view(
-        observation_state: KvSourceObservationState,
         capabilities: impl IntoIterator<Item = (WorkerId, Option<bool>)>,
         statuses: impl IntoIterator<Item = (WorkerWithDpRank, KvSourceStatus)>,
     ) -> KvSourceMembershipView {
@@ -510,7 +376,6 @@ mod tests {
         KvSourceMembershipView {
             serving_endpoint: endpoint.clone(),
             endpoint_resolution: KvStateEndpointResolution::Resolved(endpoint),
-            observation_state,
             lifecycle_generations: sources.keys().map(|worker| (*worker, 0)).collect(),
             recovery_expected: HashMap::new(),
             kv_event_publishing_enabled: capabilities.into_iter().collect(),
@@ -518,13 +383,33 @@ mod tests {
         }
     }
 
-    fn active(worker: WorkerWithDpRank) -> KvSourceStatus {
-        KvSourceStatus::ActiveLiveOnly(KvEventSource {
-            kv_state_endpoint: endpoint(),
+    fn missing(worker_id: WorkerId, dp_rank: u32) -> (WorkerWithDpRank, KvSourceStatus) {
+        (
+            WorkerWithDpRank::new(worker_id, dp_rank),
+            KvSourceStatus::Missing,
+        )
+    }
+
+    fn active(worker_id: WorkerId, dp_rank: u32) -> (WorkerWithDpRank, KvSourceStatus) {
+        let worker = WorkerWithDpRank::new(worker_id, dp_rank);
+        (
             worker,
-            publisher_id: 17,
-            recovery_target: None,
-        })
+            KvSourceStatus::ActiveLiveOnly(KvEventSource {
+                kv_state_endpoint: endpoint(),
+                worker,
+                publisher_id: 11,
+                recovery_target: None,
+            }),
+        )
+    }
+
+    fn ambiguous(worker_id: WorkerId, dp_rank: u32) -> (WorkerWithDpRank, KvSourceStatus) {
+        (
+            WorkerWithDpRank::new(worker_id, dp_rank),
+            KvSourceStatus::Ambiguous(crate::discovery::KvSourceAmbiguity::Incarnations {
+                publisher_ids: vec![1, 2],
+            }),
+        )
     }
 
     fn required_state() -> SourceHealthState {
@@ -532,223 +417,131 @@ mod tests {
     }
 
     #[test]
-    fn disabled_capability_warns_immediately_and_once() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let view = view(
-            KvSourceObservationState::Rebinding,
-            [(7, Some(false))],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let now = Instant::now();
-        let mut state = required_state();
+    fn source_health_state_matrix() {
+        struct Case {
+            name: &'static str,
+            requirement: KvEventSourceRequirement,
+            capability: Option<bool>,
+            statuses: Vec<(WorkerWithDpRank, KvSourceStatus)>,
+            expected_code: Option<DiagnosticCode>,
+            expected_ranks: Vec<u32>,
+        }
 
-        let diagnostics = state.reconcile(&view, now);
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::PublisherDisabled);
-        assert!(!diagnostics[0].kv_event_publishing_enabled);
-        assert!(state.reconcile(&view, now).is_empty());
+        let cases = [
+            Case {
+                name: "disabled publisher",
+                requirement: KvEventSourceRequirement::CacheAwareRouting,
+                capability: Some(false),
+                statuses: vec![missing(7, 3), missing(7, 1)],
+                expected_code: Some(DiagnosticCode::PublisherDisabled),
+                expected_ranks: vec![1, 3],
+            },
+            Case {
+                name: "ambiguous source",
+                requirement: KvEventSourceRequirement::CacheAwareRouting,
+                capability: Some(true),
+                statuses: vec![ambiguous(7, 0)],
+                expected_code: Some(DiagnosticCode::SourceAmbiguous),
+                expected_ranks: vec![0],
+            },
+            Case {
+                name: "active idle source",
+                requirement: KvEventSourceRequirement::CacheAwareRouting,
+                capability: Some(true),
+                statuses: vec![active(7, 0)],
+                expected_code: None,
+                expected_ranks: vec![],
+            },
+            Case {
+                name: "unknown capability",
+                requirement: KvEventSourceRequirement::CacheAwareRouting,
+                capability: None,
+                statuses: vec![missing(7, 0)],
+                expected_code: None,
+                expected_ranks: vec![],
+            },
+            Case {
+                name: "source not required",
+                requirement: KvEventSourceRequirement::NotRequired,
+                capability: Some(false),
+                statuses: vec![missing(7, 0)],
+                expected_code: None,
+                expected_ranks: vec![],
+            },
+        ];
+        let now = Instant::now();
+
+        for case in cases {
+            let source_view = view([(7, case.capability)], case.statuses);
+            let mut state = SourceHealthState::new(case.requirement);
+            let diagnostics = state.reconcile(&source_view, now);
+            assert_eq!(
+                diagnostics.first().map(|diagnostic| diagnostic.code),
+                case.expected_code,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                diagnostics
+                    .first()
+                    .map(|diagnostic| diagnostic.dp_ranks.as_slice())
+                    .unwrap_or_default(),
+                case.expected_ranks,
+                "{}",
+                case.name
+            );
+            assert!(
+                state
+                    .reconcile(&source_view, now + SOURCE_JOIN_GRACE * 2)
+                    .is_empty(),
+                "{}",
+                case.name
+            );
+            assert!(state.next_deadline().is_none(), "{}", case.name);
+        }
     }
 
     #[test]
-    fn missing_source_waits_full_grace_and_active_source_recovers_once() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let missing = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, KvSourceStatus::Missing)],
+    fn missing_source_warns_at_grace_boundary_and_recovers_once() {
+        let missing = view([(7, Some(true))], [missing(7, 0), missing(7, 1)]);
+        let active = view([(7, Some(true))], [active(7, 0), active(7, 1)]);
+        let now = Instant::now();
+        let mut state = required_state();
+
+        assert!(state.reconcile(&missing, now).is_empty());
+        assert!(
+            state
+                .reconcile(&missing, now + SOURCE_JOIN_GRACE - Duration::from_millis(1))
+                .is_empty()
+        );
+        let warning = state.reconcile(&missing, now + SOURCE_JOIN_GRACE);
+        assert_eq!(warning.len(), 1);
+        assert_eq!(warning[0].code, DiagnosticCode::SourceNotObserved);
+        assert_eq!(warning[0].dp_ranks, vec![0, 1]);
+
+        let recovered = state.reconcile(&active, now + SOURCE_JOIN_GRACE);
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].code, DiagnosticCode::SourceRecovered);
+        assert!(state.reconcile(&active, now + SOURCE_JOIN_GRACE).is_empty());
+    }
+
+    #[test]
+    fn worker_removal_clears_pending_warning() {
+        let missing = view([(7, Some(true))], [missing(7, 0)]);
+        let removed = view(
+            std::iter::empty::<(WorkerId, Option<bool>)>(),
+            std::iter::empty::<(WorkerWithDpRank, KvSourceStatus)>(),
         );
         let now = Instant::now();
         let mut state = required_state();
 
         assert!(state.reconcile(&missing, now).is_empty());
-        let deadline = state.next_deadline().expect("missing source has deadline");
-        assert!(
-            state
-                .fire_deadline(deadline, deadline.deadline - Duration::from_nanos(1))
-                .is_empty()
-        );
-        let diagnostics = state.fire_deadline(deadline, deadline.deadline);
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceNotObserved);
-        assert_eq!(diagnostics[0].waited, SOURCE_JOIN_GRACE);
-
-        let active = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, active(worker))],
-        );
-        let recovered = state.reconcile(&active, deadline.deadline + Duration::from_secs(1));
-        assert_eq!(recovered.len(), 1);
-        assert_eq!(recovered[0].code, DiagnosticCode::SourceRecovered);
-        assert!(
-            state
-                .reconcile(&active, deadline.deadline + Duration::from_secs(32))
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn rebinding_resets_pending_grace_and_fences_old_deadline() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let bound_missing = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let rebinding = view(
-            KvSourceObservationState::Rebinding,
-            [(7, Some(true))],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let now = Instant::now();
-        let mut state = required_state();
-
-        state.reconcile(&bound_missing, now);
-        let stale = state.next_deadline().unwrap();
-        state.reconcile(&rebinding, now + Duration::from_secs(20));
+        assert!(state.reconcile(&removed, now).is_empty());
         assert!(state.next_deadline().is_none());
-        state.reconcile(&bound_missing, now + Duration::from_secs(25));
-        let fresh = state.next_deadline().unwrap();
-        assert_ne!(fresh.epoch, stale.epoch);
         assert!(
             state
-                .fire_deadline(stale, now + SOURCE_JOIN_GRACE)
+                .reconcile(&missing, now + SOURCE_JOIN_GRACE)
                 .is_empty()
         );
-        assert_eq!(
-            state.fire_deadline(fresh, fresh.deadline)[0].code,
-            DiagnosticCode::SourceNotObserved
-        );
-    }
-
-    #[test]
-    fn remove_and_rejoin_fences_old_deadline() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let missing = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let removed = view(
-            KvSourceObservationState::Bound,
-            std::iter::empty(),
-            std::iter::empty(),
-        );
-        let now = Instant::now();
-        let mut state = required_state();
-
-        state.reconcile(&missing, now);
-        let stale = state.next_deadline().unwrap();
-        state.reconcile(&removed, now + Duration::from_secs(1));
-        state.reconcile(&missing, now + Duration::from_secs(2));
-        let fresh = state.next_deadline().unwrap();
-        assert_ne!(fresh.epoch, stale.epoch);
-        assert!(state.fire_deadline(stale, stale.deadline).is_empty());
-        assert_eq!(
-            state.fire_deadline(fresh, fresh.deadline)[0].code,
-            DiagnosticCode::SourceNotObserved
-        );
-    }
-
-    #[test]
-    fn ambiguity_warns_once_then_active_emits_one_recovery() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let ambiguity = crate::discovery::KvSourceAmbiguity::Incarnations {
-            publisher_ids: vec![1, 2],
-        };
-        let ambiguous = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, KvSourceStatus::Ambiguous(ambiguity))],
-        );
-        let now = Instant::now();
-        let mut state = required_state();
-
-        let diagnostics = state.reconcile(&ambiguous, now);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceAmbiguous);
-        assert!(state.reconcile(&ambiguous, now).is_empty());
-
-        let active = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(true))],
-            [(worker, active(worker))],
-        );
-        assert_eq!(
-            state.reconcile(&active, now + Duration::from_secs(1))[0].code,
-            DiagnosticCode::SourceRecovered
-        );
-        assert!(
-            state
-                .reconcile(&active, now + Duration::from_secs(2))
-                .is_empty()
-        );
-    }
-
-    #[test]
-    fn endpoint_mapping_ambiguity_warns_while_source_watch_is_unbound() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let ambiguous = view(
-            KvSourceObservationState::Rebinding,
-            [(7, Some(true))],
-            [(
-                worker,
-                KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping {
-                    endpoints: vec![endpoint()],
-                }),
-            )],
-        );
-        let now = Instant::now();
-        let mut state = required_state();
-
-        let diagnostics = state.reconcile(&ambiguous, now);
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::SourceAmbiguous);
-        assert!(state.reconcile(&ambiguous, now).is_empty());
-    }
-
-    #[test]
-    fn unknown_capability_and_unknown_requirement_are_silent() {
-        let worker = WorkerWithDpRank::new(7, 0);
-        let unknown_capability = view(
-            KvSourceObservationState::Bound,
-            [(7, None)],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let now = Instant::now();
-        let mut required = required_state();
-        assert!(required.reconcile(&unknown_capability, now).is_empty());
-        assert!(required.next_deadline().is_none());
-
-        let disabled = view(
-            KvSourceObservationState::Bound,
-            [(7, Some(false))],
-            [(worker, KvSourceStatus::Missing)],
-        );
-        let mut unknown = SourceHealthState::new(KvEventSourceRequirement::Unknown);
-        assert!(unknown.reconcile(&disabled, now).is_empty());
-        assert!(unknown.next_deadline().is_none());
-    }
-
-    #[test]
-    fn diagnostics_aggregate_by_worker_and_code() {
-        let diagnostics = aggregate_diagnostics(vec![
-            RankDiagnostic {
-                code: DiagnosticCode::SourceNotObserved,
-                worker: WorkerWithDpRank::new(7, 3),
-                kv_event_publishing_enabled: true,
-                waited: Duration::from_secs(30),
-            },
-            RankDiagnostic {
-                code: DiagnosticCode::SourceNotObserved,
-                worker: WorkerWithDpRank::new(7, 1),
-                kv_event_publishing_enabled: true,
-                waited: Duration::from_secs(31),
-            },
-        ]);
-
-        assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].worker_id, 7);
-        assert_eq!(diagnostics[0].waited_ms, 31_000);
-        assert_eq!(diagnostics[0].dp_ranks, vec![1, 3]);
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/source_health.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/source_health.rs
@@ -36,6 +36,34 @@ impl DiagnosticCode {
             Self::SourceRecovered => "kv_event_source_recovered",
         }
     }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::PublisherDisabled => {
+                "KV-event publishing is disabled for a role that requires KV events"
+            }
+            Self::SourceNotObserved => {
+                "KV-event source was not observed after the discovery grace period"
+            }
+            Self::SourceAmbiguous => "KV-event source registration is ambiguous",
+            Self::SourceRecovered => "KV-event source recovered",
+        }
+    }
+
+    fn suggested_action(self) -> &'static str {
+        match self {
+            Self::PublisherDisabled => {
+                "Enable backend KV-event publishing, or select a routing mode that does not require KV events"
+            }
+            Self::SourceNotObserved => {
+                "Check publisher startup, endpoint registration, discovery, and NATS/ZMQ connectivity"
+            }
+            Self::SourceAmbiguous => {
+                "Check for stale or duplicate publisher incarnations and conflicting KV-state endpoint mappings"
+            }
+            Self::SourceRecovered => "No action required",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -264,6 +292,8 @@ fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<Diagnostic
         .unwrap_or("unknown");
     for diagnostic in diagnostics {
         let diagnostic_code = diagnostic.code.as_str();
+        let diagnostic_message = diagnostic.code.message();
+        let suggested_action = diagnostic.code.suggested_action();
         let requirement = context.requirement.as_str();
         let waited_ms = diagnostic.waited.as_millis().min(u128::from(u64::MAX)) as u64;
         let rank_count = diagnostic.dp_ranks.len();
@@ -285,7 +315,8 @@ fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<Diagnostic
                 waited_ms,
                 rank_count,
                 dp_ranks = %dp_ranks,
-                "KV event source recovered"
+                suggested_action,
+                "{diagnostic_message}"
             );
         } else {
             tracing::warn!(
@@ -299,7 +330,8 @@ fn emit_diagnostics(context: &DiagnosticContext<'_>, diagnostics: Vec<Diagnostic
                 waited_ms,
                 rank_count,
                 dp_ranks = %dp_ranks,
-                "KV event source health warning"
+                suggested_action,
+                "{diagnostic_message}"
             );
         }
     }

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -396,6 +396,7 @@ impl Drop for KvEventSubscriptionHandle {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn start_subscriber(
     endpoint: Endpoint,
     indexer: Indexer,

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -17,12 +17,13 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    IndexerRecoveryTarget, RecoveryTarget, direct_zmq::run_direct_zmq_supervisor,
+    IndexerRecoveryTarget, RecoveryTarget, direct_zmq::run_direct_zmq_supervisor, source_health,
     worker_query::WorkerQueryClient,
 };
 use crate::{
     discovery::{KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus},
-    kv_router::{Indexer, metrics::RouterWorkerStatusMetrics},
+    kv_router::{Indexer, KvEventSourceRequirement, metrics::RouterWorkerStatusMetrics},
+    worker_type::WorkerType,
 };
 
 const SUBSCRIPTION_INITIAL_BACKOFF: Duration = Duration::from_millis(100);
@@ -34,6 +35,12 @@ enum ScopeExit {
     Stop,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum MismatchMetricScope {
+    Generic,
+    Router(KvEventSourceRequirement),
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_subscription_supervisor<T: RecoveryTarget>(
     component: Component,
@@ -43,6 +50,7 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
     mut membership_watch: KvSourceMembershipWatch,
     model: String,
     worker_type: &'static str,
+    metric_scope: MismatchMetricScope,
     cancellation_token: CancellationToken,
     mut startup_ready: Option<oneshot::Sender<()>>,
 ) {
@@ -51,7 +59,14 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
 
     loop {
         let view = membership_watch.borrow_and_update().clone();
-        update_mismatch_metric(&metrics, &view, &model, worker_type, &serving_endpoint);
+        update_mismatch_metric(
+            &metrics,
+            &view,
+            &model,
+            worker_type,
+            &serving_endpoint,
+            metric_scope,
+        );
 
         let subscriber = if let Some(kv_state_endpoint) = view.resolved_kv_state_endpoint() {
             tracing::debug!(
@@ -79,6 +94,7 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
                         &model,
                         worker_type,
                         &serving_endpoint,
+                        metric_scope,
                     );
                     if let Some(ready) = startup_ready.take() {
                         let _ = ready.send(());
@@ -135,6 +151,7 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
             &model,
             worker_type,
             &serving_endpoint,
+            metric_scope,
             &cancellation_token,
             &mut retry_delay,
         )
@@ -152,6 +169,7 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
                     &model,
                     worker_type,
                     &serving_endpoint,
+                    metric_scope,
                 );
                 if !wait_for_retry(retry_delay, &mut membership_watch, &cancellation_token).await {
                     break;
@@ -182,6 +200,7 @@ async fn consume_scope<T: RecoveryTarget>(
     model: &str,
     worker_type: &str,
     serving_endpoint: &EndpointId,
+    metric_scope: MismatchMetricScope,
     cancellation_token: &CancellationToken,
     retry_delay: &mut Duration,
 ) -> ScopeExit {
@@ -195,7 +214,14 @@ async fn consume_scope<T: RecoveryTarget>(
                 }
                 membership_watch.borrow_and_update();
                 let view = client.sync_membership().await;
-                update_mismatch_metric(metrics, &view, model, worker_type, serving_endpoint);
+                update_mismatch_metric(
+                    metrics,
+                    &view,
+                    model,
+                    worker_type,
+                    serving_endpoint,
+                    metric_scope,
+                );
                 if view.resolved_kv_state_endpoint() != Some(kv_state_endpoint) {
                     return ScopeExit::Rebind;
                 }
@@ -237,16 +263,9 @@ pub(super) fn update_mismatch_metric(
     model: &str,
     worker_type: &str,
     serving_endpoint: &EndpointId,
+    metric_scope: MismatchMetricScope,
 ) {
-    let mismatch_count = view
-        .sources
-        .iter()
-        .filter(|(worker, status)| match status {
-            KvSourceStatus::Missing | KvSourceStatus::Ambiguous(_) => true,
-            KvSourceStatus::ActiveLiveOnly(_) => view.recovery_expected(worker).unwrap_or(false),
-            KvSourceStatus::ActiveRecoverable(_) => false,
-        })
-        .count();
+    let mismatch_count = mismatch_count(view, metric_scope);
     metrics.set_kv_event_source_mismatch_workers(
         model,
         worker_type,
@@ -257,20 +276,76 @@ pub(super) fn update_mismatch_metric(
     );
 }
 
+fn mismatch_count(view: &KvSourceMembershipView, metric_scope: MismatchMetricScope) -> usize {
+    match metric_scope {
+        MismatchMetricScope::Router(KvEventSourceRequirement::NotRequired) => 0,
+        MismatchMetricScope::Router(KvEventSourceRequirement::Unknown)
+        | MismatchMetricScope::Generic => legacy_mismatch_count(view),
+        MismatchMetricScope::Router(requirement) => {
+            if !requirement.requires_source() {
+                0
+            } else {
+                view.sources
+                    .iter()
+                    .filter(|(worker, status)| {
+                        view.kv_event_publishing_enabled(worker.worker_id) == Some(false)
+                            || if view.observation_state.is_bound() {
+                                source_status_is_mismatch(view, worker, status)
+                            } else {
+                                matches!(
+                                    status,
+                                    KvSourceStatus::Ambiguous(
+                                        crate::discovery::KvSourceAmbiguity::EndpointMapping { .. }
+                                    )
+                                )
+                            }
+                    })
+                    .count()
+            }
+        }
+    }
+}
+
+fn legacy_mismatch_count(view: &KvSourceMembershipView) -> usize {
+    view.sources
+        .iter()
+        .filter(|(worker, status)| source_status_is_mismatch(view, worker, status))
+        .count()
+}
+
+fn source_status_is_mismatch(
+    view: &KvSourceMembershipView,
+    worker: &dynamo_kv_router::protocols::WorkerWithDpRank,
+    status: &KvSourceStatus,
+) -> bool {
+    match status {
+        KvSourceStatus::Missing | KvSourceStatus::Ambiguous(_) => true,
+        KvSourceStatus::ActiveLiveOnly(_) => view.recovery_expected(worker).unwrap_or(false),
+        KvSourceStatus::ActiveRecoverable(_) => false,
+    }
+}
+
 pub(super) fn update_subscription_failure_metric(
     metrics: &RouterWorkerStatusMetrics,
     view: &KvSourceMembershipView,
     model: &str,
     worker_type: &str,
     serving_endpoint: &EndpointId,
+    metric_scope: MismatchMetricScope,
 ) {
+    let count = match metric_scope {
+        MismatchMetricScope::Router(KvEventSourceRequirement::NotRequired) => 0,
+        MismatchMetricScope::Generic
+        | MismatchMetricScope::Router(KvEventSourceRequirement::Unknown)
+        | MismatchMetricScope::Router(_) => view.sources.len(),
+    };
     metrics.set_kv_event_source_mismatch_workers(
         model,
         worker_type,
         &serving_endpoint.namespace,
         &serving_endpoint.component,
         &serving_endpoint.name,
-        view.sources.len(),
+        count,
     );
 }
 
@@ -294,17 +369,22 @@ pub(super) fn clear_mismatch_metric_on_cancellation(
     );
 }
 
-/// Dropping this handle cancels the KV event subscription.
-#[must_use = "dropping the handle cancels the KV event subscription"]
+/// Dropping this handle cancels the KV event subscription and its health monitor.
+#[must_use = "dropping the handle cancels the KV event subscription and health monitor"]
 pub(crate) struct KvEventSubscriptionHandle {
     cancel: CancellationToken,
-    completion: Option<oneshot::Receiver<()>>,
+    source_health_cancel: CancellationToken,
+    completions: Vec<oneshot::Receiver<()>>,
 }
 
 impl KvEventSubscriptionHandle {
+    pub(crate) fn stop_source_health_monitor(&self) {
+        self.source_health_cancel.cancel();
+    }
+
     pub(crate) async fn shutdown(mut self) {
         self.cancel.cancel();
-        if let Some(completion) = self.completion.take() {
+        for completion in self.completions.drain(..) {
             let _ = completion.await;
         }
     }
@@ -321,12 +401,15 @@ pub async fn start_subscriber(
     indexer: Indexer,
     membership_watch: KvSourceMembershipWatch,
     model: String,
+    worker_role: Option<WorkerType>,
+    source_requirement: KvEventSourceRequirement,
     worker_type: &'static str,
     cancellation_token: CancellationToken,
 ) -> Result<KvEventSubscriptionHandle> {
     let transport_kind = endpoint.component().drt().default_event_transport_kind();
     let direct_zmq = uses_direct_zmq(transport_kind);
     let cancel = cancellation_token.child_token();
+    let cancellation_guard = cancel.clone().drop_guard();
     let client = WorkerQueryClient::spawn(
         endpoint.component().clone(),
         IndexerRecoveryTarget::new(indexer),
@@ -334,6 +417,16 @@ pub async fn start_subscriber(
         cancel.child_token(),
     )
     .await?;
+    let source_health_cancel = cancel.child_token();
+    let health_completion = source_health::spawn(
+        membership_watch.clone(),
+        model.clone(),
+        worker_role,
+        source_requirement,
+        endpoint.id(),
+        source_health_cancel.clone(),
+    );
+    let metric_scope = MismatchMetricScope::Router(source_requirement);
 
     if !direct_zmq {
         tracing::info!(
@@ -352,6 +445,7 @@ pub async fn start_subscriber(
                 membership_watch,
                 model,
                 worker_type,
+                metric_scope,
                 task_cancel,
                 Some(startup_tx),
             )
@@ -361,9 +455,11 @@ pub async fn start_subscriber(
         startup_rx.await.map_err(|_| {
             anyhow::anyhow!("KV event subscription supervisor exited before reporting readiness")
         })?;
+        let cancel = cancellation_guard.disarm();
         return Ok(KvEventSubscriptionHandle {
             cancel,
-            completion: Some(completion_rx),
+            source_health_cancel,
+            completions: vec![completion_rx, health_completion],
         });
     }
 
@@ -379,6 +475,7 @@ pub async fn start_subscriber(
             membership_watch,
             model,
             worker_type,
+            metric_scope,
             task_cancel,
             Some(startup_tx),
         )
@@ -392,9 +489,11 @@ pub async fn start_subscriber(
             anyhow::anyhow!("Direct-ZMQ ingress supervisor exited before reporting readiness")
         })?
         .map_err(anyhow::Error::msg)?;
+    let cancel = cancellation_guard.disarm();
     Ok(KvEventSubscriptionHandle {
         cancel,
-        completion: Some(completion_rx),
+        source_health_cancel,
+        completions: vec![completion_rx, health_completion],
     })
 }
 
@@ -452,6 +551,7 @@ pub(crate) async fn start_target_subscriber<T: RecoveryTarget>(
         membership_watch,
         model,
         worker_type,
+        MismatchMetricScope::Generic,
         cancel.clone(),
         Some(startup_tx),
     ));
@@ -468,23 +568,145 @@ pub(crate) async fn start_target_subscriber<T: RecoveryTarget>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    use dynamo_kv_router::protocols::WorkerWithDpRank;
+
+    use crate::discovery::{
+        KvEventSource, KvSourceAmbiguity, KvSourceObservationState, KvStateEndpointResolution,
+    };
+
+    fn metric_view(
+        observation_state: KvSourceObservationState,
+        status: KvSourceStatus,
+        capability: Option<bool>,
+    ) -> KvSourceMembershipView {
+        let serving_endpoint = EndpointId {
+            namespace: "ns".to_string(),
+            component: "worker".to_string(),
+            name: "generate".to_string(),
+        };
+        let worker = WorkerWithDpRank::new(7, 0);
+        KvSourceMembershipView {
+            serving_endpoint: serving_endpoint.clone(),
+            endpoint_resolution: KvStateEndpointResolution::Resolved(serving_endpoint),
+            observation_state,
+            sources: HashMap::from([(worker, status)]),
+            kv_event_publishing_enabled: HashMap::from([(7, capability)]),
+            lifecycle_generations: HashMap::from([(worker, 0)]),
+            recovery_expected: HashMap::from([(worker, false)]),
+        }
+    }
+
+    #[test]
+    fn router_mismatch_metric_is_requirement_and_observation_aware() {
+        let rebinding = metric_view(
+            KvSourceObservationState::Rebinding,
+            KvSourceStatus::Missing,
+            Some(true),
+        );
+        assert_eq!(mismatch_count(&rebinding, MismatchMetricScope::Generic), 1);
+        assert_eq!(
+            mismatch_count(
+                &rebinding,
+                MismatchMetricScope::Router(KvEventSourceRequirement::Unknown)
+            ),
+            1
+        );
+        assert_eq!(
+            mismatch_count(
+                &rebinding,
+                MismatchMetricScope::Router(KvEventSourceRequirement::CacheAwareRouting)
+            ),
+            0
+        );
+
+        let worker = WorkerWithDpRank::new(7, 0);
+        let active_disabled = metric_view(
+            KvSourceObservationState::Bound,
+            KvSourceStatus::ActiveLiveOnly(KvEventSource {
+                kv_state_endpoint: rebinding.serving_endpoint.clone(),
+                worker,
+                publisher_id: 11,
+                recovery_target: None,
+            }),
+            Some(false),
+        );
+        assert_eq!(
+            mismatch_count(&active_disabled, MismatchMetricScope::Generic),
+            0
+        );
+        assert_eq!(
+            mismatch_count(
+                &active_disabled,
+                MismatchMetricScope::Router(KvEventSourceRequirement::CacheAwareRouting)
+            ),
+            1
+        );
+        assert_eq!(
+            mismatch_count(
+                &rebinding,
+                MismatchMetricScope::Router(KvEventSourceRequirement::NotRequired)
+            ),
+            0
+        );
+
+        let endpoint_mapping_ambiguity = metric_view(
+            KvSourceObservationState::Rebinding,
+            KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping {
+                endpoints: vec![rebinding.serving_endpoint.clone()],
+            }),
+            Some(true),
+        );
+        assert_eq!(
+            mismatch_count(
+                &endpoint_mapping_ambiguity,
+                MismatchMetricScope::Router(KvEventSourceRequirement::CacheAwareRouting)
+            ),
+            1
+        );
+    }
 
     #[tokio::test]
-    async fn subscription_handle_shutdown_waits_for_completion() {
+    async fn subscription_handle_shutdown_waits_for_all_owned_tasks() {
         let cancel = CancellationToken::new();
-        let task_cancel = cancel.clone();
-        let (completion_tx, completion_rx) = oneshot::channel();
-        tokio::spawn(async move {
-            task_cancel.cancelled().await;
-            let _ = completion_tx.send(());
-        });
+        let source_health_cancel = cancel.child_token();
+        let mut completions = Vec::new();
+        for _ in 0..2 {
+            let task_cancel = cancel.clone();
+            let (completion_tx, completion_rx) = oneshot::channel();
+            completions.push(completion_rx);
+            tokio::spawn(async move {
+                task_cancel.cancelled().await;
+                let _ = completion_tx.send(());
+            });
+        }
         let handle = KvEventSubscriptionHandle {
             cancel,
-            completion: Some(completion_rx),
+            source_health_cancel,
+            completions,
         };
 
         tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
             .await
             .expect("subscription shutdown should complete");
+    }
+
+    #[tokio::test]
+    async fn stopping_source_health_preserves_subscription_for_inflight_requests() {
+        let cancel = CancellationToken::new();
+        let source_health_cancel = cancel.child_token();
+        let health_observer = source_health_cancel.clone();
+        let handle = KvEventSubscriptionHandle {
+            cancel: cancel.clone(),
+            source_health_cancel,
+            completions: Vec::new(),
+        };
+
+        handle.stop_source_health_monitor();
+
+        health_observer.cancelled().await;
+        assert!(!cancel.is_cancelled());
+        handle.shutdown().await;
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -289,16 +289,7 @@ fn mismatch_count(view: &KvSourceMembershipView, metric_scope: MismatchMetricSco
                     .iter()
                     .filter(|(worker, status)| {
                         view.kv_event_publishing_enabled(worker.worker_id) == Some(false)
-                            || if view.observation_state.is_bound() {
-                                source_status_is_mismatch(view, worker, status)
-                            } else {
-                                matches!(
-                                    status,
-                                    KvSourceStatus::Ambiguous(
-                                        crate::discovery::KvSourceAmbiguity::EndpointMapping { .. }
-                                    )
-                                )
-                            }
+                            || source_status_is_mismatch(view, worker, status)
                     })
                     .count()
             }
@@ -373,15 +364,10 @@ pub(super) fn clear_mismatch_metric_on_cancellation(
 #[must_use = "dropping the handle cancels the KV event subscription and health monitor"]
 pub(crate) struct KvEventSubscriptionHandle {
     cancel: CancellationToken,
-    source_health_cancel: CancellationToken,
     completions: Vec<oneshot::Receiver<()>>,
 }
 
 impl KvEventSubscriptionHandle {
-    pub(crate) fn stop_source_health_monitor(&self) {
-        self.source_health_cancel.cancel();
-    }
-
     pub(crate) async fn shutdown(mut self) {
         self.cancel.cancel();
         for completion in self.completions.drain(..) {
@@ -418,14 +404,13 @@ pub async fn start_subscriber(
         cancel.child_token(),
     )
     .await?;
-    let source_health_cancel = cancel.child_token();
     let health_completion = source_health::spawn(
         membership_watch.clone(),
         model.clone(),
         worker_role,
         source_requirement,
         endpoint.id(),
-        source_health_cancel.clone(),
+        cancel.child_token(),
     );
     let metric_scope = MismatchMetricScope::Router(source_requirement);
 
@@ -459,7 +444,6 @@ pub async fn start_subscriber(
         let cancel = cancellation_guard.disarm();
         return Ok(KvEventSubscriptionHandle {
             cancel,
-            source_health_cancel,
             completions: vec![completion_rx, health_completion],
         });
     }
@@ -493,7 +477,6 @@ pub async fn start_subscriber(
     let cancel = cancellation_guard.disarm();
     Ok(KvEventSubscriptionHandle {
         cancel,
-        source_health_cancel,
         completions: vec![completion_rx, health_completion],
     })
 }
@@ -573,15 +556,9 @@ mod tests {
 
     use dynamo_kv_router::protocols::WorkerWithDpRank;
 
-    use crate::discovery::{
-        KvEventSource, KvSourceAmbiguity, KvSourceObservationState, KvStateEndpointResolution,
-    };
+    use crate::discovery::{KvEventSource, KvStateEndpointResolution};
 
-    fn metric_view(
-        observation_state: KvSourceObservationState,
-        status: KvSourceStatus,
-        capability: Option<bool>,
-    ) -> KvSourceMembershipView {
+    fn metric_view(status: KvSourceStatus, capability: Option<bool>) -> KvSourceMembershipView {
         let serving_endpoint = EndpointId {
             namespace: "ns".to_string(),
             component: "worker".to_string(),
@@ -591,7 +568,6 @@ mod tests {
         KvSourceMembershipView {
             serving_endpoint: serving_endpoint.clone(),
             endpoint_resolution: KvStateEndpointResolution::Resolved(serving_endpoint),
-            observation_state,
             sources: HashMap::from([(worker, status)]),
             kv_event_publishing_enabled: HashMap::from([(7, capability)]),
             lifecycle_generations: HashMap::from([(worker, 0)]),
@@ -600,33 +576,28 @@ mod tests {
     }
 
     #[test]
-    fn router_mismatch_metric_is_requirement_and_observation_aware() {
-        let rebinding = metric_view(
-            KvSourceObservationState::Rebinding,
-            KvSourceStatus::Missing,
-            Some(true),
-        );
-        assert_eq!(mismatch_count(&rebinding, MismatchMetricScope::Generic), 1);
+    fn router_mismatch_metric_is_requirement_aware() {
+        let missing = metric_view(KvSourceStatus::Missing, Some(true));
+        assert_eq!(mismatch_count(&missing, MismatchMetricScope::Generic), 1);
         assert_eq!(
             mismatch_count(
-                &rebinding,
+                &missing,
                 MismatchMetricScope::Router(KvEventSourceRequirement::Unknown)
             ),
             1
         );
         assert_eq!(
             mismatch_count(
-                &rebinding,
+                &missing,
                 MismatchMetricScope::Router(KvEventSourceRequirement::CacheAwareRouting)
             ),
-            0
+            1
         );
 
         let worker = WorkerWithDpRank::new(7, 0);
         let active_disabled = metric_view(
-            KvSourceObservationState::Bound,
             KvSourceStatus::ActiveLiveOnly(KvEventSource {
-                kv_state_endpoint: rebinding.serving_endpoint.clone(),
+                kv_state_endpoint: missing.serving_endpoint.clone(),
                 worker,
                 publisher_id: 11,
                 recovery_target: None,
@@ -646,32 +617,16 @@ mod tests {
         );
         assert_eq!(
             mismatch_count(
-                &rebinding,
+                &missing,
                 MismatchMetricScope::Router(KvEventSourceRequirement::NotRequired)
             ),
             0
-        );
-
-        let endpoint_mapping_ambiguity = metric_view(
-            KvSourceObservationState::Rebinding,
-            KvSourceStatus::Ambiguous(KvSourceAmbiguity::EndpointMapping {
-                endpoints: vec![rebinding.serving_endpoint.clone()],
-            }),
-            Some(true),
-        );
-        assert_eq!(
-            mismatch_count(
-                &endpoint_mapping_ambiguity,
-                MismatchMetricScope::Router(KvEventSourceRequirement::CacheAwareRouting)
-            ),
-            1
         );
     }
 
     #[tokio::test]
     async fn subscription_handle_shutdown_waits_for_all_owned_tasks() {
         let cancel = CancellationToken::new();
-        let source_health_cancel = cancel.child_token();
         let mut completions = Vec::new();
         for _ in 0..2 {
             let task_cancel = cancel.clone();
@@ -684,30 +639,11 @@ mod tests {
         }
         let handle = KvEventSubscriptionHandle {
             cancel,
-            source_health_cancel,
             completions,
         };
 
         tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
             .await
             .expect("subscription shutdown should complete");
-    }
-
-    #[tokio::test]
-    async fn stopping_source_health_preserves_subscription_for_inflight_requests() {
-        let cancel = CancellationToken::new();
-        let source_health_cancel = cancel.child_token();
-        let health_observer = source_health_cancel.clone();
-        let handle = KvEventSubscriptionHandle {
-            cancel: cancel.clone(),
-            source_health_cancel,
-            completions: Vec::new(),
-        };
-
-        handle.stop_source_health_monitor();
-
-        health_observer.cancelled().await;
-        assert!(!cancel.is_cancelled());
-        handle.shutdown().await;
     }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -1135,7 +1135,7 @@ mod tests {
     use crate::{
         discovery::{
             KvSourceAmbiguity, KvSourceMembershipCoordinator, KvSourceMembershipView,
-            KvSourceObservationState, KvStateEndpointResolution, runtime_config_watch,
+            KvStateEndpointResolution, runtime_config_watch,
         },
         kv_router::{
             indexer::{Indexer, LowerTierIndexers},
@@ -2619,7 +2619,6 @@ mod tests {
         KvSourceMembershipView {
             serving_endpoint: serving_endpoint.clone(),
             endpoint_resolution: KvStateEndpointResolution::Resolved(kv_state_endpoint.clone()),
-            observation_state: KvSourceObservationState::Bound,
             sources: statuses,
             kv_event_publishing_enabled: HashMap::new(),
             lifecycle_generations: generations,

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -1135,7 +1135,7 @@ mod tests {
     use crate::{
         discovery::{
             KvSourceAmbiguity, KvSourceMembershipCoordinator, KvSourceMembershipView,
-            KvStateEndpointResolution, runtime_config_watch,
+            KvSourceObservationState, KvStateEndpointResolution, runtime_config_watch,
         },
         kv_router::{
             indexer::{Indexer, LowerTierIndexers},
@@ -2619,7 +2619,9 @@ mod tests {
         KvSourceMembershipView {
             serving_endpoint: serving_endpoint.clone(),
             endpoint_resolution: KvStateEndpointResolution::Resolved(kv_state_endpoint.clone()),
+            observation_state: KvSourceObservationState::Bound,
             sources: statuses,
+            kv_event_publishing_enabled: HashMap::new(),
             lifecycle_generations: generations,
             recovery_expected: HashMap::new(),
         }
@@ -2779,6 +2781,8 @@ mod tests {
                 indexer,
                 membership_watch,
                 "test-model".to_string(),
+                None,
+                crate::kv_router::KvEventSourceRequirement::Unknown,
                 "decode",
                 cancel.child_token(),
             )

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -406,7 +406,7 @@ impl RouterWorkerStatusMetrics {
                 let kv_event_source_mismatch_workers = metrics
                     .create_intgaugevec(
                         router::KV_EVENT_SOURCE_MISMATCH_WORKERS,
-                        "Number of serving workers with missing or ambiguous KV sources, or without an expected RecoveryTarget",
+                        "Number of serving workers with missing or ambiguous KV sources, explicitly disabled KV event publishing, or without an expected RecoveryTarget",
                         &[
                             labels::MODEL,
                             labels::WORKER_TYPE,

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -160,11 +160,12 @@ impl PrefillRouter {
 
             // Create KV chooser using the endpoint (this is a prefill router)
             let kv_chooser = model_manager
-                .kv_chooser_for(
+                .kv_chooser_for_with_worker_role(
                     &endpoint,
                     kv_cache_block_size,
                     kv_router_config,
                     prefill_load_estimator,
+                    Some(crate::worker_type::WorkerType::Prefill),
                     WORKER_TYPE_PREFILL,
                     Some(self.model_name.clone()),
                     is_eagle,

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -68,8 +68,41 @@ pub enum KvEventSourceConfig {
 
 enum KvEventSource {
     Zmq {
-        zmq_handle: tokio::task::JoinHandle<()>,
+        listener_abort_handle: tokio::task::AbortHandle,
+        supervisor_handle: tokio::task::JoinHandle<bool>,
     },
+}
+
+async fn supervise_zmq_listener(
+    listener_handle: tokio::task::JoinHandle<()>,
+    endpoint: String,
+    topic: String,
+    cancellation_token: CancellationToken,
+) -> bool {
+    let result = listener_handle.await;
+    if cancellation_token.is_cancelled() {
+        return false;
+    }
+
+    match result {
+        Ok(()) => {
+            tracing::error!(
+                %endpoint,
+                %topic,
+                "ZMQ listener terminated unexpectedly; stopping KV event publisher"
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                %endpoint,
+                %topic,
+                %error,
+                "ZMQ listener task failed unexpectedly; stopping KV event publisher"
+            );
+        }
+    }
+    cancellation_token.cancel();
+    true
 }
 
 impl KvEventSource {
@@ -88,30 +121,50 @@ impl KvEventSource {
                 topic,
                 image_token_id,
             } => {
-                let zmq_handle = component
-                    .drt()
-                    .runtime()
-                    .secondary()
-                    .spawn(start_zmq_listener(
-                        endpoint,
-                        topic,
-                        worker_id,
-                        tx,
-                        cancellation_token.clone(),
-                        kv_block_size,
-                        next_event_id,
-                        image_token_id,
-                    ));
+                let listener_handle =
+                    component
+                        .drt()
+                        .runtime()
+                        .secondary()
+                        .spawn(start_zmq_listener(
+                            endpoint.clone(),
+                            topic.clone(),
+                            worker_id,
+                            tx,
+                            cancellation_token.clone(),
+                            kv_block_size,
+                            next_event_id,
+                            image_token_id,
+                        ));
+                let listener_abort_handle = listener_handle.abort_handle();
+                let supervisor_handle =
+                    component
+                        .drt()
+                        .runtime()
+                        .secondary()
+                        .spawn(supervise_zmq_listener(
+                            listener_handle,
+                            endpoint,
+                            topic,
+                            cancellation_token,
+                        ));
 
-                Ok(KvEventSource::Zmq { zmq_handle })
+                Ok(KvEventSource::Zmq {
+                    listener_abort_handle,
+                    supervisor_handle,
+                })
             }
         }
     }
 
     fn shutdown(&self) {
         match self {
-            KvEventSource::Zmq { zmq_handle } => {
-                zmq_handle.abort();
+            KvEventSource::Zmq {
+                listener_abort_handle,
+                supervisor_handle,
+            } => {
+                listener_abort_handle.abort();
+                supervisor_handle.abort();
             }
         }
     }
@@ -331,6 +384,13 @@ impl KvEventPublisher {
             } else {
                 None
             };
+
+            if cancellation_token_clone.is_cancelled() {
+                if let Some(endpoint) = recovery_endpoint {
+                    let _ = endpoint.shutdown().await;
+                }
+                return;
+            }
 
             let source = DiscoveredKvEventSource {
                 kv_state_endpoint: kv_state_endpoint.clone(),

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -747,7 +747,11 @@ mod tests_startup_helpers {
         GetWorkersRequest, KvIndexer, KvIndexerInterface, WorkerKvQueryResponse,
     };
     use dynamo_kv_router::protocols::{ExternalSequenceBlockHash, LocalBlockHash};
+    use dynamo_runtime::discovery::{
+        Discovery, DiscoveryQuery, EventSourceQuery, MockDiscovery, SharedMockRegistry,
+    };
     use std::sync::{Arc, Mutex};
+    use tokio::sync::oneshot;
 
     // Type alias to resolve clippy::type_complexity warning
     type PublishedEvents = Arc<Mutex<Vec<(String, Vec<u8>)>>>;
@@ -788,6 +792,85 @@ mod tests_startup_helpers {
 
     fn local_gpu_event(worker_id: WorkerId, event: KvCacheEvent) -> Vec<PlacementEvent> {
         vec![PlacementEvent::local_gpu(worker_id, event)]
+    }
+
+    #[tokio::test]
+    async fn unexpected_zmq_listener_exit_retracts_advertised_source() {
+        let discovery = Arc::new(MockDiscovery::new(Some(1), SharedMockRegistry::new()));
+        let kv_state_endpoint = EndpointId {
+            namespace: "ns".to_string(),
+            component: "worker".to_string(),
+            name: "generate".to_string(),
+        };
+        let source_instance = discovery
+            .register(DiscoverySpec::EventSource {
+                scope: EventScope::Endpoint {
+                    endpoint: kv_state_endpoint.clone(),
+                },
+                topic: KV_EVENT_SUBJECT.to_string(),
+                publisher_id: 11,
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .unwrap();
+        let source_query = || {
+            DiscoveryQuery::EventSources(EventSourceQuery::endpoint_topic(
+                kv_state_endpoint.clone(),
+                KV_EVENT_SUBJECT,
+            ))
+        };
+        assert_eq!(discovery.list(source_query()).await.unwrap().len(), 1);
+
+        let cancellation_token = CancellationToken::new();
+        let processor_token = cancellation_token.clone();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let cleanup_discovery = discovery.clone();
+        let processor = tokio::spawn(async move {
+            let (publisher, _) = MockComponent::new();
+            start_event_processor(publisher, 1, processor_token, rx, None, None).await;
+            cleanup_discovery.unregister(source_instance).await.unwrap();
+        });
+        let listener_handle = tokio::spawn(async {});
+
+        let unexpected = supervise_zmq_listener(
+            listener_handle,
+            "ipc://events".to_string(),
+            String::new(),
+            cancellation_token.clone(),
+        )
+        .await;
+
+        assert!(unexpected);
+        assert!(cancellation_token.is_cancelled());
+        tokio::time::timeout(Duration::from_secs(1), processor)
+            .await
+            .expect("event processor did not stop after listener failure")
+            .unwrap();
+        assert!(discovery.list(source_query()).await.unwrap().is_empty());
+        drop(tx);
+    }
+
+    #[tokio::test]
+    async fn silent_zmq_listener_remains_healthy_until_normal_shutdown() {
+        let cancellation_token = CancellationToken::new();
+        let (exit_tx, exit_rx) = oneshot::channel();
+        let listener_handle = tokio::spawn(async move {
+            let _ = exit_rx.await;
+        });
+        let supervisor = tokio::spawn(supervise_zmq_listener(
+            listener_handle,
+            "ipc://events".to_string(),
+            String::new(),
+            cancellation_token.clone(),
+        ));
+
+        tokio::task::yield_now().await;
+        assert!(!cancellation_token.is_cancelled());
+        assert!(!supervisor.is_finished());
+
+        cancellation_token.cancel();
+        exit_tx.send(()).unwrap();
+        assert!(!supervisor.await.unwrap());
     }
 
     //--------------------------------------------------------------------

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -171,6 +171,12 @@ pub struct ModelRuntimeConfig {
     #[serde(default = "default_local_indexer")]
     pub enable_local_indexer: bool,
 
+    /// Whether the running engine is configured to publish KV cache events.
+    ///
+    /// `None` indicates a legacy worker that does not declare this capability.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kv_event_publishing_enabled: Option<bool>,
+
     /// Endpoint whose event sources describe this worker's KV state.
     ///
     /// When unset, consumers use the worker's serving endpoint. This keeps existing
@@ -276,6 +282,7 @@ impl Default for ModelRuntimeConfig {
             data_parallel_start_rank: default_data_parallel_start_rank(),
             data_parallel_size: default_data_parallel_size(),
             enable_local_indexer: true,
+            kv_event_publishing_enabled: None,
             kv_state_endpoint: None,
             runtime_data: HashMap::new(),
             disaggregated_endpoint: None,
@@ -621,6 +628,27 @@ mod tests {
             !serde_json::to_string(&legacy)
                 .unwrap()
                 .contains("kv_state_endpoint")
+        );
+    }
+
+    #[test]
+    fn kv_event_publishing_capability_roundtrips_and_preserves_legacy_unknown() {
+        for enabled in [true, false] {
+            let cfg = ModelRuntimeConfig {
+                kv_event_publishing_enabled: Some(enabled),
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&cfg).unwrap();
+            let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.kv_event_publishing_enabled, Some(enabled));
+        }
+
+        let legacy: ModelRuntimeConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(legacy.kv_event_publishing_enabled, None);
+        assert!(
+            !serde_json::to_string(&legacy)
+                .unwrap()
+                .contains("kv_event_publishing_enabled")
         );
     }
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -2993,6 +2993,17 @@ mod ownership_tests {
             Some("tensor")
         );
     }
+
+    #[test]
+    fn runtime_kv_event_capability_does_not_change_mdcsum() {
+        let mut disabled = ModelDeploymentCard::with_name_only("model");
+        disabled.runtime_config.kv_event_publishing_enabled = Some(false);
+
+        let mut enabled = ModelDeploymentCard::with_name_only("model");
+        enabled.runtime_config.kv_event_publishing_enabled = Some(true);
+
+        assert_eq!(disabled.mdcsum(), enabled.mdcsum());
+    }
 }
 
 #[cfg(test)]

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -31,6 +31,11 @@ from tests.router.helper import (
     wait_for_workers_ready,
 )
 from tests.router.router_process import FrontendRouterProcess, KVRouterProcess
+from tests.utils.router_logs import (
+    parse_kv_event_diagnostics,
+    select_kv_event_diagnostics,
+    wait_for_kv_event_diagnostics,
+)
 
 if TYPE_CHECKING:
     from tests.conftest import NatsServer
@@ -224,6 +229,127 @@ def _test_router_basic(
         )
 
         logger.info(f"Successfully completed {num_requests} requests")
+
+
+def _test_kv_event_publisher_disabled_diagnostic(
+    *,
+    frontend,
+    engine_workers,
+    diagnostic_workers,
+    frontend_port: int,
+    test_payload: dict,
+    model_name: str,
+    expected_worker_role: str,
+    expected_requirement: str,
+    expected_rank_count: int,
+    unexpected_worker_roles: tuple[str, ...] = (),
+    expected_total_diagnostics: int = 1,
+    store_backend: str = "etcd",
+    request_plane: str = "tcp",
+):
+    """Assert an explicit disabled publisher is diagnosed without blocking serving."""
+
+    worker_groups = (
+        list(engine_workers)
+        if isinstance(engine_workers, (list, tuple))
+        else [engine_workers]
+    )
+    expected_num_workers = sum(group.num_workers for group in worker_groups)
+
+    async def discover_diagnostic_worker_ids() -> set[int]:
+        runtime = get_runtime(
+            store_backend=store_backend,
+            request_plane=request_plane,
+        )
+        try:
+            endpoint = runtime.endpoint(
+                f"{diagnostic_workers.namespace}."
+                f"{diagnostic_workers.component_name}.generate"
+            )
+            return set(
+                await poll_for_worker_instances(
+                    endpoint,
+                    diagnostic_workers.num_workers,
+                )
+            )
+        finally:
+            runtime.shutdown()
+
+    expected_worker_ids = asyncio.run(discover_diagnostic_worker_ids())
+    expected_serving_endpoint = (
+        f"{diagnostic_workers.namespace}/"
+        f"{diagnostic_workers.component_name}/generate"
+    )
+    expected_dp_ranks = ",".join(str(rank) for rank in range(expected_rank_count))
+
+    frontend_url = f"http://localhost:{frontend_port}"
+    asyncio.run(
+        wait_for_frontend_ready(
+            frontend_url=frontend_url,
+            expected_num_workers=expected_num_workers,
+            timeout=120,
+            test_payload=test_payload,
+            engine_workers=worker_groups,
+            store_backend=store_backend,
+            request_plane=request_plane,
+        )
+    )
+
+    diagnostics = wait_for_kv_event_diagnostics(
+        frontend,
+        diagnostic_code="kv_event_publisher_disabled",
+        expected_count=expected_total_diagnostics,
+        worker_role=expected_worker_role,
+        timeout_s=10,
+    )
+    diagnostic = diagnostics[-1]
+    assert diagnostic.model == model_name
+    assert diagnostic.worker_role == expected_worker_role
+    assert diagnostic.requirement == expected_requirement
+    assert diagnostic.worker_id in expected_worker_ids
+    assert diagnostic.serving_endpoint == expected_serving_endpoint
+    assert diagnostic.kv_event_publishing_enabled is False
+    assert diagnostic.waited_ms == 0
+    assert diagnostic.rank_count == expected_rank_count
+    assert diagnostic.dp_ranks == expected_dp_ranks
+
+    async def assert_inference_succeeds() -> None:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{frontend_url}/v1/chat/completions",
+                json=test_payload,
+            ) as response:
+                body = await response.text()
+                assert response.status == 200, (
+                    "inference must continue when KV event publishing is disabled; "
+                    f"status={response.status}, body={body}"
+                )
+
+    asyncio.run(assert_inference_succeeds())
+
+    final_diagnostics = parse_kv_event_diagnostics(frontend.read_logs())
+    disabled_diagnostics = select_kv_event_diagnostics(
+        final_diagnostics,
+        diagnostic_code="kv_event_publisher_disabled",
+    )
+    assert len(disabled_diagnostics) == expected_total_diagnostics, (
+        "expected exactly one disabled-publisher diagnostic per worker lifecycle "
+        f"after successful inference, got {disabled_diagnostics}"
+    )
+    for worker_role in unexpected_worker_roles:
+        for diagnostic_code in (
+            "kv_event_publisher_disabled",
+            "kv_event_source_not_observed",
+        ):
+            unexpected = select_kv_event_diagnostics(
+                final_diagnostics,
+                diagnostic_code=diagnostic_code,
+                worker_role=worker_role,
+            )
+            assert not unexpected, (
+                f"worker role {worker_role!r} does not require KV events, but "
+                f"emitted {diagnostic_code!r} diagnostics: {unexpected}"
+            )
 
 
 def _test_router_override_router_config(

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -1,19 +1,26 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 import os
 import time
 from typing import Any, Callable, ContextManager
 
 from tests.router.common import (
+    _test_kv_event_publisher_disabled_diagnostic,
     _test_router_basic,
     _test_router_cache_salt_isolation,
     _test_router_decisions,
     _test_router_decisions_disagg,
     _test_router_indexers_sync,
 )
-from tests.router.helper import generate_random_suffix, managed_runtime
+from tests.router.helper import (
+    generate_random_suffix,
+    managed_runtime,
+    wait_for_model_absent,
+)
+from tests.router.router_process import FrontendRouterProcess
 from tests.utils.constants import DynamoPortRange
 from tests.utils.port_utils import allocate_ports, deallocate_ports
 from tests.utils.test_output import resolve_test_output_path
@@ -225,6 +232,116 @@ def run_basic_router_test(
             router_mode=router_mode,
             min_initial_workers=min_initial_workers,
         )
+
+
+def run_kv_event_publisher_disabled_test(
+    *,
+    engine_process_cls,
+    engine_args_name: str,
+    engine_args: dict[str, Any],
+    request,
+    request_plane: str,
+    block_size: int,
+    model_name: str,
+    expected_rank_count: int,
+    engine_process_kwargs: dict[str, Any],
+    test_payload: dict[str, Any] | None = None,
+):
+    process = _create_engine_process(
+        engine_process_cls=engine_process_cls,
+        engine_args_name=engine_args_name,
+        engine_args=engine_args,
+        request=request,
+        request_plane=request_plane,
+        default_process_kwargs={},
+        engine_process_kwargs=engine_process_kwargs,
+    )
+    frontend_port = allocate_frontend_ports(request, 1)[0]
+    with FrontendRouterProcess(
+        request,
+        block_size,
+        frontend_port,
+        process.namespace,
+        request_plane=request_plane,
+        router_mode="kv",
+        min_initial_workers=1,
+        extra_env={"DYN_LOGGING_JSONL": "1", "DYN_LOG": "info"},
+    ) as frontend:
+        with process as engine_workers:
+            _test_kv_event_publisher_disabled_diagnostic(
+                frontend=frontend,
+                engine_workers=engine_workers,
+                diagnostic_workers=engine_workers,
+                frontend_port=frontend_port,
+                test_payload=test_payload or build_test_payload(model_name),
+                model_name=model_name,
+                expected_worker_role="aggregated",
+                expected_requirement="cache_aware_routing",
+                expected_rank_count=expected_rank_count,
+                request_plane=request_plane,
+            )
+        asyncio.run(
+            wait_for_model_absent(
+                f"http://localhost:{frontend_port}",
+                model_name,
+            )
+        )
+        with process as engine_workers:
+            _test_kv_event_publisher_disabled_diagnostic(
+                frontend=frontend,
+                engine_workers=engine_workers,
+                diagnostic_workers=engine_workers,
+                frontend_port=frontend_port,
+                test_payload=test_payload or build_test_payload(model_name),
+                model_name=model_name,
+                expected_worker_role="aggregated",
+                expected_requirement="cache_aware_routing",
+                expected_rank_count=expected_rank_count,
+                expected_total_diagnostics=2,
+                request_plane=request_plane,
+            )
+
+
+def run_disagg_kv_event_publisher_disabled_test(
+    *,
+    request,
+    request_plane: str,
+    block_size: int,
+    model_name: str,
+    expected_prefill_rank_count: int,
+    worker_context_factory: Callable[[str], ContextManager[tuple[Any, Any]]],
+    test_payload: dict[str, Any] | None = None,
+):
+    shared_namespace = f"test-namespace-{generate_random_suffix()}"
+    frontend_port = allocate_frontend_ports(request, 1)[0]
+
+    with FrontendRouterProcess(
+        request,
+        block_size,
+        frontend_port,
+        shared_namespace,
+        request_plane=request_plane,
+        router_mode="kv",
+        min_initial_workers=1,
+        extra_env={"DYN_LOGGING_JSONL": "1", "DYN_LOG": "info"},
+    ) as frontend:
+        with worker_context_factory(shared_namespace) as (
+            prefill_workers,
+            decode_workers,
+        ):
+            _test_kv_event_publisher_disabled_diagnostic(
+                frontend=frontend,
+                engine_workers=[prefill_workers, decode_workers],
+                diagnostic_workers=prefill_workers,
+                frontend_port=frontend_port,
+                test_payload=test_payload or build_test_payload(model_name),
+                model_name=model_name,
+                expected_worker_role="prefill",
+                expected_requirement="cache_aware_routing",
+                expected_rank_count=expected_prefill_rank_count,
+                unexpected_worker_roles=("decode",),
+                request_plane=request_plane,
+            )
 
 
 def run_router_decisions_test(

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import logging
 import os
 import time
@@ -15,11 +14,7 @@ from tests.router.common import (
     _test_router_decisions_disagg,
     _test_router_indexers_sync,
 )
-from tests.router.helper import (
-    generate_random_suffix,
-    managed_runtime,
-    wait_for_model_absent,
-)
+from tests.router.helper import generate_random_suffix, managed_runtime
 from tests.router.router_process import FrontendRouterProcess
 from tests.utils.constants import DynamoPortRange
 from tests.utils.port_utils import allocate_ports, deallocate_ports
@@ -278,26 +273,6 @@ def run_kv_event_publisher_disabled_test(
                 expected_worker_role="aggregated",
                 expected_requirement="cache_aware_routing",
                 expected_rank_count=expected_rank_count,
-                request_plane=request_plane,
-            )
-        asyncio.run(
-            wait_for_model_absent(
-                f"http://localhost:{frontend_port}",
-                model_name,
-            )
-        )
-        with process as engine_workers:
-            _test_kv_event_publisher_disabled_diagnostic(
-                frontend=frontend,
-                engine_workers=engine_workers,
-                diagnostic_workers=engine_workers,
-                frontend_port=frontend_port,
-                test_payload=test_payload or build_test_payload(model_name),
-                model_name=model_name,
-                expected_worker_role="aggregated",
-                expected_requirement="cache_aware_routing",
-                expected_rank_count=expected_rank_count,
-                expected_total_diagnostics=2,
                 request_plane=request_plane,
             )
 

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -337,6 +337,38 @@ async def wait_for_frontend_ready(
         await asyncio.sleep(1)
 
 
+async def wait_for_model_absent(
+    frontend_url: str,
+    model_name: str,
+    timeout: float = 30,
+) -> None:
+    """Wait until a removed model no longer appears in the frontend model list."""
+
+    deadline = asyncio.get_running_loop().time() + timeout
+    models_url = f"{frontend_url}/v1/models"
+    async with aiohttp.ClientSession() as session:
+        while True:
+            try:
+                async with session.get(models_url) as response:
+                    if response.status == 200:
+                        payload = await response.json()
+                        model_ids = {
+                            model.get("id")
+                            for model in payload.get("data", [])
+                            if isinstance(model, dict)
+                        }
+                        if model_name not in model_ids:
+                            return
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError):
+                pass
+
+            if asyncio.get_running_loop().time() >= deadline:
+                raise TimeoutError(
+                    f"Timeout waiting for model {model_name!r} to leave {models_url}"
+                )
+            await asyncio.sleep(0.1)
+
+
 async def poll_for_worker_instances(
     endpoint,
     expected_num_workers: int,

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+from collections.abc import Mapping
 
 from tests.utils.managed_process import ManagedProcess
 
@@ -57,6 +58,7 @@ class FrontendRouterProcess(ManagedProcess):
         use_remote_indexer: bool = False,
         event_plane: str | None = None,
         session_affinity_ttl_secs: int | None = None,
+        extra_env: Mapping[str, str | None] | None = None,
     ):
         command = [
             sys.executable,
@@ -132,6 +134,11 @@ class FrontendRouterProcess(ManagedProcess):
             env.pop("NATS_SERVER", None)
         if min_initial_workers is not None:
             env["DYN_ROUTER_MIN_INITIAL_WORKERS"] = str(min_initial_workers)
+        for name, value in (extra_env or {}).items():
+            if value is None:
+                env.pop(name, None)
+            else:
+                env[name] = value
 
         super().__init__(
             command=command,

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -348,7 +348,7 @@ class CounterWorkerProcess:
                     pass
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(120)
 @pytest.mark.parametrize(
     ("topology", "request_plane"),
     [

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -40,8 +40,10 @@ from tests.router.e2e_harness import (
     allocate_frontend_ports,
     build_test_payload,
     run_basic_router_test,
+    run_disagg_kv_event_publisher_disabled_test,
     run_disagg_router_decisions_test,
     run_indexers_sync_test,
+    run_kv_event_publisher_disabled_test,
     run_router_decisions_test,
 )
 from tests.router.helper import (
@@ -344,6 +346,72 @@ class CounterWorkerProcess:
                     os.unlink(path)
                 except OSError:
                     pass
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize(
+    ("topology", "request_plane"),
+    [
+        pytest.param("aggregated", "tcp", id="aggregated"),
+        pytest.param("disaggregated", "nats", id="disaggregated"),
+    ],
+    indirect=["request_plane"],
+)
+def test_mocker_kv_event_publisher_disabled_diagnostic(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+    topology,
+    request_plane,
+):
+    dp_size = 1 if topology == "aggregated" else 2
+    mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+        "dp_size": dp_size,
+        "enable_prefix_caching": False,
+    }
+
+    if topology == "aggregated":
+        run_kv_event_publisher_disabled_test(
+            engine_process_cls=MockerProcess,
+            engine_args_name="mocker_args",
+            engine_args=mocker_args,
+            request=request,
+            request_plane=request_plane,
+            block_size=BLOCK_SIZE,
+            model_name=MODEL_NAME,
+            expected_rank_count=dp_size,
+            engine_process_kwargs={"num_mockers": 1},
+            test_payload=TEST_PAYLOAD,
+        )
+        return
+
+    decode_mocker_args = {
+        "speedup_ratio": SPEEDUP_RATIO,
+        "block_size": BLOCK_SIZE,
+        "dp_size": dp_size,
+    }
+
+    run_disagg_kv_event_publisher_disabled_test(
+        request=request,
+        request_plane=request_plane,
+        block_size=BLOCK_SIZE,
+        model_name=MODEL_NAME,
+        expected_prefill_rank_count=dp_size,
+        worker_context_factory=lambda namespace: launch_disagg_workers(
+            request,
+            namespace,
+            "prefill_first",
+            prefill_mocker_args=mocker_args,
+            decode_mocker_args=decode_mocker_args,
+            num_prefill_mockers=1,
+            num_decode_mockers=1,
+            enable_disagg_bootstrap=False,
+            request_plane=request_plane,
+        ),
+        test_payload=TEST_PAYLOAD,
+    )
 
 
 @pytest.mark.timeout(180)  # planner-profile mocker setup can exceed 120s on CI CPUs

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -348,7 +348,7 @@ class CounterWorkerProcess:
                     pass
 
 
-@pytest.mark.timeout(120)
+@pytest.mark.timeout(300)
 @pytest.mark.parametrize(
     ("topology", "request_plane"),
     [

--- a/tests/utils/router_logs.py
+++ b/tests/utils/router_logs.py
@@ -5,10 +5,12 @@
 
 from __future__ import annotations
 
+import json
 import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal, Protocol, Sequence, cast
 
 _ROUTING_MESSAGE_PATTERN = re.compile(
     r"\[ROUTING\].*with\s*(?P<overlap>\d+(?:\.\d+)?)/(?P<total>\d+)\s*blocks overlap"
@@ -17,6 +19,28 @@ _FIELD_PATTERN = re.compile(
     r"\b(?P<key>request_id|worker_id|dp_rank|overlap_blocks|total_blocks)="
     r"(?P<value>\"[^\"]*\"|\S+)"
 )
+
+KvEventDiagnosticCode = Literal[
+    "kv_event_publisher_disabled",
+    "kv_event_source_not_observed",
+    "kv_event_source_ambiguous",
+    "kv_event_source_recovered",
+]
+
+KV_EVENT_DIAGNOSTIC_CODES = frozenset(
+    {
+        "kv_event_publisher_disabled",
+        "kv_event_source_not_observed",
+        "kv_event_source_ambiguous",
+        "kv_event_source_recovered",
+    }
+)
+_SNAKE_CASE_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+
+
+class LogReadable(Protocol):
+    def read_logs(self) -> str:
+        ...
 
 
 @dataclass(frozen=True)
@@ -114,3 +138,184 @@ def wait_for_router_kv_overlap(
         f"{_context_prefix(context)}Expected a structured router KV overlap log "
         f"event after the request.\nRecent {log_label} logs:\n{last_segment[-4000:]}"
     )
+
+
+@dataclass(frozen=True)
+class KvEventDiagnostic:
+    """Typed KV-event diagnostic decoded from the runtime JSONL log stream."""
+
+    diagnostic_code: KvEventDiagnosticCode
+    model: str
+    worker_role: str
+    requirement: str
+    worker_id: int
+    serving_endpoint: str
+    kv_event_publishing_enabled: bool
+    waited_ms: int
+    rank_count: int
+    dp_ranks: str
+
+
+def _require_string(record: dict[str, object], field: str, line_number: int) -> str:
+    value = record.get(field)
+    if not isinstance(value, str):
+        raise ValueError(
+            f"router diagnostic line {line_number} field {field!r} must be a string"
+        )
+    return value
+
+
+def _require_int(record: dict[str, object], field: str, line_number: int) -> int:
+    value = record.get(field)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(
+            f"router diagnostic line {line_number} field {field!r} must be an integer"
+        )
+    return value
+
+
+def _require_bool(record: dict[str, object], field: str, line_number: int) -> bool:
+    value = record.get(field)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"router diagnostic line {line_number} field {field!r} must be a boolean"
+        )
+    return value
+
+
+def _validate_dp_ranks(dp_ranks: str, rank_count: int, line_number: int) -> None:
+    try:
+        ranks = [] if not dp_ranks else [int(rank) for rank in dp_ranks.split(",")]
+    except ValueError as error:
+        raise ValueError(
+            f"router diagnostic line {line_number} has invalid dp_ranks={dp_ranks!r}"
+        ) from error
+
+    canonical = ",".join(str(rank) for rank in sorted(set(ranks)))
+    if dp_ranks != canonical:
+        raise ValueError(
+            f"router diagnostic line {line_number} dp_ranks must be unique, "
+            "comma-separated, and ascending"
+        )
+    if rank_count != len(ranks):
+        raise ValueError(
+            f"router diagnostic line {line_number} rank_count={rank_count} "
+            f"does not match dp_ranks={dp_ranks!r}"
+        )
+
+
+def _parse_diagnostic(record: dict[str, object], line_number: int) -> KvEventDiagnostic:
+    diagnostic_code = _require_string(record, "diagnostic_code", line_number)
+    if diagnostic_code not in KV_EVENT_DIAGNOSTIC_CODES:
+        raise ValueError(
+            f"router diagnostic line {line_number} has unknown "
+            f"diagnostic_code={diagnostic_code!r}"
+        )
+
+    worker_role = _require_string(record, "worker_role", line_number)
+    if _SNAKE_CASE_PATTERN.fullmatch(worker_role) is None:
+        raise ValueError(
+            f"router diagnostic line {line_number} has non-snake-case "
+            f"worker_role={worker_role!r}"
+        )
+
+    requirement = _require_string(record, "requirement", line_number)
+    if _SNAKE_CASE_PATTERN.fullmatch(requirement) is None:
+        raise ValueError(
+            f"router diagnostic line {line_number} has non-snake-case "
+            f"requirement={requirement!r}"
+        )
+
+    waited_ms = _require_int(record, "waited_ms", line_number)
+    rank_count = _require_int(record, "rank_count", line_number)
+    dp_ranks = _require_string(record, "dp_ranks", line_number)
+    if waited_ms < 0:
+        raise ValueError(
+            f"router diagnostic line {line_number} waited_ms must be non-negative"
+        )
+    if rank_count < 0:
+        raise ValueError(
+            f"router diagnostic line {line_number} rank_count must be non-negative"
+        )
+    _validate_dp_ranks(dp_ranks, rank_count, line_number)
+
+    return KvEventDiagnostic(
+        diagnostic_code=cast(KvEventDiagnosticCode, diagnostic_code),
+        model=_require_string(record, "model", line_number),
+        worker_role=worker_role,
+        requirement=requirement,
+        worker_id=_require_int(record, "worker_id", line_number),
+        serving_endpoint=_require_string(record, "serving_endpoint", line_number),
+        kv_event_publishing_enabled=_require_bool(
+            record, "kv_event_publishing_enabled", line_number
+        ),
+        waited_ms=waited_ms,
+        rank_count=rank_count,
+        dp_ranks=dp_ranks,
+    )
+
+
+def parse_kv_event_diagnostics(log_content: str) -> list[KvEventDiagnostic]:
+    """Parse typed KV-event diagnostics, ignoring unrelated or partial log lines."""
+
+    diagnostics = []
+    for line_number, raw_line in enumerate(log_content.splitlines(), start=1):
+        json_start = raw_line.find("{")
+        if json_start < 0:
+            continue
+
+        try:
+            record = json.loads(raw_line[json_start:])
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict) or "diagnostic_code" not in record:
+            continue
+
+        diagnostics.append(_parse_diagnostic(record, line_number))
+    return diagnostics
+
+
+def select_kv_event_diagnostics(
+    diagnostics: Sequence[KvEventDiagnostic],
+    *,
+    diagnostic_code: KvEventDiagnosticCode,
+    worker_role: str | None = None,
+) -> list[KvEventDiagnostic]:
+    return [
+        diagnostic
+        for diagnostic in diagnostics
+        if diagnostic.diagnostic_code == diagnostic_code
+        and (worker_role is None or diagnostic.worker_role == worker_role)
+    ]
+
+
+def wait_for_kv_event_diagnostics(
+    process: LogReadable,
+    *,
+    diagnostic_code: KvEventDiagnosticCode,
+    expected_count: int = 1,
+    worker_role: str | None = None,
+    timeout_s: float = 10.0,
+    poll_interval_s: float = 0.1,
+) -> list[KvEventDiagnostic]:
+    """Poll a process JSONL log until at least ``expected_count`` records appear."""
+
+    if expected_count < 1:
+        raise ValueError("expected_count must be at least one")
+
+    deadline = time.monotonic() + timeout_s
+    while True:
+        diagnostics = select_kv_event_diagnostics(
+            parse_kv_event_diagnostics(process.read_logs()),
+            diagnostic_code=diagnostic_code,
+            worker_role=worker_role,
+        )
+        if len(diagnostics) >= expected_count:
+            return diagnostics
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"timed out waiting for {expected_count} {diagnostic_code!r} "
+                f"diagnostic(s) for worker_role={worker_role!r}; "
+                f"observed {len(diagnostics)}"
+            )
+        time.sleep(poll_interval_s)

--- a/tests/utils/router_logs.py
+++ b/tests/utils/router_logs.py
@@ -10,7 +10,7 @@ import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Literal, Protocol, Sequence, cast
+from typing import Literal, Protocol, Sequence, cast, get_args
 
 _ROUTING_MESSAGE_PATTERN = re.compile(
     r"\[ROUTING\].*with\s*(?P<overlap>\d+(?:\.\d+)?)/(?P<total>\d+)\s*blocks overlap"
@@ -27,15 +27,7 @@ KvEventDiagnosticCode = Literal[
     "kv_event_source_recovered",
 ]
 
-KV_EVENT_DIAGNOSTIC_CODES = frozenset(
-    {
-        "kv_event_publisher_disabled",
-        "kv_event_source_not_observed",
-        "kv_event_source_ambiguous",
-        "kv_event_source_recovered",
-    }
-)
-_SNAKE_CASE_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$")
+KV_EVENT_DIAGNOSTIC_CODES = frozenset(get_args(KvEventDiagnosticCode))
 
 
 class LogReadable(Protocol):
@@ -183,27 +175,6 @@ def _require_bool(record: dict[str, object], field: str, line_number: int) -> bo
     return value
 
 
-def _validate_dp_ranks(dp_ranks: str, rank_count: int, line_number: int) -> None:
-    try:
-        ranks = [] if not dp_ranks else [int(rank) for rank in dp_ranks.split(",")]
-    except ValueError as error:
-        raise ValueError(
-            f"router diagnostic line {line_number} has invalid dp_ranks={dp_ranks!r}"
-        ) from error
-
-    canonical = ",".join(str(rank) for rank in sorted(set(ranks)))
-    if dp_ranks != canonical:
-        raise ValueError(
-            f"router diagnostic line {line_number} dp_ranks must be unique, "
-            "comma-separated, and ascending"
-        )
-    if rank_count != len(ranks):
-        raise ValueError(
-            f"router diagnostic line {line_number} rank_count={rank_count} "
-            f"does not match dp_ranks={dp_ranks!r}"
-        )
-
-
 def _parse_diagnostic(record: dict[str, object], line_number: int) -> KvEventDiagnostic:
     diagnostic_code = _require_string(record, "diagnostic_code", line_number)
     if diagnostic_code not in KV_EVENT_DIAGNOSTIC_CODES:
@@ -212,46 +183,19 @@ def _parse_diagnostic(record: dict[str, object], line_number: int) -> KvEventDia
             f"diagnostic_code={diagnostic_code!r}"
         )
 
-    worker_role = _require_string(record, "worker_role", line_number)
-    if _SNAKE_CASE_PATTERN.fullmatch(worker_role) is None:
-        raise ValueError(
-            f"router diagnostic line {line_number} has non-snake-case "
-            f"worker_role={worker_role!r}"
-        )
-
-    requirement = _require_string(record, "requirement", line_number)
-    if _SNAKE_CASE_PATTERN.fullmatch(requirement) is None:
-        raise ValueError(
-            f"router diagnostic line {line_number} has non-snake-case "
-            f"requirement={requirement!r}"
-        )
-
-    waited_ms = _require_int(record, "waited_ms", line_number)
-    rank_count = _require_int(record, "rank_count", line_number)
-    dp_ranks = _require_string(record, "dp_ranks", line_number)
-    if waited_ms < 0:
-        raise ValueError(
-            f"router diagnostic line {line_number} waited_ms must be non-negative"
-        )
-    if rank_count < 0:
-        raise ValueError(
-            f"router diagnostic line {line_number} rank_count must be non-negative"
-        )
-    _validate_dp_ranks(dp_ranks, rank_count, line_number)
-
     return KvEventDiagnostic(
         diagnostic_code=cast(KvEventDiagnosticCode, diagnostic_code),
         model=_require_string(record, "model", line_number),
-        worker_role=worker_role,
-        requirement=requirement,
+        worker_role=_require_string(record, "worker_role", line_number),
+        requirement=_require_string(record, "requirement", line_number),
         worker_id=_require_int(record, "worker_id", line_number),
         serving_endpoint=_require_string(record, "serving_endpoint", line_number),
         kv_event_publishing_enabled=_require_bool(
             record, "kv_event_publishing_enabled", line_number
         ),
-        waited_ms=waited_ms,
-        rank_count=rank_count,
-        dp_ranks=dp_ranks,
+        waited_ms=_require_int(record, "waited_ms", line_number),
+        rank_count=_require_int(record, "rank_count", line_number),
+        dp_ranks=_require_string(record, "dp_ranks", line_number),
     )
 
 


### PR DESCRIPTION
## Summary

KV routing could become ready and serve traffic while an engine's KV-event publisher was disabled or absent, leaving the prefix index empty or incomplete without a direct diagnostic.

- Add the optional runtime capability `kv_event_publishing_enabled` and publish each backend's effective value from vLLM, SGLang, TensorRT-LLM, and Mocker. Omitted values remain legacy/unknown and do not change deployment-card checksums.
- Derive a typed KV-source requirement from the exact worker role: event-backed Prefill/Aggregated routers require a source, ordinary Decode remains load-only, and conditional-disaggregation Decode remains cache-aware.
- Add a warning-only source-health monitor with stable structured codes for disabled, missing, ambiguous, and recovered sources. Disabled publishers warn immediately; enabled-but-missing sources receive a fixed 30-second grace. Active-but-idle sources remain healthy.
- Join serving membership, runtime capability, endpoint binding, and source discovery with generation/rebinding fencing. Stop stale diagnostic monitors on WorkerSet removal without disrupting transport or in-flight request cleanup.
- Retract discovery advertisement when the upstream ZMQ listener terminates unexpectedly.
- Add structured JSONL test helpers and permanent CPU mocker E2E coverage for aggregated and disaggregated routing, including remove/rejoin lifecycle behavior.

This is diagnostic-only: it does not block readiness, routing, or inference; auto-enable engine publishers; evict workers; or rewrite deployment recipes. KV DC Relay retains its existing source-status metric policy.

### Reviewer guide

1. Requirement semantics and router ownership: `lib/llm/src/kv_router.rs`.
2. Warning state machine and lifecycle: `source_health.rs` and `recovery/subscriber.rs`.
3. Discovery joining/rebinding: `kv_source_membership.rs` and `kv_source_watch.rs`.
4. Backend capability publication and permanent E2E plumbing are integration surfaces around that core.

## Validation

- Cross-engine real-worker campaign with Qwen3-0.6B:
  - vLLM and TensorRT-LLM each emitted exactly one disabled-publisher diagnostic with mismatch `1` while readiness and inference succeeded; enabled publishers remained warning-free after 35 seconds idle, converged mismatch to `0`, and served inference.
  - Two-node SGLang DP-attention aggregated both ranks into one diagnostic, preserved normal and rank-directed inference, emitted one recovery event after a delayed nonleader source joined, and converged mismatch to `0` without idle warnings.
- Disposable compatibility checkout atop the conditional-disaggregation stack: vLLM Decode and Prefill both advertised enabled publication, two sources were active, mismatch remained `0`, and a repeated 1,664-token request took the conditional Decode bypass with successful inference.
- Permanent mocker router E2E: 2 passed, covering aggregated disabled/remove/rejoin and disaggregated Prefill-only warning behavior.
- `cargo test -p dynamo-llm --no-default-features`: passed in full.
- Conditional-stack focused suites: 24 conditional-disagg, 9 conditional-bypass, and 3 decode-router-override tests passed.
- Pre-commit hooks, Black, Ruff, DCO, and GPG signature checks passed on the rebased head.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration for enabling or disabling KV event publishing across supported inference engines and deployments.
  * Improved KV routing to account for worker roles when selecting decode and prefill workers.
  * Added KV source health monitoring with diagnostics for unavailable, ambiguous, disabled, and recovered event sources.
  * Added configuration accessors for KV event publishing status.

* **Bug Fixes**
  * Improved KV event subscription lifecycle, shutdown handling, and recovery during worker changes or listener failures.
  * Prevented stale health warnings during worker rebinds and rejoins.

* **Tests**
  * Expanded unit and end-to-end coverage for KV event configuration, routing, diagnostics, recovery, and publisher failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->