### PR TITLE
fix(kv-router): evict cancelled/stale requests parked in the admission queue

### DIFF
--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -41,6 +41,11 @@ pub const DEFAULT_MAX_BATCHED_TOKENS: u64 = 10_000_000;
 
 const ADMISSION_CHANNEL_CAPACITY: usize = 65_536;
 
+/// Cadence of the background sweep that reclaims capacity from queued requests
+/// whose client has disconnected. Small enough to bound stale-capacity
+/// retention, large enough to stay negligible against request rates.
+const QUEUE_SWEEP_INTERVAL: Duration = Duration::from_millis(100);
+
 struct ClassQueueCounters {
     pending_count: AtomicUsize,
     pending_isl_tokens: AtomicUsize,
@@ -684,7 +689,19 @@ impl<
 {
     async fn run(mut self, mut rx: mpsc::Receiver<AdmissionCommand>) {
         let mut commands_since_cleanup = 0usize;
-        while let Some(command) = rx.recv().await {
+        let mut sweep = tokio::time::interval(QUEUE_SWEEP_INTERVAL);
+        sweep.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            let command = tokio::select! {
+                command = rx.recv() => match command {
+                    Some(command) => command,
+                    None => break,
+                },
+                _ = sweep.tick() => {
+                    self.evict_stale_or_cancelled();
+                    continue;
+                }
+            };
             let drain_cleanup = self.queueing_enabled && {
                 commands_since_cleanup += 1;
                 let drain_cleanup = rx.is_empty() || commands_since_cleanup == 256;
@@ -769,6 +786,33 @@ impl<
 
             let mut request = entry.into_payload().request;
             request.respond(Err(KvSchedulerError::SubscriberShutdown));
+        }
+    }
+
+    /// Periodically reclaim capacity held by queued requests whose client has
+    /// already disconnected.
+    ///
+    /// Ticket-tracked entries are released through the admission-lease path in
+    /// `drain_cleanup`, which keeps admission accounting consistent. This sweep
+    /// is the backstop for queued requests that carry no admission ticket (for
+    /// example non-lifecycle tracked modes, which are never issued a lifecycle
+    /// lease): without it, a closed response is only noticed once the request
+    /// reaches the dispatch head, so a cancelled request parked behind others
+    /// keeps holding its counted capacity until it is dequeued. Freed capacity
+    /// is picked up by the next scheduling pass.
+    fn evict_stale_or_cancelled(&mut self) {
+        if self.pending.pending_count() == 0 {
+            return;
+        }
+        for class_index in 0..self.profile.classes().len() {
+            let (removed, _removed_ready_head) =
+                self.pending.take_if_in_class(class_index, |queued| {
+                    queued.admission.is_none() && queued.request.response_is_closed()
+                });
+            for entry in removed {
+                self.subtract_pending_counters(class_index, entry.snapshot());
+                tracing::debug!("evicted cancelled request from router admission queue");
+            }
         }
     }
 
@@ -3336,6 +3380,41 @@ policy_classes:
 
         assert_eq!(queue.pending_count(), 0);
         slots.assert_completely_drained(decay_now());
+    }
+
+    #[tokio::test]
+    async fn cancelled_pending_request_is_swept_without_dispatch() {
+        let isl = 512;
+        let (queue, _slots) = make_queue(1, 16, isl, Some(0.0));
+
+        // First request books the only worker's capacity.
+        let (first, first_rx) = make_request("first", isl);
+        queue.enqueue(first).await;
+        first_rx
+            .await
+            .expect("first response sender dropped")
+            .expect("first request should occupy the worker");
+
+        // Second request parks in the admission queue behind the capacity holder.
+        let (cancelled, cancelled_rx) = make_request("cancelled", isl);
+        queue.enqueue(cancelled).await;
+        assert_eq!(queue.pending_count(), 1);
+        assert_eq!(queue.pending_isl_tokens(), isl);
+
+        // Client goes away. No dispatch, worker free, or update follows, so only
+        // the periodic sweep can reclaim the parked capacity.
+        drop(cancelled_rx);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while queue.pending_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("sweep did not evict the cancelled pending request");
+
+        assert_eq!(queue.pending_count(), 0);
+        assert_eq!(queue.pending_isl_tokens(), 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
> **Draft** — extracted from an internally-validated fix; opening for review. CI has not been run here.

## The bug

The KV-router scheduler queue actor (`lib/kv-router/src/scheduling/queue.rs`) advances its state **only** when it receives an `AdmissionCommand` (enqueue / update / reconcile / dispatched / cleanup). A request that parks in the admission queue and whose client then disconnects keeps holding its counted capacity — the global pending count, pending ISL tokens, and the per-class counters — until it is eventually dequeued at the dispatch head (where `book_and_respond` skips booking for a closed response).

While the cancelled request is still parked *behind* other queued entries, that stale capacity keeps counting against queue limits and worker-capacity gating, needlessly throttling live traffic.

The lifecycle-lease path (`drain_cleanup`) already retracts **ticket-tracked** queued requests promptly when their `RequestLifecycleLease` drops. But queued requests that carry **no admission ticket** — e.g. non-lifecycle tracked modes, which are never issued a lease — have no equivalent backstop, so their cancellation is invisible to the actor until dispatch.

## The fix

Add a lightweight periodic sweep (`QUEUE_SWEEP_INTERVAL = 100ms`) to the actor's `run` loop via `tokio::select!`. On each tick, `evict_stale_or_cancelled`:

- returns immediately when the queue is empty (`pending.pending_count() == 0`);
- for each policy class, uses the existing `take_if_in_class` primitive to remove entries where `admission.is_none()` **and** `request.response_is_closed()`;
- releases their capacity via the existing `subtract_pending_counters` helper.

Ticket-tracked entries (`admission.is_some()`) are **deliberately excluded** — they remain owned by the lease / `drain_cleanup` path so admission accounting (and its `debug_assert` invariants) stay consistent. Freed capacity is picked up on the next scheduling pass, consistent with how the other cleanup paths already behave.

The change is confined to `queue.rs` and reuses primitives already present there; it adds no new public API and no new dependencies.

## Divergence note

The internal fix this was extracted from was written against an older queue actor that was a plain `while rx.recv().await` loop with no cancellation handling at all. Upstream has since added the event-driven `RequestLifecycleLease` / `drain_cleanup` machinery, which already covers the ticket-tracked case. This PR therefore extracts **only** the periodic cancel-eviction sweep and scopes it to the non-ticketed entries that the lease path does not cover — it is a backstop, not a replacement. The internal change also bundled an opt-in `DYN_ROUTER_MAX_QUEUE_WAIT_MS` queue-deadline feature (and a `KvSchedulerError::QueueExpired` variant); that is **intentionally not included** here, as it is a separable opt-in policy rather than a cancellation-correctness fix.

## Testing checklist

- [ ] `cargo build -p dynamo-kv-router`
- [ ] `cargo test -p dynamo-kv-router` (existing scheduling/queue tests still pass)
- [ ] New unit test `cancelled_pending_request_is_swept_without_dispatch` passes — a cancelled request parked behind a capacity holder is reclaimed by the sweep with no dispatch, worker free, or update command
- [ ] `cargo clippy -p dynamo-kv-router`
- [ ] Soak/load check: cancelled-mid-queue requests no longer pin queue-limit / worker capacity
- [ ] Confirm no regression in the lease/`drain_cleanup` path (ticket-tracked cancellations still retract via their existing tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4hEYusqJ1zdFcjqLFmfeV
