### PR TITLE
refactor(operator): move component reconciliation into a workload program

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -44,7 +44,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -437,18 +436,18 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	restartStatus := r.computeRestartStatus(ctx, dynamoDeployment)
 	restartState := dynamo.DetermineRestartState(dynamoDeployment, restartStatus)
 
-	var result ReconcileResult
-	if r.isGrovePathway(dynamoDeployment) {
-		logger.Info("Reconciling Grove resources", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.Gate.Enabled(features.LWS))
-		result, err = r.reconcileGroveResources(ctx, dynamoDeployment, restartState, checkpointInfos)
-	} else {
-		logger.Info("Reconciling Dynamo components deployments", "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.Gate.Enabled(features.LWS))
-		result, err = r.reconcileDynamoComponentsDeployments(ctx, dynamoDeployment, restartState, checkpointInfos)
+	state := &graphReconcileState{
+		DGD:             dynamoDeployment,
+		HasMultinode:    hasMultinode,
+		RestartState:    restartState,
+		CheckpointInfos: checkpointInfos,
 	}
-	if err != nil {
+	program := r.selectWorkloadProgram(state)
+	if err := program.Reconcile(ctx, state); err != nil {
 		logger.Error(err, "Failed to reconcile Dynamo components deployments")
 		return ReconcileResult{}, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
 	}
+	result := state.Result
 	result.RestartStatus = restartStatus
 	result = applyCheckpointStartupReadiness(result, checkpointInfos)
 
@@ -1659,163 +1658,6 @@ func applyCheckpointStartupReadiness(
 	result.Reason = "waiting_for_checkpoint"
 	result.Message = Message(fmt.Sprintf("Waiting for checkpoints: %s", strings.Join(waiting, ", ")))
 	return result
-}
-
-func (r *DynamoGraphDeploymentReconciler) reconcileDynamoComponentsDeployments(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment, restartState *dynamo.RestartState, checkpointInfos map[string]*checkpoint.CheckpointInfo) (ReconcileResult, error) {
-	resources := []Resource{}
-	logger := log.FromContext(ctx)
-
-	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dynamoDeployment)
-	if err != nil {
-		return ReconcileResult{}, fmt.Errorf("failed to build rolling update context: %w", err)
-	}
-
-	existingRestartAnnotations, err := r.getExistingRestartAnnotationsDCD(ctx, dynamoDeployment)
-	if err != nil {
-		logger.Error(err, "failed to get existing restart annotations")
-		return ReconcileResult{}, fmt.Errorf("failed to get existing restart annotations: %w", err)
-	}
-	if rollingUpdateCtx.InProgress() {
-		logger.Info("Rolling update in progress",
-			"newWorkerHash", rollingUpdateCtx.NewWorkerHash,
-			"oldWorkerComponentReplicas", rollingUpdateCtx.OldWorkerReplicaTargetsByComponent)
-	}
-
-	// Generate all DCDs (handles both normal and rolling update cases)
-	dynamoComponentsDeployments, err := dynamo.GenerateDynamoComponentsDeployments(
-		dynamoDeployment, restartState, existingRestartAnnotations, rollingUpdateCtx,
-	)
-	if err != nil {
-		logger.Error(err, "failed to generate the DynamoComponentsDeployments")
-		return ReconcileResult{}, fmt.Errorf("failed to generate the DynamoComponentsDeployments: %w", err)
-	}
-
-	// Sync all generated DCDs
-	for key, dcd := range dynamoComponentsDeployments {
-		if err := applyDCDCheckpointStartupPolicy(dcd, checkpointInfos[key]); err != nil {
-			return ReconcileResult{}, fmt.Errorf("failed to apply checkpoint startup policy for %s: %w", key, err)
-		}
-		logger.Info("Reconciling DynamoComponentDeployment", "key", key, "name", dcd.Name)
-		if err := r.preserveExistingDCDBackendFramework(ctx, dcd); err != nil {
-			logger.Error(err, "failed to preserve existing DynamoComponentDeployment backendFramework", "name", dcd.Name)
-			return ReconcileResult{}, fmt.Errorf("failed to preserve existing DynamoComponentDeployment backendFramework: %w", err)
-		}
-		_, syncedDCD, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*nvidiacomv1beta1.DynamoComponentDeployment, bool, error) {
-			return dcd, false, nil
-		})
-		if err != nil {
-			logger.Error(err, "failed to sync the DynamoComponentDeployment", "name", dcd.Name)
-			return ReconcileResult{}, fmt.Errorf("failed to sync the DynamoComponentDeployment: %w", err)
-		}
-		resources = append(resources, syncedDCD)
-	}
-
-	// During rolling update, scale old worker DCDs via direct patching.
-	// This is done separately from DCD generation to avoid overwriting the old spec
-	// with the new spec (which would trigger an unwanted rolling update on old workers).
-	if rollingUpdateCtx.InProgress() {
-		if err := r.scaleOldWorkerDCDs(ctx, dynamoDeployment, rollingUpdateCtx); err != nil {
-			logger.Error(err, "failed to scale old worker DCDs")
-			return ReconcileResult{}, fmt.Errorf("failed to scale old worker DCDs: %w", err)
-		}
-	}
-
-	// Check resource readiness
-	result := r.checkResourcesReadiness(resources)
-
-	// During rolling updates, aggregate old worker component statuses into the result
-	// so that Replicas, ReadyReplicas, etc. reflect the total across old and new DCDs.
-	if rollingUpdateCtx.InProgress() {
-		oldWorkerStatuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dynamoDeployment, rollingUpdateCtx)
-		if err != nil {
-			logger.Error(err, "failed to aggregate old worker component statuses")
-			// Non-fatal: continue with partial status
-		} else if len(oldWorkerStatuses) > 0 {
-			mergeWorkerComponentStatuses(result.ComponentStatus, oldWorkerStatuses)
-		}
-	}
-
-	return result, nil
-}
-
-func applyDCDCheckpointStartupPolicy(
-	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
-	checkpointInfo *checkpoint.CheckpointInfo,
-) error {
-	if dcd == nil || checkpointInfo == nil || !checkpointInfo.Enabled {
-		return nil
-	}
-
-	// DGD-managed automatic checkpoints deliberately bypass identity lookup and
-	// are resolved by the exact DynamoCheckpoint CR created for this
-	// DGD/component generation. Propagate that resolved reference into the child
-	// DCD so the DCD controller does not independently fall back to legacy
-	// identity-based reuse logic.
-	if checkpointInfo.Exists && checkpointInfo.CheckpointName != "" {
-		if dcd.Spec.Experimental == nil {
-			dcd.Spec.Experimental = &nvidiacomv1beta1.ExperimentalSpec{}
-		}
-		if dcd.Spec.Experimental.Checkpoint == nil {
-			dcd.Spec.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{}
-		}
-		checkpointName := checkpointInfo.CheckpointName
-		dcd.Spec.Experimental.Checkpoint.Enabled = true
-		dcd.Spec.Experimental.Checkpoint.CheckpointRef = &checkpointName
-		dcd.Spec.Experimental.Checkpoint.Identity = nil
-		dcd.Spec.Experimental.Checkpoint.Job = nil
-		startupPolicy := checkpointInfo.StartupPolicy
-		if startupPolicy == "" {
-			startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
-		}
-		dcd.Spec.Experimental.Checkpoint.StartupPolicy = nvidiacomv1beta1.CheckpointStartupPolicy(startupPolicy)
-	}
-
-	if checkpointInfo.StartupPolicy == nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint && !checkpointInfo.Ready {
-		dcd.Spec.Replicas = ptr.To(int32(0))
-		return nil
-	}
-	if checkpointInfo.StartupPolicy == "" ||
-		checkpointInfo.StartupPolicy == nvidiacomv1alpha1.CheckpointStartupPolicyImmediate {
-		labels := dynamo.GetPodTemplateLabels(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
-		if labels == nil {
-			if dcd.Spec.PodTemplate == nil {
-				dcd.Spec.PodTemplate = &corev1.PodTemplateSpec{}
-			}
-			if dcd.Spec.PodTemplate.Labels == nil {
-				dcd.Spec.PodTemplate.Labels = map[string]string{}
-			}
-			labels = dcd.Spec.PodTemplate.Labels
-		}
-		annotations := dynamo.GetPodTemplateAnnotations(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
-		if annotations == nil {
-			if dcd.Spec.PodTemplate == nil {
-				dcd.Spec.PodTemplate = &corev1.PodTemplateSpec{}
-			}
-			if dcd.Spec.PodTemplate.Annotations == nil {
-				dcd.Spec.PodTemplate.Annotations = map[string]string{}
-			}
-			annotations = dcd.Spec.PodTemplate.Annotations
-		}
-		return checkpoint.ApplyRestoreCandidateMetadata(labels, annotations, checkpointInfo)
-	}
-	return nil
-}
-
-func (r *DynamoGraphDeploymentReconciler) preserveExistingDCDBackendFramework(ctx context.Context, desired *nvidiacomv1beta1.DynamoComponentDeployment) error {
-	existing := &nvidiacomv1beta1.DynamoComponentDeployment{}
-	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
-	if errors.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to get existing DynamoComponentDeployment %s/%s: %w", desired.Namespace, desired.Name, err)
-	}
-
-	// backendFramework is immutable on DCDs. Older generated children may have
-	// an empty value, so preserve the stored value on update while allowing new
-	// children to be created with the inferred backend.
-	desired.Spec.BackendFramework = existing.Spec.BackendFramework
-	return nil
 }
 
 func (r *DynamoGraphDeploymentReconciler) getExistingRestartAnnotationsDCD(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) (map[string]string, error) {

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -444,8 +444,8 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	}
 	program := r.selectWorkloadProgram(state)
 	if err := program.Reconcile(ctx, state); err != nil {
-		logger.Error(err, "Failed to reconcile Dynamo components deployments")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		logger.Error(err, "Failed to reconcile workload program")
+		return ReconcileResult{}, fmt.Errorf("failed to reconcile workload program: %w", err)
 	}
 	result := state.Result
 	result.RestartStatus = restartStatus

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -78,56 +78,6 @@ func newDynamoGraphDeploymentControllerTestScheme(t testing.TB) *runtime.Scheme 
 	return s
 }
 
