### PR TITLE
fix(sglang): wire min_new_tokens and ignore_eos into the SGLang sampling params

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -283,6 +283,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
+                "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),
@@ -295,6 +296,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             param_mapping = {
                 "n": request.get("n"),
                 "max_new_tokens": request.get("max_tokens"),
+                "min_new_tokens": request.get("min_tokens"),
+                "ignore_eos": request.get("ignore_eos"),
                 **_sampling_option_params(request),
                 **_openai_stop_sampling_params(request),
                 **self._get_guided_decoding_params(request.get("guided_decoding")),


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

The SGLang decode worker builds its sampling parameters in
`DecodeWorkerHandler._build_sampling_params`
(`components/src/dynamo/sglang/request_handlers/llm/decode_handler.py`)
via a `param_mapping` dict. Two request fields were dropped before ever
reaching the SGLang engine:

- **`min_new_tokens`** — never mapped from the request's `min_tokens` in
  either the token-based branch or the OpenAI branch. A client asking for
  a minimum generation length (`min_tokens`) had that constraint silently
  ignored, so responses could stop earlier than requested (e.g. on an
  early EOS).
- **`ignore_eos`** — present only in the token-based branch. The OpenAI
  request branch omitted it, so `ignore_eos` was silently dropped for
  OpenAI-format requests.

## The fix

Mirror the mapping so both fields flow through:

- Map `min_tokens -> min_new_tokens` in both the token-based and OpenAI
  branches.
- Pass `ignore_eos` through in the OpenAI branch as well.

The existing None-filtering at the end of the method (which already
special-cases `max_new_tokens`) drops these keys when they are not
provided, so requests that don't set `min_tokens`/`ignore_eos` are
unaffected.

```diff
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
+                "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
                 ...
             param_mapping = {
                 "n": request.get("n"),
                 "max_new_tokens": request.get("max_tokens"),
+                "min_new_tokens": request.get("min_tokens"),
+                "ignore_eos": request.get("ignore_eos"),
```

## Testing checklist

- [ ] Unit test: OpenAI-format request with `min_tokens` set produces a
      sampling-params dict containing `min_new_tokens`.
- [ ] Unit test: OpenAI-format request with `ignore_eos=true` produces a
      sampling-params dict containing `ignore_eos`.
- [ ] Unit test: token-based request with `min_tokens` set produces
      `min_new_tokens`.
- [ ] Regression: requests without `min_tokens`/`ignore_eos` produce an
      unchanged sampling-params dict (keys absent).
- [ ] End-to-end: SGLang-served completion honors `min_tokens` (does not
      stop before the requested minimum) and `ignore_eos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4hEYusqJ1zdFcjqLFmfeV
