### PR TITLE
fix(ci): provision the model cache PVC on post-merge

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -858,6 +858,10 @@ jobs:
         hf_token: ${{ secrets.HF_TOKEN }}
         dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
         dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        # Provision the shared model cache PV/PVC when the repo provides its
+        # endpoint; empty vars -> no cache (workers download from HuggingFace).
+        model_cache_server: ${{ vars.AZURE_MODEL_CACHE_SERVER }}
+        model_cache_path: ${{ vars.AZURE_MODEL_CACHE_PATH }}
 
   deploy-test-vllm:
     needs: [deploy-operator, vllm-copy-to-acr]

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -71,28 +71,6 @@ jobs:
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
-      - name: Detect shared model cache PVC
-        id: model-cache
-        env:
-          PVC_NAME: model-cache
-        run: |
-          # Mount the shared cache only when the PVC is actually present. It is
-          # provisioned at vCluster creation time (setup-dynamo-operator, which needs
-          # the endpoint at `vcluster create` to sync the PV to the host), so gating
-          # here on the same repo vars would silently assume every caller wired that
-          # up -- and a caller that did not would wedge every deployment on a
-          # nonexistent PVC. Checking observed state degrades to a HuggingFace
-          # download instead.
-          # Bound, not merely present: an unbound PVC leaves every pod Pending.
-          PHASE="$(kubectl --kubeconfig="${{ github.workspace }}/.kubeconfig-vcluster" \
-            -n default get pvc "${PVC_NAME}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
-          if [ "${PHASE}" = "Bound" ]; then
-            echo "pvc=${PVC_NAME}" >> $GITHUB_OUTPUT
-            echo "PVC ${PVC_NAME} is Bound; workers will read models from the shared cache."
-          else
-            echo "pvc=" >> $GITHUB_OUTPUT
-            echo "PVC ${PVC_NAME} not usable (phase: '${PHASE:-absent}'); workers will download from HuggingFace."
-          fi
       - name: Run Dynamo Deploy Test
         id: deploy-test
         uses: ./.github/actions/dynamo-deploy-test
@@ -107,4 +85,6 @@ jobs:
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-${{ inputs.image_suffix }}
           platform_arch: amd64
           extra_pytest_args: -m framework_only
-          model_cache_pvc: ${{ steps.model-cache.outputs.pvc }}
+          # Mount the shared model cache only when both endpoint vars are set
+          # (matches the PV/PVC creation gate); otherwise workers download from HF.
+          model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}

--- a/.github/workflows/shared-deploy-test.yml
+++ b/.github/workflows/shared-deploy-test.yml
@@ -71,6 +71,28 @@ jobs:
         with:
           vcluster_name: ${{ inputs.vcluster_name }}
           vcluster_namespace: ${{ inputs.namespace }}
+      - name: Detect shared model cache PVC
+        id: model-cache
+        env:
+          PVC_NAME: model-cache
+        run: |
+          # Mount the shared cache only when the PVC is actually present. It is
+          # provisioned at vCluster creation time (setup-dynamo-operator, which needs
+          # the endpoint at `vcluster create` to sync the PV to the host), so gating
+          # here on the same repo vars would silently assume every caller wired that
+          # up -- and a caller that did not would wedge every deployment on a
+          # nonexistent PVC. Checking observed state degrades to a HuggingFace
+          # download instead.
+          # Bound, not merely present: an unbound PVC leaves every pod Pending.
+          PHASE="$(kubectl --kubeconfig="${{ github.workspace }}/.kubeconfig-vcluster" \
+            -n default get pvc "${PVC_NAME}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+          if [ "${PHASE}" = "Bound" ]; then
+            echo "pvc=${PVC_NAME}" >> $GITHUB_OUTPUT
+            echo "PVC ${PVC_NAME} is Bound; workers will read models from the shared cache."
+          else
+            echo "pvc=" >> $GITHUB_OUTPUT
+            echo "PVC ${PVC_NAME} not usable (phase: '${PHASE:-absent}'); workers will download from HuggingFace."
+          fi
       - name: Run Dynamo Deploy Test
         id: deploy-test
         uses: ./.github/actions/dynamo-deploy-test
@@ -85,6 +107,4 @@ jobs:
           image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-${{ inputs.image_suffix }}
           platform_arch: amd64
           extra_pytest_args: -m framework_only
-          # Mount the shared model cache only when both endpoint vars are set
-          # (matches the PV/PVC creation gate); otherwise workers download from HF.
-          model_cache_pvc: ${{ vars.AZURE_MODEL_CACHE_SERVER != '' && vars.AZURE_MODEL_CACHE_PATH != '' && 'model-cache' || '' }}
+          model_cache_pvc: ${{ steps.model-cache.outputs.pvc }}


### PR DESCRIPTION
## Overview

Fixes the post-merge deploy-test regression introduced by #11786.

Closes: OPS-7824, OPS-7823, OPS-7822, OPS-7821, OPS-7820

## Details

#11786 taught the deploy tests to mount a shared model-cache PVC, but split provisioning from consumption across two files and only wired provisioning into `pr.yaml`:

| | creates the PV/PVC | mounts it |
|---|---|---|
| `pr.yaml` | yes — `deploy-operator` got `model_cache_server`/`model_cache_path` | yes, via `shared-deploy-test.yml` |
| `post-merge-ci.yml` | **no — untouched by #11786** | yes, via the same `shared-deploy-test.yml` |

`shared-deploy-test.yml` passes `model_cache_pvc: model-cache` whenever the `AZURE_MODEL_CACHE_*` repo vars are set, but the PV/PVC is created by `setup-dynamo-operator`, which inside that reusable workflow only runs on the self-bootstrap rerun path. On the normal path the vCluster comes from the caller's `deploy-operator` job, and post-merge's never asked for the cache.

Result, on every post-merge run since 215c436c:

```
failed to reconcile top-level PVCs: legacy top-level PVC "model-cache" does not exist
and create is not enabled: PersistentVolumeClaim "model-cache" not found
```

followed by `Failed: Timeout (>1200.0s) from pytest-timeout` and a red `deploy-status-check`. Every profile that actually deploys fails (`vllm/agg`, `vllm/agg_router`, `sglang/agg`, `sglang/agg_router`, `trtllm/agg`, `trtllm/agg_router`); the `disagg` profiles only look green because they skip on this cluster for lack of RDMA.

Pre-merge stayed green because it exercised the one path that was wired up — the change only misbehaves under the caller #11786 did not touch.

## Fix

Pass `model_cache_server`/`model_cache_path` to `post-merge-ci.yml`'s `deploy-operator`, so the PV/PVC exists before the deploy tests reference it — and post-merge gets the shared cache #11786 intended.

The endpoint inputs belong on `setup-dynamo-operator` rather than on `shared-deploy-test.yml`: the PV needs `sync.toHost.persistentVolumes.enabled=true` at `vcluster create` time for its NFS mount options to be honored, so provisioning has to happen where the vCluster is created.

## Where should the reviewer start?

`.github/workflows/post-merge-ci.yml`, the `deploy-operator` job — that is the whole change.

## Related Issues

Regression from #11786.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