-func TestDynamoGraphDeploymentReconciler_preserveExistingDCDBackendFramework(t *testing.T) {
-	ctx := context.Background()
-	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
-
-	existing := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vllm-disagg-planner-frontend",
-			Namespace: "jsm",
-		},
-		Spec: v1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "",
-			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "Frontend",
-				ComponentType: v1beta1.ComponentTypeFrontend,
-			},
-		},
-	}
-
-	reconciler := &DynamoGraphDeploymentReconciler{
-		Client: fake.NewClientBuilder().
-			WithScheme(testScheme).
-			WithObjects(existing).
-			Build(),
-	}
-
-	desiredExisting := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      existing.Name,
-			Namespace: existing.Namespace,
-		},
-		Spec: v1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "vllm",
-		},
-	}
-	gomega.NewWithT(t).Expect(reconciler.preserveExistingDCDBackendFramework(ctx, desiredExisting)).To(gomega.Succeed())
-	gomega.NewWithT(t).Expect(desiredExisting.Spec.BackendFramework).To(gomega.Equal(""))
-
-	desiredNew := &v1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vllm-disagg-planner-vllmdecodeworker-2dad72b9",
-			Namespace: "jsm",
-		},
-		Spec: v1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "vllm",
-		},
-	}
-	gomega.NewWithT(t).Expect(reconciler.preserveExistingDCDBackendFramework(ctx, desiredNew)).To(gomega.Succeed())
-	gomega.NewWithT(t).Expect(desiredNew.Spec.BackendFramework).To(gomega.Equal("vllm"))
-}
-
 func TestDynamoGraphDeploymentReconciler_reconcileScalingAdapters(t *testing.T) {
 	testScheme := newDynamoGraphDeploymentControllerTestScheme(t)
 
@@ -2222,81 +2172,6 @@ func TestDynamoGraphDeploymentReconciler_mapAutoCheckpointToDGDRequestsAllowsRet
 	assert.Equal(t, types.NamespacedName{Namespace: "default", Name: "test-dgd"}, got[0].NamespacedName)
 }
 
