### PR TITLE
fix(runtime): make /live a shallow liveness check independent of engine readiness

### DIFF
--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -167,7 +167,7 @@ pub async fn spawn_system_status_server(
             &live_path,
             get({
                 let state = Arc::clone(&server_state);
-                move || health_handler(state)
+                move || live_handler(state)
             }),
         )
         .route(
@@ -294,6 +294,24 @@ async fn health_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
     tracing::trace!("Response {}", response.to_string());
 
     (status_code, response.to_string())
+}
+
+/// Shallow process liveness handler.
+///
+/// Reaching this handler proves that the runtime and its status server are
+/// responsive. Engine readiness is deliberately excluded and remains the
+/// responsibility of the health endpoint, so an overloaded or busy engine
+/// does not turn a liveness probe into a restart loop.
+#[tracing::instrument(skip_all, level = "trace")]
+async fn live_handler(state: Arc<SystemStatusState>) -> impl IntoResponse {
+    let uptime = state.drt().system_health().lock().uptime();
+    let response = json!({
+        "status": "live",
+        "uptime": uptime,
+    });
+
+    tracing::trace!("Response {}", response.to_string());
+    (StatusCode::OK, response.to_string())
 }
 
 /// Metrics handler with DistributedRuntime uptime
@@ -927,13 +945,15 @@ mod integration_tests {
                 }
                 match custom_live_path {
                     None => {
-                        // When using default paths, test the default paths
-                        test_cases.push(("/live", expected_status, expected_body));
+                        // When using default paths, test the default paths.
+                        // /live is a shallow liveness probe: it always returns
+                        // 200/"live" regardless of engine readiness.
+                        test_cases.push(("/live", 200, "live"));
                     }
                     Some(clp) => {
                         // When using custom paths, default paths should not exist
                         test_cases.push(("/live", 404, "Route not found"));
-                        test_cases.push((clp, expected_status, expected_body));
+                        test_cases.push((clp, 200, "live"));
                     }
                 }
                 test_cases.push(("/someRandomPathNotFoundHere", 404, "Route not found"));


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

`spawn_system_status_server` routes **both** the health path (`/health`) and the liveness path (`/live`) to the same `health_handler`. `health_handler` inspects engine readiness via `get_health_status()` and returns **503 SERVICE_UNAVAILABLE** whenever the engine is not-ready — busy, overloaded, or still warming up.

That behavior is correct for a **readiness** probe, but wrong for a **liveness** probe. In Kubernetes, a liveness probe hitting `/live` will fail (503) against a process that is fully alive and merely loaded. The kubelet then restarts the pod. For an engine that is busy or transiently overloaded, this turns into a restart loop that removes capacity and can amplify load rather than relieve it — exactly when the deployment can least afford it.

Any deployment that wires a k8s liveness probe to `/live` (or a custom `DYN_SYSTEM_LIVE_PATH`) is affected.

## The fix

Separate liveness from readiness:

- Add a shallow `live_handler` that **always returns 200** with `{ "status": "live", "uptime": <duration> }` and performs **no** engine/health-endpoint check. Reaching the handler at all is proof that the runtime and its status server are responsive.
- Point the `live_path` route at `live_handler` instead of `health_handler`.
- Engine readiness remains the responsibility of `/health` (`health_handler`, unchanged), which is the correct target for a k8s **readiness** probe.

The two affected integration test cases in `test_health_endpoints` are updated to expect the new `200`/`"live"` response on `/live` (default and custom paths), including the previously-503 `notready` scenario.

### Scope note

This extracts only the liveness-routing mechanism. The internal source commit also bundled a Prometheus probe counter and unrelated changes; those are intentionally **not** included here to keep the change minimal and focused on the liveness behavior.

## Testing checklist

- [ ] `cargo build -p dynamo-runtime`
- [ ] `cargo test -p dynamo-runtime --features integration test_health_endpoints` (covers ready/notready × default/custom paths)
- [ ] Manual: with the engine forced not-ready, `GET /health` returns 503 while `GET /live` returns 200 `{"status":"live",...}`
- [ ] Manual: custom `DYN_SYSTEM_LIVE_PATH` returns 200/"live"; default `/live` then 404s
- [ ] Deploy check: k8s liveness probe on `/live` no longer restarts a busy/overloaded-but-alive worker
