### PR TITLE
fix(vllm): seed KV gauges for every DP rank, not just the last

### DIFF
--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -141,7 +141,7 @@ class StatLoggerFactory:
         self.endpoint = endpoint
         self.component_gauges = component_gauges
         self.embedding_worker = embedding_worker
-        self.created_logger: Optional[DynamoStatLoggerPublisher] = None
+        self.created_loggers: list[DynamoStatLoggerPublisher] = []
 
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
         # Embedding workers have no KV cache and no scheduler stats worth
@@ -159,7 +159,7 @@ class StatLoggerFactory:
             dp_rank=dp_rank,
             component_gauges=self.component_gauges,
         )
-        self.created_logger = logger
+        self.created_loggers.append(logger)
 
         return logger
 
@@ -168,9 +168,9 @@ class StatLoggerFactory:
 
     # TODO Remove once we publish metadata to shared storage
     def set_num_gpu_blocks_all(self, num_blocks: int) -> None:
-        if self.created_logger:
-            self.created_logger.set_num_gpu_block(num_blocks)
+        for logger in self.created_loggers:
+            logger.set_num_gpu_block(num_blocks)
 
     def init_publish(self) -> None:
-        if self.created_logger:
-            self.created_logger.init_publish()
+        for logger in self.created_loggers:
+            logger.init_publish()

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -63,7 +63,7 @@ def test_factory_returns_noop_logger_for_embedding_worker(monkeypatch):
     # downstream ``init_publish`` / ``set_num_gpu_blocks_all`` calls in
     # the chat path are safe no-ops if anyone ever wires them on the
     # embedding branch by mistake.
-    assert factory.created_logger is None
+    assert factory.created_loggers == []
 
 
 def test_noop_stat_logger_record_is_safe_with_none_stats():
@@ -125,3 +125,39 @@ def test_factory_default_is_chat_path(monkeypatch):
     assert constructed[0]["endpoint"] is endpoint
     assert constructed[0]["dp_rank"] == 3
     assert constructed[0]["component_gauges"] is component_gauges
+
+
+def test_seed_broadcasts_to_all_dp_ranks(monkeypatch):
+    """Regression for #12052: the pre-first-record seed must reach every
+    per-rank publisher, not just the last one created.
+
+    vLLM calls the factory once per data-parallel rank, and each returned
+    ``DynamoStatLoggerPublisher`` is a distinct object vLLM retains. If the
+    factory only remembers the last one, ``set_num_gpu_blocks_all`` /
+    ``init_publish`` seed the ``total_blocks`` and ``gpu_cache_usage_percent``
+    gauges for a single rank, so non-last ranks lack their zero-valued labels
+    until the first scheduler record arrives.
+    """
+    created = []
+
+    def _fake_publisher(*_args, **kwargs):
+        m = Mock(spec=DynamoStatLoggerPublisher)
+        m.dp_rank = kwargs.get("dp_rank")
+        created.append(m)
+        return m
+
+    monkeypatch.setattr(publisher_mod, "DynamoStatLoggerPublisher", _fake_publisher)
+
+    factory = StatLoggerFactory(
+        endpoint=SimpleNamespace(), component_gauges=SimpleNamespace()
+    )
+    factory.create_stat_logger(dp_rank=0)
+    factory.create_stat_logger(dp_rank=1)
+
+    factory.set_num_gpu_blocks_all(123)
+    factory.init_publish()
+
+    assert len(created) == 2
+    for publisher in created:
+        publisher.set_num_gpu_block.assert_called_once_with(123)
+        publisher.init_publish.assert_called_once_with()

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -3,20 +3,23 @@
 
 """Unit tests for the vLLM stat-logger factory.
 
-These tests focus on the embedding-worker gating path: vLLM workers run
-either a chat/decode engine or a pooling (embedding) engine, and the
-chat-shaped Prometheus collectors are only meaningful on the former.
-The factory is the single seam where vLLM calls into dynamo per dp_rank,
-so it is also the seam where the embedding worker must short-circuit
-the chat-shaped pipeline.
+The factory is the single seam where vLLM calls into dynamo per dp_rank, which
+makes it the seam for two things: the embedding worker short-circuiting the
+chat-shaped pipeline (vLLM workers run either a chat/decode engine or a pooling
+engine, and the chat-shaped Prometheus collectors only mean something on the
+former), and the per-rank KV capacity seed reaching every rank the worker owns.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from prometheus_client import CollectorRegistry
+from vllm.v1.metrics.stats import SchedulerStats
 
 import dynamo.vllm.publisher as publisher_mod
+from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.vllm.publisher import (
     DynamoStatLoggerPublisher,
     NoopStatLogger,
@@ -128,15 +131,14 @@ def test_factory_default_is_chat_path(monkeypatch):
 
 
 def test_seed_broadcasts_to_all_dp_ranks(monkeypatch):
-    """Regression for #12052: the pre-first-record seed must reach every
-    per-rank publisher, not just the last one created.
+    """Regression for #12052: the seed must reach every per-rank publisher,
+    not just the last one created.
 
-    vLLM calls the factory once per data-parallel rank, and each returned
-    ``DynamoStatLoggerPublisher`` is a distinct object vLLM retains. If the
-    factory only remembers the last one, ``set_num_gpu_blocks_all`` /
-    ``init_publish`` seed the ``total_blocks`` and ``gpu_cache_usage_percent``
-    gauges for a single rank, so non-last ranks lack their zero-valued labels
-    until the first scheduler record arrives.
+    vLLM calls the factory once per data-parallel rank and retains each
+    returned ``DynamoStatLoggerPublisher``. If the factory only remembers the
+    last one, every other rank keeps ``num_gpu_block`` at its default of 1 for
+    the worker's lifetime; ``test_unseeded_rank_reports_empty_to_the_kv_router``
+    covers what that costs.
     """
     created = []
 
