### PR TITLE
fix(preprocessor): don't drop the response suffix when a tag is never closed

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -870,7 +870,9 @@ fn strip_tool_call_text(text: &str) -> std::borrow::Cow<'_, str> {
             if let Some(end_offset) = input[start..].find(close) {
                 input.replace_range(start..start + end_offset + close.len(), "");
             } else {
-                input.truncate(start);
+                // A length-limited response or literal marker may not have a
+                // matching close tag. Preserve it verbatim rather than
+                // deleting the entire user-visible suffix.
                 break;
             }
         }
@@ -2554,6 +2556,16 @@ thinking
         let stripped = strip_tool_call_text(text);
         assert!(!stripped.contains("<tool_call>"));
         assert!(!stripped.contains("<think>"));
+    }
+
+    #[test]
+    fn test_strip_tool_call_text_preserves_unclosed_markers() {
+        for text in [
+            "visible <tool_call>partial arguments",
+            "visible <think>partial reasoning",
+        ] {
+            assert_eq!(strip_tool_call_text(text), text);
+        }
     }
 
     // ── PR1: reasoning / text.format / service_tier pass-through tests ──


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

`strip_tag`, the helper inside `strip_tool_call_text` in `lib/llm/src/protocols/openai/responses/mod.rs`, strips `<tool_call>...</tool_call>` and `<think>...</think>` blocks out of the text returned by the Responses API.

The loop finds an opening marker, then looks for the matching close marker:

```rust
fn strip_tag(input: &mut String, open: &str, close: &str) {
    while let Some(start) = input.find(open) {
        if let Some(end_offset) = input[start..].find(close) {
            input.replace_range(start..start + end_offset + close.len(), "");
        } else {
            input.truncate(start);   // <-- deletes the whole suffix
            break;
        }
    }
}
```

When an opening marker is present but there is **no matching close marker**, the `else` branch calls `input.truncate(start)`, which discards everything from the opening marker to the end of the string.

This happens whenever:
- a response is cut off by a length / max-tokens limit mid-block (very common — the close tag simply never gets generated), or
- the model emits a literal `<tool_call>` / `<think>` marker without ever closing it.

In both cases the entire user-visible suffix of the response is silently deleted, turning a partial-but-useful answer into a truncated one with no indication of why.

## The fix

In the unclosed-marker branch, `break` out of the loop instead of truncating. The remaining text — including the unmatched marker — is preserved verbatim. Fully-closed blocks are still stripped exactly as before, so there is no behavior change for well-formed responses.

```rust
        } else {
            // A length-limited response or literal marker may not have a
            // matching close tag. Preserve it verbatim rather than
            // deleting the entire user-visible suffix.
            break;
        }
```

A unit test (`test_strip_tool_call_text_preserves_unclosed_markers`) covers unclosed `<tool_call>` and `<think>` markers.

## Testing checklist

- [ ] `cargo test -p dynamo-llm strip_tool_call_text` (new + existing `test_strip_tool_call_text` pass)
- [ ] `cargo build -p dynamo-llm`
- [ ] `cargo clippy -p dynamo-llm`
- [ ] Manual: length-limited Responses API completion containing an unclosed `<tool_call>` / `<think>` returns its visible suffix instead of an empty/truncated body
- [ ] Confirm closed `<tool_call>...</tool_call>` / `<think>...</think>` blocks are still stripped (no regression)
