### PR TITLE
refactor(operator): move rollout control into workload programs

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -74,6 +74,7 @@ type Message string
 const (
 	reasonFailedToInitializeWorkerHash Reason = "failed_to_initialize_worker_hash"
 	reasonFailedToMigrateWorkerHash    Reason = "failed_to_migrate_worker_hash"
+	reasonNoMultinodeOrchestrator      Reason = "no_multinode_orchestrator_available"
 	reasonFailedToReconcileResources   Reason = "failed_to_reconcile_the_resources"
 	reasonRollingUpdateFailed          Reason = "rolling_update_failed"
 
@@ -132,67 +133,23 @@ type DynamoGraphDeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.19.1/pkg/reconcile
 func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	logger := log.FromContext(ctx)
-
-	reason := Reason("undefined")
-	message := Message("")
-	state := nvidiacomv1beta1.DGDStatePending
 	// retrieve the CRD
 	dynamoDeployment := &nvidiacomv1beta1.DynamoGraphDeployment{}
 	if err = r.Get(ctx, req.NamespacedName, dynamoDeployment); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	defer func() {
-		// Skip status update if DGD is being deleted
-		if !dynamoDeployment.GetDeletionTimestamp().IsZero() {
-			logger.Info("Reconciliation done - skipping status update for deleted resource")
-			return
-		}
-
-		if err != nil {
-			state = nvidiacomv1beta1.DGDStateFailed
-			message = Message(err.Error())
-			logger.Error(err, "Reconciliation failed")
-		}
-		dynamoDeployment.SetState(state)
-
-		readyStatus := metav1.ConditionFalse
-		if state == nvidiacomv1beta1.DGDStateSuccessful {
-			readyStatus = metav1.ConditionTrue
-		}
-
-		// Update Ready condition
-		dynamoDeployment.AddStatusCondition(metav1.Condition{
-			Type:    "Ready",
-			Status:  readyStatus,
-			Reason:  string(reason),
-			Message: string(message),
-		})
-
-		// Only set ObservedGeneration when reconciliation succeeded (no error),
-		// so it accurately reflects the last successfully processed generation.
-		if err == nil {
-			dynamoDeployment.Status.ObservedGeneration = dynamoDeployment.Generation
-		}
-		// Propagate topology condition from framework (e.g., Grove PCS) to DGD status
-		r.propagateTopologyCondition(ctx, dynamoDeployment)
-
-		updateErr := r.Status().Update(ctx, dynamoDeployment)
-		if updateErr != nil {
-			logger.Error(updateErr, "Unable to update the CRD status", "crd", req.NamespacedName, "state", state, "reason", reason, "message", message)
-			// Set err to trigger requeue
-			if err == nil {
-				err = updateErr
-			}
-		}
-		logger.Info("Reconciliation done")
-	}()
-
 	// Handle finalizer
 	deleted, err := commoncontroller.HandleFinalizer(ctx, dynamoDeployment, r.Client, r)
 	if err != nil {
 		logger.Error(err, "failed to handle the finalizer")
-		reason = "failed_to_handle_the_finalizer"
+		if dynamoDeployment.GetDeletionTimestamp().IsZero() {
+			programResult := newWorkloadProgramResult(dynamoDeployment)
+			programResult.Fail(dynamoDeployment.Generation, "failed_to_handle_the_finalizer", err)
+			if statusErr := r.persistWorkloadProgramResult(ctx, dynamoDeployment, programResult); statusErr != nil {
+				logger.Error(statusErr, "unable to update status after finalizer failure")
+			}
+		}
 		return ctrl.Result{}, err
 	}
 	if deleted {
@@ -201,42 +158,37 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 
 	program := r.selectWorkloadProgram(dynamoDeployment)
 	programResult, programErr := program.Reconcile(ctx, workloadProgramRequest{
-		DGD:   dynamoDeployment,
-		Facts: resolvedFacts{},
+		DGD: dynamoDeployment,
 	})
 	result = programResult.Result
-	if programResult.Status != nil {
-		dynamoDeployment.Status = *programResult.Status
+	if statusErr := r.persistWorkloadProgramResult(ctx, dynamoDeployment, programResult); statusErr != nil {
+		logger.Error(statusErr, "unable to persist workload program status")
+		return result, statusErr
 	}
-	if err = programErr; err != nil {
-		logger.Error(err, "failed to reconcile the workload program")
-		reason = reasonFailedToReconcileResources
-		if programReason, ok := workloadProgramFailureReason(err); ok {
-			reason = programReason
-		}
-		return result, err
+	if programErr != nil {
+		logger.Error(programErr, "failed to reconcile the workload program")
+		return result, programErr
 	}
 
-	state = dynamoDeployment.Status.State
-	reason = programResult.ReadyReason
-	message = programResult.ReadyMessage
-
-	// Override state based on rolling update status if a rolling update is in progress
-	if dynamoDeployment.Status.RollingUpdate != nil {
-		switch dynamoDeployment.Status.RollingUpdate.Phase {
-		case nvidiacomv1beta1.RollingUpdatePhaseCompleted:
-			// Keep the reconcileResult state (should be Ready if resources are ready)
-		case nvidiacomv1beta1.RollingUpdatePhasePending, nvidiacomv1beta1.RollingUpdatePhaseInProgress:
-			// Rolling update in progress - resources are being transitioned
-			if state != nvidiacomv1beta1.DGDStateFailed {
-				state = nvidiacomv1beta1.DGDStatePending
-				reason = "rolling_update_in_progress"
-				message = "Rolling update in progress"
-			}
-		}
-	}
-
+	logger.Info("Reconciliation done")
 	return result, nil
+}
+
+func (r *DynamoGraphDeploymentReconciler) persistWorkloadProgramResult(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	result workloadProgramResult,
+) error {
+	dgd.Status = result.Status
+	if err := r.Status().Update(ctx, dgd); err != nil {
+		return fmt.Errorf("update DynamoGraphDeployment status: %w", err)
+	}
+	if r.Recorder != nil {
+		for _, event := range result.Events {
+			r.Recorder.Event(dgd, event.Type, event.Reason, event.Message)
+		}
+	}
+	return nil
 }
 
 type Resource interface {
@@ -359,10 +311,21 @@ func (r *DynamoGraphDeploymentReconciler) resolveProgramRestartState(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
+	result *workloadProgramResult,
 ) programRestart {
 	statusView := dgd.DeepCopy()
 	statusView.Status = *status
 	restartStatus := r.computeRestartStatus(ctx, statusView)
+	if restartStatus != nil && restartStatus.Phase == nvidiacomv1beta1.RestartPhaseSuperseded &&
+		(status.Restart == nil || status.Restart.ObservedID != restartStatus.ObservedID ||
+			status.Restart.Phase != restartStatus.Phase) {
+		result.Eventf(
+			corev1.EventTypeWarning,
+			"RestartSuperseded",
+			"Restart %s superseded by rolling update",
+			restartStatus.ObservedID,
+		)
+	}
 	return programRestart{
 		State:  dynamo.DetermineRestartState(statusView, restartStatus),
 		Status: restartStatus,
@@ -466,10 +429,15 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 	return updatedInProgress
 }
 
-// propagateTopologyCondition reads the PCS topology condition from Grove and maps it
-// to a TopologyLevelsAvailable condition on the DGD. This is a no-op when no
-// topology constraints are set or when the Grove pathway is not in use.
-func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context.Context, dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+// propagateTopologyCondition reads the PCS topology condition from Grove and
+// accumulates the corresponding TopologyLevelsAvailable condition in result.
+// This is a no-op when no topology constraints are set or when the Grove
+// pathway is not in use.
+func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	result *workloadProgramResult,
+) {
 	if !dgd.HasAnyTopologyConstraint() || !r.isGrovePathway(dgd) {
 		return
 	}
@@ -514,10 +482,10 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 			Reason:  reason,
 			Message: groveTopoCond.Message,
 		}
-		prev := meta.FindStatusCondition(dgd.Status.Conditions, nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable)
+		prev := meta.FindStatusCondition(result.Status.Conditions, nvidiacomv1beta1.ConditionTypeTopologyLevelsAvailable)
 		if prev == nil || prev.Status != metav1.ConditionFalse || prev.Reason != reason || prev.Message != groveTopoCond.Message {
 			logger.Info("Topology constraints no longer enforced", "reason", reason, "message", groveTopoCond.Message)
-			r.Recorder.Eventf(dgd, corev1.EventTypeWarning, reason, "Topology constraints no longer enforced: %s", groveTopoCond.Message)
+			result.Eventf(corev1.EventTypeWarning, reason, "Topology constraints no longer enforced: %s", groveTopoCond.Message)
 		}
 	} else {
 		// Grove's TopologyLevelsUnavailable is False → all levels available.
@@ -529,7 +497,7 @@ func (r *DynamoGraphDeploymentReconciler) propagateTopologyCondition(ctx context
 		}
 	}
 
-	dgd.AddStatusCondition(dynamoCond)
+	meta.SetStatusCondition(&result.Status.Conditions, dynamoCond)
 }
 
 func isRestartAlreadyProcessed(dgd *nvidiacomv1beta1.DynamoGraphDeployment) bool {
@@ -1413,8 +1381,6 @@ func (r *DynamoGraphDeploymentReconciler) computeRestartStatus(ctx context.Conte
 
 	// Supersede restart if a rolling update is in progress
 	if r.isRollingUpdateInProgress(&dgd.Status) {
-		r.Recorder.Eventf(dgd, corev1.EventTypeWarning, "RestartSuperseded",
-			"Restart %s superseded by rolling update", dgd.Spec.Restart.ID)
 		return &nvidiacomv1beta1.RestartStatus{
 			ObservedID: dgd.Spec.Restart.ID,
 			Phase:      nvidiacomv1beta1.RestartPhaseSuperseded,

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -199,28 +199,27 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	reconcileState := &graphReconcileState{DGD: dynamoDeployment}
-	program := r.selectWorkloadProgram(reconcileState)
-	if err = program.Reconcile(ctx, reconcileState); err != nil {
+	program := r.selectWorkloadProgram(dynamoDeployment)
+	programResult, programErr := program.Reconcile(ctx, workloadProgramRequest{
+		DGD:   dynamoDeployment,
+		Facts: resolvedFacts{},
+	})
+	result = programResult.Result
+	if programResult.Status != nil {
+		dynamoDeployment.Status = *programResult.Status
+	}
+	if err = programErr; err != nil {
 		logger.Error(err, "failed to reconcile the workload program")
 		reason = reasonFailedToReconcileResources
 		if programReason, ok := workloadProgramFailureReason(err); ok {
 			reason = programReason
 		}
-		return ctrl.Result{}, err
+		return result, err
 	}
-	reconcileResult := reconcileState.Result
 
-	// Assign status only after confirming the reconcile succeeded. On error,
-	// the selected program does not publish a new ReconcileResult; assigning a
-	// zero value here would wipe Components/Restart, which the deferred status
-	// update would then persist. Deferring the assignment past the error check
-	// preserves the last-known-good status on a transient failure.
-	state = reconcileResult.State
-	reason = reconcileResult.Reason
-	message = reconcileResult.Message
-	dynamoDeployment.Status.Components = reconcileResult.ComponentStatus
-	dynamoDeployment.Status.Restart = reconcileResult.RestartStatus
+	state = dynamoDeployment.Status.State
+	reason = programResult.ReadyReason
+	message = programResult.ReadyMessage
 
 	// Override state based on rolling update status if a rolling update is in progress
 	if dynamoDeployment.Status.RollingUpdate != nil {
@@ -237,7 +236,7 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 		}
 	}
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 type Resource interface {
@@ -258,18 +257,18 @@ type ReconcileResult struct {
 // complete before a selected workload program realizes its workload graph.
 func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
 	ctx context.Context,
-	state *graphReconcileState,
-) error {
+	dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment,
+) (programInputs, error) {
 	logger := log.FromContext(ctx)
-	dynamoDeployment := state.DGD
+	inputs := programInputs{}
 
 	// Ensure planner RBAC exists in cluster-wide mode
 	if r.Config.Namespace.Restricted == "" {
 		if r.RBACManager == nil {
-			return fmt.Errorf("RBAC manager not initialized in cluster-wide mode")
+			return inputs, fmt.Errorf("RBAC manager not initialized in cluster-wide mode")
 		}
 		if r.Config.RBAC.PlannerClusterRoleName == "" {
-			return fmt.Errorf("planner ClusterRole name is required in cluster-wide mode")
+			return inputs, fmt.Errorf("planner ClusterRole name is required in cluster-wide mode")
 		}
 		if err := r.RBACManager.EnsureServiceAccountWithRBAC(
 			ctx,
@@ -278,13 +277,13 @@ func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
 			r.Config.RBAC.PlannerClusterRoleName,
 		); err != nil {
 			logger.Error(err, "Failed to ensure planner RBAC")
-			return fmt.Errorf("failed to ensure planner RBAC: %w", err)
+			return inputs, fmt.Errorf("failed to ensure planner RBAC: %w", err)
 		}
 
 		// Ensure EPP RBAC exists in cluster-wide mode if EPP service is present
 		if dynamoDeployment.HasEPPComponent() {
 			if r.Config.RBAC.EPPClusterRoleName == "" {
-				return fmt.Errorf("EPP ClusterRole name is required in cluster-wide mode when EPP service is present")
+				return inputs, fmt.Errorf("EPP ClusterRole name is required in cluster-wide mode when EPP service is present")
 			}
 			if err := r.RBACManager.EnsureServiceAccountWithRBAC(
 				ctx,
@@ -293,7 +292,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
 				r.Config.RBAC.EPPClusterRoleName,
 			); err != nil {
 				logger.Error(err, "Failed to ensure EPP RBAC")
-				return fmt.Errorf("failed to ensure EPP RBAC: %w", err)
+				return inputs, fmt.Errorf("failed to ensure EPP RBAC: %w", err)
 			}
 		}
 	}
@@ -302,7 +301,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
 	err := r.reconcilePVCs(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile top-level PVCs")
-		return fmt.Errorf("failed to reconcile top-level PVCs: %w", err)
+		return inputs, fmt.Errorf("failed to reconcile top-level PVCs: %w", err)
 	}
 
 	// Reconcile discovery RBAC before checkpoints so auto-created checkpoint
@@ -311,77 +310,84 @@ func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
 	err = r.reconcileK8sDiscoveryResources(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile K8s discovery resources")
-		return fmt.Errorf("failed to reconcile K8s discovery resources: %w", err)
+		return inputs, fmt.Errorf("failed to reconcile K8s discovery resources: %w", err)
 	}
 
 	if err := r.reconcileGMSResourceClaimTemplates(ctx, dynamoDeployment); err != nil {
-		return err
+		return inputs, err
 	}
 
 	// Reconcile checkpoints for components with checkpointing enabled.
 	checkpointStatuses, checkpointInfos, err := r.reconcileCheckpoints(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile checkpoints")
-		return fmt.Errorf("failed to reconcile checkpoints: %w", err)
+		return inputs, fmt.Errorf("failed to reconcile checkpoints: %w", err)
 	}
-	dynamoDeployment.Status.Checkpoints = checkpointStatuses
+	inputs.CheckpointStatuses = checkpointStatuses
+	inputs.CheckpointInfos = checkpointInfos
 
 	// Reconcile EPP resources (ConfigMaps, Services, InferencePools) if EPP service exists
 	err = r.reconcileEPPResources(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile EPP resources")
-		return fmt.Errorf("failed to reconcile EPP resources: %w", err)
+		return inputs, fmt.Errorf("failed to reconcile EPP resources: %w", err)
 	}
 
 	// Reconcile the wait-for-leader ConfigMap for multinode mp deployments
 	err = r.reconcileWaitLeaderConfigMap(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile wait-leader ConfigMap")
-		return fmt.Errorf("failed to reconcile wait-leader ConfigMap: %w", err)
+		return inputs, fmt.Errorf("failed to reconcile wait-leader ConfigMap: %w", err)
 	}
 
 	// Determine if any component is multinode.
-	hasMultinode := dynamoDeployment.HasAnyMultinodeComponent()
+	inputs.HasMultinode = dynamoDeployment.HasAnyMultinodeComponent()
 
-	if r.SSHKeyManager != nil && hasMultinode {
+	if r.SSHKeyManager != nil && inputs.HasMultinode {
 		if err := r.SSHKeyManager.EnsureAndReplicate(ctx, dynamoDeployment.Namespace); err != nil {
 			logger.Error(err, "Failed to ensure MPI SSH key secret", "namespace", dynamoDeployment.Namespace)
-			return fmt.Errorf("failed to ensure MPI SSH key secret: %w", err)
+			return inputs, fmt.Errorf("failed to ensure MPI SSH key secret: %w", err)
 		}
 	}
 
-	state.HasMultinode = hasMultinode
-	state.CheckpointInfos = checkpointInfos
-	return nil
+	return inputs, nil
 }
 
-// resolveProgramRestartState enriches the ephemeral state after shared
-// resources and pathway-specific input validation have completed.
+// resolveProgramRestartState derives restart state after shared resources and
+// pathway-specific input validation have completed.
 func (r *DynamoGraphDeploymentReconciler) resolveProgramRestartState(
 	ctx context.Context,
-	state *graphReconcileState,
-) {
-	state.RestartStatus = r.computeRestartStatus(ctx, state.DGD)
-	state.RestartState = dynamo.DetermineRestartState(state.DGD, state.RestartStatus)
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
+) programRestart {
+	statusView := dgd.DeepCopy()
+	statusView.Status = *status
+	restartStatus := r.computeRestartStatus(ctx, statusView)
+	return programRestart{
+		State:  dynamo.DetermineRestartState(statusView, restartStatus),
+		Status: restartStatus,
+	}
 }
 
 // reconcileProgramResult applies the shared post-workload policies after the
 // selected program has produced a successful workload result.
 func (r *DynamoGraphDeploymentReconciler) reconcileProgramResult(
 	ctx context.Context,
-	state *graphReconcileState,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	inputs programInputs,
+	restart programRestart,
 	result ReconcileResult,
 ) (ReconcileResult, error) {
 	logger := log.FromContext(ctx)
-	result.RestartStatus = state.RestartStatus
-	result = applyCheckpointStartupReadiness(result, state.CheckpointInfos)
+	result.RestartStatus = restart.Status
+	result = applyCheckpointStartupReadiness(result, inputs.CheckpointInfos)
 
 	// Reconcile DynamoGraphDeploymentScalingAdapters after applying checkpoint
 	// startup readiness. In WaitForCheckpoint, the DGD deliberately reports
 	// pending before regular workers exist; letting a scaling adapter write
 	// replicas while gated would create an avoidable update loop.
 	if result.State != nvidiacomv1beta1.DGDStatePending || result.Reason != "waiting_for_checkpoint" {
-		if err := r.reconcileScalingAdapters(ctx, state.DGD); err != nil {
+		if err := r.reconcileScalingAdapters(ctx, dgd); err != nil {
 			logger.Error(err, "Failed to reconcile scaling adapters")
 			return ReconcileResult{}, fmt.Errorf("failed to reconcile scaling adapters: %w", err)
 		}
@@ -1406,7 +1412,7 @@ func (r *DynamoGraphDeploymentReconciler) computeRestartStatus(ctx context.Conte
 	}
 
 	// Supersede restart if a rolling update is in progress
-	if r.isRollingUpdateInProgress(dgd) {
+	if r.isRollingUpdateInProgress(&dgd.Status) {
 		r.Recorder.Eventf(dgd, corev1.EventTypeWarning, "RestartSuperseded",
 			"Restart %s superseded by rolling update", dgd.Spec.Restart.ID)
 		return &nvidiacomv1beta1.RestartStatus{

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -73,6 +73,8 @@ type Message string
 
 const (
 	reasonFailedToInitializeWorkerHash Reason = "failed_to_initialize_worker_hash"
+	reasonFailedToMigrateWorkerHash    Reason = "failed_to_migrate_worker_hash"
+	reasonFailedToReconcileResources   Reason = "failed_to_reconcile_the_resources"
 	reasonRollingUpdateFailed          Reason = "rolling_update_failed"
 
 	dgdComponentPodIndex = ".metadata.dgdComponent"
@@ -197,107 +199,23 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 		return ctrl.Result{}, nil
 	}
 
-	if err = r.migrateCurrentWorkerHashIfNeeded(ctx, dynamoDeployment); err != nil {
-		logger.Error(err, "Failed to migrate worker hash")
-		reason = "failed_to_migrate_worker_hash"
+	reconcileState := &graphReconcileState{DGD: dynamoDeployment}
+	program := r.selectWorkloadProgram(reconcileState)
+	if err = program.Reconcile(ctx, reconcileState); err != nil {
+		logger.Error(err, "failed to reconcile the workload program")
+		reason = reasonFailedToReconcileResources
+		if programReason, ok := workloadProgramFailureReason(err); ok {
+			reason = programReason
+		}
 		return ctrl.Result{}, err
 	}
-
-	if r.supportsManagedRollingUpdate(dynamoDeployment) {
-		if err = r.initializeWorkerHashIfNeeded(ctx, dynamoDeployment); err != nil {
-			logger.Error(err, "Failed to initialize worker hash")
-			reason = reasonFailedToInitializeWorkerHash
-			message = Message(err.Error())
-			return ctrl.Result{}, err
-		}
-
-		rollingUpdateInProgress := r.isRollingUpdateInProgress(dynamoDeployment)
-		triggerRollingUpdate := false
-		if !rollingUpdateInProgress {
-			triggerRollingUpdate, err = r.shouldTriggerRollingUpdate(dynamoDeployment)
-			if err != nil {
-				logger.Error(err, "Failed to check rolling update trigger")
-				state = nvidiacomv1beta1.DGDStateFailed
-				reason = reasonRollingUpdateFailed
-				message = Message(err.Error())
-				return ctrl.Result{}, err
-			}
-		}
-		if rollingUpdateInProgress || triggerRollingUpdate {
-			if err = r.reconcileRollingUpdate(ctx, dynamoDeployment); err != nil {
-				logger.Error(err, "Failed to reconcile rolling update")
-				state = nvidiacomv1beta1.DGDStateFailed
-				reason = reasonRollingUpdateFailed
-				message = Message(err.Error())
-				return ctrl.Result{}, err
-			}
-		}
-	} else {
-		if r.currentWorkerHashes(dynamoDeployment).empty() {
-			hashes, err := r.desiredWorkerHashes(dynamoDeployment)
-			if err != nil {
-				logger.Error(err, "Failed to compute worker hash for unsupported pathway")
-				reason = reasonFailedToInitializeWorkerHash
-				message = Message(err.Error())
-				return ctrl.Result{}, err
-			}
-			r.setCurrentWorkerHashes(dynamoDeployment, workerHashesForCompletedGeneration(hashes.v2, hashes))
-			if updateErr := r.Update(ctx, dynamoDeployment); updateErr != nil {
-				logger.Error(updateErr, "Failed to initialize worker hash for unsupported pathway")
-				reason = reasonFailedToInitializeWorkerHash
-				message = Message(updateErr.Error())
-				return ctrl.Result{}, updateErr
-			}
-		}
-
-		// For unsupported pathways, log if a rolling update would have been triggered
-		triggerRollingUpdate, err := r.shouldTriggerRollingUpdate(dynamoDeployment)
-		if err != nil {
-			logger.Error(err, "Failed to check rolling update trigger for unsupported pathway")
-			state = nvidiacomv1beta1.DGDStateFailed
-			reason = reasonRollingUpdateFailed
-			message = Message(err.Error())
-			return ctrl.Result{}, err
-		}
-		if triggerRollingUpdate {
-			logger.Info("Worker spec change detected but rolling update not supported for this pathway",
-				"isGrove", r.isGrovePathway(dynamoDeployment),
-				"hasMultinode", dynamoDeployment.HasAnyMultinodeComponent())
-			r.Recorder.Event(dynamoDeployment, corev1.EventTypeWarning, "RollingUpdateNotSupported",
-				"Worker spec changed but custom rolling updates are not supported for Grove/multinode deployments")
-
-			// Update the hash to prevent repeated warnings. If the unsupported
-			// path is processing a v2-only worker change, preserve the migrated
-			// v2-only state instead of resurrecting the downgrade-compatible v1
-			// annotation for pod contents it no longer represents.
-			hashes, err := r.desiredWorkerHashes(dynamoDeployment)
-			if err != nil {
-				logger.Error(err, "Failed to compute worker hash for unsupported pathway")
-				state = nvidiacomv1beta1.DGDStateFailed
-				reason = reasonRollingUpdateFailed
-				message = Message(err.Error())
-				return ctrl.Result{}, err
-			}
-			r.setCurrentWorkerHashes(dynamoDeployment, r.workerHashesForUnsupportedPathway(dynamoDeployment, hashes))
-			if updateErr := r.Update(ctx, dynamoDeployment); updateErr != nil {
-				logger.Error(updateErr, "Failed to update worker hash for unsupported pathway")
-			}
-		}
-	}
-
-	reconcileResult, err := r.reconcileResources(ctx, dynamoDeployment)
-
-	if err != nil {
-		logger.Error(err, "failed to reconcile the resources")
-		reason = "failed_to_reconcile_the_resources"
-		return ctrl.Result{}, err
-	}
+	reconcileResult := reconcileState.Result
 
 	// Assign status only after confirming the reconcile succeeded. On error,
-	// reconcileResources returns an empty ReconcileResult; assigning it here
-	// would wipe Components/Restart, which the deferred status update would then
-	// persist. Deferring the assignment past the error check preserves the
-	// last-known-good status on a transient failure.
+	// the selected program does not publish a new ReconcileResult; assigning a
+	// zero value here would wipe Components/Restart, which the deferred status
+	// update would then persist. Deferring the assignment past the error check
+	// preserves the last-known-good status on a transient failure.
 	state = reconcileResult.State
 	reason = reconcileResult.Reason
 	message = reconcileResult.Message
@@ -336,16 +254,22 @@ type ReconcileResult struct {
 	RestartStatus   *nvidiacomv1beta1.RestartStatus
 }
 
-func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment) (ReconcileResult, error) {
+// reconcileProgramInputs runs the shared resource reconcilers that must
+// complete before a selected workload program realizes its workload graph.
+func (r *DynamoGraphDeploymentReconciler) reconcileProgramInputs(
+	ctx context.Context,
+	state *graphReconcileState,
+) error {
 	logger := log.FromContext(ctx)
+	dynamoDeployment := state.DGD
 
 	// Ensure planner RBAC exists in cluster-wide mode
 	if r.Config.Namespace.Restricted == "" {
 		if r.RBACManager == nil {
-			return ReconcileResult{}, fmt.Errorf("RBAC manager not initialized in cluster-wide mode")
+			return fmt.Errorf("RBAC manager not initialized in cluster-wide mode")
 		}
 		if r.Config.RBAC.PlannerClusterRoleName == "" {
-			return ReconcileResult{}, fmt.Errorf("planner ClusterRole name is required in cluster-wide mode")
+			return fmt.Errorf("planner ClusterRole name is required in cluster-wide mode")
 		}
 		if err := r.RBACManager.EnsureServiceAccountWithRBAC(
 			ctx,
@@ -354,13 +278,13 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 			r.Config.RBAC.PlannerClusterRoleName,
 		); err != nil {
 			logger.Error(err, "Failed to ensure planner RBAC")
-			return ReconcileResult{}, fmt.Errorf("failed to ensure planner RBAC: %w", err)
+			return fmt.Errorf("failed to ensure planner RBAC: %w", err)
 		}
 
 		// Ensure EPP RBAC exists in cluster-wide mode if EPP service is present
 		if dynamoDeployment.HasEPPComponent() {
 			if r.Config.RBAC.EPPClusterRoleName == "" {
-				return ReconcileResult{}, fmt.Errorf("EPP ClusterRole name is required in cluster-wide mode when EPP service is present")
+				return fmt.Errorf("EPP ClusterRole name is required in cluster-wide mode when EPP service is present")
 			}
 			if err := r.RBACManager.EnsureServiceAccountWithRBAC(
 				ctx,
@@ -369,7 +293,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 				r.Config.RBAC.EPPClusterRoleName,
 			); err != nil {
 				logger.Error(err, "Failed to ensure EPP RBAC")
-				return ReconcileResult{}, fmt.Errorf("failed to ensure EPP RBAC: %w", err)
+				return fmt.Errorf("failed to ensure EPP RBAC: %w", err)
 			}
 		}
 	}
@@ -378,7 +302,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	err := r.reconcilePVCs(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile top-level PVCs")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile top-level PVCs: %w", err)
+		return fmt.Errorf("failed to reconcile top-level PVCs: %w", err)
 	}
 
 	// Reconcile discovery RBAC before checkpoints so auto-created checkpoint
@@ -387,18 +311,18 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	err = r.reconcileK8sDiscoveryResources(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile K8s discovery resources")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile K8s discovery resources: %w", err)
+		return fmt.Errorf("failed to reconcile K8s discovery resources: %w", err)
 	}
 
 	if err := r.reconcileGMSResourceClaimTemplates(ctx, dynamoDeployment); err != nil {
-		return ReconcileResult{}, err
+		return err
 	}
 
 	// Reconcile checkpoints for components with checkpointing enabled.
 	checkpointStatuses, checkpointInfos, err := r.reconcileCheckpoints(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile checkpoints")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile checkpoints: %w", err)
+		return fmt.Errorf("failed to reconcile checkpoints: %w", err)
 	}
 	dynamoDeployment.Status.Checkpoints = checkpointStatuses
 
@@ -406,14 +330,14 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	err = r.reconcileEPPResources(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile EPP resources")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile EPP resources: %w", err)
+		return fmt.Errorf("failed to reconcile EPP resources: %w", err)
 	}
 
 	// Reconcile the wait-for-leader ConfigMap for multinode mp deployments
 	err = r.reconcileWaitLeaderConfigMap(ctx, dynamoDeployment)
 	if err != nil {
 		logger.Error(err, "Failed to reconcile wait-leader ConfigMap")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile wait-leader ConfigMap: %w", err)
+		return fmt.Errorf("failed to reconcile wait-leader ConfigMap: %w", err)
 	}
 
 	// Determine if any component is multinode.
@@ -422,42 +346,42 @@ func (r *DynamoGraphDeploymentReconciler) reconcileResources(ctx context.Context
 	if r.SSHKeyManager != nil && hasMultinode {
 		if err := r.SSHKeyManager.EnsureAndReplicate(ctx, dynamoDeployment.Namespace); err != nil {
 			logger.Error(err, "Failed to ensure MPI SSH key secret", "namespace", dynamoDeployment.Namespace)
-			return ReconcileResult{}, fmt.Errorf("failed to ensure MPI SSH key secret: %w", err)
+			return fmt.Errorf("failed to ensure MPI SSH key secret: %w", err)
 		}
 	}
 
-	// return error early if Grove and LWS is not available for multinode
-	if !r.isGrovePathway(dynamoDeployment) && hasMultinode && !r.RuntimeConfig.Gate.Enabled(features.LWS) {
-		err := fmt.Errorf("no multinode orchestrator available")
-		logger.Error(err, err.Error(), "hasMultinode", hasMultinode, "lwsEnabled", r.RuntimeConfig.Gate.Enabled(features.LWS))
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
-	}
+	state.HasMultinode = hasMultinode
+	state.CheckpointInfos = checkpointInfos
+	return nil
+}
 
-	restartStatus := r.computeRestartStatus(ctx, dynamoDeployment)
-	restartState := dynamo.DetermineRestartState(dynamoDeployment, restartStatus)
+// resolveProgramRestartState enriches the ephemeral state after shared
+// resources and pathway-specific input validation have completed.
+func (r *DynamoGraphDeploymentReconciler) resolveProgramRestartState(
+	ctx context.Context,
+	state *graphReconcileState,
+) {
+	state.RestartStatus = r.computeRestartStatus(ctx, state.DGD)
+	state.RestartState = dynamo.DetermineRestartState(state.DGD, state.RestartStatus)
+}
 
-	state := &graphReconcileState{
-		DGD:             dynamoDeployment,
-		HasMultinode:    hasMultinode,
-		RestartState:    restartState,
-		CheckpointInfos: checkpointInfos,
-	}
-	program := r.selectWorkloadProgram(state)
-	if err := program.Reconcile(ctx, state); err != nil {
-		logger.Error(err, "Failed to reconcile workload program")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile workload program: %w", err)
-	}
-	result := state.Result
-	result.RestartStatus = restartStatus
-	result = applyCheckpointStartupReadiness(result, checkpointInfos)
+// reconcileProgramResult applies the shared post-workload policies after the
+// selected program has produced a successful workload result.
+func (r *DynamoGraphDeploymentReconciler) reconcileProgramResult(
+	ctx context.Context,
+	state *graphReconcileState,
+	result ReconcileResult,
+) (ReconcileResult, error) {
+	logger := log.FromContext(ctx)
+	result.RestartStatus = state.RestartStatus
+	result = applyCheckpointStartupReadiness(result, state.CheckpointInfos)
 
 	// Reconcile DynamoGraphDeploymentScalingAdapters after applying checkpoint
 	// startup readiness. In WaitForCheckpoint, the DGD deliberately reports
 	// pending before regular workers exist; letting a scaling adapter write
 	// replicas while gated would create an avoidable update loop.
 	if result.State != nvidiacomv1beta1.DGDStatePending || result.Reason != "waiting_for_checkpoint" {
-		err = r.reconcileScalingAdapters(ctx, dynamoDeployment)
-		if err != nil {
+		if err := r.reconcileScalingAdapters(ctx, state.DGD); err != nil {
 			logger.Error(err, "Failed to reconcile scaling adapters")
 			return ReconcileResult{}, fmt.Errorf("failed to reconcile scaling adapters: %w", err)
 		}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -4775,23 +4775,21 @@ func TestPropagateTopologyCondition(t *testing.T) {
 			}
 
 			fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
-			recorder := record.NewFakeRecorder(10)
-
 			reconciler := &DynamoGraphDeploymentReconciler{
-				Client:   fakeClient,
-				Recorder: recorder,
+				Client: fakeClient,
 				RuntimeConfig: &controller_common.RuntimeConfig{
 					Gate: features.Gates{Grove: tt.groveEnabled},
 				},
 			}
 
 			ctx := context.Background()
-			reconciler.propagateTopologyCondition(ctx, tt.dgd)
+			programResult := newWorkloadProgramResult(tt.dgd)
+			reconciler.propagateTopologyCondition(ctx, tt.dgd, &programResult)
 
 			var topoCond *metav1.Condition
-			for i := range tt.dgd.Status.Conditions {
-				if tt.dgd.Status.Conditions[i].Type == v1alpha1.ConditionTypeTopologyLevelsAvailable {
-					topoCond = &tt.dgd.Status.Conditions[i]
+			for i := range programResult.Status.Conditions {
+				if programResult.Status.Conditions[i].Type == v1alpha1.ConditionTypeTopologyLevelsAvailable {
+					topoCond = &programResult.Status.Conditions[i]
 					break
 				}
 			}
@@ -4805,12 +4803,8 @@ func TestPropagateTopologyCondition(t *testing.T) {
 			g.Expect(topoCond.Status).To(gomega.Equal(tt.wantStatus))
 			g.Expect(topoCond.Reason).To(gomega.Equal(tt.wantReason))
 
-			close(recorder.Events)
-			eventCount := 0
-			for range recorder.Events {
-				eventCount++
-			}
-			g.Expect(eventCount).To(gomega.Equal(tt.wantEventCount))
+			g.Expect(programResult.Events).To(gomega.HaveLen(tt.wantEventCount))
+			g.Expect(tt.dgd.Status.Conditions).To(gomega.BeEmpty(), "status projection must remain local until the outer status write")
 		})
 	}
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -506,7 +506,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_DRAV
 	}
 }
 
-func TestDynamoGraphDeploymentReconciler_reconcileResources_ValidatesGMSResourceClaimTemplatesBeforePathway(t *testing.T) {
+func TestDynamoGraphDeploymentReconciler_reconcileProgramInputs_ValidatesGMSResourceClaimTemplatesBeforePathway(t *testing.T) {
 	ctx := context.Background()
 	g := gomega.NewGomegaWithT(t)
 	s := newDynamoGraphDeploymentControllerTestScheme(t)
@@ -537,7 +537,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileResources_ValidatesGMSResource
 		RuntimeConfig: &controller_common.RuntimeConfig{},
 	}
 
-	_, err := reconciler.reconcileResources(ctx, dgd)
+	err := reconciler.reconcileProgramInputs(ctx, &graphReconcileState{DGD: dgd})
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("requires DRA"))
 	g.Expect(err.Error()).To(gomega.ContainSubstring("explicitly disabled"))
@@ -3945,7 +3945,7 @@ func Test_computeRestartStatus(t *testing.T) {
 	}
 }
 
-func TestComponentProgram_Reconcile(t *testing.T) {
+func TestComponentProgram_ReconcileWorkloads(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
@@ -4578,10 +4578,10 @@ func TestComponentProgram_Reconcile(t *testing.T) {
 			}
 
 			state := &graphReconcileState{DGD: dgd}
-			err = (&componentProgram{reconciler: reconciler}).Reconcile(ctx, state)
+			result, err := (&componentProgram{reconciler: reconciler}).reconcileWorkloads(ctx, state)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
-			g.Expect(state.Result).To(gomega.Equal(tt.wantReconcileResult))
+			g.Expect(result).To(gomega.Equal(tt.wantReconcileResult))
 		})
 	}
 }

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -537,7 +537,7 @@ func TestDynamoGraphDeploymentReconciler_reconcileProgramInputs_ValidatesGMSReso
 		RuntimeConfig: &controller_common.RuntimeConfig{},
 	}
 
-	err := reconciler.reconcileProgramInputs(ctx, &graphReconcileState{DGD: dgd})
+	_, err := reconciler.reconcileProgramInputs(ctx, dgd)
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("requires DRA"))
 	g.Expect(err.Error()).To(gomega.ContainSubstring("explicitly disabled"))
@@ -4577,8 +4577,10 @@ func TestComponentProgram_ReconcileWorkloads(t *testing.T) {
 				RuntimeConfig: &controller_common.RuntimeConfig{},
 			}
 
-			state := &graphReconcileState{DGD: dgd}
-			result, err := (&componentProgram{reconciler: reconciler}).reconcileWorkloads(ctx, state)
+			result, err := (&componentProgram{reconciler: reconciler}).reconcileWorkloads(
+				ctx,
+				workloadReconcileRequest{DGD: dgd},
+			)
 			g.Expect(err).NotTo(gomega.HaveOccurred())
 
 			g.Expect(result).To(gomega.Equal(tt.wantReconcileResult))

--- a/deploy/operator/internal/controller/dynamographdeployment_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -42,6 +43,7 @@ type graphReconcileState struct {
 	DGD             *nvidiacomv1beta1.DynamoGraphDeployment
 	HasMultinode    bool
 	RestartState    *dynamo.RestartState
+	RestartStatus   *nvidiacomv1beta1.RestartStatus
 	CheckpointInfos map[string]*checkpoint.CheckpointInfo
 	Result          ReconcileResult
 }
@@ -52,6 +54,31 @@ type graphReconcileState struct {
 // lifecycle callbacks.
 type workloadProgram interface {
 	Reconcile(context.Context, *graphReconcileState) error
+}
+
+type workloadProgramFailure struct {
+	reason Reason
+	err    error
+}
+
+func (e *workloadProgramFailure) Error() string {
+	return e.err.Error()
+}
+
+func (e *workloadProgramFailure) Unwrap() error {
+	return e.err
+}
+
+func failWorkloadProgram(reason Reason, err error) error {
+	return &workloadProgramFailure{reason: reason, err: err}
+}
+
+func workloadProgramFailureReason(err error) (Reason, bool) {
+	var failure *workloadProgramFailure
+	if !errors.As(err, &failure) {
+		return "", false
+	}
+	return failure.reason, true
 }
 
 // groveReconcileFunc is the temporary strangler seam around the existing Grove
@@ -71,25 +98,52 @@ type componentProgram struct {
 	lwsEnabled bool
 }
 
+// Reconcile composes the complete component pathway. Each earlier operation
+// enriches the ephemeral state consumed by the later workload and result
+// operations; only the final successful result is published back to state.
 func (p *componentProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
 	log.FromContext(ctx).Info(
 		"Reconciling Dynamo components deployments",
-		"hasMultinode", state.HasMultinode,
+		"hasMultinode", state.DGD.HasAnyMultinodeComponent(),
 		"lwsEnabled", p.lwsEnabled,
 	)
 
-	result, err := p.reconcile(ctx, state)
+	if err := p.reconcileWorkerRollout(ctx, state.DGD); err != nil {
+		return err
+	}
+	if err := p.reconciler.reconcileProgramInputs(ctx, state); err != nil {
+		return err
+	}
+	if state.HasMultinode && !p.lwsEnabled {
+		err := fmt.Errorf("no multinode orchestrator available")
+		log.FromContext(ctx).Error(
+			err,
+			err.Error(),
+			"hasMultinode", state.HasMultinode,
+			"lwsEnabled", p.lwsEnabled,
+		)
+		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+	}
+	p.reconciler.resolveProgramRestartState(ctx, state)
+
+	result, err := p.reconcileWorkloads(ctx, state)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+	}
+	result, err = p.reconciler.reconcileProgramResult(ctx, state, result)
 	if err != nil {
 		return err
 	}
+
 	state.Result = result
 	return nil
 }
 
-// reconcile owns the component pathway's complete DCD graph reconciliation.
+// reconcileWorkloads owns the component pathway's complete DCD graph
+// reconciliation.
 // Managed rolling-update helpers remain on the DGD reconciler until their
 // dedicated extraction; this program owns when they participate in the flow.
-func (p *componentProgram) reconcile(
+func (p *componentProgram) reconcileWorkloads(
 	ctx context.Context,
 	state *graphReconcileState,
 ) (ReconcileResult, error) {
@@ -171,6 +225,113 @@ func (p *componentProgram) reconcile(
 	}
 
 	return result, nil
+}
+
+func (p *componentProgram) reconcileWorkerRollout(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) error {
+	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, dgd); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
+		return failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
+	}
+
+	if p.supportsManagedRollingUpdate(dgd) {
+		return p.reconcileManagedWorkerRollout(ctx, dgd)
+	}
+	return reconcileUnsupportedWorkerRollout(ctx, p.reconciler, dgd, false)
+}
+
+func (p *componentProgram) reconcileManagedWorkerRollout(
+	ctx context.Context,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) error {
+	r := p.reconciler
+	logger := log.FromContext(ctx)
+
+	if err := r.initializeWorkerHashIfNeeded(ctx, dgd); err != nil {
+		logger.Error(err, "Failed to initialize worker hash")
+		return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
+	}
+
+	rollingUpdateInProgress := r.isRollingUpdateInProgress(dgd)
+	triggerRollingUpdate := false
+	if !rollingUpdateInProgress {
+		var err error
+		triggerRollingUpdate, err = r.shouldTriggerRollingUpdate(dgd)
+		if err != nil {
+			logger.Error(err, "Failed to check rolling update trigger")
+			return failWorkloadProgram(reasonRollingUpdateFailed, err)
+		}
+	}
+	if rollingUpdateInProgress || triggerRollingUpdate {
+		if err := r.reconcileRollingUpdate(ctx, dgd); err != nil {
+			logger.Error(err, "Failed to reconcile rolling update")
+			return failWorkloadProgram(reasonRollingUpdateFailed, err)
+		}
+	}
+	return nil
+}
+
+func reconcileUnsupportedWorkerRollout(
+	ctx context.Context,
+	r *DynamoGraphDeploymentReconciler,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	isGrove bool,
+) error {
+	logger := log.FromContext(ctx)
+
+	if r.currentWorkerHashes(dgd).empty() {
+		hashes, err := r.desiredWorkerHashes(dgd)
+		if err != nil {
+			logger.Error(err, "Failed to compute worker hash for unsupported pathway")
+			return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
+		}
+		r.setCurrentWorkerHashes(dgd, workerHashesForCompletedGeneration(hashes.v2, hashes))
+		if err := r.Update(ctx, dgd); err != nil {
+			logger.Error(err, "Failed to initialize worker hash for unsupported pathway")
+			return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
+		}
+	}
+
+	// For unsupported pathways, log if a rolling update would have been triggered.
+	triggerRollingUpdate, err := r.shouldTriggerRollingUpdate(dgd)
+	if err != nil {
+		logger.Error(err, "Failed to check rolling update trigger for unsupported pathway")
+		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+	}
+	if !triggerRollingUpdate {
+		return nil
+	}
+
+	logger.Info(
+		"Worker spec change detected but rolling update not supported for this pathway",
+		"isGrove", isGrove,
+		"hasMultinode", dgd.HasAnyMultinodeComponent(),
+	)
+	r.Recorder.Event(
+		dgd,
+		corev1.EventTypeWarning,
+		"RollingUpdateNotSupported",
+		"Worker spec changed but custom rolling updates are not supported for Grove/multinode deployments",
+	)
+
+	// Update the hash to prevent repeated warnings. If the unsupported path is
+	// processing a v2-only worker change, preserve the migrated v2-only state
+	// instead of resurrecting the downgrade-compatible v1 annotation for pod
+	// contents it no longer represents.
+	hashes, err := r.desiredWorkerHashes(dgd)
+	if err != nil {
+		logger.Error(err, "Failed to compute worker hash for unsupported pathway")
+		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+	}
+	r.setCurrentWorkerHashes(dgd, r.workerHashesForUnsupportedPathway(dgd, hashes))
+	if err := r.Update(ctx, dgd); err != nil {
+		// Preserve the existing best-effort behavior: the next reconciliation
+		// retries the metadata update and may emit another warning.
+		logger.Error(err, "Failed to update worker hash for unsupported pathway")
+	}
+	return nil
 }
 
 func (p *componentProgram) applyCheckpointStartupPolicy(
@@ -258,28 +419,59 @@ func (p *componentProgram) preserveExistingBackendFramework(
 }
 
 type groveProgram struct {
+	reconciler *DynamoGraphDeploymentReconciler
 	reconcile  groveReconcileFunc
 	lwsEnabled bool
 }
 
+// Reconcile composes the current Grove pathway around its temporary workload
+// adapter while keeping shared resource ordering and result publication
+// identical to the component program.
 func (p *groveProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
 	log.FromContext(ctx).Info(
 		"Reconciling Grove resources",
-		"hasMultinode", state.HasMultinode,
+		"hasMultinode", state.DGD.HasAnyMultinodeComponent(),
 		"lwsEnabled", p.lwsEnabled,
 	)
 
-	result, err := p.reconcile(
+	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, state.DGD); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
+		return failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
+	}
+	if err := reconcileUnsupportedWorkerRollout(ctx, p.reconciler, state.DGD, true); err != nil {
+		return err
+	}
+	if err := p.reconciler.reconcileProgramInputs(ctx, state); err != nil {
+		return err
+	}
+	p.reconciler.resolveProgramRestartState(ctx, state)
+
+	result, err := p.reconcileWorkloads(
+		ctx,
+		state,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+	}
+	result, err = p.reconciler.reconcileProgramResult(ctx, state, result)
+	if err != nil {
+		return err
+	}
+
+	state.Result = result
+	return nil
+}
+
+func (p *groveProgram) reconcileWorkloads(
+	ctx context.Context,
+	state *graphReconcileState,
+) (ReconcileResult, error) {
+	return p.reconcile(
 		ctx,
 		state.DGD,
 		state.RestartState,
 		state.CheckpointInfos,
 	)
-	if err != nil {
-		return err
-	}
-	state.Result = result
-	return nil
 }
 
 func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
@@ -287,6 +479,7 @@ func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
 ) workloadProgram {
 	if r.isGrovePathway(state.DGD) {
 		return &groveProgram{
+			reconciler: r,
 			reconcile:  r.reconcileGroveResources,
 			lwsEnabled: r.RuntimeConfig.Gate.Enabled(features.LWS),
 		}

--- a/deploy/operator/internal/controller/dynamographdeployment_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program.go
@@ -32,20 +32,45 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// graphReconcileState is ephemeral state shared by the common DGD flow and the
-// selected workload program during one reconciliation. It is intentionally
-// small: dependencies belong to concrete programs, and provider-native API
-// objects must not be added here.
-type graphReconcileState struct {
+// resolvedFacts contains immutable observations resolved independently of the
+// selected workload program. It is intentionally empty until such a fact is
+// demonstrated; program-derived values remain typed locals.
+type resolvedFacts struct{}
+
+type workloadProgramRequest struct {
+	// DGD is the mutable primary object. Programs may mutate and directly
+	// persist non-status fields; status is returned through workloadProgramResult.
+	DGD *nvidiacomv1beta1.DynamoGraphDeployment
+
+	Facts resolvedFacts
+}
+
+type workloadProgramResult struct {
+	ctrl.Result
+	Status       *nvidiacomv1beta1.DynamoGraphDeploymentStatus
+	ReadyReason  Reason
+	ReadyMessage Message
+}
+
+type programInputs struct {
+	HasMultinode       bool
+	CheckpointInfos    map[string]*checkpoint.CheckpointInfo
+	CheckpointStatuses map[string]nvidiacomv1beta1.ComponentCheckpointStatus
+}
+
+type programRestart struct {
+	State  *dynamo.RestartState
+	Status *nvidiacomv1beta1.RestartStatus
+}
+
+type workloadReconcileRequest struct {
 	DGD             *nvidiacomv1beta1.DynamoGraphDeployment
-	HasMultinode    bool
 	RestartState    *dynamo.RestartState
-	RestartStatus   *nvidiacomv1beta1.RestartStatus
 	CheckpointInfos map[string]*checkpoint.CheckpointInfo
-	Result          ReconcileResult
 }
 
 // workloadProgram owns the complete graph-workload state machine for one
@@ -53,7 +78,22 @@ type graphReconcileState struct {
 // it does not drive provider rendering, rollout, readiness, or cleanup through
 // lifecycle callbacks.
 type workloadProgram interface {
-	Reconcile(context.Context, *graphReconcileState) error
+	Reconcile(context.Context, workloadProgramRequest) (workloadProgramResult, error)
+}
+
+func newWorkloadProgramResult(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) workloadProgramResult {
+	status := dgd.DeepCopy().Status
+	return workloadProgramResult{Status: &status}
+}
+
+func (r *workloadProgramResult) applyReconcileResult(result ReconcileResult) {
+	r.Status.State = result.State
+	r.Status.Components = result.ComponentStatus
+	r.Status.Restart = result.RestartStatus
+	r.ReadyReason = result.Reason
+	r.ReadyMessage = result.Message
 }
 
 type workloadProgramFailure struct {
@@ -99,44 +139,56 @@ type componentProgram struct {
 }
 
 // Reconcile composes the complete component pathway. Each earlier operation
-// enriches the ephemeral state consumed by the later workload and result
-// operations; only the final successful result is published back to state.
-func (p *componentProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
+// returns a typed value consumed by later operations. Non-status DGD changes
+// are persisted through req.DGD; status accumulates in the returned result.
+func (p *componentProgram) Reconcile(
+	ctx context.Context,
+	req workloadProgramRequest,
+) (workloadProgramResult, error) {
+	programResult := newWorkloadProgramResult(req.DGD)
 	log.FromContext(ctx).Info(
 		"Reconciling Dynamo components deployments",
-		"hasMultinode", state.DGD.HasAnyMultinodeComponent(),
+		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
 		"lwsEnabled", p.lwsEnabled,
 	)
 
-	if err := p.reconcileWorkerRollout(ctx, state.DGD); err != nil {
-		return err
+	if err := p.reconcileWorkerRollout(ctx, req.DGD, programResult.Status); err != nil {
+		return programResult, err
 	}
-	if err := p.reconciler.reconcileProgramInputs(ctx, state); err != nil {
-		return err
+	inputs, err := p.reconciler.reconcileProgramInputs(ctx, req.DGD)
+	if inputs.CheckpointStatuses != nil {
+		programResult.Status.Checkpoints = inputs.CheckpointStatuses
 	}
-	if state.HasMultinode && !p.lwsEnabled {
+	if err != nil {
+		return programResult, err
+	}
+	if inputs.HasMultinode && !p.lwsEnabled {
 		err := fmt.Errorf("no multinode orchestrator available")
 		log.FromContext(ctx).Error(
 			err,
 			err.Error(),
-			"hasMultinode", state.HasMultinode,
+			"hasMultinode", inputs.HasMultinode,
 			"lwsEnabled", p.lwsEnabled,
 		)
-		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		return programResult, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
 	}
-	p.reconciler.resolveProgramRestartState(ctx, state)
+	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, programResult.Status)
 
-	result, err := p.reconcileWorkloads(ctx, state)
+	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
+		DGD:             req.DGD,
+		RestartState:    restart.State,
+		CheckpointInfos: inputs.CheckpointInfos,
+	})
 	if err != nil {
-		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		return programResult, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
 	}
-	result, err = p.reconciler.reconcileProgramResult(ctx, state, result)
+	result, err = p.reconciler.reconcileProgramResult(ctx, req.DGD, inputs, restart, result)
 	if err != nil {
-		return err
+		return programResult, err
 	}
 
-	state.Result = result
-	return nil
+	programResult.applyReconcileResult(result)
+	return programResult, nil
 }
 
 // reconcileWorkloads owns the component pathway's complete DCD graph
@@ -145,10 +197,10 @@ func (p *componentProgram) Reconcile(ctx context.Context, state *graphReconcileS
 // dedicated extraction; this program owns when they participate in the flow.
 func (p *componentProgram) reconcileWorkloads(
 	ctx context.Context,
-	state *graphReconcileState,
+	req workloadReconcileRequest,
 ) (ReconcileResult, error) {
 	r := p.reconciler
-	dynamoDeployment := state.DGD
+	dynamoDeployment := req.DGD
 	resources := []Resource{}
 	logger := log.FromContext(ctx)
 
@@ -172,7 +224,7 @@ func (p *componentProgram) reconcileWorkloads(
 	// rolling update.
 	dynamoComponentsDeployments, err := dynamo.GenerateDynamoComponentsDeployments(
 		dynamoDeployment,
-		state.RestartState,
+		req.RestartState,
 		existingRestartAnnotations,
 		rollingUpdateCtx,
 	)
@@ -183,7 +235,7 @@ func (p *componentProgram) reconcileWorkloads(
 
 	// Apply resolved checkpoint policy and synchronize every desired DCD.
 	for key, dcd := range dynamoComponentsDeployments {
-		if err := p.applyCheckpointStartupPolicy(dcd, state.CheckpointInfos[key]); err != nil {
+		if err := p.applyCheckpointStartupPolicy(dcd, req.CheckpointInfos[key]); err != nil {
 			return ReconcileResult{}, fmt.Errorf("failed to apply checkpoint startup policy for %s: %w", key, err)
 		}
 		logger.Info("Reconciling DynamoComponentDeployment", "key", key, "name", dcd.Name)
@@ -230,6 +282,7 @@ func (p *componentProgram) reconcileWorkloads(
 func (p *componentProgram) reconcileWorkerRollout(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 ) error {
 	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, dgd); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
@@ -237,7 +290,7 @@ func (p *componentProgram) reconcileWorkerRollout(
 	}
 
 	if p.supportsManagedRollingUpdate(dgd) {
-		return p.reconcileManagedWorkerRollout(ctx, dgd)
+		return p.reconcileManagedWorkerRollout(ctx, dgd, status)
 	}
 	return reconcileUnsupportedWorkerRollout(ctx, p.reconciler, dgd, false)
 }
@@ -245,6 +298,7 @@ func (p *componentProgram) reconcileWorkerRollout(
 func (p *componentProgram) reconcileManagedWorkerRollout(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 ) error {
 	r := p.reconciler
 	logger := log.FromContext(ctx)
@@ -254,7 +308,7 @@ func (p *componentProgram) reconcileManagedWorkerRollout(
 		return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
 	}
 
-	rollingUpdateInProgress := r.isRollingUpdateInProgress(dgd)
+	rollingUpdateInProgress := r.isRollingUpdateInProgress(status)
 	triggerRollingUpdate := false
 	if !rollingUpdateInProgress {
 		var err error
@@ -265,7 +319,7 @@ func (p *componentProgram) reconcileManagedWorkerRollout(
 		}
 	}
 	if rollingUpdateInProgress || triggerRollingUpdate {
-		if err := r.reconcileRollingUpdate(ctx, dgd); err != nil {
+		if err := r.reconcileRollingUpdate(ctx, dgd, status); err != nil {
 			logger.Error(err, "Failed to reconcile rolling update")
 			return failWorkloadProgram(reasonRollingUpdateFailed, err)
 		}
@@ -427,57 +481,66 @@ type groveProgram struct {
 // Reconcile composes the current Grove pathway around its temporary workload
 // adapter while keeping shared resource ordering and result publication
 // identical to the component program.
-func (p *groveProgram) Reconcile(ctx context.Context, state *graphReconcileState) error {
+func (p *groveProgram) Reconcile(
+	ctx context.Context,
+	req workloadProgramRequest,
+) (workloadProgramResult, error) {
+	programResult := newWorkloadProgramResult(req.DGD)
 	log.FromContext(ctx).Info(
 		"Reconciling Grove resources",
-		"hasMultinode", state.DGD.HasAnyMultinodeComponent(),
+		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
 		"lwsEnabled", p.lwsEnabled,
 	)
 
-	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, state.DGD); err != nil {
+	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, req.DGD); err != nil {
 		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
-		return failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
+		return programResult, failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
 	}
-	if err := reconcileUnsupportedWorkerRollout(ctx, p.reconciler, state.DGD, true); err != nil {
-		return err
+	if err := reconcileUnsupportedWorkerRollout(ctx, p.reconciler, req.DGD, true); err != nil {
+		return programResult, err
 	}
-	if err := p.reconciler.reconcileProgramInputs(ctx, state); err != nil {
-		return err
+	inputs, err := p.reconciler.reconcileProgramInputs(ctx, req.DGD)
+	if inputs.CheckpointStatuses != nil {
+		programResult.Status.Checkpoints = inputs.CheckpointStatuses
 	}
-	p.reconciler.resolveProgramRestartState(ctx, state)
-
-	result, err := p.reconcileWorkloads(
-		ctx,
-		state,
-	)
 	if err != nil {
-		return fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		return programResult, err
 	}
-	result, err = p.reconciler.reconcileProgramResult(ctx, state, result)
+	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, programResult.Status)
+
+	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
+		DGD:             req.DGD,
+		RestartState:    restart.State,
+		CheckpointInfos: inputs.CheckpointInfos,
+	})
 	if err != nil {
-		return err
+		return programResult, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+	}
+	result, err = p.reconciler.reconcileProgramResult(ctx, req.DGD, inputs, restart, result)
+	if err != nil {
+		return programResult, err
 	}
 
-	state.Result = result
-	return nil
+	programResult.applyReconcileResult(result)
+	return programResult, nil
 }
 
 func (p *groveProgram) reconcileWorkloads(
 	ctx context.Context,
-	state *graphReconcileState,
+	req workloadReconcileRequest,
 ) (ReconcileResult, error) {
 	return p.reconcile(
 		ctx,
-		state.DGD,
-		state.RestartState,
-		state.CheckpointInfos,
+		req.DGD,
+		req.RestartState,
+		req.CheckpointInfos,
 	)
 }
 
 func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
-	state *graphReconcileState,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) workloadProgram {
-	if r.isGrovePathway(state.DGD) {
+	if r.isGrovePathway(dgd) {
 		return &groveProgram{
 			reconciler: r,
 			reconcile:  r.reconcileGroveResources,

--- a/deploy/operator/internal/controller/dynamographdeployment_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program.go
@@ -30,30 +30,30 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// resolvedFacts contains immutable observations resolved independently of the
-// selected workload program. It is intentionally empty until such a fact is
-// demonstrated; program-derived values remain typed locals.
-type resolvedFacts struct{}
-
 type workloadProgramRequest struct {
 	// DGD is the mutable primary object. Programs may mutate and directly
 	// persist non-status fields; status is returned through workloadProgramResult.
 	DGD *nvidiacomv1beta1.DynamoGraphDeployment
+}
 
-	Facts resolvedFacts
+type workloadProgramEvent struct {
+	Type    string
+	Reason  string
+	Message string
 }
 
 type workloadProgramResult struct {
 	ctrl.Result
-	Status       *nvidiacomv1beta1.DynamoGraphDeploymentStatus
-	ReadyReason  Reason
-	ReadyMessage Message
+	Status nvidiacomv1beta1.DynamoGraphDeploymentStatus
+	Events []workloadProgramEvent
 }
 
 type programInputs struct {
@@ -85,15 +85,88 @@ func newWorkloadProgramResult(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) workloadProgramResult {
 	status := dgd.DeepCopy().Status
-	return workloadProgramResult{Status: &status}
+	return workloadProgramResult{Status: status}
 }
 
-func (r *workloadProgramResult) applyReconcileResult(result ReconcileResult) {
+func (r *workloadProgramResult) Eventf(
+	eventType string,
+	reason string,
+	format string,
+	args ...any,
+) {
+	r.Events = append(r.Events, workloadProgramEvent{
+		Type:    eventType,
+		Reason:  reason,
+		Message: fmt.Sprintf(format, args...),
+	})
+}
+
+func (r *workloadProgramResult) Fail(generation int64, reason Reason, err error) {
+	r.Status.State = nvidiacomv1beta1.DGDStateFailed
+	meta.SetStatusCondition(&r.Status.Conditions, metav1.Condition{
+		Type:               "Ready",
+		Status:             metav1.ConditionFalse,
+		ObservedGeneration: generation,
+		Reason:             string(reason),
+		Message:            err.Error(),
+	})
+}
+
+func (r *workloadProgramResult) applyReconcileResult(
+	generation int64,
+	result ReconcileResult,
+) {
 	r.Status.State = result.State
 	r.Status.Components = result.ComponentStatus
 	r.Status.Restart = result.RestartStatus
-	r.ReadyReason = result.Reason
-	r.ReadyMessage = result.Message
+	if rollingUpdateInProgress(r.Status.RollingUpdate) {
+		r.Status.State = nvidiacomv1beta1.DGDStatePending
+	}
+	meta.SetStatusCondition(&r.Status.Conditions, readyCondition(generation, r.Status, result))
+	r.Status.ObservedGeneration = generation
+}
+
+func readyCondition(
+	generation int64,
+	status nvidiacomv1beta1.DynamoGraphDeploymentStatus,
+	workloads ReconcileResult,
+) metav1.Condition {
+	if rollingUpdateInProgress(status.RollingUpdate) {
+		return metav1.Condition{
+			Type:               "Ready",
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: generation,
+			Reason:             "rolling_update_in_progress",
+			Message:            "Rolling update in progress",
+		}
+	}
+
+	conditionStatus := metav1.ConditionFalse
+	if workloads.State == nvidiacomv1beta1.DGDStateSuccessful {
+		conditionStatus = metav1.ConditionTrue
+	}
+	return metav1.Condition{
+		Type:               "Ready",
+		Status:             conditionStatus,
+		ObservedGeneration: generation,
+		Reason:             string(workloads.Reason),
+		Message:            string(workloads.Message),
+	}
+}
+
+func rollingUpdateInProgress(status *nvidiacomv1beta1.RollingUpdateStatus) bool {
+	if status == nil {
+		return false
+	}
+	return status.Phase == nvidiacomv1beta1.RollingUpdatePhasePending ||
+		status.Phase == nvidiacomv1beta1.RollingUpdatePhaseInProgress
+}
+
+func rollingUpdatePhase(status *nvidiacomv1beta1.RollingUpdateStatus) nvidiacomv1beta1.RollingUpdatePhase {
+	if status == nil {
+		return nvidiacomv1beta1.RollingUpdatePhaseNone
+	}
+	return status.Phase
 }
 
 type workloadProgramFailure struct {
@@ -144,17 +217,29 @@ type componentProgram struct {
 func (p *componentProgram) Reconcile(
 	ctx context.Context,
 	req workloadProgramRequest,
-) (workloadProgramResult, error) {
-	programResult := newWorkloadProgramResult(req.DGD)
+) (programResult workloadProgramResult, retErr error) {
+	programResult = newWorkloadProgramResult(req.DGD)
+	defer func() {
+		if retErr == nil {
+			return
+		}
+		reason := reasonFailedToReconcileResources
+		if classified, ok := workloadProgramFailureReason(retErr); ok {
+			reason = classified
+		}
+		programResult.Fail(req.DGD.Generation, reason, retErr)
+	}()
 	log.FromContext(ctx).Info(
 		"Reconciling Dynamo components deployments",
 		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
 		"lwsEnabled", p.lwsEnabled,
 	)
 
-	if err := p.reconcileWorkerRollout(ctx, req.DGD, programResult.Status); err != nil {
+	previousRolloutPhase := rollingUpdatePhase(programResult.Status.RollingUpdate)
+	if err := p.reconcileWorkerRollout(ctx, req.DGD, &programResult.Status); err != nil {
 		return programResult, err
 	}
+	p.recordRollingUpdateTransition(req.DGD, previousRolloutPhase, &programResult)
 	inputs, err := p.reconciler.reconcileProgramInputs(ctx, req.DGD)
 	if inputs.CheckpointStatuses != nil {
 		programResult.Status.Checkpoints = inputs.CheckpointStatuses
@@ -170,9 +255,10 @@ func (p *componentProgram) Reconcile(
 			"hasMultinode", inputs.HasMultinode,
 			"lwsEnabled", p.lwsEnabled,
 		)
-		return programResult, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		return programResult, failWorkloadProgram(reasonNoMultinodeOrchestrator, err)
 	}
-	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, programResult.Status)
+	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, &programResult.Status, &programResult)
+	programResult.Status.Restart = restart.Status
 
 	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
 		DGD:             req.DGD,
@@ -187,7 +273,7 @@ func (p *componentProgram) Reconcile(
 		return programResult, err
 	}
 
-	programResult.applyReconcileResult(result)
+	programResult.applyReconcileResult(req.DGD.Generation, result)
 	return programResult, nil
 }
 
@@ -327,6 +413,39 @@ func (p *componentProgram) reconcileManagedWorkerRollout(
 	return nil
 }
 
+func (p *componentProgram) recordRollingUpdateTransition(
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	previous nvidiacomv1beta1.RollingUpdatePhase,
+	result *workloadProgramResult,
+) {
+	current := rollingUpdatePhase(result.Status.RollingUpdate)
+	switch {
+	case current == nvidiacomv1beta1.RollingUpdatePhasePending && previous != current:
+		desired, err := p.reconciler.desiredWorkerHashes(dgd)
+		if err != nil {
+			return
+		}
+		result.Eventf(
+			corev1.EventTypeNormal,
+			"RollingUpdateStarted",
+			"Starting rolling update to worker hash %s",
+			p.reconciler.activeWorkerHashForDCDGeneration(dgd, desired),
+		)
+	case current == nvidiacomv1beta1.RollingUpdatePhaseCompleted && previous != current:
+		currentHashes := p.reconciler.currentWorkerHashes(dgd)
+		workerHash := currentHashes.v2
+		if workerHash == "" {
+			workerHash = currentHashes.v1
+		}
+		result.Eventf(
+			corev1.EventTypeNormal,
+			"RollingUpdateCompleted",
+			"Rolling update completed, worker hash %s",
+			workerHash,
+		)
+	}
+}
+
 func reconcileUnsupportedWorkerRollout(
 	ctx context.Context,
 	r *DynamoGraphDeploymentReconciler,
@@ -358,18 +477,6 @@ func reconcileUnsupportedWorkerRollout(
 		return nil
 	}
 
-	logger.Info(
-		"Worker spec change detected but rolling update not supported for this pathway",
-		"isGrove", isGrove,
-		"hasMultinode", dgd.HasAnyMultinodeComponent(),
-	)
-	r.Recorder.Event(
-		dgd,
-		corev1.EventTypeWarning,
-		"RollingUpdateNotSupported",
-		"Worker spec changed but custom rolling updates are not supported for Grove/multinode deployments",
-	)
-
 	// Update the hash to prevent repeated warnings. If the unsupported path is
 	// processing a v2-only worker change, preserve the migrated v2-only state
 	// instead of resurrecting the downgrade-compatible v1 annotation for pod
@@ -377,13 +484,28 @@ func reconcileUnsupportedWorkerRollout(
 	hashes, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
 		logger.Error(err, "Failed to compute worker hash for unsupported pathway")
-		return failWorkloadProgram(reasonRollingUpdateFailed, err)
+		return failWorkloadProgram(reasonFailedToInitializeWorkerHash, err)
 	}
 	r.setCurrentWorkerHashes(dgd, r.workerHashesForUnsupportedPathway(dgd, hashes))
 	if err := r.Update(ctx, dgd); err != nil {
 		// Preserve the existing best-effort behavior: the next reconciliation
 		// retries the metadata update and may emit another warning.
 		logger.Error(err, "Failed to update worker hash for unsupported pathway")
+		return nil
+	}
+
+	logger.Info(
+		"Worker spec change detected but rolling update not supported for this pathway",
+		"isGrove", isGrove,
+		"hasMultinode", dgd.HasAnyMultinodeComponent(),
+	)
+	if r.Recorder != nil {
+		r.Recorder.Event(
+			dgd,
+			corev1.EventTypeWarning,
+			"RollingUpdateNotSupported",
+			"Worker spec changed but custom rolling updates are not supported for Grove/multinode deployments",
+		)
 	}
 	return nil
 }
@@ -484,8 +606,18 @@ type groveProgram struct {
 func (p *groveProgram) Reconcile(
 	ctx context.Context,
 	req workloadProgramRequest,
-) (workloadProgramResult, error) {
-	programResult := newWorkloadProgramResult(req.DGD)
+) (programResult workloadProgramResult, retErr error) {
+	programResult = newWorkloadProgramResult(req.DGD)
+	defer func() {
+		if retErr != nil {
+			reason := reasonFailedToReconcileResources
+			if classified, ok := workloadProgramFailureReason(retErr); ok {
+				reason = classified
+			}
+			programResult.Fail(req.DGD.Generation, reason, retErr)
+		}
+		p.reconciler.propagateTopologyCondition(ctx, req.DGD, &programResult)
+	}()
 	log.FromContext(ctx).Info(
 		"Reconciling Grove resources",
 		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
@@ -506,7 +638,8 @@ func (p *groveProgram) Reconcile(
 	if err != nil {
 		return programResult, err
 	}
-	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, programResult.Status)
+	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, &programResult.Status, &programResult)
+	programResult.Status.Restart = restart.Status
 
 	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
 		DGD:             req.DGD,
@@ -514,14 +647,14 @@ func (p *groveProgram) Reconcile(
 		CheckpointInfos: inputs.CheckpointInfos,
 	})
 	if err != nil {
-		return programResult, fmt.Errorf("failed to reconcile Dynamo components deployments: %w", err)
+		return programResult, fmt.Errorf("failed to reconcile Grove workloads: %w", err)
 	}
 	result, err = p.reconciler.reconcileProgramResult(ctx, req.DGD, inputs, restart, result)
 	if err != nil {
 		return programResult, err
 	}
 
-	programResult.applyReconcileResult(result)
+	programResult.applyReconcileResult(req.DGD.Generation, result)
 	return programResult, nil
 }
 

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -69,11 +69,9 @@ func TestDynamoGraphDeploymentReconciler_selectWorkloadProgram(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Log("Build the ephemeral state and reconciler selection inputs")
-			state := &graphReconcileState{
-				DGD: &nvidiacomv1beta1.DynamoGraphDeployment{
-					ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
-				},
+			t.Log("Build the reconciler selection inputs")
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations},
 			}
 			reconciler := &DynamoGraphDeploymentReconciler{
 				RuntimeConfig: &commonController.RuntimeConfig{
@@ -82,7 +80,7 @@ func TestDynamoGraphDeploymentReconciler_selectWorkloadProgram(t *testing.T) {
 			}
 
 			t.Log("Select one complete workload program")
-			got := reconciler.selectWorkloadProgram(state)
+			got := reconciler.selectWorkloadProgram(dgd)
 
 			assert.IsType(t, tt.wantProgram, got)
 			if component, ok := got.(*componentProgram); ok {
@@ -95,13 +93,36 @@ func TestDynamoGraphDeploymentReconciler_selectWorkloadProgram(t *testing.T) {
 	}
 }
 
+func TestNewWorkloadProgramResultCopiesStatus(t *testing.T) {
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		Status: nvidiacomv1beta1.DynamoGraphDeploymentStatus{
+			Checkpoints: map[string]nvidiacomv1beta1.ComponentCheckpointStatus{
+				"worker": {},
+			},
+			RollingUpdate: &nvidiacomv1beta1.RollingUpdateStatus{
+				Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+			},
+		},
+	}
+
+	t.Log("Create a status accumulator independent from request.DGD.Status")
+	result := newWorkloadProgramResult(dgd)
+	require.NotNil(t, result.Status)
+	result.Status.Checkpoints["decode"] = nvidiacomv1beta1.ComponentCheckpointStatus{}
+	result.Status.RollingUpdate.Phase = nvidiacomv1beta1.RollingUpdatePhaseCompleted
+
+	t.Log("Verify status accumulation does not mutate the request object")
+	assert.NotContains(t, dgd.Status.Checkpoints, "decode")
+	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
+}
+
 func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
 	reconcileErr := errors.New("reconcile failed")
 	tests := []struct {
 		name         string
 		returned     ReconcileResult
 		reconcileErr error
-		wantState    ReconcileResult
+		wantResult   ReconcileResult
 		wantErr      error
 	}{
 		{
@@ -110,7 +131,7 @@ func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
 				State:  nvidiacomv1beta1.DGDStatePending,
 				Reason: "grove_pending",
 			},
-			wantState: ReconcileResult{
+			wantResult: ReconcileResult{
 				State:  nvidiacomv1beta1.DGDStatePending,
 				Reason: "grove_pending",
 			},
@@ -122,31 +143,22 @@ func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
 				Reason: "must_not_be_committed",
 			},
 			reconcileErr: reconcileErr,
-			wantState: ReconcileResult{
-				State:  nvidiacomv1beta1.DGDStatePending,
-				Reason: "existing",
-			},
-			wantErr: reconcileErr,
+			wantErr:      reconcileErr,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Log("Build ephemeral inputs that must be passed unchanged to the program")
+			t.Log("Build typed workload inputs that must be passed unchanged")
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			restartState := &dynamo.RestartState{Timestamp: "restart"}
 			checkpointInfos := map[string]*checkpoint.CheckpointInfo{
 				"worker": {CheckpointName: "checkpoint"},
 			}
-			state := &graphReconcileState{
+			req := workloadReconcileRequest{
 				DGD:             dgd,
-				HasMultinode:    true,
 				RestartState:    restartState,
 				CheckpointInfos: checkpointInfos,
-				Result: ReconcileResult{
-					State:  nvidiacomv1beta1.DGDStatePending,
-					Reason: "existing",
-				},
 			}
 			called := false
 			reconcile := func(
@@ -162,21 +174,21 @@ func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
 				return tt.returned, tt.reconcileErr
 			}
 
-			t.Log("Run the selected complete workload program")
-			result, err := (&groveProgram{reconcile: reconcile}).reconcileWorkloads(context.Background(), state)
+			t.Log("Run the temporary Grove workload adapter")
+			result, err := (&groveProgram{reconcile: reconcile}).reconcileWorkloads(context.Background(), req)
 
 			t.Log("Verify the adapter forwards inputs and outputs unchanged")
 			require.True(t, called)
 			require.ErrorIs(t, err, tt.wantErr)
 			if tt.reconcileErr == nil {
-				assert.Equal(t, tt.wantState, result)
+				assert.Equal(t, tt.wantResult, result)
 			}
 		})
 	}
 }
 
 func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
-	t.Log("Inject a component-path API failure before a result can be committed")
+	t.Log("Inject a component-path API failure before new status is produced")
 	reconcileErr := errors.New("reconcile failed")
 	kubeClient := fake.NewClientBuilder().
 		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
@@ -189,22 +201,24 @@ func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 	program := &componentProgram{
 		reconciler: &DynamoGraphDeploymentReconciler{Client: kubeClient},
 	}
-	previous := ReconcileResult{
-		State:  nvidiacomv1beta1.DGDStatePending,
-		Reason: "existing",
-	}
-	state := &graphReconcileState{
-		DGD: &nvidiacomv1beta1.DynamoGraphDeployment{
-			ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "graph", Namespace: "default"},
+		Status: nvidiacomv1beta1.DynamoGraphDeploymentStatus{
+			State: nvidiacomv1beta1.DGDStatePending,
+			Components: map[string]nvidiacomv1beta1.ComponentReplicaStatus{
+				"worker": {Replicas: 1},
+			},
 		},
-		Result: previous,
 	}
+	previous := dgd.DeepCopy().Status
 
-	err := program.Reconcile(context.Background(), state)
+	result, err := program.Reconcile(context.Background(), workloadProgramRequest{DGD: dgd})
 
-	t.Log("Verify failed reconciliation cannot publish a partial result")
+	t.Log("Verify the error result preserves prior status without mutating request.DGD.Status")
 	require.ErrorIs(t, err, reconcileErr)
-	assert.Equal(t, previous, state.Result)
+	require.NotNil(t, result.Status)
+	assert.Equal(t, previous, *result.Status)
+	assert.Equal(t, previous, dgd.Status)
 	reason, ok := workloadProgramFailureReason(err)
 	require.True(t, ok)
 	assert.Equal(t, reasonFailedToInitializeWorkerHash, reason)
@@ -240,20 +254,48 @@ func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
 			return ReconcileResult{}, nil
 		},
 	}
-	previous := ReconcileResult{
-		State:  nvidiacomv1beta1.DGDStatePending,
-		Reason: "existing",
+	dgd.Status = nvidiacomv1beta1.DynamoGraphDeploymentStatus{
+		State: nvidiacomv1beta1.DGDStatePending,
+		Components: map[string]nvidiacomv1beta1.ComponentReplicaStatus{
+			"worker": {Replicas: 1},
+		},
 	}
-	state := &graphReconcileState{DGD: dgd, Result: previous}
+	previous := dgd.DeepCopy().Status
 
-	err := program.Reconcile(context.Background(), state)
+	result, err := program.Reconcile(context.Background(), workloadProgramRequest{DGD: dgd})
 
-	t.Log("Verify failed reconciliation cannot publish a partial result")
+	t.Log("Verify failed primary mutation does not mutate request.DGD.Status")
 	require.ErrorIs(t, err, reconcileErr)
-	assert.Equal(t, previous, state.Result)
+	require.NotNil(t, result.Status)
+	assert.Equal(t, previous, *result.Status)
+	assert.Equal(t, previous, dgd.Status)
 	reason, ok := workloadProgramFailureReason(err)
 	require.True(t, ok)
 	assert.Equal(t, reasonFailedToInitializeWorkerHash, reason)
+}
+
+func TestComponentProgram_ReconcileReturnsPartialRolloutStatusOnLaterError(t *testing.T) {
+	t.Log("Build a worker change that starts rollout before shared input reconciliation")
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {
+			ComponentType: commonconsts.ComponentTypeWorker,
+			Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "new"}},
+		},
+	})
+	dgd.Annotations = map[string]string{
+		commonconsts.AnnotationCurrentWorkerHash: "old-worker-hash",
+	}
+	reconciler := createTestReconcilerWithStatus(dgd)
+	program := &componentProgram{reconciler: reconciler}
+
+	result, err := program.Reconcile(context.Background(), workloadProgramRequest{DGD: dgd})
+
+	t.Log("Verify rollout status is returned on the later shared-input failure")
+	require.ErrorContains(t, err, "RBAC manager not initialized")
+	require.NotNil(t, result.Status)
+	require.NotNil(t, result.Status.RollingUpdate)
+	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, result.Status.RollingUpdate.Phase)
+	assert.Nil(t, dgd.Status.RollingUpdate)
 }
 
 func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
@@ -269,11 +311,13 @@ func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
 		}
 		reconciler := createTestReconcilerWithStatus(dgd)
 		program := &componentProgram{reconciler: reconciler}
+		status := dgd.DeepCopy().Status
 
-		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd))
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd, &status))
 
-		require.NotNil(t, dgd.Status.RollingUpdate)
-		assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
+		require.NotNil(t, status.RollingUpdate)
+		assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, status.RollingUpdate.Phase)
+		assert.Nil(t, dgd.Status.RollingUpdate)
 		assert.Equal(t, "old-worker-hash", dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash])
 	})
 
@@ -290,9 +334,11 @@ func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
 		}
 		reconciler := createTestReconcilerWithStatus(dgd)
 		program := &componentProgram{reconciler: reconciler}
+		status := dgd.DeepCopy().Status
 
-		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd))
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd, &status))
 
+		assert.Nil(t, status.RollingUpdate)
 		assert.Nil(t, dgd.Status.RollingUpdate)
 		desired, err := reconciler.desiredWorkerHashes(dgd)
 		require.NoError(t, err)

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -107,13 +108,143 @@ func TestNewWorkloadProgramResultCopiesStatus(t *testing.T) {
 
 	t.Log("Create a status accumulator independent from request.DGD.Status")
 	result := newWorkloadProgramResult(dgd)
-	require.NotNil(t, result.Status)
 	result.Status.Checkpoints["decode"] = nvidiacomv1beta1.ComponentCheckpointStatus{}
 	result.Status.RollingUpdate.Phase = nvidiacomv1beta1.RollingUpdatePhaseCompleted
 
 	t.Log("Verify status accumulation does not mutate the request object")
 	assert.NotContains(t, dgd.Status.Checkpoints, "decode")
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
+}
+
+func TestPersistWorkloadProgramResultEmitsEventsAfterStatusUpdate(t *testing.T) {
+	statusUpdateErr := errors.New("status update failed")
+	tests := []struct {
+		name      string
+		updateErr error
+		wantEvent bool
+	}{
+		{
+			name:      "successful status update flushes queued events",
+			wantEvent: true,
+		},
+		{
+			name:      "failed status update retains queued events without emitting them",
+			updateErr: statusUpdateErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build an authoritative status result with one queued transition event")
+			statusUpdated := false
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(
+						context.Context,
+						client.Client,
+						string,
+						client.Object,
+						...client.SubResourceUpdateOption,
+					) error {
+						statusUpdated = true
+						return tt.updateErr
+					},
+				}).
+				Build()
+			recorder := record.NewFakeRecorder(1)
+			reconciler := &DynamoGraphDeploymentReconciler{Client: kubeClient, Recorder: recorder}
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			result := newWorkloadProgramResult(dgd)
+			result.Eventf(corev1.EventTypeNormal, "Transition", "transition persisted")
+
+			t.Log("Persist status through the outer controller boundary")
+			err := reconciler.persistWorkloadProgramResult(context.Background(), dgd, result)
+
+			t.Log("Verify event publication is strictly ordered after successful status persistence")
+			require.True(t, statusUpdated)
+			if tt.updateErr != nil {
+				require.ErrorIs(t, err, tt.updateErr)
+				assert.Empty(t, recorder.Events)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantEvent {
+				assert.Len(t, recorder.Events, 1)
+			}
+		})
+	}
+}
+
+func TestWorkloadProgramResultOwnsReadyAndObservedGeneration(t *testing.T) {
+	t.Run("success installs Ready and advances observed generation", func(t *testing.T) {
+		t.Log("Build a successful workload observation")
+		result := newWorkloadProgramResult(&nvidiacomv1beta1.DynamoGraphDeployment{})
+		workloads := ReconcileResult{
+			State:   nvidiacomv1beta1.DGDStateSuccessful,
+			Reason:  "all_resources_are_ready",
+			Message: "All resources are ready",
+		}
+
+		t.Log("Apply the successful observation to authoritative program status")
+		result.applyReconcileResult(7, workloads)
+
+		t.Log("Verify the program owns overall state, Ready, and observed generation")
+		assert.Equal(t, nvidiacomv1beta1.DGDStateSuccessful, result.Status.State)
+		assert.Equal(t, int64(7), result.Status.ObservedGeneration)
+		ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionTrue, ready.Status)
+		assert.Equal(t, int64(7), ready.ObservedGeneration)
+	})
+
+	t.Run("active rolling update keeps an otherwise ready deployment pending", func(t *testing.T) {
+		t.Log("Build an otherwise successful workload observation during a rolling update")
+		result := newWorkloadProgramResult(&nvidiacomv1beta1.DynamoGraphDeployment{
+			Status: nvidiacomv1beta1.DynamoGraphDeploymentStatus{
+				RollingUpdate: &nvidiacomv1beta1.RollingUpdateStatus{
+					Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+				},
+			},
+		})
+		workloads := ReconcileResult{
+			State:   nvidiacomv1beta1.DGDStateSuccessful,
+			Reason:  "all_resources_are_ready",
+			Message: "All resources are ready",
+		}
+
+		t.Log("Apply the workload observation to authoritative program status")
+		result.applyReconcileResult(8, workloads)
+
+		t.Log("Verify rollout state owns overall readiness until the transition completes")
+		assert.Equal(t, nvidiacomv1beta1.DGDStatePending, result.Status.State)
+		assert.Equal(t, int64(8), result.Status.ObservedGeneration)
+		ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionFalse, ready.Status)
+		assert.Equal(t, "rolling_update_in_progress", ready.Reason)
+		assert.Equal(t, int64(8), ready.ObservedGeneration)
+	})
+
+	t.Run("failure preserves the last successfully observed generation", func(t *testing.T) {
+		t.Log("Build status from the last successful generation")
+		result := newWorkloadProgramResult(&nvidiacomv1beta1.DynamoGraphDeployment{
+			Status: nvidiacomv1beta1.DynamoGraphDeploymentStatus{ObservedGeneration: 5},
+		})
+		reconcileErr := errors.New("workload failed")
+
+		t.Log("Install a failure for a newer generation")
+		result.Fail(6, reasonFailedToReconcileResources, reconcileErr)
+
+		t.Log("Verify only the Ready condition observes the failed attempt")
+		assert.Equal(t, int64(5), result.Status.ObservedGeneration)
+		assert.Equal(t, nvidiacomv1beta1.DGDStateFailed, result.Status.State)
+		ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+		require.NotNil(t, ready)
+		assert.Equal(t, metav1.ConditionFalse, ready.Status)
+		assert.Equal(t, int64(6), ready.ObservedGeneration)
+		assert.Equal(t, reconcileErr.Error(), ready.Message)
+	})
 }
 
 func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
@@ -214,10 +345,14 @@ func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 
 	result, err := program.Reconcile(context.Background(), workloadProgramRequest{DGD: dgd})
 
-	t.Log("Verify the error result preserves prior status without mutating request.DGD.Status")
+	t.Log("Verify the error result preserves prior fields and installs authoritative failure status")
 	require.ErrorIs(t, err, reconcileErr)
-	require.NotNil(t, result.Status)
-	assert.Equal(t, previous, *result.Status)
+	assert.Equal(t, previous.Components, result.Status.Components)
+	assert.Equal(t, nvidiacomv1beta1.DGDStateFailed, result.Status.State)
+	ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, string(reasonFailedToInitializeWorkerHash), ready.Reason)
 	assert.Equal(t, previous, dgd.Status)
 	reason, ok := workloadProgramFailureReason(err)
 	require.True(t, ok)
@@ -264,10 +399,14 @@ func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
 
 	result, err := program.Reconcile(context.Background(), workloadProgramRequest{DGD: dgd})
 
-	t.Log("Verify failed primary mutation does not mutate request.DGD.Status")
+	t.Log("Verify failed primary mutation returns failure status without mutating request.DGD.Status")
 	require.ErrorIs(t, err, reconcileErr)
-	require.NotNil(t, result.Status)
-	assert.Equal(t, previous, *result.Status)
+	assert.Equal(t, previous.Components, result.Status.Components)
+	assert.Equal(t, nvidiacomv1beta1.DGDStateFailed, result.Status.State)
+	ready := meta.FindStatusCondition(result.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
+	assert.Equal(t, string(reasonFailedToInitializeWorkerHash), ready.Reason)
 	assert.Equal(t, previous, dgd.Status)
 	reason, ok := workloadProgramFailureReason(err)
 	require.True(t, ok)
@@ -292,10 +431,105 @@ func TestComponentProgram_ReconcileReturnsPartialRolloutStatusOnLaterError(t *te
 
 	t.Log("Verify rollout status is returned on the later shared-input failure")
 	require.ErrorContains(t, err, "RBAC manager not initialized")
-	require.NotNil(t, result.Status)
 	require.NotNil(t, result.Status.RollingUpdate)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, result.Status.RollingUpdate.Phase)
+	assert.Equal(t, nvidiacomv1beta1.DGDStateFailed, result.Status.State)
+	require.Len(t, result.Events, 1)
+	assert.Equal(t, "RollingUpdateStarted", result.Events[0].Reason)
 	assert.Nil(t, dgd.Status.RollingUpdate)
+}
+
+func TestUnsupportedWorkerRolloutEmitsWarningOnlyAfterHashUpdate(t *testing.T) {
+	updateErr := errors.New("update failed")
+	tests := []struct {
+		name      string
+		updateErr error
+		wantEvent bool
+	}{
+		{
+			name:      "successful hash update emits warning",
+			wantEvent: true,
+		},
+		{
+			name:      "failed hash update does not emit warning",
+			updateErr: updateErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Build an unsupported pathway with a changed worker specification")
+			dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: commonconsts.ComponentTypeWorker,
+					Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "new"}},
+				},
+			})
+			dgd.Annotations = map[string]string{
+				commonconsts.AnnotationCurrentWorkerHash: "old-worker-hash",
+			}
+			kubeClient := fake.NewClientBuilder().
+				WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Update: func(
+						context.Context,
+						client.WithWatch,
+						client.Object,
+						...client.UpdateOption,
+					) error {
+						return tt.updateErr
+					},
+				}).
+				Build()
+			recorder := record.NewFakeRecorder(1)
+			reconciler := &DynamoGraphDeploymentReconciler{Client: kubeClient, Recorder: recorder}
+
+			t.Log("Advance the unsupported pathway hash")
+			require.NoError(t, reconcileUnsupportedWorkerRollout(
+				context.Background(),
+				reconciler,
+				dgd,
+				true,
+			))
+
+			t.Log("Verify the warning reflects a successfully persisted primary mutation")
+			if tt.wantEvent {
+				assert.Len(t, recorder.Events, 1)
+				return
+			}
+			assert.Empty(t, recorder.Events)
+		})
+	}
+}
+
+func TestResolveProgramRestartStateQueuesSupersededTransition(t *testing.T) {
+	t.Log("Build an active rolling update that supersedes a new restart request")
+	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Restart: &nvidiacomv1beta1.Restart{ID: "restart-1"},
+		},
+	}
+	result := newWorkloadProgramResult(dgd)
+	result.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+		Phase: nvidiacomv1beta1.RollingUpdatePhaseInProgress,
+	}
+	reconciler := &DynamoGraphDeploymentReconciler{}
+
+	t.Log("Resolve restart state against the program-owned status accumulator")
+	restart := reconciler.resolveProgramRestartState(
+		context.Background(),
+		dgd,
+		&result.Status,
+		&result,
+	)
+	result.Status.Restart = restart.Status
+
+	t.Log("Verify status and its transition event remain coupled in the result")
+	require.NotNil(t, result.Status.Restart)
+	assert.Equal(t, nvidiacomv1beta1.RestartPhaseSuperseded, result.Status.Restart.Phase)
+	require.Len(t, result.Events, 1)
+	assert.Equal(t, "RestartSuperseded", result.Events[0].Reason)
+	assert.Empty(t, dgd.Status.Restart)
 }
 
 func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -87,11 +88,14 @@ func TestDynamoGraphDeploymentReconciler_selectWorkloadProgram(t *testing.T) {
 			if component, ok := got.(*componentProgram); ok {
 				assert.Same(t, reconciler, component.reconciler)
 			}
+			if grove, ok := got.(*groveProgram); ok {
+				assert.Same(t, reconciler, grove.reconciler)
+			}
 		})
 	}
 }
 
