### PR TITLE
fix(codeowners): assign squeeze-evolve to router

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -50,6 +50,7 @@ areas:
   - components/src/dynamo/global_router/
   - components/src/dynamo/global_router/tests/
   - components/src/dynamo/router/
+  - components/src/dynamo/squeeze_evolve/
   - components/src/dynamo/thunderagent_router/
   - lib/kv-router/
   - lib/kv-router/src/indexer/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -74,6 +74,7 @@
 /lib/kv-router/src/scheduling/                                               @ai-dynamo/dynamo-router-codeowners
 /components/src/dynamo/kv_dc_relay/                                          @ai-dynamo/dynamo-router-codeowners
 /components/src/dynamo/global_router/                                        @ai-dynamo/dynamo-router-codeowners
+/components/src/dynamo/squeeze_evolve/                                       @ai-dynamo/dynamo-router-codeowners
 /examples/router/policy-class-queues.yaml                                    @ai-dynamo/dynamo-router-codeowners
 /components/src/dynamo/global_router/tests/                                  @ai-dynamo/dynamo-router-codeowners
 /components/src/dynamo/thunderagent_router/                                  @ai-dynamo/dynamo-router-codeowners


### PR DESCRIPTION
## Summary

- assign `components/src/dynamo/squeeze_evolve/` to the router ownership area
- regenerate root `CODEOWNERS` from `.github/codeowners/areas.yaml`
- resolve the ownership gap reported in the follow-up to #10785

## Validation

- `uv run --no-project --with pyyaml --with pytest python -m pytest .github/codeowners/test_codeowners.py -q -p no:cacheprovider --override-ini=addopts= --override-ini=filterwarnings=` (86 passed)
- `.venv/bin/python .github/codeowners/build_codeowners.py --areas .github/codeowners/areas.yaml --repo . --strict` (4732/4732 explicitly owned; 0 catch-all-only)
- regenerated `CODEOWNERS` and verified no unstaged drift
- `git diff --cached --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules for the `squeeze_evolve` component.
  * Changes to this area will now be routed to the appropriate code review team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->