### PR TITLE
fix(mocker): model SGLang KV allocation by page

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -5,6 +5,7 @@
 //!
 //! Reference: sglang/python/sglang/srt/mem_cache/radix_cache.py
 
+use dynamo_kv_router::protocols::{BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq};
 use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
 use std::time::Instant;
@@ -14,66 +15,172 @@ new_key_type! {
     pub struct NodeId;
 }
 
-/// Manages free / allocated token slot indices for the KV cache pool.
-pub struct TokenPool {
-    next_fresh: usize,
-    free: Vec<usize>,
-    total: usize,
+/// Physical page identifier in the simulated SGLang KV pool.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct KvPageId(usize);
+
+impl KvPageId {
+    pub(crate) fn from_token_index(index: usize, page_size: usize) -> Self {
+        Self(index / page_size)
+    }
+
+    pub(crate) fn first_token_index(self, page_size: usize) -> usize {
+        self.0 * page_size
+    }
+
+    pub(crate) fn terminal_token_index(self, page_size: usize) -> usize {
+        self.first_token_index(page_size) + page_size - 1
+    }
 }
 
-impl TokenPool {
-    pub fn new(total: usize) -> Self {
+/// Manages free / allocated pages for the simulated SGLang KV cache.
+///
+/// SGLang's paged allocator owns and frees whole pages even though its public
+/// interface returns flattened token indices. This pool preserves that
+/// ownership model and only expands page IDs while a request is active.
+pub struct PagePool {
+    next_fresh: usize,
+    free: Vec<KvPageId>,
+    total_pages: usize,
+    page_size: usize,
+}
+
+impl PagePool {
+    pub fn new(total_tokens: usize, page_size: usize) -> Self {
+        assert!(page_size >= 1, "page_size must be >= 1");
         Self {
             next_fresh: 0,
             free: Vec::new(),
-            total,
+            total_pages: total_tokens / page_size,
+            page_size,
         }
     }
 
-    /// Allocate `n` token slots. Returns `None` if not enough free slots.
-    pub fn allocate(&mut self, n: usize) -> Option<Vec<usize>> {
-        let mut indices = Vec::new();
-        self.allocate_into(n, &mut indices).then_some(indices)
+    pub fn allocate_pages(&mut self, count: usize) -> Option<Vec<KvPageId>> {
+        if self.available_pages() < count {
+            return None;
+        }
+
+        let recycled = count.min(self.free.len());
+        let fresh = count - recycled;
+        let mut pages = Vec::with_capacity(count);
+        pages.extend(self.free.drain(self.free.len() - recycled..));
+        pages.extend((self.next_fresh..self.next_fresh + fresh).map(KvPageId));
+        self.next_fresh += fresh;
+        Some(pages)
     }
 
-    /// Append `n` allocated token slots to `indices` without an intermediate vector.
-    pub fn allocate_into(&mut self, n: usize, indices: &mut Vec<usize>) -> bool {
-        if self.available() < n {
+    #[cfg(test)]
+    pub fn allocate(&mut self, token_count: usize) -> Option<Vec<usize>> {
+        let mut indices = Vec::new();
+        self.allocate_indices_into(token_count, &mut indices)
+            .then_some(indices)
+    }
+
+    /// Append flattened indices for `new_tokens`, allocating whole pages only
+    /// when the request's current final page has no remaining slots.
+    pub fn allocate_indices_into(&mut self, new_tokens: usize, indices: &mut Vec<usize>) -> bool {
+        if new_tokens == 0 {
+            return true;
+        }
+
+        let available_in_last_page = indices
+            .last()
+            .map_or(0, |last| self.page_size - 1 - (last % self.page_size));
+        let tokens_requiring_pages = new_tokens.saturating_sub(available_in_last_page);
+        let required_pages = tokens_requiring_pages.div_ceil(self.page_size);
+        if self.available_pages() < required_pages {
             return false;
         }
 
-        indices.reserve(n);
-        let recycled = n.min(self.free.len());
-        let fresh = n - recycled;
-        indices.extend(self.free.drain(self.free.len() - recycled..));
-        indices.extend(self.next_fresh..self.next_fresh + fresh);
-        self.next_fresh += fresh;
+        indices.reserve(new_tokens);
+        let from_existing = new_tokens.min(available_in_last_page);
+        if from_existing > 0 {
+            let start = indices.last().copied().expect("last page must exist") + 1;
+            indices.extend(start..start + from_existing);
+        }
+
+        let remaining = new_tokens - from_existing;
+        let Some(pages) = self.allocate_pages(required_pages) else {
+            return false;
+        };
+        for (page_idx, page) in pages.into_iter().enumerate() {
+            let take = remaining
+                .saturating_sub(page_idx * self.page_size)
+                .min(self.page_size);
+            let start = page.first_token_index(self.page_size);
+            indices.extend(start..start + take);
+        }
         true
     }
 
-    /// Return token slots to the free pool.
+    pub fn expand_pages(&self, pages: &[KvPageId], token_count: usize) -> Vec<usize> {
+        assert!(
+            token_count <= pages.len() * self.page_size,
+            "cannot expand {token_count} tokens from {} pages of size {}",
+            pages.len(),
+            self.page_size
+        );
+        let mut indices = Vec::with_capacity(token_count);
+        for (page_idx, page) in pages.iter().copied().enumerate() {
+            let take = token_count
+                .saturating_sub(page_idx * self.page_size)
+                .min(self.page_size);
+            let start = page.first_token_index(self.page_size);
+            indices.extend(start..start + take);
+        }
+        indices
+    }
+
+    pub fn free_pages(&mut self, pages: &[KvPageId]) {
+        self.free.extend_from_slice(pages);
+    }
+
+    /// Free every distinct page represented by a contiguous request-index list.
+    pub fn free_indices(&mut self, indices: &[usize]) -> Vec<KvPageId> {
+        let mut pages = Vec::with_capacity(indices.len().div_ceil(self.page_size));
+        for &index in indices {
+            let page = KvPageId::from_token_index(index, self.page_size);
+            if pages.last().copied() != Some(page) {
+                pages.push(page);
+            }
+        }
+        self.free_pages(&pages);
+        pages
+    }
+
+    #[cfg(test)]
     pub fn free(&mut self, indices: &[usize]) {
-        self.free.extend(indices);
+        self.free_indices(indices);
+    }
+
+    pub fn available_pages(&self) -> usize {
+        self.free.len() + self.total_pages - self.next_fresh
     }
 
     pub fn available(&self) -> usize {
-        self.free.len() + self.total - self.next_fresh
+        self.available_pages() * self.page_size
     }
 
     pub fn total(&self) -> usize {
-        self.total
+        self.total_pages * self.page_size
     }
 }
 
 /// A single node in the radix tree.
 pub struct TreeNode {
-    /// Children keyed by `child.key[..page_size]` (a "child key").
-    pub children: FxHashMap<Vec<u32>, NodeId>,
+    /// Children keyed by the first complete page on the child edge.
+    pub children: FxHashMap<LocalBlockHash, NodeId>,
     pub parent: Option<NodeId>,
-    /// Token IDs stored at this edge.
-    pub key: Vec<u32>,
-    /// KV cache pool token indices. Length = `key.len()`.
-    pub value: Vec<usize>,
+    /// One content identity per complete page stored on this compressed edge.
+    ///
+    /// The mocker intentionally uses the router's 64-bit local block hash as
+    /// page identity so completed radix state does not retain token IDs.
+    /// Consequently, as in router-side indexing, hash collisions are treated
+    /// as identical pages rather than guarded by an exact-token comparison.
+    pub key: Vec<LocalBlockHash>,
+    /// One physical page ID per key. Length = `key.len()`.
+    pub value: Vec<KvPageId>,
     /// Walk-to-root reference count (protected when > 0).
     pub lock_ref: usize,
     /// Monotonic timestamp for LRU eviction.
@@ -84,7 +191,7 @@ pub struct TreeNode {
 pub struct RadixCache {
     nodes: SlotMap<NodeId, TreeNode>,
     root: NodeId,
-    pub token_pool: TokenPool,
+    pub page_pool: PagePool,
     page_size: usize,
     /// Total token count in evictable nodes.
     pub evictable_leaves: FxHashSet<NodeId>,
@@ -108,7 +215,7 @@ impl RadixCache {
         Self {
             nodes,
             root,
-            token_pool: TokenPool::new(total_tokens),
+            page_pool: PagePool::new(total_tokens, page_size),
             page_size,
             evictable_leaves: FxHashSet::default(),
             evictable_size: 0,
@@ -129,47 +236,58 @@ impl RadixCache {
         self.nodes.len()
     }
 
-    fn child_key<'a>(&self, key: &'a [u32]) -> &'a [u32] {
-        &key[..self.page_size.min(key.len())]
+    fn page_hashes(&self, tokens: &[u32]) -> Vec<LocalBlockHash> {
+        compute_block_hash_for_seq(tokens, self.page_size as u32, BlockHashOptions::default())
     }
 
-    fn page_align(&self, len: usize) -> usize {
-        len / self.page_size * self.page_size
+    fn page_ids(&self, indices: &[usize], page_count: usize) -> Vec<KvPageId> {
+        assert!(
+            indices.len() >= page_count * self.page_size,
+            "not enough token indices for {page_count} complete pages"
+        );
+        indices
+            .chunks_exact(self.page_size)
+            .take(page_count)
+            .map(|chunk| {
+                let page = KvPageId::from_token_index(chunk[0], self.page_size);
+                let start = page.first_token_index(self.page_size);
+                assert!(
+                    chunk.iter().copied().eq(start..start + self.page_size),
+                    "SGLang cached pages must contain contiguous page-aligned indices"
+                );
+                page
+            })
+            .collect()
     }
 
-    fn key_match(&self, key0: &[u32], key1: &[u32]) -> usize {
-        if self.page_size == 1 {
-            key0.iter().zip(key1).take_while(|(a, b)| a == b).count()
-        } else {
-            let min_len = key0.len().min(key1.len());
-            let mut i = 0;
-            while i + self.page_size <= min_len {
-                if key0[i..i + self.page_size] != key1[i..i + self.page_size] {
-                    break;
-                }
-                i += self.page_size;
-            }
-            i
-        }
+    fn key_match(key0: &[LocalBlockHash], key1: &[LocalBlockHash]) -> usize {
+        key0.iter().zip(key1).take_while(|(a, b)| a == b).count()
     }
 
     pub fn match_prefix(&mut self, key: &[u32]) -> (usize, NodeId) {
+        let page_keys = self.page_hashes(key);
         let now = Instant::now();
         self.nodes[self.root].last_access_time = now;
 
         let mut current = self.root;
-        let mut matched: usize = 0;
+        let mut matched_pages: usize = 0;
 
-        while matched < key.len() {
-            let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(ck).copied() {
+        while matched_pages < page_keys.len() {
+            let child_id = match self.nodes[current]
+                .children
+                .get(&page_keys[matched_pages])
+                .copied()
+            {
                 Some(id) => id,
                 None => break,
             };
 
             let (common_len, child_len) = {
                 let child_key = &self.nodes[child_id].key;
-                (self.key_match(child_key, &key[matched..]), child_key.len())
+                (
+                    Self::key_match(child_key, &page_keys[matched_pages..]),
+                    child_key.len(),
+                )
             };
 
             if common_len < child_len {
@@ -177,45 +295,48 @@ impl RadixCache {
                     let intermediate = self.split_node(child_id, common_len);
                     current = intermediate;
                 }
-                matched += common_len;
+                matched_pages += common_len;
                 break;
             }
 
-            matched += common_len;
+            matched_pages += common_len;
             current = child_id;
             self.nodes[current].last_access_time = now;
         }
 
-        (matched, current)
+        (matched_pages * self.page_size, current)
     }
 
     /// Read-only prefix match length (does not mutate timestamps or split nodes).
     /// Used for LPM scheduling scoring.
     pub fn prefix_match_len(&self, key: &[u32]) -> usize {
+        let page_keys = self.page_hashes(key);
         let mut current = self.root;
-        let mut matched: usize = 0;
+        let mut matched_pages: usize = 0;
 
-        while matched < key.len() {
-            let ck = self.child_key(&key[matched..]);
-            let child_id = match self.nodes[current].children.get(ck).copied() {
+        while matched_pages < page_keys.len() {
+            let child_id = match self.nodes[current]
+                .children
+                .get(&page_keys[matched_pages])
+                .copied()
+            {
                 Some(id) => id,
                 None => break,
             };
 
             let child_key = &self.nodes[child_id].key;
-            let common_len = self.key_match(child_key, &key[matched..]);
+            let common_len = Self::key_match(child_key, &page_keys[matched_pages..]);
 
             if common_len < child_key.len() {
-                matched += common_len;
+                matched_pages += common_len;
                 break;
             }
 
-            matched += common_len;
+            matched_pages += common_len;
             current = child_id;
         }
 
-        // Round down to page boundary
-        matched / self.page_size * self.page_size
+        matched_pages * self.page_size
     }
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
@@ -246,10 +367,10 @@ impl RadixCache {
         value: &[usize],
         allow_locked_tail_extension: bool,
     ) -> NodeId {
-        let aligned_len = self.page_align(key.len());
+        let aligned_len = key.len() / self.page_size * self.page_size;
         assert_eq!(
-            prefix_len,
-            self.page_align(prefix_len),
+            prefix_len % self.page_size,
+            0,
             "prefix length must be page-aligned"
         );
         assert!(
@@ -264,16 +385,20 @@ impl RadixCache {
             "not enough token indices: need {aligned_len}, got {}",
             value.len()
         );
-        let key = &key[..aligned_len];
-        let value = &value[..aligned_len];
+        // `start_node` already represents the retained prefix. Hashing and
+        // validating it again on every decode-page completion makes growth
+        // quadratic in sequence length; only the newly completed suffix is
+        // needed for insertion.
+        let page_keys = self.page_hashes(&key[prefix_len..aligned_len]);
+        let page_ids = self.page_ids(&value[prefix_len..aligned_len], page_keys.len());
 
         let now = Instant::now();
         self.touch_path(start_node, now);
 
         let mut current = start_node;
-        let mut key_offset = prefix_len;
+        let mut key_offset = 0;
 
-        while key_offset < key.len() {
+        while key_offset < page_keys.len() {
             let can_extend_leaf = current != self.root
                 && self.nodes[current].children.is_empty()
                 && (self.nodes[current].lock_ref == 0
@@ -281,21 +406,33 @@ impl RadixCache {
                         && current == start_node
                         && self.nodes[current].lock_ref == 1));
             if can_extend_leaf {
-                return self.extend_leaf(current, &key[key_offset..], &value[key_offset..], now);
+                return self.extend_leaf(
+                    current,
+                    &page_keys[key_offset..],
+                    &page_ids[key_offset..],
+                    now,
+                );
             }
 
-            let ck = self.child_key(&key[key_offset..]);
-            let child_id = match self.nodes[current].children.get(ck).copied() {
+            let child_id = match self.nodes[current]
+                .children
+                .get(&page_keys[key_offset])
+                .copied()
+            {
                 Some(id) => id,
                 None => {
-                    return self.create_child(current, &key[key_offset..], &value[key_offset..]);
+                    return self.create_child(
+                        current,
+                        &page_keys[key_offset..],
+                        &page_ids[key_offset..],
+                    );
                 }
             };
 
             let (common_len, child_len) = {
                 let child_key = &self.nodes[child_id].key;
                 (
-                    self.key_match(child_key, &key[key_offset..]),
+                    Self::key_match(child_key, &page_keys[key_offset..]),
                     child_key.len(),
                 )
             };
@@ -308,11 +445,11 @@ impl RadixCache {
                 if common_len > 0 {
                     let intermediate = self.split_node(child_id, common_len);
                     key_offset += common_len;
-                    if key_offset < key.len() {
+                    if key_offset < page_keys.len() {
                         return self.create_child(
                             intermediate,
-                            &key[key_offset..],
-                            &value[key_offset..],
+                            &page_keys[key_offset..],
+                            &page_ids[key_offset..],
                         );
                     }
                     return intermediate;
@@ -335,8 +472,8 @@ impl RadixCache {
     fn extend_leaf(
         &mut self,
         node_id: NodeId,
-        key: &[u32],
-        value: &[usize],
+        key: &[LocalBlockHash],
+        value: &[KvPageId],
         now: Instant,
     ) -> NodeId {
         let node = &mut self.nodes[node_id];
@@ -346,9 +483,9 @@ impl RadixCache {
         node.value.extend_from_slice(value);
         node.last_access_time = now;
         if node.lock_ref == 0 {
-            self.evictable_size += key.len();
+            self.evictable_size += key.len() * self.page_size;
         } else {
-            self.protected_size += key.len();
+            self.protected_size += key.len() * self.page_size;
         }
         node_id
     }
@@ -357,12 +494,12 @@ impl RadixCache {
         let (child_parent, original_ck, prefix_key, prefix_value, suffix_ck, lock_ref, accessed) = {
             let child = &mut self.nodes[child_id];
             let child_parent = child.parent;
-            let original_ck = child.key[..self.page_size].to_vec();
+            let original_ck = child.key[0];
             let suffix_key = child.key.split_off(split_pos);
             let prefix_key = std::mem::replace(&mut child.key, suffix_key);
             let suffix_value = child.value.split_off(split_pos);
             let prefix_value = std::mem::replace(&mut child.value, suffix_value);
-            let suffix_ck = child.key[..self.page_size].to_vec();
+            let suffix_ck = child.key[0];
             (
                 child_parent,
                 original_ck,
@@ -400,7 +537,12 @@ impl RadixCache {
         inter_id
     }
 
-    fn create_child(&mut self, parent_id: NodeId, key: &[u32], value: &[usize]) -> NodeId {
+    fn create_child(
+        &mut self,
+        parent_id: NodeId,
+        key: &[LocalBlockHash],
+        value: &[KvPageId],
+    ) -> NodeId {
         let new_node = TreeNode {
             children: FxHashMap::default(),
             parent: Some(parent_id),
@@ -409,7 +551,7 @@ impl RadixCache {
             lock_ref: 0,
             last_access_time: Instant::now(),
         };
-        let ck = self.child_key(key).to_vec();
+        let ck = key[0];
         let new_id = self.nodes.insert(new_node);
 
         self.evictable_leaves.remove(&parent_id);
@@ -417,7 +559,7 @@ impl RadixCache {
         self.nodes[parent_id].children.insert(ck, new_id);
 
         self.evictable_leaves.insert(new_id);
-        self.evictable_size += key.len();
+        self.evictable_size += key.len() * self.page_size;
 
         new_id
     }
@@ -433,7 +575,7 @@ impl RadixCache {
                 break;
             }
             let node = &mut self.nodes[id];
-            let tokens = node.key.len();
+            let tokens = node.key.len() * self.page_size;
             node.lock_ref += 1;
             if node.lock_ref == 1 {
                 self.evictable_leaves.remove(&id);
@@ -457,7 +599,7 @@ impl RadixCache {
             }
             node.lock_ref -= 1;
             if node.lock_ref == 0 {
-                let tokens = node.key.len();
+                let tokens = node.key.len() * self.page_size;
                 self.protected_size -= tokens;
                 self.evictable_size += tokens;
                 if self.is_leaf(id) {
@@ -469,10 +611,11 @@ impl RadixCache {
     }
 
     /// Evict tokens from the cache by LRU order, rounding partial leaves to full pages.
-    /// Returns `(num_tokens_evicted, evicted_page_indices)`.
-    pub fn evict(&mut self, num_tokens: usize) -> (usize, Vec<usize>) {
+    /// Returns `(num_tokens_evicted, evicted_page_ids)`.
+    pub fn evict(&mut self, num_tokens: usize) -> (usize, Vec<KvPageId>) {
         let mut evicted = 0;
-        let mut evicted_indices = Vec::with_capacity(num_tokens.min(self.evictable_size));
+        let mut evicted_indices =
+            Vec::with_capacity(num_tokens.min(self.evictable_size).div_ceil(self.page_size));
         while evicted < num_tokens {
             let victim = self
                 .evictable_leaves
@@ -484,22 +627,21 @@ impl RadixCache {
                 break;
             };
 
-            let victim_tokens = self.nodes[victim_id].key.len();
+            let victim_pages = self.nodes[victim_id].key.len();
+            let victim_tokens = victim_pages * self.page_size;
             let remaining = num_tokens - evicted;
-            let eviction_len = remaining
-                .div_ceil(self.page_size)
-                .saturating_mul(self.page_size)
-                .min(victim_tokens);
+            let eviction_pages = remaining.div_ceil(self.page_size).min(victim_pages);
+            let eviction_len = eviction_pages * self.page_size;
 
             // A compressed leaf may span pages. Preserve its indexed prefix when
             // only the newest suffix pages are needed to satisfy this eviction.
             if eviction_len < victim_tokens {
-                let split_pos = victim_tokens - eviction_len;
-                let (nodes, token_pool) = (&mut self.nodes, &mut self.token_pool);
+                let split_pos = victim_pages - eviction_pages;
+                let (nodes, page_pool) = (&mut self.nodes, &mut self.page_pool);
                 let victim_node = &mut nodes[victim_id];
                 victim_node.key.truncate(split_pos);
                 let evicted_values = &victim_node.value[split_pos..];
-                token_pool.free(evicted_values);
+                page_pool.free_pages(evicted_values);
                 evicted_indices.extend_from_slice(evicted_values);
                 victim_node.value.truncate(split_pos);
 
@@ -512,7 +654,7 @@ impl RadixCache {
                 .nodes
                 .remove(victim_id)
                 .expect("evictable leaf disappeared before removal");
-            let tokens = victim_node.key.len();
+            let tokens = victim_node.key.len() * self.page_size;
             let parent_id = victim_node.parent;
 
             self.evictable_leaves.remove(&victim_id);
@@ -520,11 +662,10 @@ impl RadixCache {
             evicted += tokens;
 
             evicted_indices.extend_from_slice(&victim_node.value);
-            self.token_pool.free(&victim_node.value);
+            self.page_pool.free_pages(&victim_node.value);
 
             if let Some(pid) = parent_id {
-                let ck = self.child_key(&victim_node.key);
-                self.nodes[pid].children.remove(ck);
+                self.nodes[pid].children.remove(&victim_node.key[0]);
 
                 if pid != self.root
                     && self.nodes[pid].children.is_empty()
@@ -538,11 +679,11 @@ impl RadixCache {
     }
 
     pub fn available_tokens(&self) -> usize {
-        self.token_pool.available()
+        self.page_pool.available()
     }
 
     pub fn total_tokens(&self) -> usize {
-        self.token_pool.total()
+        self.page_pool.total()
     }
 }
 
@@ -551,36 +692,37 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_token_pool_allocate_and_free() {
-        let mut pool = TokenPool::new(10);
-        assert_eq!(pool.available(), 10);
+    fn test_page_pool_allocate_extend_and_free() {
+        let mut pool = PagePool::new(12, 4);
+        assert_eq!(pool.available(), 12);
         assert!(pool.allocate(usize::MAX).is_none());
         let a = pool.allocate(3).unwrap();
         assert_eq!(a.len(), 3);
-        assert_eq!(pool.available(), 7);
-        let b = pool.allocate(7).unwrap();
+        assert_eq!(pool.available(), 8);
+        let mut extended = a.clone();
+        assert!(pool.allocate_indices_into(1, &mut extended));
+        assert_eq!(extended, vec![0, 1, 2, 3]);
+        assert_eq!(pool.available(), 8);
+        let b = pool.allocate(5).unwrap();
         assert_eq!(pool.available(), 0);
         assert!(pool.allocate(1).is_none());
         pool.free(&a);
-        assert_eq!(pool.available(), 3);
+        assert_eq!(pool.available(), 4);
         pool.free(&b);
-        assert_eq!(pool.available(), 10);
+        assert_eq!(pool.available(), 12);
     }
 
     #[test]
-    fn test_allocate_into_failure_is_atomic() {
-        let mut pool = TokenPool::new(6);
-        let allocated = pool.allocate(4).unwrap();
-        pool.free(&allocated[1..3]);
+    fn test_allocate_indices_into_failure_is_atomic() {
+        let mut pool = PagePool::new(8, 4);
+        let mut destination = pool.allocate(4).unwrap();
+        let _other = pool.allocate(4).unwrap();
         let available_before = pool.available();
-        let mut destination = vec![99];
+        let destination_before = destination.clone();
 
-        assert!(!pool.allocate_into(available_before + 1, &mut destination));
-        assert_eq!(destination, vec![99]);
+        assert!(!pool.allocate_indices_into(1, &mut destination));
+        assert_eq!(destination, destination_before);
         assert_eq!(pool.available(), available_before);
-
-        let subsequent = pool.allocate(available_before).unwrap();
-        assert_eq!(subsequent, vec![1, 2, 4, 5]);
     }
 
     #[test]
@@ -601,10 +743,23 @@ mod tests {
         let (len, node) = cache.match_prefix(&[1, 2, 3, 4, 5, 9, 9]);
         assert_eq!(len, 5);
         let n = cache.node(node);
-        assert_eq!(n.key, vec![1, 2, 3, 4, 5]);
-        assert_eq!(n.value, vec![10, 20, 30, 40, 50]);
-        let &suffix_id = n.children.get(&vec![6]).unwrap();
-        assert_eq!(cache.node(suffix_id).value, vec![60, 70]);
+        assert_eq!(n.key, cache.page_hashes(&[1, 2, 3, 4, 5]));
+        assert_eq!(
+            n.value,
+            vec![
+                KvPageId(10),
+                KvPageId(20),
+                KvPageId(30),
+                KvPageId(40),
+                KvPageId(50)
+            ]
+        );
+        let suffix_key = cache.page_hashes(&[6])[0];
+        let &suffix_id = n.children.get(&suffix_key).unwrap();
+        assert_eq!(
+            cache.node(suffix_id).value,
+            vec![KvPageId(60), KvPageId(70)]
+        );
     }
 
     #[test]
@@ -652,7 +807,10 @@ mod tests {
 
         assert_eq!(extended, tail);
         assert_eq!(cache.num_nodes(), nodes_before);
-        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(
+            cache.node(tail).key,
+            cache.page_hashes(&[1, 2, 3, 4, 5, 6, 7, 8])
+        );
         assert_eq!(cache.protected_size, 8);
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
     }
@@ -675,21 +833,21 @@ mod tests {
 
         assert_ne!(extended, tail);
         assert_eq!(cache.num_nodes(), nodes_before + 1);
-        assert_eq!(cache.node(tail).key, vec![1, 2, 3, 4]);
-        assert_eq!(cache.node(extended).key, vec![5, 6, 7, 8]);
+        assert_eq!(cache.node(tail).key, cache.page_hashes(&[1, 2, 3, 4]));
+        assert_eq!(cache.node(extended).key, cache.page_hashes(&[5, 6, 7, 8]));
     }
 
     #[test]
     fn test_page_size() {
         // Insert and match with page_size=4
         let mut cache = RadixCache::new(100, 4);
-        assert_eq!(cache.token_pool.total(), 100);
+        assert_eq!(cache.page_pool.total(), 100);
         cache.insert(&[1, 2, 3, 4, 5, 6, 7], &[0, 1, 2, 3, 4, 5, 6]);
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4]).0, 4);
         let (_, node) = cache.match_prefix(&[1, 2, 3, 4]);
-        assert_eq!(cache.node(node).value, vec![0, 1, 2, 3]);
+        assert_eq!(cache.node(node).value, vec![KvPageId(0)]);
 
-        cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[0, 1, 2, 3, 10, 11, 12, 13]);
+        cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[0, 1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(cache.match_prefix(&[1, 2, 3, 4, 5, 6, 7, 8]).0, 8);
 
         // Children disambiguated by first page_size tokens
@@ -702,10 +860,23 @@ mod tests {
 
         // Split at page boundary preserves value
         let mut cache = RadixCache::new(100, 4);
-        cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[0, 1, 2, 3, 10, 11, 12, 13]);
+        cache.insert(&[1, 2, 3, 4, 5, 6, 7, 8], &[0, 1, 2, 3, 4, 5, 6, 7]);
         cache.match_prefix(&[1, 2, 3, 4, 9, 9, 9, 9]);
         let (_, node) = cache.match_prefix(&[1, 2, 3, 4]);
-        assert_eq!(cache.node(node).value, vec![0, 1, 2, 3]);
+        assert_eq!(cache.node(node).value, vec![KvPageId(0)]);
+    }
+
+    #[test]
+    fn completed_edges_store_one_key_and_page_id_per_page() {
+        let mut cache = RadixCache::new(256, 64);
+        let tokens = (0..128).collect::<Vec<u32>>();
+        let indices = cache.page_pool.allocate(tokens.len()).unwrap();
+        let node = cache.insert(&tokens, &indices);
+
+        assert_eq!(cache.node(node).key.len(), 2);
+        assert_eq!(cache.node(node).value.len(), 2);
+        assert_eq!(cache.node(node).value, vec![KvPageId(0), KvPageId(1)]);
+        assert_eq!(cache.match_prefix(&tokens).0, tokens.len());
     }
 
     #[test]
@@ -747,7 +918,7 @@ mod tests {
         // Evicted indices should match the pool indices originally inserted for [1,2,3]
         let mut sorted_evicted = evicted_indices.clone();
         sorted_evicted.sort();
-        let mut expected_indices = vec![0, 1, 2];
+        let mut expected_indices = vec![KvPageId(0), KvPageId(1), KvPageId(2)];
         expected_indices.sort();
         assert_eq!(
             sorted_evicted, expected_indices,
@@ -771,7 +942,7 @@ mod tests {
         sorted_evicted.sort();
         assert_eq!(
             sorted_evicted,
-            vec![3, 4, 5],
+            vec![KvPageId(3), KvPageId(4), KvPageId(5)],
             "should evict unlocked [4,5,6] indices"
         );
         assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
@@ -780,10 +951,10 @@ mod tests {
     #[test]
     fn test_evictable_size_includes_unlocked_internal_prefix() {
         let mut cache = RadixCache::new(16, 4);
-        let first = cache.token_pool.allocate(8).unwrap();
+        let first = cache.page_pool.allocate(8).unwrap();
         cache.insert(&[1; 8], &first);
         let mut branch = first[..4].to_vec();
-        branch.extend(cache.token_pool.allocate(4).unwrap());
+        branch.extend(cache.page_pool.allocate(4).unwrap());
         cache.insert(&[1, 1, 1, 1, 2, 2, 2, 2], &branch);
 
         assert_eq!(cache.evictable_size, 12);

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -4,7 +4,7 @@
 //! SGLang KV manager — wraps [`RadixCache`] with request-level lifecycle
 //! operations and KV event publishing.
 
-use crate::cache::radix_cache::{NodeId, RadixCache};
+use crate::cache::radix_cache::{KvPageId, NodeId, RadixCache};
 use crate::common::kv_cache_trace;
 use crate::common::protocols::KvEventPublishers;
 use dynamo_kv_router::protocols::{
@@ -86,45 +86,61 @@ pub struct SglangKvManager {
 }
 
 pub struct DecodeTokenReservation {
-    indices: Vec<usize>,
+    pages: Vec<KvPageId>,
     next: usize,
+    page_size: usize,
 }
 
 pub struct SglangDestinationReservation {
     pub(crate) prefix_len: usize,
     prefix_indices: Vec<usize>,
     last_node: NodeId,
-    unpublished_indices: Vec<usize>,
+    unpublished_pages: Vec<KvPageId>,
+    page_size: usize,
+    missing_tokens: usize,
     pub(crate) allocated_tokens: usize,
 }
 
 impl SglangDestinationReservation {
     pub(crate) fn transferable_prompt_tokens(&self) -> usize {
-        self.unpublished_indices.len()
+        self.unpublished_pages.len() * self.page_size
     }
 
     #[cfg(test)]
     pub(crate) fn indices(&self) -> Vec<usize> {
         self.prefix_indices
             .iter()
-            .chain(&self.unpublished_indices)
             .copied()
+            .chain(
+                self.unpublished_pages
+                    .iter()
+                    .flat_map(|page| {
+                        let start = page.first_token_index(self.page_size);
+                        start..start + self.page_size
+                    })
+                    .take(self.missing_tokens),
+            )
             .collect()
     }
 }
 
 impl DecodeTokenReservation {
-    fn take(&mut self) -> usize {
-        let idx = *self
-            .indices
+    fn take(&mut self, last_idx: Option<usize>) -> usize {
+        if let Some(last_idx) = last_idx
+            && (last_idx + 1) % self.page_size != 0
+        {
+            return last_idx + 1;
+        }
+        let page = *self
+            .pages
             .get(self.next)
-            .expect("reserved decode token allocation must be infallible");
+            .expect("reserved decode page allocation must be infallible");
         self.next += 1;
-        idx
+        page.first_token_index(self.page_size)
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.indices.len() - self.next
+        self.pages.len() - self.next
     }
 }
 
@@ -153,30 +169,46 @@ impl SglangKvManager {
         &mut self.cache
     }
 
-    /// Try to allocate KV cache for a new request.
-    /// Returns `None` if the pool doesn't have enough token slots (OOM).
+    /// Match and protect a reusable prefix, evict other cached pages if needed,
+    /// then allocate KV pages for a new request.
+    ///
+    /// Returns `None` if protected and free capacity cannot satisfy the request.
     pub(crate) fn allocate_for_request(&mut self, token_ids: &[u32]) -> Option<AllocResult> {
         let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
-
         let new_tokens = token_ids.len() - prefix_len;
+        let required_tokens = new_tokens.div_ceil(self.cache.page_size()) * self.cache.page_size();
 
+        // Protect the matched path before making room. Otherwise an LRU
+        // eviction can remove the prefix used to size this allocation, and a
+        // second match would require more pages than were freed.
+        self.cache.inc_lock_ref(last_node);
+        let reservable = self.cache.available_tokens() + self.cache.evictable_size;
+        if required_tokens > reservable {
+            self.cache.dec_lock_ref(last_node);
+            return None;
+        }
+        let available = self.cache.available_tokens();
+        if required_tokens > available {
+            self.evict(required_tokens - available);
+        }
         let prefix_indices = self.collect_path_indices(last_node);
 
         let mut kv_indices = prefix_indices;
+        let available_before = self.cache.available_tokens();
         if !self
             .cache
-            .token_pool
-            .allocate_into(new_tokens, &mut kv_indices)
+            .page_pool
+            .allocate_indices_into(new_tokens, &mut kv_indices)
         {
+            self.cache.dec_lock_ref(last_node);
             return None;
         }
-
-        self.cache.inc_lock_ref(last_node);
+        let allocated_tokens = available_before - self.cache.available_tokens();
 
         // Router-visible KV events are complete-block only.
         self.publish_stored_event(token_ids, &kv_indices, prefix_len);
 
-        self.log_trace("allocation", new_tokens);
+        self.log_trace("allocation", allocated_tokens);
 
         Some(AllocResult {
             prefix_len,
@@ -206,16 +238,18 @@ impl SglangKvManager {
             token_ids.len()
         );
         let new_tokens = token_ids.len() - prefix_len;
+        let available_before = self.cache.available_tokens();
         if !self
             .cache
-            .token_pool
-            .allocate_into(new_tokens, &mut lease.kv_indices)
+            .page_pool
+            .allocate_indices_into(new_tokens, &mut lease.kv_indices)
         {
             return false;
         }
+        let allocated_tokens = available_before - self.cache.available_tokens();
 
         self.publish_stored_event(token_ids, &lease.kv_indices, prefix_len);
-        self.log_trace("allocation", new_tokens);
+        self.log_trace("allocation", allocated_tokens);
         true
     }
 
@@ -248,8 +282,7 @@ impl SglangKvManager {
         reservation: &mut DecodeTokenReservation,
     ) {
         debug_assert!(lease.is_active());
-        let new_idx = reservation.take();
-        self.publish_decode_token(new_idx, lease.last_index());
+        let new_idx = reservation.take(lease.last_index());
         lease.kv_indices.push(new_idx);
     }
 
@@ -366,20 +399,26 @@ impl SglangKvManager {
         new_last_node
     }
 
-    /// Allocate a single token slot for decode output.
+    /// Allocate a decode token, consuming a new page only at a page boundary.
     /// Router-visible BlockStored events are published once a full block exists.
     pub fn allocate_decode_token(&mut self, last_idx: Option<usize>) -> Option<usize> {
-        let indices = self.cache.token_pool.allocate(1)?;
-        let idx = indices[0];
-        self.publish_decode_token(idx, last_idx);
+        let mut reservation = self.reserve_decode_pages(usize::from(
+            last_idx.is_none_or(|idx| (idx + 1) % self.cache.page_size() == 0),
+        ))?;
+        let idx = reservation.take(last_idx);
         Some(idx)
     }
 
-    pub fn reserve_decode_tokens(&mut self, count: usize) -> Option<DecodeTokenReservation> {
-        self.cache
-            .token_pool
-            .allocate(count)
-            .map(|indices| DecodeTokenReservation { indices, next: 0 })
+    pub fn reserve_decode_pages(&mut self, count: usize) -> Option<DecodeTokenReservation> {
+        let pages = self.cache.page_pool.allocate_pages(count)?;
+        if !pages.is_empty() {
+            self.log_trace("allocation", pages.len() * self.cache.page_size());
+        }
+        Some(DecodeTokenReservation {
+            pages,
+            next: 0,
+            page_size: self.cache.page_size(),
+        })
     }
 
     pub(crate) fn reserve_destination(
@@ -397,16 +436,17 @@ impl SglangKvManager {
             token_ids.len().div_ceil(self.cache.page_size()) * self.cache.page_size()
         };
         let fresh_tokens = allocated_tokens.saturating_sub(prefix_len);
-        let reservable = self.cache.token_pool.available() + self.cache.evictable_size;
+        let fresh_pages = fresh_tokens / self.cache.page_size();
+        let reservable = self.cache.available_tokens() + self.cache.evictable_size;
         if fresh_tokens > reservable {
             self.cache.dec_lock_ref(last_node);
             return None;
         }
-        let available = self.cache.token_pool.available();
+        let available = self.cache.available_tokens();
         if fresh_tokens > available {
             self.evict(fresh_tokens - available);
         }
-        let Some(unpublished_indices) = self.cache.token_pool.allocate(fresh_tokens) else {
+        let Some(unpublished_pages) = self.cache.page_pool.allocate_pages(fresh_pages) else {
             self.cache.dec_lock_ref(last_node);
             return None;
         };
@@ -415,7 +455,9 @@ impl SglangKvManager {
             prefix_len,
             prefix_indices,
             last_node,
-            unpublished_indices,
+            unpublished_pages,
+            page_size: self.cache.page_size(),
+            missing_tokens: token_ids.len().saturating_sub(prefix_len),
             allocated_tokens,
         })
     }
@@ -429,12 +471,15 @@ impl SglangKvManager {
             prefix_len,
             mut prefix_indices,
             last_node,
-            mut unpublished_indices,
+            unpublished_pages,
+            page_size: _,
+            missing_tokens,
             allocated_tokens: _,
         } = reservation;
-        let missing_tokens = token_ids.len().saturating_sub(prefix_len);
-        let surplus = unpublished_indices.split_off(missing_tokens);
-        self.release_unpublished_indices(surplus);
+        let mut unpublished_indices = self
+            .cache
+            .page_pool
+            .expand_pages(&unpublished_pages, missing_tokens);
         prefix_indices.append(&mut unpublished_indices);
         let new_last_node =
             self.cache_unfinished_req(token_ids, &mut prefix_indices, last_node, prefix_len);
@@ -451,29 +496,24 @@ impl SglangKvManager {
 
     pub(crate) fn cancel_destination(&mut self, reservation: SglangDestinationReservation) {
         self.cache.dec_lock_ref(reservation.last_node);
-        self.release_unpublished_indices(reservation.unpublished_indices);
-    }
-
-    pub fn publish_decode_token(&mut self, idx: usize, last_idx: Option<usize>) {
-        let _ = (idx, last_idx);
-        self.log_trace("allocation", 1);
+        self.release_unpublished_pages(reservation.unpublished_pages);
     }
 
     pub fn release_decode_reservation(&mut self, reservation: DecodeTokenReservation) {
-        let indices = &reservation.indices[reservation.next..];
-        if indices.is_empty() {
+        let pages = &reservation.pages[reservation.next..];
+        if pages.is_empty() {
             return;
         }
-        self.cache.token_pool.free(indices);
-        self.log_trace("release_unpublished", indices.len());
+        self.cache.page_pool.free_pages(pages);
+        self.log_trace("release_unpublished", pages.len() * self.cache.page_size());
     }
 
-    fn release_unpublished_indices(&mut self, indices: Vec<usize>) {
-        if indices.is_empty() {
+    fn release_unpublished_pages(&mut self, pages: Vec<KvPageId>) {
+        if pages.is_empty() {
             return;
         }
-        self.cache.token_pool.free(&indices);
-        self.log_trace("release_unpublished", indices.len());
+        self.cache.page_pool.free_pages(&pages);
+        self.log_trace("release_unpublished", pages.len() * self.cache.page_size());
     }
 
     #[cfg(test)]
@@ -488,9 +528,9 @@ impl SglangKvManager {
             return;
         }
 
-        self.cache.token_pool.free(indices);
-        self.publish_removed_event(indices);
-        self.log_trace("free", indices.len());
+        let pages = self.cache.page_pool.free_indices(indices);
+        self.publish_removed_pages(&pages);
+        self.log_trace("free", pages.len() * self.cache.page_size());
     }
 
     fn release_active_lease(&mut self, mut lease: ActiveKvLease) -> bool {
@@ -531,10 +571,15 @@ impl SglangKvManager {
         }
         path.reverse();
 
-        // Collect token indices from each node's value
+        // Expand cached page IDs only for the bounded active request.
         let mut indices = Vec::new();
         for node_id in path {
-            indices.extend_from_slice(&self.cache.node(node_id).value);
+            let node = self.cache.node(node_id);
+            indices.extend(
+                self.cache
+                    .page_pool
+                    .expand_pages(&node.value, node.value.len() * self.cache.page_size()),
+            );
         }
         indices
     }
@@ -551,11 +596,12 @@ impl SglangKvManager {
             return;
         }
 
-        let mut unretained_indices = Vec::new();
+        let mut unretained_pages = Vec::new();
         let mut current = last_node;
-        let mut path_end = complete_len;
+        let first_new_page = first_new_token / block_size;
+        let mut path_end = complete_len / block_size;
 
-        while path_end > first_new_token {
+        while path_end > first_new_page {
             debug_assert_ne!(current, self.cache.root());
             if current == self.cache.root() {
                 tracing::error!(
@@ -580,14 +626,14 @@ impl SglangKvManager {
                 break;
             }
             let path_start = path_end - node_len;
-            let reconcile_start = path_start.max(first_new_token);
+            let reconcile_start = path_start.max(first_new_page);
 
-            for block_start in (reconcile_start..path_end).step_by(block_size) {
-                let block_end = block_start + block_size;
-                let node_start = block_start - path_start;
-                let node_end = node_start + block_size;
-                if kv_indices[block_start..block_end] != node.value[node_start..node_end] {
-                    unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
+            for page_idx in reconcile_start..path_end {
+                let token_start = page_idx * block_size;
+                let incoming_page = KvPageId::from_token_index(kv_indices[token_start], block_size);
+                let canonical_page = node.value[page_idx - path_start];
+                if incoming_page != canonical_page {
+                    unretained_pages.push(incoming_page);
                 }
             }
 
@@ -595,7 +641,7 @@ impl SglangKvManager {
             current = node.parent.unwrap_or(self.cache.root());
         }
 
-        self.free_indices(&unretained_indices);
+        self.free_pages(&unretained_pages);
     }
 
     fn canonicalize_unfinished_indices(
@@ -621,24 +667,29 @@ impl SglangKvManager {
             kv_indices.len()
         );
 
-        let mut unretained_indices = Vec::new();
+        let mut unretained_pages = Vec::new();
         let mut current = last_node;
-        let mut path_end = complete_len;
+        let first_new_page = first_new_token / block_size;
+        let mut path_end = complete_len / block_size;
 
-        while path_end > first_new_token {
+        while path_end > first_new_page {
             let node = self.cache.node(current);
             let node_len = node.value.len();
             let path_start = path_end - node_len;
-            let reconcile_start = path_start.max(first_new_token);
+            let reconcile_start = path_start.max(first_new_page);
 
-            for block_start in (reconcile_start..path_end).step_by(block_size) {
-                let block_end = block_start + block_size;
-                let node_start = block_start - path_start;
-                let node_end = node_start + block_size;
-                let canonical = &node.value[node_start..node_end];
-                if kv_indices[block_start..block_end] != *canonical {
-                    unretained_indices.extend_from_slice(&kv_indices[block_start..block_end]);
-                    kv_indices[block_start..block_end].copy_from_slice(canonical);
+            for page_idx in reconcile_start..path_end {
+                let token_start = page_idx * block_size;
+                let token_end = token_start + block_size;
+                let incoming_page = KvPageId::from_token_index(kv_indices[token_start], block_size);
+                let canonical_page = node.value[page_idx - path_start];
+                if incoming_page != canonical_page {
+                    unretained_pages.push(incoming_page);
+                    let canonical = self
+                        .cache
+                        .page_pool
+                        .expand_pages(&[canonical_page], block_size);
+                    kv_indices[token_start..token_end].copy_from_slice(&canonical);
                 }
             }
 
@@ -646,16 +697,19 @@ impl SglangKvManager {
             current = node.parent.unwrap_or_else(|| self.cache.root());
         }
 
-        self.free_indices(&unretained_indices);
+        self.free_pages(&unretained_pages);
     }
 
     fn radix_path_covers(
         &self,
         mut current: NodeId,
         first_new_token: usize,
-        mut path_end: usize,
+        path_end: usize,
     ) -> bool {
-        while path_end > first_new_token {
+        let page_size = self.cache.page_size();
+        let first_new_page = first_new_token / page_size;
+        let mut path_end = path_end / page_size;
+        while path_end > first_new_page {
             if current == self.cache.root() {
                 return false;
             }
@@ -671,11 +725,20 @@ impl SglangKvManager {
 
     /// Evict tokens from the cache, publish BlockRemoved events, and log a trace.
     pub fn evict(&mut self, num_tokens: usize) {
-        let (evicted, evicted_indices) = self.cache.evict(num_tokens);
-        if !evicted_indices.is_empty() {
-            self.publish_removed_event(&evicted_indices);
+        let (evicted, evicted_pages) = self.cache.evict(num_tokens);
+        if !evicted_pages.is_empty() {
+            self.publish_removed_pages(&evicted_pages);
         }
         self.log_trace("eviction", evicted);
+    }
+
+    fn free_pages(&mut self, pages: &[KvPageId]) {
+        if pages.is_empty() {
+            return;
+        }
+        self.cache.page_pool.free_pages(pages);
+        self.publish_removed_pages(pages);
+        self.log_trace("free", pages.len() * self.cache.page_size());
     }
 
     fn log_trace(&self, event: &str, num_tokens: usize) {
@@ -801,13 +864,14 @@ impl SglangKvManager {
         )
     }
 
-    fn publish_removed_event(&mut self, evicted_indices: &[usize]) {
+    fn publish_removed_pages(&mut self, evicted_pages: &[KvPageId]) {
         if self.kv_event_publishers.is_empty() {
             return;
         }
 
         let mut block_hashes = Vec::new();
-        for &idx in evicted_indices {
+        for &page in evicted_pages {
+            let idx = page.terminal_token_index(self.cache.page_size());
             let Some(block_hash) = self.idx_to_block_hash.remove(&idx) else {
                 continue;
             };
@@ -914,26 +978,86 @@ mod tests {
     }
 
     #[test]
+    fn active_partial_page_owns_full_capacity_and_extends_in_place() {
+        let mut mgr = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
+        let mut alloc = mgr.allocate_for_request(&[1]).unwrap();
+        assert_eq!(mgr.cache().available_tokens(), 8);
+
+        assert!(mgr.extend_allocation(&[1, 2, 3, 4], &mut alloc.lease));
+        assert_eq!(
+            mgr.cache().available_tokens(),
+            8,
+            "filling an owned partial page must not allocate another page"
+        );
+
+        assert!(mgr.extend_allocation(&[1, 2, 3, 4, 5], &mut alloc.lease));
+        assert_eq!(mgr.cache().available_tokens(), 4);
+        assert!(mgr.retract(alloc.lease));
+        assert_eq!(mgr.cache().available_tokens(), 12);
+    }
+
+    #[test]
+    fn fresh_allocation_protects_matched_prefix_before_eviction() {
+        let mut mgr = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
+        let prefix = [1, 2, 3, 4];
+        let other = [9, 10, 11, 12, 13, 14, 15, 16];
+
+        let prefix_alloc = mgr.allocate_for_request(&prefix).unwrap();
+        mgr.finish(&prefix, prefix_alloc.lease);
+        let other_alloc = mgr.allocate_for_request(&other).unwrap();
+        mgr.finish(&other, other_alloc.lease);
+        // Make `prefix` the LRU victim. The new request must protect it before
+        // evicting one of `other`'s pages to satisfy its suffix allocation.
+        assert_eq!(mgr.cache_mut().match_prefix(&other).0, other.len());
+        assert_eq!(mgr.cache().available_tokens(), 0);
+
+        let extended = [1, 2, 3, 4, 5, 6, 7, 8];
+        let alloc = mgr
+            .allocate_for_request(&extended)
+            .expect("protected prefix plus one evicted page should fit");
+
+        assert_eq!(alloc.prefix_len, prefix.len());
+        assert_eq!(mgr.cache().prefix_match_len(&prefix), prefix.len());
+        assert_eq!(mgr.cache().available_tokens(), 0);
+    }
+
+    #[test]
+    fn finish_drops_partial_tail_page_and_caches_compact_complete_page() {
+        let mut mgr = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
+        let tokens = [1, 2, 3, 4, 5];
+        let alloc = mgr.allocate_for_request(&tokens).unwrap();
+        assert_eq!(mgr.cache().available_tokens(), 4);
+
+        mgr.finish(&tokens, alloc.lease);
+
+        assert_eq!(mgr.cache().available_tokens(), 8);
+        let (matched, node) = mgr.cache_mut().match_prefix(&tokens);
+        assert_eq!(matched, 4);
+        assert_eq!(mgr.cache().node(node).key.len(), 1);
+        assert_eq!(mgr.cache().node(node).value.len(), 1);
+    }
+
+    #[test]
     fn partially_consumed_decode_reservation_releases_only_unused_slots() {
         let mut mgr = SglangKvManager::new(4, 1, KvEventPublishers::default(), 0);
-        let mut reservation = mgr.reserve_decode_tokens(3).unwrap();
-        let consumed = reservation.take();
+        let mut reservation = mgr.reserve_decode_pages(3).unwrap();
+        let consumed = reservation.take(None);
         assert_eq!(reservation.len(), 2);
-        let mut expected_unused = reservation.indices[reservation.next..].to_vec();
+        let mut expected_unused = reservation.pages[reservation.next..].to_vec();
 
         mgr.release_decode_reservation(reservation);
         assert_eq!(mgr.cache().available_tokens(), 3);
 
         let mut reallocated = mgr
             .cache_mut()
-            .token_pool
-            .allocate(expected_unused.len())
+            .page_pool
+            .allocate_pages(expected_unused.len())
             .unwrap();
         expected_unused.sort_unstable();
         reallocated.sort_unstable();
         assert_eq!(reallocated, expected_unused);
         assert!(reallocated.windows(2).all(|pair| pair[0] != pair[1]));
-        assert!(!reallocated.contains(&consumed));
+        assert!(!reallocated.contains(&KvPageId::from_token_index(consumed, 1)));
     }
 
     #[test]
@@ -947,7 +1071,7 @@ mod tests {
         assert_eq!(alloc.lease.len(), 6);
         assert!(mgr.retract(alloc.lease));
 
-        assert_eq!(mgr.cache().token_pool.available(), 12);
+        assert_eq!(mgr.cache().page_pool.available(), 12);
         assert_eq!(mgr.cache().protected_size, 0);
         assert_eq!(mgr.cache().evictable_size, 4);
         assert_eq!(mgr.cache().prefix_match_len(&[1, 2, 3, 4]), 4);
@@ -992,7 +1116,7 @@ mod tests {
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
         }
-        assert_eq!(mgr.cache().token_pool.available(), 16);
+        assert_eq!(mgr.cache().page_pool.available(), 16);
         assert_eq!(mgr.cache().protected_size, 0);
         assert_eq!(mgr.cache().evictable_size, 0);
         assert_eq!(mgr.cache().num_nodes(), 1);
@@ -1005,7 +1129,7 @@ mod tests {
         let result = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(result.prefix_len, 0);
         assert_eq!(result.lease.kv_indices.len(), 5);
-        assert_eq!(mgr.cache().token_pool.available(), 95);
+        assert_eq!(mgr.cache().page_pool.available(), 95);
     }
 
     #[test]
@@ -1026,7 +1150,7 @@ mod tests {
         let r2 = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
         assert_eq!(r2.prefix_len, 5);
         assert_eq!(r2.lease.kv_indices.len(), 7); // 5 reused + 2 new pages
-        assert_eq!(mgr.cache().token_pool.available(), 93); // 100 - 5 - 2
+        assert_eq!(mgr.cache().page_pool.available(), 93); // 100 - 5 - 2
     }
 
     #[test]
@@ -1137,7 +1261,7 @@ mod tests {
         let mut mgr =
             SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
-        let indices = mgr.cache_mut().token_pool.allocate(tokens.len()).unwrap();
+        let indices = mgr.cache_mut().page_pool.allocate(tokens.len()).unwrap();
 
         assert_eq!(mgr.publish_stored_event(&tokens[..4], &indices[..4], 0), 1);
         assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 1);
@@ -1172,7 +1296,7 @@ mod tests {
         );
 
         let mut kv_indices = alloc.lease.kv_indices;
-        kv_indices.extend_from_slice(&mgr.cache_mut().token_pool.allocate(4).unwrap());
+        kv_indices.extend_from_slice(&mgr.cache_mut().page_pool.allocate(4).unwrap());
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
         let last_after_first_cache =
@@ -1239,7 +1363,7 @@ mod tests {
         let req1 = mgr.allocate_for_request(&tokens).unwrap();
         let req2 = mgr.allocate_for_request(&tokens).unwrap();
         assert_eq!(
-            mgr.cache().token_pool.available(),
+            mgr.cache().page_pool.available(),
             94,
             "both identical requests should allocate before either is cached"
         );
@@ -1267,7 +1391,7 @@ mod tests {
             "canonical completion should not emit Removed blocks"
         );
         assert_eq!(
-            mgr.cache().token_pool.available(),
+            mgr.cache().page_pool.available(),
             94,
             "canonical completion should retain the first request's slots"
         );
@@ -1285,7 +1409,7 @@ mod tests {
             "duplicate completion should only decrement duplicate refcounts"
         );
         assert_eq!(
-            mgr.cache().token_pool.available(),
+            mgr.cache().page_pool.available(),
             97,
             "duplicate completion should return unretained request slots"
         );
@@ -1327,7 +1451,7 @@ mod tests {
         harness.apply_events(stored_events).await;
         assert_eq!(harness.overlap_for_hashes(query_hashes.clone()).await, 2);
         assert_eq!(mgr.cache().evictable_size, 8);
-        assert_eq!(mgr.cache().token_pool.available(), 0);
+        assert_eq!(mgr.cache().page_pool.available(), 0);
 
         mgr.evict(4);
         let eviction_events = buffer.drain();
@@ -1338,7 +1462,7 @@ mod tests {
         assert_eq!(mgr.cache().prefix_match_len(&tokens), 4);
         assert_eq!(mgr.cache().evictable_size, 4);
         assert_eq!(mgr.cache().protected_size, 0);
-        assert_eq!(mgr.cache().token_pool.available(), 4);
+        assert_eq!(mgr.cache().page_pool.available(), 4);
         assert_eq!(harness.overlap_for_hashes(query_hashes).await, 1);
         harness.shutdown();
     }
@@ -1379,7 +1503,7 @@ mod tests {
             "the active duplicate must switch to radix-owned canonical pages"
         );
         assert_eq!(
-            mgr.cache().token_pool.available(),
+            mgr.cache().page_pool.available(),
             24,
             "every duplicate slot in the four-token page must return to the pool"
         );
@@ -1440,7 +1564,7 @@ mod tests {
     #[should_panic(expected = "invalid SGLang canonicalization range or radix path")]
     fn invalid_canonical_path_is_fatal() {
         let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
-        let mut indices = mgr.cache_mut().token_pool.allocate(4).unwrap();
+        let mut indices = mgr.cache_mut().page_pool.allocate(4).unwrap();
         let root = mgr.cache().root();
 
         mgr.canonicalize_unfinished_indices(&mut indices, root, 0, 4);

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -266,12 +266,12 @@ impl SglangCore {
                 let Some((_, reservation)) = self.destination_holds.remove(handoff_id) else {
                     return Ok(SchedulerCommandEffects::new(SchedulerCommandResult::Noop));
                 };
-                let available_before = self.kv_manager.cache().token_pool.available();
+                let available_before = self.kv_manager.cache().available_tokens();
                 let request = reservation.activate(&mut self.kv_manager, self.config.block_size);
                 self.active_destination_handoffs
                     .insert(handoff_id, request.uuid);
                 self.prebuilt_ready.push_back(request);
-                if self.kv_manager.cache().token_pool.available() > available_before {
+                if self.kv_manager.cache().available_tokens() > available_before {
                     self.bump_capacity_generation();
                 }
                 Ok(self.effects_after_capacity_change(SchedulerCommandResult::Applied))
@@ -752,24 +752,9 @@ impl SglangCore {
     }
 
     fn active_kv_blocks(&self) -> u64 {
-        let active_reserved = self
-            .waiting
-            .iter()
-            .map(SglangRequest::extra_reserved_tokens)
-            .sum::<usize>()
-            + self
-                .prebuilt_ready
-                .iter()
-                .map(SglangRequest::extra_reserved_tokens)
-                .sum::<usize>()
-            + self
-                .running
-                .iter()
-                .map(SglangRequest::extra_reserved_tokens)
-                .sum::<usize>();
         let actual_used =
             self.kv_manager.cache().total_tokens() - self.kv_manager.cache().available_tokens();
-        (actual_used + active_reserved).div_ceil(self.config.block_size) as u64
+        actual_used.div_ceil(self.config.block_size) as u64
     }
 
     fn promote_prebuilt_ready(&mut self) -> Vec<crate::scheduler::AdmissionEvent> {

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -20,6 +20,22 @@ pub(super) struct DecodeResult {
     pub(super) end_ms: f64,
 }
 
+fn decode_page_growth_needed(
+    running: &[SglangRequest],
+    block_size: usize,
+    max_burst: usize,
+) -> usize {
+    running
+        .iter()
+        .map(|req| {
+            let burst = max_burst.min(req.remaining_output_tokens());
+            let target =
+                super::config::ceil_to_block(req.current_sequence_len() + burst, block_size);
+            target.saturating_sub(req.allocated_tokens)
+        })
+        .sum()
+}
+
 fn decode_capacity_state(
     running: &[SglangRequest],
     kv_manager: &SglangKvManager,
@@ -31,15 +47,7 @@ fn decode_capacity_state(
     // Full partial pages are already owned by PagePool and excluded from
     // `actual_available`; subtracting their slack again would double-charge it.
     let logical_available = actual_available;
-    let page_growth_needed = running
-        .iter()
-        .map(|req| {
-            let burst = max_burst.min(req.remaining_output_tokens());
-            let target =
-                super::config::ceil_to_block(req.current_sequence_len() + burst, config.block_size);
-            target.saturating_sub(req.allocated_tokens)
-        })
-        .sum();
+    let page_growth_needed = decode_page_growth_needed(running, config.block_size, max_burst);
 
     (actual_available, logical_available, page_growth_needed)
 }
@@ -109,15 +117,7 @@ fn check_decode_mem_for_burst(
     }
 
     let available = kv_manager.cache().available_tokens();
-    let page_growth_needed = running
-        .iter()
-        .map(|req| {
-            let burst = max_burst.min(req.remaining_output_tokens());
-            let target =
-                super::config::ceil_to_block(req.current_sequence_len() + burst, config.block_size);
-            target.saturating_sub(req.allocated_tokens)
-        })
-        .sum::<usize>();
+    let page_growth_needed = decode_page_growth_needed(running, config.block_size, max_burst);
     if available < page_growth_needed {
         kv_manager.evict(page_growth_needed - available);
     }
@@ -261,16 +261,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         unscaled_time
     };
 
-    let reserved_page_tokens = running
-        .iter()
-        .map(|req| {
-            let target = super::config::ceil_to_block(
-                req.current_sequence_len() + max_burst.min(req.remaining_output_tokens()),
-                config.block_size,
-            );
-            target.saturating_sub(req.allocated_tokens)
-        })
-        .sum::<usize>();
+    let reserved_page_tokens = decode_page_growth_needed(running, config.block_size, max_burst);
     let reserved_pages = reserved_page_tokens / config.block_size;
     let Some(mut reservation) = kv_manager.reserve_decode_pages(reserved_pages) else {
         tracing::warn!(

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -28,11 +28,9 @@ fn decode_capacity_state(
 ) -> (usize, usize, usize) {
     let actual_available =
         kv_manager.cache().available_tokens() + kv_manager.cache().evictable_size;
-    let reserved_tokens = running
-        .iter()
-        .map(SglangRequest::extra_reserved_tokens)
-        .sum::<usize>();
-    let logical_available = actual_available.saturating_sub(reserved_tokens);
+    // Full partial pages are already owned by PagePool and excluded from
+    // `actual_available`; subtracting their slack again would double-charge it.
+    let logical_available = actual_available;
     let page_growth_needed = running
         .iter()
         .map(|req| {
@@ -86,13 +84,9 @@ fn check_decode_mem_for_burst(
     let mut retracted = Vec::new();
 
     loop {
-        let (actual_available, logical_available, page_growth_needed) =
+        let (_actual_available, logical_available, page_growth_needed) =
             decode_capacity_state(running, kv_manager, config, max_burst);
-        let needed = running
-            .iter()
-            .map(|req| max_burst.min(req.remaining_output_tokens()))
-            .sum::<usize>();
-        if actual_available >= needed && logical_available >= page_growth_needed {
+        if logical_available >= page_growth_needed {
             break;
         }
         if running.len() <= 1 {
@@ -114,13 +108,18 @@ fn check_decode_mem_for_burst(
         retracted.push(req);
     }
 
-    let available = kv_manager.cache().token_pool.available();
-    let needed = running
+    let available = kv_manager.cache().available_tokens();
+    let page_growth_needed = running
         .iter()
-        .map(|req| max_burst.min(req.remaining_output_tokens()))
+        .map(|req| {
+            let burst = max_burst.min(req.remaining_output_tokens());
+            let target =
+                super::config::ceil_to_block(req.current_sequence_len() + burst, config.block_size);
+            target.saturating_sub(req.allocated_tokens)
+        })
         .sum::<usize>();
-    if available < needed {
-        kv_manager.evict(needed - available);
+    if available < page_growth_needed {
+        kv_manager.evict(page_growth_needed - available);
     }
 
     if !retracted.is_empty() {
@@ -209,7 +208,6 @@ pub(super) fn simulate_decode_step_with_sampler(
             }
         })
         .collect::<Vec<_>>();
-    let no_token_signal_count = output_signals.len();
     let mut completed_requests = already_completed_indices
         .iter()
         .rev()
@@ -263,14 +261,21 @@ pub(super) fn simulate_decode_step_with_sampler(
         unscaled_time
     };
 
-    let reserved_tokens = running
+    let reserved_page_tokens = running
         .iter()
-        .map(|req| max_burst.min(req.remaining_output_tokens()))
-        .sum();
-    let Some(mut reservation) = kv_manager.reserve_decode_tokens(reserved_tokens) else {
+        .map(|req| {
+            let target = super::config::ceil_to_block(
+                req.current_sequence_len() + max_burst.min(req.remaining_output_tokens()),
+                config.block_size,
+            );
+            target.saturating_sub(req.allocated_tokens)
+        })
+        .sum::<usize>();
+    let reserved_pages = reserved_page_tokens / config.block_size;
+    let Some(mut reservation) = kv_manager.reserve_decode_pages(reserved_pages) else {
         tracing::warn!(
-            reserved_tokens,
-            "Failed to reserve speculative decode tokens after capacity preflight"
+            reserved_pages,
+            "Failed to reserve speculative decode pages after capacity preflight"
         );
         return DecodeResult {
             completed_requests,
@@ -328,10 +333,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         }
     }
 
-    debug_assert_eq!(
-        reservation.len(),
-        reserved_tokens.saturating_sub(output_signals.len() - no_token_signal_count)
-    );
+    debug_assert!(reservation.len() <= reserved_pages);
     kv_manager.release_decode_reservation(reservation);
 
     let mut newly_completed_requests = Vec::with_capacity(completed_indices.len());

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -43,18 +43,11 @@ pub(super) fn get_new_batch_prefill(
             remaining_output as f64 * new_token_ratio
         })
         .sum();
-    let reserved_page_overhead = waiting
-        .iter()
-        .map(SglangRequest::extra_reserved_tokens)
-        .sum::<usize>()
-        + running
-            .iter()
-            .map(SglangRequest::extra_reserved_tokens)
-            .sum::<usize>();
-
-    let mut rem_total_tokens = (cache.available_tokens() + cache.evictable_size)
-        .saturating_sub(reserved_page_overhead) as f64
-        - reserved_decode_output;
+    // PagePool already removes the full physical footprint of every active
+    // partial page from available capacity, so page slack must not be charged
+    // a second time here.
+    let mut rem_total_tokens =
+        (cache.available_tokens() + cache.evictable_size) as f64 - reserved_decode_output;
     let mut rem_input_tokens = config.max_prefill_tokens as f64;
     let mut rem_chunk_tokens = config.chunked_prefill_size as f64;
 
@@ -107,10 +100,13 @@ pub(super) fn get_new_batch_prefill(
         let old_allocated_tokens = req.allocated_tokens;
         let mut lease = std::mem::take(&mut req.kv_lease);
         let alloc_tokens = req.sequence_prefix(chunk_end);
-        let actual_new_tokens = alloc_tokens.len().saturating_sub(req.materialized_tokens);
-        let available = kv_manager.cache().token_pool.available();
-        if available < actual_new_tokens {
-            kv_manager.evict(actual_new_tokens - available);
+        if req.materialized_tokens > 0 {
+            let target_allocated_tokens = ceil_to_block(chunk_end, config.block_size);
+            let required_capacity = target_allocated_tokens.saturating_sub(old_allocated_tokens);
+            let available = kv_manager.cache().available_tokens();
+            if available < required_capacity {
+                kv_manager.evict(required_capacity - available);
+            }
         }
 
         let prefix_len = if req.materialized_tokens > 0 {

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -43,6 +43,7 @@ impl SglangRequest {
         self.max_output_tokens.saturating_sub(self.output_len())
     }
 
+    #[cfg(debug_assertions)]
     pub(super) fn extra_reserved_tokens(&self) -> usize {
         self.allocated_tokens.saturating_sub(self.kv_len())
     }
@@ -52,6 +53,7 @@ impl SglangRequest {
         self.kv_lease.indices()
     }
 
+    #[cfg(debug_assertions)]
     pub(super) fn kv_len(&self) -> usize {
         self.kv_lease.len()
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -199,9 +199,9 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     assert_eq!(req.cached_tokens(), prompt.len());
     assert_eq!(req.kv_indices(), cached_indices);
 
-    // Leave four free slots and one block of page growth for the cache-hit
-    // request. Reserved page overhead makes check_decode_mem retract it, while
-    // the remaining request still fits without evicting the cached prompt.
+    // The three-token blocker owns a complete physical page. With two pages
+    // total there is no free capacity, so the cache-hit request is retracted
+    // while the blocker can fill the remainder of its existing page.
     let blocker_tokens = vec![9, 10, 11];
     let blocker_alloc = kv_manager.allocate_for_request(&blocker_tokens).unwrap();
     let blocker = SglangRequest {
@@ -221,7 +221,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     assert_eq!(retracted.len(), 1);
     assert_eq!(retracted[0].uuid, Uuid::from_u128(90_002));
     assert_eq!(removed_event_count(&buffer.drain()), 0);
-    assert_eq!(kv_manager.cache().token_pool.available(), 4);
+    assert_eq!(kv_manager.cache().page_pool.available(), 0);
     assert_eq!(kv_manager.cache_mut().match_prefix(&prompt).0, prompt.len());
 }
 
@@ -858,7 +858,7 @@ mod destination_lifecycle {
     }
 
     #[test]
-    fn activation_surplus_immediately_retries_pending_head() {
+    fn activation_retains_partial_page_until_owner_is_cancelled() {
         let args = MockEngineArgs::builder()
             .engine_type(EngineType::Sglang)
             .num_gpu_blocks(3)
@@ -908,22 +908,11 @@ mod destination_lifecycle {
                 true,
             )
             .unwrap();
-        assert!(matches!(
-            activated.lifecycle_events.as_slice(),
-            [SchedulerLifecycleEvent::DestinationReserved {
-                handoff_id,
-                request_id,
-                ..
-            }] if *handoff_id == follower_handoff && *request_id == follower_request
-        ));
-
-        assert_eq!(
-            core.apply_command(SchedulerCommand::CancelDestination {
-                handoff_id: follower_handoff,
-            })
-            .unwrap(),
-            SchedulerCommandResult::Applied
+        assert!(
+            activated.lifecycle_events.is_empty(),
+            "activating a partial prompt must retain its complete physical page"
         );
+
         assert_eq!(
             core.apply_command(SchedulerCommand::CancelDestination {
                 handoff_id: owner_handoff,
@@ -931,7 +920,15 @@ mod destination_lifecycle {
             .unwrap(),
             SchedulerCommandResult::Applied
         );
-        core.kv_manager.cache_mut().token_pool.free(&[blocker]);
+        assert!(core.destination_is_held(follower_handoff));
+        assert_eq!(
+            core.apply_command(SchedulerCommand::CancelDestination {
+                handoff_id: follower_handoff,
+            })
+            .unwrap(),
+            SchedulerCommandResult::Applied
+        );
+        core.kv_manager.cache_mut().page_pool.free(&[blocker]);
     }
 }
 
@@ -1341,19 +1338,19 @@ mod core_behavior {
                 .build()
                 .unwrap(),
         );
-        let mut kv_manager = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
-        let first = kv_manager.cache_mut().token_pool.allocate(4).unwrap();
-        let second = kv_manager.cache_mut().token_pool.allocate(4).unwrap();
+        let mut kv_manager = SglangKvManager::new(16, 4, KvEventPublishers::default(), 0);
+        let first = kv_manager.cache_mut().page_pool.allocate(8).unwrap();
+        let second = kv_manager.cache_mut().page_pool.allocate(5).unwrap();
 
         let mut running = vec![
             SglangRequest {
                 uuid: Uuid::new_v4(),
-                sequence_tokens: vec![1, 2, 3, 4, 11, 12, 13],
+                sequence_tokens: vec![1, 2, 3, 4, 11, 12, 13, 14],
                 prompt_len: 4,
                 max_output_tokens: 10,
                 planned_output_ids: None,
                 kv_lease: ActiveKvLease::from_parts(first, 4, kv_manager.cache().root()),
-                materialized_tokens: 7,
+                materialized_tokens: 8,
                 allocated_tokens: 8,
             },
             SglangRequest {
@@ -1728,15 +1725,23 @@ mod router_events {
         let config = SglangConfig::from_args(&args);
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
         let mut kv_manager =
-            SglangKvManager::new(10, 4, KvEventPublishers::new(Some(sink), None), 0);
+            SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink), None), 0);
 
-        let req1 = make_decoded_request(&mut kv_manager, &config, vec![1, 2, 3, 4], 4);
+        let req1 = make_decoded_request(&mut kv_manager, &config, vec![1, 2, 3, 4, 5, 6, 7], 4);
         let req1_events = buffer.drain();
         let req1_hashes = stored_hashes(&req1_events);
         harness.apply_events(req1_events).await;
+        assert_eq!(
+            harness.overlap_for_hashes(req1_hashes.clone()).await,
+            req1_hashes.len() as u32
+        );
 
-        let req2 = make_decoded_request(&mut kv_manager, &config, vec![9, 8, 7, 6], 4);
+        let req2 = make_decoded_request(&mut kv_manager, &config, vec![9, 8, 7, 6, 5, 4, 3], 4);
         harness.apply_events(buffer.drain()).await;
+        assert_eq!(
+            harness.overlap_for_hashes(req1_hashes.clone()).await,
+            req1_hashes.len() as u32
+        );
 
         let mut running = vec![req1, req2];
         let retracted = decode::check_decode_mem(&mut running, &mut kv_manager, &config);
@@ -1745,7 +1750,11 @@ mod router_events {
         let retract_events = buffer.drain();
         harness.apply_events(retract_events).await;
 
-        assert_eq!(harness.overlap_for_hashes(req1_hashes).await, 1);
+        assert_eq!(
+            harness.overlap_for_hashes(req1_hashes.clone()).await,
+            1,
+            "one evictable suffix page is removed to make physical room"
+        );
         harness.shutdown();
     }
 
@@ -1781,12 +1790,12 @@ mod router_events {
         let config = SglangConfig::from_args(&args);
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
         let mut kv_manager =
-            SglangKvManager::new(12, 4, KvEventPublishers::new(Some(sink), None), 0);
+            SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink), None), 0);
 
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
-            sequence_tokens: vec![1, 2, 3, 4, 5, 6],
-            prompt_len: 6,
+            sequence_tokens: vec![1, 2, 3, 4, 5, 6, 7],
+            prompt_len: 7,
             max_output_tokens: 3,
             planned_output_ids: None,
             materialized_tokens: 0,
@@ -1807,7 +1816,8 @@ mod router_events {
         harness.apply_events(buffer.drain()).await;
         let req1 = running.pop().unwrap();
 
-        let req2 = make_decoded_request(&mut kv_manager, &config, vec![9, 10, 11, 12], 3);
+        let req2 =
+            make_decoded_request(&mut kv_manager, &config, vec![9, 10, 11, 12, 13, 14, 15], 3);
         harness.apply_events(buffer.drain()).await;
 
         let mut running = vec![req1, req2];


### PR DESCRIPTION
## Overview

The SGLang mocker currently allocates and retains individual token-slot IDs even though SGLang's paged allocator owns and frees whole pages. This undercounts active partial-page occupancy, retains per-token metadata in the completed radix cache, and can produce capacity and eviction behavior that the real allocator cannot.

## Motivation

Offline replay maintains an independent SGLang radix tree for every simulated worker. On large production traces, retaining a token-slot ID for every token in every completed cached page makes the radix-tree memory footprint grow with both cached tokens and worker count; this became the dominant memory cost in high-worker-count Astra replay runs. Completed pages only need page/block identity, so this PR replaces that unnecessary per-token state with compact per-page metadata while preserving SGLang allocator semantics.

## Summary

- Replace the token-slot pool with a whole-page allocator while preserving flattened token indices only for bounded active requests.
- Store one router-compatible block hash and one physical page ID per completed radix page instead of per-token IDs.
- Make prefill, decode, destination reservations, eviction, retraction, and worker KV metrics account for physical page ownership.
- Protect a matched prefix before eviction and allocation, avoiding a false-OOM race when the matching prefix is the LRU victim.
- Hash and validate only the newly completed suffix during retained-prefix insertion, avoiding quadratic decode growth.

## Details

Completed radix edges now retain `LocalBlockHash + KvPageId` per page. Active partial pages consume their full physical capacity and extend in place until the page boundary; decode reserves new pages only when a request crosses that boundary. Finished partial tails release the entire page, while complete pages remain compactly indexed in the radix tree.

The 64-bit local block hash is intentionally the page identity, matching router-side indexing. Hash collisions are therefore treated as identical pages, rather than retaining an exact per-token collision guard.

At constrained capacity, replay results can intentionally differ from the previous mocker because unused positions in an active partial page are no longer exposed as allocatable capacity.

## Where should the reviewer start?

- `lib/mocker/src/cache/radix_cache.rs`: `PagePool`, compact radix representation, suffix-only insertion, and page-granular eviction.
- `lib/mocker/src/kv_manager/sglang_backend.rs`: request ownership, atomic match/protect/evict/allocate, decode and destination reservations, canonicalization, and router events.
- `lib/mocker/src/scheduler/sglang/{prefill,decode,core}.rs`: page-aware admission, reservation, and KV usage accounting.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-mocker --lib --tests -- -D warnings`
- `cargo test -p dynamo-mocker --lib -- --test-threads=1` — 600 passed, 1 ignored
- `cargo bench -p dynamo-bench --bench offline_replay_bench --no-default-features --features replay-bench --no-run`
- Independent ownership and SGLang allocator semantic audits passed.
- Deterministic SGLang KV-router replay, two independent processes per revision/topology:
  - aggregated, 4 workers, 16,384 blocks/worker: baseline and candidate canonical reports match exactly;
  - disaggregated, 2P+2D, 131,072 blocks/worker: canonical reports match exactly;
  - disaggregated, 2P+2D, 16,384 blocks/worker: deterministic expected differences from whole-page pressure semantics; increasing capacity removes all differences.
- Paired release replay performance, 5 warmups + 30 pairs:
  - aggregated candidate/baseline median ratio: 0.762;
  - disaggregated candidate/baseline median ratio: 0.806.
- 5,000-request aggregated replay max RSS: 591,052 KiB to 339,860 KiB (-42.5%).

## Related Issues

**This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - KV-cache management now uses page-based allocation, improving handling of partial pages and cache reuse.
  - Decode and destination reservations more accurately track available cache capacity.

- **Bug Fixes**
  - Improved cache eviction and cleanup to prevent stale blocks and preserve active generated output.
  - Refined prefill, decode, activation, and retraction capacity calculations for more reliable scheduling.

- **Tests**
  - Updated coverage for page allocation, eviction, cancellation, re-prefill, and mixed decode workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->