### PR TITLE
feat(llm): add classify and pooling model support

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -901,9 +901,29 @@ impl ModelType {
     const Realtime: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Realtime,
     };
+    #[classattr]
+    const Classify: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Classify,
+    };
+    #[classattr]
+    const Pooling: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Pooling,
+    };
 
     fn supports_chat(&self) -> bool {
         self.inner.supports_chat()
+    }
+
+    fn supports_embedding(&self) -> bool {
+        self.inner.supports_embedding()
+    }
+
+    fn supports_classify(&self) -> bool {
+        self.inner.supports_classify()
+    }
+
+    fn supports_pooling(&self) -> bool {
+        self.inner.supports_pooling()
     }
 
     fn __or__(&self, other: &Self) -> Self {

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1634,7 +1634,11 @@ class ModelInput:
 
 
 class ModelType:
-    """What type of request this model supports: Chat, Completions, Embedding, Tensor, Images, Videos, Realtime, or Empty (no OpenAI surface)"""
+    """OpenAI-style surfaces supported by a model.
+
+    Values are Chat, Completions, Embedding, Classify, Pooling, TensorBased,
+    Images, Audios, Videos, Realtime, and Empty (no OpenAI surface).
+    """
     # No OpenAI surface — used by prefill / encode workers whose role is
     # carried by WorkerType. Symmetric with the other ModelType.Foo members.
     Empty: ModelType
@@ -1650,12 +1654,29 @@ class ModelType:
     Audios: ModelType
     Videos: ModelType
     Realtime: ModelType
+    # Sequence-classification / cross-encoder pooling models served on /v1/classify.
+    Classify: ModelType
+    # Raw pooler output served on /v1/pooling (token embeddings, logits, rewards).
+    # Usually combined with Classify or Embedding: ModelType.Classify | ModelType.Pooling.
+    Pooling: ModelType
 
     def __or__(self, other: ModelType) -> ModelType:
         ...
 
     def supports_chat(self) -> bool:
         """Return True if this model type supports chat."""
+        ...
+
+    def supports_embedding(self) -> bool:
+        """Return True if this model type supports /v1/embeddings."""
+        ...
+
+    def supports_classify(self) -> bool:
+        """Return True if this model type supports /v1/classify."""
+        ...
+
+    def supports_pooling(self) -> bool:
+        """Return True if this model type supports /v1/pooling."""
         ...
 
 class RouterMode:

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -23,8 +23,9 @@ use crate::types::{
     openai::{
         audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
-        completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
-        generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
+        classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
+        embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
+        images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
         videos::OpenAIVideosStreamingEngine,
     },
 };
@@ -328,6 +329,20 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_embeddings_engine())
+    }
+
+    /// Check if any WorkerSet has a classify engine.
+    pub fn has_classify_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_classify_engine())
+    }
+
+    /// Check if any WorkerSet has a pooling engine.
+    pub fn has_pooling_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_pooling_engine())
     }
 
     /// Check if any WorkerSet has a tensor engine.
@@ -694,6 +709,16 @@ impl Model {
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.embeddings_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_embeddings_engine()))
+    }
+
+    pub fn get_classify_engine(&self) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.classify_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_classify_engine()))
+    }
+
+    pub fn get_pooling_engine(&self) -> Result<OpenAIPoolingStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.pooling_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_pooling_engine()))
     }
 
     pub fn get_images_engine(&self) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -47,9 +47,10 @@ use crate::{
         openai::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
-            completions::OpenAICompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
     worker_type::WorkerType,
@@ -555,6 +556,22 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_classify_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_classify_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
+    pub fn list_pooling_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_pooling_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_tensor_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -628,6 +645,26 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_embeddings_engine()
+    }
+
+    pub fn get_classify_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_classify_engine()
+    }
+
+    pub fn get_pooling_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIPoolingStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_pooling_engine()
     }
 
     pub fn get_completions_engine(
@@ -852,6 +889,48 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_classify_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIClassifyStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_classify_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_classify_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.classify_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_pooling_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIPoolingStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_pooling_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_pooling_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.pooling_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_tensor_model(
         &self,
         model: &str,
@@ -1031,6 +1110,20 @@ impl ModelManager {
 
     pub fn remove_embeddings_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_embeddings_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_classify_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_classify_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_pooling_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_pooling_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -50,9 +50,11 @@ use crate::{
             chat_completions::{
                 NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
             },
+            classify::{NvCreateClassifyRequest, NvCreateClassifyResponse},
             completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
             embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
             images::{NvCreateImageRequest, NvImagesResponse},
+            pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse},
             videos::{NvCreateVideoRequest, NvVideosResponse},
         },
         tensor::{NvCreateTensorRequest, NvCreateTensorResponse},
@@ -276,6 +278,8 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Realtime,
+    ModelType::Classify,
+    ModelType::Pooling,
 ];
 
 /// Returns true if no models in the manager support the given model type.
@@ -296,9 +300,33 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_tensor_models().is_empty()
     } else if model_type == ModelType::Realtime {
         manager.list_realtime_models().is_empty()
+    } else if model_type == ModelType::Classify {
+        manager.list_classify_models().is_empty()
+    } else if model_type == ModelType::Pooling {
+        manager.list_pooling_models().is_empty()
     } else {
         true
     }
