### PR TITLE
fix(runtime): release request-plane inflight counter via RAII (panic/cancel-safe)

### DIFF
--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -134,6 +134,23 @@ struct WorkItem {
     endpoint_name: String,
 }
 
+impl Drop for WorkItem {
+    /// Release the request-plane inflight slot via RAII.
+    ///
+    /// The inflight counter is incremented once in `read_loop` when the
+    /// `WorkItem` is built. Decrementing it here (rather than manually at the
+    /// tail of `handle_work_item`, after an `.await`) guarantees the release
+    /// runs on *every* exit path — normal completion, handler panic, task
+    /// cancellation, or the item being dropped undelivered (rejected/overflow,
+    /// or still sitting in the queue at shutdown). Each `WorkItem` owns exactly
+    /// one inflight increment, so this fires exactly once per increment and
+    /// cannot double-decrement.
+    fn drop(&mut self) {
+        self.inflight.fetch_sub(1, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
+}
+
 /// Shared TCP server that handles multiple endpoints on a single port
 pub struct SharedTcpServer {
     handlers: Arc<DashMap<String, Arc<EndpointHandler>>>,
@@ -324,9 +341,12 @@ impl SharedTcpServer {
             .or_else(|| work_item.headers.get("x-dynamo-request-id"))
             .cloned();
 
+        // Clone rather than move `payload` out: `WorkItem` implements `Drop`
+        // (for the inflight release), so a field cannot be moved out of it.
+        // `Bytes` is Arc-backed, so the clone is cheap.
         let result = work_item
             .service_handler
-            .handle_payload(work_item.payload, request_id)
+            .handle_payload(work_item.payload.clone(), request_id)
             .instrument(span)
             .await;
 
@@ -338,8 +358,9 @@ impl SharedTcpServer {
             );
         }
 
-        work_item.inflight.fetch_sub(1, Ordering::SeqCst);
-        work_item.notify.notify_one();
+        // The inflight counter is released by `WorkItem`'s `Drop` impl when
+        // `work_item` goes out of scope here — panic/cancel-safe, no manual
+        // decrement needed.
     }
 
     /// Bind the server and start accepting connections.
@@ -668,16 +689,17 @@ impl SharedTcpServer {
                     send_response(TcpResponseMessage::new(Bytes::from_static(
                         b"Server overloaded: worker at capacity",
                     )));
-                    handler.inflight.fetch_sub(1, Ordering::SeqCst);
-                    handler.notify.notify_one();
+                    // `work_item` is dropped undelivered at the end of this loop
+                    // iteration; its `Drop` releases the inflight slot. Do not
+                    // decrement here or the counter would go negative/underflow.
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                     WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.inc();
                     send_response(TcpResponseMessage::new(Bytes::from_static(
                         b"Server unavailable: worker pool channel closed",
                     )));
-                    handler.inflight.fetch_sub(1, Ordering::SeqCst);
-                    handler.notify.notify_one();
+                    // `work_item` is dropped undelivered when we break out of the
+                    // loop; its `Drop` releases the inflight slot.
                     tracing::error!("Worker pool channel closed, shutting down read loop");
                     break;
                 }


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

The shared TCP request-plane ingress (`lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs`) bounds per-endpoint concurrency with an `inflight: Arc<AtomicU64>` counter. `read_loop` increments it exactly once when it builds each `WorkItem`:

```rust
handler.inflight.fetch_add(1, Ordering::SeqCst);
let work_item = WorkItem { /* ... */ inflight: handler.inflight.clone(), /* ... */ };
```

The matching decrement was done **manually at the tail of `handle_work_item`, after the `.await`**:

```rust
let result = work_item.service_handler.handle_payload(...).instrument(span).await;
// ...
work_item.inflight.fetch_sub(1, Ordering::SeqCst);   // <-- skipped on panic / cancellation
work_item.notify.notify_one();
```

Any exit path that does not fall through that tail line leaks one count permanently:

- the handler **panics** inside `handle_payload().await`;
- the tokio task is **cancelled** / the future is dropped (e.g. runtime shutdown) before the tail runs.

Each leak permanently inflates the endpoint's inflight count. Once the leaked total reaches the configured engine + queue capacity, `read_loop` rejects **every** subsequent request with `503 "Server overloaded: worker at capacity"` even though the worker is actually idle. The leak also blocks `unregister_endpoint`, whose `drain_inflight` waits for the counter to reach zero and can therefore hang for the full graceful-shutdown timeout.

## The fix

Release the slot with RAII instead of a manual decrement:

```rust
impl Drop for WorkItem {
    fn drop(&mut self) {
        self.inflight.fetch_sub(1, Ordering::SeqCst);
        self.notify.notify_one();
    }
}
```

Because every `WorkItem` owns exactly one inflight increment, `Drop` runs the release on **all** exit paths — normal completion, handler panic, task cancellation, and items dropped undelivered (overflow-rejected, channel-closed, or still sitting in the queue at shutdown).

To keep the accounting a single decrement per increment, the now-redundant manual `fetch_sub`/`notify` calls are removed from:

- the tail of `handle_work_item` (the owned `work_item` is dropped when the task returns/unwinds → `Drop` fires);
- both reject arms of `read_loop` — `TrySendError::Full` and `TrySendError::Closed` — where the undelivered `work_item` is dropped in-scope at the end of the loop iteration → `Drop` fires.

Decrement audit — every path decrements exactly once, none twice:

| path | how `WorkItem` ends | decrement |
|------|---------------------|-----------|
| direct dispatch | moved into spawned task → dropped on completion/panic/cancel | `Drop` ×1 |
| queued | moved into channel → dropped when dispatcher processes it (or when channel drops at shutdown) | `Drop` ×1 |
| reject (queue Full) | not moved → dropped at end of loop iteration | `Drop` ×1 |
| reject (channel Closed) | not moved → dropped on `break` | `Drop` ×1 |

One required side effect: since `WorkItem` now implements `Drop`, a field can no longer be moved out of it, so `handle_work_item` clones the payload (`work_item.payload.clone()`) instead of moving it. `payload` is `bytes::Bytes` (Arc-backed), so the clone is a cheap refcount bump.

## Testing checklist

- [ ] `cargo build -p dynamo-runtime`
- [ ] `cargo test -p dynamo-runtime` — existing `shared_tcp_endpoint` tests (graceful-shutdown drain, worker-pool concurrency bound, permit-wait metrics) still pass
- [ ] `cargo clippy -p dynamo-runtime`
- [ ] New regression test: a handler that panics (or a task cancelled mid-`await`) does **not** leak the inflight counter — after the request settles, the endpoint accepts new requests and `drain_inflight` completes promptly
- [ ] Soak / load test: inflight gauge returns to 0 after a burst that includes handler panics; worker does not enter a permanent "at capacity" reject state
