### PR TITLE
fix(vllm): suppress pooling-family LoRA capacity

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -751,7 +751,7 @@ async def register_vllm_model(
         model_aliases=config.served_model_aliases or None,
         # Advertise LoRA capacity on the BASE card so the frontend can place the first
         # adapter onto an idle worker. Decode, aggregated, and prefill workers all serve
-        # lifecycle registration; embeddings still do not.
+        # lifecycle registration; embeddings and classify still do not.
         max_gpu_lora_count=_base_model_lora_capacity(config, model_type),
     )
 
@@ -759,7 +759,15 @@ async def register_vllm_model(
 def _base_model_lora_capacity(config: Config, model_type: ModelType) -> int | None:
     if not getattr(config.engine_args, "enable_lora", False):
         return None
-    if model_type == ModelType.Embedding:
+    # Pooling-family workers (embedding, classify|pooling) do not serve the
+    # LoRA load endpoints, so they must not advertise adapter capacity. Use
+    # capability checks, not identity: the classify worker registers the
+    # combined ModelType.Classify | ModelType.Pooling bits.
+    if (
+        model_type.supports_embedding()
+        or model_type.supports_classify()
+        or model_type.supports_pooling()
+    ):
         return None
     return config.engine_args.max_loras
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -77,6 +77,11 @@ def _load_vllm_main() -> ModuleType:
         (True, dynamo_llm.ModelType.Prefill, 3),
         (True, dynamo_llm.ModelType.Chat, 3),
         (True, dynamo_llm.ModelType.Embedding, None),
+        (
+            True,
+            dynamo_llm.ModelType.Classify | dynamo_llm.ModelType.Pooling,
+            None,
+        ),
         (False, dynamo_llm.ModelType.Prefill, None),
     ],
 )


### PR DESCRIPTION
## Summary

- Prevent pooling-family workers from advertising generation-style LoRA capacity.
- Land this registration safeguard before the worker is enabled so no intermediate activation can publish incorrect capacity.
- Stack layer extracted from #12058.

## Validation

- The focused vLLM registration test passed.
- Pre-commit hooks passed for the changed files.

## Stack

- **10 of 14**
- Previous: [#12130](https://github.com/ai-dynamo/dynamo/pull/12130)
- Next: [#12132](https://github.com/ai-dynamo/dynamo/pull/12132)
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `jihao/vllm-classify-worker-wiring`
- Head: `jihao/vllm-pooling-registration-safeguard`