-func TestGroveProgram_ReconcileAdapter(t *testing.T) {
+func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
 	reconcileErr := errors.New("reconcile failed")
 	tests := []struct {
 		name         string
@@ -159,12 +163,14 @@ func TestGroveProgram_ReconcileAdapter(t *testing.T) {
 			}
 
 			t.Log("Run the selected complete workload program")
-			err := (&groveProgram{reconcile: reconcile}).Reconcile(context.Background(), state)
+			result, err := (&groveProgram{reconcile: reconcile}).reconcileWorkloads(context.Background(), state)
 
-			t.Log("Verify state is committed only after successful reconciliation")
+			t.Log("Verify the adapter forwards inputs and outputs unchanged")
 			require.True(t, called)
 			require.ErrorIs(t, err, tt.wantErr)
-			assert.Equal(t, tt.wantState, state.Result)
+			if tt.reconcileErr == nil {
+				assert.Equal(t, tt.wantState, result)
+			}
 		})
 	}
 }
@@ -199,6 +205,99 @@ func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 	t.Log("Verify failed reconciliation cannot publish a partial result")
 	require.ErrorIs(t, err, reconcileErr)
 	assert.Equal(t, previous, state.Result)
+	reason, ok := workloadProgramFailureReason(err)
+	require.True(t, ok)
+	assert.Equal(t, reasonFailedToInitializeWorkerHash, reason)
+}
+
+func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
+	t.Log("Inject an unsupported-path metadata failure before shared reconciliation")
+	reconcileErr := errors.New("reconcile failed")
+	dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+		"worker": {ComponentType: commonconsts.ComponentTypeWorker},
+	})
+	kubeClient := fake.NewClientBuilder().
+		WithScheme(newDynamoGraphDeploymentControllerTestScheme(t)).
+		WithObjects(dgd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+				return reconcileErr
+			},
+		}).
+		Build()
+	program := &groveProgram{
+		reconciler: &DynamoGraphDeploymentReconciler{
+			Client:   kubeClient,
+			Recorder: record.NewFakeRecorder(10),
+		},
+		reconcile: func(
+			context.Context,
+			*nvidiacomv1beta1.DynamoGraphDeployment,
+			*dynamo.RestartState,
+			map[string]*checkpoint.CheckpointInfo,
+		) (ReconcileResult, error) {
+			t.Fatal("Grove workload reconciliation must not run after rollout preparation fails")
+			return ReconcileResult{}, nil
+		},
+	}
+	previous := ReconcileResult{
+		State:  nvidiacomv1beta1.DGDStatePending,
+		Reason: "existing",
+	}
+	state := &graphReconcileState{DGD: dgd, Result: previous}
+
+	err := program.Reconcile(context.Background(), state)
+
+	t.Log("Verify failed reconciliation cannot publish a partial result")
+	require.ErrorIs(t, err, reconcileErr)
+	assert.Equal(t, previous, state.Result)
+	reason, ok := workloadProgramFailureReason(err)
+	require.True(t, ok)
+	assert.Equal(t, reasonFailedToInitializeWorkerHash, reason)
+}
+
+func TestComponentProgram_ReconcileWorkerRollout(t *testing.T) {
+	t.Run("single-node component workload starts a managed rollout", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: commonconsts.ComponentTypeWorker,
+				Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "new"}},
+			},
+		})
+		dgd.Annotations = map[string]string{
+			commonconsts.AnnotationCurrentWorkerHash: "old-worker-hash",
+		}
+		reconciler := createTestReconcilerWithStatus(dgd)
+		program := &componentProgram{reconciler: reconciler}
+
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd))
+
+		require.NotNil(t, dgd.Status.RollingUpdate)
+		assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
+		assert.Equal(t, "old-worker-hash", dgd.Annotations[commonconsts.AnnotationCurrentWorkerHash])
+	})
+
+	t.Run("multinode component workload keeps unsupported-path hash behavior", func(t *testing.T) {
+		dgd := createTestDGD("test-dgd", map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+			"worker": {
+				ComponentType: commonconsts.ComponentTypeWorker,
+				Envs:          []corev1.EnvVar{{Name: "WORKER_VERSION", Value: "new"}},
+				Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
+			},
+		})
+		dgd.Annotations = map[string]string{
+			commonconsts.AnnotationCurrentWorkerHash: "old-worker-hash",
+		}
+		reconciler := createTestReconcilerWithStatus(dgd)
+		program := &componentProgram{reconciler: reconciler}
+
+		require.NoError(t, program.reconcileWorkerRollout(context.Background(), dgd))
+
+		assert.Nil(t, dgd.Status.RollingUpdate)
+		desired, err := reconciler.desiredWorkerHashes(dgd)
+		require.NoError(t, err)
+		assert.True(t, currentWorkerHashesMatchDesired(reconciler.currentWorkerHashes(dgd), desired))
+	})
 }
 
 func TestComponentProgram_PreserveExistingBackendFramework(t *testing.T) {

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -533,9 +533,6 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	rollingUpdateStatus.StartTime = &now
 	rollingUpdateStatus.UpdatedComponents = nil
 
-	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateStarted",
-		"Starting rolling update to worker hash %s", newWorkerHash)
-
 	return nil // the workload program returns this status to the outer reconciler
 }
 
