### PR TITLE
perf(tokens): remove redundant inner DashMap sharding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2904,6 +2904,7 @@ dependencies = [
  "derive-getters",
  "itertools 0.14.0",
  "rmp-serde",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1906,6 +1906,7 @@ dependencies = [
  "bytemuck",
  "dashmap",
  "derive-getters",
+ "rustc-hash 2.1.2",
  "serde",
  "thiserror 2.0.18",
  "uuid",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "bytemuck",
  "dashmap",
  "derive-getters",
+ "rustc-hash 2.1.2",
  "serde",
  "thiserror 2.0.18",
  "uuid",

--- a/lib/kvbm-logical/src/registry/handle.rs
+++ b/lib/kvbm-logical/src/registry/handle.rs
@@ -87,7 +87,7 @@ impl Drop for BlockRegistrationHandleInner {
         // during `drop_in_place` the inner allocation is still live (the
         // implicit weak from the strong refcount is released after `Drop`
         // returns). Only remove if the entry still points to us.
-        let map = registry.prefix(&self.seq_hash);
+        let mut map = registry.prefix(&self.seq_hash);
         let should_remove = match map.get(&self.seq_hash) {
             Some(weak_ref) => std::ptr::eq(weak_ref.as_ptr(), self as *const Self),
             None => {

--- a/lib/kvbm-logical/src/registry/mod.rs
+++ b/lib/kvbm-logical/src/registry/mod.rs
@@ -229,8 +229,8 @@ impl BlockRegistry {
     // pattern should replace the direct EventsManager call here.
     #[inline]
     pub fn register_sequence_hash(&self, seq_hash: SequenceHash) -> BlockRegistrationHandle {
-        let map = self.prt.prefix(&seq_hash);
-        let mut weak = map.entry(seq_hash).or_default();
+        let mut map = self.prt.prefix(&seq_hash);
+        let weak = map.entry(seq_hash).or_default();
 
         if let Some(inner) = weak.upgrade() {
             return BlockRegistrationHandle::from_inner(inner);
@@ -334,13 +334,13 @@ impl BlockRegistry {
         let mut entries = entries.into_iter().peekable();
         while let Some(first) = entries.next() {
             let position = first.1.position();
-            let map = self.prt.prefix(&first.1);
+            let mut map = self.prt.prefix(&first.1);
             let mut current = first;
 
             loop {
                 let (key, seq_hash) = current;
                 debug_assert_eq!(seq_hash.position(), position);
-                let mut weak = map.entry(seq_hash).or_default();
+                let weak = map.entry(seq_hash).or_default();
                 let (inner, is_new) = match weak.upgrade() {
                     Some(inner) => (inner, false),
                     None => {
@@ -364,8 +364,8 @@ impl BlockRegistry {
     /// Used when copying blocks between pools where we don't want to count the transfer as a new access.
     #[allow(dead_code)]
     pub(crate) fn transfer_registration(&self, seq_hash: SequenceHash) -> BlockRegistrationHandle {
-        let map = self.prt.prefix(&seq_hash);
-        let mut weak = map.entry(seq_hash).or_default();
+        let mut map = self.prt.prefix(&seq_hash);
+        let weak = map.entry(seq_hash).or_default();
 
         match weak.upgrade() {
             Some(inner) => BlockRegistrationHandle::from_inner(inner),

--- a/lib/kvbm-logical/src/registry/tests.rs
+++ b/lib/kvbm-logical/src/registry/tests.rs
@@ -726,8 +726,8 @@ fn drop_does_not_remove_entry_when_replaced_by_newer_registration() {
         Arc::downgrade(&registry.prt),
     ));
     {
-        let map = registry.prt.prefix(&seq_hash);
-        let mut weak = map.get_mut(&seq_hash).expect("entry present");
+        let mut map = registry.prt.prefix(&seq_hash);
+        let weak = map.get_mut(&seq_hash).expect("entry present");
         *weak = Arc::downgrade(&inner_b);
     }
 

--- a/lib/tokens/Cargo.toml
+++ b/lib/tokens/Cargo.toml
@@ -14,6 +14,7 @@ repository.workspace = true
 [dependencies]
 dashmap = { workspace = true }
 derive-getters = { workspace = true }
+rustc-hash = "2"
 serde = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }

--- a/lib/tokens/src/lib.rs
+++ b/lib/tokens/src/lib.rs
@@ -2940,6 +2940,30 @@ mod tests {
         assert_eq!(pos0_map.len(), 1);
     }
 
+    #[test]
+    fn test_positional_radix_tree_concurrent_same_position() {
+        use crate::PositionalRadixTree;
+        use std::sync::Arc;
+
+        let tree = Arc::new(PositionalRadixTree::new());
+        let threads: Vec<_> = (0..8_u64)
+            .map(|value| {
+                let tree = Arc::clone(&tree);
+                std::thread::spawn(move || {
+                    let key = PositionalSequenceHash::new(value, 7, value);
+                    tree.prefix(&key).insert(key, value);
+                })
+            })
+            .collect();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        assert_eq!(tree.len(), 8);
+        assert_eq!(tree.position(7).unwrap().len(), 8);
+    }
+
     // === PositionalSequenceHash Additional Tests ===
 
     #[test]

--- a/lib/tokens/src/lib.rs
+++ b/lib/tokens/src/lib.rs
@@ -2890,7 +2890,7 @@ mod tests {
 
         // Test retrieval
         assert_eq!(
-            tree.prefix(&psh1).get(&psh1).map(|v| v.clone()),
+            tree.prefix(&psh1).get(&psh1).cloned(),
             Some("value1".to_string())
         );
     }
@@ -2910,8 +2910,8 @@ mod tests {
         tree.prefix(&plh2).insert(plh2, 200);
 
         assert_eq!(tree.len(), 2);
-        assert_eq!(tree.prefix(&plh1).get(&plh1).map(|v| *v), Some(100));
-        assert_eq!(tree.prefix(&plh2).get(&plh2).map(|v| *v), Some(200));
+        assert_eq!(tree.prefix(&plh1).get(&plh1).copied(), Some(100));
+        assert_eq!(tree.prefix(&plh2).get(&plh2).copied(), Some(200));
     }
 
     #[test]

--- a/lib/tokens/src/radix.rs
+++ b/lib/tokens/src/radix.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dashmap::DashMap;
+use rustc_hash::FxHashMap;
 use std::hash::Hash;
 
 use crate::{PositionalHash, PositionalSequenceHash};
@@ -12,7 +13,9 @@ pub struct PositionalRadixTree<V, K = PositionalSequenceHash>
 where
     K: PositionalHash + Hash + Eq + Clone,
 {
-    map: DashMap<u64, DashMap<K, V>>,
+    // Access to a position's inner map is serialized by the outer DashMap's
+    // RefMut guard, so sharding the inner map adds memory without concurrency.
+    map: DashMap<u64, FxHashMap<K, V>>,
 }
 
 impl<V, K> PositionalRadixTree<V, K>
@@ -27,7 +30,7 @@ where
     }
 
     /// Provides the entry for the key at the given position.
-    pub fn prefix(&self, key: &K) -> dashmap::mapref::one::RefMut<'_, u64, DashMap<K, V>> {
+    pub fn prefix(&self, key: &K) -> dashmap::mapref::one::RefMut<'_, u64, FxHashMap<K, V>> {
         let position = key.position();
         self.map.entry(position).or_default()
     }
@@ -36,7 +39,7 @@ where
     pub fn position(
         &self,
         position: u64,
-    ) -> Option<dashmap::mapref::one::RefMut<'_, u64, DashMap<K, V>>> {
+    ) -> Option<dashmap::mapref::one::RefMut<'_, u64, FxHashMap<K, V>>> {
         self.map.get_mut(&position)
     }
 


### PR DESCRIPTION
## Summary

- replace each positional radix bucket's inner `DashMap` with `FxHashMap`
- retain the outer `DashMap` as the concurrency boundary
- add focused same-position concurrent insertion coverage
- reduce peak mocker RSS by 5.51 GiB (35.3%) in a 32-worker AgentX A/B

Every inner-map access already holds the outer `DashMap`'s exclusive `RefMut`, so inner sharding provided no additional concurrency while replicating shard scaffolding for every position.

## Validation

- `cargo test -p dynamo-tokens positional_radix_tree`
- `cargo test -p kvbm-logical registry::tests`
- `cargo test -p kvbm-logical concurrent`
- `cargo fmt --all -- --check`
- unprofiled AgentX A/B: 32 workers, 128,000 blocks per worker, block size 16, concurrency 512
  - baseline: 15,996.0 MiB peak RSS, 243.90 req/s
  - patched: 10,356.2 MiB peak RSS, 251.97 req/s
  - reduction: 5,639.9 MiB / 5.51 GiB / 35.3%
  - both arms: 32/32 workers, zero errors, zero cancellations, zero affinity violations

The A/B contains one accepted run per arm. Throughput was healthy in both arms, but the observed difference is not presented as a speedup claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved registration cleanup to prevent newer registrations from being removed when older handles are dropped.
  - Improved reliability when multiple registration operations occur concurrently.

- **Performance**
  - Optimized internal token indexing to reduce nested map overhead.

- **Tests**
  - Added coverage for concurrent token insertion and registration replacement scenarios.
  - Updated test handling for safer value retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->