@@ -161,3 +163,68 @@ def test_seed_broadcasts_to_all_dp_ranks(monkeypatch):
     for publisher in created:
         publisher.set_num_gpu_block.assert_called_once_with(123)
         publisher.init_publish.assert_called_once_with()
+
+
+def _gauge_value(registry, suffix, dp_rank):
+    for family in registry.collect():
+        if not family.name.endswith(suffix):
+            continue
+        for sample in family.samples:
+            if sample.labels.get("dp_rank") == str(dp_rank):
+                return sample.value
+    return None
+
+
+def test_unseeded_rank_reports_empty_to_the_kv_router(monkeypatch):
+    """The seed gap is a routing bug, not a startup-only metrics gap.
+
+    ``num_gpu_block`` defaults to 1 and ``record`` re-reads it on every
+    scheduler iteration, so a rank that misses the seed publishes
+    ``kv_used_blocks=int(1 * usage)`` -- 0 for any usage below 100% -- and pins
+    ``total_blocks`` at 1 for the worker's lifetime. The KV router reads that
+    rank as permanently empty and keeps sending it work.
+
+    This drives the real ``DynamoStatLoggerPublisher`` over three scheduler
+    iterations; only the Rust NATS boundary (``WorkerMetricsPublisher``) is
+    substituted, to capture what the router would receive.
+    """
+    published = []
+
+    class _RecordingMetricsPublisher:
+        async def create_endpoint(self, _endpoint):
+            return None
+
+        def publish(self, dp_rank, **kwargs):
+            published.append((dp_rank, kwargs["kv_used_blocks"]))
+
+    monkeypatch.setattr(
+        publisher_mod, "WorkerMetricsPublisher", _RecordingMetricsPublisher
+    )
+
+    registry = CollectorRegistry()
+    gauges = LLMBackendMetrics(
+        registry, model_name="Qwen/Qwen3-0.6B", component_name="backend"
+    )
+    per_rank_blocks = 8192
+
+    async def _drive_two_ranks():
+        factory = StatLoggerFactory(endpoint=SimpleNamespace(), component_gauges=gauges)
+        loggers = [factory(SimpleNamespace(), dp_rank) for dp_rank in (0, 1)]
+        await asyncio.sleep(0)  # endpoint tasks are scheduled, not awaited
+
+        factory.set_num_gpu_blocks_all(per_rank_blocks)
+        factory.init_publish()
+        published.clear()
+
+        for _ in range(3):
+            for logger in loggers:
+                logger.record(SchedulerStats(kv_cache_usage=0.5), None)
+
+    asyncio.run(_drive_two_ranks())
+
+    expected_used = int(per_rank_blocks * 0.5)
+    assert published == [(0, expected_used), (1, expected_used)] * 3
+    for dp_rank in (0, 1):
+        assert (
+            _gauge_value(registry, "total_blocks", dp_rank) == per_rank_blocks
+        ), f"dp_rank={dp_rank} must report its real capacity, not the default 1"


### PR DESCRIPTION
## Summary