@@ -681,9 +678,6 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	}
 	sort.Strings(allWorkerComponents)
 	rollingUpdateStatus.UpdatedComponents = allWorkerComponents
-
-	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateCompleted",
-		"Rolling update completed, worker hash %s", newWorkerHash)
 
 	logger.Info("Rolling update finalized", "newWorkerHash", newWorkerHash)
 

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -327,13 +327,13 @@ func (r *DynamoGraphDeploymentReconciler) findLegacyWorkerDCDs(
 	return legacyDCDs, nil
 }
 
-// supportsManagedRollingUpdate checks if DGD pathway supports operator managed rolling updates.
-// Grove and LWS deployments currently do not support operator managed rolling updates.
-// They fall back to the default rolling update mechanism.
-func (r *DynamoGraphDeploymentReconciler) supportsManagedRollingUpdate(
+// supportsManagedRollingUpdate checks whether the component pathway can use
+// operator-managed rolling updates. Multinode component workloads rely on
+// external orchestration and retain the compatibility hash behavior instead.
+func (p *componentProgram) supportsManagedRollingUpdate(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) bool {
-	return !r.isGrovePathway(dgd) && !dgd.HasAnyMultinodeComponent()
+	return !dgd.HasAnyMultinodeComponent()
 }
 
 // getCurrentWorkerHash returns the v1 worker generation stored on the DGD.

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate.go
@@ -393,24 +393,24 @@ func (r *DynamoGraphDeploymentReconciler) setLegacyWorkerHash(
 
 // getOrCreateRollingUpdateStatus returns the existing rolling update status or creates a new one.
 func (r *DynamoGraphDeploymentReconciler) getOrCreateRollingUpdateStatus(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 ) *nvidiacomv1beta1.RollingUpdateStatus {
-	if dgd.Status.RollingUpdate == nil {
-		dgd.Status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
+	if status.RollingUpdate == nil {
+		status.RollingUpdate = &nvidiacomv1beta1.RollingUpdateStatus{
 			Phase: nvidiacomv1beta1.RollingUpdatePhaseNone,
 		}
 	}
-	return dgd.Status.RollingUpdate
+	return status.RollingUpdate
 }
 
 // isRollingUpdateInProgress returns true if a rolling update is currently active.
 func (r *DynamoGraphDeploymentReconciler) isRollingUpdateInProgress(
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 ) bool {
-	if dgd.Status.RollingUpdate == nil {
+	if status.RollingUpdate == nil {
 		return false
 	}
-	phase := dgd.Status.RollingUpdate.Phase
+	phase := status.RollingUpdate.Phase
 	return phase == nvidiacomv1beta1.RollingUpdatePhasePending ||
 		phase == nvidiacomv1beta1.RollingUpdatePhaseInProgress
 }
@@ -419,10 +419,11 @@ func (r *DynamoGraphDeploymentReconciler) isRollingUpdateInProgress(
 func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 ) error {
 	logger := log.FromContext(ctx)
 
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(status)
 
 	desired, err := r.desiredWorkerHashes(dgd)
 	if err != nil {
@@ -488,19 +489,19 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 		logger.Info("Detected stuck rolling update: hashes match but phase is InProgress",
 			"hash", newWorkerHash,
 			"phase", rollingUpdateStatus.Phase)
-		return r.completeRollingUpdate(ctx, dgd, newWorkerHash)
+		return r.completeRollingUpdate(ctx, dgd, status, newWorkerHash)
 	}
 
 	switch rollingUpdateStatus.Phase {
 	case nvidiacomv1beta1.RollingUpdatePhaseNone:
-		return r.startRollingUpdate(ctx, dgd, newWorkerHash)
+		return r.startRollingUpdate(ctx, dgd, status, newWorkerHash)
 
 	case nvidiacomv1beta1.RollingUpdatePhasePending:
 		rollingUpdateStatus.Phase = nvidiacomv1beta1.RollingUpdatePhaseInProgress
-		return nil // deferred function in Reconcile() persists status
+		return nil // the workload program returns this status to the outer reconciler
 
 	case nvidiacomv1beta1.RollingUpdatePhaseInProgress:
-		return r.continueRollingUpdate(ctx, dgd, newWorkerHash)
+		return r.continueRollingUpdate(ctx, dgd, status, newWorkerHash)
 
 	case nvidiacomv1beta1.RollingUpdatePhaseCompleted:
 		logger.Info("Rolling update already completed")
@@ -514,6 +515,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileRollingUpdate(
 func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
@@ -526,7 +528,7 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 		"newHash", newWorkerHash)
 
 	now := metav1.Now()
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(status)
 	rollingUpdateStatus.Phase = nvidiacomv1beta1.RollingUpdatePhasePending
 	rollingUpdateStatus.StartTime = &now
 	rollingUpdateStatus.UpdatedComponents = nil
@@ -534,13 +536,14 @@ func (r *DynamoGraphDeploymentReconciler) startRollingUpdate(
 	r.Recorder.Eventf(dgd, corev1.EventTypeNormal, "RollingUpdateStarted",
 		"Starting rolling update to worker hash %s", newWorkerHash)
 
-	return nil // deferred function in Reconcile() persists status
+	return nil // the workload program returns this status to the outer reconciler
 }
 
 // continueRollingUpdate handles the in-progress phase of a rolling update.
 func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
@@ -566,15 +569,15 @@ func (r *DynamoGraphDeploymentReconciler) continueRollingUpdate(
 		"newWorkerHash", newWorkerHash)
 
 	updatedComponents, totalWorkerComponents := completedWorkerComponents(dgd, oldInfo, newInfo)
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(status)
 	rollingUpdateStatus.UpdatedComponents = updatedComponents
 
 	// Rolling update is complete when every worker component is individually updated.
 	if len(updatedComponents) == totalWorkerComponents && totalWorkerComponents > 0 {
-		return r.completeRollingUpdate(ctx, dgd, newWorkerHash)
+		return r.completeRollingUpdate(ctx, dgd, status, newWorkerHash)
 	}
 
-	return nil // deferred function in Reconcile() persists UpdatedComponents
+	return nil // the workload program returns UpdatedComponents to the outer reconciler
 }
 
 func completedWorkerComponents(
@@ -632,6 +635,7 @@ func workerGenerationComplete(
 func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 	ctx context.Context,
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+	status *nvidiacomv1beta1.DynamoGraphDeploymentStatus,
 	newWorkerHash string,
 ) error {
 	logger := log.FromContext(ctx)
@@ -661,7 +665,7 @@ func (r *DynamoGraphDeploymentReconciler) completeRollingUpdate(
 		return fmt.Errorf("failed to update current worker hash: %w", err)
 	}
 
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(status)
 	rollingUpdateStatus.Phase = nvidiacomv1beta1.RollingUpdatePhaseCompleted
 	now := metav1.Now()
 	rollingUpdateStatus.EndTime = &now

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -288,7 +288,7 @@ func TestCanonicalWorkerHashLifecycle_FirstDeploySpecChangeAndCompletion(t *test
 	require.Equal(t, newV2Hash, rollingCtx.NewWorkerHash)
 	require.NotEqual(t, newLegacyHash, rollingCtx.NewWorkerHash)
 
-	require.NoError(t, r.completeRollingUpdate(ctx, dgd, newV2Hash))
+	require.NoError(t, r.completeRollingUpdate(ctx, dgd, &dgd.Status, newV2Hash))
 	require.NotContains(t, dgd.Annotations, consts.AnnotationCurrentWorkerHash)
 	require.Equal(t, newV2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
@@ -505,7 +505,7 @@ func TestLegacyAlphaHashCompatibility_V2OnlyChangeUsesNewV2Generation(t *testing
 	require.Equal(t, newV2Hash, rollingCtx.NewWorkerHash)
 	require.NotEqual(t, newLegacyHash, rollingCtx.NewWorkerHash)
 
-	require.NoError(t, r.completeRollingUpdate(context.Background(), dgd, newV2Hash))
+	require.NoError(t, r.completeRollingUpdate(context.Background(), dgd, &dgd.Status, newV2Hash))
 	require.Empty(t, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
 	require.Equal(t, newV2Hash, dgd.Annotations[consts.AnnotationCurrentWorkerHashV2])
 }
@@ -687,7 +687,7 @@ func TestGetOrCreateRollingUpdateStatus(t *testing.T) {
 			dgd.Status.RollingUpdate = tt.existingStatus
 
 			r := createTestReconcilerWithStatus(dgd)
-			status := r.getOrCreateRollingUpdateStatus(dgd)
+			status := r.getOrCreateRollingUpdateStatus(&dgd.Status)
 
 			assert.NotNil(t, status)
 			assert.Equal(t, tt.expectedPhase, status.Phase)
@@ -736,7 +736,7 @@ func TestIsRollingUpdateInProgress(t *testing.T) {
 			dgd.Status.RollingUpdate = tt.status
 
 			r := createTestReconcilerWithStatus(dgd)
-			result := r.isRollingUpdateInProgress(dgd)
+			result := r.isRollingUpdateInProgress(&dgd.Status)
 
 			assert.Equal(t, tt.expected, result)
 		})
@@ -981,7 +981,7 @@ func TestContinueRollingUpdate_UpdatedComponentsPartialCompletion(t *testing.T) 
 	ctx := context.Background()
 
 	rollingUpdateStatus := dgd.Status.RollingUpdate
-	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
 	require.NoError(t, err)
 
 	// Prefill is updated (new ready >= desired, old gone), decode is not
@@ -1064,8 +1064,8 @@ func TestContinueRollingUpdate_AggregateReadyButPerServiceNot(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD, newDecodeDCD))
 	ctx := context.Background()
 
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
-	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(&dgd.Status)
+	err := r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
 	require.NoError(t, err)
 
 	// Only prefill is updated; decode has 0 ready replicas
@@ -1093,10 +1093,10 @@ func TestStartRollingUpdate_UpdatedComponentsInitializedToNil(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
-	err := r.startRollingUpdate(ctx, dgd, testNewWorkerHash)
+	err := r.startRollingUpdate(ctx, dgd, &dgd.Status, testNewWorkerHash)
 	require.NoError(t, err)
 
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(&dgd.Status)
 	assert.Nil(t, rollingUpdateStatus.UpdatedComponents)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, rollingUpdateStatus.Phase)
 }
@@ -1129,7 +1129,7 @@ func TestCompleteRollingUpdate_UpdatedComponentsContainsAllWorkers(t *testing.T)
 	r := createTestReconcilerWithStatus(dgd)
 	ctx := context.Background()
 
-	err := r.completeRollingUpdate(ctx, dgd, newWorkerHash)
+	err := r.completeRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
 	require.NoError(t, err)
 
 	// Check dgd.Status.RollingUpdate directly because r.Update() inside completeRollingUpdate
@@ -1212,7 +1212,7 @@ func TestContinueRollingUpdate_AllServicesUpdated(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD, newDecodeDCD))
 	ctx := context.Background()
 
-	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
 	require.NoError(t, err)
 
 	// Rolling update should complete, and all services should be listed.
@@ -1315,7 +1315,7 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 
 			// Zero ready replicas satisfy the status-only completion check, but the
 			// running old Pod must keep both the rollout and its hash in place.
-			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd))
+			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd, &dgd.Status))
 			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
 			assert.Equal(t, oldWorkerHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
 			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(oldDCD), &nvidiacomv1beta1.DynamoComponentDeployment{}))
@@ -1327,7 +1327,7 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 			cachedPod.Status.Phase = corev1.PodSucceeded
 			require.NoError(t, r.Status().Update(ctx, cachedPod))
 
-			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd))
+			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd, &dgd.Status))
 			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
 			assert.True(t, r.currentWorkerHashes(dgd).contains(newWorkerHash))
 			err := r.Get(ctx, client.ObjectKeyFromObject(oldDCD), &nvidiacomv1beta1.DynamoComponentDeployment{})