+}
+
+fn removed_model_cards(
+    manager: &ModelManager,
+    card: &ModelDeploymentCard,
+) -> Vec<ModelDeploymentCard> {
+    ALL_MODEL_TYPES
+        .iter()
+        .filter_map(|model_type| {
+            if card.model_type.intersects(*model_type)
+                && is_model_type_list_empty(manager, *model_type)
+            {
+                let mut removed_card = card.clone();
+                removed_card.model_type = *model_type;
+                Some(removed_card)
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// RAII guard that removes a key from a `DashSet` on drop and wakes any tasks
@@ -1212,12 +1240,8 @@ impl ModelWatcher {
         }
 
         if let Some(tx) = &self.model_update_tx {
-            for model_type in ALL_MODEL_TYPES {
-                if card.model_type.intersects(*model_type)
-                    && is_model_type_list_empty(&self.manager, *model_type)
-                {
-                    tx.send(ModelUpdate::Removed(card.clone())).await.ok();
-                }
+            for removed_card in removed_model_cards(&self.manager, &card) {
+                tx.send(ModelUpdate::Removed(removed_card)).await.ok();
             }
         }
 
@@ -1872,27 +1896,44 @@ impl ModelWatcher {
                     card.name()
                 );
             }
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_embedding() {
-            // Case: Text + Embeddings
-            let push_router = PushRouter::<
-                NvCreateEmbeddingRequest,
-                Annotated<NvCreateEmbeddingResponse>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.embeddings_engine = Some(Arc::new(push_router));
-        }
-        // Case: Text + (Images, Audio, Videos)
-        // Must come before the plain Text+Chat / Text+Completions branches because
-        // diffusion models often set both Images and Chat flags. The branch below
-        // handles the chat registration internally when supports_chat() is true.
-        else if card.model_input == ModelInput::Text
-            && (card.model_type.supports_images()
-                || card.model_type.supports_audios()
-                || card.model_type.supports_videos())
-        {
-            // Image/Audio/Video models can also support chat completions (vLLM omni way)
+        } else if card.model_input == ModelInput::Text {
+            // Text workers tokenize in the backend and can advertise multiple
+            // OpenAI surfaces. Build each declared surface independently:
+            // ModelType is a bitflag, so choosing one mutually-exclusive branch
+            // would silently omit engines for mixed-capability cards.
+            if card.model_type.supports_embedding() {
+                let push_router = PushRouter::<
+                    NvCreateEmbeddingRequest,
+                    Annotated<NvCreateEmbeddingResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.embeddings_engine = Some(Arc::new(push_router));
+            }
+
+            if card.model_type.supports_classify() {
+                let push_router = PushRouter::<
+                    NvCreateClassifyRequest,
+                    Annotated<NvCreateClassifyResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.classify_engine = Some(Arc::new(push_router));
+            }
+
+            if card.model_type.supports_pooling() {
+                let push_router = PushRouter::<
+                    NvCreatePoolingRequest,
+                    Annotated<NvCreatePoolingResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.pooling_engine = Some(Arc::new(push_router));
+            }
+
             if card.model_type.supports_chat() {
                 let chat_router = PushRouter::<
                     NvCreateChatCompletionRequest,
@@ -1902,6 +1943,17 @@ impl ModelWatcher {
                 )
                 .await?;
                 worker_set.chat_engine = Some(Arc::new(chat_router));
+            }
+
+            if card.model_type.supports_completions() {
+                let completions_router = PushRouter::<
+                    NvCreateCompletionRequest,
+                    Annotated<NvCreateCompletionResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.completions_engine = Some(Arc::new(completions_router));
             }
 
             if card.model_type.supports_images() {
@@ -1932,25 +1984,30 @@ impl ModelWatcher {
                 .await?;
                 worker_set.audios_engine = Some(Arc::new(audios_router));
             }
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
-            // Case: Text + Chat (pure text-to-text, no diffusion)
-            let push_router =
-                PushRouter::<
-                    NvCreateChatCompletionRequest,
-                    Annotated<NvCreateChatCompletionStreamResponse>,
-                >::from_client_with_monitor(client, router_config.router_mode, None)
+
+            if card.model_type.supports_realtime() {
+                // `Text` is overloaded for Realtime; its I/O passes through.
+                let realtime_router = PushRouter::<
+                    RealtimeClientEvent,
+                    Annotated<RealtimeServerEvent>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
                 .await?;
-            worker_set.chat_engine = Some(Arc::new(push_router));
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_completions() {
-            // Case: Text + Completions
-            let push_router = PushRouter::<
-                NvCreateCompletionRequest,
-                Annotated<NvCreateCompletionResponse>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.completions_engine = Some(Arc::new(push_router));
+                worker_set.realtime_engine = Some(Arc::new(realtime_router));
+            }
+
+            if card.model_type.is_empty() {
+                tracing::info!(
+                    model_name = card.name(),
+                    "Topology-only worker (empty model_type), registering for serving readiness only"
+                );
+            } else if !worker_set.has_any_serving_engine() {
+                anyhow::bail!(
+                    "Unsupported model configuration: {} with Text input",
+                    card.model_type
+                );
+            }
         } else if card.model_input == ModelInput::Tokens && card.model_type.supports_embedding() {
             // Case 4: Tokens + Embeddings
             // Create preprocessing pipeline similar to Backend
@@ -1994,17 +2051,6 @@ impl ModelWatcher {
             )
             .await?;
             worker_set.tensor_engine = Some(Arc::new(push_router));
-        } else if card.model_input == ModelInput::Text && card.model_type.supports_realtime() {
-            // Case 7: Text + Realtime
-            // 'Text' is being overloaded here, it simply means the I/O will be passed through
-            let realtime_router = PushRouter::<
-                RealtimeClientEvent,
-                Annotated<RealtimeServerEvent>,
-            >::from_client_with_monitor(
-                client, router_config.router_mode, None
-            )
-            .await?;
-            worker_set.realtime_engine = Some(Arc::new(realtime_router));
         } else if card.model_type.is_empty() {
             // No OpenAI surface declared: a topology-only worker that exists
             // purely for serving-readiness accounting — e.g. a surface-less
@@ -2023,7 +2069,7 @@ impl ModelWatcher {
             // prefill is routed off `worker_type`.)
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
-                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Realtime), \
+                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Classify|Pooling|Realtime), \
                 Tokens+Embeddings, Tensor+TensorBased",
                 card.model_type,
                 card.model_input.as_str()
@@ -2266,6 +2312,50 @@ mod tests {
         assert!(!supports_encoder_result_handoff(&card));
     }
 
+    #[tokio::test]
+    async fn text_pooling_family_preserves_chat_engine() {
+        use dynamo_runtime::{Runtime, distributed::DistributedConfig};
+
+        let runtime = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let manager = Arc::new(ModelManager::new());
+        let watcher = ModelWatcher::new(
+            drt,
+            manager.clone(),
+            RouterConfig::default(),
+            0,
+            None,
+            None,
+            None,
+            Arc::new(Metrics::new_with_prefix(Some(
+                "watcher_mixed_text_test".to_string(),
+            ))),
+        );
+        let mcid = ModelCardInstanceId {
+            namespace: "mixed-text-ns".to_string(),
+            component: "workers".to_string(),
+            endpoint: "generate".to_string(),
+            instance_id: 1,
+            model_suffix: None,
+        };
+        let mut card = ModelDeploymentCard::with_name_only("mixed-text-model");
+        card.model_input = ModelInput::Text;
+        card.model_type = ModelType::Chat | ModelType::Classify | ModelType::Pooling;
+        card.worker_type = Some(WorkerType::Aggregated);
+
+        watcher
+            .do_worker_set_registration(&mcid, &mut card)
+            .await
+            .unwrap();
+
+        let model = manager.get_model(card.name()).unwrap();
+        assert!(model.has_chat_engine());
+        assert!(model.has_classify_engine());
+        assert!(model.has_pooling_engine());
+    }
+
     #[test]
     fn base_card_with_capacity_seeds_idle_lora_capable_worker() {
         // jh-nv (watcher base-card seeding): a base worker card (lora=None) carrying
@@ -2431,6 +2521,33 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
+        assert!(is_model_type_list_empty(&mm, ModelType::Classify));
+        assert!(is_model_type_list_empty(&mm, ModelType::Pooling));
+    }
+
+    #[test]
+    fn removal_cards_contain_only_the_empty_model_type() {
+        let mm = ModelManager::new();
+        let mut card = ModelDeploymentCard::with_name_only("model");
+        card.model_type = ModelType::Classify | ModelType::Pooling;
+
+        let removed_cards = removed_model_cards(&mm, &card);
+        assert_eq!(removed_cards.len(), 2);
+        assert!(
+            removed_cards
+                .iter()
+                .any(|card| card.model_type == ModelType::Classify)
+        );
+        assert!(
+            removed_cards
+                .iter()
+                .any(|card| card.model_type == ModelType::Pooling)
+        );
+        assert!(
+            removed_cards
+                .iter()
+                .all(|card| card.model_type.bits().count_ones() == 1)
+        );
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -20,9 +20,10 @@ use crate::{
         openai::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
-            completions::OpenAICompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -46,6 +47,8 @@ pub struct WorkerSet {
     pub(crate) chat_engine: Option<OpenAIChatCompletionsStreamingEngine>,
     pub(crate) completions_engine: Option<OpenAICompletionsStreamingEngine>,
     pub(crate) embeddings_engine: Option<OpenAIEmbeddingsStreamingEngine>,
+    pub(crate) classify_engine: Option<OpenAIClassifyStreamingEngine>,
+    pub(crate) pooling_engine: Option<OpenAIPoolingStreamingEngine>,
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
@@ -82,6 +85,8 @@ impl WorkerSet {
             chat_engine: None,
             completions_engine: None,
             embeddings_engine: None,
+            classify_engine: None,
+            pooling_engine: None,
             images_engine: None,
             videos_engine: None,
             audios_engine: None,
@@ -126,6 +131,14 @@ impl WorkerSet {
 
     pub fn has_embeddings_engine(&self) -> bool {
         self.embeddings_engine.is_some()
+    }
+
+    pub fn has_classify_engine(&self) -> bool {
+        self.classify_engine.is_some()
+    }
+
+    pub fn has_pooling_engine(&self) -> bool {
+        self.pooling_engine.is_some()
     }
 
     pub fn has_images_engine(&self) -> bool {
@@ -173,6 +186,8 @@ impl WorkerSet {
         self.has_chat_engine()
             || self.has_completions_engine()
             || self.has_embeddings_engine()
+            || self.has_classify_engine()
+            || self.has_pooling_engine()
             || self.has_images_engine()
             || self.has_tensor_engine()
             || self.has_videos_engine()
@@ -245,11 +260,13 @@ mod tests {
     use crate::types::openai::chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
     };
+    use crate::types::openai::classify::{NvCreateClassifyRequest, NvCreateClassifyResponse};
     use crate::types::openai::completions::{
         NvCreateCompletionRequest, NvCreateCompletionResponse,
     };
     use crate::types::openai::embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse};
     use crate::types::openai::images::{NvCreateImageRequest, NvImagesResponse};
+    use crate::types::openai::pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse};
     use crate::types::openai::videos::{NvCreateVideoRequest, NvVideosResponse};
     use async_trait::async_trait;
     use dynamo_runtime::engine::AsyncEngine;
@@ -301,6 +318,8 @@ mod tests {
         assert!(!ws.has_chat_engine());
         assert!(!ws.has_completions_engine());
         assert!(!ws.has_embeddings_engine());
+        assert!(!ws.has_classify_engine());
+        assert!(!ws.has_pooling_engine());
         assert!(!ws.has_images_engine());
         assert!(!ws.has_videos_engine());
         assert!(!ws.has_audios_engine());
@@ -348,6 +367,18 @@ mod tests {
             has_embeddings_engine,
             StubEngine::<NvCreateEmbeddingRequest, NvCreateEmbeddingResponse>::new(),
             "embeddings"
+        );
+        check!(
+            classify_engine,
+            has_classify_engine,
+            StubEngine::<NvCreateClassifyRequest, NvCreateClassifyResponse>::new(),
+            "classify"
+        );
+        check!(
+            pooling_engine,
+            has_pooling_engine,
+            StubEngine::<NvCreatePoolingRequest, NvCreatePoolingResponse>::new(),
+            "pooling"
         );
         check!(
             images_engine,

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -52,6 +52,16 @@ bitflags! {
         const Audios = 1 << 6;
         const Videos = 1 << 7;
         const Realtime = 1 << 8;
+        /// Sequence-classification / cross-encoder pooling models served on
+        /// the `/v1/classify` endpoint (e.g. NLI, sentiment). Like `Embedding`,
+        /// this is a pooling capability, not a token-generating surface.
+        const Classify = 1 << 9;
+        /// Raw pooler output served on the `/v1/pooling` endpoint (token-level
+        /// embeddings, per-token classification logits, reward scores, …).
+        /// Usually combined with `Classify` or `Embedding`: native vLLM
+        /// mounts its `/pooling` alongside those surfaces for every
+        /// pooling-runner model.
+        const Pooling = 1 << 10;
     }
 }
 
@@ -91,6 +101,12 @@ impl ModelType {
     pub fn supports_realtime(&self) -> bool {
         self.contains(ModelType::Realtime)
     }
+    pub fn supports_classify(&self) -> bool {
+        self.contains(ModelType::Classify)
+    }
+    pub fn supports_pooling(&self) -> bool {
+        self.contains(ModelType::Pooling)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -120,6 +136,12 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push("realtime");
+        }
+        if self.supports_classify() {
+            result.push("classify");
+        }
+        if self.supports_pooling() {
+            result.push("pooling");
         }
         result
     }
@@ -154,6 +176,12 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push(ModelType::Realtime);
+        }
+        if self.supports_classify() {
+            result.push(ModelType::Classify);
+        }
+        if self.supports_pooling() {
+            result.push(ModelType::Pooling);
         }
         result
     }
@@ -319,6 +347,53 @@ mod tests {
         let endpoints = (ModelType::Chat | ModelType::Realtime).as_endpoint_types();
         assert!(endpoints.contains(&EndpointType::Chat));
         assert!(endpoints.contains(&EndpointType::Realtime));
+    }
+
+    #[test]
+    fn classify_bit_position() {
+        assert_eq!(ModelType::Classify.bits(), 1 << 9);
+    }
+
+    #[test]
+    fn classify_supports_classify() {
+        assert!(ModelType::Classify.supports_classify());
+        assert!(!ModelType::Chat.supports_classify());
+        assert!(!ModelType::Embedding.supports_classify());
+    }
+
+    #[test]
+    fn classify_in_as_vec_and_units() {
+        assert_eq!(ModelType::Classify.as_vec(), vec!["classify"]);
+        assert_eq!(ModelType::Classify.units(), vec![ModelType::Classify]);
+    }
+
+    #[test]
+    fn pooling_bit_position() {
+        assert_eq!(ModelType::Pooling.bits(), 1 << 10);
+    }
+
+    #[test]
+    fn pooling_supports_pooling() {
+        assert!(ModelType::Pooling.supports_pooling());
+        assert!(!ModelType::Classify.supports_pooling());
+        assert!(!ModelType::Embedding.supports_pooling());
+    }
+
+    #[test]
+    fn pooling_in_as_vec_and_units() {
+        assert_eq!(ModelType::Pooling.as_vec(), vec!["pooling"]);
+        assert_eq!(ModelType::Pooling.units(), vec![ModelType::Pooling]);
+    }
+
+    #[test]
+    fn classify_pooling_combination_decomposes() {
+        let combined = ModelType::Classify | ModelType::Pooling;
+        assert!(combined.supports_classify());
+        assert!(combined.supports_pooling());
+        assert_eq!(
+            combined.units(),
+            vec![ModelType::Classify, ModelType::Pooling]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -3,6 +3,7 @@
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use super::{
     ContentProvider,
@@ -15,6 +16,7 @@ use crate::types::TokenIdType;
 pub mod audios;
 pub mod batches;
 pub mod chat_completions;
+pub mod classify;
 pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;
@@ -22,6 +24,7 @@ pub mod embeddings;
 pub mod generate;
 pub mod images;
 pub mod models;
+pub mod pooling;
 pub mod responses;
 pub mod stream_aggregator;
 pub mod tools;
@@ -32,6 +35,14 @@ use validate::{
     BEST_OF_RANGE, FREQUENCY_PENALTY_RANGE, MIN_P_RANGE, N_RANGE, PRESENCE_PENALTY_RANGE,
     TEMPERATURE_RANGE, TOP_P_RANGE, validate_range,
 };
+
+/// Side from which prompt tokens are truncated.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PromptTruncationSide {
+    Left,
+    Right,
+}
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnnotatedDelta<R> {

--- a/lib/llm/src/protocols/openai/classify.rs
+++ b/lib/llm/src/protocols/openai/classify.rs
@@ -1,0 +1,318 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/v1/classify` endpoint (sequence-classification /
+//! cross-encoder pooling models, e.g. NLI or sentiment).
+//!
+//! There is no OpenAI-native classification schema, so — unlike embeddings,
+//! which wraps `dynamo_protocols::types::CreateEmbeddingRequest` — these types
+//! are defined fully in-repo. The wire shape mirrors vLLM's `/classify`
+//! endpoint (`vllm/entrypoints/pooling/classify/protocol.py`, vLLM 0.25.1):
+//! request `{model, input, ...}` → response
+//! `{id, object, created, model, data:[{index, label, probs, num_classes}], usage}`.
+//!
+//! Only the **completion-style** request (`input`) is supported. vLLM also
+//! accepts a chat-style variant (`messages`) that renders a chat template;
+//! that is out of scope here. Pooling controls such as `priority`,
+//! `cache_salt`, `mm_processor_kwargs`, `use_activation`,
+//! `add_special_tokens`, `truncate_prompt_tokens`, and `truncation_side` are
+//! forwarded.
+
+use std::collections::HashMap;
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+
+use super::PromptTruncationSide;
+pub use super::embeddings::{NvExt, NvExtProvider};
+
+/// Classification input — text or pre-tokenized prompts, single or batched.
+/// Mirrors the `input` field of vLLM's `ClassificationCompletionRequest`
+/// (`CompletionRequestMixin`: `list[int] | list[list[int]] | str | list[str]`),
+/// so upstream-tokenized clients migrate unchanged.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ClassificationInput {
+    /// A single text to classify.
+    Single(String),
+    /// A batch of texts to classify.
+    Batch(Vec<String>),
+    /// A single pre-tokenized prompt (token IDs).
+    Tokens(Vec<u32>),
+    /// A batch of pre-tokenized prompts.
+    TokenBatch(Vec<Vec<u32>>),
+}
+
+/// Request for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyRequest {
+    /// The model to use for classification.
+    pub model: String,
+
+    /// The text (or texts) to classify.
+    pub input: ClassificationInput,
+
+    /// A unique identifier representing the end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Optional caller-provided identifier used in the response ID. Internal
+    /// engine request IDs remain server-generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    /// Scheduling priority. Lower values are scheduled first.
+    #[serde(default)]
+    pub priority: i64,
+
+    /// Additional keyword arguments forwarded to the Hugging Face processor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+
+    /// Salt applied to prefix-cache keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    /// Whether to apply the classification pooler's activation
+    /// (sigmoid/softmax). `None` uses the pooler's default. Forwarded verbatim
+    /// to `PoolingParams`, mirroring vLLM's `ClassifyRequestMixin`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_activation: Option<bool>,
+
+    /// Whether to add the tokenizer's special tokens (BOS/CLS/SEP). `None`
+    /// uses the tokenizer default (`true`). Forwarded to the worker's
+    /// tokenization, mirroring vLLM's `CompletionRequestMixin.add_special_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_special_tokens: Option<bool>,
+
+    /// Truncate the tokenized prompt to this many tokens (`-1` = model max).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
+    /// Which side to truncate from. When omitted, the tokenizer default is
+    /// used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation_side: Option<PromptTruncationSide>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One classification result within a [`NvCreateClassifyResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct ClassificationData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Predicted label (from the model's `id2label`), if available.
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// Per-class probability vector.
+    pub probs: Vec<f32>,
+
+    /// Number of classes (== `probs.len()`).
+    pub num_classes: u32,
+}
+
+/// Usage information for a classification response.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ClassificationUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Response for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<ClassificationData>,
+    pub usage: ClassificationUsage,
+}
+
+impl NvCreateClassifyResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "classify".to_string(),
+            data: vec![],
+            usage: ClassificationUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreateClassifyRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreateClassifyRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreateClassifyRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreateClassifyRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Single(_)));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["input"], "hello world");
+    }
+
+    #[test]
+    fn batch_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::Batch(v) => assert_eq!(v.len(), 2),
+            _ => panic!("expected batch input"),
+        }
+    }
+
+    #[test]
+    fn token_inputs_parse_as_token_variants() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [101, 2023, 102]
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Tokens(_)));
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [[101, 102], [101, 103]]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::TokenBatch(v) => assert_eq!(v.len(), 2),
+            other => panic!("expected token batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn use_activation_round_trips_and_defaults_to_none() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.use_activation.is_none());
+        // Omitted → not serialized onto the wire to the worker.
+        assert!(
+            serde_json::to_value(&request)
+                .unwrap()
+                .get("use_activation")
+                .is_none()
+        );
+
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "use_activation": false
+        }))
+        .unwrap();
+        assert_eq!(request.use_activation, Some(false));
+        assert_eq!(
+            serde_json::to_value(&request).unwrap()["use_activation"],
+            serde_json::json!(false)
+        );
+    }
+
+    #[test]
+    fn tokenization_options_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "add_special_tokens": false,
+            "truncate_prompt_tokens": 128,
+            "truncation_side": "left"
+        }))
+        .unwrap();
+        assert_eq!(request.add_special_tokens, Some(false));
+        assert_eq!(request.truncate_prompt_tokens, Some(128));
+        assert_eq!(request.truncation_side, Some(PromptTruncationSide::Left));
+
+        // All omitted → None, none serialized onto the worker wire.
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&request).unwrap();
+        assert!(value.get("add_special_tokens").is_none());
+        assert!(value.get("truncate_prompt_tokens").is_none());
+        assert!(value.get("truncation_side").is_none());
+    }
+
+    #[test]
+    fn classify_request_controls_round_trip() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "user": "user-1",
+            "request_id": "request-1",
+            "priority": -2,
+            "mm_processor_kwargs": {"do_resize": false},
+            "cache_salt": "salt"
+        }))
+        .unwrap();
+
+        assert_eq!(request.user.as_deref(), Some("user-1"));
+        assert_eq!(request.request_id.as_deref(), Some("request-1"));
+        assert_eq!(request.priority, -2);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
+        assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn omitted_nvext_is_not_serialized() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.nvext.is_none());
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("nvext").is_none());
+    }
+}

