### PR TITLE
feat(snapshot): agentInject agent-only checkpoint storage (POC, do not merge)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1143,6 +1143,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
 
   deploy-operator-checkpoint-sglang:
@@ -1173,6 +1174,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
 
   deploy-operator-checkpoint-trtllm:
@@ -1203,6 +1205,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
 
   deploy-snapshot-agent-checkpoint-vllm:
@@ -1238,6 +1241,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1251,6 +1255,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
 
   deploy-snapshot-agent-checkpoint-sglang:
     name: SGLang DynamoCheckpoint Snapshot Agent Setup
@@ -1285,6 +1290,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1298,6 +1304,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
 
   deploy-snapshot-agent-checkpoint-trtllm:
     name: TRTLLM DynamoCheckpoint Snapshot Agent Setup
@@ -1332,6 +1339,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1345,6 +1353,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
 
   deploy-test-checkpoint-vllm:
     name: vLLM DynamoCheckpoint Deploy Test
@@ -1380,6 +1389,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1394,6 +1404,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
       - name: Run DynamoCheckpoint Deploy Test
         uses: ./.github/actions/dynamo-deploy-test
         with:
@@ -1445,6 +1456,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1459,6 +1471,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
       - name: Run DynamoCheckpoint Deploy Test
         uses: ./.github/actions/dynamo-deploy-test
         with:
@@ -1510,6 +1523,7 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_LOGIN_USER }}
           dockerhub_password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
           checkpoint_enabled: 'true'
+          checkpoint_storage_access_mode: agentInject
           checkpoint_storage_size: 64Gi
       - name: Connect to vCluster
         id: connect-vcluster
@@ -1524,6 +1538,7 @@ jobs:
           kubeconfig_base64: ${{ steps.connect-vcluster.outputs.kubeconfig_base64 }}
           namespace: default
           snapshot_agent_image: ${{ secrets.AZURE_ACR_HOSTNAME }}/ai-dynamo/dynamo:${{ github.sha }}-snapshot-agent
+          storage_access_mode: agentInject
       - name: Run DynamoCheckpoint Deploy Test
         uses: ./.github/actions/dynamo-deploy-test
         with:

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -41,7 +41,6 @@ class DGDRPhase(str, Enum):
     Deployed = "Deployed"
     Failed = "Failed"
 
-
 class ProfilingPhase(str, Enum):
     Initializing = "Initializing"
     SweepingPrefill = "SweepingPrefill"
@@ -51,11 +50,9 @@ class ProfilingPhase(str, Enum):
     GeneratingDGD = "GeneratingDGD"
     Done = "Done"
 
-
 class SearchStrategy(str, Enum):
     Rapid = "rapid"
     Thorough = "thorough"
-
 
 class GPUSKUType(str, Enum):
     GB200SXM = "gb200_sxm"
@@ -76,13 +73,11 @@ class GPUSKUType(str, Enum):
     MI200 = "mi200"
     MI300 = "mi300"
 
-
 class BackendType(str, Enum):
     Auto = "auto"
     Sglang = "sglang"
     Trtllm = "trtllm"
     Vllm = "vllm"
-
 
 class OptimizationType(str, Enum):
     Latency = "latency"
@@ -92,21 +87,10 @@ class OptimizationType(str, Enum):
 class WorkloadSpec(BaseModel):
     """WorkloadSpec defines the workload characteristics for SLA-based profiling."""
 
-    isl: Optional[int] = Field(
-        default=4000, description="ISL is the Input Sequence Length (number of tokens)."
-    )
-    osl: Optional[int] = Field(
-        default=1000,
-        description="OSL is the Output Sequence Length (number of tokens).",
-    )
-    concurrency: Optional[float] = Field(
-        default=None,
-        description="Concurrency is the target concurrency level. Required (or RequestRate) when the planner is disabled.",
-    )
-    requestRate: Optional[float] = Field(
-        default=None,
-        description="RequestRate is the target request rate (req/s). Required (or Concurrency) when the planner is disabled.",
-    )
+    isl: Optional[int] = Field(default=4000, description="ISL is the Input Sequence Length (number of tokens).")
+    osl: Optional[int] = Field(default=1000, description="OSL is the Output Sequence Length (number of tokens).")
+    concurrency: Optional[float] = Field(default=None, description="Concurrency is the target concurrency level. Required (or RequestRate) when the planner is disabled.")
+    requestRate: Optional[float] = Field(default=None, description="RequestRate is the target request rate (req/s). Required (or Concurrency) when the planner is disabled.")
 
 
 class SLASpec(BaseModel):
