### PR TITLE
fix(router): clear a worker's overloaded mark on every healthy load sample

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -992,9 +992,7 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                         }
 
                         // Recompute the full overloaded set only when thresholds change;
-                        // otherwise incrementally update just this worker. When the set
-                        // changes, publish to both the decode Client and (in disaggregated
-                        // serving) the prefill Client — see `publish_overloaded_instances`.
+                        // otherwise incrementally update just this worker.
                         let overloaded_changed = if thresholds_changed {
                             last_thresholds = cfg.clone();
                             let overloaded_workers =
@@ -1004,13 +1002,25 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             overloaded_tracker.update_worker(worker_id, worker_overloaded)
                         };
 
+                        // Publish on every fresh load sample, even when the threshold-derived
+                        // set did not change. A worker can also be marked overloaded from the
+                        // request path via `Client::mark_overloaded_immediate` (on a
+                        // `ResourceExhausted` / "worker at capacity" response); that fast-path
+                        // state lives outside `overloaded_tracker` and is cleared only when the
+                        // monitor republishes the (now healthy) set. Gating the publish on
+                        // `overloaded_changed` means an unchanged healthy sample never
+                        // republishes, so a worker that briefly reported overload stays excluded
+                        // from routing indefinitely — the router then returns "All workers are
+                        // busy" forever even though the worker is idle. Publishing every sample
+                        // lets the healthy set overwrite the stale immediate mark.
+                        let overloaded_instances = overloaded_tracker.ids();
+                        publish_overloaded_instances(
+                            &client,
+                            &prefill_client_holder,
+                            &overloaded_instances,
+                        );
                         if overloaded_changed {
-                            let overloaded_instances = overloaded_tracker.ids();
-                            publish_overloaded_instances(
-                                &client,
-                                &prefill_client_holder,
-                                &overloaded_instances,
-                            );
+                            tracing::debug!(?overloaded_instances, "worker overload set changed");
                         }
                     }
 


### PR DESCRIPTION
> **Draft** — opening for discussion/validation. The fix is a small, targeted change; CI has not yet been run and I'd welcome maintainer input on the approach before finalizing.

## Overview

A worker that is ever marked overloaded via the request path (`Client::mark_overloaded_immediate`) can be **excluded from routing permanently**, causing the router to return `ResourceExhausted` / "All workers are busy, please retry later" **forever — even when the worker is idle and healthy.** Only a frontend restart recovers.

## Root cause

Two independent code paths add a worker to the router's overloaded set:

1. **Monitor path** — `KvWorkerMonitor` computes an overloaded set from load thresholds and calls `publish_overloaded_instances(...)` to push it to the routing `Client`.
2. **Request fast-path** — on a `ResourceExhausted` / "worker at capacity" response, `push_router` calls `Client::mark_overloaded_immediate(instance_id)`, which inserts the worker into `RoutingInstances.overloaded_ids` **directly, outside** the monitor's `overloaded_tracker`.

The fast-path mark (2) is only cleared when the monitor republishes the full set (1) via `set_overloaded_instances`. But in `worker_monitor.rs` that publish is gated on `overloaded_changed`:

```rust
if overloaded_changed {
    let overloaded_instances = overloaded_tracker.ids();
    publish_overloaded_instances(&client, &prefill_client_holder, &overloaded_instances);
}
```

When load thresholds are **unconfigured (the default)**, `overloaded_tracker` never changes, so `overloaded_changed` is never `true`, so the monitor **never republishes**. The immediate mark set in (2) is therefore never overwritten — the worker stays in `overloaded_ids` indefinitely, `free_ids = routable − overloaded` stays empty, and every subsequent request hits the "All workers are busy" branch. The worker itself is idle/healthy the whole time (its per-request permits are RAII and released).

## Fix

Publish the overloaded set on **every fresh load sample** rather than only when the threshold-derived set changes, so the healthy set overwrites the stale immediate mark once the transient overload passes. `overloaded_changed` is retained only to gate a debug log. One file, `lib/llm/src/discovery/worker_monitor.rs`.

## Reproduction

Single worker, `DYN_ENGINE_REQUEST_LIMIT` small (e.g. 8) + a small overflow queue, model slow enough that the 8 engine slots stay occupied under load. Drive it closed-loop at concurrency well above `limit + queue` for ~25 s so the engine + queue co-saturate and the worker emits "worker at capacity" at least once. After the burst drains, every request returns a permanent `500` / `ResourceExhausted "All workers are busy"` while the worker sits idle (`sglang:num_running_reqs=0`). With this change, the endpoint recovers on the next load sample.

(Observed live on a GB200 deployment; the failure and the fix were both confirmed against the exact code in `worker_monitor.rs`.)

## Testing

- [ ] `cargo test -p dynamo-llm` (not yet run in this draft)
- [ ] add a regression test asserting the overloaded set is republished on an unchanged healthy sample after an immediate mark

Happy to add the regression test and adjust the approach per review.