-func TestApplyDCDCheckpointStartupPolicy(t *testing.T) {
-	t.Run("immediate stamps stable restore candidate metadata", func(t *testing.T) {
-		dcd := &v1beta1.DynamoComponentDeployment{
-			Spec: v1beta1.DynamoComponentDeploymentSpec{
-				DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
-					Replicas: ptr.To(int32(2)),
-					PodTemplate: &corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								snapshotprotocol.CheckpointIDLabel: "stale",
-							},
-							Annotations: map[string]string{
-								snapshotprotocol.CheckpointStatusAnnotation: "stale",
-							},
-						},
-					},
-				},
-			},
-		}
-		info := &checkpoint.CheckpointInfo{
-			Enabled:        true,
-			Exists:         true,
-			Ready:          true,
-			Hash:           "checkpoint-id",
-			CheckpointName: "checkpoint-name",
-			StartupPolicy:  v1alpha1.CheckpointStartupPolicyImmediate,
-		}
-
-		if err := applyDCDCheckpointStartupPolicy(dcd, info); err != nil {
-			t.Fatalf("applyDCDCheckpointStartupPolicy() error = %v", err)
-		}
-
-		require.NotNil(t, dcd.Spec.Experimental)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Identity)
-		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Job)
-		assert.Equal(t, v1beta1.CheckpointStartupPolicyImmediate, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
-		assert.Equal(t, int32(2), *dcd.Spec.Replicas)
-		assert.Empty(t, dcd.Spec.PodTemplate.Labels[snapshotprotocol.CheckpointIDLabel])
-		assert.Equal(t, commonconsts.KubeLabelValueTrue, dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointRestoreCandidateAnnotation])
-		assert.Equal(t, "checkpoint-name", dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointNameAnnotation])
-		assert.Equal(t, commonconsts.MainContainerName, dcd.Spec.PodTemplate.Annotations[snapshotprotocol.TargetContainersAnnotation])
-	})
-
-	t.Run("wait for checkpoint gates replicas until ready", func(t *testing.T) {
-		dcd := &v1beta1.DynamoComponentDeployment{
-			Spec: v1beta1.DynamoComponentDeploymentSpec{
-				DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
-					Replicas: ptr.To(int32(3)),
-				},
-			},
-		}
-		info := &checkpoint.CheckpointInfo{
-			Enabled:        true,
-			Exists:         true,
-			Ready:          false,
-			CheckpointName: "checkpoint-name",
-			StartupPolicy:  v1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
-		}
-
-		if err := applyDCDCheckpointStartupPolicy(dcd, info); err != nil {
-			t.Fatalf("applyDCDCheckpointStartupPolicy() error = %v", err)
-		}
-
-		require.NotNil(t, dcd.Spec.Experimental)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, v1beta1.CheckpointStartupPolicyWaitForCheckpoint, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
-		assert.Equal(t, int32(0), *dcd.Spec.Replicas)
-	})
-}
-
 // mockScaleClient implements scale.ScalesGetter for testing
 type mockScaleClient struct{}
 
@@ -2320,6 +2195,91 @@ func (m *mockScaleInterface) Update(ctx context.Context, resource schema.GroupRe
 func (m *mockScaleInterface) Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*autoscalingv1.Scale, error) {
 	// Return a dummy scale object
 	return &autoscalingv1.Scale{}, nil
+}
+
+func TestDynamoGraphDeploymentReconciler_isGrovePathway(t *testing.T) {
+	tests := []struct {
+		name         string
+		groveEnabled bool
+		annotations  map[string]string
+		want         bool
+	}{
+		{
+			name:         "feature disabled without annotation selects component pathway",
+			groveEnabled: false,
+			want:         false,
+		},
+		{
+			name:         "feature disabled ignores explicit enable annotation",
+			groveEnabled: false,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueTrue,
+			},
+			want: false,
+		},
+		{
+			name:         "feature enabled without annotations selects Grove",
+			groveEnabled: true,
+			want:         true,
+		},
+		{
+			name:         "feature enabled with unrelated annotation selects Grove",
+			groveEnabled: true,
+			annotations: map[string]string{
+				"example.com/unrelated": "value",
+			},
+			want: true,
+		},
+		{
+			name:         "feature enabled with explicit enable annotation selects Grove",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueTrue,
+			},
+			want: true,
+		},
+		{
+			name:         "feature enabled with explicit disable annotation selects component pathway",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse,
+			},
+			want: false,
+		},
+		{
+			name:         "explicit disable annotation is case insensitive",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: "FaLsE",
+			},
+			want: false,
+		},
+		{
+			name:         "unknown annotation value does not disable Grove",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: "invalid",
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build a reconciler and DGD with the pathway-selection inputs")
+			reconciler := &DynamoGraphDeploymentReconciler{
+				RuntimeConfig: &controller_common.RuntimeConfig{
+					Gate: features.Gates{Grove: tt.groveEnabled},
+				},
+			}
+			dgd := &v1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
+			}
+
+			t.Log("Evaluate the current Grove pathway-selection contract")
+			assert.Equal(t, tt.want, reconciler.isGrovePathway(dgd))
+		})
+	}
 }
 
 func Test_reconcileGroveResources(t *testing.T) {
@@ -3985,7 +3945,7 @@ func Test_computeRestartStatus(t *testing.T) {
 	}
 }
 