@@ -117,21 +101,10 @@ class SLASpec(BaseModel):
     - ``ttft`` + ``itl``: explicit latency targets (default: 2000 ms / 30 ms)
     - ``e2eLatency``: end-to-end latency target (mutually exclusive with ttft/itl)"""
 
-    ttft: Optional[float] = Field(
-        default=2000,
-        description="TTFT is the Time To First Token target in milliseconds.",
-    )
-    itl: Optional[float] = Field(
-        default=30, description="ITL is the Inter-Token Latency target in milliseconds."
-    )
-    e2eLatency: Optional[float] = Field(
-        default=None,
-        description="E2ELatency is the target end-to-end request latency in milliseconds. Alternative to specifying TTFT + ITL.",
-    )
-    optimizationType: Optional[OptimizationType] = Field(
-        default=None,
-        description="OptimizationType is the optimization target for SLA profiling. Valid values: latency, throughput.",
-    )
+    ttft: Optional[float] = Field(default=2000, description="TTFT is the Time To First Token target in milliseconds.")
+    itl: Optional[float] = Field(default=30, description="ITL is the Inter-Token Latency target in milliseconds.")
+    e2eLatency: Optional[float] = Field(default=None, description="E2ELatency is the target end-to-end request latency in milliseconds. Alternative to specifying TTFT + ITL.")
+    optimizationType: Optional[OptimizationType] = Field(default=None, description="OptimizationType is the optimization target for SLA profiling. Valid values: latency, throughput.")
 
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
@@ -140,9 +113,7 @@ class SLASpec(BaseModel):
         ttft_itl_touched = (
             "ttft" in self.model_fields_set or "itl" in self.model_fields_set
         )
-        has_ttft_itl = (
-            self.ttft is not None or self.itl is not None
-        ) and ttft_itl_touched
+        has_ttft_itl = (self.ttft is not None or self.itl is not None) and ttft_itl_touched
         if has_e2e and has_ttft_itl:
             raise ValueError(
                 "SLA must specify either (ttft and itl) or e2eLatency, not both."
@@ -155,215 +126,98 @@ class SLASpec(BaseModel):
 class ModelCacheSpec(BaseModel):
     """ModelCacheSpec references a PVC containing pre-downloaded model weights."""
 
-    pvcName: Optional[str] = Field(
-        default=None,
-        description="PVCName is the name of the PersistentVolumeClaim containing model weights. The PVC must exist in the same namespace as the DGDR.",
-    )
-    pvcModelPath: Optional[str] = Field(
-        default=None,
-        description='PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8").',
-    )
-    pvcMountPath: str = Field(
-        default="/opt/model-cache",
-        description="PVCMountPath is the mount path for the PVC inside the container.",
-    )
+    pvcName: Optional[str] = Field(default=None, description="PVCName is the name of the PersistentVolumeClaim containing model weights. The PVC must exist in the same namespace as the DGDR.")
+    pvcModelPath: Optional[str] = Field(default=None, description="PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. \"deepseek-r1\" or \"models/Llama-3.1-405B-FP8\").")
+    pvcMountPath: str = Field(default="/opt/model-cache", description="PVCMountPath is the mount path for the PVC inside the container.")
 
 
 class OverridesSpec(BaseModel):
     """OverridesSpec allows customizing the profiling job and the generated DynamoGraphDeployment."""
 
-    profilingJob: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="ProfilingJob allows overriding the profiling Job specification. Fields set here are merged into the controller-generated Job spec.",
-    )
-    dgd: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="DGD provides a partial, versioned DynamoGraphDeployment override for the profiler-generated deployment. Set apiVersion to nvidia.com/v1alpha1 or nvidia.com/v1beta1 and kind to DynamoGraphDeployment.  The profiler merges the override using the schema for its declared version. If the generated DGD uses another supported version, the complete DGD is converted before the merge and converted back afterward. The final DGD selected or created by a DGDR is nvidia.com/v1beta1.  The override can update DGD fields, but topology entries are limited to services or components already present in the generated DGD. Metadata labels and annotations are merged, metadata.name selects the final DGD name, and other identity or runtime metadata is ignored. V1alpha1 worker argument lists retain legacy append behavior. V1beta1 follows structural schema merge behavior, including map-list merging and atomic-list replacement.  The raw embedded resource preserves either supported schema. The API server validates that it has apiVersion and kind; override processing validates the DGD kind, supported version, and field schema.",
-    )
+    profilingJob: Optional[Dict[str, Any]] = Field(default=None, description="ProfilingJob allows overriding the profiling Job specification. Fields set here are merged into the controller-generated Job spec.")
+    dgd: Optional[Dict[str, Any]] = Field(default=None, description="DGD provides a partial, versioned DynamoGraphDeployment override for the profiler-generated deployment. Set apiVersion to nvidia.com/v1alpha1 or nvidia.com/v1beta1 and kind to DynamoGraphDeployment.  The profiler merges the override using the schema for its declared version. If the generated DGD uses another supported version, the complete DGD is converted before the merge and converted back afterward. The final DGD selected or created by a DGDR is nvidia.com/v1beta1.  The override can update DGD fields, but topology entries are limited to services or components already present in the generated DGD. Metadata labels and annotations are merged, metadata.name selects the final DGD name, and other identity or runtime metadata is ignored. V1alpha1 worker argument lists retain legacy append behavior. V1beta1 follows structural schema merge behavior, including map-list merging and atomic-list replacement.  The raw embedded resource preserves either supported schema. The API server validates that it has apiVersion and kind; override processing validates the DGD kind, supported version, and field schema.")
 
 
 class MockerSpec(BaseModel):
     """MockerSpec configures the simulated (mocker) backend."""
 
-    enabled: Optional[bool] = Field(
-        default=None,
-        description="Enabled indicates whether to deploy mocker workers instead of real inference workers. Useful for large-scale testing without GPUs.",
-    )
+    enabled: Optional[bool] = Field(default=None, description="Enabled indicates whether to deploy mocker workers instead of real inference workers. Useful for large-scale testing without GPUs.")
 
 
 class KVRouterSpec(BaseModel):
     """KVRouterSpec configures KV-cache-aware routing."""
 
-    enabled: Optional[bool] = Field(
-        default=None,
-        description="Enabled indicates whether to enable KV-cache-aware routing in the generated DGD. KV routing optimizes request scheduling based on KV cache locality.",
-    )
+    enabled: Optional[bool] = Field(default=None, description="Enabled indicates whether to enable KV-cache-aware routing in the generated DGD. KV routing optimizes request scheduling based on KV cache locality.")
 
 
 class FeaturesSpec(BaseModel):
     """FeaturesSpec controls optional Dynamo platform features in the generated deployment."""
 
-    planner: Optional[PlannerConfig] = Field(
-        default=None,
-        description="Planner contains the raw Planner configuration passed to the Planner service. Its schema is defined by dynamo.planner.config.planner_config.PlannerConfig. See https://docs.dynamo.nvidia.com/dynamo/components/planner/planner-guide#plannerconfig-reference. DGDR passes this object through without field-level validation; the Planner service validates it at startup. The presence of this field (non-null) enables the planner in the generated DGD.",
-    )
-    mocker: Optional[MockerSpec] = Field(
-        default=None,
-        description="Mocker configures the simulated (mocker) backend for testing without GPUs.",
-    )
+    planner: Optional[PlannerConfig] = Field(default=None, description="Planner contains the raw Planner configuration passed to the Planner service. Its schema is defined by dynamo.planner.config.planner_config.PlannerConfig. See https://docs.dynamo.nvidia.com/dynamo/components/planner/planner-guide#plannerconfig-reference. DGDR passes this object through without field-level validation; the Planner service validates it at startup. The presence of this field (non-null) enables the planner in the generated DGD.")
+    mocker: Optional[MockerSpec] = Field(default=None, description="Mocker configures the simulated (mocker) backend for testing without GPUs.")
 
 
 class HardwareSpec(BaseModel):
     """HardwareSpec describes the GPU hardware for profiling and deployment. All fields are auto-detected from cluster GPU nodes when omitted (requires cluster-wide mode with GPU discovery enabled). gpuSku is a selector (restricts which nodes are considered); the other fields are pure overrides passed to the profiler. If all four fields are set, discovery is skipped."""
 
-    gpuSku: Optional[GPUSKUType] = Field(
-        default=None,
-        description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.",
-    )
-    vramMb: Optional[float] = Field(
-        default=None,
-        description="VRAMMB is the VRAM per GPU in MiB. When omitted, auto-detected from cluster GPU nodes.",
-    )
-    totalGpus: Optional[int] = Field(
-        default=None,
-        description="TotalGPUs is the GPU budget for profiling and deployment. The profiler uses this to determine parallelism and replica count. When omitted, computed by counting GPUs on discovered nodes (filtered by gpuSku when set), temporarily capped at 32 to limit profiler search space. This cap may be removed in a future release. Set this field explicitly to override.",
-    )
-    numGpusPerNode: Optional[int] = Field(
-        default=None,
-        description="NumGPUsPerNode is the number of GPUs per node. When omitted, auto-detected from cluster GPU nodes.",
-    )
-    interconnect: Optional[str] = Field(
-        default=None,
-        description='Interconnect describes the primary GPU-to-GPU interconnect *within a node*.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT configure or enable any GPU interconnect; it only describes what is available/assumed. - When omitted, the operator may attempt best-effort discovery (currently distinguishes "nvlink" vs "pcie" based on DCGM NVLink link count). If discovery is unavailable, it may remain empty.  Impact of wrong / missing values: - If set more optimistically than reality (e.g., "nvlink" when only PCIe is present), performance models may overestimate intra-node bandwidth and choose overly aggressive parallelism or layouts, resulting in degraded performance compared to expectations. - If set more pessimistically than reality (e.g., "pcie" when NVLink is present), the system may choose conservative plans and leave performance on the table. - If unset and undiscovered, consumers should treat the interconnect as unknown and fall back to conservative assumptions.  Example values: "pcie", "nvlink". Other values may be accepted but may not be auto-detected. ',
-    )
-    rdma: Optional[bool] = Field(
-        default=None,
-        description="RDMA indicates whether the cluster has RDMA-capable networking available for Dynamo data movement.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT install, enable, or configure RDMA (e.g., drivers, SR-IOV, NVIDIA network operator, GPUDirect settings). It only expresses availability/intent. - When omitted, the operator may attempt best-effort discovery (e.g., via node labels indicating RDMA/SR-IOV capability and/or presence of NVIDIA network-operator RDMA components). If discovery is unavailable, it may remain unset.  Impact of wrong / missing values: - False positive (set true when RDMA is not actually usable end-to-end) may cause plans or deployments to assume RDMA is available; depending on the runtime transport selection and fallback behavior, this can lead to connection/setup failures or performance regressions. - False negative (set false when RDMA is available) will typically avoid RDMA-optimized paths and fall back to non-RDMA transports, usually remaining functional but potentially slower. - If unset and undiscovered, consumers should treat RDMA availability as unknown and use conservative defaults / fallback transports. ",
-    )
+    gpuSku: Optional[GPUSKUType] = Field(default=None, description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.")
+    vramMb: Optional[float] = Field(default=None, description="VRAMMB is the VRAM per GPU in MiB. When omitted, auto-detected from cluster GPU nodes.")
+    totalGpus: Optional[int] = Field(default=None, description="TotalGPUs is the GPU budget for profiling and deployment. The profiler uses this to determine parallelism and replica count. When omitted, computed by counting GPUs on discovered nodes (filtered by gpuSku when set), temporarily capped at 32 to limit profiler search space. This cap may be removed in a future release. Set this field explicitly to override.")
+    numGpusPerNode: Optional[int] = Field(default=None, description="NumGPUsPerNode is the number of GPUs per node. When omitted, auto-detected from cluster GPU nodes.")
+    interconnect: Optional[str] = Field(default=None, description="Interconnect describes the primary GPU-to-GPU interconnect *within a node*.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT configure or enable any GPU interconnect; it only describes what is available/assumed. - When omitted, the operator may attempt best-effort discovery (currently distinguishes \"nvlink\" vs \"pcie\" based on DCGM NVLink link count). If discovery is unavailable, it may remain empty.  Impact of wrong / missing values: - If set more optimistically than reality (e.g., \"nvlink\" when only PCIe is present), performance models may overestimate intra-node bandwidth and choose overly aggressive parallelism or layouts, resulting in degraded performance compared to expectations. - If set more pessimistically than reality (e.g., \"pcie\" when NVLink is present), the system may choose conservative plans and leave performance on the table. - If unset and undiscovered, consumers should treat the interconnect as unknown and fall back to conservative assumptions.  Example values: \"pcie\", \"nvlink\". Other values may be accepted but may not be auto-detected. ")
+    rdma: Optional[bool] = Field(default=None, description="RDMA indicates whether the cluster has RDMA-capable networking available for Dynamo data movement.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT install, enable, or configure RDMA (e.g., drivers, SR-IOV, NVIDIA network operator, GPUDirect settings). It only expresses availability/intent. - When omitted, the operator may attempt best-effort discovery (e.g., via node labels indicating RDMA/SR-IOV capability and/or presence of NVIDIA network-operator RDMA components). If discovery is unavailable, it may remain unset.  Impact of wrong / missing values: - False positive (set true when RDMA is not actually usable end-to-end) may cause plans or deployments to assume RDMA is available; depending on the runtime transport selection and fallback behavior, this can lead to connection/setup failures or performance regressions. - False negative (set false when RDMA is available) will typically avoid RDMA-optimized paths and fall back to non-RDMA transports, usually remaining functional but potentially slower. - If unset and undiscovered, consumers should treat RDMA availability as unknown and use conservative defaults / fallback transports. ")
 
 
 class DynamoGraphDeploymentRequestSpec(BaseModel):
     """DynamoGraphDeploymentRequestSpec defines the desired state of a DynamoGraphDeploymentRequest. Only the Model field is required; all other fields are optional and have sensible defaults."""
 
-    model: str = Field(
-        description='Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b"). Can be a HuggingFace ID or a private model name.'
-    )
-    backend: BackendType = Field(
-        default="auto",
-        description="Backend specifies the inference backend to use for profiling and deployment.",
-    )
-    image: Optional[str] = Field(
-        default=None,
-        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1". For Dynamo < 1.1.0, use dynamo-frontend.',
-    )
-    modelCache: Optional[ModelCacheSpec] = Field(
-        default=None,
-        description="ModelCache provides optional PVC configuration for pre-downloaded model weights. When provided, weights are loaded from the PVC instead of downloading from HuggingFace.",
-    )
-    hardware: Optional[HardwareSpec] = Field(
-        default=None,
-        description="Hardware describes the hardware resources available for profiling and deployment. Typically auto-filled by the operator from cluster discovery.",
-    )
-    workload: Optional[WorkloadSpec] = Field(
-        default=None,
-        description="Workload defines the expected workload characteristics for SLA-based profiling.",
-    )
-    sla: Optional[SLASpec] = Field(
-        default=None,
-        description="SLA defines service-level agreement targets that drive profiling optimization.",
-    )
-    overrides: Optional[OverridesSpec] = Field(
-        default=None,
-        description="Overrides allows customizing the profiling job and the generated DynamoGraphDeployment.",
-    )
-    features: Optional[FeaturesSpec] = Field(
-        default=None,
-        description="Features controls optional Dynamo platform features in the generated deployment.",
-    )
-    searchStrategy: SearchStrategy = Field(
-        default="rapid",
-        description='SearchStrategy controls the profiling search depth. "rapid" performs a fast sweep; "thorough" explores more configurations.',
-    )
-    autoApply: Optional[bool] = Field(
-        default=True,
-        description="AutoApply indicates whether to automatically create a DynamoGraphDeployment after profiling completes. If false, the generated spec is stored in status for manual review and application.",
-    )
+    model: str = Field(description="Model specifies the model to deploy (e.g., \"Qwen/Qwen3-0.6B\", \"meta-llama/Llama-3-70b\"). Can be a HuggingFace ID or a private model name.")
+    backend: BackendType = Field(default="auto", description="Backend specifies the inference backend to use for profiling and deployment.")
+    image: Optional[str] = Field(default=None, description="Image is the container image reference for the profiling job (planner image). Example: \"nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1\". For Dynamo < 1.1.0, use dynamo-frontend.")
+    modelCache: Optional[ModelCacheSpec] = Field(default=None, description="ModelCache provides optional PVC configuration for pre-downloaded model weights. When provided, weights are loaded from the PVC instead of downloading from HuggingFace.")
+    hardware: Optional[HardwareSpec] = Field(default=None, description="Hardware describes the hardware resources available for profiling and deployment. Typically auto-filled by the operator from cluster discovery.")
+    workload: Optional[WorkloadSpec] = Field(default=None, description="Workload defines the expected workload characteristics for SLA-based profiling.")
+    sla: Optional[SLASpec] = Field(default=None, description="SLA defines service-level agreement targets that drive profiling optimization.")
+    overrides: Optional[OverridesSpec] = Field(default=None, description="Overrides allows customizing the profiling job and the generated DynamoGraphDeployment.")
+    features: Optional[FeaturesSpec] = Field(default=None, description="Features controls optional Dynamo platform features in the generated deployment.")
+    searchStrategy: SearchStrategy = Field(default="rapid", description="SearchStrategy controls the profiling search depth. \"rapid\" performs a fast sweep; \"thorough\" explores more configurations.")
+    autoApply: Optional[bool] = Field(default=True, description="AutoApply indicates whether to automatically create a DynamoGraphDeployment after profiling completes. If false, the generated spec is stored in status for manual review and application.")
 
 
 class ParetoConfig(BaseModel):
     """ParetoConfig is retained for compatibility with status objects produced by older profiler releases. Deprecated: The profiler no longer generates Pareto configurations."""
 
-    config: Dict[str, Any] = Field(
-        description="Config is the full deployment configuration for this Pareto point."
-    )
+    config: Dict[str, Any] = Field(description="Config is the full deployment configuration for this Pareto point.")
 
 
 class ProfilingResultsStatus(BaseModel):
     """ProfilingResultsStatus contains the output of the profiling process."""
 
-    pareto: Optional[List[ParetoConfig]] = Field(
-        default=None,
-        description="Pareto is retained for compatibility with existing status objects. Deprecated: The controller no longer populates this field.",
-    )
-    selectedConfig: Optional[Dict[str, Any]] = Field(
-        default=None,
-        description="SelectedConfig is the recommended configuration chosen by the profiler based on the SLA targets. This is the configuration used for deployment when autoApply is true.",
-    )
+    pareto: Optional[List[ParetoConfig]] = Field(default=None, description="Pareto is retained for compatibility with existing status objects. Deprecated: The controller no longer populates this field.")
+    selectedConfig: Optional[Dict[str, Any]] = Field(default=None, description="SelectedConfig is the recommended configuration chosen by the profiler based on the SLA targets. This is the configuration used for deployment when autoApply is true.")
 
 
 class DeploymentInfoStatus(BaseModel):
     """DeploymentInfoStatus tracks the state of the deployed DynamoGraphDeployment."""
 
-    replicas: Optional[int] = Field(
-        default=None, description="Replicas is the desired number of replicas."
-    )
-    availableReplicas: Optional[int] = Field(
-        default=None,
-        description="AvailableReplicas is the number of replicas that are available and ready.",
-    )
+    replicas: Optional[int] = Field(default=None, description="Replicas is the desired number of replicas.")
+    availableReplicas: Optional[int] = Field(default=None, description="AvailableReplicas is the number of replicas that are available and ready.")
 
 
 class DynamoGraphDeploymentRequestStatus(BaseModel):
     """DynamoGraphDeploymentRequestStatus represents the observed state of a DynamoGraphDeploymentRequest."""
 
-    phase: Optional[DGDRPhase] = Field(
-        default=None,
-        description="Phase is the high-level lifecycle phase of the deployment request.",
-    )
-    profilingPhase: Optional[ProfilingPhase] = Field(
-        default=None,
-        description='ProfilingPhase indicates the current sub-phase of the profiling pipeline. Only meaningful when Phase is "Profiling". Cleared when profiling completes or fails.',
-    )
-    dgdName: Optional[str] = Field(
-        default=None,
-        description="DGDName is the name of the generated or created DynamoGraphDeployment.",
-    )
-    profilingJobName: Optional[str] = Field(
-        default=None,
-        description="ProfilingJobName is the name of the Kubernetes Job running the profiler.",
-    )
-    profilingResults: Optional[ProfilingResultsStatus] = Field(
-        default=None,
-        description="ProfilingResults contains the selected deployment configuration produced by profiling. Deprecated compatibility fields may remain on objects created by older releases.",
-    )
-    deploymentInfo: Optional[DeploymentInfoStatus] = Field(
-        default=None,
-        description="DeploymentInfo tracks the state of the deployed DynamoGraphDeployment. Populated when a DGD has been created (either via autoApply or manually).",
-    )
-    observedGeneration: Optional[int] = Field(
-        default=None,
-        description="ObservedGeneration is the most recent generation observed by the controller.",
-    )
+    phase: Optional[DGDRPhase] = Field(default=None, description="Phase is the high-level lifecycle phase of the deployment request.")
+    profilingPhase: Optional[ProfilingPhase] = Field(default=None, description="ProfilingPhase indicates the current sub-phase of the profiling pipeline. Only meaningful when Phase is \"Profiling\". Cleared when profiling completes or fails.")
+    dgdName: Optional[str] = Field(default=None, description="DGDName is the name of the generated or created DynamoGraphDeployment.")
+    profilingJobName: Optional[str] = Field(default=None, description="ProfilingJobName is the name of the Kubernetes Job running the profiler.")
+    profilingResults: Optional[ProfilingResultsStatus] = Field(default=None, description="ProfilingResults contains the selected deployment configuration produced by profiling. Deprecated compatibility fields may remain on objects created by older releases.")
+    deploymentInfo: Optional[DeploymentInfoStatus] = Field(default=None, description="DeploymentInfo tracks the state of the deployed DynamoGraphDeployment. Populated when a DGD has been created (either via autoApply or manually).")
+    observedGeneration: Optional[int] = Field(default=None, description="ObservedGeneration is the most recent generation observed by the controller.")
 
 
 class DynamoGraphDeploymentRequest(BaseModel):
     """DynamoGraphDeploymentRequest is the Schema for the dynamographdeploymentrequests API. It provides a simplified, SLA-driven interface for deploying inference models on Dynamo. Users specify a model and optional performance targets; the controller handles profiling, configuration selection, and deployment."""
 
-    spec: Optional[DynamoGraphDeploymentRequestSpec] = Field(
-        default=None,
-        description="Spec defines the desired state for this deployment request.",
-    )
-    status: Optional[DynamoGraphDeploymentRequestStatus] = Field(
-        default=None,
-        description="Status reflects the current observed state of this deployment request.",
-    )
+    spec: Optional[DynamoGraphDeploymentRequestSpec] = Field(default=None, description="Spec defines the desired state for this deployment request.")
+    status: Optional[DynamoGraphDeploymentRequestStatus] = Field(default=None, description="Status reflects the current observed state of this deployment request.")

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -41,6 +41,7 @@ class DGDRPhase(str, Enum):
     Deployed = "Deployed"
     Failed = "Failed"
 
+
 class ProfilingPhase(str, Enum):
     Initializing = "Initializing"
     SweepingPrefill = "SweepingPrefill"
@@ -50,9 +51,11 @@ class ProfilingPhase(str, Enum):
     GeneratingDGD = "GeneratingDGD"
     Done = "Done"
 
+
 class SearchStrategy(str, Enum):
     Rapid = "rapid"
     Thorough = "thorough"
+
 
 class GPUSKUType(str, Enum):
     GB200SXM = "gb200_sxm"
@@ -73,11 +76,13 @@ class GPUSKUType(str, Enum):
     MI200 = "mi200"
     MI300 = "mi300"
 
+
 class BackendType(str, Enum):
     Auto = "auto"
     Sglang = "sglang"
     Trtllm = "trtllm"
     Vllm = "vllm"
+
 
 class OptimizationType(str, Enum):
     Latency = "latency"
@@ -87,10 +92,21 @@ class OptimizationType(str, Enum):
 class WorkloadSpec(BaseModel):
     """WorkloadSpec defines the workload characteristics for SLA-based profiling."""
 
-    isl: Optional[int] = Field(default=4000, description="ISL is the Input Sequence Length (number of tokens).")
-    osl: Optional[int] = Field(default=1000, description="OSL is the Output Sequence Length (number of tokens).")
-    concurrency: Optional[float] = Field(default=None, description="Concurrency is the target concurrency level. Required (or RequestRate) when the planner is disabled.")
-    requestRate: Optional[float] = Field(default=None, description="RequestRate is the target request rate (req/s). Required (or Concurrency) when the planner is disabled.")
+    isl: Optional[int] = Field(
+        default=4000, description="ISL is the Input Sequence Length (number of tokens)."
+    )
+    osl: Optional[int] = Field(
+        default=1000,
+        description="OSL is the Output Sequence Length (number of tokens).",
+    )
+    concurrency: Optional[float] = Field(
+        default=None,
+        description="Concurrency is the target concurrency level. Required (or RequestRate) when the planner is disabled.",
+    )
+    requestRate: Optional[float] = Field(
+        default=None,
+        description="RequestRate is the target request rate (req/s). Required (or Concurrency) when the planner is disabled.",
+    )
 
 
 class SLASpec(BaseModel):
@@ -101,10 +117,21 @@ class SLASpec(BaseModel):
     - ``ttft`` + ``itl``: explicit latency targets (default: 2000 ms / 30 ms)
     - ``e2eLatency``: end-to-end latency target (mutually exclusive with ttft/itl)"""
 
