### PR TITLE
feat(ci): collect subprocess coverage and upload to Datadog

### DIFF
--- a/.coveragerc.subprocess
+++ b/.coveragerc.subprocess
@@ -1,0 +1,19 @@
+# Coverage config for the product processes the tests launch (frontend, backend workers).
+#
+# Kept separate from .coveragerc so it can never affect the main pytest-cov run or the
+# combine/report step. tests/utils/managed_process.py injects COVERAGE_PROCESS_START
+# pointing at this file into the processes it launches; it propagates through the launch
+# shell scripts to the real `python -m dynamo.*` workers, where the site .pth bootstrap
+# (tests/utils/coverage_subprocess_bootstrap.py) calls coverage.process_startup(). The
+# recorded source-tree paths are remapped back by the [paths] section in .coveragerc
+# during `coverage combine`.
+[run]
+# Unique per-process data files so the existing `coverage combine` merges them.
+parallel = True
+# Save promptly on SIGTERM for processes that don't override the handler (e.g. the
+# frontend). Backend workers that force-exit on a launch-script's double-SIGTERM are
+# covered instead by the bootstrap's periodic flush.
+sigterm = true
+# Restrict measurement to the dynamo product package; otherwise every heavy dependency
+# (torch, vllm, ...) the worker executes would be recorded, bloating the data files.
+source_pkgs = dynamo

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -221,6 +221,23 @@ runs:
             COVERAGE_FLAGS="--cov=components/src/dynamo --cov=lib/bindings/python/src/dynamo --cov-report="
             export COVERAGE_FILE="${TEST_RESULTS_DIR}/.coverage"
             export PYTHONPATH="${CONTAINER_WORKSPACE}/components/src:${CONTAINER_WORKSPACE}/lib/bindings/python/src${PYTHONPATH:+:${PYTHONPATH}}"
+            # Product code (frontend, workers) runs in separate `python -m dynamo.*`
+            # processes — usually spawned by a launch shell script, so the worker is a
+            # grandchild of the test process. Install coverage's site .pth bootstrap so any
+            # python descendant self-instruments when COVERAGE_PROCESS_START is set in its
+            # env; tests/utils/managed_process.py injects COVERAGE_PROCESS_START (pointing at
+            # the subprocess rcfile) into the processes it launches. Their `.coverage.*`
+            # files land next to COVERAGE_FILE and are picked up by `coverage combine`.
+            export DYN_SUBPROCESS_COVERAGE="${CONTAINER_WORKSPACE}/.coveragerc.subprocess"
+            # Install the bootstrap module + a .pth that imports it, so every python
+            # descendant self-instruments when COVERAGE_PROCESS_START is set in its env.
+            # Prefer site-packages; fall back to the writable user-site when site-packages
+            # is read-only (CI runner uid differs from the image build uid).
+            COV_PTH_DIR="$(python -c 'import os, sysconfig, site; p = sysconfig.get_path("purelib"); print(p if os.access(p, os.W_OK) else site.getusersitepackages())')"
+            mkdir -p "${COV_PTH_DIR}"
+            cp "${CONTAINER_WORKSPACE}/tests/utils/coverage_subprocess_bootstrap.py" "${COV_PTH_DIR}/coverage_subprocess_bootstrap.py"
+            echo 'import coverage_subprocess_bootstrap' > "${COV_PTH_DIR}/dynamo_coverage_subprocess.pth"
+            echo "🧩 Subprocess coverage bootstrap: ${COV_PTH_DIR}/dynamo_coverage_subprocess.pth"
           fi
 
           PYTEST_CMD="python -m pytest ${PARALLEL_OPTS} ${VRAM_OPTS} ${DIST_OPTS} --continue-on-collection-errors -v --tb=short --basetemp=${WORK_DIR}/pytest_temp -o cache_dir=${WORK_DIR}/.pytest_cache --junitxml=${TEST_RESULTS_DIR}/${{ env.PYTEST_XML_FILE }} --alluredir=${TEST_RESULTS_DIR}/allure-results --durations=10 ${COVERAGE_FLAGS} -m \"${{ inputs.pytest_marks }}\""

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -840,6 +840,38 @@ jobs:
       - name: Post to Workflow Summary
         run: cat coverage-summary.md >> $GITHUB_STEP_SUMMARY
 