-func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
+func TestComponentProgram_Reconcile(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
@@ -4617,10 +4577,11 @@ func Test_reconcileDynamoComponentsDeployments(t *testing.T) {
 				RuntimeConfig: &controller_common.RuntimeConfig{},
 			}
 
-			result, err := reconciler.reconcileDynamoComponentsDeployments(ctx, dgd, nil, nil)
+			state := &graphReconcileState{DGD: dgd}
+			err = (&componentProgram{reconciler: reconciler}).Reconcile(ctx, state)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
-			g.Expect(result).To(gomega.Equal(tt.wantReconcileResult))
+			g.Expect(state.Result).To(gomega.Equal(tt.wantReconcileResult))
 		})
 	}
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program.go
@@ -1,0 +1,298 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// graphReconcileState is ephemeral state shared by the common DGD flow and the
+// selected workload program during one reconciliation. It is intentionally
+// small: dependencies belong to concrete programs, and provider-native API
+// objects must not be added here.
+type graphReconcileState struct {
+	DGD             *nvidiacomv1beta1.DynamoGraphDeployment
+	HasMultinode    bool
+	RestartState    *dynamo.RestartState
+	CheckpointInfos map[string]*checkpoint.CheckpointInfo
+	Result          ReconcileResult
+}
+
+// workloadProgram owns the complete graph-workload state machine for one
+// pathway. The common DGD controller selects one program and invokes it once;
+// it does not drive provider rendering, rollout, readiness, or cleanup through
+// lifecycle callbacks.
+type workloadProgram interface {
+	Reconcile(context.Context, *graphReconcileState) error
+}
+
+// groveReconcileFunc is the temporary strangler seam around the existing Grove
+// pathway. It disappears when Grove reconciliation moves into groveProgram.
+type groveReconcileFunc func(
+	context.Context,
+	*nvidiacomv1beta1.DynamoGraphDeployment,
+	*dynamo.RestartState,
+	map[string]*checkpoint.CheckpointInfo,
+) (ReconcileResult, error)
+
+type componentProgram struct {
+	// The DGD reconciler temporarily supplies shared controller dependencies and
+	// managed rolling-update helpers. Later extractions can narrow this without
+	// moving component-path orchestration back into the common controller flow.
+	reconciler *DynamoGraphDeploymentReconciler
+	lwsEnabled bool
+}
+
+func (p *componentProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
+	log.FromContext(ctx).Info(
+		"Reconciling Dynamo components deployments",
+		"hasMultinode", state.HasMultinode,
+		"lwsEnabled", p.lwsEnabled,
+	)
+
+	result, err := p.reconcile(ctx, state)
+	if err != nil {
+		return err
+	}
+	state.Result = result
+	return nil
+}
+
+// reconcile owns the component pathway's complete DCD graph reconciliation.
+// Managed rolling-update helpers remain on the DGD reconciler until their
+// dedicated extraction; this program owns when they participate in the flow.
+func (p *componentProgram) reconcile(
+	ctx context.Context,
+	state *graphReconcileState,
+) (ReconcileResult, error) {
+	r := p.reconciler
+	dynamoDeployment := state.DGD
+	resources := []Resource{}
+	logger := log.FromContext(ctx)
+
+	rollingUpdateCtx, err := r.buildRollingUpdateContext(ctx, dynamoDeployment)
+	if err != nil {
+		return ReconcileResult{}, fmt.Errorf("failed to build rolling update context: %w", err)
+	}
+
+	existingRestartAnnotations, err := r.getExistingRestartAnnotationsDCD(ctx, dynamoDeployment)
+	if err != nil {
+		logger.Error(err, "failed to get existing restart annotations")
+		return ReconcileResult{}, fmt.Errorf("failed to get existing restart annotations: %w", err)
+	}
+	if rollingUpdateCtx.InProgress() {
+		logger.Info("Rolling update in progress",
+			"newWorkerHash", rollingUpdateCtx.NewWorkerHash,
+			"oldWorkerComponentReplicas", rollingUpdateCtx.OldWorkerReplicaTargetsByComponent)
+	}
+
+	// Generate all DCDs, including the desired generations during a managed
+	// rolling update.
+	dynamoComponentsDeployments, err := dynamo.GenerateDynamoComponentsDeployments(
+		dynamoDeployment,
+		state.RestartState,
+		existingRestartAnnotations,
+		rollingUpdateCtx,
+	)
+	if err != nil {
+		logger.Error(err, "failed to generate the DynamoComponentsDeployments")
+		return ReconcileResult{}, fmt.Errorf("failed to generate the DynamoComponentsDeployments: %w", err)
+	}
+
+	// Apply resolved checkpoint policy and synchronize every desired DCD.
+	for key, dcd := range dynamoComponentsDeployments {
+		if err := p.applyCheckpointStartupPolicy(dcd, state.CheckpointInfos[key]); err != nil {
+			return ReconcileResult{}, fmt.Errorf("failed to apply checkpoint startup policy for %s: %w", key, err)
+		}
+		logger.Info("Reconciling DynamoComponentDeployment", "key", key, "name", dcd.Name)
+		if err := p.preserveExistingBackendFramework(ctx, dcd); err != nil {
+			logger.Error(err, "failed to preserve existing DynamoComponentDeployment backendFramework", "name", dcd.Name)
+			return ReconcileResult{}, fmt.Errorf("failed to preserve existing DynamoComponentDeployment backendFramework: %w", err)
+		}
+		_, syncedDCD, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(context.Context) (*nvidiacomv1beta1.DynamoComponentDeployment, bool, error) {
+			return dcd, false, nil
+		})
+		if err != nil {
+			logger.Error(err, "failed to sync the DynamoComponentDeployment", "name", dcd.Name)
+			return ReconcileResult{}, fmt.Errorf("failed to sync the DynamoComponentDeployment: %w", err)
+		}
+		resources = append(resources, syncedDCD)
+	}
+
+	// Old worker DCDs are scaled through direct patches so their stored specs
+	// are not overwritten with the new generation's desired spec.
+	if rollingUpdateCtx.InProgress() {
+		if err := r.scaleOldWorkerDCDs(ctx, dynamoDeployment, rollingUpdateCtx); err != nil {
+			logger.Error(err, "failed to scale old worker DCDs")
+			return ReconcileResult{}, fmt.Errorf("failed to scale old worker DCDs: %w", err)
+		}
+	}
+
+	result := r.checkResourcesReadiness(resources)
+
+	// Include old worker generations in status while a managed rolling update
+	// is active. A transient aggregation error remains non-fatal so readiness
+	// can continue with the statuses already collected above.
+	if rollingUpdateCtx.InProgress() {
+		oldWorkerStatuses, err := r.aggregateOldWorkerComponentStatuses(ctx, dynamoDeployment, rollingUpdateCtx)
+		if err != nil {
+			logger.Error(err, "failed to aggregate old worker component statuses")
+		} else if len(oldWorkerStatuses) > 0 {
+			mergeWorkerComponentStatuses(result.ComponentStatus, oldWorkerStatuses)
+		}
+	}
+
+	return result, nil
+}
+
+func (p *componentProgram) applyCheckpointStartupPolicy(
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+	checkpointInfo *checkpoint.CheckpointInfo,
+) error {
+	if dcd == nil || checkpointInfo == nil || !checkpointInfo.Enabled {
+		return nil
+	}
+
+	// DGD-managed automatic checkpoints deliberately bypass identity lookup and
+	// are resolved by the exact DynamoCheckpoint CR created for this
+	// DGD/component generation. Propagate that resolved reference into the child
+	// DCD so the DCD controller does not independently fall back to legacy
+	// identity-based reuse logic.
+	if checkpointInfo.Exists && checkpointInfo.CheckpointName != "" {
+		if dcd.Spec.Experimental == nil {
+			dcd.Spec.Experimental = &nvidiacomv1beta1.ExperimentalSpec{}
+		}
+		if dcd.Spec.Experimental.Checkpoint == nil {
+			dcd.Spec.Experimental.Checkpoint = &nvidiacomv1beta1.ComponentCheckpointConfig{}
+		}
+		checkpointName := checkpointInfo.CheckpointName
+		dcd.Spec.Experimental.Checkpoint.Enabled = true
+		dcd.Spec.Experimental.Checkpoint.CheckpointRef = &checkpointName
+		dcd.Spec.Experimental.Checkpoint.Identity = nil
+		dcd.Spec.Experimental.Checkpoint.Job = nil
+		startupPolicy := checkpointInfo.StartupPolicy
+		if startupPolicy == "" {
+			startupPolicy = nvidiacomv1alpha1.CheckpointStartupPolicyImmediate
+		}
+		dcd.Spec.Experimental.Checkpoint.StartupPolicy = nvidiacomv1beta1.CheckpointStartupPolicy(startupPolicy)
+	}
+
+	if checkpointInfo.StartupPolicy == nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint && !checkpointInfo.Ready {
+		dcd.Spec.Replicas = ptr.To(int32(0))
+		return nil
+	}
+	if checkpointInfo.StartupPolicy == "" ||
+		checkpointInfo.StartupPolicy == nvidiacomv1alpha1.CheckpointStartupPolicyImmediate {
+		labels := dynamo.GetPodTemplateLabels(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
+		if labels == nil {
+			if dcd.Spec.PodTemplate == nil {
+				dcd.Spec.PodTemplate = &corev1.PodTemplateSpec{}
+			}
+			if dcd.Spec.PodTemplate.Labels == nil {
+				dcd.Spec.PodTemplate.Labels = map[string]string{}
+			}
+			labels = dcd.Spec.PodTemplate.Labels
+		}
+		annotations := dynamo.GetPodTemplateAnnotations(&dcd.Spec.DynamoComponentDeploymentSharedSpec)
+		if annotations == nil {
+			if dcd.Spec.PodTemplate == nil {
+				dcd.Spec.PodTemplate = &corev1.PodTemplateSpec{}
+			}
+			if dcd.Spec.PodTemplate.Annotations == nil {
+				dcd.Spec.PodTemplate.Annotations = map[string]string{}
+			}
+			annotations = dcd.Spec.PodTemplate.Annotations
+		}
+		return checkpoint.ApplyRestoreCandidateMetadata(labels, annotations, checkpointInfo)
+	}
+	return nil
+}
+
+func (p *componentProgram) preserveExistingBackendFramework(
+	ctx context.Context,
+	desired *nvidiacomv1beta1.DynamoComponentDeployment,
+) error {
+	r := p.reconciler
+	existing := &nvidiacomv1beta1.DynamoComponentDeployment{}
+	err := r.Get(ctx, types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get existing DynamoComponentDeployment %s/%s: %w", desired.Namespace, desired.Name, err)
+	}
+
+	// backendFramework is immutable on DCDs. Older generated children may have
+	// an empty value, so preserve the stored value on update while allowing new
+	// children to be created with the inferred backend.
+	desired.Spec.BackendFramework = existing.Spec.BackendFramework
+	return nil
+}
+
+type groveProgram struct {
+	reconcile  groveReconcileFunc
+	lwsEnabled bool
+}
+
+func (p *groveProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
+	log.FromContext(ctx).Info(
+		"Reconciling Grove resources",
+		"hasMultinode", state.HasMultinode,
+		"lwsEnabled", p.lwsEnabled,
+	)
+
+	result, err := p.reconcile(
+		ctx,
+		state.DGD,
+		state.RestartState,
+		state.CheckpointInfos,
+	)
+	if err != nil {
+		return err
+	}
+	state.Result = result
+	return nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
+	state *graphReconcileState,
+) workloadProgram {
+	if r.isGrovePathway(state.DGD) {
+		return &groveProgram{
+			reconcile:  r.reconcileGroveResources,
+			lwsEnabled: r.RuntimeConfig.Gate.Enabled(features.LWS),
+		}
+	}
+	return &componentProgram{
+		reconciler: r,
+		lwsEnabled: r.RuntimeConfig.Gate.Enabled(features.LWS),
+	}
+}

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -1,0 +1,326 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestDynamoGraphDeploymentReconciler_selectWorkloadProgram(t *testing.T) {
+	tests := []struct {
+		name         string
+		groveEnabled bool
+		annotations  map[string]string
+		wantProgram  workloadProgram
+	}{
+		{
+			name:        "Grove feature disabled selects component program",
+			wantProgram: &componentProgram{},
+		},
+		{
+			name:         "Grove feature enabled selects Grove program",
+			groveEnabled: true,
+			wantProgram:  &groveProgram{},
+		},
+		{
+			name:         "explicit Grove disable selects component program",
+			groveEnabled: true,
+			annotations: map[string]string{
+				commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse,
+			},
+			wantProgram: &componentProgram{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build the ephemeral state and reconciler selection inputs")
+			state := &graphReconcileState{
+				DGD: &nvidiacomv1beta1.DynamoGraphDeployment{
+					ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
+				},
+			}
+			reconciler := &DynamoGraphDeploymentReconciler{
+				RuntimeConfig: &commonController.RuntimeConfig{
+					Gate: features.Gates{Grove: tt.groveEnabled},
+				},
+			}
+
+			t.Log("Select one complete workload program")
+			got := reconciler.selectWorkloadProgram(state)
+
+			assert.IsType(t, tt.wantProgram, got)
+			if component, ok := got.(*componentProgram); ok {
+				assert.Same(t, reconciler, component.reconciler)
+			}
+		})
+	}
+}
+
+func TestGroveProgram_ReconcileAdapter(t *testing.T) {
+	reconcileErr := errors.New("reconcile failed")
+	tests := []struct {
+		name         string
+		returned     ReconcileResult
+		reconcileErr error
+		wantState    ReconcileResult
+		wantErr      error
+	}{
+		{
+			name: "Grove program records a successful result",
+			returned: ReconcileResult{
+				State:  nvidiacomv1beta1.DGDStatePending,
+				Reason: "grove_pending",
+			},
+			wantState: ReconcileResult{
+				State:  nvidiacomv1beta1.DGDStatePending,
+				Reason: "grove_pending",
+			},
+		},
+		{
+			name: "Grove program preserves prior state on error",
+			returned: ReconcileResult{
+				State:  nvidiacomv1beta1.DGDStateSuccessful,
+				Reason: "must_not_be_committed",
+			},
+			reconcileErr: reconcileErr,
+			wantState: ReconcileResult{
+				State:  nvidiacomv1beta1.DGDStatePending,
+				Reason: "existing",
+			},
+			wantErr: reconcileErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build ephemeral inputs that must be passed unchanged to the program")
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			restartState := &dynamo.RestartState{Timestamp: "restart"}
+			checkpointInfos := map[string]*checkpoint.CheckpointInfo{
+				"worker": {CheckpointName: "checkpoint"},
+			}
+			state := &graphReconcileState{
+				DGD:             dgd,
+				HasMultinode:    true,
+				RestartState:    restartState,
+				CheckpointInfos: checkpointInfos,
+				Result: ReconcileResult{
+					State:  nvidiacomv1beta1.DGDStatePending,
+					Reason: "existing",
+				},
+			}
+			called := false
+			reconcile := func(
+				_ context.Context,
+				gotDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+				gotRestartState *dynamo.RestartState,
+				gotCheckpointInfos map[string]*checkpoint.CheckpointInfo,
+			) (ReconcileResult, error) {
+				called = true
+				require.Same(t, dgd, gotDGD)
+				require.Same(t, restartState, gotRestartState)
+				require.Equal(t, checkpointInfos, gotCheckpointInfos)
+				return tt.returned, tt.reconcileErr
+			}
+
+			t.Log("Run the selected complete workload program")
+			err := (&groveProgram{reconcile: reconcile}).Reconcile(context.Background(), state)
+
+			t.Log("Verify state is committed only after successful reconciliation")
+			require.True(t, called)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.wantState, state.Result)
+		})
+	}
+}
+
+func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
+	t.Log("Inject a component-path API failure before a result can be committed")
+	reconcileErr := errors.New("reconcile failed")
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return reconcileErr
+			},
+		}).
+		Build()
+	program := &componentProgram{
+		reconciler: &DynamoGraphDeploymentReconciler{Client: kubeClient},
+	}
+	previous := ReconcileResult{
+		State:  nvidiacomv1beta1.DGDStatePending,
+		Reason: "existing",
+	}
+	state := &graphReconcileState{
+		DGD: &nvidiacomv1beta1.DynamoGraphDeployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+		},
+		Result: previous,
+	}
+
+	err := program.Reconcile(context.Background(), state)
+
+	t.Log("Verify failed reconciliation cannot publish a partial result")
+	require.ErrorIs(t, err, reconcileErr)
+	assert.Equal(t, previous, state.Result)
+}
+
+func TestComponentProgram_PreserveExistingBackendFramework(t *testing.T) {
+	ctx := context.Background()
+	existing := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vllm-disagg-planner-frontend",
+			Namespace: "jsm",
+		},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: "",
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "Frontend",
+				ComponentType: nvidiacomv1beta1.ComponentTypeFrontend,
+			},
+		},
+	}
+	program := &componentProgram{
+		reconciler: &DynamoGraphDeploymentReconciler{
+			Client: fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithObjects(existing).
+				Build(),
+		},
+	}
+
+	t.Log("Preserve the immutable stored backend when updating an existing DCD")
+	desiredExisting := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      existing.Name,
+			Namespace: existing.Namespace,
+		},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: "vllm",
+		},
+	}
+	require.NoError(t, program.preserveExistingBackendFramework(ctx, desiredExisting))
+	assert.Empty(t, desiredExisting.Spec.BackendFramework)
+
+	t.Log("Keep the inferred backend when creating a new DCD")
+	desiredNew := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vllm-disagg-planner-vllmdecodeworker-2dad72b9",
+			Namespace: "jsm",
+		},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: "vllm",
+		},
+	}
+	require.NoError(t, program.preserveExistingBackendFramework(ctx, desiredNew))
+	assert.Equal(t, "vllm", desiredNew.Spec.BackendFramework)
+}
+
+func TestComponentProgram_ApplyCheckpointStartupPolicy(t *testing.T) {
+	program := &componentProgram{}
+
+	t.Run("immediate stamps stable restore candidate metadata", func(t *testing.T) {
+		dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
+			Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					Replicas: ptr.To(int32(2)),
+					PodTemplate: &corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								snapshotprotocol.CheckpointIDLabel: "stale",
+							},
+							Annotations: map[string]string{
+								snapshotprotocol.CheckpointStatusAnnotation: "stale",
+							},
+						},
+					},
+				},
+			},
+		}
+		info := &checkpoint.CheckpointInfo{
+			Enabled:        true,
+			Exists:         true,
+			Ready:          true,
+			Hash:           "checkpoint-id",
+			CheckpointName: "checkpoint-name",
+			StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
+		}
+
+		require.NoError(t, program.applyCheckpointStartupPolicy(dcd, info))
+
+		require.NotNil(t, dcd.Spec.Experimental)
+		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
+		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Identity)
+		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Job)
+		assert.Equal(t, nvidiacomv1beta1.CheckpointStartupPolicyImmediate, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
+		assert.Equal(t, int32(2), *dcd.Spec.Replicas)
+		assert.Empty(t, dcd.Spec.PodTemplate.Labels[snapshotprotocol.CheckpointIDLabel])
+		assert.Equal(t, commonconsts.KubeLabelValueTrue, dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointRestoreCandidateAnnotation])
+		assert.Equal(t, "checkpoint-name", dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointNameAnnotation])
+		assert.Equal(t, commonconsts.MainContainerName, dcd.Spec.PodTemplate.Annotations[snapshotprotocol.TargetContainersAnnotation])
+	})
+
+	t.Run("wait for checkpoint gates replicas until ready", func(t *testing.T) {
+		dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
+			Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+				DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+					Replicas: ptr.To(int32(3)),
+				},
+			},
+		}
+		info := &checkpoint.CheckpointInfo{
+			Enabled:        true,
+			Exists:         true,
+			Ready:          false,
+			CheckpointName: "checkpoint-name",
+			StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
+		}
+
+		require.NoError(t, program.applyCheckpointStartupPolicy(dcd, info))
+
+		require.NotNil(t, dcd.Spec.Experimental)
+		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
+		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+		assert.Equal(t, nvidiacomv1beta1.CheckpointStartupPolicyWaitForCheckpoint, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
+		assert.Equal(t, int32(0), *dcd.Spec.Replicas)
+	})
+}

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -202,125 +202,148 @@ func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 }
 
 func TestComponentProgram_PreserveExistingBackendFramework(t *testing.T) {
-	ctx := context.Background()
-	existing := &nvidiacomv1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vllm-disagg-planner-frontend",
-			Namespace: "jsm",
+	tests := []struct {
+		name          string
+		dcdName       string
+		existing      bool
+		wantFramework string
+	}{
+		{
+			name:          "existing DCD preserves its immutable stored backend",
+			dcdName:       "vllm-disagg-planner-frontend",
+			existing:      true,
+			wantFramework: "",
 		},
-		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "",
-			DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-				ComponentName: "Frontend",
-				ComponentType: nvidiacomv1beta1.ComponentTypeFrontend,
-			},
-		},
-	}
-	program := &componentProgram{
-		reconciler: &DynamoGraphDeploymentReconciler{
-			Client: fake.NewClientBuilder().
-				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
-				WithObjects(existing).
-				Build(),
+		{
+			name:          "new DCD keeps its inferred backend",
+			dcdName:       "vllm-disagg-planner-vllmdecodeworker-2dad72b9",
+			wantFramework: "vllm",
 		},
 	}
 
-	t.Log("Preserve the immutable stored backend when updating an existing DCD")
-	desiredExisting := &nvidiacomv1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      existing.Name,
-			Namespace: existing.Namespace,
-		},
-		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "vllm",
-		},
-	}
-	require.NoError(t, program.preserveExistingBackendFramework(ctx, desiredExisting))
-	assert.Empty(t, desiredExisting.Spec.BackendFramework)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build the desired DCD and any existing immutable API state")
+			objects := []client.Object{}
+			if tt.existing {
+				objects = append(objects, &nvidiacomv1beta1.DynamoComponentDeployment{
+					ObjectMeta: metav1.ObjectMeta{Name: tt.dcdName, Namespace: "jsm"},
+					Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+						DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+							ComponentName: "Frontend",
+							ComponentType: nvidiacomv1beta1.ComponentTypeFrontend,
+						},
+					},
+				})
+			}
+			program := &componentProgram{
+				reconciler: &DynamoGraphDeploymentReconciler{
+					Client: fake.NewClientBuilder().
+						WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+						WithObjects(objects...).
+						Build(),
+				},
+			}
+			desired := &nvidiacomv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: tt.dcdName, Namespace: "jsm"},
+				Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+					BackendFramework: "vllm",
+				},
+			}
 
