### PR TITLE
fix(validation): reject response_format json_schema schema=false as unsatisfiable

### DIFF
--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -196,6 +196,13 @@ pub fn validate_response_format(
                     "`response_format.json_schema.schema` is required when `response_format.type` is `json_schema`"
                 );
             }
+            // Reject a literal `false` schema: it is a valid JSON Schema that
+            // matches no value, so it can never be satisfied by any output.
+            if json_schema.schema == Some(serde_json::Value::Bool(false)) {
+                anyhow::bail!(
+                    "`response_format.json_schema.schema` cannot be false because it is unsatisfiable"
+                );
+            }
             Ok(())
         }
     }


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## Bug

`validate_response_format` (in `lib/llm/src/protocols/openai/validate.rs`) validates the `json_schema` variant of an OpenAI `response_format` by rejecting an empty `name` and a missing `schema`, but it accepts **any** `schema` value that is present.

A JSON Schema of literal `false` is syntactically valid, but it is the "match nothing" schema — it can never be satisfied by any output. When a client sends:

```json
{
  "response_format": {
    "type": "json_schema",
    "json_schema": { "name": "x", "schema": false }
  }
}
```

the request passes validation and the unsatisfiable constraint is handed to guided decoding, where it surfaces later as an opaque backend failure rather than a clear, immediate client-facing error.

## Fix

Reject a `schema` of literal `false` in the same validation function that already rejects a missing schema and an empty name:

```rust
if json_schema.schema == Some(serde_json::Value::Bool(false)) {
    anyhow::bail!(
        "`response_format.json_schema.schema` cannot be false because it is unsatisfiable"
    );
}
```

- A `true` schema (match anything) remains valid — only `false` is rejected.
- `serde_json` is already a dependency of `lib/llm` and used throughout this file, so no new import is needed.
- The change is a single guard added after the existing schema-presence check; no other behavior is affected.

## Testing checklist

- [ ] `cargo build -p dynamo-llm`
- [ ] `cargo clippy -p dynamo-llm`
- [ ] A request with `response_format.json_schema.schema = false` is rejected with HTTP 400 and the message `` `response_format.json_schema.schema` cannot be false because it is unsatisfiable ``
- [ ] A request with `schema = true` still succeeds
- [ ] A request with a normal object schema still succeeds
- [ ] A request with a missing schema still returns the existing "schema is required" error
