### PR TITLE
feat(profiler): generalize Pareto frontier computation

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_pareto.py
+++ b/components/src/dynamo/profiler/tests/unit/test_pareto.py
@@ -1,9 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import math
+import random
+from itertools import product
+from types import SimpleNamespace
+
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 
-from dynamo.profiler.utils.pareto import compute_pareto
+from dynamo.profiler.utils.defaults import DEFAULT_GPU_COST_PER_HOUR
+from dynamo.profiler.utils.pareto import ParetoDirection, compute_pareto
+from dynamo.profiler.utils.plot import plot_pd_joint_results
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -12,16 +21,166 @@ pytestmark = [
 ]
 
 
-def test_compute_pareto_skips_nan_points():
-    xs, ys, indices = compute_pareto(
-        [float("nan"), 10.0, 20.0],
-        [100.0, float("nan"), 200.0],
+def _brute_force_pareto_indices(
+    objectives: list[list[float]],
+    directions: tuple[ParetoDirection, ...],
+    *,
+    keep_equivalent: bool,
+) -> list[int]:
+    multipliers = [
+        1.0 if direction is ParetoDirection.MAXIMIZE else -1.0
+        for direction in directions
+    ]
+    points = [
+        tuple(
+            objective[index] * multiplier
+            for objective, multiplier in zip(objectives, multipliers, strict=True)
+        )
+        for index in range(len(objectives[0]))
+    ]
+    frontier = []
+    for index, point in enumerate(points):
+        dominated = any(
+            other_index != index
+            and all(a >= b for a, b in zip(other, point, strict=True))
+            and any(a > b for a, b in zip(other, point, strict=True))
+            for other_index, other in enumerate(points)
+        )
+        if dominated:
+            continue
+        if not keep_equivalent and any(points[kept] == point for kept in frontier):
+            continue
+        frontier.append(index)
+    return frontier
+
+
+def test_compute_pareto_supports_objective_directions():
+    objectives = [
+        [5.0, 4.0, 3.0, 2.0],
+        [5.0, 6.0, 4.0, 7.0],
+    ]
+
+    assert compute_pareto(
+        objectives,
+        [ParetoDirection.MINIMIZE, ParetoDirection.MAXIMIZE],
+    ) == [3]
+    assert compute_pareto(
+        objectives,
+        [ParetoDirection.MAXIMIZE, ParetoDirection.MAXIMIZE],
+    ) == [0, 1, 3]
+
+
+def test_compute_pareto_controls_equivalent_rows():
+    objectives = [[1.0, 1.0, 2.0], [3.0, 3.0, 2.0]]
+    directions = [ParetoDirection.MINIMIZE, ParetoDirection.MAXIMIZE]
+
+    assert compute_pareto(objectives, directions) == [0, 1]
+    assert compute_pareto(
+        objectives,
+        directions,
+        keep_equivalent=False,
+    ) == [0]
+
+
+def test_compute_pareto_skips_any_invalid_objective():
+    assert compute_pareto(
+        [
+            [1.0, 2.0, math.nan, 4.0, "not-a-number", 10**400],
+            [5.0, math.inf, 3.0, 2.0, 1.0, 0.0],
+        ],
+        [ParetoDirection.MINIMIZE, ParetoDirection.MAXIMIZE],
+    ) == [0]
+
+
+def test_compute_pareto_supports_empty_and_single_objective_inputs():
+    assert compute_pareto([], []) == []
+    assert compute_pareto([[]], ["maximize"]) == []
+    assert compute_pareto([[3.0, 1.0, 1.0, 2.0]], ["minimize"]) == [1, 2]
+    assert compute_pareto(
+        [[3.0, 1.0, 1.0, 2.0]],
+        ["minimize"],
+        keep_equivalent=False,
+    ) == [1]
+    assert (
+        compute_pareto(
+            [[math.nan, math.inf]],
+            ["maximize"],
+        )
+        == []
     )
 
-    assert xs == [20.0]
-    assert ys == [200.0]
-    assert indices == [2]
+
+@pytest.mark.parametrize("objective_count", [2, 3, 4])
+@pytest.mark.parametrize("keep_equivalent", [False, True])
+def test_compute_pareto_matches_brute_force_oracle(
+    objective_count: int,
+    keep_equivalent: bool,
+):
+    random_source = random.Random(42 + objective_count)
+    objectives = [
+        [float(random_source.randrange(6)) for _ in range(80)]
+        for _ in range(objective_count)
+    ]
+
+    for directions in product(ParetoDirection, repeat=objective_count):
+        assert compute_pareto(
+            objectives,
+            directions,
+            keep_equivalent=keep_equivalent,
+        ) == _brute_force_pareto_indices(
+            objectives,
+            directions,
+            keep_equivalent=keep_equivalent,
+        )
 
 
-def test_compute_pareto_returns_empty_when_all_points_are_invalid():
-    assert compute_pareto([float("nan")], [float("nan")]) == ([], [], [])
+def test_compute_pareto_rejects_invalid_contracts():
+    with pytest.raises(ValueError, match="same length"):
+        compute_pareto([[1.0]], [])
+    with pytest.raises(ValueError, match="same length"):
+        compute_pareto([[1.0], [1.0, 2.0]], ["maximize", "maximize"])
+    with pytest.raises(ValueError, match="invalid Pareto direction"):
+        compute_pareto([[1.0]], ["sideways"])
+
+
+def test_plot_pd_joint_results_uses_sorted_pareto_pairs(monkeypatch):
+    prefill_data = SimpleNamespace(
+        ttft=["20", 10.0, 30.0],
+        thpt_per_gpu=[200.0, 100.0, 150.0],
+    )
+    decode_data = SimpleNamespace(
+        itl=[3.0, "1", 2.0],
+        thpt_per_gpu=[300.0, 100.0, 250.0],
+    )
+    plotted_lines = []
+
+    def capture_plot(*_args, **_kwargs):
+        plotted_lines.extend(
+            (
+                np.asarray(line.get_xdata(), dtype=float),
+                np.asarray(line.get_ydata(), dtype=float),
+            )
+            for line in plt.gca().lines
+        )
+
+    monkeypatch.setattr("matplotlib.pyplot.savefig", capture_plot)
+
+    plot_pd_joint_results(100, 10, prefill_data, decode_data, "/unused")
+
+    decode_rates = np.array([1000.0, 500.0, 1000.0 / 3.0])
+    decode_cost = (
+        10 * 1000 / np.array([100.0, 250.0, 300.0]) * DEFAULT_GPU_COST_PER_HOUR / 3600
+    )
+    expected_prefill_costs = [
+        100 * 1000 / throughput * DEFAULT_GPU_COST_PER_HOUR / 3600
+        for throughput in (100.0, 200.0)
+    ]
+
+    assert len(plotted_lines) == 2
+    for (actual_x, actual_y), prefill_cost in zip(
+        plotted_lines,
+        expected_prefill_costs,
+        strict=True,
+    ):
+        np.testing.assert_allclose(actual_x, decode_rates)
+        np.testing.assert_allclose(actual_y, decode_cost + prefill_cost)

--- a/components/src/dynamo/profiler/utils/pareto.py
+++ b/components/src/dynamo/profiler/utils/pareto.py
@@ -2,59 +2,133 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import math
+from enum import Enum
+from itertools import groupby
 from typing import Sequence
 
 
-def compute_pareto(
-    x: Sequence[float], y: Sequence[float]
-) -> tuple[list[float], list[float], list[int]]:
-    """
-    Compute the pareto front (top-left is better) for the given x and y values.
+class ParetoDirection(str, Enum):
+    """Optimization direction for one Pareto objective."""
 
-    Returns:
-        tuple: (xs, ys, indices) where:
-            - xs: list of x values on the pareto front
-            - ys: list of y values on the pareto front
-            - indices: list of original indices corresponding to the pareto points
-    """
-    # Validate inputs
-    if x is None or y is None:
-        return [], [], []
+    MINIMIZE = "minimize"
+    MAXIMIZE = "maximize"
 
-    if len(x) != len(y):
-        raise ValueError("x and y must have the same length")
 
-    if len(x) == 0:
-        return [], [], []
+def _direction_multiplier(direction: ParetoDirection | str) -> float:
+    try:
+        resolved = ParetoDirection(direction)
+    except ValueError as error:
+        valid = ", ".join(value.value for value in ParetoDirection)
+        raise ValueError(
+            f"invalid Pareto direction {direction!r}; expected one of: {valid}"
+        ) from error
+    return 1.0 if resolved is ParetoDirection.MAXIMIZE else -1.0
 
-    # Build point list with original indices and sort by x asc, then y desc
-    points = []
-    for i in range(len(x)):
+
+def _valid_points(
+    objectives: Sequence[Sequence[float]],
+    directions: Sequence[ParetoDirection | str],
+) -> list[tuple[tuple[float, ...], int]]:
+    if len(objectives) != len(directions):
+        raise ValueError("objectives and directions must have the same length")
+    if len(objectives) == 0:
+        return []
+
+    row_count = len(objectives[0])
+    if any(len(objective) != row_count for objective in objectives[1:]):
+        raise ValueError("all objective columns must have the same length")
+
+    multipliers = tuple(_direction_multiplier(direction) for direction in directions)
+    points: list[tuple[tuple[float, ...], int]] = []
+    for index in range(row_count):
         try:
-            px = float(x[i])
-            py = float(y[i])
-        except (TypeError, ValueError):
+            values = tuple(
+                float(objective[index]) * multiplier
+                for objective, multiplier in zip(objectives, multipliers, strict=True)
+            )
+        except (OverflowError, TypeError, ValueError):
             continue
-        if not math.isfinite(px) or not math.isfinite(py):
+        if all(math.isfinite(value) for value in values):
+            points.append((values, index))
+    return points
+
+
+def _compute_pareto_2d(
+    points: Sequence[tuple[tuple[float, ...], int]],
+    *,
+    keep_equivalent: bool,
+) -> list[int]:
+    ordered = sorted(
+        points,
+        key=lambda point: (-point[0][0], -point[0][1], point[1]),
+    )
+    frontier: list[int] = []
+    best_second = float("-inf")
+    for _, group_iter in groupby(ordered, key=lambda point: point[0][0]):
+        group = list(group_iter)
+        group_best_second = group[0][0][1]
+        if group_best_second <= best_second:
             continue
-        points.append((px, py, i))
 
-    if len(points) == 0:
-        return [], [], []
+        equivalents = [
+            index for values, index in group if values[1] == group_best_second
+        ]
+        frontier.extend(equivalents if keep_equivalent else equivalents[:1])
+        best_second = group_best_second
+    return sorted(frontier)
 
-    points.sort(key=lambda p: (p[0], -p[1]))
 
-    # Single pass to keep only non-dominated points (minimize x, maximize y)
-    pareto = []
-    max_y = float("-inf")
-    for px, py, idx in points:
-        if py > max_y:
-            pareto.append((px, py, idx))
-            max_y = py
+def _dominates(left: Sequence[float], right: Sequence[float]) -> bool:
+    return all(a >= b for a, b in zip(left, right, strict=True)) and any(
+        a > b for a, b in zip(left, right, strict=True)
+    )
 
-    # Return sorted by x ascending for convenience
-    pareto.sort(key=lambda p: (p[0], p[1]))
-    xs = [px for px, _, _ in pareto]
-    ys = [py for _, py, _ in pareto]
-    indices = [idx for _, _, idx in pareto]
-    return xs, ys, indices
+
+def _compute_pareto_nd(
+    points: Sequence[tuple[tuple[float, ...], int]],
+    *,
+    keep_equivalent: bool,
+) -> list[int]:
+    ordered = sorted(points, key=lambda point: (point[0], -point[1]), reverse=True)
+    frontier_values: list[tuple[float, ...]] = []
+    frontier_indices: list[int] = []
+    for values, group_iter in groupby(ordered, key=lambda point: point[0]):
+        if any(_dominates(existing, values) for existing in frontier_values):
+            continue
+        indices = [index for _, index in group_iter]
+        frontier_values.append(values)
+        frontier_indices.extend(indices if keep_equivalent else indices[:1])
+    return sorted(frontier_indices)
+
+
+def compute_pareto(
+    objectives: Sequence[Sequence[float]],
+    directions: Sequence[ParetoDirection | str],
+    *,
+    keep_equivalent: bool = True,
+) -> list[int]:
+    """Return input indices for the exact non-dominated objective rows.
+
+    Each entry in ``objectives`` is one objective column. Values are normalized
+    to finite Python floats, and ``directions`` declares whether the corresponding
+    column is minimized or maximized. Rows that cannot be normalized are excluded.
+
+    Equivalent objective rows are all non-dominated mathematically. Keep them by
+    default, or set ``keep_equivalent=False`` to retain the first input row only.
+    Returned indices are ordered by their position in the input.
+
+    The two-objective path is O(n log n). The generic path compares against the
+    current unique frontier and can be quadratic when many N-D rows are
+    non-dominated.
+    """
+
+    points = _valid_points(objectives, directions)
+    if len(objectives) == 2:
+        return _compute_pareto_2d(
+            points,
+            keep_equivalent=keep_equivalent,
+        )
+    return _compute_pareto_nd(
+        points,
+        keep_equivalent=keep_equivalent,
+    )

--- a/components/src/dynamo/profiler/utils/plot.py
+++ b/components/src/dynamo/profiler/utils/plot.py
@@ -23,7 +23,7 @@ from matplotlib import cm
 from scipy.interpolate import griddata
 
 from dynamo.profiler.utils.defaults import DEFAULT_GPU_COST_PER_HOUR
-from dynamo.profiler.utils.pareto import compute_pareto
+from dynamo.profiler.utils.pareto import ParetoDirection, compute_pareto
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -321,17 +321,28 @@ def plot_pd_joint_results(
         decode_data: DecodeProfileData instance containing profiling results
         output_dir: directory to save the plot
     """
-    # compute pareto front for prefill
-    p_ttft, p_thpt, _ = compute_pareto(prefill_data.ttft, prefill_data.thpt_per_gpu)
+    directions = (ParetoDirection.MINIMIZE, ParetoDirection.MAXIMIZE)
+    prefill_ttft = np.asarray(prefill_data.ttft, dtype=float)
+    prefill_thpt = np.asarray(prefill_data.thpt_per_gpu, dtype=float)
+    decode_itl = np.asarray(decode_data.itl, dtype=float)
+    decode_thpt = np.asarray(decode_data.thpt_per_gpu, dtype=float)
+    prefill_indices = compute_pareto(
+        (prefill_ttft, prefill_thpt),
+        directions,
+        keep_equivalent=False,
+    )
+    prefill_indices.sort(key=prefill_ttft.__getitem__)
+    decode_indices = compute_pareto(
+        (decode_itl, decode_thpt),
+        directions,
+        keep_equivalent=False,
+    )
+    decode_indices.sort(key=decode_itl.__getitem__)
 
-    # compute pareto front for decode
-    d_itl, d_thpt, _ = compute_pareto(decode_data.itl, decode_data.thpt_per_gpu)
-
-    # convert to cost per thousand requests
-    p_ttft = np.array(p_ttft)
-    p_thpt = np.array(p_thpt)
-    d_itl = np.array(d_itl)
-    d_thpt = np.array(d_thpt)
+    p_ttft = prefill_ttft[prefill_indices]
+    p_thpt = prefill_thpt[prefill_indices]
+    d_itl = decode_itl[decode_indices]
+    d_thpt = decode_thpt[decode_indices]
 
     tokens_per_user = []
     cost = []


### PR DESCRIPTION
## Summary

- replace the fixed minimize-x/maximize-y helper with an objective-column API that requires explicit minimize/maximize directions
- preserve or collapse equivalent frontier rows intentionally, filter invalid rows, use an O(n log n) two-objective path, and support exact N-D frontiers with a documented quadratic worst case
- update the profiler plot caller to rank and plot the same normalized float values
- add a deterministic brute-force oracle across two to four objectives, every direction combination, tie behavior, invalid inputs, and the plot's sorted Pareto pairs

This intentionally changes the small internal API instead of preserving the old tuple-returning shape. It does not add approximate frontier fitting or heuristic search.

## Validation

- Reanalyzed 8,688 saved DynoSim campaign points end to end: 8,688 complete, 0 missing, and exact candidate-ID agreement with an independent brute-force oracle for both the 14-point latency/capacity frontier and the 167-point interactivity/capacity frontier.
- `PYTHONPATH=components/src:lib/bindings/python/src .venv/bin/python -m pytest -q components/src/dynamo/profiler/tests/unit/test_pareto.py` (`12 passed`)
- Commit hooks passed: isort, black, flake8, codespell, Ruff, and repository hygiene checks.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multi-objective Pareto analysis with configurable minimize/maximize directions.
  - Added optional handling of equivalent results and filtering of invalid or non-finite measurements.
  - Improved profiler plots to display sorted Pareto-efficient prefill and decode results with combined cost calculations.

- **Bug Fixes**
  - Improved handling of empty, single-objective, and invalid measurement data.
  - Corrected Pareto result ordering and plotting behavior across varied profiling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->