-	t.Log("Keep the inferred backend when creating a new DCD")
-	desiredNew := &nvidiacomv1beta1.DynamoComponentDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vllm-disagg-planner-vllmdecodeworker-2dad72b9",
-			Namespace: "jsm",
-		},
-		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-			BackendFramework: "vllm",
-		},
+			t.Log("Resolve the backend value that can safely be synchronized")
+			require.NoError(t, program.preserveExistingBackendFramework(context.Background(), desired))
+
+			t.Log("Verify updates preserve stored state while creates keep the inferred value")
+			assert.Equal(t, tt.wantFramework, desired.Spec.BackendFramework)
+		})
 	}
-	require.NoError(t, program.preserveExistingBackendFramework(ctx, desiredNew))
-	assert.Equal(t, "vllm", desiredNew.Spec.BackendFramework)
 }
 
 func TestComponentProgram_ApplyCheckpointStartupPolicy(t *testing.T) {
 	program := &componentProgram{}
-
-	t.Run("immediate stamps stable restore candidate metadata", func(t *testing.T) {
-		dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
-			Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-				DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					Replicas: ptr.To(int32(2)),
-					PodTemplate: &corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								snapshotprotocol.CheckpointIDLabel: "stale",
-							},
-							Annotations: map[string]string{
-								snapshotprotocol.CheckpointStatusAnnotation: "stale",
-							},
-						},
+	tests := []struct {
+		name              string
+		replicas          int32
+		podTemplate       *corev1.PodTemplateSpec
+		checkpointInfo    checkpoint.CheckpointInfo
+		wantReplicas      int32
+		wantStartupPolicy nvidiacomv1beta1.CheckpointStartupPolicy
+		wantCandidate     bool
+	}{
+		{
+			name:     "immediate stamps stable restore candidate metadata",
+			replicas: 2,
+			podTemplate: &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						snapshotprotocol.CheckpointIDLabel: "stale",
+					},
+					Annotations: map[string]string{
+						snapshotprotocol.CheckpointStatusAnnotation: "stale",
 					},
 				},
 			},
