### PR TITLE
fix(trtllm): preserve unset KV cache config fields

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -515,6 +515,40 @@ async def test_init_llm_worker_engine_args_with_extra_engine_args(
         assert config.max_batch_size == 512
 
 
+@pytest.mark.core
+@pytest.mark.asyncio
+async def test_publish_events_does_not_materialize_unset_kv_cache_defaults(monkeypatch):
+    """Event setup must not turn an omitted TRT-LLM field into an override."""
+    monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
+    # Keep extra_engine_args unset so kv_cache_config reaches event setup as the
+    # typed model whose serialization caused this regression.
+    config = parse_args(["--model", "fake-model", "--publish-kv-events"])
+
+    with (
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=_mock_get_llm_engine,
+        ),
+    ):
+        with pytest.raises(EngineArgsCaptured) as exc_info:
+            await init_llm_worker(
+                runtime=mock.MagicMock(),
+                config=config,
+                shutdown_event=asyncio.Event(),
+            )
+
+    kv_cache_config = exc_info.value.engine_args["kv_cache_config"]
+    assert (
+        kv_cache_config["free_gpu_memory_fraction"] == config.free_gpu_memory_fraction
+    )
+    assert kv_cache_config["event_buffer_max_size"] > 0
+    assert "enable_swa_scratch_reuse" not in kv_cache_config
+
+
 class MultimodalProcessorInstantiated(Exception):
     """Custom exception for testing MultimodalRequestProcessor."""
 

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -371,9 +371,11 @@ async def init_llm_worker(
         # Add it to kv_cache_config while preserving all settings from YAML
         current_kv_config = arg_map["kv_cache_config"]
         if isinstance(current_kv_config, KvCacheConfig):
-            # Convert KvCacheConfig object to dict, preserving ALL existing settings
-            # This ensures YAML overrides are not lost when adding event_buffer_max_size
-            current_kv_config = current_kv_config.model_dump(exclude_none=True)
+            # Convert to a dict while preserving only explicitly configured settings.
+            # Generic defaults must remain unset so TRT-LLM can apply model defaults.
+            current_kv_config = current_kv_config.model_dump(
+                exclude_none=True, exclude_unset=True
+            )
             arg_map["kv_cache_config"] = current_kv_config
 
         if not isinstance(current_kv_config, dict):


### PR DESCRIPTION
## Summary

- serialize typed TRT-LLM `KvCacheConfig` objects with `exclude_unset=True` when enabling KV event publication
- preserve explicitly configured fields while leaving generic defaults unset for TRT-LLM's model-specific default application
- add a focused regression test that exercises the typed-config branch without `extra_engine_args`

## Root cause

The KV-event setup path converted a typed `KvCacheConfig` with `model_dump(exclude_none=True)`. That materialized every generic Pydantic default as an explicit engine override. With TensorRT-LLM 1.3.0rc21, for example, an omitted `enable_swa_scratch_reuse` became explicit `false`, preventing a model-specific `true` default from applying.

The regression test deliberately does not pass nested YAML overrides: TRT-LLM normalizes those overrides to a dictionary before Dynamo's event setup, which bypasses the affected typed-model branch. The test captures the final engine arguments and verifies that an omitted model-defaulted field stays absent while explicitly constructed fields and the KV event buffer remain present.

## Validation

- isort, Black, Flake8, codespell, and Ruff hooks passed
- `git diff --check` and Python compilation passed
- Pydantic sensitivity check confirmed the pre-fix serialization materializes the omitted field and the fixed serialization does not
- repository-wide marker report found zero missing marker sets, then hit an unrelated sandbox port-allocation failure; skipped for the signed commit
- targeted pytest could not collect in this local checkout because the TensorRT-LLM package and built Dynamo bindings are not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KV-cache event publishing so unspecified engine settings retain TRT-LLM’s model defaults.
  * Preserved explicitly configured cache settings while ensuring event buffering is enabled correctly.

* **Tests**
  * Added coverage to verify that omitted KV-cache options are not unintentionally added during worker initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->