### PR TITLE
fix(glm52): chat template parity fixes — arguments normalization and streaming tool_call recovery

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -28,7 +28,6 @@ from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
 from tensorrt_llm.executor.result import GenerationResult
 from tensorrt_llm.executor.utils import RequestError
 from tensorrt_llm.llmapi import DisaggregatedParams as LlmDisaggregatedParams
-from tensorrt_llm.llmapi.disagg_utils import get_global_disagg_request_id
 from tensorrt_llm.llmapi.llm import SamplingParams
 from tensorrt_llm.sampling_params import GuidedDecodingParams
 from tensorrt_llm.scheduling_params import SchedulingParams
@@ -61,6 +60,7 @@ from dynamo.trtllm.request_handlers.base_generative_handler import BaseGenerativ
 from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParams,
     DisaggregatedParamsCodec,
+    get_compatible_global_disagg_request_id,
 )
 from dynamo.trtllm.utils.request_utils import (
     apply_stop_conditions_to_sampling_params,
@@ -728,7 +728,7 @@ class HandlerBase(BaseGenerativeHandler):
             else:
                 disaggregated_params = LlmDisaggregatedParams(
                     request_type="context_only",
-                    disagg_request_id=get_global_disagg_request_id(
+                    disagg_request_id=get_compatible_global_disagg_request_id(
                         self.disagg_machine_id
                     ),
                 )
@@ -737,8 +737,8 @@ class HandlerBase(BaseGenerativeHandler):
             # ep_disaggregated_params, so the PYTHON transceiver can track
             # requests across prefill/decode workers.
             if disaggregated_params.disagg_request_id is None:
-                disaggregated_params.disagg_request_id = get_global_disagg_request_id(
-                    self.disagg_machine_id
+                disaggregated_params.disagg_request_id = (
+                    get_compatible_global_disagg_request_id(self.disagg_machine_id)
                 )
 
         # AGGREGATED (prefill_and_decode) mode with encoder disaggregation:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_disagg_request_id.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_disagg_request_id.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import patch
+
+import pytest
+
+from dynamo.trtllm.utils import disagg_utils
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.core,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_1,
+]
+
+
+def test_rc22_machine_id_is_split_losslessly():
+    with (
+        patch.object(disagg_utils, "_TRTLLM_DISAGG_ID_HAS_PROCESS_ID", True),
+        patch.object(
+            disagg_utils,
+            "_trtllm_get_global_disagg_request_id",
+            return_value=123,
+        ) as generate,
+    ):
+        result = disagg_utils.get_compatible_global_disagg_request_id(1020)
+
+    assert result == 123
+    generate.assert_called_once_with(15, 60)
+
+
+def test_rc22_all_dynamo_machine_ids_are_in_range_and_unique():
+    pairs = {
+        divmod(machine_id, disagg_utils._TRTLLM_PROCESS_ID_SPACE)
+        for machine_id in range(disagg_utils._DYNAMO_DISAGG_MACHINE_ID_SPACE)
+    }
+
+    assert len(pairs) == disagg_utils._DYNAMO_DISAGG_MACHINE_ID_SPACE
+    assert all(0 <= node_id < 256 for node_id, _ in pairs)
+    assert all(0 <= process_id < 64 for _, process_id in pairs)
+
+
+def test_rc21_keeps_legacy_machine_id():
+    with (
+        patch.object(disagg_utils, "_TRTLLM_DISAGG_ID_HAS_PROCESS_ID", False),
+        patch.object(
+            disagg_utils,
+            "_trtllm_get_global_disagg_request_id",
+            return_value=456,
+        ) as generate,
+    ):
+        result = disagg_utils.get_compatible_global_disagg_request_id(1020)
+
+    assert result == 456
+    generate.assert_called_once_with(1020)
+
+
+@pytest.mark.parametrize("machine_id", [-1, 1021])
+def test_invalid_dynamo_machine_id_fails_fast(machine_id):
+    with pytest.raises(ValueError, match="machine_id must be in range"):
+        disagg_utils.get_compatible_global_disagg_request_id(machine_id)

--- a/components/src/dynamo/trtllm/utils/disagg_utils.py
+++ b/components/src/dynamo/trtllm/utils/disagg_utils.py
@@ -15,9 +15,46 @@
 
 import base64
 import dataclasses
+import inspect
 
 from tensorrt_llm.executor.result import Logprob
 from tensorrt_llm.llmapi import DisaggregatedParams
+from tensorrt_llm.llmapi.disagg_utils import (
+    get_global_disagg_request_id as _trtllm_get_global_disagg_request_id,
+)
+
+# Dynamo maps its distributed-runtime connection ID into TRT-LLM's historical
+# 10-bit machine-ID space with ``connection_id % 1021``. TRT-LLM rc22 split
+# that field into an 8-bit node ID and a 6-bit process ID. Preserve Dynamo's
+# existing 10-bit worker slot and encode it losslessly into the new pair.
+_TRTLLM_DISAGG_ID_HAS_PROCESS_ID = (
+    "process_id" in inspect.signature(_trtllm_get_global_disagg_request_id).parameters
+)
+_TRTLLM_PROCESS_ID_SPACE = 1 << 6
+_DYNAMO_DISAGG_MACHINE_ID_SPACE = 1021
+
+
+def get_compatible_global_disagg_request_id(machine_id: int) -> int:
+    """Generate a global TRT-LLM disaggregation request ID across API versions.
+
+    TRT-LLM <= rc21 accepts a 10-bit ``machine_id``. TRT-LLM >= rc22 accepts
+    an 8-bit ``node_id`` plus a 6-bit ``process_id``. Dynamo's existing
+    machine ID is in ``[0, 1021)``; splitting that value with ``divmod(64)``
+    produces a unique, in-range pair without changing Dynamo's collision
+    characteristics.
+    """
+
+    if not 0 <= machine_id < _DYNAMO_DISAGG_MACHINE_ID_SPACE:
+        raise ValueError(
+            "Dynamo disagg machine_id must be in range "
+            f"[0, {_DYNAMO_DISAGG_MACHINE_ID_SPACE}), got {machine_id}"
+        )
+
+    if _TRTLLM_DISAGG_ID_HAS_PROCESS_ID:
+        node_id, process_id = divmod(machine_id, _TRTLLM_PROCESS_ID_SPACE)
+        return _trtllm_get_global_disagg_request_id(node_id, process_id)
+
+    return _trtllm_get_global_disagg_request_id(machine_id)
 
 
 class DisaggregatedParamsCodec:

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -17,7 +17,7 @@ use super::{PrefillCompletion, PrefillError, PrefillRouter};
 use crate::{
     kv_router::KvPushRouter,
     protocols::common::{
-        llm_backend::{LLMEngineOutput, PreprocessedRequest},
+        llm_backend::{FinishReason, LLMEngineOutput, PreprocessedRequest},
         timing::RequestTracker,
     },
     session_affinity::{AffinityTarget, SessionAffinityPushRouter},
@@ -110,6 +110,21 @@ impl PrefillRouter {
             tokio::spawn(async move { while prefill_response.next().await.is_some() {} });
         }
 
+        // A CTX request that reaches EOS/stop during its one-token prefill step
+        // is already complete and does not establish a KV-cache handoff. A
+        // missing finish reason is equivalent to TRT-LLM's "not_finished";
+        // Length also requires the normal GEN handoff.
+        let is_terminal = first_output
+            .data
+            .as_ref()
+            .and_then(|output| output.finish_reason.as_ref())
+            .is_some_and(|reason| !matches!(reason, FinishReason::Length));
+        if is_terminal {
+            return Ok(PrefillCompletion::Terminal {
+                output: first_output,
+            });
+        }
+
         let Some(output) = &first_output.data else {
             return Err(PrefillError::NoDisaggregatedParams(
                 "Prefill router output has no data field".to_string(),
@@ -121,7 +136,7 @@ impl PrefillRouter {
             ));
         };
 
-        Ok(PrefillCompletion {
+        Ok(PrefillCompletion::Handoff {
             result: crate::protocols::common::preprocessor::PrefillResult {
                 disaggregated_params,
                 prompt_tokens_details,
@@ -202,5 +217,68 @@ mod tests {
 
         assert!(result.is_err());
         assert!(!tracker.record_prefill_complete());
+    }
+
+    #[tokio::test]
+    async fn terminal_prefill_without_handoff_is_returned_to_caller() {
+        let output = LLMEngineOutput {
+            token_ids: vec![2],
+            finish_reason: Some(FinishReason::EoS),
+            ..Default::default()
+        };
+        let result = PrefillRouter::consume_prefill_stream(
+            prefill_stream(vec![Annotated::from_data(output)]),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let PrefillCompletion::Terminal { output } = result else {
+            panic!("expected terminal prefill completion");
+        };
+        assert_eq!(
+            output.data.and_then(|data| data.finish_reason),
+            Some(FinishReason::EoS)
+        );
+    }
+
+    #[tokio::test]
+    async fn length_limited_prefill_still_requires_handoff() {
+        let output = LLMEngineOutput {
+            finish_reason: Some(FinishReason::Length),
+            disaggregated_params: Some(json!({"ctx_request_id": 42})),
+            ..Default::default()
+        };
+        let result = PrefillRouter::consume_prefill_stream(
+            prefill_stream(vec![Annotated::from_data(output)]),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let PrefillCompletion::Handoff { result, .. } = result else {
+            panic!("expected prefill handoff");
+        };
+        assert_eq!(result.disaggregated_params, json!({"ctx_request_id": 42}));
+    }
+
+    #[tokio::test]
+    async fn unfinished_prefill_still_requires_handoff() {
+        let output = LLMEngineOutput {
+            finish_reason: None,
+            disaggregated_params: Some(json!({"ctx_request_id": 42})),
+            ..Default::default()
+        };
+        let result = PrefillRouter::consume_prefill_stream(
+            prefill_stream(vec![Annotated::from_data(output)]),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let PrefillCompletion::Handoff { result, .. } = result else {
+            panic!("expected prefill handoff");
+        };
+        assert_eq!(result.disaggregated_params, json!({"ctx_request_id": 42}));
     }
 }

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicU8;
 use std::sync::{Arc, OnceLock};
 
 use anyhow::Result;
+use futures::stream;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -90,6 +91,9 @@ enum PrefillOutcome {
         worker_id: u64,
         worker_link: Option<TraceLink>,
     },
+    Terminal {
+        output: Annotated<LLMEngineOutput>,
+    },
 }
 
 fn extract_bootstrap_info(params: &serde_json::Value) -> Option<BootstrapInfo> {
@@ -121,9 +125,14 @@ pub enum PrefillQueryOutcome {
     },
 }
 
-struct PrefillCompletion {
-    result: PrefillResult,
-    worker_link: Option<TraceLink>,
+enum PrefillCompletion {
+    Handoff {
+        result: PrefillResult,
+        worker_link: Option<TraceLink>,
+    },
+    Terminal {
+        output: Annotated<LLMEngineOutput>,
+    },
 }
 
 /// PrefillRouter is a forward-only operator that sits between Migration and the decode router.
@@ -248,19 +257,27 @@ impl
                 drop(prefill_phase_barrier);
                 let completion = Self::consume_prefill_stream(prefill_stream, tracker).await?;
 
-                if let Some(bootstrap_info) =
-                    extract_bootstrap_info(&completion.result.disaggregated_params)
-                {
-                    PrefillOutcome::Bootstrap {
-                        bootstrap_info,
-                        worker_id: prepared.worker_id,
+                match completion {
+                    PrefillCompletion::Handoff {
+                        result,
+                        worker_link,
+                    } => {
+                        if let Some(bootstrap_info) =
+                            extract_bootstrap_info(&result.disaggregated_params)
+                        {
+                            PrefillOutcome::Bootstrap {
+                                bootstrap_info,
+                                worker_id: prepared.worker_id,
+                            }
+                        } else {
+                            PrefillOutcome::Completed {
+                                result,
+                                worker_id: prepared.worker_id,
+                                worker_link,
+                            }
+                        }
                     }
-                } else {
-                    PrefillOutcome::Completed {
-                        result: completion.result,
-                        worker_id: prepared.worker_id,
-                        worker_link: completion.worker_link,
-                    }
+                    PrefillCompletion::Terminal { output } => PrefillOutcome::Terminal { output },
                 }
             };
             Ok((outcome, topology_constraints))
@@ -280,6 +297,23 @@ impl
                 }
                 return Err(error);
             }
+        };
+
+        // A prefill request can terminate before the backend establishes a KV
+        // handoff (for example, EOS on the one-token context step). Native
+        // disaggregated backends return that context response directly instead
+        // of launching a generation-only request with missing handoff IDs.
+        let outcome = match outcome {
+            PrefillOutcome::Terminal { mut output } => {
+                if let Some(data) = output.data.as_mut() {
+                    data.disaggregated_params = None;
+                }
+                return Ok(dynamo_runtime::pipeline::ResponseStream::new(
+                    Box::pin(stream::once(async move { output })),
+                    engine_ctx,
+                ));
+            }
+            outcome => outcome,
         };
 
         // NVBugs 5969206: Do NOT abort decode routing when context is killed.
@@ -321,6 +355,9 @@ impl
                 decode_req.prefill_result = Some(result);
                 decode_req.migration_link = worker_link;
                 decode_req.routing_mut().prefill_worker_id = Some(worker_id);
+            }
+            PrefillOutcome::Terminal { .. } => {
+                unreachable!("terminal prefill outcomes return before decode routing")
             }
         };
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2973,18 +2973,15 @@ impl OpenAIPreprocessor {
                 p.template = Some(metrics);
             }
             // Buffer input content only for glm47 (truncation recovery).
-            if is_glm47 {
-                if let Some(data) = &a.data {
-                    let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
-                    for choice in &data.inner.choices {
-                        if let Some(ChatCompletionMessageContent::Text(content)) =
-                            &choice.delta.content
-                        {
-                            cr.entry(choice.index)
-                                .or_default()
-                                .input_text
-                                .push_str(content);
-                        }
+            if is_glm47 && let Some(data) = &a.data {
+                let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
+                for choice in &data.inner.choices {
+                    if let Some(ChatCompletionMessageContent::Text(content)) = &choice.delta.content
+                    {
+                        cr.entry(choice.index)
+                            .or_default()
+                            .input_text
+                            .push_str(content);
                     }
                 }
             }
@@ -3035,46 +3032,42 @@ impl OpenAIPreprocessor {
             // <tool_call> markup — callers that require strict "no tool tags in content"
             // must filter on finish_reason=length.
             let mut recoveries: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
-            if is_glm47 {
-                if let Some(ref data) = nv_chunk.data {
-                    let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
-                    for choice in &data.inner.choices {
-                        let state = cr.entry(choice.index).or_default();
-                        if matches!(
-                            choice.finish_reason,
-                            Some(dynamo_protocols::types::FinishReason::Length)
-                        ) {
-                            let recovered =
-                                state.input_text.rfind("<tool_call>").and_then(|start| {
-                                    let tail = &state.input_text[start..];
-                                    if !tail.contains("</tool_call>") {
-                                        Some(tail.to_string())
-                                    } else {
-                                        None
-                                    }
-                                });
-                            if let Some(recovered) = recovered {
-                                tracing::warn!(
-                                    choice_index = choice.index,
-                                    recovered_bytes = recovered.len(),
-                                    "glm47 streaming: partial <tool_call> emitted as content \
-                                     on length finish (TRT-LLM parity; raw markup in content)"
-                                );
-                                let mut rec = nv_chunk.clone();
-                                if let Some(ref mut rd) = rec.data {
-                                    rd.inner.usage = None;
-                                    rd.llm_metrics = None;
-                                    rd.inner.choices.retain(|c| c.index == choice.index);
-                                    for rc in &mut rd.inner.choices {
-                                        rc.delta.content = Some(
-                                            ChatCompletionMessageContent::Text(recovered.clone()),
-                                        );
-                                        rc.delta.tool_calls = None;
-                                        rc.finish_reason = None;
-                                    }
-                                }
-                                recoveries.push(rec);
+            if is_glm47 && let Some(ref data) = nv_chunk.data {
+                let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
+                for choice in &data.inner.choices {
+                    let state = cr.entry(choice.index).or_default();
+                    if matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    ) {
+                        let recovered = state.input_text.rfind("<tool_call>").and_then(|start| {
+                            let tail = &state.input_text[start..];
+                            if !tail.contains("</tool_call>") {
+                                Some(tail.to_string())
+                            } else {
+                                None
                             }
+                        });
+                        if let Some(recovered) = recovered {
+                            tracing::warn!(
+                                choice_index = choice.index,
+                                recovered_bytes = recovered.len(),
+                                "glm47 streaming: partial <tool_call> emitted as content \
+                                 on length finish (TRT-LLM parity; raw markup in content)"
+                            );
+                            let mut rec = nv_chunk.clone();
+                            if let Some(ref mut rd) = rec.data {
+                                rd.inner.usage = None;
+                                rd.llm_metrics = None;
+                                rd.inner.choices.retain(|c| c.index == choice.index);
+                                for rc in &mut rd.inner.choices {
+                                    rc.delta.content =
+                                        Some(ChatCompletionMessageContent::Text(recovered.clone()));
+                                    rc.delta.tool_calls = None;
+                                    rc.finish_reason = None;
+                                }
+                            }
+                            recoveries.push(rec);
                         }
                     }
                 }
@@ -3774,6 +3767,7 @@ impl
             &next,
             &self.formatter,
             &self.tokenizer,
+            self.tool_arguments_mode,
         );
 
         let final_stream = crate::request_trace::wrap_chat_request_end_stream(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -76,7 +76,10 @@ use crate::protocols::{
 };
 use crate::tokenizers::traits::Tokenizer;
 
-use crate::preprocessor::prompt::{MediaRequestExt, prompt_formatter_from_mdc};
+use crate::preprocessor::prompt::{
+    MediaRequestExt, ToolArgumentsMode, ToolArgumentsModeGuard, detect_tool_arguments_mode,
+    mdc_jinja_template_text, prompt_formatter_from_mdc,
+};
 use dynamo_renderer::{OAIChatLikeRequest, PromptFormatter, PromptInput, TextInput, TokenInput};
 
 pub use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
@@ -326,6 +329,10 @@ pub struct OpenAIPreprocessor {
     /// KV cache block size published in the model deployment card.
     kv_cache_block_size: usize,
     tool_call_parser: Option<String>,
+    /// Whether the loaded chat template requires tool_calls[*].function.arguments
+    /// as a parsed serde_json object (vs. the OpenAI wire-schema JSON string).
+    /// Derived once from the Jinja template source at construction.
+    tool_arguments_mode: ToolArgumentsMode,
     media_loader: Option<MediaLoader>,
     /// Max context length (in tokens) this model can handle, from ModelDeploymentCard
     context_length: u32,
@@ -658,6 +665,12 @@ impl OpenAIPreprocessor {
         };
         let model_info = model_info.get_model_info()?;
         let tool_call_parser = mdc.runtime_config.tool_call_parser.clone();
+        // Detect argument mode from the Jinja template source once at construction.
+        // Falls back to JsonString (no-op normalization) for models without a .jinja file.
+        let tool_arguments_mode = mdc_jinja_template_text(&mdc)
+            .as_deref()
+            .map(detect_tool_arguments_mode)
+            .unwrap_or_default();
 
         if let Some(ref lora_name) = lora_name {
             tracing::info!(model = %mdc.display_name, lora_name, "LoRA adapter detected in MDC");
@@ -850,6 +863,7 @@ impl OpenAIPreprocessor {
             runtime_config,
             kv_cache_block_size,
             tool_call_parser,
+            tool_arguments_mode,
             media_loader,
             context_length,
             #[cfg(feature = "mm-routing")]
@@ -919,6 +933,7 @@ impl OpenAIPreprocessor {
         let template_start = Instant::now();
         let formatted_prompt = {
             let _nvtx = dynamo_nvtx_range!("preprocess.template");
+            let _mode_guard = ToolArgumentsModeGuard::new(self.tool_arguments_mode);
             self.apply_template(request)
                 .with_context(|| "Failed to apply prompt template")?
         };

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2953,12 +2953,40 @@ impl OpenAIPreprocessor {
         let pending = Arc::new(Mutex::new(PendingMetrics::default()));
         let pending_in = Arc::clone(&pending);
 
+        // Per-choice recovery state — allocated only for glm47 since only that
+        // parser emits <tool_call> XML that can be truncated at max_tokens.
+        // Buffers raw input per choice.index so n > 1 is handled correctly.
+        #[derive(Default)]
+        struct ChoiceRecovery {
+            input_text: String,
+        }
+        let is_glm47 = tool_call_parser.as_deref() == Some("glm47");
+        let choice_recovery: Arc<Mutex<std::collections::HashMap<u32, ChoiceRecovery>>> =
+            Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let choice_recovery_in = Arc::clone(&choice_recovery);
+
         // dynamo `Annotated<Nv>` -> jail `Annotated<Create>` (buffer llm_metrics)
         let jail_input = stream.map(move |mut a| {
             if let Some(metrics) = a.data.as_mut().and_then(|nv| nv.llm_metrics.take()) {
                 let mut p = pending_in.lock().expect("jail metrics buffer poisoned");
                 p.chunk_tokens = p.chunk_tokens.saturating_add(metrics.chunk_tokens);
                 p.template = Some(metrics);
+            }
+            // Buffer input content only for glm47 (truncation recovery).
+            if is_glm47 {
+                if let Some(data) = &a.data {
+                    let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
+                    for choice in &data.inner.choices {
+                        if let Some(ChatCompletionMessageContent::Text(content)) =
+                            &choice.delta.content
+                        {
+                            cr.entry(choice.index)
+                                .or_default()
+                                .input_text
+                                .push_str(content);
+                        }
+                    }
+                }
             }
             JailAnnotated {
                 data: a.data.map(|nv| nv.inner),
@@ -2977,7 +3005,7 @@ impl OpenAIPreprocessor {
             uses_tool_call_structural_tag,
             jail_input,
         )
-        .map(move |a| {
+        .flat_map(move |a| {
             // Stamp the accumulated metrics onto the next emitted data chunk;
             // data-less/synthesized chunks carry it forward (or `None`).
             let llm_metrics = a.data.as_ref().and_then(|_| {
@@ -2989,7 +3017,7 @@ impl OpenAIPreprocessor {
                     metrics
                 })
             });
-            Annotated {
+            let nv_chunk = Annotated {
                 data: a.data.map(|inner| NvCreateChatCompletionStreamResponse {
                     inner,
                     nvext: None,
@@ -2999,7 +3027,63 @@ impl OpenAIPreprocessor {
                 event: a.event,
                 comment: a.comment,
                 error: a.error.map(DynamoError::msg),
+            };
+
+            // glm47: on finish_reason=length, recover the last incomplete <tool_call>
+            // block. rfind skips complete blocks, so earlier parsed tool calls are
+            // never duplicated as raw content. Recovered content WILL contain raw
+            // <tool_call> markup — callers that require strict "no tool tags in content"
+            // must filter on finish_reason=length.
+            let mut recoveries: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
+            if is_glm47 {
+                if let Some(ref data) = nv_chunk.data {
+                    let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
+                    for choice in &data.inner.choices {
+                        let state = cr.entry(choice.index).or_default();
+                        if matches!(
+                            choice.finish_reason,
+                            Some(dynamo_protocols::types::FinishReason::Length)
+                        ) {
+                            let recovered =
+                                state.input_text.rfind("<tool_call>").and_then(|start| {
+                                    let tail = &state.input_text[start..];
+                                    if !tail.contains("</tool_call>") {
+                                        Some(tail.to_string())
+                                    } else {
+                                        None
+                                    }
+                                });
+                            if let Some(recovered) = recovered {
+                                tracing::warn!(
+                                    choice_index = choice.index,
+                                    recovered_bytes = recovered.len(),
+                                    "glm47 streaming: partial <tool_call> emitted as content \
+                                     on length finish (TRT-LLM parity; raw markup in content)"
+                                );
+                                let mut rec = nv_chunk.clone();
+                                if let Some(ref mut rd) = rec.data {
+                                    rd.inner.usage = None;
+                                    rd.llm_metrics = None;
+                                    rd.inner.choices.retain(|c| c.index == choice.index);
+                                    for rc in &mut rd.inner.choices {
+                                        rc.delta.content = Some(
+                                            ChatCompletionMessageContent::Text(recovered.clone()),
+                                        );
+                                        rc.delta.tool_calls = None;
+                                        rc.finish_reason = None;
+                                    }
+                                }
+                                recoveries.push(rec);
+                            }
+                        }
+                    }
+                }
             }
+
+            let mut out = Vec::with_capacity(recoveries.len() + 1);
+            out.extend(recoveries);
+            out.push(nv_chunk);
+            futures::stream::iter(out)
         })
     }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -35,13 +35,335 @@ pub trait MediaRequestExt {
     fn media_io_kwargs(&self) -> Option<&MediaDecoder>;
 }
 
+/// How a chat template expects tool_calls[*].function.arguments to be passed.
+/// Inferred once from the Jinja source at formatter construction; never from the
+/// served model name, which is arbitrary and not reliable for template detection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ToolArgumentsMode {
+    /// Template receives arguments as a JSON-object string (OpenAI wire default).
+    #[default]
+    JsonString,
+    /// Template calls `.items()` on arguments (e.g. GLM-5.2's
+    /// `{% for k, v in _args.items() %}`), so arguments must be a parsed object.
+    ParsedObject,
+}
+
+pub fn detect_tool_arguments_mode(template: &str) -> ToolArgumentsMode {
+    // GLM-5.2: `{% set _args = tc.arguments %}{% for k, v in _args.items() %}`
+    if template.contains("_args.items()") || template.contains("arguments.items()") {
+        ToolArgumentsMode::ParsedObject
+    } else {
+        ToolArgumentsMode::JsonString
+    }
+}
+
+thread_local! {
+    /// Argument mode for the current formatter.render() call. Set by the preprocessor
+    /// immediately before the synchronous `apply_template` invocation; never across an
+    /// `.await` point. Using a thread-local avoids adding a field to
+    /// `NvCreateChatCompletionRequest` (which would require updating every struct literal).
+    static RENDER_TOOL_ARGUMENTS_MODE: std::cell::Cell<ToolArgumentsMode> =
+        const { std::cell::Cell::new(ToolArgumentsMode::JsonString) };
+}
+
+/// RAII guard that sets the thread-local tool-argument mode for the duration of a
+/// synchronous rendering call and restores the previous mode on drop.
+///
+/// SAFETY: Only use in a *synchronous* (non-`async`) scope with no `.await`
+/// between guard creation and drop. Thread-locals are not preserved across
+/// async executor boundaries — the task may resume on a different OS thread.
+pub(crate) struct ToolArgumentsModeGuard {
+    previous: ToolArgumentsMode,
+}
+
+impl ToolArgumentsModeGuard {
+    pub(crate) fn new(mode: ToolArgumentsMode) -> Self {
+        let previous = RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.replace(mode));
+        Self { previous }
+    }
+}
+
+impl Drop for ToolArgumentsModeGuard {
+    fn drop(&mut self) {
+        RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.set(self.previous));
+    }
+}
+
+pub(crate) fn get_tool_arguments_mode_for_render() -> ToolArgumentsMode {
+    RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.get())
+}
+
+/// Extract the Jinja template source from a ModelDeploymentCard for analysis.
+///
+/// Priority order:
+/// 1. `mdc.chat_template_file` — standalone `.jinja` or `chat_template.json` file.
+/// 2. `mdc.prompt_formatter` — `tokenizer_config.json` with an embedded
+///    `"chat_template"` string (the normal HF layout for most models).
+///
+/// This covers both layouts so models that ship only a tokenizer config are not
+/// silently left in [`ToolArgumentsMode::JsonString`] when their template calls
+/// `.items()` on tool-call arguments.
+pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
+    fn read_embedded(checked_file: &crate::common::checked_file::CheckedFile) -> Option<String> {
+        let path = checked_file.path()?;
+        let contents = std::fs::read_to_string(path).ok()?;
+        let config: serde_json::Value = serde_json::from_str(&contents).ok()?;
+        let value = config.get("chat_template")?;
+        if let Some(s) = value.as_str() {
+            return Some(s.to_owned());
+        }
+        // Some HF configs store templates as [{name, template}, ...]. Concatenate
+        // so .items() in any variant is visible to detect_tool_arguments_mode.
+        if let Some(arr) = value.as_array() {
+            let combined: String = arr
+                .iter()
+                .filter_map(|v| v.get("template").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !combined.is_empty() {
+                return Some(combined);
+            }
+        }
+        None
+    }
+
+    if let Some(artifact) = mdc.chat_template_file.as_ref() {
+        match artifact {
+            PromptFormatterArtifact::HfChatTemplateJinja { file, .. } => {
+                if let Some(path) = file.path() {
+                    if let Ok(s) = std::fs::read_to_string(path) {
+                        return Some(s);
+                    }
+                }
+            }
+            // HfChatTemplateJson and HfTokenizerConfigJson both embed the template
+            // under the "chat_template" JSON key; read_embedded handles both.
+            PromptFormatterArtifact::HfChatTemplateJson { file, .. }
+            | PromptFormatterArtifact::HfTokenizerConfigJson(file) => {
+                if let Some(s) = read_embedded(file) {
+                    return Some(s);
+                }
+            }
+        }
+    }
+
+    // Fallback: normal HF layout stores tokenizer_config.json in mdc.prompt_formatter;
+    // chat_template_file is None unless a separate template file was present.
+    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref() {
+        if let Some(s) = read_embedded(f) {
+            return Some(s);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_mode_glm_items_pattern() {
+        let glm_snippet = r#"
+            {%- set _args = tc.arguments -%}
+            {%- for k, v in _args.items() -%}
+        "#;
+        assert_eq!(
+            detect_tool_arguments_mode(glm_snippet),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_direct_arguments_items() {
+        assert_eq!(
+            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_standard_template_no_items() {
+        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
+        assert_eq!(
+            detect_tool_arguments_mode(standard),
+            ToolArgumentsMode::JsonString
+        );
+    }
+
+    #[test]
+    fn normalize_parses_json_string_to_object() {
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "read",
+                    "arguments": r#"{"path": "/tmp/foo"}"#
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(
+            args.is_object(),
+            "arguments should be an object after normalization"
+        );
+        assert_eq!(args["path"], "/tmp/foo");
+    }
+
+    #[test]
+    fn normalize_ignores_non_assistant_messages() {
+        let mut msgs = serde_json::json!([{
+            "role": "user",
+            "content": "hello"
+        }]);
+        let original = msgs.clone();
+        normalize_tool_call_arguments(&mut msgs);
+        assert_eq!(msgs, original);
+    }
+
+    #[test]
+    fn normalize_skips_already_object_arguments() {
+        // If somehow arguments is already an object, it should remain unchanged.
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "f",
+                    "arguments": {"key": "val"}
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_object());
+        assert_eq!(args["key"], "val");
+    }
+
+    /// Test that mdc_jinja_template_text reads the embedded chat_template
+    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
+    #[test]
+    fn mdc_template_text_reads_prompt_formatter_embedded() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tc_path = dir.path().join("tokenizer_config.json");
+        std::fs::write(
+            &tc_path,
+            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
+
+        // Build a minimal MDC with only prompt_formatter set.
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
+
+        let text = mdc_jinja_template_text(&mdc).expect("should find template");
+        assert!(
+            text.contains("_args.items()"),
+            "extracted template should contain .items() pattern"
+        );
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
+    #[test]
+    fn mdc_template_text_reads_chat_template_json() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chat_template.json");
+        std::fs::write(
+            &path,
+            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
+
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
+            file: checked,
+            is_custom: false,
+        });
+
+        let text = mdc_jinja_template_text(&mdc).expect("template");
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+}
+
+/// Parse `tool_calls[*].function.arguments` from JSON string to object in a
+/// serialized messages array before handing it to MiniJinja.
+/// Only applied when `ToolArgumentsMode::ParsedObject` is detected from the template.
+pub(crate) fn normalize_tool_call_arguments(messages_json: &mut serde_json::Value) {
+    let Some(messages) = messages_json.as_array_mut() else {
+        return;
+    };
+    for message in messages {
+        let Some(tool_calls) = message
+            .get_mut("tool_calls")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for tc in tool_calls.iter_mut() {
+            let Some(args_str) = tc.pointer("/function/arguments").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let value = match serde_json::from_str::<serde_json::Value>(args_str) {
+                Ok(v) if v.is_object() => v,
+                Ok(_) => {
+                    // Scalar or array — GLM's .items() would panic at render time.
+                    tracing::warn!(
+                        args_len = args_str.len(),
+                        "tool_call arguments parsed to a non-object; \
+                         substituting {{}} for GLM template safety"
+                    );
+                    serde_json::Value::Object(serde_json::Map::new())
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        args_len = args_str.len(),
+                        "tool_call arguments are not valid JSON; \
+                         substituting {{}} for GLM template safety"
+                    );
+                    serde_json::Value::Object(serde_json::Map::new())
+                }
+            };
+            if let Some(obj) = tc
+                .get_mut("function")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                obj.insert("arguments".to_string(), value);
+            }
+        }
+    }
+}
+
 impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     fn model(&self) -> String {
         self.inner.model.clone()
     }
 
     fn messages(&self) -> Value {
-        let messages_json = serde_json::to_value(&self.inner.messages).unwrap();
+        let mut messages_json = serde_json::to_value(&self.inner.messages).unwrap();
+        // Normalize tool_calls[*].function.arguments from JSON string to object when
+        // the loaded Jinja template requires dict args (e.g. GLM-5.2 .items() call).
+        // The mode is written by OpenAIPreprocessor::preprocess before template render.
+        if get_tool_arguments_mode_for_render() == ToolArgumentsMode::ParsedObject {
+            normalize_tool_call_arguments(&mut messages_json);
+        }
         Value::from_serialize(&messages_json)
     }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -130,10 +130,10 @@ pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
     if let Some(artifact) = mdc.chat_template_file.as_ref() {
         match artifact {
             PromptFormatterArtifact::HfChatTemplateJinja { file, .. } => {
-                if let Some(path) = file.path() {
-                    if let Ok(s) = std::fs::read_to_string(path) {
-                        return Some(s);
-                    }
+                if let Some(path) = file.path()
+                    && let Ok(s) = std::fs::read_to_string(path)
+                {
+                    return Some(s);
                 }
             }
             // HfChatTemplateJson and HfTokenizerConfigJson both embed the template
@@ -149,158 +149,13 @@ pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
 
     // Fallback: normal HF layout stores tokenizer_config.json in mdc.prompt_formatter;
     // chat_template_file is None unless a separate template file was present.
-    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref() {
-        if let Some(s) = read_embedded(f) {
-            return Some(s);
-        }
+    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref()
+        && let Some(s) = read_embedded(f)
+    {
+        return Some(s);
     }
 
     None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn detect_mode_glm_items_pattern() {
-        let glm_snippet = r#"
-            {%- set _args = tc.arguments -%}
-            {%- for k, v in _args.items() -%}
-        "#;
-        assert_eq!(
-            detect_tool_arguments_mode(glm_snippet),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    #[test]
-    fn detect_mode_direct_arguments_items() {
-        assert_eq!(
-            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    #[test]
-    fn detect_mode_standard_template_no_items() {
-        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
-        assert_eq!(
-            detect_tool_arguments_mode(standard),
-            ToolArgumentsMode::JsonString
-        );
-    }
-
-    #[test]
-    fn normalize_parses_json_string_to_object() {
-        let mut msgs = serde_json::json!([{
-            "role": "assistant",
-            "tool_calls": [{
-                "function": {
-                    "name": "read",
-                    "arguments": r#"{"path": "/tmp/foo"}"#
-                }
-            }]
-        }]);
-        normalize_tool_call_arguments(&mut msgs);
-        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
-        assert!(
-            args.is_object(),
-            "arguments should be an object after normalization"
-        );
-        assert_eq!(args["path"], "/tmp/foo");
-    }
-
-    #[test]
-    fn normalize_ignores_non_assistant_messages() {
-        let mut msgs = serde_json::json!([{
-            "role": "user",
-            "content": "hello"
-        }]);
-        let original = msgs.clone();
-        normalize_tool_call_arguments(&mut msgs);
-        assert_eq!(msgs, original);
-    }
-
-    #[test]
-    fn normalize_skips_already_object_arguments() {
-        // If somehow arguments is already an object, it should remain unchanged.
-        let mut msgs = serde_json::json!([{
-            "role": "assistant",
-            "tool_calls": [{
-                "function": {
-                    "name": "f",
-                    "arguments": {"key": "val"}
-                }
-            }]
-        }]);
-        normalize_tool_call_arguments(&mut msgs);
-        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
-        assert!(args.is_object());
-        assert_eq!(args["key"], "val");
-    }
-
-    /// Test that mdc_jinja_template_text reads the embedded chat_template
-    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
-    #[test]
-    fn mdc_template_text_reads_prompt_formatter_embedded() {
-        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
-
-        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
-        let dir = tempfile::tempdir().expect("tempdir");
-        let tc_path = dir.path().join("tokenizer_config.json");
-        std::fs::write(
-            &tc_path,
-            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
-        )
-        .expect("write");
-
-        let checked =
-            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
-
-        // Build a minimal MDC with only prompt_formatter set.
-        let mut mdc = ModelDeploymentCard::default();
-        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
-
-        let text = mdc_jinja_template_text(&mdc).expect("should find template");
-        assert!(
-            text.contains("_args.items()"),
-            "extracted template should contain .items() pattern"
-        );
-        assert_eq!(
-            detect_tool_arguments_mode(&text),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
-    #[test]
-    fn mdc_template_text_reads_chat_template_json() {
-        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("chat_template.json");
-        std::fs::write(
-            &path,
-            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
-        )
-        .expect("write");
-
-        let checked =
-            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
-
-        let mut mdc = ModelDeploymentCard::default();
-        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
-            file: checked,
-            is_custom: false,
-        });
-
-        let text = mdc_jinja_template_text(&mdc).expect("template");
-        assert_eq!(
-            detect_tool_arguments_mode(&text),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
 }
 
 /// Parse `tool_calls[*].function.arguments` from JSON string to object in a
@@ -593,5 +448,150 @@ pub fn prompt_formatter_from_mdc(mdc: &ModelDeploymentCard) -> Result<PromptForm
         | PromptFormatterArtifact::HfChatTemplateJson { .. } => Err(anyhow::anyhow!(
             "prompt_formatter should not have type HfChatTemplate*"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_mode_glm_items_pattern() {
+        let glm_snippet = r#"
+            {%- set _args = tc.arguments -%}
+            {%- for k, v in _args.items() -%}
+        "#;
+        assert_eq!(
+            detect_tool_arguments_mode(glm_snippet),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_direct_arguments_items() {
+        assert_eq!(
+            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_standard_template_no_items() {
+        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
+        assert_eq!(
+            detect_tool_arguments_mode(standard),
+            ToolArgumentsMode::JsonString
+        );
+    }
+
+    #[test]
+    fn normalize_parses_json_string_to_object() {
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "read",
+                    "arguments": r#"{"path": "/tmp/foo"}"#
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(
+            args.is_object(),
+            "arguments should be an object after normalization"
+        );
+        assert_eq!(args["path"], "/tmp/foo");
+    }
+
+    #[test]
+    fn normalize_ignores_non_assistant_messages() {
+        let mut msgs = serde_json::json!([{
+            "role": "user",
+            "content": "hello"
+        }]);
+        let original = msgs.clone();
+        normalize_tool_call_arguments(&mut msgs);
+        assert_eq!(msgs, original);
+    }
+
+    #[test]
+    fn normalize_skips_already_object_arguments() {
+        // If somehow arguments is already an object, it should remain unchanged.
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "f",
+                    "arguments": {"key": "val"}
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_object());
+        assert_eq!(args["key"], "val");
+    }
+
+    /// Test that mdc_jinja_template_text reads the embedded chat_template
+    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
+    #[test]
+    fn mdc_template_text_reads_prompt_formatter_embedded() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tc_path = dir.path().join("tokenizer_config.json");
+        std::fs::write(
+            &tc_path,
+            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
+
+        // Build a minimal MDC with only prompt_formatter set.
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
+
+        let text = mdc_jinja_template_text(&mdc).expect("should find template");
+        assert!(
+            text.contains("_args.items()"),
+            "extracted template should contain .items() pattern"
+        );
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
+    #[test]
+    fn mdc_template_text_reads_chat_template_json() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chat_template.json");
+        std::fs::write(
+            &path,
+            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
+
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
+            file: checked,
+            is_custom: false,
+        });
+
+        let text = mdc_jinja_template_text(&mdc).expect("template");
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
     }
 }

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -24,6 +24,7 @@ use dynamo_runtime::engine::AsyncEngine;
 use dynamo_runtime::pipeline::{Context as PipelineContext, Error, ManyOut, SingleIn};
 use dynamo_runtime::protocols::annotated::Annotated;
 
+use crate::preprocessor::prompt::{ToolArgumentsMode, normalize_tool_call_arguments};
 use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
 use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 use crate::protocols::openai::chat_completions::{
@@ -38,11 +39,18 @@ use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 /// exact prefix the next user turn will see.
 pub struct SpeculativePrefillRequest {
     messages: Vec<ChatCompletionRequestMessage>,
+    tool_arguments_mode: ToolArgumentsMode,
 }
 
 impl SpeculativePrefillRequest {
-    pub fn new(messages: Vec<ChatCompletionRequestMessage>) -> Self {
-        Self { messages }
+    pub fn new(
+        messages: Vec<ChatCompletionRequestMessage>,
+        tool_arguments_mode: ToolArgumentsMode,
+    ) -> Self {
+        Self {
+            messages,
+            tool_arguments_mode,
+        }
     }
 }
 
@@ -52,7 +60,10 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
     }
 
     fn messages(&self) -> Value {
-        let json = serde_json::to_value(&self.messages).unwrap();
+        let mut json = serde_json::to_value(&self.messages).unwrap();
+        if self.tool_arguments_mode == ToolArgumentsMode::ParsedObject {
+            normalize_tool_call_arguments(&mut json);
+        }
         Value::from_serialize(&json)
     }
 
@@ -80,6 +91,7 @@ pub fn maybe_wrap_stream(
     >,
     formatter: &Arc<dyn OAIPromptFormatter>,
     tokenizer: &Arc<dyn Tokenizer>,
+    tool_arguments_mode: ToolArgumentsMode,
 ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
     let enabled = request
         .nvext
@@ -102,7 +114,16 @@ pub fn maybe_wrap_stream(
         let Ok(response_text) = rx.await else {
             return;
         };
-        if let Err(e) = prefill_task(next, formatter, tokenizer, messages, response_text).await {
+        if let Err(e) = prefill_task(
+            next,
+            formatter,
+            tokenizer,
+            messages,
+            response_text,
+            tool_arguments_mode,
+        )
+        .await
+        {
             tracing::warn!(error = %e, "Speculative prefill failed");
         }
     });
@@ -139,6 +160,7 @@ async fn prefill_task(
     tokenizer: Arc<dyn Tokenizer>,
     original_messages: Vec<ChatCompletionRequestMessage>,
     response_text: String,
+    tool_arguments_mode: ToolArgumentsMode,
 ) -> Result<()> {
     let assistant_msg =
         ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
@@ -151,7 +173,7 @@ async fn prefill_task(
     let mut messages = original_messages;
     messages.push(assistant_msg);
 
-    let prefill_request = SpeculativePrefillRequest::new(messages);
+    let prefill_request = SpeculativePrefillRequest::new(messages, tool_arguments_mode);
     let formatted_prompt = formatter.render(&prefill_request)?;
     let encoding = tokenizer.encode(&formatted_prompt)?;
     let token_ids = encoding.token_ids().to_vec();

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -388,6 +388,25 @@ impl DeltaAggregator {
                 // (tool_choice=required/named or structural-tag, gated by
                 // experimental_v2_batch_eligible — see tool_parser_v2::batch_tool_choice_eligible)
                 // keep the v1 finalize path.
+                // Extract the truncated tail BEFORE parsing so a second <tool_call>
+                // truncated after a complete first one is not silently dropped.
+                let glm47_truncated_tail = if parser == "glm47"
+                    && matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    ) {
+                    choice.text.rfind("<tool_call>").and_then(|start| {
+                        let tail = &choice.text[start..];
+                        if !tail.contains("</tool_call>") {
+                            Some(tail.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
+
                 let parse_result = if super::tool_parser_v2::enabled()
                     && super::tool_parser_v2::supports_family(parser)
                     && parsing_options.experimental_v2_batch_eligible
@@ -416,9 +435,40 @@ impl DeltaAggregator {
                             .map(super::tool_call_response_to_protocol)
                             .collect(),
                     );
+                    // Start with prose before tool calls (may be empty).
                     choice.text = content.unwrap_or_default();
                 } else if is_harmony_parser(parser) && contains_harmony_protocol(&choice.text) {
                     choice.text = content.unwrap_or_default();
+                } else if parser == "glm47"
+                    && matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    )
+                    && choice.text.contains("<tool_call>")
+                {
+                    tracing::warn!(
+                        parser,
+                        "glm47: partial <tool_call> returned as content on length finish \
+                         (TRT-LLM parity; raw markup in content)"
+                    );
+                }
+
+                // Recover any tail saved before parsing — the parser drops a truncated
+                // second block silently when an earlier complete block was already parsed.
+                if let Some(tail) = glm47_truncated_tail {
+                    if !choice.text.contains(&tail) {
+                        tracing::warn!(
+                            parser,
+                            tail_bytes = tail.len(),
+                            "glm47: truncated later <tool_call> appended as content \
+                         (TRT-LLM parity; raw markup in content)"
+                        );
+                        if choice.text.is_empty() {
+                            choice.text = tail;
+                        } else {
+                            choice.text.push_str(&tail);
+                        }
+                    }
                 }
             }
         }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -455,19 +455,19 @@ impl DeltaAggregator {
 
                 // Recover any tail saved before parsing — the parser drops a truncated
                 // second block silently when an earlier complete block was already parsed.
-                if let Some(tail) = glm47_truncated_tail {
-                    if !choice.text.contains(&tail) {
-                        tracing::warn!(
-                            parser,
-                            tail_bytes = tail.len(),
-                            "glm47: truncated later <tool_call> appended as content \
+                if let Some(tail) = glm47_truncated_tail
+                    && !choice.text.contains(&tail)
+                {
+                    tracing::warn!(
+                        parser,
+                        tail_bytes = tail.len(),
+                        "glm47: truncated later <tool_call> appended as content \
                          (TRT-LLM parity; raw markup in content)"
-                        );
-                        if choice.text.is_empty() {
-                            choice.text = tail;
-                        } else {
-                            choice.text.push_str(&tail);
-                        }
+                    );
+                    if choice.text.is_empty() {
+                        choice.text = tail;
+                    } else {
+                        choice.text.push_str(&tail);
                     }
                 }
             }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -463,7 +463,12 @@ impl OAIChatLikeRequest for UnifiedRequest {
     }
 
     fn messages(&self) -> minijinja::value::Value {
-        let messages_json = serde_json::to_value(&self.inner.inner.messages).unwrap();
+        let mut messages_json = serde_json::to_value(&self.inner.inner.messages).unwrap();
+        if crate::preprocessor::prompt::get_tool_arguments_mode_for_render()
+            == crate::preprocessor::prompt::ToolArgumentsMode::ParsedObject
+        {
+            crate::preprocessor::prompt::normalize_tool_call_arguments(&mut messages_json);
+        }
         minijinja::value::Value::from_serialize(&messages_json)
     }
 


### PR DESCRIPTION
## Summary

- **Fix: tool_calls[*].function.arguments JSON string → dict before MiniJinja render** — GLM-5.2 Jinja template iterates arguments with \`{% for k, v in _args.items() %}\` which requires a dict; the wire schema stores arguments as a JSON-object string. Added \`normalize_tool_call_arguments()\` shared helper in \`preprocessor/prompt.rs\`, called from both \`NvCreateChatCompletionRequest::messages()\` (the \`/v1/chat/completions\` path RWLT uses) and \`UnifiedRequest::messages()\`.

- **Fix: streaming glm47 truncated tool_call → preserve as content** — When \`max_tokens\` is hit mid-\`<tool_call>\` block, \`glm47_parser\` drops the block silently (\`allow_eof_recovery=false\`). Added content-recovery to the streaming jail path in \`preprocessor.rs::apply_tool_calling_jail()\`: buffers input text, detects \`finish_reason=length\` with no tool_calls output, and emits the dropped text as a synthetic content chunk before the finish. Also covers the non-streaming aggregation path in \`aggregator.rs\`.

## Context

Discovered during GLM-5.2 NVfp4 GB300 RWLT benchmarking. Dynamo showed ~3K fewer ISL tokens and shorter OSL vs TRT-LLM on identical trajectories. OSL gap included 1315 truncated tool_call drops per SLO50 run (confirmed from frontend logs) and Dynamo prose-before-tool fraction of 24% vs TRT-LLM 88%. The streaming fix matches TRT-LLM behavior where partial XML is returned as content rather than silently dropped.

Companion fix in AA repo: \`peili/dynamo_conv_routing@767073e\` (AgentPerf \`setdefault\` for \`reasoning_content\`).

## Test plan
- [ ] Rebuild image from this branch
- [ ] Parity test: compare \`server_input_tokens\` on shared (conversation_id, conversation_idx, turn) pairs between Dynamo and TRT-LLM
- [ ] Confirm truncated tool_call drop warnings go to 0 in frontend logs
- [ ] Confirm ISL gap narrows with AA reasoning_content fix active

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12109" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->