### PR TITLE
feat(vllm): advertise the pooling endpoint

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -183,8 +183,8 @@ class DynamoVllmArgGroup(ArgGroup):
             flag_name="--classify-worker",
             env_var="DYN_VLLM_CLASSIFY_WORKER",
             default=False,
-            help="Run as a sequence-classification worker, exposing /v1/classify. "
-            "Engine must be started with vLLM's --runner pooling. "
+            help="Run as a sequence-classification worker, exposing /v1/classify and "
+            "/v1/pooling endpoints. Engine must be started with vLLM's --runner pooling. "
             "Skips KV events, KV router registration, and InstrumentedScheduler injection.",
         )
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -580,7 +580,7 @@ class TestCreate:
 
 
 @pytest.mark.asyncio
-async def test_classify_worker_registers_only_classify(
+async def test_classify_worker_registers_classify_and_pooling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     endpoint = Mock()
@@ -633,16 +633,23 @@ async def test_classify_worker_registers_only_classify(
         shutdown_endpoints,
     )
 
-    register_model.assert_awaited_once_with(
-        ModelInput.Text,
-        ModelType.Classify,
+    register_model.assert_awaited_once()
+    register_args = register_model.await_args.args
+    registered_model_type = register_args[1]
+    assert register_args[0] == ModelInput.Text
+    assert registered_model_type.supports_classify()
+    assert registered_model_type.supports_pooling()
+    assert not registered_model_type.supports_embedding()
+    assert register_args[2:] == (
         endpoint,
         config,
         engine_client,
         vllm_config,
-        worker_type=WorkerType.Aggregated,
-        needs=[],
     )
+    assert register_model.await_args.kwargs == {
+        "worker_type": WorkerType.Aggregated,
+        "needs": [],
+    }
     assert shutdown_endpoints == [endpoint]
     handler.cleanup.assert_called_once()
 

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -774,9 +774,8 @@ class WorkerFactory:
         """Initialize an aggregated sequence-classification worker.
 
         Like the embeddings worker, this uses a pooling ``AsyncLLM`` and skips
-        the generation-only KV-cache and scheduler machinery. This wiring
-        initially advertises only ``ModelType.Classify``; pooling endpoint
-        registration is enabled separately.
+        the generation-only KV-cache and scheduler machinery. The combined
+        model type advertises both pooling-family endpoints.
         """
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
@@ -818,7 +817,7 @@ class WorkerFactory:
                 ),
                 self.register_vllm_model(
                     ModelInput.Text,
-                    ModelType.Classify,
+                    ModelType.Classify | ModelType.Pooling,
                     generate_endpoint,
                     config,
                     engine_client,


### PR DESCRIPTION
## Summary

- Advertise /v1/pooling from the already-enabled pooling-family worker.
- Keep classify and pooling endpoint publication explicit and covered at the factory boundary.
- Stack layer extracted from #12058.

## Validation

- A live local vLLM Dynamo stack served both /v1/classify and /v1/pooling.
- Live checks passed for float, base64, bytes, bytes_only, pre-tokenized truncation on both sides, batched token IDs, and token_classify.
- Pre-commit hooks passed for the changed files.

## Stack

- **12 of 14**
- Previous: [#12132](https://github.com/ai-dynamo/dynamo/pull/12132)
- Next: [#12134](https://github.com/ai-dynamo/dynamo/pull/12134)
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `jihao/vllm-classify-enable`
- Head: `jihao/vllm-pooling-enable`
