### PR TITLE
feat(http): define classify and pooling endpoints

### DIFF
--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -20,6 +20,10 @@ pub enum EndpointType {
     Videos,
     /// Realtime API (bidirectional streaming over WebSocket)
     Realtime,
+    /// Classification API (sequence classification / cross-encoder pooling)
+    Classify,
+    /// Pooling API (raw pooler output: token embeddings, logits, rewards)
+    Pooling,
     /// Responses API
     Responses,
     /// Anthropic Messages API
@@ -40,6 +44,8 @@ impl EndpointType {
             Self::Audios => "audios",
             Self::Videos => "videos",
             Self::Realtime => "realtime",
+            Self::Classify => "classify",
+            Self::Pooling => "pooling",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
             Self::Generate => "generate",
@@ -56,6 +62,8 @@ impl EndpointType {
             Self::Audios,
             Self::Videos,
             Self::Realtime,
+            Self::Classify,
+            Self::Pooling,
             Self::Responses,
             Self::AnthropicMessages,
             Self::Generate,

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -285,6 +285,8 @@ struct StateFlags {
     chat_endpoints_enabled: AtomicBool,
     cmpl_endpoints_enabled: AtomicBool,
     embeddings_endpoints_enabled: AtomicBool,
+    classify_endpoints_enabled: AtomicBool,
+    pooling_endpoints_enabled: AtomicBool,
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
@@ -301,6 +303,8 @@ impl StateFlags {
             EndpointType::Chat => self.chat_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Completion => self.cmpl_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Embedding => self.embeddings_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Classify => self.classify_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Pooling => self.pooling_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
@@ -324,6 +328,12 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Embedding => self
                 .embeddings_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Classify => self
+                .classify_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Pooling => self
+                .pooling_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Images => self
                 .images_endpoints_enabled
@@ -370,6 +380,8 @@ impl State {
                 chat_endpoints_enabled: AtomicBool::new(false),
                 cmpl_endpoints_enabled: AtomicBool::new(false),
                 embeddings_endpoints_enabled: AtomicBool::new(false),
+                classify_endpoints_enabled: AtomicBool::new(false),
+                pooling_endpoints_enabled: AtomicBool::new(false),
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -227,6 +227,12 @@ impl ModelType {
         if self.contains(Self::Realtime) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Realtime);
         }
+        if self.contains(Self::Classify) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Classify);
+        }
+        if self.contains(Self::Pooling) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Pooling);
+        }
         // [gluo NOTE] ModelType::Tensor doesn't map to any endpoint type,
         // current use of endpoint type is LLM specific and so does the HTTP
         // server that uses it.
@@ -368,6 +374,14 @@ mod tests {
     }
 
     #[test]
+    fn classify_endpoint_mapping() {
+        assert_eq!(
+            ModelType::Classify.as_endpoint_types(),
+            vec![EndpointType::Classify]
+        );
+    }
+
+    #[test]
     fn pooling_bit_position() {
         assert_eq!(ModelType::Pooling.bits(), 1 << 10);
     }
@@ -393,6 +407,10 @@ mod tests {
         assert_eq!(
             combined.units(),
             vec![ModelType::Classify, ModelType::Pooling]
+        );
+        assert_eq!(
+            combined.as_endpoint_types(),
+            vec![EndpointType::Classify, EndpointType::Pooling]
         );
     }
 


### PR DESCRIPTION
## Summary

- Define classify and pooling endpoint kinds and their service-state flags.
- Handle the new variants exhaustively while leaving route registration for the next HTTP layer.
- Stack layer extracted from #12058.

## Validation

- Targeted dynamo-llm tests passed.
- Pre-commit hooks passed for the changed files.

## Stack

- **4 of 14**
- Previous: [#12124](https://github.com/ai-dynamo/dynamo/pull/12124)
- Next: [#12126](https://github.com/ai-dynamo/dynamo/pull/12126)
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `jihao/vllm-pooling-discovery`
- Head: `jihao/vllm-pooling-endpoint-types`