-		}
-		info := &checkpoint.CheckpointInfo{
-			Enabled:        true,
-			Exists:         true,
-			Ready:          true,
-			Hash:           "checkpoint-id",
-			CheckpointName: "checkpoint-name",
-			StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
-		}
-
-		require.NoError(t, program.applyCheckpointStartupPolicy(dcd, info))
-
-		require.NotNil(t, dcd.Spec.Experimental)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Identity)
-		assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Job)
-		assert.Equal(t, nvidiacomv1beta1.CheckpointStartupPolicyImmediate, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
-		assert.Equal(t, int32(2), *dcd.Spec.Replicas)
-		assert.Empty(t, dcd.Spec.PodTemplate.Labels[snapshotprotocol.CheckpointIDLabel])
-		assert.Equal(t, commonconsts.KubeLabelValueTrue, dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointRestoreCandidateAnnotation])
-		assert.Equal(t, "checkpoint-name", dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointNameAnnotation])
-		assert.Equal(t, commonconsts.MainContainerName, dcd.Spec.PodTemplate.Annotations[snapshotprotocol.TargetContainersAnnotation])
-	})
-
-	t.Run("wait for checkpoint gates replicas until ready", func(t *testing.T) {
-		dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
-			Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
-				DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
-					Replicas: ptr.To(int32(3)),
-				},
+			checkpointInfo: checkpoint.CheckpointInfo{
+				Enabled:        true,
+				Exists:         true,
+				Ready:          true,
+				Hash:           "checkpoint-id",
+				CheckpointName: "checkpoint-name",
+				StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyImmediate,
 			},
-		}
-		info := &checkpoint.CheckpointInfo{
-			Enabled:        true,
-			Exists:         true,
-			Ready:          false,
-			CheckpointName: "checkpoint-name",
-			StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
-		}
+			wantReplicas:      2,
+			wantStartupPolicy: nvidiacomv1beta1.CheckpointStartupPolicyImmediate,
+			wantCandidate:     true,
+		},
+		{
+			name:     "wait for checkpoint gates replicas until ready",
+			replicas: 3,
+			checkpointInfo: checkpoint.CheckpointInfo{
+				Enabled:        true,
+				Exists:         true,
+				Ready:          false,
+				CheckpointName: "checkpoint-name",
+				StartupPolicy:  nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint,
+			},
+			wantReplicas:      0,
+			wantStartupPolicy: nvidiacomv1beta1.CheckpointStartupPolicyWaitForCheckpoint,
+		},
+	}
 