-    ttft: Optional[float] = Field(default=2000, description="TTFT is the Time To First Token target in milliseconds.")
-    itl: Optional[float] = Field(default=30, description="ITL is the Inter-Token Latency target in milliseconds.")
-    e2eLatency: Optional[float] = Field(default=None, description="E2ELatency is the target end-to-end request latency in milliseconds. Alternative to specifying TTFT + ITL.")
-    optimizationType: Optional[OptimizationType] = Field(default=None, description="OptimizationType is the optimization target for SLA profiling. Valid values: latency, throughput.")
+    ttft: Optional[float] = Field(
+        default=2000,
+        description="TTFT is the Time To First Token target in milliseconds.",
+    )
+    itl: Optional[float] = Field(
+        default=30, description="ITL is the Inter-Token Latency target in milliseconds."
+    )
+    e2eLatency: Optional[float] = Field(
+        default=None,
+        description="E2ELatency is the target end-to-end request latency in milliseconds. Alternative to specifying TTFT + ITL.",
+    )
+    optimizationType: Optional[OptimizationType] = Field(
+        default=None,
+        description="OptimizationType is the optimization target for SLA profiling. Valid values: latency, throughput.",
+    )
 
     @model_validator(mode="after")
     def _validate_sla_options(self) -> "SLASpec":
@@ -113,7 +140,9 @@ class SLASpec(BaseModel):
         ttft_itl_touched = (
             "ttft" in self.model_fields_set or "itl" in self.model_fields_set
         )
-        has_ttft_itl = (self.ttft is not None or self.itl is not None) and ttft_itl_touched
+        has_ttft_itl = (
+            self.ttft is not None or self.itl is not None
+        ) and ttft_itl_touched
         if has_e2e and has_ttft_itl:
             raise ValueError(
                 "SLA must specify either (ttft and itl) or e2eLatency, not both."
@@ -126,98 +155,215 @@ class SLASpec(BaseModel):
 class ModelCacheSpec(BaseModel):
     """ModelCacheSpec references a PVC containing pre-downloaded model weights."""
 
-    pvcName: Optional[str] = Field(default=None, description="PVCName is the name of the PersistentVolumeClaim containing model weights. The PVC must exist in the same namespace as the DGDR.")
-    pvcModelPath: Optional[str] = Field(default=None, description="PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. \"deepseek-r1\" or \"models/Llama-3.1-405B-FP8\").")
-    pvcMountPath: str = Field(default="/opt/model-cache", description="PVCMountPath is the mount path for the PVC inside the container.")
+    pvcName: Optional[str] = Field(
+        default=None,
+        description="PVCName is the name of the PersistentVolumeClaim containing model weights. The PVC must exist in the same namespace as the DGDR.",
+    )
+    pvcModelPath: Optional[str] = Field(
+        default=None,
+        description='PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8").',
+    )
+    pvcMountPath: str = Field(
+        default="/opt/model-cache",
+        description="PVCMountPath is the mount path for the PVC inside the container.",
+    )
 
 
 class OverridesSpec(BaseModel):
     """OverridesSpec allows customizing the profiling job and the generated DynamoGraphDeployment."""
 
-    profilingJob: Optional[Dict[str, Any]] = Field(default=None, description="ProfilingJob allows overriding the profiling Job specification. Fields set here are merged into the controller-generated Job spec.")
-    dgd: Optional[Dict[str, Any]] = Field(default=None, description="DGD provides a partial, versioned DynamoGraphDeployment override for the profiler-generated deployment. Set apiVersion to nvidia.com/v1alpha1 or nvidia.com/v1beta1 and kind to DynamoGraphDeployment.  The profiler merges the override using the schema for its declared version. If the generated DGD uses another supported version, the complete DGD is converted before the merge and converted back afterward. The final DGD selected or created by a DGDR is nvidia.com/v1beta1.  The override can update DGD fields, but topology entries are limited to services or components already present in the generated DGD. Metadata labels and annotations are merged, metadata.name selects the final DGD name, and other identity or runtime metadata is ignored. V1alpha1 worker argument lists retain legacy append behavior. V1beta1 follows structural schema merge behavior, including map-list merging and atomic-list replacement.  The raw embedded resource preserves either supported schema. The API server validates that it has apiVersion and kind; override processing validates the DGD kind, supported version, and field schema.")
+    profilingJob: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="ProfilingJob allows overriding the profiling Job specification. Fields set here are merged into the controller-generated Job spec.",
+    )
+    dgd: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="DGD provides a partial, versioned DynamoGraphDeployment override for the profiler-generated deployment. Set apiVersion to nvidia.com/v1alpha1 or nvidia.com/v1beta1 and kind to DynamoGraphDeployment.  The profiler merges the override using the schema for its declared version. If the generated DGD uses another supported version, the complete DGD is converted before the merge and converted back afterward. The final DGD selected or created by a DGDR is nvidia.com/v1beta1.  The override can update DGD fields, but topology entries are limited to services or components already present in the generated DGD. Metadata labels and annotations are merged, metadata.name selects the final DGD name, and other identity or runtime metadata is ignored. V1alpha1 worker argument lists retain legacy append behavior. V1beta1 follows structural schema merge behavior, including map-list merging and atomic-list replacement.  The raw embedded resource preserves either supported schema. The API server validates that it has apiVersion and kind; override processing validates the DGD kind, supported version, and field schema.",
+    )
 
 
 class MockerSpec(BaseModel):
     """MockerSpec configures the simulated (mocker) backend."""
 
-    enabled: Optional[bool] = Field(default=None, description="Enabled indicates whether to deploy mocker workers instead of real inference workers. Useful for large-scale testing without GPUs.")
+    enabled: Optional[bool] = Field(
+        default=None,
+        description="Enabled indicates whether to deploy mocker workers instead of real inference workers. Useful for large-scale testing without GPUs.",
+    )
 
 
 class KVRouterSpec(BaseModel):
     """KVRouterSpec configures KV-cache-aware routing."""
 
-    enabled: Optional[bool] = Field(default=None, description="Enabled indicates whether to enable KV-cache-aware routing in the generated DGD. KV routing optimizes request scheduling based on KV cache locality.")
+    enabled: Optional[bool] = Field(
+        default=None,
+        description="Enabled indicates whether to enable KV-cache-aware routing in the generated DGD. KV routing optimizes request scheduling based on KV cache locality.",
+    )
 
 
 class FeaturesSpec(BaseModel):
     """FeaturesSpec controls optional Dynamo platform features in the generated deployment."""
 
-    planner: Optional[PlannerConfig] = Field(default=None, description="Planner contains the raw Planner configuration passed to the Planner service. Its schema is defined by dynamo.planner.config.planner_config.PlannerConfig. See https://docs.dynamo.nvidia.com/dynamo/components/planner/planner-guide#plannerconfig-reference. DGDR passes this object through without field-level validation; the Planner service validates it at startup. The presence of this field (non-null) enables the planner in the generated DGD.")
-    mocker: Optional[MockerSpec] = Field(default=None, description="Mocker configures the simulated (mocker) backend for testing without GPUs.")
+    planner: Optional[PlannerConfig] = Field(
+        default=None,
+        description="Planner contains the raw Planner configuration passed to the Planner service. Its schema is defined by dynamo.planner.config.planner_config.PlannerConfig. See https://docs.dynamo.nvidia.com/dynamo/components/planner/planner-guide#plannerconfig-reference. DGDR passes this object through without field-level validation; the Planner service validates it at startup. The presence of this field (non-null) enables the planner in the generated DGD.",
+    )
+    mocker: Optional[MockerSpec] = Field(
+        default=None,
+        description="Mocker configures the simulated (mocker) backend for testing without GPUs.",
+    )
 
 
 class HardwareSpec(BaseModel):
     """HardwareSpec describes the GPU hardware for profiling and deployment. All fields are auto-detected from cluster GPU nodes when omitted (requires cluster-wide mode with GPU discovery enabled). gpuSku is a selector (restricts which nodes are considered); the other fields are pure overrides passed to the profiler. If all four fields are set, discovery is skipped."""
 
-    gpuSku: Optional[GPUSKUType] = Field(default=None, description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.")
-    vramMb: Optional[float] = Field(default=None, description="VRAMMB is the VRAM per GPU in MiB. When omitted, auto-detected from cluster GPU nodes.")
-    totalGpus: Optional[int] = Field(default=None, description="TotalGPUs is the GPU budget for profiling and deployment. The profiler uses this to determine parallelism and replica count. When omitted, computed by counting GPUs on discovered nodes (filtered by gpuSku when set), temporarily capped at 32 to limit profiler search space. This cap may be removed in a future release. Set this field explicitly to override.")
-    numGpusPerNode: Optional[int] = Field(default=None, description="NumGPUsPerNode is the number of GPUs per node. When omitted, auto-detected from cluster GPU nodes.")
-    interconnect: Optional[str] = Field(default=None, description="Interconnect describes the primary GPU-to-GPU interconnect *within a node*.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT configure or enable any GPU interconnect; it only describes what is available/assumed. - When omitted, the operator may attempt best-effort discovery (currently distinguishes \"nvlink\" vs \"pcie\" based on DCGM NVLink link count). If discovery is unavailable, it may remain empty.  Impact of wrong / missing values: - If set more optimistically than reality (e.g., \"nvlink\" when only PCIe is present), performance models may overestimate intra-node bandwidth and choose overly aggressive parallelism or layouts, resulting in degraded performance compared to expectations. - If set more pessimistically than reality (e.g., \"pcie\" when NVLink is present), the system may choose conservative plans and leave performance on the table. - If unset and undiscovered, consumers should treat the interconnect as unknown and fall back to conservative assumptions.  Example values: \"pcie\", \"nvlink\". Other values may be accepted but may not be auto-detected. ")
-    rdma: Optional[bool] = Field(default=None, description="RDMA indicates whether the cluster has RDMA-capable networking available for Dynamo data movement.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT install, enable, or configure RDMA (e.g., drivers, SR-IOV, NVIDIA network operator, GPUDirect settings). It only expresses availability/intent. - When omitted, the operator may attempt best-effort discovery (e.g., via node labels indicating RDMA/SR-IOV capability and/or presence of NVIDIA network-operator RDMA components). If discovery is unavailable, it may remain unset.  Impact of wrong / missing values: - False positive (set true when RDMA is not actually usable end-to-end) may cause plans or deployments to assume RDMA is available; depending on the runtime transport selection and fallback behavior, this can lead to connection/setup failures or performance regressions. - False negative (set false when RDMA is available) will typically avoid RDMA-optimized paths and fall back to non-RDMA transports, usually remaining functional but potentially slower. - If unset and undiscovered, consumers should treat RDMA availability as unknown and use conservative defaults / fallback transports. ")
+    gpuSku: Optional[GPUSKUType] = Field(
+        default=None,
+        description="GPUSKU selects the GPU type to target. When omitted, auto-detected by selecting the GPU with the highest node count, then highest VRAM. In mixed-GPU clusters, set this to choose which GPU type to use. Discovery and totalGpus are then restricted to nodes matching this SKU.",
+    )
+    vramMb: Optional[float] = Field(
+        default=None,
+        description="VRAMMB is the VRAM per GPU in MiB. When omitted, auto-detected from cluster GPU nodes.",
+    )
+    totalGpus: Optional[int] = Field(
+        default=None,
+        description="TotalGPUs is the GPU budget for profiling and deployment. The profiler uses this to determine parallelism and replica count. When omitted, computed by counting GPUs on discovered nodes (filtered by gpuSku when set), temporarily capped at 32 to limit profiler search space. This cap may be removed in a future release. Set this field explicitly to override.",
+    )
+    numGpusPerNode: Optional[int] = Field(
+        default=None,
+        description="NumGPUsPerNode is the number of GPUs per node. When omitted, auto-detected from cluster GPU nodes.",
+    )
+    interconnect: Optional[str] = Field(
+        default=None,
+        description='Interconnect describes the primary GPU-to-GPU interconnect *within a node*.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT configure or enable any GPU interconnect; it only describes what is available/assumed. - When omitted, the operator may attempt best-effort discovery (currently distinguishes "nvlink" vs "pcie" based on DCGM NVLink link count). If discovery is unavailable, it may remain empty.  Impact of wrong / missing values: - If set more optimistically than reality (e.g., "nvlink" when only PCIe is present), performance models may overestimate intra-node bandwidth and choose overly aggressive parallelism or layouts, resulting in degraded performance compared to expectations. - If set more pessimistically than reality (e.g., "pcie" when NVLink is present), the system may choose conservative plans and leave performance on the table. - If unset and undiscovered, consumers should treat the interconnect as unknown and fall back to conservative assumptions.  Example values: "pcie", "nvlink". Other values may be accepted but may not be auto-detected. ',
+    )
+    rdma: Optional[bool] = Field(
+        default=None,
+        description="RDMA indicates whether the cluster has RDMA-capable networking available for Dynamo data movement.  Semantics / usage: - This is capability metadata used for profiling, planning, and deployment decisions. - It does NOT install, enable, or configure RDMA (e.g., drivers, SR-IOV, NVIDIA network operator, GPUDirect settings). It only expresses availability/intent. - When omitted, the operator may attempt best-effort discovery (e.g., via node labels indicating RDMA/SR-IOV capability and/or presence of NVIDIA network-operator RDMA components). If discovery is unavailable, it may remain unset.  Impact of wrong / missing values: - False positive (set true when RDMA is not actually usable end-to-end) may cause plans or deployments to assume RDMA is available; depending on the runtime transport selection and fallback behavior, this can lead to connection/setup failures or performance regressions. - False negative (set false when RDMA is available) will typically avoid RDMA-optimized paths and fall back to non-RDMA transports, usually remaining functional but potentially slower. - If unset and undiscovered, consumers should treat RDMA availability as unknown and use conservative defaults / fallback transports. ",
+    )
 
 
 class DynamoGraphDeploymentRequestSpec(BaseModel):
     """DynamoGraphDeploymentRequestSpec defines the desired state of a DynamoGraphDeploymentRequest. Only the Model field is required; all other fields are optional and have sensible defaults."""
 
-    model: str = Field(description="Model specifies the model to deploy (e.g., \"Qwen/Qwen3-0.6B\", \"meta-llama/Llama-3-70b\"). Can be a HuggingFace ID or a private model name.")
-    backend: BackendType = Field(default="auto", description="Backend specifies the inference backend to use for profiling and deployment.")
-    image: Optional[str] = Field(default=None, description="Image is the container image reference for the profiling job (planner image). Example: \"nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1\". For Dynamo < 1.1.0, use dynamo-frontend.")
-    modelCache: Optional[ModelCacheSpec] = Field(default=None, description="ModelCache provides optional PVC configuration for pre-downloaded model weights. When provided, weights are loaded from the PVC instead of downloading from HuggingFace.")
-    hardware: Optional[HardwareSpec] = Field(default=None, description="Hardware describes the hardware resources available for profiling and deployment. Typically auto-filled by the operator from cluster discovery.")
-    workload: Optional[WorkloadSpec] = Field(default=None, description="Workload defines the expected workload characteristics for SLA-based profiling.")
-    sla: Optional[SLASpec] = Field(default=None, description="SLA defines service-level agreement targets that drive profiling optimization.")
-    overrides: Optional[OverridesSpec] = Field(default=None, description="Overrides allows customizing the profiling job and the generated DynamoGraphDeployment.")
-    features: Optional[FeaturesSpec] = Field(default=None, description="Features controls optional Dynamo platform features in the generated deployment.")
-    searchStrategy: SearchStrategy = Field(default="rapid", description="SearchStrategy controls the profiling search depth. \"rapid\" performs a fast sweep; \"thorough\" explores more configurations.")
-    autoApply: Optional[bool] = Field(default=True, description="AutoApply indicates whether to automatically create a DynamoGraphDeployment after profiling completes. If false, the generated spec is stored in status for manual review and application.")
+    model: str = Field(
+        description='Model specifies the model to deploy (e.g., "Qwen/Qwen3-0.6B", "meta-llama/Llama-3-70b"). Can be a HuggingFace ID or a private model name.'
+    )
+    backend: BackendType = Field(
+        default="auto",
+        description="Backend specifies the inference backend to use for profiling and deployment.",
+    )
+    image: Optional[str] = Field(
+        default=None,
+        description='Image is the container image reference for the profiling job (planner image). Example: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1". For Dynamo < 1.1.0, use dynamo-frontend.',
+    )
+    modelCache: Optional[ModelCacheSpec] = Field(
+        default=None,
+        description="ModelCache provides optional PVC configuration for pre-downloaded model weights. When provided, weights are loaded from the PVC instead of downloading from HuggingFace.",
+    )
+    hardware: Optional[HardwareSpec] = Field(
+        default=None,
+        description="Hardware describes the hardware resources available for profiling and deployment. Typically auto-filled by the operator from cluster discovery.",
+    )
+    workload: Optional[WorkloadSpec] = Field(
+        default=None,
+        description="Workload defines the expected workload characteristics for SLA-based profiling.",
+    )
+    sla: Optional[SLASpec] = Field(
+        default=None,
+        description="SLA defines service-level agreement targets that drive profiling optimization.",
+    )
+    overrides: Optional[OverridesSpec] = Field(
+        default=None,
+        description="Overrides allows customizing the profiling job and the generated DynamoGraphDeployment.",
+    )
+    features: Optional[FeaturesSpec] = Field(
+        default=None,
+        description="Features controls optional Dynamo platform features in the generated deployment.",
+    )
+    searchStrategy: SearchStrategy = Field(
+        default="rapid",
+        description='SearchStrategy controls the profiling search depth. "rapid" performs a fast sweep; "thorough" explores more configurations.',
+    )
+    autoApply: Optional[bool] = Field(
+        default=True,
+        description="AutoApply indicates whether to automatically create a DynamoGraphDeployment after profiling completes. If false, the generated spec is stored in status for manual review and application.",
+    )
 
 
 class ParetoConfig(BaseModel):
     """ParetoConfig is retained for compatibility with status objects produced by older profiler releases. Deprecated: The profiler no longer generates Pareto configurations."""
 
-    config: Dict[str, Any] = Field(description="Config is the full deployment configuration for this Pareto point.")
+    config: Dict[str, Any] = Field(
+        description="Config is the full deployment configuration for this Pareto point."
+    )
 
 
 class ProfilingResultsStatus(BaseModel):
     """ProfilingResultsStatus contains the output of the profiling process."""
 
-    pareto: Optional[List[ParetoConfig]] = Field(default=None, description="Pareto is retained for compatibility with existing status objects. Deprecated: The controller no longer populates this field.")
-    selectedConfig: Optional[Dict[str, Any]] = Field(default=None, description="SelectedConfig is the recommended configuration chosen by the profiler based on the SLA targets. This is the configuration used for deployment when autoApply is true.")
+    pareto: Optional[List[ParetoConfig]] = Field(
+        default=None,
+        description="Pareto is retained for compatibility with existing status objects. Deprecated: The controller no longer populates this field.",
+    )
+    selectedConfig: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="SelectedConfig is the recommended configuration chosen by the profiler based on the SLA targets. This is the configuration used for deployment when autoApply is true.",
+    )
 
 
 class DeploymentInfoStatus(BaseModel):
     """DeploymentInfoStatus tracks the state of the deployed DynamoGraphDeployment."""
 
