### PR TITLE
feat(mocker): model per-worker KV transfer bandwidth

### DIFF
--- a/components/src/dynamo/mocker/args.py
+++ b/components/src/dynamo/mocker/args.py
@@ -572,6 +572,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "For intra-node NVLink, typical value is ~450.",
     )
     parser.add_argument(
+        "--kv-transfer-bandwidth-model",
+        choices=("fifo", "independent"),
+        default="fifo",
+        help="Per-prefill-worker KV transfer contention model. 'fifo' allows one transfer "
+        "at full bandwidth and queues later transfers; 'independent' gives every transfer "
+        "the full bandwidth concurrently.",
+    )
+    parser.add_argument(
         "--kv-transfer-timing-mode",
         choices=("full_prompt", "destination_missing"),
         default="full_prompt",

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -313,6 +313,7 @@ def build_mocker_engine_args(args: argparse.Namespace) -> MockEngineArgs:
         enable_local_indexer=True,
         kv_bytes_per_token=getattr(args, "kv_bytes_per_token", None),
         kv_transfer_bandwidth=getattr(args, "kv_transfer_bandwidth", None),
+        kv_transfer_bandwidth_model=getattr(args, "kv_transfer_bandwidth_model", "fifo"),
         kv_transfer_timing_mode=getattr(args, "kv_transfer_timing_mode", "full_prompt"),
         num_g2_blocks=getattr(args, "num_g2_blocks", None),
         num_g3_blocks=getattr(args, "num_g3_blocks", None),

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -47,6 +47,7 @@ def make_args(**overrides):
         "dp_size": 1,
         "startup_time": None,
         "kv_transfer_bandwidth": 64.0,
+        "kv_transfer_bandwidth_model": "fifo",
         "kv_transfer_timing_mode": "full_prompt",
         "reasoning": None,
         "response_replay_trace_path": None,
@@ -258,6 +259,7 @@ def test_runtime_config_disables_local_indexer_for_decode_worker():
 
 def test_entrypoint_args_accept_typed_mocker_engine_args():
     engine_args = CONFIG.build_mocker_engine_args(make_args())
+    assert engine_args.kv_transfer_bandwidth_model == "fifo"
 
     entrypoint_args = EntrypointArgs(
         engine_type=EngineType.Mocker,
@@ -297,6 +299,7 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
         is_decode_worker=False,
         kv_bytes_per_token=131072,
         kv_transfer_bandwidth=123.0,
+        kv_transfer_bandwidth_model="independent",
         kv_transfer_timing_mode="destination_missing",
         response_replay_trace_path=None,
         num_g2_blocks=8192,
@@ -348,6 +351,7 @@ def test_build_mocker_engine_args_preserves_cli_mapped_fields(tmp_path):
     assert engine_args.aic_moe_ep_size is None
     assert engine_args.aic_attention_dp_size is None
     assert engine_args.bootstrap_port is None
+    assert engine_args.kv_transfer_bandwidth_model == "independent"
     assert engine_args.kv_transfer_timing_mode == "destination_missing"
     assert engine_args.num_g2_blocks == 8192
     assert engine_args.num_g3_blocks == 16384
@@ -423,6 +427,16 @@ def test_mocker_cli_accepts_native_g1_for_trtllm():
 
     assert args.engine_type == "trtllm"
     assert args.g1_backend == "native"
+
+
+def test_mocker_cli_defaults_to_fifo_transfer_bandwidth_model():
+    assert parse_args([]).kv_transfer_bandwidth_model == "fifo"
+    assert (
+        parse_args(
+            ["--kv-transfer-bandwidth-model", "independent"]
+        ).kv_transfer_bandwidth_model
+        == "independent"
+    )
 
 
 def test_mocker_cli_accepts_max_model_len():

--- a/docs/dynosim/mocker.md
+++ b/docs/dynosim/mocker.md
@@ -87,7 +87,7 @@ python3 -m dynamo.mocker --help
 | Control prefix and prefill behavior | `--enable-prefix-caching`, `--enable-chunked-prefill`, `--preemption-mode` |
 | Scale the worker topology | `--num-workers`, `--data-parallel-size`, `--stagger-delay` |
 | Choose timing | `--planner-profile-data`, `--aic-perf-model`, `--aic-*`, `--speedup-ratio`, `--decode-speedup-ratio` |
-| Configure direct or coordinated P/D handoff | `--disaggregation-mode`, `--bootstrap-ports`, `--kv-transfer-bandwidth`, `--kv-transfer-timing-mode` |
+| Configure direct or coordinated P/D handoff | `--disaggregation-mode`, `--bootstrap-ports`, `--kv-transfer-bandwidth`, `--kv-transfer-bandwidth-model`, `--kv-transfer-timing-mode` |
 | Configure KVBM lower tiers | `--num-g2-blocks`, `--num-g3-blocks`, `--enable-g4-storage`, `--offload-batch-size`, `--bandwidth-*-gbps` |
 | Select runtime integration | `--discovery-backend`, `--request-plane`, `--event-plane`, `--endpoint` |
 | Replay exact outputs | `--response-replay-trace-path` |
@@ -196,6 +196,12 @@ activation, cancellation, and source release.
 from the model configuration and `--kv-cache-dtype`; use `--kv-bytes-per-token` to override it. Set
 `--kv-transfer-bandwidth 0` to disable the delay. TensorRT-LLM disaggregation is not supported. See
 [Prefill/Decode Handoff](modeling.md#prefilldecode-handoff) for the semantic differences.
+
+By default, `--kv-transfer-bandwidth-model fifo` allows one full-bandwidth transfer at a time per
+logical prefill worker. Transfers from data-parallel ranks of the same prefill worker wait in
+first-in, first-out order; transfers from different prefill workers can overlap. Set
+`--kv-transfer-bandwidth-model independent` to retain the prior behavior, in which concurrent
+transfers each use the configured bandwidth.
 
 ## Scale Workers and Observe Overhead
 

--- a/lib/bench/README.md
+++ b/lib/bench/README.md
@@ -157,6 +157,10 @@ cargo bench --package dynamo-bench --bench offline_replay_bench \
   --kv-bytes-per-token 131072
 ```
 
+Disaggregated replay defaults to `--kv-transfer-bandwidth-model fifo`, which runs one
+full-bandwidth transfer at a time for each prefill worker. Use
+`--kv-transfer-bandwidth-model independent` to preserve overlapping full-bandwidth transfers.
+
 KVBM offload is available only when the benchmark is built with
 `mocker-kvbm-offload`. Build and run this configuration on a supported Linux
 environment:

--- a/lib/bench/offline_replay_bench.rs
+++ b/lib/bench/offline_replay_bench.rs
@@ -19,7 +19,8 @@ use anyhow::ensure;
 use anyhow::{Context, Result};
 use clap::{Parser, ValueEnum};
 use dynamo_mocker::common::protocols::{
-    EngineType, KvTransferTimingMode, MockEngineArgs, SglangArgs, WorkerType,
+    EngineType, KvTransferBandwidthModel, KvTransferTimingMode, MockEngineArgs, SglangArgs,
+    WorkerType,
 };
 use dynamo_mocker::loadgen::Trace;
 use dynamo_mocker::replay::{
@@ -89,6 +90,12 @@ enum KvTransferTimingModeArg {
     DestinationMissing,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+enum KvTransferBandwidthModelArg {
+    Fifo,
+    Independent,
+}
+
 impl From<EngineTypeArg> for EngineType {
     fn from(value: EngineTypeArg) -> Self {
         match value {
@@ -113,6 +120,15 @@ impl From<KvTransferTimingModeArg> for KvTransferTimingMode {
         match value {
             KvTransferTimingModeArg::FullPrompt => KvTransferTimingMode::FullPrompt,
             KvTransferTimingModeArg::DestinationMissing => KvTransferTimingMode::DestinationMissing,
+        }
+    }
+}
+
+impl From<KvTransferBandwidthModelArg> for KvTransferBandwidthModel {
+    fn from(value: KvTransferBandwidthModelArg) -> Self {
+        match value {
+            KvTransferBandwidthModelArg::Fifo => KvTransferBandwidthModel::Fifo,
+            KvTransferBandwidthModelArg::Independent => KvTransferBandwidthModel::Independent,
         }
     }
 }
@@ -193,6 +209,10 @@ struct Args {
     #[arg(long)]
     kv_transfer_bandwidth: Option<f64>,
 
+    /// Per-prefill-worker KV-transfer contention model
+    #[arg(long, value_enum, default_value_t = KvTransferBandwidthModelArg::Fifo)]
+    kv_transfer_bandwidth_model: KvTransferBandwidthModelArg,
+
     /// Disaggregated transfer timing model
     #[arg(long, value_enum, default_value_t = KvTransferTimingModeArg::FullPrompt)]
     kv_transfer_timing_mode: KvTransferTimingModeArg,
@@ -269,6 +289,7 @@ fn build_engine_args(args: &Args) -> Result<MockEngineArgs> {
         .block_size(args.block_size)
         .kv_bytes_per_token(args.kv_bytes_per_token)
         .kv_transfer_bandwidth(args.kv_transfer_bandwidth)
+        .kv_transfer_bandwidth_model(args.kv_transfer_bandwidth_model.into())
         .kv_transfer_timing_mode(args.kv_transfer_timing_mode.into());
     if args.engine_type == EngineTypeArg::Sglang {
         builder = builder.sglang(Some(SglangArgs {

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -182,7 +182,7 @@ impl MockEngineArgs {
 #[pymethods]
 impl MockEngineArgs {
     #[new]
-    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_timing_mode="full_prompt", reasoning=None, response_replay_trace_path=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None, max_model_len=None, g1_backend="kvbm"))]
+    #[pyo3(signature = (engine_type="vllm", num_gpu_blocks=None, block_size=0, max_num_seqs=Some(256), max_num_batched_tokens=Some(8192), enable_prefix_caching=true, enable_chunked_prefill=true, speedup_ratio=1.0, decode_speedup_ratio=1.0, dp_size=1, startup_time=None, worker_type="aggregated", planner_profile_data=None, aic_backend=None, aic_system=None, aic_backend_version=None, aic_tp_size=None, aic_model_path=None, aic_moe_tp_size=None, aic_moe_ep_size=None, aic_attention_dp_size=None, aic_nextn=None, aic_nextn_accept_rates=None, aic_mtp_seed=42, aic_gemm_dtype=None, aic_moe_dtype=None, aic_fmha_dtype=None, aic_kv_cache_dtype=None, aic_comm_dtype=None, gpu_memory_utilization=None, mem_fraction_static=None, free_gpu_memory_fraction=None, enable_local_indexer=false, bootstrap_port=None, handoff_session_timeout_ms=300000, kv_bytes_per_token=None, kv_transfer_bandwidth=None, kv_transfer_bandwidth_model="fifo", kv_transfer_timing_mode="full_prompt", reasoning=None, response_replay_trace_path=None, zmq_kv_events_port=None, zmq_replay_port=None, preemption_mode="lifo", router_queue_policy=None, sglang=None, trtllm=None, num_g2_blocks=None, num_g3_blocks=None, offload_batch_size=None, bandwidth_g1_to_g2_gbps=None, bandwidth_g2_to_g1_gbps=None, bandwidth_g2_to_g3_gbps=None, bandwidth_g3_to_g2_gbps=None, enable_g4_storage=false, bandwidth_g2_to_g4_gbps=None, bandwidth_g4_to_g2_gbps=None, max_model_len=None, g1_backend="kvbm"))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         engine_type: &str,
@@ -222,6 +222,7 @@ impl MockEngineArgs {
         handoff_session_timeout_ms: u64,
         kv_bytes_per_token: Option<usize>,
         kv_transfer_bandwidth: Option<f64>,
+        kv_transfer_bandwidth_model: &str,
         kv_transfer_timing_mode: &str,
         reasoning: Option<ReasoningConfig>,
         response_replay_trace_path: Option<PathBuf>,
@@ -248,6 +249,9 @@ impl MockEngineArgs {
         let worker_type = parse_worker_type(worker_type)?;
         let preemption_mode = parse_preemption_mode(preemption_mode)?;
         let g1_backend = parse_g1_backend(g1_backend)?;
+        let kv_transfer_bandwidth_model = kv_transfer_bandwidth_model
+            .parse()
+            .map_err(|error: String| PyException::new_err(error))?;
         let kv_transfer_timing_mode = kv_transfer_timing_mode
             .parse()
             .map_err(|error: String| PyException::new_err(error))?;
@@ -298,6 +302,7 @@ impl MockEngineArgs {
             .handoff_session_timeout_ms(handoff_session_timeout_ms)
             .kv_bytes_per_token(kv_bytes_per_token)
             .kv_transfer_bandwidth(kv_transfer_bandwidth)
+            .kv_transfer_bandwidth_model(kv_transfer_bandwidth_model)
             .kv_transfer_timing_mode(kv_transfer_timing_mode)
             .num_g2_blocks(num_g2_blocks)
             .num_g3_blocks(num_g3_blocks)
@@ -440,6 +445,16 @@ impl MockEngineArgs {
             dynamo_mocker::common::protocols::KvTransferTimingMode::FullPrompt => "full_prompt",
             dynamo_mocker::common::protocols::KvTransferTimingMode::DestinationMissing => {
                 "destination_missing"
+            }
+        }
+    }
+
+    #[getter]
+    fn kv_transfer_bandwidth_model(&self) -> &'static str {
+        match self.inner.kv_transfer_bandwidth_model {
+            dynamo_mocker::common::protocols::KvTransferBandwidthModel::Fifo => "fifo",
+            dynamo_mocker::common::protocols::KvTransferBandwidthModel::Independent => {
+                "independent"
             }
         }
     }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -26,8 +26,8 @@ use dashmap::DashMap;
 use dynamo_kv_router::protocols::{KvCacheEvent, StorageTier};
 use dynamo_mocker::common::handoff::HandoffId;
 use dynamo_mocker::common::protocols::{
-    DirectRequest, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal,
-    RawKvEventSink,
+    DirectRequest, KvCacheEventSink, KvEventPublishers, KvTransferBandwidthModel, MockEngineArgs,
+    OutputSignal, RawKvEventSink,
 };
 use dynamo_mocker::engine::create_engine;
 use dynamo_mocker::loadgen::{OUTPUT_REPLAY_ID_ANNOTATION_KEY, effective_replay_key};
@@ -199,13 +199,64 @@ fn generate_random_token() -> TokenIdType {
     rng.random_range(1000..2000)
 }
 
-async fn wait_for_no_bootstrap_handoff_delay(
-    is_prefill: bool,
-    has_handoff_session: bool,
-    delay_ms: Option<f64>,
-) {
-    if let Some(delay) = no_bootstrap_handoff_delay(is_prefill, has_handoff_session, delay_ms) {
+#[derive(Clone)]
+struct KvTransferGate {
+    model: KvTransferBandwidthModel,
+    permit: Arc<Semaphore>,
+}
+
+impl KvTransferGate {
+    fn new(model: KvTransferBandwidthModel) -> Self {
+        Self {
+            model,
+            permit: Arc::new(Semaphore::new(1)),
+        }
+    }
+
+    async fn wait(&self, delay: Duration) {
+        if delay.is_zero() {
+            return;
+        }
+        let _permit = match self.model {
+            KvTransferBandwidthModel::Fifo => Some(
+                self.permit
+                    .acquire()
+                    .await
+                    .expect("KV transfer gate must remain open"),
+            ),
+            KvTransferBandwidthModel::Independent => None,
+        };
         tokio::time::sleep(delay).await;
+    }
+
+    async fn wait_with_queue_deadline(
+        &self,
+        delay: Duration,
+        queue_deadline: tokio::time::Instant,
+    ) -> bool {
+        if delay.is_zero() {
+            return true;
+        }
+        let _permit = match self.model {
+            KvTransferBandwidthModel::Fifo => {
+                let permit = tokio::select! {
+                    biased;
+                    permit = self.permit.acquire() => permit
+                        .expect("KV transfer gate must remain open"),
+                    _ = tokio::time::sleep_until(queue_deadline) => return false,
+                };
+                Some(permit)
+            }
+            KvTransferBandwidthModel::Independent => None,
+        };
+        tokio::time::sleep(delay).await;
+        true
+    }
+}
+
+impl Default for KvTransferGate {
+    fn default() -> Self {
+        Self::new(KvTransferBandwidthModel::Fifo)
     }
 }
 
@@ -230,6 +281,7 @@ pub struct MockEngine {
     // context stop/response-stream drop path to targeted cancellation. Until then, lib/mocker
     // cancellation is not wired end to end through MockEngine.
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,
+    kv_transfer_gate: KvTransferGate,
     senders_ready: Notify,
     engine_args: MockEngineArgs,
     response_replay_table: Option<ResponseReplayTable>,
@@ -257,6 +309,7 @@ struct PreparedBootstrap {
 impl MockEngine {
     /// Create a new MockEngine with the given parameters
     pub fn new(engine_args: MockEngineArgs) -> Self {
+        let kv_transfer_gate = KvTransferGate::new(engine_args.kv_transfer_bandwidth_model);
         let native_metrics = NativeMockerMetrics::new(engine_args.engine_type, engine_args.dp_size)
             .expect("mocker native metrics collectors should be valid");
         let response_replay_table = engine_args
@@ -281,6 +334,7 @@ impl MockEngine {
             request_senders: OnceCell::new(),
             command_senders: OnceCell::new(),
             handoff_session_permits: OnceCell::new(),
+            kv_transfer_gate,
             senders_ready: Notify::new(),
             engine_args,
             response_replay_table,
@@ -341,10 +395,11 @@ impl MockEngine {
         let incoming_rx = server
             .take_incoming_receiver()
             .expect("new bootstrap server must own its incoming receiver");
-        let manager = SourceHandoffManager::start(
+        let manager = SourceHandoffManager::start_with_transfer_gate(
             incoming_rx,
             max_sessions,
             Duration::from_millis(self.engine_args.handoff_session_timeout_ms),
+            self.kv_transfer_gate.clone(),
             self.handoff_shutdown.clone(),
         );
         assert!(
@@ -972,6 +1027,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
         let reasoning = self.engine_args.reasoning.clone();
         let handoff_session_timeout =
             Duration::from_millis(self.engine_args.handoff_session_timeout_ms);
+        let kv_transfer_gate = self.kv_transfer_gate.clone();
         let mut native_timing = native_timing;
         let response_task_tracker = (source_completion_rx.is_some()
             || destination_cleanup.is_some())
@@ -1074,12 +1130,21 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             }
                             native_timing.record_tokens(1);
 
-                            wait_for_no_bootstrap_handoff_delay(
+                            if let Some(delay) = no_bootstrap_handoff_delay(
                                 is_prefill,
                                 has_handoff_session,
                                 signal.handoff_delay_ms,
-                            )
-                            .await;
+                            ) {
+                                tokio::select! {
+                                    biased;
+                                    _ = async_context.stopped() => {
+                                        handoff_cancel.cancel();
+                                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
+                                        break;
+                                    }
+                                    _ = kv_transfer_gate.wait(delay) => {}
+                                }
+                            }
 
                             if !source_handoff_complete
                                 && let Some(completion_rx) = source_completion_rx.take()
@@ -1318,6 +1383,164 @@ mod tests {
         assert!(finish.token_ids.is_empty());
         assert!(finish.finish_reason.is_some());
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fifo_transfer_gate_serializes_one_prefill_worker() {
+        let gate = KvTransferGate::default();
+        let first_gate = gate.clone();
+        let first = tokio::spawn(async move {
+            first_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+        let second_gate = gate.clone();
+        let second = tokio::spawn(async move {
+            second_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(first.is_finished());
+        assert!(!second.is_finished());
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(second.is_finished());
+        first.await.unwrap();
+        second.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn independent_transfer_gate_allows_overlap() {
+        let independent = KvTransferGate::new(KvTransferBandwidthModel::Independent);
+        let first_gate = independent.clone();
+        let first = tokio::spawn(async move {
+            first_gate.wait(Duration::from_millis(100)).await;
+        });
+        let second_gate = independent.clone();
+        let second = tokio::spawn(async move {
+            second_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(first.is_finished());
+        assert!(second.is_finished());
+        first.await.unwrap();
+        second.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn separate_prefill_worker_transfer_gates_overlap() {
+        let first_worker = KvTransferGate::default();
+        let second_worker = KvTransferGate::default();
+        let first = tokio::spawn(async move {
+            first_worker.wait(Duration::from_millis(100)).await;
+        });
+        let second = tokio::spawn(async move {
+            second_worker.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(first.is_finished());
+        assert!(second.is_finished());
+        first.await.unwrap();
+        second.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn canceling_fifo_transfer_releases_the_next_waiter() {
+        let gate = KvTransferGate::default();
+        let active_gate = gate.clone();
+        let active = tokio::spawn(async move {
+            active_gate.wait(Duration::from_secs(1)).await;
+        });
+        tokio::task::yield_now().await;
+        let queued_gate = gate.clone();
+        let queued = tokio::spawn(async move {
+            queued_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        active.abort();
+        let _ = active.await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(queued.is_finished());
+        queued.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn canceling_queued_fifo_transfer_preserves_the_next_waiter() {
+        let gate = KvTransferGate::default();
+        let active_gate = gate.clone();
+        let active = tokio::spawn(async move {
+            active_gate.wait(Duration::from_secs(1)).await;
+        });
+        tokio::task::yield_now().await;
+        let canceled_gate = gate.clone();
+        let canceled = tokio::spawn(async move {
+            canceled_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+        let next_gate = gate.clone();
+        let next = tokio::spawn(async move {
+            next_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        canceled.abort();
+        let _ = canceled.await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::task::yield_now().await;
+        assert!(active.is_finished());
+        assert!(!next.is_finished());
+
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(next.is_finished());
+        active.await.unwrap();
+        next.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timing_out_queued_fifo_transfer_preserves_the_next_waiter() {
+        let gate = KvTransferGate::default();
+        let active_gate = gate.clone();
+        let active = tokio::spawn(async move {
+            active_gate.wait(Duration::from_secs(1)).await;
+        });
+        tokio::task::yield_now().await;
+        let timed_out_gate = gate.clone();
+        let queue_deadline = tokio::time::Instant::now() + Duration::from_millis(50);
+        let timed_out = tokio::spawn(async move {
+            timed_out_gate
+                .wait_with_queue_deadline(Duration::from_millis(100), queue_deadline)
+                .await
+        });
+        tokio::task::yield_now().await;
+        let next_gate = gate.clone();
+        let next = tokio::spawn(async move {
+            next_gate.wait(Duration::from_millis(100)).await;
+        });
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(Duration::from_millis(50)).await;
+        tokio::task::yield_now().await;
+        assert!(!timed_out.await.unwrap());
+
+        active.abort();
+        let _ = active.await;
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_millis(100)).await;
+        tokio::task::yield_now().await;
+        assert!(next.is_finished());
+        next.await.unwrap();
     }
 
     #[tokio::test]

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -25,6 +25,8 @@ use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
+use super::KvTransferGate;
+
 const SESSION_INBOX_CAPACITY: usize = 32;
 const PARTICIPANT_RENDEZVOUS_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -175,22 +177,49 @@ struct SourceHandoffManagerTestState {
     retired: HashSet<HandoffId>,
 }
 
+struct SourceHandoffManagerOptions {
+    max_sessions: usize,
+    session_timeout: Duration,
+    rendezvous_timeout: Duration,
+    transfer_gate: KvTransferGate,
+}
+
 impl SourceHandoffManager {
+    #[cfg(test)]
     pub(crate) fn start(
         incoming_rx: mpsc::Receiver<IncomingBootstrapConnection>,
         max_sessions: usize,
         session_timeout: Duration,
         shutdown: CancellationToken,
     ) -> Self {
-        Self::start_with_rendezvous_timeout(
+        Self::start_with_options(
             incoming_rx,
             max_sessions,
             session_timeout,
             PARTICIPANT_RENDEZVOUS_TIMEOUT,
+            KvTransferGate::default(),
             shutdown,
         )
     }
 
+    pub(crate) fn start_with_transfer_gate(
+        incoming_rx: mpsc::Receiver<IncomingBootstrapConnection>,
+        max_sessions: usize,
+        session_timeout: Duration,
+        transfer_gate: KvTransferGate,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self::start_with_options(
+            incoming_rx,
+            max_sessions,
+            session_timeout,
+            PARTICIPANT_RENDEZVOUS_TIMEOUT,
+            transfer_gate,
+            shutdown,
+        )
+    }
+
+    #[cfg(test)]
     fn start_with_rendezvous_timeout(
         incoming_rx: mpsc::Receiver<IncomingBootstrapConnection>,
         max_sessions: usize,
@@ -198,17 +227,39 @@ impl SourceHandoffManager {
         rendezvous_timeout: Duration,
         shutdown: CancellationToken,
     ) -> Self {
+        Self::start_with_options(
+            incoming_rx,
+            max_sessions,
+            session_timeout,
+            rendezvous_timeout,
+            KvTransferGate::default(),
+            shutdown,
+        )
+    }
+
+    fn start_with_options(
+        incoming_rx: mpsc::Receiver<IncomingBootstrapConnection>,
+        max_sessions: usize,
+        session_timeout: Duration,
+        rendezvous_timeout: Duration,
+        transfer_gate: KvTransferGate,
+        shutdown: CancellationToken,
+    ) -> Self {
         let (source_tx, source_rx) = mpsc::channel(max_sessions.max(1));
         let (closed_tx, closed_rx) = watch::channel(false);
         #[cfg(test)]
         let (state_tx, state_rx) = watch::channel(SourceHandoffManagerTestState::default());
+        let options = SourceHandoffManagerOptions {
+            max_sessions: max_sessions.max(1),
+            session_timeout,
+            rendezvous_timeout,
+            transfer_gate,
+        };
         tokio::spawn(async move {
             run_manager(
                 source_rx,
                 incoming_rx,
-                max_sessions.max(1),
-                session_timeout,
-                rendezvous_timeout,
+                options,
                 shutdown,
                 #[cfg(test)]
                 state_tx,
@@ -280,12 +331,16 @@ struct PendingSession {
 async fn run_manager(
     mut source_rx: mpsc::Receiver<SourceRegistration>,
     mut incoming_rx: mpsc::Receiver<IncomingBootstrapConnection>,
-    max_sessions: usize,
-    session_timeout: Duration,
-    rendezvous_timeout: Duration,
+    options: SourceHandoffManagerOptions,
     shutdown: CancellationToken,
     #[cfg(test)] state_tx: watch::Sender<SourceHandoffManagerTestState>,
 ) {
+    let SourceHandoffManagerOptions {
+        max_sessions,
+        session_timeout,
+        rendezvous_timeout,
+        transfer_gate,
+    } = options;
     let mut pending = HashMap::<HandoffId, PendingSession>::new();
     let mut active = HashSet::<HandoffId>::new();
     let mut retired = HashMap::<HandoffId, Instant>::new();
@@ -334,6 +389,7 @@ async fn run_manager(
                     &mut pending,
                     &mut active,
                     session_timeout,
+                    transfer_gate.clone(),
                     shutdown.clone(),
                     done_tx.clone(),
                     &sessions,
@@ -383,6 +439,7 @@ async fn run_manager(
                     &mut pending,
                     &mut active,
                     session_timeout,
+                    transfer_gate.clone(),
                     shutdown.clone(),
                     done_tx.clone(),
                     &sessions,
@@ -528,6 +585,7 @@ fn maybe_start_session(
     pending: &mut HashMap<HandoffId, PendingSession>,
     active: &mut HashSet<HandoffId>,
     session_timeout: Duration,
+    transfer_gate: KvTransferGate,
     shutdown: CancellationToken,
     done_tx: mpsc::Sender<HandoffId>,
     sessions: &TaskTracker,
@@ -570,7 +628,14 @@ fn maybe_start_session(
 
     active.insert(handoff_id);
     sessions.spawn(async move {
-        let _ = run_source_session(source, destination.connection, session_timeout, shutdown).await;
+        let _ = run_source_session(
+            source,
+            destination.connection,
+            session_timeout,
+            transfer_gate,
+            shutdown,
+        )
+        .await;
         let _ = done_tx.try_send(handoff_id);
     });
 }
@@ -799,6 +864,7 @@ async fn run_source_session(
     source: SourceRegistration,
     connection: BootstrapConnection,
     session_timeout: Duration,
+    transfer_gate: KvTransferGate,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let SourceRegistration {
@@ -904,17 +970,27 @@ async fn run_source_session(
                         );
                         let event_tx = event_tx.clone();
                         let action_stop = action_stop.clone();
+                        let transfer_gate = transfer_gate.clone();
+                        let queue_deadline = session_started + session_timeout;
                         action_tasks.spawn(async move {
                             tokio::select! {
                                 biased;
                                 _ = action_stop.cancelled() => {}
-                                _ = tokio::time::sleep(Duration::from_secs_f64(
+                                completed = transfer_gate.wait_with_queue_deadline(
+                                    Duration::from_secs_f64(
                                     delay_ms.max(0.0) / 1000.0,
-                                )) => {
+                                    ),
+                                    queue_deadline,
+                                ) => {
+                                    let event = if completed {
+                                        SourceSessionEvent::TransferCompleted
+                                    } else {
+                                        SourceSessionEvent::Deadline
+                                    };
                                     send_source_session_event(
                                         &event_tx,
                                         &action_stop,
-                                        SourceSessionEvent::TransferCompleted,
+                                        event,
                                     ).await;
                                 }
                             }

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -619,6 +619,7 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
         source,
         source_connection,
         Duration::from_secs(2),
+        KvTransferGate::default(),
         shutdown.clone(),
     ));
 
@@ -808,6 +809,7 @@ async fn run_source_terminal_trigger(trigger: SourceTerminalTrigger, id: u128) -
         source,
         source_connection,
         Duration::from_secs(2),
+        KvTransferGate::default(),
         shutdown.clone(),
     ));
     assert!(matches!(
@@ -1930,6 +1932,7 @@ async fn expired_source_session_deadline_still_cleans_held_ownership() {
         source,
         source_connection,
         Duration::from_millis(100),
+        KvTransferGate::default(),
         transport_shutdown.clone(),
     ));
 

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -473,6 +473,33 @@ impl FromStr for KvTransferTimingMode {
     }
 }
 
+/// Contention model applied to disaggregated KV transfers from one prefill worker.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum KvTransferBandwidthModel {
+    /// One transfer per prefill worker uses the full configured bandwidth;
+    /// later transfers wait in FIFO order.
+    #[default]
+    Fifo,
+    /// Preserve the legacy model where every transfer independently receives
+    /// the full configured bandwidth.
+    Independent,
+}
+
+impl FromStr for KvTransferBandwidthModel {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value.to_ascii_lowercase().as_str() {
+            "fifo" => Ok(Self::Fifo),
+            "independent" => Ok(Self::Independent),
+            _ => Err(format!(
+                "Invalid kv_transfer_bandwidth_model '{value}'. Must be 'fifo' or 'independent'."
+            )),
+        }
+    }
+}
+
 /// Configuration for reasoning/thinking token output in the mocker.
 ///
 /// When set, the mocker wraps the first portion of each response in thinking
@@ -623,6 +650,7 @@ struct MockEngineArgsSerde {
     handoff_session_timeout_ms: OptionalConfigValue<u64>,
     kv_bytes_per_token: OptionalConfigValue<usize>,
     kv_transfer_bandwidth: OptionalConfigValue<f64>,
+    kv_transfer_bandwidth_model: OptionalConfigValue<String>,
     kv_transfer_timing_mode: OptionalConfigValue<String>,
     num_g2_blocks: OptionalConfigValue<usize>,
     num_g3_blocks: OptionalConfigValue<usize>,
@@ -879,6 +907,11 @@ pub struct MockEngineArgs {
     #[builder(default = "None")]
     #[validate(range(min = 0.0))]
     pub kv_transfer_bandwidth: Option<f64>,
+
+    /// Selects whether a prefill worker serializes KV transfers through one
+    /// FIFO bandwidth queue or models every transfer independently.
+    #[builder(default = "KvTransferBandwidthModel::Fifo")]
+    pub kv_transfer_bandwidth_model: KvTransferBandwidthModel,
 
     /// Selects whether disaggregated transfer timing charges the full prompt
     /// or only the physical prompt footprint missing at the destination.
@@ -1280,6 +1313,12 @@ impl TryFrom<MockEngineArgsSerde> for MockEngineArgs {
         if let Some(kv_transfer_bandwidth) = compat.kv_transfer_bandwidth.into_nullable() {
             builder = builder.kv_transfer_bandwidth(kv_transfer_bandwidth);
         }
+        if let Some(model) = compat
+            .kv_transfer_bandwidth_model
+            .into_non_null("kv_transfer_bandwidth_model")?
+        {
+            builder = builder.kv_transfer_bandwidth_model(model.parse()?);
+        }
         if let Some(mode) = compat
             .kv_transfer_timing_mode
             .into_non_null("kv_transfer_timing_mode")?
@@ -1641,6 +1680,7 @@ mod tests {
         });
         payload["max_model_len"] = serde_json::json!(args.max_model_len);
         payload["g1_backend"] = serde_json::json!(args.g1_backend);
+        payload["kv_transfer_bandwidth_model"] = serde_json::json!("fifo");
 
         let restored = MockEngineArgs::from_json_str(&payload.to_string()).unwrap();
 
@@ -1650,8 +1690,36 @@ mod tests {
         assert_eq!(restored.max_num_batched_tokens, None);
         assert_eq!(restored.g1_backend, G1Backend::Native);
         assert_eq!(
+            restored.kv_transfer_bandwidth_model,
+            KvTransferBandwidthModel::Fifo
+        );
+        assert_eq!(
             restored.kv_transfer_timing_mode,
             KvTransferTimingMode::FullPrompt
+        );
+    }
+
+    #[test]
+    fn kv_transfer_bandwidth_model_defaults_to_fifo_and_accepts_independent() {
+        assert_eq!(
+            MockEngineArgs::default().kv_transfer_bandwidth_model,
+            KvTransferBandwidthModel::Fifo
+        );
+
+        let args = MockEngineArgs::from_json_str(
+            &json!({
+                "kv_transfer_bandwidth_model": "independent",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            args.kv_transfer_bandwidth_model,
+            KvTransferBandwidthModel::Independent
+        );
+        assert_eq!(
+            serde_json::to_value(args).unwrap()["kv_transfer_bandwidth_model"],
+            "independent"
         );
     }
 

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -231,6 +231,13 @@ aggregate approximation.
 It keeps one logical clock and one completion-event heap, but request ownership moves through a
 two-stage state machine instead of the aggregated single-pool lifecycle.
 
+KV transfer delay uses one FIFO queue per logical prefill worker by default. Only the active
+transfer owns a future completion event; completion or cancellation starts the next queued transfer
+at the same logical timestamp. Set `kv_transfer_bandwidth_model` to `independent` to schedule every
+transfer from its start timestamp without source-side contention. Zero transfer delay bypasses the
+queue. This model shares source bandwidth across a worker's DP ranks, but does not coordinate
+bandwidth across separate prefill workers or destination network interfaces.
+
 The prefill router is derived from the main router config with `router_track_active_blocks = false`.
 The decode router is derived with:
 

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -41,7 +41,9 @@ use crate::common::handoff::{
 };
 #[cfg(test)]
 use crate::common::protocols::ForwardPassSnapshot;
-use crate::common::protocols::{DirectRequest, EngineType, MockEngineArgs, OutputSignal};
+use crate::common::protocols::{
+    DirectRequest, EngineType, KvTransferBandwidthModel, MockEngineArgs, OutputSignal,
+};
 use crate::loadgen::{ReplayRequestHashes, ReplayRequestPayload, WorkloadDriver};
 #[cfg(test)]
 use crate::replay::ReplayRouterMode;
@@ -279,9 +281,110 @@ enum PrefillSignalDisposition {
     Completed,
 }
 
+#[derive(Clone, Copy)]
 struct ScheduledTransfer {
-    at_ms: f64,
+    delay_ms: f64,
     handoff_id: HandoffId,
+}
+
+#[derive(Default)]
+struct WorkerTransferQueue {
+    active: Option<HandoffId>,
+    pending: VecDeque<ScheduledTransfer>,
+}
+
+#[derive(Default)]
+struct FifoTransferQueues {
+    by_worker: HashMap<usize, WorkerTransferQueue>,
+    worker_by_handoff: HashMap<HandoffId, usize>,
+}
+
+struct CanceledTransfer {
+    was_active: bool,
+    next: Option<ScheduledTransfer>,
+}
+
+impl FifoTransferQueues {
+    fn enqueue(
+        &mut self,
+        worker_id: usize,
+        transfer: ScheduledTransfer,
+    ) -> Result<Option<ScheduledTransfer>> {
+        if self
+            .worker_by_handoff
+            .insert(transfer.handoff_id, worker_id)
+            .is_some()
+        {
+            bail!(
+                "offline disagg replay queued transfer {:?} more than once",
+                transfer.handoff_id
+            );
+        }
+        let queue = self.by_worker.entry(worker_id).or_default();
+        if queue.active.is_none() {
+            queue.active = Some(transfer.handoff_id);
+            Ok(Some(transfer))
+        } else {
+            queue.pending.push_back(transfer);
+            Ok(None)
+        }
+    }
+
+    fn complete(&mut self, handoff_id: HandoffId) -> Result<Option<ScheduledTransfer>> {
+        let worker_id = self
+            .worker_by_handoff
+            .remove(&handoff_id)
+            .ok_or_else(|| anyhow!("offline disagg replay completed an unknown FIFO transfer"))?;
+        let (next, empty) = {
+            let queue = self
+                .by_worker
+                .get_mut(&worker_id)
+                .expect("FIFO transfer must retain its worker queue");
+            if queue.active != Some(handoff_id) {
+                bail!("offline disagg replay completed a queued FIFO transfer out of order");
+            }
+            let next = queue.pending.pop_front();
+            queue.active = next.map(|transfer| transfer.handoff_id);
+            (next, queue.active.is_none())
+        };
+        if empty {
+            self.by_worker.remove(&worker_id);
+        }
+        Ok(next)
+    }
+
+    fn cancel(&mut self, handoff_id: HandoffId) -> Result<Option<CanceledTransfer>> {
+        let Some(worker_id) = self.worker_by_handoff.remove(&handoff_id) else {
+            return Ok(None);
+        };
+        let (was_active, next, empty) = {
+            let queue = self
+                .by_worker
+                .get_mut(&worker_id)
+                .expect("FIFO transfer must retain its worker queue");
+            if queue.active == Some(handoff_id) {
+                let next = queue.pending.pop_front();
+                queue.active = next.map(|transfer| transfer.handoff_id);
+                (true, next, queue.active.is_none())
+            } else {
+                let position = queue
+                    .pending
+                    .iter()
+                    .position(|transfer| transfer.handoff_id == handoff_id)
+                    .ok_or_else(|| anyhow!("offline disagg replay lost a queued FIFO transfer"))?;
+                queue.pending.remove(position);
+                (
+                    false,
+                    None,
+                    queue.active.is_none() && queue.pending.is_empty(),
+                )
+            }
+        };
+        if empty {
+            self.by_worker.remove(&worker_id);
+        }
+        Ok(Some(CanceledTransfer { was_active, next }))
+    }
 }
 
 impl DisaggFlowState {
@@ -682,7 +785,7 @@ impl DisaggFlowState {
         let handoff_id = self.state(uuid)?.handoff_id;
         if delay_ms > 0.0 {
             return Ok(Some(ScheduledTransfer {
-                at_ms: now_ms + delay_ms,
+                delay_ms,
                 handoff_id,
             }));
         }
@@ -811,7 +914,12 @@ impl DisaggFlowState {
     }
 
     #[inline(never)]
-    fn prepare_logical_finish(&mut self, uuid: Uuid, remove_actions: bool) -> Result<()> {
+    fn prepare_logical_finish(
+        &mut self,
+        uuid: Uuid,
+        remove_actions: bool,
+        count_stale_transfer_event: bool,
+    ) -> Result<()> {
         let transfer_was_pending = {
             let state = self.state_mut(uuid)?;
             if !state.counted_in_flight || state.phase == DisaggPhase::Done {
@@ -826,7 +934,7 @@ impl DisaggFlowState {
             .logical_in_flight
             .checked_sub(1)
             .expect("logical in-flight request count underflow");
-        if transfer_was_pending {
+        if transfer_was_pending && count_stale_transfer_event {
             self.stale_transfer_events = self
                 .stale_transfer_events
                 .checked_add(1)
@@ -894,6 +1002,8 @@ where
     prefill_placement: PlacementPolicyImpl,
     decode_placement: PlacementPolicyImpl,
     flow: DisaggFlowState,
+    transfer_bandwidth_model: KvTransferBandwidthModel,
+    fifo_transfers: FifoTransferQueues,
     collector: TraceCollector,
     events: BinaryHeap<SimulationEvent<Observation::Batch>>,
     progress: ReplayProgress,
@@ -1039,6 +1149,8 @@ where
             prefill_placement,
             decode_placement,
             flow: DisaggFlowState::new(handoff_order, capture_conformance),
+            transfer_bandwidth_model: config.prefill_args.kv_transfer_bandwidth_model,
+            fifo_transfers: FifoTransferQueues::default(),
             collector,
             events: BinaryHeap::new(),
             progress,
@@ -1370,6 +1482,53 @@ where
         self.flow.action_queues.wake_deferred(stage, worker_idx);
     }
 
+    fn schedule_transfer_completion(&mut self, transfer: ScheduledTransfer) {
+        push_transfer_complete(
+            &mut self.events,
+            &mut self.next_event_seq,
+            self.now_ms + transfer.delay_ms,
+            transfer.handoff_id,
+        );
+    }
+
+    fn enqueue_fifo_transfer(
+        &mut self,
+        worker_id: usize,
+        transfer: ScheduledTransfer,
+    ) -> Result<()> {
+        if let Some(active) = self.fifo_transfers.enqueue(worker_id, transfer)? {
+            self.schedule_transfer_completion(active);
+        }
+        Ok(())
+    }
+
+    fn complete_fifo_transfer(&mut self, handoff_id: HandoffId) -> Result<()> {
+        if let Some(next) = self.fifo_transfers.complete(handoff_id)? {
+            self.schedule_transfer_completion(next);
+        }
+        Ok(())
+    }
+
+    fn cancel_fifo_transfer(&mut self, handoff_id: HandoffId) -> Result<()> {
+        let Some(canceled) = self.fifo_transfers.cancel(handoff_id)? else {
+            return Ok(());
+        };
+        if canceled.was_active {
+            self.events.retain(|event| {
+                !matches!(
+                    &event.kind,
+                    super::events::SimulationEventKind::TransferComplete {
+                        handoff_id: scheduled,
+                    } if *scheduled == handoff_id
+                )
+            });
+            if let Some(next) = canceled.next {
+                self.schedule_transfer_completion(next);
+            }
+        }
+        Ok(())
+    }
+
     fn execute_action(
         &mut self,
         uuid: Uuid,
@@ -1402,12 +1561,26 @@ where
                     self.now_ms,
                     &mut self.collector,
                 )? {
-                    push_transfer_complete(
-                        &mut self.events,
-                        &mut self.next_event_seq,
-                        transfer.at_ms,
-                        transfer.handoff_id,
-                    );
+                    match self.transfer_bandwidth_model {
+                        KvTransferBandwidthModel::Independent => {
+                            self.schedule_transfer_completion(transfer);
+                        }
+                        KvTransferBandwidthModel::Fifo => {
+                            let rank_id =
+                                self.state(uuid)?.prefill_worker_idx().ok_or_else(|| {
+                                    anyhow!(
+                                        "offline disagg transfer has no prefill worker for {uuid}"
+                                    )
+                                })?;
+                            let (worker_id, _) =
+                                self.prefill_engine.rank_identity(rank_id).ok_or_else(|| {
+                                    anyhow!(
+                                        "offline disagg transfer has unknown prefill rank {rank_id}"
+                                    )
+                                })?;
+                            self.enqueue_fifo_transfer(worker_id, transfer)?;
+                        }
+                    }
                     #[cfg(test)]
                     self.stats
                         .transition_log
@@ -1611,7 +1784,17 @@ where
     }
 
     fn finish_logical_request(&mut self, uuid: Uuid, remove_actions: bool) -> Result<()> {
-        self.flow.prepare_logical_finish(uuid, remove_actions)?;
+        let transfer_was_pending = self.state(uuid)?.phase == DisaggPhase::TransferPending;
+        if transfer_was_pending && self.transfer_bandwidth_model == KvTransferBandwidthModel::Fifo {
+            let handoff_id = self.state(uuid)?.handoff_id;
+            self.cancel_fifo_transfer(handoff_id)?;
+        }
+        self.flow.prepare_logical_finish(
+            uuid,
+            remove_actions,
+            transfer_was_pending
+                && self.transfer_bandwidth_model == KvTransferBandwidthModel::Independent,
+        )?;
         CoreAdmissionSource::on_terminal(&mut self.admission, uuid, self.now_ms, false)?;
         self.progress.inc_completed();
         #[cfg(test)]
@@ -1882,7 +2065,11 @@ where
     fn apply_transfer_completions(&mut self) -> Result<bool> {
         let mut changed = false;
         while let Some(handoff_id) = pop_ready_transfer_complete(&mut self.events, self.now_ms) {
+            if self.transfer_bandwidth_model == KvTransferBandwidthModel::Fifo {
+                self.complete_fifo_transfer(handoff_id)?;
+            }
             let Some(uuid) = self.flow.requests_by_handoff.get(&handoff_id).copied() else {
+                changed = true;
                 continue;
             };
             self.apply_handoff_fact(uuid, HandoffFact::TransferCompleted { handoff_id })?;
@@ -2161,6 +2348,9 @@ where
     }
 
     fn prune_stale_transfer_events(&mut self) -> bool {
+        if self.transfer_bandwidth_model == KvTransferBandwidthModel::Fifo {
+            return false;
+        }
         let mut removed = false;
         while self.events.peek().is_some_and(|event| {
             matches!(

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -13,7 +13,8 @@ use super::super::extensions::kv_events::HandoffDisaggRuntime;
 use super::super::planner_hook::PlannerTickDecision;
 use super::*;
 use crate::common::protocols::{
-    EngineType, KvTransferTimingMode, MockEngineArgs, SglangArgs, WorkerType,
+    EngineType, KvTransferBandwidthModel, KvTransferTimingMode, MockEngineArgs, SglangArgs,
+    WorkerType,
 };
 use crate::loadgen::{SessionTrace, Trace, TurnTrace};
 use crate::replay::TraceSimulationReport;
@@ -1078,6 +1079,172 @@ fn source_only_reuse_does_not_reduce_destination_missing_transfer() {
         assert_eq!(measured.decode_reused_input_tokens, Some(0));
         assert!(transfer_span >= 128.0 && transfer_span - 128.0 < 1.0);
     }
+}
+
+#[rstest::rstest]
+#[case(EngineType::Vllm)]
+#[case(EngineType::Sglang)]
+fn fifo_transfer_bandwidth_serializes_handoffs_from_one_prefill(#[case] engine_type: EngineType) {
+    let report = run_trace_with_details(
+        &transfer_timing_config(engine_type, KvTransferTimingMode::FullPrompt, 2),
+        vec![request(1, 64, 1, 0.0), request(2, 64, 1, 0.0)],
+        None,
+        ReplayRouterMode::RoundRobin,
+    );
+    let mut transfer_spans = report
+        .per_request
+        .iter()
+        .map(|record| {
+            record.destination_activated_ms.unwrap() - record.destination_reserved_ms.unwrap()
+        })
+        .collect::<Vec<_>>();
+    transfer_spans.sort_by(f64::total_cmp);
+
+    assert_eq!(transfer_spans.len(), 2);
+    assert!(
+        (transfer_spans[0] - 64.0).abs() < 0.1,
+        "{engine_type:?}: first transfer span was {}ms",
+        transfer_spans[0]
+    );
+    assert!(
+        (transfer_spans[1] - 128.0).abs() < 0.1,
+        "{engine_type:?}: queued transfer span was {}ms",
+        transfer_spans[1]
+    );
+}
+
+#[test]
+fn independent_transfer_bandwidth_preserves_overlapping_handoffs() {
+    let mut config = transfer_timing_config(EngineType::Vllm, KvTransferTimingMode::FullPrompt, 2);
+    config.prefill_args.kv_transfer_bandwidth_model = KvTransferBandwidthModel::Independent;
+    let report = run_trace_with_details(
+        &config,
+        vec![request(1, 64, 1, 0.0), request(2, 64, 1, 0.0)],
+        None,
+        ReplayRouterMode::RoundRobin,
+    );
+
+    for record in &report.per_request {
+        let transfer_span =
+            record.destination_activated_ms.unwrap() - record.destination_reserved_ms.unwrap();
+        assert!(
+            (transfer_span - 64.0).abs() < 1e-6,
+            "independent transfer span was {transfer_span}ms"
+        );
+    }
+}
+
+#[test]
+fn fifo_transfer_bandwidth_is_independent_across_prefill_workers() {
+    let mut config = transfer_timing_config(EngineType::Vllm, KvTransferTimingMode::FullPrompt, 2);
+    config.num_prefill_workers = 2;
+    let report = run_trace_with_details(
+        &config,
+        vec![request(1, 64, 1, 0.0), request(2, 64, 1, 0.0)],
+        None,
+        ReplayRouterMode::RoundRobin,
+    );
+    let worker_ids = report
+        .per_request
+        .iter()
+        .map(|record| record.prefill_worker_idx.unwrap())
+        .collect::<std::collections::HashSet<_>>();
+
+    assert_eq!(worker_ids.len(), 2);
+    for record in &report.per_request {
+        let transfer_span =
+            record.destination_activated_ms.unwrap() - record.destination_reserved_ms.unwrap();
+        assert!(
+            (transfer_span - 64.0).abs() < 1e-6,
+            "worker {} transfer span was {transfer_span}ms",
+            record.prefill_worker_idx.unwrap()
+        );
+    }
+}
+
+#[rstest::rstest]
+#[case(false)]
+#[case(true)]
+fn canceling_fifo_transfer_keeps_the_next_completion_wakeup(#[case] cancel_active: bool) {
+    let config = transfer_timing_config(EngineType::Vllm, KvTransferTimingMode::FullPrompt, 2);
+    let mut runtime = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        VecDeque::from([request(1, 64, 1, 0.0), request(2, 64, 1, 0.0)]),
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap()
+    .with_per_request_records(true);
+
+    runtime.drain_current_timestamp().unwrap();
+    for _ in 0..32 {
+        let pending = [Uuid::from_u128(1), Uuid::from_u128(2)]
+            .into_iter()
+            .filter(|uuid| runtime.state(*uuid).unwrap().phase == DisaggPhase::TransferPending)
+            .count();
+        if pending == 2 {
+            break;
+        }
+        let next = runtime.next_timestamp().unwrap();
+        runtime.advance_now_ms(next);
+        runtime.drain_current_timestamp().unwrap();
+    }
+
+    let active_handoff = runtime
+        .events
+        .iter()
+        .find_map(|event| match &event.kind {
+            crate::replay::offline::events::SimulationEventKind::TransferComplete {
+                handoff_id,
+            } => Some(*handoff_id),
+            _ => None,
+        })
+        .expect("FIFO queue must retain an active completion event");
+    let active_uuid = runtime.flow.requests_by_handoff[&active_handoff];
+    let canceled_uuid = if cancel_active {
+        active_uuid
+    } else {
+        [Uuid::from_u128(1), Uuid::from_u128(2)]
+            .into_iter()
+            .find(|uuid| *uuid != active_uuid)
+            .unwrap()
+    };
+    let canceled_handoff = runtime.state(canceled_uuid).unwrap().handoff_id;
+    runtime
+        .apply_handoff_fact(
+            canceled_uuid,
+            HandoffFact::Canceled {
+                handoff_id: canceled_handoff,
+            },
+        )
+        .unwrap();
+    runtime.drain_current_timestamp().unwrap();
+
+    assert!(runtime.events.iter().any(|event| matches!(
+        &event.kind,
+        crate::replay::offline::events::SimulationEventKind::TransferComplete { .. }
+    )));
+    let (collector, _) = runtime.run().unwrap();
+    let records = collector.per_request_records();
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        records
+            .iter()
+            .find(|record| record.uuid == canceled_uuid.to_string())
+            .unwrap()
+            .terminal_status,
+        ReplayTerminalStatus::Canceled
+    );
+    assert_eq!(
+        records
+            .iter()
+            .find(|record| record.uuid != canceled_uuid.to_string())
+            .unwrap()
+            .terminal_status,
+        ReplayTerminalStatus::Completed
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add `KvTransferBandwidthModel` with FIFO as the default and `independent` as a compatibility mode, including Rust serde, Python configuration, live mocker CLI, and offline replay benchmark plumbing.
- Model each logical prefill worker as a single full-bandwidth KV transfer server. DP ranks and bootstrap/no-bootstrap handoff paths on the same `MockEngine` share one cancellation-aware FIFO gate.
- Count FIFO queue acquisition against `handoff_session_timeout_ms` while retaining the calculated service-time allowance after a transfer becomes active.
- Add per-prefill-worker active and pending transfer queues to offline replay. Completion or cancellation starts the next transfer at the same logical timestamp while preserving a concrete future completion event.
- Keep zero-delay transfers outside the queue and preserve the previous overlapping behavior in `independent` mode.
- Document that the model covers source-side contention only; separate prefill workers and destination-side NICs remain independent.

Existing trace fields and report schemas are unchanged. Queue delay naturally appears in destination-reservation-to-activation time and downstream TTFT.

## Validation

- `cargo test -p dynamo-mocker --lib replay::offline:: --no-fail-fast` (178 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload --lib replay::offline:: --no-fail-fast` (181 passed)
- `cargo test -p dynamo-llm --lib mocker:: --no-fail-fast` (34 passed)
- `PYTHONPATH=components/src .venv/bin/pytest -q components/src/dynamo/mocker/tests/unit/test_config.py` (39 passed)
- `cargo clippy -p dynamo-mocker -p dynamo-llm --all-targets -- -D warnings`
- `cargo check -p dynamo-bench --no-default-features --features offline-replay --bench offline_replay_bench`
- `cargo fmt --all -- --check`
- `git diff --check`
- `fern check`
- `fern docs broken-links`