+      # Experimental: publish the merged coverage to Datadog's Code Coverage product.
+      # Separate from the Datadog Test Visibility step in shared-test.yml (which uploads
+      # test results, not coverage) and independent of ITR, which stays disabled.
+      - name: Upload Coverage to Datadog
+        if: always()
+        continue-on-error: true
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          DD_SITE: us3.datadoghq.com
+        run: |
+          if [[ -z "${DD_API_KEY}" ]]; then
+            echo "ℹ️  DD_API_KEY not available; skipping Datadog coverage upload."
+            exit 0
+          fi
+          npm install -g @datadog/datadog-ci
+          UPLOAD_PATHS=()
+          if [[ -f coverage-merged.xml ]]; then
+            UPLOAD_PATHS+=(coverage-merged.xml)
+          else
+            echo "⚠️  coverage-merged.xml not found (no Python coverage to upload)."
+          fi
+          # Per-crate Rust LCOV files (coverage-rust.lcov) live under this dir; best-effort.
+          if find coverage-rust-artifacts/ -name 'coverage-rust.lcov' -type f 2>/dev/null | grep -q .; then
+            UPLOAD_PATHS+=(coverage-rust-artifacts/)
+          fi
+          if [[ ${#UPLOAD_PATHS[@]} -eq 0 ]]; then
+            echo "⚠️  No coverage reports to upload to Datadog."
+            exit 0
+          fi
+          echo "📤 Uploading to Datadog: ${UPLOAD_PATHS[*]}"
+          datadog-ci coverage upload "${UPLOAD_PATHS[@]}"
+
       - name: Upload Coverage Reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         if: always()

--- a/tests/utils/coverage_subprocess_bootstrap.py
+++ b/tests/utils/coverage_subprocess_bootstrap.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Subprocess-coverage bootstrap for the Dynamo test suite.
+#
+# CI installs this module into a site directory and points a ``.pth`` at it
+# (``import coverage_subprocess_bootstrap``) so it runs at interpreter startup for every
+# python process. It only does anything when ``COVERAGE_PROCESS_START`` is set in the
+# environment, which tests/utils/managed_process.py injects into the product processes it
+# launches (and which propagates through launch shell scripts to the real
+# ``python -m dynamo.*`` workers). No pytest process ever gets ``COVERAGE_PROCESS_START``,
+# so this is a no-op there and pytest-cov is unaffected.
+#
+# Beyond starting coverage, it runs a daemon thread that flushes the data every few
+# seconds. Backend workers (vLLM/SGLang/TensorRT-LLM) are launched by scripts whose
+# ``trap 'kill 0' EXIT`` double-signals the worker on shutdown; the framework force-exits
+# on the second signal before coverage's atexit flush runs, so without a periodic flush
+# the worker's coverage would be lost. The last periodic save survives a forced exit.
+import os
+import threading
+import time
+
+# Seconds between background flushes; small enough that a forced exit loses little.
+_SAVE_INTERVAL = float(os.environ.get("DYN_SUBPROCESS_COVERAGE_SAVE_INTERVAL", "5"))
+
+try:
+    import coverage
+
+    coverage.process_startup()
+    _cov = getattr(coverage.process_startup, "coverage", None)
+    if _cov is not None and os.environ.get("COVERAGE_PROCESS_START"):
+
+        def _periodic_save():
+            while True:
+                time.sleep(_SAVE_INTERVAL)
+                try:
+                    _cov.save()
+                except Exception:
+                    pass
+
+        threading.Thread(
+            target=_periodic_save, name="dynamo-cov-periodic-save", daemon=True
+        ).start()
+except Exception:
+    # Never let coverage bootstrap break a product process.
+    pass

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -430,6 +430,30 @@ class ManagedProcess:
         if process.poll() is None:
             raise ManagedProcessStopTimeoutError(attr_name, process.pid, wait_timeout)
 
+    def _child_env_with_coverage(self):
+        """Return the child environment, adding subprocess-coverage vars when CI enables it.
+
+        Dynamo runs product code (frontend, workers) in separate OS processes — usually via
+        a launch shell script, so the real ``python -m dynamo.*`` is a *grandchild* of this
+        ManagedProcess, not a direct child. Setting ``COVERAGE_PROCESS_START`` here (it
+        propagates through the shell to every python descendant) makes coverage's site
+        ``.pth`` call ``coverage.process_startup()``, so each product process records its own
+        ``.coverage.*`` file next to ``COVERAGE_FILE`` (combined later by the coverage job).
+
+        Scoped to child environments only: no pytest process (main or xdist worker) ever
+        gets ``COVERAGE_PROCESS_START``, so pytest-cov in those processes is unaffected.
+        """
+        env = self.env or os.environ.copy()
+        rcfile = os.environ.get("DYN_SUBPROCESS_COVERAGE")
+        if rcfile:
+            # Copy so we never mutate a caller-provided dict or os.environ.
+            env = dict(env)
+            env["COVERAGE_PROCESS_START"] = rcfile
+            cov_file = os.environ.get("COVERAGE_FILE")
+            if cov_file:
+                env.setdefault("COVERAGE_FILE", cov_file)
+        return env
+
     def _start_process(self):
         assert self._command_name
         assert self._log_path
@@ -440,6 +464,10 @@ class ManagedProcess:
             self.working_dir or os.getcwd(),
         )
 
+        # Product children (and their shell-script grandchildren) are launched here as
+        # separate OS processes; propagate coverage env when CI requests it (no-op otherwise).
+        child_env = self._child_env_with_coverage()
+
         stdin = subprocess.DEVNULL
         stdout = subprocess.PIPE
         stderr = subprocess.STDOUT
@@ -447,7 +475,7 @@ class ManagedProcess:
         if self.display_output:
             self.proc = subprocess.Popen(
                 self.command,
-                env=self.env or os.environ.copy(),
+                env=child_env,
                 cwd=self.working_dir,
                 stdin=stdin,
                 stdout=stdout,
@@ -474,7 +502,7 @@ class ManagedProcess:
             with open(self._log_path, "w", encoding="utf-8") as f:
                 self.proc = subprocess.Popen(
                     self.command,
-                    env=self.env or os.environ.copy(),
+                    env=child_env,
                     cwd=self.working_dir,
                     stdin=stdin,
                     stdout=stdout,


### PR DESCRIPTION
## Summary

Dynamo's nightly coverage was incomplete and never reached Datadog. Product code (frontend, backend workers) runs in separate `python -m dynamo.*` processes — usually spawned by a launch shell script — that the pytest process's in-process coverage.py never sees. The Datadog integration today only uploads test-visibility (JUnit) results; no code coverage is sent. This PR:

1. **Collects coverage from the launched product processes** (frontend + vLLM/SGLang/TRT-LLM workers), and
2. **Uploads the merged report to Datadog's Code Coverage product** (us3), independent of ITR (which stays disabled).

### How it works
- **`tests/utils/coverage_subprocess_bootstrap.py`** (new): a site `.pth` bootstrap that calls `coverage.process_startup()` and runs a daemon that periodically flushes. Backend workers are launched by scripts whose `trap 'kill 0' EXIT` double-signals the worker on shutdown; the framework force-exits on the second signal before coverage's atexit/sigterm flush runs — the periodic save makes the data survive. It is a no-op unless `COVERAGE_PROCESS_START` is set, so pytest/xdist processes (and pytest-cov) are unaffected.
- **`.coveragerc.subprocess`** (new): `parallel` + `sigterm` + `source_pkgs = dynamo`, kept separate from `.coveragerc` so it cannot affect the main pytest-cov run or the combine/report step.
- **`tests/utils/managed_process.py`**: injects `COVERAGE_PROCESS_START`/`COVERAGE_FILE` into the launched process env, which propagates through the launch shell to the real `python -m dynamo.*` grandchildren.
- **`.github/actions/pytest-local/action.yml`**: installs the bootstrap module + `.pth` into a writable site dir (user-site fallback for the runner-uid ≠ image-uid case) and sets `DYN_SUBPROCESS_COVERAGE`, under the existing `enable_coverage` gate.
- **`.github/workflows/nightly-ci.yml`**: adds a `datadog-ci coverage upload` step in the `coverage-report` job for `coverage-merged.xml` (Cobertura) plus the Rust LCOV (best-effort), gated on `DD_API_KEY`.

The per-job `.coverage.*` files land next to the already-exported `COVERAGE_FILE` and are swept up by the existing `coverage combine` — no combine/report changes needed.

## Validation

Validated end-to-end on a local GPU (RTX 6000 Ada) in `vllm-runtime-omni` with Qwen3-0.6B via the real `agg.sh` launch path, installing the shipped files exactly as the CI action does:

```
components/src/dynamo/vllm/handlers.py  1559 1155 26%   ← live request handling
components/src/dynamo/vllm/main.py        281  102 64%
components/src/dynamo/vllm/args.py        294  161 45%
components/src/dynamo/frontend/main.py    149   71 52%
→ 37 dynamo/vllm files + 4 frontend files + runtime/llm bindings
```

Both the frontend and the vLLM backend worker were previously invisible to coverage. `pre-commit run` passes on all changed files. The full nightly Datadog upload runs only on the scheduled workflow, so it is not exercised by PR CI.

## Notes / follow-ups
- Nightly-only (matches where `enable_coverage` is set today); enabling on PRs would add GPU cost.
- Rust-under-Python coverage (instrumenting the PyO3 `_core.so`) is a deferred follow-up, likely its own DEP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage collection for subprocesses launched during tests.
  * Added reliable coverage saving when subprocesses receive termination signals.
  * Limited collected coverage to the relevant product package for clearer reports.

* **CI**
  * Added optional Datadog coverage report uploads during nightly builds.
  * Coverage uploads remain non-blocking and provide informative messages when reports or credentials are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->