@@ -1339,7 +1339,7 @@ func TestReconcileRollingUpdate_RecreateAtZeroWaitsForOldPodTermination(t *testi
 			trigger, err := r.shouldTriggerRollingUpdate(dgd)
 			require.NoError(t, err)
 			assert.False(t, trigger)
-			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd))
+			require.NoError(t, r.reconcileRollingUpdate(ctx, dgd, &dgd.Status))
 			assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
 			assert.True(t, r.currentWorkerHashes(dgd).contains(newWorkerHash))
 		})
@@ -2105,7 +2105,7 @@ func TestInitializeWorkerHashIfNeeded_LegacyDCDsMigration(t *testing.T) {
 
 	desired, err := r.desiredWorkerHashes(dgd)
 	require.NoError(t, err)
-	require.NoError(t, r.completeRollingUpdate(ctx, dgd, desired.v1))
+	require.NoError(t, r.completeRollingUpdate(ctx, dgd, &dgd.Status, desired.v1))
 
 	trigger, err := r.shouldTriggerRollingUpdate(dgd)
 	require.NoError(t, err)
@@ -3254,11 +3254,11 @@ func TestContinueRollingUpdate_CascadingSpecChange(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, withObjects(genADCD, genBDCD, genCDCD))
 	ctx := context.Background()
 
-	err := r.continueRollingUpdate(ctx, dgd, newWorkerHash)
+	err := r.continueRollingUpdate(ctx, dgd, &dgd.Status, newWorkerHash)
 	require.NoError(t, err)
 
 	// Both A and B have ready replicas, C has 0 — rolling update not complete
-	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(dgd)
+	rollingUpdateStatus := r.getOrCreateRollingUpdateStatus(&dgd.Status)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, rollingUpdateStatus.Phase)
 	assert.Empty(t, rollingUpdateStatus.UpdatedComponents, "No services should be fully updated yet")
 }