-		require.NoError(t, program.applyCheckpointStartupPolicy(dcd, info))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build a generated DCD and its resolved checkpoint observation")
+			dcd := &nvidiacomv1beta1.DynamoComponentDeployment{
+				Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+					DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+						Replicas:    ptr.To(tt.replicas),
+						PodTemplate: tt.podTemplate,
+					},
+				},
+			}
 
-		require.NotNil(t, dcd.Spec.Experimental)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
-		require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
-		assert.Equal(t, nvidiacomv1beta1.CheckpointStartupPolicyWaitForCheckpoint, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
-		assert.Equal(t, int32(0), *dcd.Spec.Replicas)
-	})
+			t.Log("Apply the checkpoint startup policy before synchronizing the DCD")
+			require.NoError(t, program.applyCheckpointStartupPolicy(dcd, &tt.checkpointInfo))
+
+			t.Log("Verify the child checkpoint reference, startup policy, and replica gate")
+			require.NotNil(t, dcd.Spec.Experimental)
+			require.NotNil(t, dcd.Spec.Experimental.Checkpoint)
+			require.NotNil(t, dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+			assert.Equal(t, "checkpoint-name", *dcd.Spec.Experimental.Checkpoint.CheckpointRef)
+			assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Identity)
+			assert.Nil(t, dcd.Spec.Experimental.Checkpoint.Job)
+			assert.Equal(t, tt.wantStartupPolicy, dcd.Spec.Experimental.Checkpoint.StartupPolicy)
+			assert.Equal(t, tt.wantReplicas, *dcd.Spec.Replicas)
+			if !tt.wantCandidate {
+				return
+			}
+
+			t.Log("Verify immediate startup publishes stable restore-candidate metadata")
+			assert.Empty(t, dcd.Spec.PodTemplate.Labels[snapshotprotocol.CheckpointIDLabel])
+			assert.Equal(t, commonconsts.KubeLabelValueTrue, dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointRestoreCandidateAnnotation])
+			assert.Equal(t, "checkpoint-name", dcd.Spec.PodTemplate.Annotations[commonconsts.CheckpointNameAnnotation])
+			assert.Equal(t, commonconsts.MainContainerName, dcd.Spec.PodTemplate.Annotations[snapshotprotocol.TargetContainersAnnotation])
+		})
+	}
 }


