### PR TITLE
test(vllm): cover classify and pooling endpoints

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -29,12 +29,14 @@ from tests.utils.payload_builder import (
     chat_payload,
     chat_payload_default,
     chat_payload_with_logprobs,
+    classify_payload,
     completion_payload_default,
     completion_payload_with_logprobs,
     embedding_payload,
     embedding_payload_default,
     kv_events_metrics_payload,
     metric_payload_default,
+    pooling_payload,
     router_cached_tokens_chat_payload,
     router_selection_chat_payload_default,
 )
@@ -730,6 +732,90 @@ vllm_configs = {
                 repeat_count=1,
                 expected_log=[],
                 expected_response=["Generated 1 embeddings with dimension 128"],
+            ),
+        ],
+    ),
+    "classify_agg": VLLMConfig(
+        name="classify_agg",
+        directory=vllm_dir,
+        script_name="agg_classify.sh",
+        marks=[
+            pytest.mark.core,
+            pytest.mark.gpu_1,
+            # Small RoBERTa NLI classifier plus vLLM pooling overhead.
+            pytest.mark.profiled_vram_gib(3.0),
+            # Pooling models do not use a KV cache, but the harness requires
+            # a non-zero allocation budget.
+            pytest.mark.requested_vllm_kv_cache_bytes(559_693_824),
+            pytest.mark.timeout(360),
+            pytest.mark.pre_merge,
+        ],
+        model="cross-encoder/nli-MiniLM2-L6-H768",
+        request_payloads=[
+            classify_payload(
+                input_data=("A man is playing a sport. Some men are playing a sport."),
+            ),
+            classify_payload(
+                input_data=[
+                    "A soccer game is underway. Some men are playing a sport.",
+                    "A cat sleeps on a mat. A dog is swimming in the ocean.",
+                ],
+            ),
+            # A single token-ID prompt must be truncated through vLLM's
+            # renderer rather than bypassing truncate_prompt_tokens.
+            classify_payload(
+                input_data=[0, 101, 102, 2],
+                expected_prompt_tokens=2,
+                extra_body={"truncate_prompt_tokens": 2},
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+            ),
+            # Token-level classification preserves the token-by-class matrix.
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="token_classify",
+            ),
+            # A batch of token-ID prompts covers the second pre-tokenized
+            # request shape from the vLLM completion-input contract.
+            pooling_payload(
+                input_data=[[0, 101, 102, 2], [0, 201, 202, 2]],
+                task="classify",
+                expected_prompt_tokens=4,
+                extra_body={"truncate_prompt_tokens": 2},
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                extra_body={
+                    "encoding_format": "base64",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                expected_response=["Pooled 1 binary tensors"],
+                extra_body={
+                    "encoding_format": "bytes",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
+            ),
+            pooling_payload(
+                input_data="Some men are playing a sport.",
+                task="classify",
+                expected_response=["Pooled bytes_only response"],
+                extra_body={
+                    "encoding_format": "bytes_only",
+                    "embed_dtype": "float16",
+                    "endianness": "big",
+                },
             ),
         ],
     ),

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -11,6 +11,7 @@ from tests.utils.payloads import (
     CachedTokensChatPayload,
     ChatPayload,
     ChatPayloadWithLogprobs,
+    ClassifyPayload,
     ClearKVBlocksPayload,
     CompletionPayload,
     CompletionPayloadWithLogprobs,
@@ -21,6 +22,7 @@ from tests.utils.payloads import (
     KvEventMetricsPayload,
     LMCacheMetricsPayload,
     MetricsPayload,
+    PoolingPayload,
     ResponsesPayload,
     ResponsesStreamPayload,
     RouterNvextChatPayload,
@@ -511,6 +513,64 @@ def embedding_payload(
         expected_log=expected_log or [],
         expected_response=expected_response
         or [f"Generated {expected_count} embeddings with dimension"],
+    )
+
+
+PoolingInput = Union[str, List[str], List[int], List[List[int]]]
+
+
+def _pooling_input_count(input_data: PoolingInput) -> int:
+    if isinstance(input_data, str):
+        return 1
+    if input_data and isinstance(input_data[0], int):
+        return 1
+    return len(input_data)
+
+
+def classify_payload(
+    input_data: PoolingInput,
+    repeat_count: int = 1,
+    expected_response: Optional[List[str]] = None,
+    expected_log: Optional[List[str]] = None,
+    expected_prompt_tokens: Optional[int] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> ClassifyPayload:
+    body: Dict[str, Any] = {"input": input_data}
+    if extra_body:
+        body.update(extra_body)
+    expected_count = _pooling_input_count(input_data)
+
+    return ClassifyPayload(
+        body=body,
+        repeat_count=repeat_count,
+        expected_log=expected_log or [],
+        expected_response=expected_response or [f"Classified {expected_count} inputs"],
+        expected_prompt_tokens=expected_prompt_tokens,
+    )
+
+
+def pooling_payload(
+    input_data: PoolingInput,
+    task: Optional[str] = None,
+    repeat_count: int = 1,
+    expected_response: Optional[List[str]] = None,
+    expected_log: Optional[List[str]] = None,
+    expected_prompt_tokens: Optional[int] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> PoolingPayload:
+    body: Dict[str, Any] = {"input": input_data}
+    if task is not None:
+        body["task"] = task
+    if extra_body:
+        body.update(extra_body)
+    expected_count = _pooling_input_count(input_data)
+
+    return PoolingPayload(
+        body=body,
+        repeat_count=repeat_count,
+        expected_log=expected_log or [],
+        expected_response=expected_response or [f"Pooled {expected_count} inputs"],
+        expected_prompt_tokens=expected_prompt_tokens,
     )
 
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1284,6 +1284,121 @@ class EmbeddingPayload(BasePayload):
 
 
 @dataclass
+class ClassifyPayload(BasePayload):
+    """Payload for the ``/v1/classify`` endpoint."""
+
+    endpoint: str = "/v1/classify"
+    expected_prompt_tokens: Optional[int] = None
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        result = response.json()
+        assert (
+            result.get("object") == "list"
+        ), f"Expected object='list', got {result.get('object')}"
+        assert result.get("data"), "Empty classification data"
+
+        for index, item in enumerate(result["data"]):
+            assert item.get("index") == index
+            probs = item.get("probs")
+            assert isinstance(probs, list) and probs, "probs must be a non-empty list"
+            assert item.get("num_classes") == len(probs)
+            assert all(isinstance(prob, (int, float)) for prob in probs)
+            assert item.get("label") is None or isinstance(item["label"], str)
+
+        usage = result.get("usage")
+        assert isinstance(usage, dict), "Missing usage in classification response"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Classified {len(result['data'])} inputs"
+
+
+@dataclass
+class PoolingPayload(BasePayload):
+    """Payload for JSON and binary ``/v1/pooling`` responses."""
+
+    endpoint: str = "/v1/pooling"
+    expected_prompt_tokens: Optional[int] = None
+
+    @staticmethod
+    def _validate_json_data(data: Any) -> None:
+        assert isinstance(data, list) and data, "pooling data must be non-empty"
+        values = data[0] if isinstance(data[0], list) else data
+        assert values and all(isinstance(value, (int, float)) for value in values)
+
+    def _handle_json_response(self, response: Any) -> str:
+        result = response.json()
+        assert (
+            result.get("object") == "list"
+        ), f"Expected object='list', got {result.get('object')}"
+        assert result.get("data"), "Empty pooling data"
+
+        encoding_format = self.body.get("encoding_format", "float")
+        dtype_width = {
+            "float32": 4,
+            "float16": 2,
+            "bfloat16": 2,
+            "fp8_e4m3": 1,
+            "fp8_e5m2": 1,
+        }[self.body.get("embed_dtype", "float32")]
+        for index, item in enumerate(result["data"]):
+            assert item.get("index") == index
+            assert item.get("object") == "pooling"
+            data = item.get("data")
+            if encoding_format == "base64":
+                assert isinstance(data, str)
+                decoded = base64.b64decode(data, validate=True)
+                assert decoded and len(decoded) % dtype_width == 0
+            else:
+                self._validate_json_data(data)
+
+        usage = result.get("usage")
+        assert isinstance(usage, dict), "Missing usage in pooling response"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        assert usage.get("completion_tokens") == 0
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Pooled {len(result['data'])} inputs as {encoding_format}"
+
+    def _handle_binary_response(self, response: Any) -> str:
+        assert response.headers.get("content-type") == "application/octet-stream"
+        assert response.content, "Empty binary pooling response"
+
+        encoding_format = self.body["encoding_format"]
+        metadata_header = response.headers.get("metadata")
+        if encoding_format == "bytes_only":
+            assert metadata_header is None
+            return f"Pooled bytes_only response with {len(response.content)} bytes"
+
+        assert metadata_header is not None, "bytes response is missing metadata"
+        metadata = json.loads(metadata_header)
+        assert metadata.get("data"), "bytes metadata has no tensor entries"
+        for index, item in enumerate(metadata["data"]):
+            assert item.get("index") == index
+            assert item.get("embed_dtype") == self.body.get("embed_dtype", "float32")
+            assert item.get("endianness") == self.body.get("endianness", "native")
+            assert item["start"] < item["end"] <= len(response.content)
+            assert item.get("shape")
+
+        usage = metadata.get("usage")
+        assert isinstance(usage, dict), "bytes metadata is missing usage"
+        assert usage.get("prompt_tokens") == usage.get("total_tokens")
+        if self.expected_prompt_tokens is not None:
+            assert usage.get("prompt_tokens") == self.expected_prompt_tokens
+
+        return f"Pooled {len(metadata['data'])} binary tensors"
+
+    def response_handler(self, response: Any) -> str:
+        response.raise_for_status()
+        if self.body.get("encoding_format") in ("bytes", "bytes_only"):
+            return self._handle_binary_response(response)
+        return self._handle_json_response(response)
+
+
+@dataclass
 class EmbeddingMultiWorkerDispatchPayload(BasePayload):
     """Send ``repeat_count`` embedding requests to the frontend, capturing a
     per-worker ``/metrics`` snapshot on the FIRST iteration and on the LAST

--- a/tests/utils/test_pooling_payload.py
+++ b/tests/utils/test_pooling_payload.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from tests.utils.payload_builder import classify_payload, pooling_payload
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+def _response(
+    *,
+    json_body: dict | None = None,
+    content: bytes = b"",
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = json_body
+    response.content = content
+    response.headers = headers or {}
+    return response
+
+
+def test_classify_payload_validates_truncated_usage():
+    payload = classify_payload(
+        input_data=[0, 1, 2, 3],
+        expected_prompt_tokens=2,
+        extra_body={"truncate_prompt_tokens": 2},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {
+                    "index": 0,
+                    "label": "entailment",
+                    "probs": [0.1, 0.8, 0.1],
+                    "num_classes": 3,
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "total_tokens": 2},
+        }
+    )
+
+    assert payload.process_response(response) == "Classified 1 inputs"
+
+
+def test_pooling_payload_validates_nested_float_output():
+    payload = pooling_payload(
+        input_data=[[0, 1, 2], [3, 4, 5]],
+        expected_prompt_tokens=4,
+        extra_body={"truncate_prompt_tokens": 2},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {"index": 0, "object": "pooling", "data": [[0.1], [0.2]]},
+                {"index": 1, "object": "pooling", "data": [[0.3], [0.4]]},
+            ],
+            "usage": {
+                "prompt_tokens": 4,
+                "total_tokens": 4,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert payload.process_response(response) == "Pooled 2 inputs as float"
+
+
+def test_pooling_payload_validates_base64_dtype_width():
+    payload = pooling_payload(
+        input_data="text",
+        extra_body={"encoding_format": "base64", "embed_dtype": "float16"},
+    )
+    response = _response(
+        json_body={
+            "object": "list",
+            "data": [
+                {
+                    "index": 0,
+                    "object": "pooling",
+                    "data": base64.b64encode(b"\x00\x01\x02\x03").decode(),
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 1,
+                "total_tokens": 1,
+                "completion_tokens": 0,
+            },
+        }
+    )
+
+    assert payload.process_response(response) == "Pooled 1 inputs as base64"
+
+
+def test_pooling_payload_validates_bytes_metadata():
+    payload = pooling_payload(
+        input_data="text",
+        expected_response=["Pooled 1 binary tensors"],
+        expected_prompt_tokens=3,
+        extra_body={
+            "encoding_format": "bytes",
+            "embed_dtype": "float16",
+            "endianness": "big",
+        },
+    )
+    metadata = {
+        "data": [
+            {
+                "index": 0,
+                "embed_dtype": "float16",
+                "endianness": "big",
+                "start": 0,
+                "end": 6,
+                "shape": [3],
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "total_tokens": 3},
+    }
+    response = _response(
+        content=b"\x00\x01\x02\x03\x04\x05",
+        headers={
+            "content-type": "application/octet-stream",
+            "metadata": json.dumps(metadata),
+        },
+    )
+
+    assert payload.process_response(response) == "Pooled 1 binary tensors"
+
+
+def test_pooling_payload_validates_bytes_only_without_metadata():
+    payload = pooling_payload(
+        input_data="text",
+        expected_response=["Pooled bytes_only response"],
+        extra_body={"encoding_format": "bytes_only"},
+    )
+    response = _response(
+        content=b"\x00\x01\x02\x03",
+        headers={"content-type": "application/octet-stream"},
+    )
+
+    assert payload.process_response(response) == (
+        "Pooled bytes_only response with 4 bytes"
+    )


### PR DESCRIPTION
## Summary

- Add shared classify/pooling payload builders and aggregate vLLM end-to-end coverage.
- Cover text and pre-tokenized inputs, batched tokens, truncation side, all encoding modes, classify parity, and token_classify.
- Stack layer extracted from #12058.

## Validation

- All 10 final live endpoint payload cases passed against cross-encoder/nli-MiniLM2-L6-H768.
- 104 targeted Python tests passed across the stack.
- 40 targeted Rust classify/pooling protocol tests passed.
- Pre-commit hooks passed for every changed file.

## Stack

- **14 of 14**
- Previous: [#12134](https://github.com/ai-dynamo/dynamo/pull/12134)
- Next: final layer
- Original unsplit PR: [#12058](https://github.com/ai-dynamo/dynamo/pull/12058)
- Base: `jihao/vllm-pooling-example`
- Head: `jihao/vllm-pooling-e2e`