--- a/lib/llm/src/protocols/openai/classify.rs
+++ b/lib/llm/src/protocols/openai/classify.rs
@@ -119,11 +119,15 @@ pub struct ClassificationData {
     pub num_classes: u32,
 }
 
-/// Usage information for a classification response.
+/// Usage information for a classification response. `completion_tokens` is
+/// always 0 (a classification pass generates nothing) but is kept for parity
+/// with vLLM's `UsageInfo`, which serializes it.
 #[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
 pub struct ClassificationUsage {
     pub prompt_tokens: u32,
     pub total_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
 }
 
 /// Response for the `/classify` endpoint.
@@ -302,6 +306,27 @@ mod tests {
         let value = serde_json::to_value(request).unwrap();
         assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
         assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn usage_mirrors_vllm_usage_info() {
+        // vLLM's `ClassificationResponse.usage` is the shared `UsageInfo`,
+        // dumped without exclusions — so `completion_tokens` is always on the
+        // wire even though a classification pass generates nothing. A worker
+        // that omits it still parses, defaulting to 0.
+        let response: NvCreateClassifyResponse = serde_json::from_value(json!({
+            "id": "classify-1",
+            "object": "list",
+            "created": 1,
+            "model": "m",
+            "data": [{"index": 0, "label": "entailment", "probs": [0.9, 0.1], "num_classes": 2}],
+            "usage": {"prompt_tokens": 3, "total_tokens": 3}
+        }))
+        .unwrap();
+        assert_eq!(response.usage.completion_tokens, 0);
+
+        let value = serde_json::to_value(&response).unwrap();
+        assert_eq!(value["usage"]["completion_tokens"], 0);
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -31,6 +31,7 @@ impl StreamAggregable for NvCreateClassifyResponse {
         self.data.extend(next.data);
         self.usage.prompt_tokens += next.usage.prompt_tokens;
         self.usage.total_tokens += next.usage.total_tokens;
+        self.usage.completion_tokens += next.usage.completion_tokens;
     }
 }
 
@@ -77,6 +78,7 @@ mod tests {
             usage: super::super::ClassificationUsage {
                 prompt_tokens,
                 total_tokens: prompt_tokens,
+                completion_tokens: 0,
             },
         };
         Annotated::from_data(response)
@@ -118,6 +120,7 @@ mod tests {
         assert_eq!(response.data[0].index, 0);
         assert_eq!(response.data[1].index, 1);
         assert_eq!(response.usage.total_tokens, 10);
+        assert_eq!(response.usage.completion_tokens, 0);
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreateClassifyResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+};
+
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
+use futures::Stream;
+
+impl StreamAggregable for NvCreateClassifyResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "classify" && next.model != "classify" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+    }
+}
+
+impl NvCreateClassifyResponse {
+    /// Converts an SSE stream into a [`NvCreateClassifyResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        let stream = convert_sse_stream::<NvCreateClassifyResponse>(stream);
+        NvCreateClassifyResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of classification responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
+    ) -> Result<NvCreateClassifyResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::classify::ClassificationData;
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        label: &str,
+        probs: Vec<f32>,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreateClassifyResponse> {
+        let response = NvCreateClassifyResponse {
+            id: "classify-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![ClassificationData {
+                index,
+                label: Some(label.to_string()),
+                num_classes: probs.len() as u32,
+                probs,
+            }],
+            usage: super::super::ClassificationUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_classification() {
+        let annotated = make_response(0, "entailment", vec![0.1, 0.7, 0.2], 5);
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].label.as_deref(), Some("entailment"));
+        assert_eq!(response.data[0].num_classes, 3);
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_classifications() {
+        let a = make_response(0, "entailment", vec![0.8, 0.2], 4);
+        let b = make_response(1, "contradiction", vec![0.3, 0.7], 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreateClassifyResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_stream_errors() {
+        use dynamo_runtime::{
+            error::{BackendError, ErrorType},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let backend_error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid classify input")
+            .build();
+        let stream = stream::iter(vec![Annotated::<NvCreateClassifyResponse>::from_err(
+            backend_error,
+        )]);
+
+        let error = NvCreateClassifyResponse::from_annotated_stream(stream)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid classify input");
+    }
+}

--- a/lib/llm/src/protocols/openai/pooling.rs
+++ b/lib/llm/src/protocols/openai/pooling.rs
@@ -1,0 +1,447 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/v1/pooling` endpoint (raw pooler output from
+//! pooling-runner models: token-level embeddings, per-token classification
+//! logits, reward-model scores, …).
+//!
+//! Like `/classify`, there is no OpenAI-native schema; the wire shape mirrors
+//! vLLM's `/pooling` endpoint (`vllm/entrypoints/pooling/pooling/protocol.py`):
+//! request `{model, input, task?, encoding_format?, use_activation?, …}` →
+//! response `{id, object, created, model,
+//! data:[{index, object: "pooling", data}], usage}`.
+//!
+//! The completion-style request (`input`) is supported; vLLM's chat-messages
+//! and IOProcessor-plugin request variants are not. Pooling controls such as
+//! `task`, `priority`, `cache_salt`, `mm_processor_kwargs`, `use_activation`,
+//! `encoding_format`, `add_special_tokens`, and `truncate_prompt_tokens` are
+//! forwarded; `dimensions` is rejected with a 400.
+//!
+//! `task` is forwarded verbatim when set. When omitted, the worker resolves
+//! the model's configured/default task using vLLM's `ModelConfig`.
+
+use std::collections::HashMap;
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+
+use super::PromptTruncationSide;
+pub use super::embeddings::{NvExt, NvExtProvider};
+
+/// Pooling input — raw text or pre-tokenized prompts, single or batched.
+/// Mirrors the `input` field of vLLM's pooling request
+/// (`list[int] | list[list[int]] | str | list[str]`).
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum PoolingInput {
+    /// A single text prompt.
+    Single(String),
+    /// A batch of text prompts.
+    Batch(Vec<String>),
+    /// A single pre-tokenized prompt (token IDs).
+    Tokens(Vec<u32>),
+    /// A batch of pre-tokenized prompts.
+    TokenBatch(Vec<Vec<u32>>),
+}
+
+/// Client-visible pooling response representation.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingEncodingFormat {
+    #[default]
+    Float,
+    Base64,
+    Bytes,
+    BytesOnly,
+}
+
+/// Element type used for base64 and binary pooling responses.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PoolingEmbedDType {
+    #[default]
+    #[serde(rename = "float32")]
+    Float32,
+    #[serde(rename = "float16")]
+    Float16,
+    #[serde(rename = "bfloat16")]
+    Bfloat16,
+    #[serde(rename = "fp8_e4m3")]
+    Fp8E4m3,
+    #[serde(rename = "fp8_e5m2")]
+    Fp8E5m2,
+}
+
+impl PoolingEmbedDType {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Float32 => "float32",
+            Self::Float16 => "float16",
+            Self::Bfloat16 => "bfloat16",
+            Self::Fp8E4m3 => "fp8_e4m3",
+            Self::Fp8E5m2 => "fp8_e5m2",
+        }
+    }
+}
+
+/// Byte order used for base64 and binary pooling responses.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PoolingEndianness {
+    #[default]
+    Native,
+    Big,
+    Little,
+}
+
+impl PoolingEndianness {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Big => "big",
+            Self::Little => "little",
+        }
+    }
+}
+
+/// Request for the `/v1/pooling` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreatePoolingRequest {
+    /// The model to run the pooling pass on.
+    pub model: String,
+
+    /// The prompt(s) to pool.
+    pub input: PoolingInput,
+
+    /// A unique identifier representing the end user.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub user: Option<String>,
+
+    /// Optional caller-provided identifier used in the response ID. Internal
+    /// engine request IDs remain server-generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+
+    /// Scheduling priority. Lower values are scheduled first.
+    #[serde(default)]
+    pub priority: i64,
+
+    /// Additional keyword arguments forwarded to the Hugging Face processor.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mm_processor_kwargs: Option<HashMap<String, serde_json::Value>>,
+
+    /// Salt applied to prefix-cache keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_salt: Option<String>,
+
+    /// vLLM pooling task (`embed`, `classify`, `token_embed`,
+    /// `token_classify`, …). Forwarded verbatim when set; `None` lets the
+    /// worker resolve the model's configured/default task.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<String>,
+
+    /// `"float"` (default), `"base64"`, `"bytes"`, or `"bytes_only"`. Always
+    /// serialized: the classify and pooling engines push to the same worker
+    /// endpoint, and the worker dispatches on this key's presence.
+    #[serde(default)]
+    pub encoding_format: PoolingEncodingFormat,
+
+    /// Whether to apply the pooler's activation (sigmoid/softmax) to the
+    /// output. `None` uses the pooler's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_activation: Option<bool>,
+
+    /// Whether to add the tokenizer's special tokens (BOS/CLS/SEP). `None`
+    /// uses the tokenizer default (`true`). Forwarded to the worker's
+    /// tokenization, mirroring vLLM's `CompletionRequestMixin.add_special_tokens`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_special_tokens: Option<bool>,
+
+    /// Which side to truncate from. When omitted, the tokenizer default is
+    /// used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncation_side: Option<PromptTruncationSide>,
+
+    /// Matryoshka dimensionality reduction. vLLM's `/pooling` rejects this
+    /// parameter ("dimensions is currently not supported"); accepted here so
+    /// the same 400 can be returned instead of silently ignoring it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<u32>,
+
+    /// Element dtype for base64 and binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embed_dtype: Option<PoolingEmbedDType>,
+
+    /// Byte order for base64 and binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub endianness: Option<PoolingEndianness>,
+
+    /// Truncate the tokenized prompt to this many tokens (`-1` = model max).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One pooled output within a [`NvCreatePoolingResponse`]. The payload shape
+/// depends on the resolved task: a matrix for token-level tasks
+/// (`token_embed` / `token_classify`), a vector for sequence-level tasks
+/// (`embed` / `classify`), or a base64 string of packed tensor bytes for an
+/// encoded response. Binary responses are decoded at the HTTP boundary.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum PoolingOutput {
+    /// Base64-encoded packed tensor bytes.
+    Base64(String),
+    /// Sequence-level pooled vector.
+    Vector(Vec<f32>),
+    /// Token-level output: one row per input token.
+    Matrix(Vec<Vec<f32>>),
+}
+
+fn default_pooling_object() -> String {
+    "pooling".to_string()
+}
+
+/// One result item within a [`NvCreatePoolingResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct PoolingData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Always `"pooling"`.
+    #[serde(default = "default_pooling_object")]
+    pub object: String,
+
+    /// The raw pooler output for this input.
+    pub data: PoolingOutput,
+
+    /// Tensor shape carried on Dynamo's internal wire for binary responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(ignore)]
+    pub shape: Option<Vec<u64>>,
+}
+
+/// Usage information for a pooling response. `completion_tokens` is always 0
+/// (a pooling pass generates nothing) but is kept for parity with vLLM's
+/// `UsageInfo`, which serializes it.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct PoolingUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+}
+
+/// Response for the `/v1/pooling` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreatePoolingResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<PoolingData>,
+    pub usage: PoolingUsage,
+}
+
+impl NvCreatePoolingResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "pooling".to_string(),
+            data: vec![],
+            usage: PoolingUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreatePoolingRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreatePoolingRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreatePoolingRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreatePoolingRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips_and_wire_carries_encoding_format() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, PoolingInput::Single(_)));
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Float);
+        assert!(request.task.is_none());
+
+        // The wire discriminator must survive serialization even when the
+        // client omitted it (see ClassifyWorkerHandler dispatch).
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["encoding_format"], "float");
+        assert!(value.get("task").is_none());
+    }
+
+    #[test]
+    fn token_inputs_parse_as_token_variants() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [101, 2023, 102]
+        }))
+        .unwrap();
+        assert!(matches!(request.input, PoolingInput::Tokens(_)));
+
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": [[101, 102], [101, 103]]
+        }))
+        .unwrap();
+        match &request.input {
+            PoolingInput::TokenBatch(v) => assert_eq!(v.len(), 2),
+            other => panic!("expected token batch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task_and_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"],
+            "task": "token_classify",
+            "encoding_format": "base64",
+            "use_activation": false
+        }))
+        .unwrap();
+        assert_eq!(request.task.as_deref(), Some("token_classify"));
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Base64);
+        assert_eq!(request.use_activation, Some(false));
+    }
+
+    #[test]
+    fn binary_encoding_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "encoding_format": "bytes",
+            "embed_dtype": "float16",
+            "endianness": "big"
+        }))
+        .unwrap();
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::Bytes);
+        assert_eq!(request.embed_dtype, Some(PoolingEmbedDType::Float16));
+        assert_eq!(request.endianness, Some(PoolingEndianness::Big));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["encoding_format"], "bytes");
+        assert_eq!(value["embed_dtype"], "float16");
+        assert_eq!(value["endianness"], "big");
+
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "encoding_format": "bytes_only",
+            "embed_dtype": "fp8_e4m3",
+            "endianness": "little"
+        }))
+        .unwrap();
+        assert_eq!(request.encoding_format, PoolingEncodingFormat::BytesOnly);
+        assert_eq!(request.embed_dtype, Some(PoolingEmbedDType::Fp8E4m3));
+        assert_eq!(request.endianness, Some(PoolingEndianness::Little));
+
+        // Omitted → None, and not serialized onto the worker wire.
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi"
+        }))
+        .unwrap();
+        assert!(request.embed_dtype.is_none() && request.endianness.is_none());
+        let value = serde_json::to_value(&request).unwrap();
+        assert!(value.get("embed_dtype").is_none() && value.get("endianness").is_none());
+    }
+
+    #[test]
+    fn tokenization_options_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hi",
+            "add_special_tokens": false,
+            "truncate_prompt_tokens": 64,
+            "truncation_side": "left"
+        }))
+        .unwrap();
+        assert_eq!(request.add_special_tokens, Some(false));
+        assert_eq!(request.truncate_prompt_tokens, Some(64));
+        assert_eq!(request.truncation_side, Some(PromptTruncationSide::Left));
+    }
+
+    #[test]
+    fn pooling_request_controls_round_trip() {
+        let request: NvCreatePoolingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello",
+            "user": "user-1",
+            "request_id": "request-1",
+            "priority": -2,
+            "mm_processor_kwargs": {"do_resize": false},
+            "cache_salt": "salt"
+        }))
+        .unwrap();
+
+        assert_eq!(request.user.as_deref(), Some("user-1"));
+        assert_eq!(request.request_id.as_deref(), Some("request-1"));
+        assert_eq!(request.priority, -2);
+        assert_eq!(request.cache_salt.as_deref(), Some("salt"));
+
+        let value = serde_json::to_value(request).unwrap();
+        assert_eq!(value["mm_processor_kwargs"]["do_resize"], false);
+        assert_eq!(value["priority"], -2);
+    }
+
+    #[test]
+    fn response_data_accepts_vector_matrix_and_base64() {
+        let response: NvCreatePoolingResponse = serde_json::from_value(json!({
+            "id": "pool-1",
+            "object": "list",
+            "created": 1,
+            "model": "m",
+            "data": [
+                {"index": 0, "object": "pooling", "data": [0.1, 0.2]},
+                {"index": 1, "object": "pooling", "data": [[0.1], [0.2]]},
+                {"index": 2, "object": "pooling", "data": "AAAA"}
+            ],
+            "usage": {"prompt_tokens": 3, "total_tokens": 3}
+        }))
+        .unwrap();
+        assert!(matches!(response.data[0].data, PoolingOutput::Vector(_)));
+        assert!(matches!(response.data[1].data, PoolingOutput::Matrix(_)));
+        assert!(matches!(response.data[2].data, PoolingOutput::Base64(_)));
+        assert_eq!(response.usage.completion_tokens, 0);
+    }
+}

