### PR TITLE
fix(bindings): preserve ResourceExhausted error type across the Rust to Python boundary

### DIFF
--- a/lib/bindings/python/rust/errors.rs
+++ b/lib/bindings/python/rust/errors.rs
@@ -11,13 +11,25 @@
 //! corresponding entry to the macro invocation below to keep Python exceptions
 //! in sync.
 
-use dynamo_runtime::error::BackendError;
+use dynamo_runtime::error::{BackendError, ErrorType, match_error_chain};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 
 // Base exception for all Dynamo errors.
 pyo3::create_exception!(dynamo._core, DynamoException, pyo3::exceptions::PyException);
 pyo3::create_exception!(dynamo._core, RouterQueueLimitExceeded, DynamoException);
+pyo3::create_exception!(dynamo._core, ResourceExhausted, DynamoException);
+
+/// Preserve resource exhaustion as a typed exception across the Rust -> Python
+/// boundary. The generic binding fallback stringifies `anyhow::Error`, which
+/// loses `ErrorType::ResourceExhausted` and causes the HTTP layer to emit 500
+/// instead of a retryable status.
+pub fn routed_engine_error_to_pyerr(error: anyhow::Error) -> PyErr {
+    if match_error_chain(error.as_ref(), &[ErrorType::ResourceExhausted], &[]) {
+        return ResourceExhausted::new_err("Service temporarily overloaded");
+    }
+    crate::to_pyerr(error)
+}
 
 pub fn queue_rejection_to_pyerr(rejection: dynamo_kv_router::scheduling::QueueRejection) -> PyErr {
     let error = PyErr::new::<RouterQueueLimitExceeded, _>(rejection.to_string());
@@ -99,6 +111,10 @@ macro_rules! define_dynamo_exceptions {
             m.add(
                 "RouterQueueLimitExceeded",
                 m.py().get_type::<RouterQueueLimitExceeded>(),
+            )?;
+            m.add(
+                "ResourceExhausted",
+                m.py().get_type::<ResourceExhausted>(),
             )?;
             m.add(
                 "SelectionServiceError",

--- a/lib/bindings/python/rust/llm/routed_engine.rs
+++ b/lib/bindings/python/rust/llm/routed_engine.rs
@@ -13,7 +13,7 @@ use dynamo_runtime::logging::{DistributedTraceContext, otel_parent_context_from_
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, SingleIn};
 use dynamo_runtime::protocols::annotated::Annotated as RsAnnotated;
 
-use crate::to_pyerr;
+use crate::{errors::routed_engine_error_to_pyerr, to_pyerr};
 
 #[pyclass]
 pub struct RoutedEngine {
@@ -68,7 +68,10 @@ impl RoutedEngine {
         pyo3_async_runtimes::tokio::future_into_py(
             py,
             async move {
-                let mut stream = inner.generate(request_context).await.map_err(to_pyerr)?;
+                let mut stream = inner
+                    .generate(request_context)
+                    .await
+                    .map_err(routed_engine_error_to_pyerr)?;
                 let task_context = stream.context();
                 let (tx, rx) = tokio::sync::mpsc::channel::<RsAnnotated<PyObject>>(32);
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -3360,6 +3360,11 @@ class RouterQueueLimitExceeded(DynamoException):
     current: int
     limit: int
 
+class ResourceExhausted(DynamoException):
+    """The selected worker cannot admit more work; callers should retry."""
+
+    ...
+
 class Unknown(DynamoException):
     """Uncategorized or unknown error."""
 

--- a/lib/bindings/python/src/dynamo/llm/exceptions.py
+++ b/lib/bindings/python/src/dynamo/llm/exceptions.py
@@ -13,6 +13,7 @@ from dynamo._core import DynamoException as DynamoException
 from dynamo._core import EngineShutdown as EngineShutdown
 from dynamo._core import InvalidArgument as InvalidArgument
 from dynamo._core import RouterQueueLimitExceeded as RouterQueueLimitExceeded
+from dynamo._core import ResourceExhausted as ResourceExhausted
 from dynamo._core import SelectionServiceError as SelectionServiceError
 from dynamo._core import StreamIncomplete as StreamIncomplete
 from dynamo._core import Unknown as Unknown


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

`RoutedEngine::generate` in the Python bindings maps engine errors to Python
through the generic `to_pyerr` fallback, which stringifies the underlying
`anyhow::Error`:

```rust
let mut stream = inner.generate(request_context).await.map_err(to_pyerr)?;
```

Stringifying collapses every failure into an untyped `DynamoException`. In
particular `ErrorType::ResourceExhausted` — raised when the selected worker
cannot admit more work and the caller is expected to retry — becomes
indistinguishable from an internal fault. The HTTP layer downstream then can't
tell it apart from any other error and emits a generic **HTTP 500**, even
though this condition should surface as a **retryable status** (429/503-class).

## The fix

Preserve the resource-exhaustion type as a dedicated typed exception across the
Rust → Python boundary:

- Add a `ResourceExhausted` Python exception (subclass of `DynamoException`),
  registered on the `_core` module next to its siblings.
- Add `routed_engine_error_to_pyerr(error: anyhow::Error) -> PyErr`, which walks
  the error chain with `match_error_chain(..., &[ErrorType::ResourceExhausted], &[])`
  and raises the typed `ResourceExhausted` exception when it matches, otherwise
  falls back to the existing `to_pyerr` for all other errors.
- Use the new conversion in `RoutedEngine::generate` (the `depythonize` path
  keeps using `to_pyerr` — only the generation result changes).
- Add the `_core.pyi` stub and re-export `ResourceExhausted` from
  `dynamo.llm.exceptions` so callers can `except ResourceExhausted` at the
  documented import path, consistent with the other binding exceptions.

The change is intentionally scoped to error-type preservation only. Non-matching
errors are unaffected; the fallback path is byte-for-byte the previous behavior.

All required symbols (`ErrorType`, `ErrorType::ResourceExhausted`,
`match_error_chain`) already exist in `dynamo_runtime::error` on `main`, so no
runtime-side changes are needed.

## Testing checklist

- [ ] `cargo build -p dynamo-bindings` (or the bindings crate) compiles cleanly
- [ ] `cargo clippy` on the bindings crate — no unused-import / dead-code warnings (`to_pyerr` still used by the `depythonize` path)
- [ ] Build the Python wheel (`maturin develop`) and confirm `from dynamo.llm.exceptions import ResourceExhausted` imports
- [ ] Unit test: an engine error whose chain contains `ErrorType::ResourceExhausted` surfaces as `ResourceExhausted` (not a bare `DynamoException`) through `RoutedEngine.generate`
- [ ] Unit test: a non-resource-exhausted error still maps via `to_pyerr` (behavior unchanged)
- [ ] End-to-end: an overloaded worker returns a retryable HTTP status (429/503-class) rather than 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4hEYusqJ1zdFcjqLFmfeV