-    replicas: Optional[int] = Field(default=None, description="Replicas is the desired number of replicas.")
-    availableReplicas: Optional[int] = Field(default=None, description="AvailableReplicas is the number of replicas that are available and ready.")
+    replicas: Optional[int] = Field(
+        default=None, description="Replicas is the desired number of replicas."
+    )
+    availableReplicas: Optional[int] = Field(
+        default=None,
+        description="AvailableReplicas is the number of replicas that are available and ready.",
+    )
 
 
 class DynamoGraphDeploymentRequestStatus(BaseModel):
     """DynamoGraphDeploymentRequestStatus represents the observed state of a DynamoGraphDeploymentRequest."""
 
-    phase: Optional[DGDRPhase] = Field(default=None, description="Phase is the high-level lifecycle phase of the deployment request.")
-    profilingPhase: Optional[ProfilingPhase] = Field(default=None, description="ProfilingPhase indicates the current sub-phase of the profiling pipeline. Only meaningful when Phase is \"Profiling\". Cleared when profiling completes or fails.")
-    dgdName: Optional[str] = Field(default=None, description="DGDName is the name of the generated or created DynamoGraphDeployment.")
-    profilingJobName: Optional[str] = Field(default=None, description="ProfilingJobName is the name of the Kubernetes Job running the profiler.")
-    profilingResults: Optional[ProfilingResultsStatus] = Field(default=None, description="ProfilingResults contains the selected deployment configuration produced by profiling. Deprecated compatibility fields may remain on objects created by older releases.")
-    deploymentInfo: Optional[DeploymentInfoStatus] = Field(default=None, description="DeploymentInfo tracks the state of the deployed DynamoGraphDeployment. Populated when a DGD has been created (either via autoApply or manually).")
-    observedGeneration: Optional[int] = Field(default=None, description="ObservedGeneration is the most recent generation observed by the controller.")
+    phase: Optional[DGDRPhase] = Field(
+        default=None,
+        description="Phase is the high-level lifecycle phase of the deployment request.",
+    )
+    profilingPhase: Optional[ProfilingPhase] = Field(
+        default=None,
+        description='ProfilingPhase indicates the current sub-phase of the profiling pipeline. Only meaningful when Phase is "Profiling". Cleared when profiling completes or fails.',
+    )
+    dgdName: Optional[str] = Field(
+        default=None,
+        description="DGDName is the name of the generated or created DynamoGraphDeployment.",
+    )
+    profilingJobName: Optional[str] = Field(
+        default=None,
+        description="ProfilingJobName is the name of the Kubernetes Job running the profiler.",
+    )
+    profilingResults: Optional[ProfilingResultsStatus] = Field(
+        default=None,
+        description="ProfilingResults contains the selected deployment configuration produced by profiling. Deprecated compatibility fields may remain on objects created by older releases.",
+    )
+    deploymentInfo: Optional[DeploymentInfoStatus] = Field(
+        default=None,
+        description="DeploymentInfo tracks the state of the deployed DynamoGraphDeployment. Populated when a DGD has been created (either via autoApply or manually).",
+    )
+    observedGeneration: Optional[int] = Field(
+        default=None,
+        description="ObservedGeneration is the most recent generation observed by the controller.",
+    )
 
 
 class DynamoGraphDeploymentRequest(BaseModel):
     """DynamoGraphDeploymentRequest is the Schema for the dynamographdeploymentrequests API. It provides a simplified, SLA-driven interface for deploying inference models on Dynamo. Users specify a model and optional performance targets; the controller handles profiling, configuration selection, and deployment."""
 
-    spec: Optional[DynamoGraphDeploymentRequestSpec] = Field(default=None, description="Spec defines the desired state for this deployment request.")
-    status: Optional[DynamoGraphDeploymentRequestStatus] = Field(default=None, description="Status reflects the current observed state of this deployment request.")
+    spec: Optional[DynamoGraphDeploymentRequestSpec] = Field(
+        default=None,
+        description="Spec defines the desired state for this deployment request.",
+    )
+    status: Optional[DynamoGraphDeploymentRequestStatus] = Field(
+        default=None,
+        description="Status reflects the current observed state of this deployment request.",
+    )

--- a/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-config.yaml
@@ -180,9 +180,18 @@ data:
       {{- $pvc := .pvc | default dict }}
       storage:
         type: {{ .type | quote }}
+        {{- if .accessMode }}
+        accessMode: {{ .accessMode | quote }}
+        {{- end }}
         {{- if eq .type "pvc" }}
         pvc:
-          pvcName: {{ required "checkpoint.storage.pvc.pvcName is required when checkpoint.storage.type=pvc" $pvc.pvcName | quote }}
+          {{- if eq (.accessMode | default "") "agentInject" }}
+          {{- if $pvc.pvcName }}
+          pvcName: {{ $pvc.pvcName | quote }}
+          {{- end }}
+          {{- else }}
+          pvcName: {{ required "checkpoint.storage.pvc.pvcName is required when checkpoint.storage.type=pvc and accessMode is not agentInject" $pvc.pvcName | quote }}
+          {{- end }}
           basePath: {{ required "checkpoint.storage.pvc.basePath is required when checkpoint.storage.type=pvc" $pvc.basePath | quote }}
           {{- if $pvc.create }}
           create: true

--- a/deploy/helm/charts/snapshot/templates/configmap.yaml
+++ b/deploy/helm/charts/snapshot/templates/configmap.yaml
@@ -6,8 +6,8 @@ kind: ConfigMap
 {{- if ne .Values.storage.type "pvc" }}
 {{- fail (printf "snapshot.storage.type=%q is not supported yet; only pvc is currently implemented" .Values.storage.type) }}
 {{- end }}
-{{- if not (has .Values.storage.accessMode (list "agentMount" "podMount")) }}
-{{- fail (printf "snapshot.storage.accessMode=%q is not supported; expected agentMount or podMount" .Values.storage.accessMode) }}
+{{- if not (has .Values.storage.accessMode (list "agentMount" "podMount" "agentInject")) }}
+{{- fail (printf "snapshot.storage.accessMode=%q is not supported; expected agentMount, podMount, or agentInject" .Values.storage.accessMode) }}
 {{- end }}
 metadata:
   name: {{ include "snapshot.fullname" . }}-config

--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -125,8 +125,9 @@ spec:
             - name: config
               mountPath: /etc/snapshot
               readOnly: true
-            {{- if and (eq .Values.storage.type "pvc") (eq .Values.storage.accessMode "agentMount") }}
-            # Mount the checkpoint PVC directly in namespace-local agent mode
+            {{- if and (eq .Values.storage.type "pvc") (has .Values.storage.accessMode (list "agentMount" "agentInject")) }}
+            # Mount the checkpoint PVC directly. agentMount serves it to the pod;
+            # agentInject clones it into the target container via move_mount.
             - name: checkpoints
               mountPath: {{ .Values.storage.pvc.basePath }}
             {{- end }}
@@ -182,7 +183,7 @@ spec:
             path: /var/lib/kubelet/seccomp
             type: DirectoryOrCreate
         {{- end }}
-        {{- if and (eq .Values.storage.type "pvc") (eq .Values.storage.accessMode "agentMount") }}
+        {{- if and (eq .Values.storage.type "pvc") (has .Values.storage.accessMode (list "agentMount" "agentInject")) }}
         - name: checkpoints
           persistentVolumeClaim:
             claimName: {{ .Values.storage.pvc.name }}

--- a/deploy/helm/charts/snapshot/templates/pvc.yaml
+++ b/deploy/helm/charts/snapshot/templates/pvc.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if and (eq .Values.storage.type "pvc") (eq .Values.storage.accessMode "agentMount") .Values.storage.pvc.create }}
+{{- if and (eq .Values.storage.type "pvc") (has .Values.storage.accessMode (list "agentMount" "agentInject")) .Values.storage.pvc.create }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -46,6 +46,12 @@ storage:
   #   DaemonSet in an infrastructure namespace. Because the DaemonSet no longer
   #   mounts the PVC from every GPU node, suitable ReadWriteOnce storage
   #   classes can be used for sequential checkpoint/restore workflows.
+  # - agentInject: workload pods NEVER mount the checkpoint PVC. The agent mounts
+  #   it (like agentMount) and, for restore, grafts the checkpoint dir into the
+  #   target container's mount namespace via open_tree(OPEN_TREE_CLONE)+move_mount
+  #   before nsrestore reads it. Set the operator's checkpoint.storage.accessMode
+  #   to agentInject to match (the operator then skips injecting the PVC into
+  #   workload pods).
   accessMode: agentMount
 
   # PVC configuration (when type=pvc)

--- a/deploy/operator/api/config/v1alpha1/types.go
+++ b/deploy/operator/api/config/v1alpha1/types.go
@@ -389,6 +389,12 @@ func (c *CheckpointConfiguration) EffectiveSeccompProfile() string {
 type CheckpointStorageConfiguration struct {
 	// Type is the storage backend type. Only pvc is implemented today.
 	Type string `json:"type"`
+	// AccessMode selects how the snapshot-agent reaches storage and must match the
+	// snapshot chart's storage.accessMode. "agentInject" tells the operator to
+	// stamp checkpoint metadata but NOT mount the PVC into workload pods (the agent
+	// grafts the checkpoint into the container instead); pvcName is then not
+	// required. Empty/"agentMount"/"podMount" preserve the existing behavior.
+	AccessMode string `json:"accessMode,omitempty"`
 	// PVC configuration for pvc-based settings.
 	PVC CheckpointPVCConfig `json:"pvc"`
 	// Deprecated: S3 is retained for compatibility and ignored.

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -166,6 +166,32 @@ func TestStorageFromConfig(t *testing.T) {
 		assert.Equal(t, "/snapshots", storage.BasePath)
 	})
 
+	t.Run("agentInject resolves storage without a pvcName", func(t *testing.T) {
+		storage, ok, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
+			Type:       snapshotprotocol.StorageTypePVC,
+			AccessMode: snapshotprotocol.StorageAccessModeAgentInject,
+			PVC: configv1alpha1.CheckpointPVCConfig{
+				BasePath: "/checkpoints",
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, ok)
+		assert.Equal(t, snapshotprotocol.StorageTypePVC, storage.Type)
+		assert.Equal(t, "", storage.PVCName, "agentInject must not carry a workload PVC name")
+		assert.Equal(t, "/checkpoints", storage.BasePath)
+		assert.Equal(t, snapshotprotocol.StorageAccessModeAgentInject, storage.AccessMode)
+	})
+
+	t.Run("non-agentInject still requires a pvcName", func(t *testing.T) {
+		_, _, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
+			Type: snapshotprotocol.StorageTypePVC,
+			PVC: configv1alpha1.CheckpointPVCConfig{
+				BasePath: "/checkpoints",
+			},
+		})
+		require.Error(t, err)
+	})
+
 	t.Run("pvc config normalizes clean base path", func(t *testing.T) {
 		storage, ok, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
 			Type: snapshotprotocol.StorageTypePVC,

--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -167,6 +167,7 @@ func TestStorageFromConfig(t *testing.T) {
 	})
 
 	t.Run("agentInject resolves storage without a pvcName", func(t *testing.T) {
+		t.Log("Configure agentInject storage without a workload PVC")
 		storage, ok, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
 			Type:       snapshotprotocol.StorageTypePVC,
 			AccessMode: snapshotprotocol.StorageAccessModeAgentInject,
@@ -174,6 +175,8 @@ func TestStorageFromConfig(t *testing.T) {
 				BasePath: "/checkpoints",
 			},
 		})
+
+		t.Log("Verify storage resolves for agent-side injection")
 		require.NoError(t, err)
 		require.True(t, ok)
 		assert.Equal(t, snapshotprotocol.StorageTypePVC, storage.Type)
@@ -183,13 +186,31 @@ func TestStorageFromConfig(t *testing.T) {
 	})
 
 	t.Run("non-agentInject still requires a pvcName", func(t *testing.T) {
+		t.Log("Configure conventional storage without its required workload PVC")
 		_, _, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
 			Type: snapshotprotocol.StorageTypePVC,
 			PVC: configv1alpha1.CheckpointPVCConfig{
 				BasePath: "/checkpoints",
 			},
 		})