--- a/lib/llm/src/protocols/openai/pooling/aggregator.rs
+++ b/lib/llm/src/protocols/openai/pooling/aggregator.rs
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreatePoolingResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+};
+
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
+use futures::Stream;
+
+impl StreamAggregable for NvCreatePoolingResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "pooling" && next.model != "pooling" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+        self.usage.completion_tokens += next.usage.completion_tokens;
+    }
+}
+
+impl NvCreatePoolingResponse {
+    /// Converts an SSE stream into a [`NvCreatePoolingResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreatePoolingResponse, DynamoError> {
+        let stream = convert_sse_stream::<NvCreatePoolingResponse>(stream);
+        NvCreatePoolingResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of pooling responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreatePoolingResponse>>,
+    ) -> Result<NvCreatePoolingResponse, DynamoError> {
+        aggregate_typed_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::pooling::{PoolingData, PoolingOutput, PoolingUsage};
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        data: PoolingOutput,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreatePoolingResponse> {
+        let response = NvCreatePoolingResponse {
+            id: "pool-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![PoolingData {
+                index,
+                object: "pooling".to_string(),
+                data,
+                shape: None,
+            }],
+            usage: PoolingUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+                completion_tokens: 0,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_pooling_output() {
+        let annotated = make_response(
+            0,
+            PoolingOutput::Matrix(vec![vec![0.1, 0.7], vec![0.2, 0.3]]),
+            5,
+        );
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert!(matches!(response.data[0].data, PoolingOutput::Matrix(_)));
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_pooling_outputs() {
+        let a = make_response(0, PoolingOutput::Vector(vec![0.8, 0.2]), 4);
+        let b = make_response(1, PoolingOutput::Vector(vec![0.3, 0.7]), 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreatePoolingResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreatePoolingResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_stream_errors() {
+        use dynamo_runtime::{
+            error::{BackendError, ErrorType},
+            protocols::maybe_error::MaybeError,
+        };
+
+        let backend_error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid pooling input")
+            .build();
+        let stream = stream::iter(vec![Annotated::<NvCreatePoolingResponse>::from_err(
+            backend_error,
+        )]);
+
+        let error = NvCreatePoolingResponse::from_annotated_stream(stream)
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid pooling input");
+    }
+}

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -4,6 +4,7 @@
 use futures::{Stream, StreamExt};
 
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 /// Response types whose `Annotated<T>` streams can be folded into a single `T`
 /// using shared aggregation infrastructure.
@@ -28,6 +29,39 @@ where
 
     while let Some(delta) = stream.next().await {
         let delta = delta.ok()?;
+        if let Some(data) = delta.data {
+            match response.as_mut() {
+                Some(existing) => existing.merge(data),
+                None => response = Some(data),
+            }
+        }
+    }
+
+    Ok(response.unwrap_or_else(T::empty))
+}
+
+/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
+/// errors. Existing callers that expose string errors can continue to use
+/// [`aggregate_stream`].
+pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
+where
+    T: StreamAggregable,
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response: Option<T> = None;
+
+    while let Some(delta) = stream.next().await {
+        if delta.is_error() {
+            return Err(delta.error.unwrap_or_else(|| {
+                DynamoError::msg(
+                    delta
+                        .comment
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            }));
+        }
         if let Some(data) = delta.data {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -78,6 +78,34 @@ pub mod openai {
             ServerStreamingEngine<NvCreateEmbeddingRequest, Annotated<NvCreateEmbeddingResponse>>;
     }
 
+    pub mod classify {
+        use super::*;
+
+        pub use protocols::openai::classify::{NvCreateClassifyRequest, NvCreateClassifyResponse};
+
+        /// A [`UnaryEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyUnaryEngine =
+            UnaryEngine<NvCreateClassifyRequest, NvCreateClassifyResponse>;
+
+        /// A [`ServerStreamingEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyStreamingEngine =
+            ServerStreamingEngine<NvCreateClassifyRequest, Annotated<NvCreateClassifyResponse>>;
+    }
+
+    pub mod pooling {
+        use super::*;
+
+        pub use protocols::openai::pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse};
+
+        /// A [`UnaryEngine`] implementation for the `/pooling` API
+        pub type OpenAIPoolingUnaryEngine =
+            UnaryEngine<NvCreatePoolingRequest, NvCreatePoolingResponse>;
+
+        /// A [`ServerStreamingEngine`] implementation for the `/pooling` API
+        pub type OpenAIPoolingStreamingEngine =
+            ServerStreamingEngine<NvCreatePoolingRequest, Annotated<NvCreatePoolingResponse>>;
+    }
+
     pub mod images {
         use super::*;
 


### PR DESCRIPTION
## Summary

- Add OpenAI-compatible classify and pooling request/response protocols and aggregators.
- Add classify/pooling model types, discovery, and Python binding support.
- Keep the feature dormant: this layer adds neither HTTP routes nor backend activation.
- This is PR 1 of 4 and consolidates drafts #12122–#12124.

## Validation

- This commit's pre-commit hooks passed.
- On the complete four-PR stack: 20 classify and 20 pooling Rust tests passed.
- The PyO3 binding built successfully with `maturin develop --uv`.
- The final tree exactly matches a clean merge of the former 14-PR stack onto current `main`.

## Stack

Merge in this order:

1. [#12140 — core protocols and model discovery](https://github.com/ai-dynamo/dynamo/pull/12140) **(this PR)**
2. [#12139 — frontend HTTP integration](https://github.com/ai-dynamo/dynamo/pull/12139)
3. [#12142 — vLLM worker integration and activation](https://github.com/ai-dynamo/dynamo/pull/12142)
4. [#12141 — examples and end-to-end validation](https://github.com/ai-dynamo/dynamo/pull/12141)

The original monolithic #12058 remains open; this four-PR stack replaces only the earlier 14-draft split (#12122–#12135).


## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to DIS-2528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenAI-compatible classification and pooling endpoints, supporting text and token inputs.
  * Added classification results with labels, probabilities, and usage details.
  * Added pooling outputs in vector, matrix, and encoded formats.
  * Added model capability checks and discovery for classification, embedding, chat, and pooling support.
  * Added streaming response aggregation with structured error handling.
  * Added prompt truncation direction options for left- or right-side truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->