@@ -3712,7 +3712,7 @@ func TestReconcileRollingUpdate_NoChange(t *testing.T) {
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	// Phase should stay Completed — no spec change
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
@@ -3728,7 +3728,7 @@ func TestReconcileRollingUpdate_SpecChangeStartsRollout(t *testing.T) {
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	// Should transition to Pending (new rollout started)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
@@ -3745,7 +3745,7 @@ func TestReconcileRollingUpdate_PendingToInProgress(t *testing.T) {
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseInProgress, dgd.Status.RollingUpdate.Phase)
 }
@@ -3765,7 +3765,7 @@ func TestReconcileRollingUpdate_StuckDetection(t *testing.T) {
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	// Should auto-complete
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhaseCompleted, dgd.Status.RollingUpdate.Phase)
@@ -3807,7 +3807,7 @@ func TestReconcileRollingUpdate_NewRollingUpdate(t *testing.T) {
 	r := createTestReconcilerWithStatus(dgd, withObjects(newDCD))
 
 	// When computed hash != current hash and no DCDs exist with computed hash, start rollout.
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	// Should start a new rolling update (Pending) since computed hash DCDs don't exist
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
@@ -3848,7 +3848,7 @@ func TestReconcileRollingUpdate_StaleAnnotationRequiresAllNewWorkersReady(t *tes
 	})
 	r := createTestReconcilerWithStatus(dgd, withObjects(newPrefillDCD))
 
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 
 	assert.Equal(t, testOldWorkerHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
@@ -3898,7 +3898,7 @@ func TestReconcileRollingUpdate_StaleAnnotationUpdatesAfterAllNewWorkersReady(t 
 		),
 	)
 
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 
 	assert.NotContains(t, dgd.Annotations, consts.AnnotationCurrentWorkerHash)
@@ -3916,7 +3916,7 @@ func TestReconcileRollingUpdate_NonePhaseStartsRollout(t *testing.T) {
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 	assert.Equal(t, nvidiacomv1beta1.RollingUpdatePhasePending, dgd.Status.RollingUpdate.Phase)
 	assert.NotNil(t, dgd.Status.RollingUpdate.StartTime)
@@ -3942,7 +3942,7 @@ func TestReconcileRollingUpdate_StuckDetection_CompletesViaCompleteRollingUpdate
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	err := r.reconcileRollingUpdate(context.Background(), dgd)
+	err := r.reconcileRollingUpdate(context.Background(), dgd, &dgd.Status)
 	require.NoError(t, err)
 
 	// Phase should be Completed

--- a/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_rollingupdate_test.go
@@ -527,7 +527,7 @@ func TestUnsupportedPathwayMigratesV1OnlyAndKeepsV2OnlyGeneration(t *testing.T) 
 	}
 
 	r := createTestReconcilerWithStatus(dgd)
-	require.False(t, r.supportsManagedRollingUpdate(dgd))
+	require.False(t, (&componentProgram{reconciler: r}).supportsManagedRollingUpdate(dgd))
 
 	require.NoError(t, r.migrateCurrentWorkerHashIfNeeded(context.Background(), dgd))
 	require.Equal(t, legacyHash, dgd.Annotations[consts.AnnotationCurrentWorkerHash])
@@ -561,7 +561,7 @@ func TestUnsupportedPathwayMigratesV1OnlyAndKeepsV2OnlyGeneration(t *testing.T) 
 	require.Equal(t, newV2Hash, rollingCtx.NewWorkerHash)
 }
 