### PR DESCRIPTION
## Summary

This MR introduces the first concrete composition-first boundary in the `DynamoGraphDeployment` reconciler.

The common DGD reconciliation flow now:

1. Resolves shared reconciliation inputs.
2. Builds ephemeral `graphReconcileState`.
3. Selects one complete workload program.
4. Invokes that program once.
5. Applies the resulting common status.

The component pathway is implemented as `componentProgram`, which now owns the complete DCD graph reconciliation flow:

- DCD generation and synchronization
- checkpoint startup policy application
- preservation of the immutable DCD backend framework
- restart annotation propagation
- managed rolling-update orchestration
- readiness calculation and status aggregation

The Grove pathway remains behind a temporary adapter around the existing Grove reconciliation method. This preserves current behavior while establishing the seam for a later dedicated `groveProgram` extraction.

`graphReconcileState` remains intentionally ephemeral. Results are published back to the common reconciliation flow only after the selected program completes successfully.

This MR is stacked on #12115.

## Motivation

The DGD controller currently selects between workload implementations inside a shared reconciliation method. As more pathways and workload APIs are added, that structure makes the common controller increasingly aware of provider-specific behavior.

This change establishes a composition-first model where each pathway is represented by a complete reconciler rather than a collection of lifecycle callbacks.

The common controller owns shared DGD concerns, while the selected workload program owns its workload graph and reconciliation ordering.

## Design

The new boundary consists of:

- `graphReconcileState`: ephemeral inputs and outputs for one reconciliation
- `workloadProgram`: the contract implemented by a complete workload pathway
- `componentProgram`: the concrete DCD-based implementation
- `groveProgram`: a temporary adapter around the existing Grove implementation
- `selectWorkloadProgram`: centralized pathway selection

The program contract deliberately contains a single `Reconcile` method. This keeps ordering and policy decisions inside each complete pathway instead of exposing provider-specific hooks to the common controller.

The existing managed rolling-update helpers remain on `DynamoGraphDeploymentReconciler` for now, but `componentProgram` owns when and how they participate in the component reconciliation flow. Moving those helpers behind a narrower dependency boundary is deferred to a follow-up MR.

## Behavior and compatibility

This is intended to be a behavior-preserving refactor:

- Pathway selection semantics are unchanged.
- Existing DCD generation and synchronization behavior is unchanged.
- Checkpoint startup behavior is unchanged.
- Backend-framework compatibility behavior is unchanged.
- Managed rolling-update behavior is unchanged.
- Grove reconciliation continues to use the existing implementation.

There are no CRD, API, or persisted-state changes.

## Tests

Added or updated coverage for:

- workload-program selection
- current Grove pathway-selection semantics
- the temporary Grove adapter
- component reconciliation through `componentProgram`
- preserving the previous reconciliation result when a program fails
- checkpoint startup policy ownership
- immutable backend-framework preservation
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pathway selection for DynamoGraphDeployment reconciliation based on Grove settings and annotations.
  - Improved component deployment handling during rolling updates, including worker scaling and readiness reporting.
  - Added checkpoint startup policy support, including immediate restore candidates and wait-before-start behavior.
  - Preserved existing backend framework settings when updating component deployments.

- **Bug Fixes**
  - Improved reconciliation state preservation when errors occur.
  - Added coverage for pathway selection, checkpoint behavior, and deployment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->