### PR TITLE
feat(llm): add classify protocol types

### DIFF
--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::{
     ContentProvider,
@@ -15,6 +16,7 @@ use crate::types::TokenIdType;
 pub mod audios;
 pub mod batches;
 pub mod chat_completions;
+pub mod classify;
 pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;
@@ -32,6 +34,14 @@ use validate::{
     BEST_OF_RANGE, FREQUENCY_PENALTY_RANGE, MIN_P_RANGE, N_RANGE, PRESENCE_PENALTY_RANGE,
     TEMPERATURE_RANGE, TOP_P_RANGE, validate_range,
 };
+
+/// Side from which prompt tokens are truncated.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptTruncationSide {
+    Left,
+    Right,
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnnotatedDelta<R> {

--- a/lib/llm/src/protocols/openai/classify.rs
+++ b/lib/llm/src/protocols/openai/classify.rs
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/v1/classify` endpoint (sequence-classification /
+//! cross-encoder pooling models, e.g. NLI or sentiment).
+//!
+//! There is no OpenAI-native classification schema, so — unlike embeddings,
+//! which wraps `dynamo_protocols::types::CreateEmbeddingRequest` — these types
+//! are defined fully in-repo. The wire shape mirrors vLLM's `/classify`
+//! endpoint (`vllm/entrypoints/pooling/classify/protocol.py`, vLLM 0.25.1):
+//! request `{model, input, ...}` → response
+//! `{id, object, created, model, data:[{index, label, probs, num_classes}], usage}`.
+//!
+//! Only the **completion-style** request (`input`) is supported. vLLM also
+//! accepts a chat-style variant (`messages`) that renders a chat template;
+//! that is out of scope here. Pooling controls such as `priority`,
+//! `cache_salt`, `mm_processor_kwargs`, `use_activation`,
+//! `add_special_tokens`, `truncate_prompt_tokens`, and `truncation_side` are
+//! forwarded.
+
+use std::collections::HashMap;
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+
+use super::PromptTruncationSide;
+pub use super::embeddings::{NvExt, NvExtProvider};
+
+/// Classification input — text or pre-tokenized prompts, single or batched.
+/// Mirrors the `input` field of vLLM's `ClassificationCompletionRequest`
+/// (`CompletionRequestMixin`: `list[int] | list[list[int]] | str | list[str]`),
+/// so upstream-tokenized clients migrate unchanged.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ClassificationInput {
+    /// A single text to classify.
+    Single(String),
+    /// A batch of texts to classify.
+    Batch(Vec<String>),
+    /// A single pre-tokenized prompt (token IDs).
+    Tokens(Vec<u32>),
+    /// A batch of pre-tokenized prompts.
+    TokenBatch(Vec<Vec<u32>>),
+}
+
+/// Request for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyRequest {
+    /// The model to use for classification.
+    pub model: String,
+
+    /// The text (or texts) to classify.
+    pub input: ClassificationInput,
+
+    /// A unique identifier representing the end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Optional caller-provided identifier used in the response ID. Internal
+    /// engine request IDs remain server-generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    /// Scheduling priority. Lower values are scheduled first.
+    #[serde(default)]
+    pub priority: i64,
+
+    /// Additional keyword arguments forwarded to the Hugging Face processor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+
+    /// Salt applied to prefix-cache keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    /// Whether to apply the classification pooler's activation
+    /// (sigmoid/softmax). `None` uses the pooler's default. Forwarded verbatim
+    /// to `PoolingParams`, mirroring vLLM's `ClassifyRequestMixin`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_activation: Option<bool>,
+
+    /// Whether to add the tokenizer's special tokens (BOS/CLS/SEP). `None`
+    /// uses the tokenizer default (`true`). Forwarded to the worker's
+    /// tokenization, mirroring vLLM's `CompletionRequestMixin.add_special_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_special_tokens: Option<bool>,
+
+    /// Truncate the tokenized prompt to this many tokens (`-1` = model max).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
+    /// Which side to truncate from. When omitted, the tokenizer default is
+    /// used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation_side: Option<PromptTruncationSide>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One classification result within a [`NvCreateClassifyResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct ClassificationData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Predicted label (from the model's `id2label`), if available.
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// Per-class probability vector.
+    pub probs: Vec<f32>,
+
+    /// Number of classes (== `probs.len()`).
+    pub num_classes: u32,
+}
+
+/// Usage information for a classification response.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ClassificationUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Response for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<ClassificationData>,
+    pub usage: ClassificationUsage,
+}
+
+impl NvCreateClassifyResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "classify".to_string(),
+            data: vec![],
+            usage: ClassificationUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreateClassifyRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreateClassifyRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreateClassifyRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreateClassifyRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Single(_)));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["input"], "hello world");
+    }
+
+    #[test]
+    fn batch_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::Batch(v) => assert_eq!(v.len(), 2),
+            _ => panic!("expected batch input"),
+        }
+    }
+
+    #[test]
+    fn token_inputs_parse_as_token_variants() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [101, 2023, 102]
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Tokens(_)));
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [[101, 102], [101, 103]]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::TokenBatch(v) => assert_eq!(v.len(), 2),
+            other => panic!("expected token batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn use_activation_round_trips_and_defaults_to_none() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.use_activation.is_none());
+        // Omitted → not serialized onto the wire to the worker.
+        assert!(
+            serde_json::to_value(&request)
+                .unwrap()
+                .get("use_activation")
+                .is_none()
+        );
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "use_activation": false
+        }))
+        .unwrap();
+        assert_eq!(request.use_activation, Some(false));
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["use_activation"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn tokenization_options_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "add_special_tokens": false,
+            "truncate_prompt_tokens": 128,
+            "truncation_side": "left"
+        }))
+        .unwrap();
+        assert_eq!(request.add_special_tokens, Some(false));
+        assert_eq!(request.truncate_prompt_tokens, Some(128));
+        assert_eq!(request.truncation_side, Some(PromptTruncationSide::Left));
+
+        // All omitted → None, none serialized onto the worker wire.
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&request).unwrap();
+        assert!(value.get("add_special_tokens").is_none());
+        assert!(value.get("truncate_prompt_tokens").is_none());
+        assert!(value.get("truncation_side").is_none());
+    }
+
+    #[test]
+    fn classify_request_controls_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "user": "user-1",
+            "request_id": "request-1",
+            "priority": -2,
+            "mm_processor_kwargs": {"do_resize": false},
+            "cache_salt": "salt"
+        }))
+        .unwrap();
+
+        assert_eq!(request.user.as_deref(), Some("user-1"));
+        assert_eq!(request.request_id.as_deref(), Some("request-1"));
+        assert_eq!(request.priority, -2);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
+        assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn omitted_nvext_is_not_serialized() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.nvext.is_none());
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("nvext").is_none());
+    }
+}

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreateClassifyResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+};
+
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
+use futures::Stream;
+
+impl StreamAggregable for NvCreateClassifyResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "classify" && next.model != "classify" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+    }
+}
+
+impl NvCreateClassifyResponse {
+    /// Converts an SSE stream into a [`NvCreateClassifyResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        let stream = convert_sse_stream::<NvCreateClassifyResponse>(stream);
+        NvCreateClassifyResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of classification responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::classify::ClassificationData;
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        label: &str,
+        probs: Vec<f32>,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreateClassifyResponse> {
+        let response = NvCreateClassifyResponse {
+            id: "classify-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![ClassificationData {
+                index,
+                label: Some(label.to_string()),
+                num_classes: probs.len() as u32,
+                probs,
+            }],
+            usage: super::super::ClassificationUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_classification() {
+        let annotated = make_response(0, "entailment", vec![0.1, 0.7, 0.2], 5);
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].label.as_deref(), Some("entailment"));
+        assert_eq!(response.data[0].num_classes, 3);
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_classifications() {
+        let a = make_response(0, "entailment", vec![0.8, 0.2], 4);
+        let b = make_response(1, "contradiction", vec![0.3, 0.7], 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreateClassifyResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_stream_errors() {
+        use dynamo_runtime::{
+            error::{BackendError, ErrorType},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let backend_error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid classify input")
+            .build();
+        let stream = stream::iter(vec![Annotated::<NvCreateClassifyResponse>::from_err(
+            backend_error,
+        )]);
+
+        let error = NvCreateClassifyResponse::from_annotated_stream(stream)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid classify input");
+    }
+}

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -4,6 +4,7 @@
 use futures::{Stream, StreamExt};
 
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 /// Response types whose `Annotated<T>` streams can be folded into a single `T`
 /// using shared aggregation infrastructure.
@@ -28,6 +29,39 @@ where
 
     while let Some(delta) = stream.next().await {
         let delta = delta.ok()?;
+        if let Some(data) = delta.data {
+            match response.as_mut() {
+                Some(existing) => existing.merge(data),
+                None => response = Some(data),
+            }
+        }
+    }
+
+    Ok(response.unwrap_or_else(T::empty))
+}
+
+/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
+/// errors. Existing callers that expose string errors can continue to use
+/// [`aggregate_stream`].
+pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
+where
+    T: StreamAggregable,
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response: Option<T> = None;
+
+    while let Some(delta) = stream.next().await {
+        if delta.is_error() {
+            return Err(delta.error.unwrap_or_else(|| {
+                DynamoError::msg(
+                    delta
+                        .comment
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            }));
+        }
         if let Some(data) = delta.data {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),


### PR DESCRIPTION
## Summary

- Add OpenAI-compatible classify request, response, streaming, and aggregation protocol types.
- Keep the types dormant: this layer does not register or expose a new HTTP endpoint.
- First PR in the stack extracted from #12058.

## Validation

- 20 targeted Rust classify protocol tests passed.
- Pre-commit hooks passed for the changed files.
- The complete stacked tree was exercised against a local vLLM Dynamo service.

## Stack

- **1 of 14**
- Previous: `main`
- Next: [#12123](https://github.com/ai-dynamo/dynamo/pull/12123)
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `main`
- Head: `jihao/vllm-classify-protocol`