`StatLoggerFactory` kept only the last publisher vLLM asked it to create, so the KV
capacity seed reached a single data-parallel rank.

vLLM calls the factory once per DP rank and retains each returned
`DynamoStatLoggerPublisher`. The factory stored each one in a single field,
overwriting the previous, so `set_num_gpu_blocks_all()` and `init_publish()`, called
once at engine start (`worker_factory.py:920-921`), only ever reached the last rank.

That gap is not startup-only. `num_gpu_block` defaults to `1` (`publisher.py:35`) and
`record()` re-reads it on every scheduler iteration (`publisher.py:64-68`), so an
unseeded rank publishes `kv_used_blocks = int(1 * kv_cache_usage)`, `0` for any usage
below 100%, and pins `total_blocks` at `1` for the worker's lifetime. The KV router
reads that rank as permanently empty and keeps sending it work, so the cost is routing
correctness rather than a missing metric label.

This hits the internal and hybrid DP load-balancing shapes, where one worker owns
several ranks (`get_dp_range_for_worker`). External LB gives each worker exactly one
rank, so it and `DP = 1` are unaffected.

The factory now retains every per-rank publisher and broadcasts the seed to all of them.

Fixes #12052

## Validation

Real `vllm==0.23.0` and the `dynamo.vllm` from this branch, DP 2 over 16384 KV blocks
(8192 per rank) at `kv_cache_usage=0.5`, driving the real `DynamoStatLoggerPublisher`
for three scheduler iterations. Only `WorkerMetricsPublisher`, the Rust/NATS boundary,
which carries the values but does not compute them, is substituted, to capture what
the KV router would receive.

| dp_rank | `num_gpu_block` | `kv_used_blocks` published | `total_blocks` gauge |
| --- | --- | --- | --- |
| 0 (before) | 1 | `[0, 0, 0]` | 1.0 |
| 1 (before) | 8192 | `[4096, 4096, 4096]` | 8192.0 |
| 0 (after) | 8192 | `[4096, 4096, 4096]` | 8192.0 |
| 1 (after) | 8192 | `[4096, 4096, 4096]` | 8192.0 |

Rank 0 stays empty on every iteration before the fix, not just the first, which is the
router-visible symptom. `test_unseeded_rank_reports_empty_to_the_kv_router` pins those
values so the regression cannot come back as a passing test.

<details>
<summary>Raw logs</summary>

Unit tests, before the fix (`publisher.py` reverted to `main`, tests kept):

```console
$ PYTHONPATH=components/src python -m pytest \
    components/src/dynamo/vllm/tests/test_vllm_publisher.py -v
platform linux -- Python 3.12.13, pytest-9.1.1
rootdir: /repo
configfile: pyproject.toml

published  = [(0, 0), (1, 4096), (0, 0), (1, 4096), (0, 0), (1, 4096)]
E       AssertionError: assert [(0, 0), (1, ...0), (1, 4096)] == [(0, 4096), (...6), (1, 4096)]
E         At index 0 diff: (0, 0) != (0, 4096)

FAILED ...::test_factory_returns_noop_logger_for_embedding_worker
FAILED ...::test_seed_broadcasts_to_all_dp_ranks
FAILED ...::test_unseeded_rank_reports_empty_to_the_kv_router
3 failed, 3 passed in 4.97s
```

Unit tests, with the fix:

```console
$ PYTHONPATH=components/src python -m pytest \
    components/src/dynamo/vllm/tests/test_vllm_publisher.py -v
collected 6 items

components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_factory_returns_noop_logger_for_embedding_worker PASSED [ 16%]
components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_noop_stat_logger_record_is_safe_with_none_stats PASSED [ 33%]
components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_factory_embedding_flag_skips_component_gauges_assert PASSED [ 50%]
components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_factory_default_is_chat_path PASSED [ 66%]
components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_seed_broadcasts_to_all_dp_ranks PASSED [ 83%]
components/src/dynamo/vllm/tests/test_vllm_publisher.py::test_unseeded_rank_reports_empty_to_the_kv_router PASSED [100%]

6 passed in 3.60s
```

Standalone driver producing the table above, before the fix:

```console
$ PYTHONPATH=components/src python dp_rank_repro.py
engine start: 16384 KV blocks / DP 2 -> per_rank_kv_blocks=8192
publisher.py under test: /repo/components/src/dynamo/vllm/publisher.py
factory retains: NoneType (main: single 'created_logger' field)

steady state: 3 scheduler iterations at kv_cache_usage=0.5
dp_rank  num_gpu_block  kv_used_blocks published    total_blocks gauge
0        1              [0, 0, 0]                   1.0
1        8192           [4096, 4096, 4096]          8192.0

expected per rank: kv_used_blocks=[4096, 4096, 4096], total_blocks=8192.0
RESULT: FAIL - a rank reports empty to the KV router
```

and with the fix:

```console
$ PYTHONPATH=components/src python dp_rank_repro.py
engine start: 16384 KV blocks / DP 2 -> per_rank_kv_blocks=8192
publisher.py under test: /repo/components/src/dynamo/vllm/publisher.py
factory retains: list (main: single 'created_logger' field)

steady state: 3 scheduler iterations at kv_cache_usage=0.5
dp_rank  num_gpu_block  kv_used_blocks published    total_blocks gauge
0        8192           [4096, 4096, 4096]          8192.0
1        8192           [4096, 4096, 4096]          8192.0

expected per rank: kv_used_blocks=[4096, 4096, 4096], total_blocks=8192.0
RESULT: PASS - every rank reports its real occupancy
```

<details>
<summary>dp_rank_repro.py</summary>

```python
import asyncio
import sys
from types import SimpleNamespace

from prometheus_client import CollectorRegistry
from vllm.v1.metrics.stats import SchedulerStats

import dynamo.vllm.publisher as pub
from dynamo.common.utils.prometheus import LLMBackendMetrics
from dynamo.vllm.capacity import per_rank_kv_blocks

TOTAL_KV_BLOCKS, DP_SIZE, USAGE, ITERATIONS = 16384, 2, 0.5, 3
published = []

class RecordingMetricsPublisher:
    async def create_endpoint(self, _endpoint):
        return None

    def publish(self, dp_rank, **kwargs):
        published.append((dp_rank, kwargs["kv_used_blocks"]))

def gauge(registry, suffix, dp_rank):
    for family in registry.collect():
        if family.name.endswith(suffix):
            for sample in family.samples:
                if sample.labels.get("dp_rank") == str(dp_rank):
                    return sample.value
    return None

async def main():
    pub.WorkerMetricsPublisher = RecordingMetricsPublisher
    registry = CollectorRegistry()
    gauges = LLMBackendMetrics(
        registry, model_name="Qwen/Qwen3-0.6B", component_name="backend"
    )
    factory = pub.StatLoggerFactory(endpoint=SimpleNamespace(), component_gauges=gauges)
    loggers = [factory(SimpleNamespace(), r) for r in range(DP_SIZE)]
    await asyncio.sleep(0)

    per_rank = per_rank_kv_blocks(TOTAL_KV_BLOCKS, DP_SIZE)
    print(f"engine start: {TOTAL_KV_BLOCKS} KV blocks / DP {DP_SIZE} "
          f"-> per_rank_kv_blocks={per_rank}")
    print(f"publisher.py under test: {pub.__file__}")
    print(f"factory retains: {type(getattr(factory, 'created_loggers', None)).__name__}"
          f" (main: single 'created_logger' field)")

    factory.set_num_gpu_blocks_all(per_rank or 0)
    factory.init_publish()
    published.clear()

    for _ in range(ITERATIONS):
        for logger in loggers:
            logger.record(SchedulerStats(kv_cache_usage=USAGE), None)

    print(f"\nsteady state: {ITERATIONS} scheduler iterations at kv_cache_usage={USAGE}")
    print(f"{'dp_rank':<9}{'num_gpu_block':<15}{'kv_used_blocks published':<28}"
          f"{'total_blocks gauge':<20}")
    ok = True
    for rank, logger in enumerate(loggers):
        seen = [used for r, used in published if r == rank]
        total = gauge(registry, "total_blocks", rank)
        print(f"{rank:<9}{logger.num_gpu_block:<15}{str(seen):<28}{str(total):<20}")
        if seen != [int(per_rank * USAGE)] * ITERATIONS or total != per_rank:
            ok = False

    print(f"\nexpected per rank: kv_used_blocks={[int(per_rank * USAGE)] * ITERATIONS}, "
          f"total_blocks={per_rank}.0")
    print("RESULT:", "PASS - every rank reports its real occupancy" if ok
          else "FAIL - a rank reports empty to the KV router")
    return 0 if ok else 1

sys.exit(asyncio.run(main()))
```

</details>
</details>