+
+		t.Log("Verify the incomplete storage configuration is rejected")
 		require.Error(t, err)
+	})
+
+	t.Run("unknown storage access mode is rejected", func(t *testing.T) {
+		t.Log("Configure storage with a misspelled access mode")
+		_, _, err := StorageFromConfig(configv1alpha1.CheckpointStorageConfiguration{
+			Type:       snapshotprotocol.StorageTypePVC,
+			AccessMode: "agentInjec",
+			PVC: configv1alpha1.CheckpointPVCConfig{
+				BasePath: "/checkpoints",
+			},
+		})
+
+		t.Log("Verify the unknown mode is not propagated into pod metadata")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "checkpoint.storage.accessMode")
 	})
 
 	t.Run("pvc config normalizes clean base path", func(t *testing.T) {
@@ -1023,13 +1044,16 @@ func TestApplyRestorePodMetadata_DisabledClearsAnnotation(t *testing.T) {
 
 func TestApplyRestoreCandidateMetadata(t *testing.T) {
 	t.Run("ready checkpoint stamps candidate metadata without restore labels", func(t *testing.T) {
+		t.Log("Start with stale restore storage metadata")
 		labels := map[string]string{
 			snapshotprotocol.CheckpointIDLabel: "stale",
 		}
 		annotations := map[string]string{
-			snapshotprotocol.CheckpointStatusAnnotation: "stale",
+			snapshotprotocol.CheckpointStatusAnnotation:            "stale",
+			snapshotprotocol.CheckpointStorageAccessModeAnnotation: snapshotprotocol.StorageAccessModeAgentInject,
 		}
 
+		t.Log("Reclassify the pod as a restore candidate")
 		err := ApplyRestoreCandidateMetadata(labels, annotations, &CheckpointInfo{
 			Enabled:                 true,
 			Exists:                  true,
@@ -1040,9 +1064,11 @@ func TestApplyRestoreCandidateMetadata(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		t.Log("Verify stale restore metadata is cleared before candidate metadata is stamped")
 		assert.Empty(t, labels[snapshotprotocol.CheckpointIDLabel])
 		assert.Empty(t, labels[snapshotprotocol.RestoreTargetLabel])
 		assert.Empty(t, annotations[snapshotprotocol.CheckpointStatusAnnotation])
+		assert.NotContains(t, annotations, snapshotprotocol.CheckpointStorageAccessModeAnnotation)
 		assert.Equal(t, consts.KubeLabelValueTrue, annotations[consts.CheckpointRestoreCandidateAnnotation])
 		assert.Equal(t, "worker-checkpoint", annotations[consts.CheckpointNameAnnotation])
 		assert.Equal(t, string(nvidiacomv1alpha1.CheckpointStartupPolicyWaitForCheckpoint), annotations[consts.CheckpointStartupPolicyAnnotation])

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -107,6 +107,7 @@ func ApplyRestoreCandidateMetadata(labels map[string]string, annotations map[str
 	delete(annotations, snapshotprotocol.CheckpointStatusAnnotation)
 	delete(annotations, snapshotprotocol.CheckpointStorageTypeAnnotation)
 	delete(annotations, snapshotprotocol.CheckpointStorageBasePathAnnotation)
+	delete(annotations, snapshotprotocol.CheckpointStorageAccessModeAnnotation)
 	delete(annotations, commonconsts.CheckpointRestoreCandidateAnnotation)
 	delete(annotations, commonconsts.CheckpointNameAnnotation)
 	delete(annotations, commonconsts.CheckpointStartupPolicyAnnotation)

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -73,6 +73,7 @@ func ApplyRestorePodMetadataWithStorageConfig(
 		delete(annotations, snapshotprotocol.TargetContainersAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageTypeAnnotation)
 		delete(annotations, snapshotprotocol.CheckpointStorageBasePathAnnotation)
+		delete(annotations, snapshotprotocol.CheckpointStorageAccessModeAnnotation)
 		delete(annotations, commonconsts.CheckpointRestoreCandidateAnnotation)
 		delete(annotations, commonconsts.CheckpointNameAnnotation)
 		delete(annotations, commonconsts.CheckpointStartupPolicyAnnotation)

--- a/deploy/operator/internal/checkpoint/storage.go
+++ b/deploy/operator/internal/checkpoint/storage.go
@@ -24,6 +24,20 @@ import (
 func StorageFromConfig(config configv1alpha1.CheckpointStorageConfiguration) (snapshotprotocol.Storage, bool, error) {
 	storageType := strings.TrimSpace(config.Type)
 	storageAccessMode := strings.TrimSpace(config.AccessMode)
+	switch storageAccessMode {
+	case "",
+		snapshotprotocol.StorageAccessModeAgentMount,
+		snapshotprotocol.StorageAccessModePodMount,
+		snapshotprotocol.StorageAccessModeAgentInject:
+	default:
+		return snapshotprotocol.Storage{}, false, fmt.Errorf(
+			"checkpoint.storage.accessMode %q is not supported; expected %q, %q, %q, or empty",
+			storageAccessMode,
+			snapshotprotocol.StorageAccessModeAgentMount,
+			snapshotprotocol.StorageAccessModePodMount,
+			snapshotprotocol.StorageAccessModeAgentInject,
+		)
+	}
 	agentInject := storageAccessMode == snapshotprotocol.StorageAccessModeAgentInject
 	pvcName := strings.TrimSpace(config.PVC.PVCName)
 	basePath := strings.TrimSpace(config.PVC.BasePath)

--- a/deploy/operator/internal/checkpoint/storage.go
+++ b/deploy/operator/internal/checkpoint/storage.go
@@ -23,12 +23,14 @@ import (
 
 func StorageFromConfig(config configv1alpha1.CheckpointStorageConfiguration) (snapshotprotocol.Storage, bool, error) {
 	storageType := strings.TrimSpace(config.Type)
+	storageAccessMode := strings.TrimSpace(config.AccessMode)
+	agentInject := storageAccessMode == snapshotprotocol.StorageAccessModeAgentInject
 	pvcName := strings.TrimSpace(config.PVC.PVCName)
 	basePath := strings.TrimSpace(config.PVC.BasePath)
 	size := strings.TrimSpace(config.PVC.Size)
 	storageClassName := strings.TrimSpace(config.PVC.StorageClassName)
 	accessMode := strings.TrimSpace(config.PVC.AccessMode)
-	hasPVCConfig := pvcName != "" || basePath != "" || config.PVC.Create || size != "" || storageClassName != "" || accessMode != ""
+	hasPVCConfig := pvcName != "" || basePath != "" || config.PVC.Create || size != "" || storageClassName != "" || accessMode != "" || storageAccessMode != ""
 	if storageType == "" && !hasPVCConfig {
 		return snapshotprotocol.Storage{}, false, nil
 	}
@@ -46,22 +48,32 @@ func StorageFromConfig(config configv1alpha1.CheckpointStorageConfiguration) (sn
 	if storageType != snapshotprotocol.StorageTypePVC {
 		return snapshotprotocol.Storage{}, false, fmt.Errorf("checkpoint storage type %q is not supported; only pvc is implemented today", storageType)
 	}
-	if pvcName == "" || basePath == "" {
-		return snapshotprotocol.Storage{}, false, fmt.Errorf("checkpoint.storage.pvc.pvcName and checkpoint.storage.pvc.basePath are required when checkpoint storage is configured")
+	// agentInject: the workload pod never mounts the checkpoint PVC, so pvcName is
+	// not required (and is deliberately left empty so no PVC is injected into the
+	// pod). Only basePath is needed to locate the artifact.
+	if basePath == "" || (!agentInject && pvcName == "") {
+		return snapshotprotocol.Storage{}, false, fmt.Errorf("checkpoint.storage.pvc.basePath (and pvcName unless accessMode=agentInject) are required when checkpoint storage is configured")
 	}
 	basePath, err := normalizeStorageBasePath(basePath)
 	if err != nil {
 		return snapshotprotocol.Storage{}, false, err
 	}
-	if config.PVC.Create {
+	// agentInject does not create a workload-namespace PVC; skip PVC access-mode
+	// validation, which only governs operator-created claims.
+	if config.PVC.Create && !agentInject {
 		if _, err := storagePVCAccessMode(accessMode); err != nil {
 			return snapshotprotocol.Storage{}, false, err
 		}
 	}
+	resolvedPVCName := pvcName
+	if agentInject {
+		resolvedPVCName = ""
+	}
 	return snapshotprotocol.Storage{
-		Type:     snapshotprotocol.StorageTypePVC,
-		PVCName:  pvcName,
-		BasePath: basePath,
+		Type:       snapshotprotocol.StorageTypePVC,
+		PVCName:    resolvedPVCName,
+		BasePath:   basePath,
+		AccessMode: storageAccessMode,
 	}, true, nil
 }
 
@@ -76,6 +88,11 @@ func EnsureStoragePVC(
 		return err
 	}
 	if !ok {
+		return nil
+	}
+	// agentInject leaves PVCName empty: the workload pod never mounts a PVC, so
+	// there is no namespace-local claim for the operator to ensure or create.
+	if storage.PVCName == "" {
 		return nil
 	}
 	if kubeClient == nil {

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -78,8 +78,13 @@ func buildCheckpointJob(
 	if storage, ok, err := checkpoint.StorageFromConfig(config.Checkpoint.Storage); err != nil {
 		return nil, err
 	} else if ok {
-		snapshotprotocol.InjectCheckpointVolume(&podTemplate.Spec, storage.PVCName)
-		snapshotprotocol.InjectCheckpointVolumeMount(targetContainer, storage.BasePath)
+		// agentInject leaves PVCName empty: skip injecting the PVC into the
+		// checkpoint Job pod. The agent writes the dump through its own mount, so
+		// only the storage metadata (type/basePath/accessMode) needs stamping.
+		if storage.PVCName != "" {
+			snapshotprotocol.InjectCheckpointVolume(&podTemplate.Spec, storage.PVCName)
+			snapshotprotocol.InjectCheckpointVolumeMount(targetContainer, storage.BasePath)
+		}
 		if podTemplate.Annotations == nil {
 			podTemplate.Annotations = map[string]string{}
 		}

--- a/deploy/snapshot/cmd/nsrestore/main.go
+++ b/deploy/snapshot/cmd/nsrestore/main.go
@@ -20,6 +20,7 @@ func main() {
 	cudaDeviceMap := flag.String("cuda-device-map", "", "CUDA device map for cuda-checkpoint-helper restore")
 	cgroupRoot := flag.String("cgroup-root", "", "CRIU cgroup root remap path")
 	targetPodIP := flag.String("target-pod-ip", "", "Restore pod IP for CRIU TCP socket remapping")
+	checkpointFD := flag.Int("checkpoint-fd", -1, "Inherited fd of a detached checkpoint mount (agentInject); grafted at --checkpoint-path before restore")
 	flag.Parse()
 
 	if *checkpointPath == "" {
@@ -31,6 +32,7 @@ func main() {
 		CUDADeviceMap:  *cudaDeviceMap,
 		CgroupRoot:     *cgroupRoot,
 		TargetPodIP:    *targetPodIP,
+		CheckpointFD:   *checkpointFD,
 	}
 
 	result, err := executor.RestoreInNamespace(context.Background(), opts, log)

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -462,7 +462,8 @@ func (w *NodeController) startRestoreForContainer(
 	}
 
 	placeholderPID := 0
-	if strings.TrimSpace(w.config.Storage.AccessMode) == types.StorageAccessModePodMount {
+	accessMode := w.effectiveAccessMode(pod)
+	if accessMode == types.StorageAccessModePodMount {
 		resolvedPID, _, err := w.runtime.ResolveContainer(ctx, containerID)
 		if err != nil {
 			w.log.Error(err, "Failed to resolve restore standby container", "pod", podKey, "container", containerName)
@@ -476,7 +477,7 @@ func (w *NodeController) startRestoreForContainer(
 		w.log.Error(err, "Restore pod is missing storage metadata", "pod", podKey, "checkpoint_id", checkpointID)
 		return
 	}
-	if err := w.validatePodMountContainerPID(ctx, containerID, placeholderPID); err != nil {
+	if err := w.validatePodMountContainerPID(ctx, containerID, placeholderPID, accessMode); err != nil {
 		w.log.Error(err, "Restore placeholder container changed before storage access", "pod", podKey, "container", containerName)
 		return
 	}
@@ -739,7 +740,7 @@ func (w *NodeController) checkpointLocationsFromPod(pod *corev1.Pod, checkpointI
 	if !filepath.IsAbs(location) || filepath.Clean(location) != location {
 		return checkpointLocations{}, fmt.Errorf("checkpoint location must be an absolute, clean path: %q", location)
 	}
-	if strings.TrimSpace(w.config.Storage.AccessMode) == types.StorageAccessModePodMount {
+	if w.effectiveAccessMode(pod) == types.StorageAccessModePodMount {
 		if hostPID <= 0 {
 			return checkpointLocations{}, fmt.Errorf("host PID is required for %s storage access", types.StorageAccessModePodMount)
 		}
@@ -755,7 +756,8 @@ func (w *NodeController) checkpointLocationsFromPod(pod *corev1.Pod, checkpointI
 }
 
 func (w *NodeController) refreshRestoreCheckpointLocation(ctx context.Context, pod *corev1.Pod, containerID string, checkpointID string, checkpointLocation checkpointLocations) (checkpointLocations, error) {
-	if strings.TrimSpace(w.config.Storage.AccessMode) != types.StorageAccessModePodMount {
+	accessMode := w.effectiveAccessMode(pod)
+	if accessMode != types.StorageAccessModePodMount {
 		return checkpointLocation, nil
 	}
 
@@ -767,7 +769,7 @@ func (w *NodeController) refreshRestoreCheckpointLocation(ctx context.Context, p
 	if err != nil {
 		return checkpointLocations{}, err
 	}
-	if err := w.validatePodMountContainerPID(ctx, containerID, currentHostPID); err != nil {
+	if err := w.validatePodMountContainerPID(ctx, containerID, currentHostPID, accessMode); err != nil {
 		return checkpointLocations{}, err
 	}
 	return refreshedLocation, nil
@@ -788,8 +790,8 @@ func (w *NodeController) restoreCheckpointReady(log logr.Logger, podKey, checkpo
 	return true, nil
 }
 
-func (w *NodeController) validatePodMountContainerPID(ctx context.Context, containerID string, expectedHostPID int) error {
-	if strings.TrimSpace(w.config.Storage.AccessMode) != types.StorageAccessModePodMount {
+func (w *NodeController) validatePodMountContainerPID(ctx context.Context, containerID string, expectedHostPID int, accessMode string) error {
+	if accessMode != types.StorageAccessModePodMount {
 		return nil
 	}
 	if expectedHostPID <= 0 {

--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -583,6 +583,7 @@ func (w *NodeController) runRestore(ctx context.Context, pod *corev1.Pod, contai
 		TargetPodIP:                 pod.Status.PodIP,
 		ContainerName:               containerName,
 		Clientset:                   w.clientset,
+		AccessMode:                  w.effectiveAccessMode(pod),
 	}
 	placeholderHostPID, err := executor.Restore(restoreCtx, w.runtime, log, req)
 	if err != nil {
@@ -694,6 +695,19 @@ func chooseActiveContent(objs []interface{}) string {
 		return ""
 	}
 	return chosen.Name
+}
+
+// effectiveAccessMode returns the operator-stamped storage access mode from the
+// pod (the single source of truth), falling back to the agent's own configured
+// mode when the annotation is absent (legacy pods). Making the stamped value
+// authoritative prevents the operator and agent configs from silently disagreeing.
+func (w *NodeController) effectiveAccessMode(pod *corev1.Pod) string {
+	if pod != nil {
+		if m := strings.TrimSpace(pod.Annotations[snapshotprotocol.CheckpointStorageAccessModeAnnotation]); m != "" {
+			return m
+		}
+	}
+	return strings.TrimSpace(w.config.Storage.AccessMode)
 }
 
 func (w *NodeController) checkpointLocationsFromPod(pod *corev1.Pod, checkpointID string, hostPID int) (checkpointLocations, error) {

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -182,6 +182,45 @@ func TestCheckpointLocationsFromPod(t *testing.T) {
 		}
 	})
 
+	t.Run("operator-stamped agentInject overrides podMount agent config", func(t *testing.T) {
+		annotatedPod := pod.DeepCopy()
+		annotatedPod.Annotations[snapshotprotocol.CheckpointStorageAccessModeAnnotation] = types.StorageAccessModeAgentInject
+
+		w := makeTestController(t)
+		w.config.Storage.BasePath = "/checkpoints"
+		w.config.Storage.AccessMode = types.StorageAccessModePodMount
+
+		locations, err := w.checkpointLocationsFromPod(annotatedPod, "abc123", 0)
+		if err != nil {
+			t.Fatalf("checkpointLocationsFromPod() error = %v", err)
+		}
+
+		expected := "/checkpoints/abc123/versions/2"
+		if locations.HostPath != expected || locations.ContainerPath != expected {
+			t.Fatalf("locations = %#v, want host and container path %q", locations, expected)
+		}
+	})
+
+	t.Run("operator-stamped podMount overrides agentMount agent config", func(t *testing.T) {
+		annotatedPod := pod.DeepCopy()
+		annotatedPod.Annotations[snapshotprotocol.CheckpointStorageAccessModeAnnotation] = types.StorageAccessModePodMount
+
+		w := makeTestController(t)
+		w.config.Storage.BasePath = "/checkpoints"
+		w.config.Storage.AccessMode = types.StorageAccessModeAgentMount
+
+		locations, err := w.checkpointLocationsFromPod(annotatedPod, "abc123", 1234)
+		if err != nil {
+			t.Fatalf("checkpointLocationsFromPod() error = %v", err)
+		}
+
+		expectedContainerPath := "/checkpoints/abc123/versions/2"
+		expectedHostPath := filepath.Join(snapshotruntime.HostProcPath, "1234", "root", "checkpoints/abc123/versions/2")
+		if locations.HostPath != expectedHostPath || locations.ContainerPath != expectedContainerPath {
+			t.Fatalf("locations = %#v, want host %q and container %q", locations, expectedHostPath, expectedContainerPath)
+		}
+	})
+
 	t.Run("pod storage annotation overrides agent base path", func(t *testing.T) {
 		annotatedPod := pod.DeepCopy()
 		annotatedPod.Annotations[snapshotprotocol.CheckpointStorageBasePathAnnotation] = "/pod-checkpoints/"
@@ -713,4 +752,3 @@ func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
 		}
 	}
 }
-

--- a/deploy/snapshot/internal/controller/podsnapshotcontent.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent.go
@@ -189,7 +189,7 @@ func (w *NodeController) reconcileSourcePod(ctx context.Context, pod *corev1.Pod
 	if err != nil {
 		return w.setSnapshotContentFailed(ctx, content, "InvalidDestination", err)
 	}
-	if err := w.validatePodMountContainerPID(ctx, containerID, containerPID); err != nil {
+	if err := w.validatePodMountContainerPID(ctx, containerID, containerPID, w.effectiveAccessMode(pod)); err != nil {
 		return w.setSnapshotContentFailed(ctx, content, "ContainerChanged", err)
 	}
 

--- a/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
@@ -37,14 +37,23 @@ type fakeCheckpointer struct {
 	called bool
 	params CheckpointParams
 	err    error
+	// block, when non-nil, is received before returning so callers can observe
+	// mid-checkpoint state (e.g. the Lease exists while the dump runs).
+	block <-chan struct{}
 }
 
 // fn is the checkpointFn seam the NodeController invokes for the dump.
-func (fc *fakeCheckpointer) fn(_ context.Context, params CheckpointParams) error {
+func (fc *fakeCheckpointer) fn(ctx context.Context, params CheckpointParams) error {
 	fc.mu.Lock()
-	defer fc.mu.Unlock()
 	fc.called = true
 	fc.params = params
+	fc.mu.Unlock()
+	if fc.block != nil {
+		select {
+		case <-fc.block:
+		case <-ctx.Done():
+		}
+	}
 	return fc.err
 }
 
@@ -475,16 +484,23 @@ func TestReconcileSnapshotContent_NotReadyQuiesceNoOp(t *testing.T) {
 func TestReconcileSnapshotContent_CapturesFromPod(t *testing.T) {
 	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
 	pod := makeSourcePod("abc")
-	fc := &fakeCheckpointer{}
+	// Block the fake checkpoint until we have verified the Lease exists. Without
+	// this, the goroutine can complete and releaseLease can delete the Lease before
+	// the assertion below, causing a spurious failure on fast runners.
+	unblock := make(chan struct{})
+	fc := &fakeCheckpointer{block: unblock}
 	w := makeNodeController(t, fc, content, pod)
 	w.runtime = &fakeRuntime{resolveContainerPID: 7}
 
 	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
 
-	// acquireLease runs synchronously in reconcileSourcePod before the goroutine is launched, so
-	// the Lease exists immediately after the function returns.
+	// The Lease is created synchronously inside reconcileSourcePod. The checkpoint
+	// goroutine is blocked on fc.block, so the Lease has not been released yet.
 	_, err := w.clientset.CoordinationV1().Leases("inference").Get(context.Background(), "checkpoint-lease-abc", metav1.GetOptions{})
 	assert.NoError(t, err, "Lease checkpoint-lease-abc must exist in namespace inference")
+
+	// Let the checkpoint proceed.
+	close(unblock)
 
 	require.Eventually(t, fc.wasCalled, time.Second, 5*time.Millisecond)
 

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -21,6 +21,11 @@ type RestoreOptions struct {
 	CUDADeviceMap  string
 	CgroupRoot     string
 	TargetPodIP    string
+	// CheckpointFD, when >= 0, is an inherited fd of a detached checkpoint mount
+	// (agentInject mode). nsrestore grafts it at CheckpointPath inside this
+	// container's mount namespace before reading the checkpoint. -1 means the
+	// checkpoint is already visible (agentMount/podMount).
+	CheckpointFD int
 }
 
 type RestoreInNamespaceResult struct {
@@ -38,7 +43,23 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		"has_cuda_map", opts.CUDADeviceMap != "",
 		"cgroup_root", opts.CgroupRoot,
 		"target_pod_ip_present", opts.TargetPodIP != "",
+		"checkpoint_fd", opts.CheckpointFD,
 	)
+
+	// agentInject: graft the agent-supplied detached checkpoint mount into this
+	// container's mount namespace at CheckpointPath before anything reads it. This
+	// must precede ReadManifest/ApplyRootfsDiff, which both read the checkpoint dir.
+	if opts.CheckpointFD >= 0 {
+		detach, err := snapshotruntime.AttachCheckpointTree(opts.CheckpointFD, opts.CheckpointPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to graft checkpoint mount: %w", err)
+		}
+		defer func() {
+			if err := detach(); err != nil {
+				log.Error(err, "Failed to detach grafted checkpoint mount")
+			}
+		}()
+	}
 
 	manifestReadStart := time.Now()
 	m, err := types.ReadManifest(opts.CheckpointPath)

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -38,6 +38,13 @@ type RestoreRequest struct {
 	// AccessMode is the operator-stamped storage access mode. For agentInject the
 	// workload pod has no checkpoint PVC mount, so the agent clones its own
 	// checkpoint dir and grafts it into the container ns via nsrestore.
+	//
+	// agentInject is only supported for restore workloads that cannot acquire
+	// CAP_SYS_ADMIN in the user namespace that owns their mount namespace.
+	// Linux does not expose the kernel-internal MNT_LOCK_READONLY flag through
+	// mount_setattr(2), so a sufficiently privileged workload could otherwise
+	// clear the graft's read-only mount attribute. Admission/callers must reject
+	// privileged or CAP_SYS_ADMIN-capable workloads when selecting agentInject.
 	AccessMode string
 }
 
@@ -231,6 +238,10 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 		if err != nil {
 			return nil, fmt.Errorf("agentInject checkpoint clone: %w", err)
 		}
+		// This defer owns the agent process's descriptor. ExtraFiles duplicates
+		// it into the child as fd 3; AttachCheckpointTree consumes and closes
+		// that child-side descriptor after move_mount. Closing either descriptor
+		// does not close the other process's descriptor.
 		defer tree.Close()
 		extraFiles = append(extraFiles, tree)
 		// First ExtraFiles entry lands at fd 3 in nsenter and is inherited by

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -35,6 +35,10 @@ type RestoreRequest struct {
 	TargetPodIP                 string
 	ContainerName               string
 	Clientset                   kubernetes.Interface
+	// AccessMode is the operator-stamped storage access mode. For agentInject the
+	// workload pod has no checkpoint PVC mount, so the agent clones its own
+	// checkpoint dir and grafts it into the container ns via nsrestore.
+	AccessMode string
 }
 
 // Restore performs external restore for the given request.
@@ -218,7 +222,24 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 		args = append(args, "--target-pod-ip", req.TargetPodIP)
 	}
 
+	// agentInject: the workload pod does not mount the checkpoint PVC. Clone the
+	// agent's own checkpoint dir into a detached mount and hand it to nsrestore,
+	// which grafts it into the container's mount namespace at --checkpoint-path.
+	var extraFiles []*os.File
+	if req.AccessMode == types.StorageAccessModeAgentInject {
+		tree, err := snapshotruntime.OpenCheckpointTree(req.CheckpointLocation)
+		if err != nil {
+			return nil, fmt.Errorf("agentInject checkpoint clone: %w", err)
+		}
+		defer tree.Close()
+		extraFiles = append(extraFiles, tree)
+		// First ExtraFiles entry lands at fd 3 in nsenter and is inherited by
+		// nsrestore across the execve chain (nsenter does not close it).
+		args = append(args, "--checkpoint-fd", "3")
+	}
+
 	cmd := exec.CommandContext(ctx, "nsenter", args...)
+	cmd.ExtraFiles = extraFiles
 	// Inherit the agent environment so nsrestore uses the same logger settings.
 	cmd.Env = os.Environ()
 	log.V(1).Info("Executing nsenter + nsrestore", "cmd", cmd.String())

--- a/deploy/snapshot/internal/runtime/nsmount.go
+++ b/deploy/snapshot/internal/runtime/nsmount.go
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const checkpointMountAttrs = unix.MOUNT_ATTR_RDONLY |
+	unix.MOUNT_ATTR_NOSUID |
+	unix.MOUNT_ATTR_NODEV |
+	unix.MOUNT_ATTR_NOEXEC
+
+// OpenCheckpointTree creates a detached clone of the mount subtree rooted at
+// path (the agent's own checkpoint dir) and returns it as an *os.File so it can
+// be handed to a child process via exec.Cmd.ExtraFiles.
+//
+// The clone is an anonymous mount (attached to no mount namespace), which is the
+// only thing that can be grafted into a different mount namespace. A plain bind
+// of /proc/self/fd/N fails with EINVAL from inside another namespace because the
+// source mount belongs to this (the agent's) namespace; open_tree(OPEN_TREE_CLONE)
+// plus move_mount is the kernel API built for exactly this transfer. The full
+// hardened sequence requires Linux 5.12+ (mount_setattr).
+func OpenCheckpointTree(path string) (*os.File, error) {
+	if !filepath.IsAbs(path) || filepath.Clean(path) != path || path == string(os.PathSeparator) {
+		return nil, fmt.Errorf("checkpoint tree source must be an absolute, clean, non-root path: %q", path)
+	}
+	// Resolve the exact version directory once, rejecting symlinks in every
+	// component. open_tree then clones from this pinned O_PATH descriptor rather
+	// than resolving an attacker-changeable shared-PVC pathname a second time.
+	sourceFD, err := unix.Openat2(unix.AT_FDCWD, path, &unix.OpenHow{
+		Flags:   unix.O_PATH | unix.O_DIRECTORY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_MAGICLINKS,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint tree source %s without symlinks: %w", path, err)
+	}
+	defer unix.Close(sourceFD)
+
+	fd, err := unix.OpenTree(sourceFD, "",
+		uint(unix.OPEN_TREE_CLONE|unix.AT_RECURSIVE|unix.OPEN_TREE_CLOEXEC|unix.AT_EMPTY_PATH))
+	if err != nil {
+		return nil, fmt.Errorf("open_tree(%s): %w", path, err)
+	}
+	// open_tree(OPEN_TREE_CLONE) is equivalent to a detached recursive bind
+	// mount: it references the same backing filesystem and inherits the source
+	// mount's writable attributes. Harden the anonymous tree before it crosses
+	// into the untrusted restore container's mount namespace. AT_RECURSIVE
+	// applies the attributes to any nested submount too.
+	//
+	// NOTE: these attributes are set, not MNT_LOCK_*-locked (neither
+	// mount_setattr nor move_mount locks; only cross-user-namespace copy_mnt_ns
+	// does, and Linux exposes no API to set MNT_LOCK_READONLY explicitly). So
+	// read-only holds because a normal restore target lacks CAP_SYS_ADMIN over
+	// its own user namespace, which makes `mount -o remount,rw` return EPERM.
+	// A target that DID hold CAP_SYS_ADMIN could remount rw, but that is out of
+	// scope: such a container is already privileged enough to cause worse harm,
+	// and confinement still bounds it to its own versions/<v>. The guarantee this
+	// hardening provides is against a normal, unprivileged workload.
+	attr := &unix.MountAttr{
+		Attr_set:    checkpointMountAttrs,
+		Propagation: unix.MS_PRIVATE,
+	}
+	if err := unix.MountSetattr(
+		fd,
+		"",
+		uint(unix.AT_EMPTY_PATH|unix.AT_RECURSIVE),
+		attr,
+	); err != nil {
+		_ = unix.Close(fd)
+		return nil, fmt.Errorf("mount_setattr(%s, read-only): %w", path, err)
+	}
+	return os.NewFile(uintptr(fd), "checkpoint-tree:"+path), nil
+}
+
+// openOrCreateMountTarget securely walks target from the current namespace's
+// root, creating missing directories without following symlinks. The returned
+// O_PATH fd pins the exact directory used by move_mount, closing the
+// MkdirAll/path-replacement race against the untrusted placeholder process.
+func openOrCreateMountTarget(target string) (int, error) {
+	if !filepath.IsAbs(target) || filepath.Clean(target) != target || target == string(os.PathSeparator) {
+		return -1, fmt.Errorf("checkpoint mount target must be an absolute, clean, non-root path: %q", target)
+	}
+
+	currentFD, err := unix.Open(
+		string(os.PathSeparator),
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return -1, fmt.Errorf("open mount namespace root: %w", err)
+	}
+
+	components := strings.Split(strings.TrimPrefix(target, string(os.PathSeparator)), string(os.PathSeparator))
+	for _, component := range components {
+		if component == "" || component == "." || component == ".." {
+			_ = unix.Close(currentFD)
+			return -1, fmt.Errorf("checkpoint mount target contains invalid component %q: %q", component, target)
+		}
+		if err := unix.Mkdirat(currentFD, component, 0o755); err != nil && !errors.Is(err, unix.EEXIST) {
+			_ = unix.Close(currentFD)
+			return -1, fmt.Errorf("create checkpoint mount target component %q in %s: %w", component, target, err)
+		}
+		nextFD, err := unix.Openat(
+			currentFD,
+			component,
+			unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		_ = unix.Close(currentFD)
+		if err != nil {
+			return -1, fmt.Errorf("open checkpoint mount target component %q in %s without symlinks: %w", component, target, err)
+		}
+		currentFD = nextFD
+	}
+	return currentFD, nil
+}
+
+// rejectSharedMountTarget fails closed if the mount containing targetFD is a
+// shared-propagation mount. Attaching below a shared mount can propagate the
+// graft into peer mount namespaces before the new mount's own MS_PRIVATE
+// setting can contain subsequent events.
+func rejectSharedMountTarget(targetFD int, target string) error {
+	fdInfo, err := os.ReadFile(fmt.Sprintf("/proc/self/fdinfo/%d", targetFD))
+	if err != nil {
+		return fmt.Errorf("read mount information for checkpoint target %s: %w", target, err)
+	}
+	var mountID string
+	for _, line := range strings.Split(string(fdInfo), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[0] == "mnt_id:" {
+			if _, err := strconv.ParseUint(fields[1], 10, 64); err != nil {
+				return fmt.Errorf("parse mount ID %q for checkpoint target %s: %w", fields[1], target, err)
+			}
+			mountID = fields[1]
+			break
+		}
+	}
+	if mountID == "" {
+		return fmt.Errorf("mount ID is unavailable for checkpoint target %s", target)
+	}
+
+	mountInfo, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		return fmt.Errorf("read mount propagation for checkpoint target %s: %w", target, err)
+	}
+	for _, line := range strings.Split(string(mountInfo), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 7 || fields[0] != mountID {
+			continue
+		}
+		for i := 6; i < len(fields) && fields[i] != "-"; i++ {
+			if strings.HasPrefix(fields[i], "shared:") {
+				return fmt.Errorf("checkpoint mount target %s is on shared-propagation mount %s", target, mountID)
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("mount %s for checkpoint target %s is absent from /proc/self/mountinfo", mountID, target)
+}
+
+// AttachCheckpointTree grafts the detached mount referred to by treeFD onto
+// target inside the CURRENT mount namespace, creating target if absent without
+// following symlinks. It consumes treeFD and returns a cleanup func that lazily
+// detaches the mount. It is meant to run from inside the target container's
+// mount namespace (i.e. from nsrestore), so the checkpoint dir becomes visible
+// to CRIU without the workload pod ever mounting the PVC.
+func AttachCheckpointTree(treeFD int, target string) (func() error, error) {
+	// This is the child-side duplicate inherited through ExtraFiles. Close it
+	// as soon as move_mount has attached the tree so nsrestore cannot
+	// accidentally retain or pass an O_PATH reference to the checkpoint mount.
+	defer unix.Close(treeFD)
+
+	targetFD, err := openOrCreateMountTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(targetFD)
+
+	if err := rejectSharedMountTarget(targetFD, target); err != nil {
+		return nil, err
+	}
+
+	if err := unix.MoveMount(
+		treeFD,
+		"",
+		targetFD,
+		"",
+		unix.MOVE_MOUNT_F_EMPTY_PATH|unix.MOVE_MOUNT_T_EMPTY_PATH,
+	); err != nil {
+		return nil, fmt.Errorf("move_mount -> %s: %w", target, err)
+	}
+	return func() error {
+		// UMOUNT_NOFOLLOW prevents final-component symlink substitution during
+		// cleanup. MNT_DETACH removes the graft from pathname lookup
+		// immediately even if CRIU or the workload still holds open files.
+		if err := unix.Unmount(target, unix.MNT_DETACH|unix.UMOUNT_NOFOLLOW); err != nil {
+			return fmt.Errorf("detach checkpoint mount %s: %w", target, err)
+		}
+		return nil
+	}, nil
+}

--- a/deploy/snapshot/internal/runtime/nsmount_test.go
+++ b/deploy/snapshot/internal/runtime/nsmount_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package runtime
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestCheckpointMountAttrs(t *testing.T) {
+	want := uint64(unix.MOUNT_ATTR_RDONLY |
+		unix.MOUNT_ATTR_NOSUID |
+		unix.MOUNT_ATTR_NODEV |
+		unix.MOUNT_ATTR_NOEXEC)
+	if checkpointMountAttrs != want {
+		t.Fatalf("checkpointMountAttrs = %#x, want %#x", checkpointMountAttrs, want)
+	}
+}
+
+func TestOpenOrCreateMountTargetCreatesCleanDirectory(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "checkpoint", "id", "versions", "1")
+
+	fd, err := openOrCreateMountTarget(target)
+	if err != nil {
+		t.Fatalf("openOrCreateMountTarget(%q): %v", target, err)
+	}
+	defer unix.Close(fd)
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		t.Fatalf("fstat target fd: %v", err)
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFDIR {
+		t.Fatalf("target fd mode = %#o, want directory", stat.Mode)
+	}
+	if info, err := os.Stat(target); err != nil {
+		t.Fatalf("stat created target: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("created target mode = %v, want directory", info.Mode())
+	}
+}
+
+func TestOpenOrCreateMountTargetRejectsSymlinkComponent(t *testing.T) {
+	root := t.TempDir()
+	redirect := t.TempDir()
+	link := filepath.Join(root, "checkpoint")
+	if err := os.Symlink(redirect, link); err != nil {
+		t.Fatalf("create target symlink: %v", err)
+	}
+
+	target := filepath.Join(link, "id", "versions", "1")
+	fd, err := openOrCreateMountTarget(target)
+	if fd >= 0 {
+		unix.Close(fd)
+		t.Fatalf("openOrCreateMountTarget(%q) unexpectedly returned fd %d", target, fd)
+	}
+	if err == nil {
+		t.Fatalf("openOrCreateMountTarget(%q) unexpectedly succeeded", target)
+	}
+	if _, statErr := os.Stat(filepath.Join(redirect, "id")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("symlink target was modified, stat error = %v", statErr)
+	}
+}
+
+func TestOpenOrCreateMountTargetRejectsUnsafePaths(t *testing.T) {
+	for _, target := range []string{
+		"relative/path",
+		"/",
+		"/checkpoint/../escape",
+		"/checkpoint//double",
+	} {
+		t.Run(target, func(t *testing.T) {
+			fd, err := openOrCreateMountTarget(target)
+			if fd >= 0 {
+				unix.Close(fd)
+				t.Fatalf("openOrCreateMountTarget(%q) unexpectedly returned fd %d", target, fd)
+			}
+			if err == nil {
+				t.Fatalf("openOrCreateMountTarget(%q) unexpectedly succeeded", target)
+			}
+		})
+	}
+}
+
+func TestOpenCheckpointTreeRejectsUnsafePathsBeforeSyscall(t *testing.T) {
+	for _, path := range []string{
+		"relative/path",
+		"/tmp/../tmp/checkpoint",
+		"/",
+	} {
+		t.Run(path, func(t *testing.T) {
+			if _, err := OpenCheckpointTree(path); err == nil {
+				t.Fatalf("OpenCheckpointTree(%q) succeeded, want error", path)
+			}
+		})
+	}
+}

--- a/deploy/snapshot/internal/types/config.go
+++ b/deploy/snapshot/internal/types/config.go
@@ -26,6 +26,11 @@ const (
 	// StorageAccessModePodMount means workload pods mount the checkpoint PVC,
 	// and snapshot-agent reaches it through /host/proc/<pid>/root.
 	StorageAccessModePodMount = "podMount"
+	// StorageAccessModeAgentInject means workload pods do NOT mount the checkpoint
+	// PVC. The snapshot-agent mounts it (like agentMount) and, for restore, grafts
+	// the checkpoint dir into the target container's mount namespace via
+	// open_tree(OPEN_TREE_CLONE)+move_mount before nsrestore reads it.
+	StorageAccessModeAgentInject = "agentInject"
 )
 
 func (c *AgentConfig) LoadEnvOverrides() {
@@ -58,11 +63,11 @@ func (c *AgentConfig) Validate() error {
 		accessMode = StorageAccessModeAgentMount
 	}
 	switch accessMode {
-	case StorageAccessModeAgentMount, StorageAccessModePodMount:
+	case StorageAccessModeAgentMount, StorageAccessModePodMount, StorageAccessModeAgentInject:
 	default:
 		return &ConfigError{
 			Field:   "storage.accessMode",
-			Message: fmt.Sprintf("unsupported access mode %q; expected %q or %q", c.Storage.AccessMode, StorageAccessModeAgentMount, StorageAccessModePodMount),
+			Message: fmt.Sprintf("unsupported access mode %q; expected %q, %q, or %q", c.Storage.AccessMode, StorageAccessModeAgentMount, StorageAccessModePodMount, StorageAccessModeAgentInject),
 		}
 	}
 	c.Storage.AccessMode = accessMode

--- a/deploy/snapshot/internal/types/config.go
+++ b/deploy/snapshot/internal/types/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // AgentConfig holds the full agent configuration: static checkpoint settings
@@ -22,15 +24,15 @@ type AgentConfig struct {
 const (
 	// StorageAccessModeAgentMount means the snapshot-agent pod mounts the
 	// checkpoint store directly at Storage.BasePath.
-	StorageAccessModeAgentMount = "agentMount"
+	StorageAccessModeAgentMount = snapshotprotocol.StorageAccessModeAgentMount
 	// StorageAccessModePodMount means workload pods mount the checkpoint PVC,
 	// and snapshot-agent reaches it through /host/proc/<pid>/root.
-	StorageAccessModePodMount = "podMount"
+	StorageAccessModePodMount = snapshotprotocol.StorageAccessModePodMount
 	// StorageAccessModeAgentInject means workload pods do NOT mount the checkpoint
 	// PVC. The snapshot-agent mounts it (like agentMount) and, for restore, grafts
 	// the checkpoint dir into the target container's mount namespace via
 	// open_tree(OPEN_TREE_CLONE)+move_mount before nsrestore reads it.
-	StorageAccessModeAgentInject = "agentInject"
+	StorageAccessModeAgentInject = snapshotprotocol.StorageAccessModeAgentInject
 )
 
 func (c *AgentConfig) LoadEnvOverrides() {

--- a/deploy/snapshot/internal/types/config_test.go
+++ b/deploy/snapshot/internal/types/config_test.go
@@ -51,3 +51,15 @@ func TestAgentConfigValidateDefaultsStorageAccessMode(t *testing.T) {
 		t.Fatalf("Storage.AccessMode = %q, want %q", cfg.Storage.AccessMode, StorageAccessModeAgentMount)
 	}
 }
+
+func TestAgentConfigValidateAcceptsAgentInject(t *testing.T) {
+	cfg := validAgentConfig()
+	cfg.Storage.AccessMode = StorageAccessModeAgentInject
+
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if cfg.Storage.AccessMode != StorageAccessModeAgentInject {
+		t.Fatalf("Storage.AccessMode = %q, want %q", cfg.Storage.AccessMode, StorageAccessModeAgentInject)
+	}
+}

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -52,13 +52,13 @@ const (
 	// silently disagree.
 	CheckpointStorageAccessModeAnnotation = "nvidia.com/snapshot-storage-access-mode"
 	CheckpointVolumeName                  = "checkpoint-storage"
-	DefaultCheckpointArtifactVersion    = "1"
-	DefaultCheckpointJobTTLSeconds      = int32(300)
-	DefaultSeccompLocalhostProfile      = "profiles/block-iouring.json"
-	StorageTypePVC                      = "pvc"
-	// StorageAccessModeAgentInject mirrors types.StorageAccessModeAgentInject so
-	// the operator (which imports protocol, not internal/types) can recognize the
-	// mode. In this mode the workload pod does not mount the checkpoint PVC.
+	DefaultCheckpointArtifactVersion      = "1"
+	DefaultCheckpointJobTTLSeconds        = int32(300)
+	DefaultSeccompLocalhostProfile        = "profiles/block-iouring.json"
+	StorageTypePVC                        = "pvc"
+	StorageAccessModeAgentMount           = "agentMount"
+	StorageAccessModePodMount             = "podMount"
+	// In agentInject mode the workload pod does not mount the checkpoint PVC.
 	StorageAccessModeAgentInject = "agentInject"
 
 	CheckpointStatusCompleted = "completed"

--- a/deploy/snapshot/protocol/common.go
+++ b/deploy/snapshot/protocol/common.go
@@ -46,11 +46,20 @@ const (
 
 	CheckpointStorageTypeAnnotation     = "nvidia.com/snapshot-storage-type"
 	CheckpointStorageBasePathAnnotation = "nvidia.com/snapshot-storage-base-path"
-	CheckpointVolumeName                = "checkpoint-storage"
+	// CheckpointStorageAccessModeAnnotation carries the operator-resolved storage
+	// access mode to the agent. The operator is the sole writer; the agent treats
+	// this stamped value as authoritative over its own config so the two cannot
+	// silently disagree.
+	CheckpointStorageAccessModeAnnotation = "nvidia.com/snapshot-storage-access-mode"
+	CheckpointVolumeName                  = "checkpoint-storage"
 	DefaultCheckpointArtifactVersion    = "1"
 	DefaultCheckpointJobTTLSeconds      = int32(300)
 	DefaultSeccompLocalhostProfile      = "profiles/block-iouring.json"
 	StorageTypePVC                      = "pvc"
+	// StorageAccessModeAgentInject mirrors types.StorageAccessModeAgentInject so
+	// the operator (which imports protocol, not internal/types) can recognize the
+	// mode. In this mode the workload pod does not mount the checkpoint PVC.
+	StorageAccessModeAgentInject = "agentInject"
 
 	CheckpointStatusCompleted = "completed"
 	CheckpointStatusFailed    = "failed"
@@ -64,6 +73,10 @@ type Storage struct {
 	Location string
 	PVCName  string
 	BasePath string
+	// AccessMode mirrors the agent storage access mode (agentMount, podMount,
+	// agentInject). For agentInject the workload pod never mounts the PVC, so
+	// PVCName is empty and the agent grafts the checkpoint into the container.
+	AccessMode string
 }
 
 type RestoreStatusAnnotationKeys struct {
@@ -218,9 +231,13 @@ func ApplyCheckpointStorageMetadata(annotations map[string]string, storage Stora
 	}
 	delete(annotations, CheckpointStorageTypeAnnotation)
 	delete(annotations, CheckpointStorageBasePathAnnotation)
+	delete(annotations, CheckpointStorageAccessModeAnnotation)
 	storageType := strings.TrimSpace(storage.Type)
 	if storageType != "" {
 		annotations[CheckpointStorageTypeAnnotation] = storageType
+	}
+	if accessMode := strings.TrimSpace(storage.AccessMode); accessMode != "" {
+		annotations[CheckpointStorageAccessModeAnnotation] = accessMode
 	}
 	basePath := strings.TrimSpace(storage.BasePath)
 	if basePath != "" {
@@ -264,8 +281,9 @@ func resolveStorageConfig(storage Storage) (Storage, error) {
 		basePath = "/"
 	}
 	return Storage{
-		Type:     storageType,
-		PVCName:  strings.TrimSpace(storage.PVCName),
-		BasePath: basePath,
+		Type:       storageType,
+		PVCName:    strings.TrimSpace(storage.PVCName),
+		BasePath:   basePath,
+		AccessMode: strings.TrimSpace(storage.AccessMode),
 	}, nil
 }

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -91,7 +91,7 @@ func PrepareRestorePodSpec(
 		if container == nil {
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
-		if storage.BasePath != "" {
+		if storage.BasePath != "" && storage.AccessMode != StorageAccessModeAgentInject {
 			InjectCheckpointVolumeMount(container, storage.BasePath)
 		}
 		EnsureControlVolume(podSpec, container)
@@ -204,7 +204,7 @@ func ValidateRestorePodSpec(
 		if container == nil {
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
-		if storage.BasePath != "" {
+		if storage.BasePath != "" && storage.AccessMode != StorageAccessModeAgentInject {
 			hasMount := false
 			for _, mount := range container.VolumeMounts {
 				if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -91,7 +91,12 @@ func PrepareRestorePodSpec(
 		if container == nil {
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
-		if storage.BasePath != "" && storage.AccessMode != StorageAccessModeAgentInject {
+		if storage.AccessMode == StorageAccessModeAgentInject {
+			if err := validateAgentInjectTarget(container); err != nil {
+				return err
+			}
+		}
+		if storage.BasePath != "" && storage.PVCName != "" {
 			InjectCheckpointVolumeMount(container, storage.BasePath)
 		}
 		EnsureControlVolume(podSpec, container)
@@ -204,7 +209,12 @@ func ValidateRestorePodSpec(
 		if container == nil {
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
-		if storage.BasePath != "" && storage.AccessMode != StorageAccessModeAgentInject {
+		if storage.AccessMode == StorageAccessModeAgentInject {
+			if err := validateAgentInjectTarget(container); err != nil {
+				return err
+			}
+		}
+		if storage.BasePath != "" && storage.PVCName != "" {
 			hasMount := false
 			for _, mount := range container.VolumeMounts {
 				if mount.Name == CheckpointVolumeName && mount.MountPath == storage.BasePath {
@@ -252,6 +262,24 @@ func ValidateRestorePodSpec(
 	profile := podSpec.SecurityContext.SeccompProfile
 	if profile.Type != corev1.SeccompProfileTypeLocalhost || profile.LocalhostProfile == nil || *profile.LocalhostProfile != seccompProfile {
 		return fmt.Errorf("expected localhost seccomp profile %q", seccompProfile)
+	}
+	return nil
+}
+
+func validateAgentInjectTarget(container *corev1.Container) error {
+	securityContext := container.SecurityContext
+	if securityContext == nil {
+		return nil
+	}
+	if securityContext.Privileged != nil && *securityContext.Privileged {
+		return fmt.Errorf("agentInject restore target container %q must not be privileged", container.Name)
+	}
+	if securityContext.Capabilities != nil {
+		for _, capability := range securityContext.Capabilities.Add {
+			if strings.EqualFold(string(capability), "SYS_ADMIN") {
+				return fmt.Errorf("agentInject restore target container %q must not add CAP_SYS_ADMIN", container.Name)
+			}
+		}
 	}
 	return nil
 }

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -255,6 +255,40 @@ func TestNewRestorePodRejectsUnknownContainer(t *testing.T) {
 	}
 }
 
+func TestPrepareRestorePodSpecAgentInjectSkipsPVC(t *testing.T) {
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{Name: "main"}},
+	}
+	// agentInject resolves with an empty PVCName: the workload pod must NOT mount
+	// the checkpoint PVC; the agent grafts the checkpoint in at restore time.
+	storage := Storage{
+		Type:       StorageTypePVC,
+		PVCName:    "",
+		BasePath:   "/checkpoints",
+		AccessMode: StorageAccessModeAgentInject,
+	}
+	annotations := map[string]string{TargetContainersAnnotation: "main"}
+	if err := PrepareRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile, true); err != nil {
+		t.Fatalf("PrepareRestorePodSpec error: %v", err)
+	}
+
+	for _, v := range podSpec.Volumes {
+		if v.Name == CheckpointVolumeName {
+			t.Fatalf("agentInject must not inject the %s PVC volume: %#v", CheckpointVolumeName, podSpec.Volumes)
+		}
+	}
+	for _, m := range podSpec.Containers[0].VolumeMounts {
+		if m.Name == CheckpointVolumeName {
+			t.Fatalf("agentInject must not inject the %s volume mount: %#v", CheckpointVolumeName, podSpec.Containers[0].VolumeMounts)
+		}
+	}
+	// The control volume/probe are still required and present, so validation passes
+	// even though the PVC is absent.
+	if err := ValidateRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
+		t.Fatalf("ValidateRestorePodSpec rejected an agentInject pod: %v", err)
+	}
+}
+
 func TestPrepareRestorePodSpec(t *testing.T) {
 	podSpec := corev1.PodSpec{}
 	readinessProbe := &corev1.Probe{PeriodSeconds: 13, SuccessThreshold: 1}

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -11,6 +11,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestNewRestorePod(t *testing.T) {
@@ -255,37 +256,80 @@ func TestNewRestorePodRejectsUnknownContainer(t *testing.T) {
 	}
 }
 
-func TestPrepareRestorePodSpecAgentInjectSkipsPVC(t *testing.T) {
+func TestPrepareRestorePodSpecSkipsMountWithoutPVC(t *testing.T) {
+	t.Log("Configure resolved storage without a workload PVC")
 	podSpec := corev1.PodSpec{
 		Containers: []corev1.Container{{Name: "main"}},
 	}
-	// agentInject resolves with an empty PVCName: the workload pod must NOT mount
-	// the checkpoint PVC; the agent grafts the checkpoint in at restore time.
 	storage := Storage{
-		Type:       StorageTypePVC,
-		PVCName:    "",
-		BasePath:   "/checkpoints",
-		AccessMode: StorageAccessModeAgentInject,
+		Type:     StorageTypePVC,
+		PVCName:  "",
+		BasePath: "/checkpoints",
 	}
 	annotations := map[string]string{TargetContainersAnnotation: "main"}
 	if err := PrepareRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile, true); err != nil {
 		t.Fatalf("PrepareRestorePodSpec error: %v", err)
 	}
 
+	t.Log("Verify restore shaping does not create a dangling checkpoint mount")
 	for _, v := range podSpec.Volumes {
 		if v.Name == CheckpointVolumeName {
-			t.Fatalf("agentInject must not inject the %s PVC volume: %#v", CheckpointVolumeName, podSpec.Volumes)
+			t.Fatalf("storage without a PVC must not inject the %s volume: %#v", CheckpointVolumeName, podSpec.Volumes)
 		}
 	}
 	for _, m := range podSpec.Containers[0].VolumeMounts {
 		if m.Name == CheckpointVolumeName {
-			t.Fatalf("agentInject must not inject the %s volume mount: %#v", CheckpointVolumeName, podSpec.Containers[0].VolumeMounts)
+			t.Fatalf("storage without a PVC must not inject the %s volume mount: %#v", CheckpointVolumeName, podSpec.Containers[0].VolumeMounts)
 		}
 	}
-	// The control volume/probe are still required and present, so validation passes
-	// even though the PVC is absent.
+
+	t.Log("Verify the PVC-free restore pod still satisfies the protocol")
 	if err := ValidateRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
-		t.Fatalf("ValidateRestorePodSpec rejected an agentInject pod: %v", err)
+		t.Fatalf("ValidateRestorePodSpec rejected storage without a PVC: %v", err)
+	}
+}
+
+func TestPrepareRestorePodSpecAgentInjectRejectsMountAdminTargets(t *testing.T) {
+	tests := []struct {
+		name            string
+		securityContext *corev1.SecurityContext
+	}{
+		{
+			name: "privileged",
+			securityContext: &corev1.SecurityContext{
+				Privileged: ptr.To(true),
+			},
+		},
+		{
+			name: "CAP_SYS_ADMIN",
+			securityContext: &corev1.SecurityContext{
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"SYS_ADMIN"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podSpec := corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:            "main",
+					SecurityContext: tt.securityContext,
+				}},
+			}
+			storage := Storage{
+				Type:       StorageTypePVC,
+				BasePath:   "/checkpoints",
+				AccessMode: StorageAccessModeAgentInject,
+			}
+			annotations := map[string]string{TargetContainersAnnotation: "main"}
+
+			err := PrepareRestorePodSpec(&podSpec, annotations, storage, DefaultSeccompLocalhostProfile, true)
+			if err == nil {
+				t.Fatal("expected agentInject to reject a mount-admin-capable target")
+			}
+		})
 	}
 }
 

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -3282,6 +3282,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `type` _string_ | Type is the storage backend type. Only pvc is implemented today. |  |  |
+| `accessMode` _string_ | AccessMode selects how the snapshot-agent reaches storage and must match the<br />snapshot chart's storage.accessMode. "agentInject" tells the operator to<br />stamp checkpoint metadata but NOT mount the PVC into workload pods (the agent<br />grafts the checkpoint into the container instead); pvcName is then not<br />required. Empty/"agentMount"/"podMount" preserve the existing behavior. |  |  |
 | `pvc` _[CheckpointPVCConfig](#checkpointpvcconfig)_ | PVC configuration for pvc-based settings. |  |  |
 | `s3` _[CheckpointS3Config](#checkpoints3config)_ | Deprecated: S3 is retained for compatibility and ignored. |  |  |
 | `oci` _[CheckpointOCIConfig](#checkpointociconfig)_ | Deprecated: OCI is retained for compatibility and ignored. |  |  |


### PR DESCRIPTION
## POC — do not merge

Proof-of-concept for an **agent-only** checkpoint storage mode (`accessMode: agentInject`) where the
workload pod never mounts the checkpoint PVC. The node agent owns the PVC and grafts the checkpoint
into the restore container's mount namespace via `open_tree(OPEN_TREE_CLONE)` + `move_mount`, so CRIU
can read it. Opened to exercise CI on the change; not intended to merge as-is.

### What it does
- New opt-in `accessMode: agentInject` (agent config + operator config + Helm).
- Operator skips injecting the checkpoint PVC into capture/restore pods (leaves `PVCName` empty) and
  stamps the resolved access mode; the agent treats the stamped value as authoritative.
- `nsrestore` gains `--checkpoint-fd`: the agent clones its own checkpoint dir into a detached mount
  (`open_tree`), passes the fd via `exec.Cmd.ExtraFiles`, and `nsrestore` grafts it with `move_mount`
  inside the container before CRIU restore.
- Capture is unchanged from `agentMount` (agent writes via its own mount).

### Validation done outside CI
- Cross-namespace mechanism proven on a live kernel: plain `/proc/self/fd` bind is `EINVAL`
  cross-ns; `open_tree` + `move_mount` works.
- Full real-CRIU run: checkpoint a live process, graft via `open_tree`+`move_mount`, `criu restore`
  from the grafted mount, process resumes.
- Both Go modules build; operator unit tests pass.

### Not covered here
- Full GPU/k8s e2e (agent ↔ PodSnapshotContent, CUDA-checkpoint) runs on the cluster, not in this PR.

See `plans/snapshot-migration/agent-inject-cross-ns-explainer.md` for the kernel-level writeup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agentInject` checkpoint storage mode for PVC-backed snapshots.
  * Restore operations can now access checkpoint data without mounting the PVC into workload containers.
  * Added support for restoring checkpoints through inherited file descriptors.

* **Bug Fixes**
  * PVC names are no longer required when using `agentInject`.
  * Updated storage validation and workload preparation to handle the new mode correctly.

* **Documentation**
  * Added configuration guidance for `agentInject` behavior and setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->