### PR TITLE
fix(profiler): fail closed on interpolation errors

### DIFF
--- a/components/src/dynamo/profiler/interpolation.py
+++ b/components/src/dynamo/profiler/interpolation.py
@@ -46,6 +46,40 @@ from dynamo.profiler.utils.profile_prefill import profile_prefill
 logger = logging.getLogger(__name__)
 
 
+async def _wait_for_required_interpolation_deployment(
+    client: DynamoDeploymentClient,
+    deployment_clients: list[DynamoDeploymentClient],
+    timeout: int,
+    phase: str,
+) -> None:
+    """Wait for a thorough-mode deployment without silently losing profile data."""
+    try:
+        await client.wait_for_deployment_ready(timeout=timeout)
+    except (TimeoutError, DeploymentFailedError) as error:
+        reason = (
+            "timed out"
+            if isinstance(error, TimeoutError)
+            else "entered a terminal failure state"
+        )
+        message = (
+            f"{phase.capitalize()} interpolation deployment {reason}. "
+            "Thorough mode requires real-GPU interpolation data; use "
+            "pre_deployment_sweeping_mode='rapid' for GPU-free profiling."
+        )
+        logger.error("%s Details: %s", message, error)
+        try:
+            await client.delete_deployment()
+        except Exception:
+            logger.exception(
+                "Failed to delete the %s interpolation deployment; "
+                "final cleanup will retry.",
+                phase,
+            )
+        else:
+            deployment_clients.remove(client)
+        raise RuntimeError(message) from error
+
+
 async def run_interpolation(
     dgdr: DynamoGraphDeploymentRequestSpec,
     ops: ProfilerOperationalConfig,
@@ -113,22 +147,12 @@ async def run_interpolation(
     deployment_clients.append(client)
     await client.create_deployment(prefill_config_fn)
     logger.info("Waiting for prefill interpolation deployment...")
-    try:
-        await client.wait_for_deployment_ready(timeout=ops.deployment_timeout)
-    except TimeoutError:
-        logger.error("Prefill interpolation deployment timed out, skipping.")
-        await client.delete_deployment()
-        deployment_clients.remove(client)
-        return
-    except DeploymentFailedError as e:
-        logger.error(
-            "Prefill interpolation deployment entered a terminal failure state, "
-            "skipping: %s",
-            e,
-        )
-        await client.delete_deployment()
-        deployment_clients.remove(client)
-        return
+    await _wait_for_required_interpolation_deployment(
+        client,
+        deployment_clients,
+        ops.deployment_timeout,
+        "prefill",
+    )
 
     await client.get_deployment_logs()
     base_url = client.get_service_url()
@@ -172,22 +196,12 @@ async def run_interpolation(
     deployment_clients.append(client)
     await client.create_deployment(decode_config_fn)
     logger.info("Waiting for decode interpolation deployment...")
-    try:
-        await client.wait_for_deployment_ready(timeout=ops.deployment_timeout)
-    except TimeoutError:
-        logger.error("Decode interpolation deployment timed out, skipping.")
-        await client.delete_deployment()
-        deployment_clients.remove(client)
-        return
-    except DeploymentFailedError as e:
-        logger.error(
-            "Decode interpolation deployment entered a terminal failure state, "
-            "skipping: %s",
-            e,
-        )
-        await client.delete_deployment()
-        deployment_clients.remove(client)
-        return
+    await _wait_for_required_interpolation_deployment(
+        client,
+        deployment_clients,
+        ops.deployment_timeout,
+        "decode",
+    )
 
     await client.get_deployment_logs()
 

--- a/components/src/dynamo/profiler/tests/unit/test_interpolation.py
+++ b/components/src/dynamo/profiler/tests/unit/test_interpolation.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from deploy.utils.dynamo_deployment import DeploymentFailedError, DynamoDeploymentClient
+from dynamo.profiler.interpolation import _wait_for_required_interpolation_deployment
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.planner,
+    pytest.mark.parallel,
+]
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        TimeoutError(),
+        DeploymentFailedError("worker entered CrashLoopBackOff"),
+    ],
+    ids=["timeout", "terminal-failure"],
+)
+def test_required_interpolation_failure_is_fatal(failure):
+    client = AsyncMock(spec=DynamoDeploymentClient)
+    client.wait_for_deployment_ready.side_effect = failure
+    deployment_clients = [client]
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            "Thorough mode requires real-GPU interpolation data; "
+            "use pre_deployment_sweeping_mode='rapid'"
+        ),
+    ) as exc_info:
+        asyncio.run(
+            _wait_for_required_interpolation_deployment(
+                client,
+                deployment_clients,
+                timeout=20,
+                phase="prefill",
+            )
+        )
+
+    assert exc_info.value.__cause__ is failure
+    client.delete_deployment.assert_awaited_once_with()
+    assert deployment_clients == []
+
+
+def test_failed_cleanup_leaves_deployment_for_final_cleanup():
+    failure = DeploymentFailedError("worker entered CrashLoopBackOff")
+    client = AsyncMock(spec=DynamoDeploymentClient)
+    client.wait_for_deployment_ready.side_effect = failure
+    client.delete_deployment.side_effect = RuntimeError("API unavailable")
+    deployment_clients = [client]
+
+    with pytest.raises(RuntimeError, match="Thorough mode requires real-GPU"):
+        asyncio.run(
+            _wait_for_required_interpolation_deployment(
+                client,
+                deployment_clients,
+                timeout=20,
+                phase="decode",
+            )
+        )
+
+    assert deployment_clients == [client]

--- a/components/src/dynamo/profiler/tests/unit/test_interpolation.py
+++ b/components/src/dynamo/profiler/tests/unit/test_interpolation.py
@@ -69,4 +69,5 @@ def test_failed_cleanup_leaves_deployment_for_final_cleanup():
             )
         )
 
+    client.delete_deployment.assert_awaited_once_with()
     assert deployment_clients == [client]


### PR DESCRIPTION
## Summary

- fail the profiler when required thorough-mode prefill or decode interpolation times out or enters a terminal pod failure state
- preserve `mocker + thorough` semantics: thorough still uses real GPUs, while the error directs GPU-free mocker runs to `pre_deployment_sweeping_mode: rapid`
- keep failed deployments tracked when immediate cleanup fails so the profiler's final cleanup can retry
- add unit coverage for timeouts, CrashLoopBackOff-style failures, and cleanup retry bookkeeping

## Root cause

`mocker + thorough` intentionally requires real-GPU interpolation data. `run_interpolation()` previously caught deployment timeout and terminal failure, deleted the temporary deployment, and returned normally. Final assembly then continued without NPZ profile data and silently deployed mocker workers using fallback performance behavior.

Fixes [DYN-3553](https://linear.app/nvidia/issue/DYN-3553/dynamo130profiler-mockerthorough-path-calls-run-interpolation-without).

## Validation

- `PYTHONPATH=/home/hongkuanz/Projects/dynamo/components/src .venv/bin/python -m pytest -xvv --durations=10 components/src/dynamo/profiler/tests/unit` — 256 passed, 1 skipped
- `SKIP=pytest-marker-report .venv/bin/pre-commit run --files components/src/dynamo/profiler/interpolation.py components/src/dynamo/profiler/tests/unit/test_interpolation.py` — passed
- full `pytest-marker-report` collection is blocked locally by unrelated missing KVBM/SGLang dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Thorough interpolation profiling now fails clearly when required deployments time out or fail, instead of silently skipping profiling.
  * Failed deployments are cleaned up automatically, with improved handling when cleanup itself encounters an error.

* **Tests**
  * Added coverage for deployment timeouts, terminal failures, and cleanup failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->