-func TestSupportsManagedRollingUpdate(t *testing.T) {
+func TestComponentProgram_SupportsManagedRollingUpdate(t *testing.T) {
 	tests := []struct {
 		name     string
 		services map[string]*nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
@@ -591,9 +591,9 @@ func TestSupportsManagedRollingUpdate(t *testing.T) {
 			dgd := createTestDGD("test-dgd", tt.services)
 			r := createTestReconcilerWithStatus(dgd)
 
-			result := r.supportsManagedRollingUpdate(dgd)
+			result := (&componentProgram{reconciler: r}).supportsManagedRollingUpdate(dgd)
 			if result != tt.expected {
-				t.Errorf("isUnsupportedRollingUpdatePathway() = %v, expected %v", result, tt.expected)
+				t.Errorf("supportsManagedRollingUpdate() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This MR moves workload rollout control out of the outer `DynamoGraphDeployment` reconciliation flow and into the selected workload program.

After finalization, the outer DGD controller now:

1. Builds the ephemeral reconciliation state.
2. Selects exactly one workload program.
3. Invokes that program once.
4. Projects the successful result into DGD status.

Each concrete program composes its complete ordered reconciliation flow.

The component pathway now performs:

1. Worker-hash migration.
2. Managed or unsupported-path rollout handling.
3. Shared resource reconciliation.
4. Component-specific multinode validation.
5. Restart-state resolution.
6. DCD workload reconciliation.
7. Shared checkpoint-readiness and scaling-adapter processing.

The Grove pathway performs the equivalent composition while retaining its existing unsupported managed-rollout behavior and temporary Grove workload adapter.

This MR is stacked on the preceding workload-program MR.

## Motivation

The outer DGD controller previously selected the workload pathway in one place while independently deciding rollout behavior in another.

That left the common controller coupled to component-specific decisions such as:

- whether managed rolling updates are supported;
- when to initialize worker hashes;
- when to start or advance a rollout;
- how unsupported pathways acknowledge worker changes.

It also meant the selected workload program did not yet own its complete graph-level state machine.

This change makes rollout behavior part of each concrete program’s composition while keeping shared resource operations reusable and explicit.

## Design

### Complete workload programs

The `workloadProgram` contract remains a single `Reconcile` method. No provider lifecycle callbacks such as `Prepare`, `Render`, `Scale`, or `Cleanup` are added.

`componentProgram.Reconcile` and `groveProgram.Reconcile` explicitly compose their operations in order. Earlier operations enrich `graphReconcileState`; later operations consume those resolved values.

### Shared reconciliation steps

The former `reconcileResources` flow is split into focused shared operations:

- `reconcileProgramInputs` reconciles common resources and records resolved checkpoint and multinode information.
- `resolveProgramRestartState` computes restart state after pathway-specific validation.
- `reconcileProgramResult` applies checkpoint-readiness policy and reconciles scaling adapters.

These are concrete shared operations composed by each program, not hooks driven by a generic framework.

### Rollout ownership

`componentProgram` now decides whether a component deployment uses:

- the existing managed rolling-update state machine for single-node component workloads; or
- the existing unsupported-path worker-hash behavior for multinode component workloads.

`groveProgram` explicitly composes the unsupported-path worker-hash behavior.

The underlying rolling-update helper implementations remain on `DynamoGraphDeploymentReconciler` temporarily. This MR moves control-flow ownership without combining it with a large mechanical dependency/receiver migration.

### Failure semantics

Program-specific rollout failures retain their existing DGD failure reasons:

- `failed_to_migrate_worker_hash`
- `failed_to_initialize_worker_hash`
- `rolling_update_failed`

Other program failures retain `failed_to_reconcile_the_resources`.

A program publishes `state.Result` only after its entire reconciliation sequence succeeds. A rollout, shared-resource, workload, or post-processing error therefore cannot replace the last-known-good component or restart status with a partial result.

## Behavior and compatibility

This is intended to be a behavior-preserving refactor:

- Finalization remains owned by the outer DGD controller.
- The outer DGD controller remains the only DGD status writer.
- Workload-program selection semantics are unchanged.
- Managed rolling updates remain limited to single-node component workloads.
- Grove and multinode workloads retain their existing unsupported-path behavior.
- Worker-hash migration and compatibility behavior are unchanged.
- Rollout reconciliation still occurs before shared resource reconciliation.
- Component multinode validation still occurs before restart-state resolution.
- Checkpoint readiness and scaling-adapter ordering are unchanged.
- Rolling-update status continues to override the overall DGD state where applicable.
- Results are still projected only after successful resource reconciliation.

There are no CRD, rendered-resource, ownership, watch-registration, or persisted-state changes.

## Tests

Added or updated coverage for:

- component-owned managed-rollout selection;
- managed rollout startup for single-node workloads;
- unsupported-path behavior for multinode component workloads;
- Grove unsupported-path failure handling;
- preservation of the previous program result on rollout errors;
- preservation of rollout-specific failure reasons;
- workload adapters independently from the complete program composition;
- shared resource validation before workload reconciliation.

The existing rolling-update characterization suite remains unchanged apart from transferring the managed-rollout support predicate to `componentProgram`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved deployment reconciliation reliability and status reporting.
  * Added clearer handling for worker rollout, migration, and resource reconciliation failures.
  * Improved rolling-update tracking and completion behavior.
  * Added support for pathway-specific reconciliation and more consistent readiness reporting.

* **Tests**
  * Expanded coverage for reconciliation failures, status preservation, workload selection, and rolling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->