### PR TITLE
feat(vllm): wire the classify worker factory

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -43,6 +43,7 @@ def _make_config(**overrides) -> Mock:
         "route_to_encoder": False,
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
+        "classify_worker": False,
     }
     defaults.update(overrides)
     return Mock(**defaults)
@@ -471,6 +472,7 @@ class TestCreate:
         factory._create_prefill_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_decode_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_embedding_worker = AsyncMock()  # type: ignore[assignment]
+        factory._create_classify_worker = AsyncMock()  # type: ignore[assignment]
         return factory
 
     # Tests for non-legacy worker config, 'route_to_encode' is worker internal config
@@ -536,6 +538,17 @@ class TestCreate:
         factory._create_prefill_worker.assert_not_called()  # type: ignore[union-attr]
         factory._create_multimodal_encode_worker.assert_not_called()  # type: ignore[union-attr]
 
+    async def test_classify_worker_takes_priority(self, factory: WorkerFactory) -> None:
+        config = _make_config(classify_worker=True)
+        shutdown_event = asyncio.Event()
+
+        await factory.create(Mock(), config, shutdown_event, [])
+
+        factory._create_classify_worker.assert_called_once()  # type: ignore[union-attr]
+        factory._create_decode_worker.assert_not_called()  # type: ignore[union-attr]
+        factory._create_prefill_worker.assert_not_called()  # type: ignore[union-attr]
+        factory._create_multimodal_encode_worker.assert_not_called()  # type: ignore[union-attr]
+
     async def test_passes_snapshot_engine(self, factory: WorkerFactory) -> None:
         config = _make_config(multimodal_worker=True)
         runtime = Mock()
@@ -564,6 +577,74 @@ class TestCreate:
             shutdown_endpoints,
             snapshot_engine=snapshot_engine,
         )
+
+
+@pytest.mark.asyncio
+async def test_classify_worker_registers_only_classify(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = Mock()
+    endpoint.connection_id.return_value = "worker-1"
+    endpoint.serve_endpoint = AsyncMock()
+    runtime = Mock()
+    runtime.endpoint.return_value = endpoint
+
+    engine_client = Mock()
+    vllm_config = Mock(model_config=Mock())
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        None,
+    )
+    register_model = AsyncMock()
+    handler = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.ClassifyWorkerHandler",
+        Mock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory",
+        Mock(return_value=Mock()),
+    )
+
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(),
+        register_vllm_model_fn=register_model,
+        setup_fpm_relay_fn=Mock(),
+        setup_metrics_collection_fn=Mock(),
+    )
+    config = _make_config(
+        classify_worker=True,
+        namespace="dynamo",
+        component="worker",
+        endpoint="generate",
+        served_model_name="model",
+        model="model",
+    )
+    shutdown_endpoints: list = []
+
+    await factory._create_classify_worker(
+        runtime,
+        config,
+        asyncio.Event(),
+        shutdown_endpoints,
+    )
+
+    register_model.assert_awaited_once_with(
+        ModelInput.Text,
+        ModelType.Classify,
+        endpoint,
+        config,
+        engine_client,
+        vllm_config,
+        worker_type=WorkerType.Aggregated,
+        needs=[],
+    )
+    assert shutdown_endpoints == [endpoint]
+    handler.cleanup.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -45,6 +45,7 @@ from .health_check import (
 )
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .multimodal_handlers import EncodeWorkerHandler
+from .pooling_handlers import ClassifyWorkerHandler
 from .publisher import StatLoggerFactory
 
 logger = logging.getLogger(__name__)
@@ -573,6 +574,14 @@ class WorkerFactory:
             )
             return
 
+        # This getattr keeps the factory wiring dormant until the
+        # --classify-worker configuration flag is introduced.
+        if getattr(config, "classify_worker", False):
+            await self._create_classify_worker(
+                runtime, config, shutdown_event, shutdown_endpoints
+            )
+            return
+
         # NOTE: --benchmark-mode is only supported for prefill/decode workers.
         # The encode worker path does not wire benchmark waiting or
         # the get_perf_metrics endpoint.
@@ -751,6 +760,75 @@ class WorkerFactory:
             )
         except Exception as e:
             logger.error(f"Failed to serve embedding worker endpoint: {e}")
+            raise
+        finally:
+            handler.cleanup()
+
+    async def _create_classify_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,  # mutated in place
+    ) -> None:
+        """Initialize an aggregated sequence-classification worker.
+
+        Like the embeddings worker, this uses a pooling ``AsyncLLM`` and skips
+        the generation-only KV-cache and scheduler machinery. This wiring
+        initially advertises only ``ModelType.Classify``; pooling endpoint
+        registration is enabled separately.
+        """
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        shutdown_endpoints[:] = [generate_endpoint]
+
+        fpm_worker_id = str(generate_endpoint.connection_id())
+        factory = StatLoggerFactory(
+            endpoint=generate_endpoint,
+            embedding_worker=True,
+        )
+        (
+            engine_client,
+            vllm_config,
+            _default_sampling_params,
+            _prometheus_temp_dir,
+            _component_gauges,
+        ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+
+        handler = ClassifyWorkerHandler(
+            runtime=runtime,
+            engine=engine_client,
+            config=config,
+            model_config=getattr(vllm_config, "model_config", None),
+            shutdown_event=shutdown_event,
+        )
+
+        classify_health_check_payload = VllmEmbeddingHealthCheckPayload(
+            model_name=config.served_model_name or config.model
+        ).to_dict()
+
+        logger.info("Starting to serve the classify worker endpoint...")
+        try:
+            await asyncio.gather(
+                generate_endpoint.serve_endpoint(
+                    handler.generate,
+                    metrics_labels=[("model", config.model)],
+                    health_check_payload=classify_health_check_payload,
+                ),
+                self.register_vllm_model(
+                    ModelInput.Text,
+                    ModelType.Classify,
+                    generate_endpoint,
+                    config,
+                    engine_client,
+                    vllm_config,
+                    worker_type=WorkerType.Aggregated,
+                    needs=[],
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to serve classify worker endpoint: {e}")
             raise
         finally:
             handler.cleanup()


### PR DESCRIPTION
## Summary

- Wire the pooling-family handler into the vLLM worker factory behind classify-worker configuration.
- Keep the new path dormant until the later CLI/configuration activation layer.
- Add factory-level coverage for handler selection and endpoint publication.
- Stack layer extracted from #12058.

## Validation

- 28 worker-factory tests passed.
- Pre-commit hooks passed for the changed files.

## Stack

- **9 of 14**
- Previous: [#12129](https://github.com/ai-dynamo/dynamo/pull/12129)
- Next: [#12131](https://github.com/ai-dynamo/dynamo/pull/12131)
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `jihao/vllm-pooling-worker-tests`
- Head: `jihao/vllm-classify-worker-wiring`
