### PR TITLE
fix(operator): support vLLM multinode with GPU DRA

### DIFF
--- a/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
+++ b/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
@@ -335,6 +335,7 @@ rules:
   - resource.k8s.io
   resources:
   - deviceclasses
+  - resourceclaims
   verbs:
   - get
   - list

--- a/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
+++ b/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
@@ -317,6 +317,7 @@ rules:
   - resource.k8s.io
   resources:
   - deviceclasses
+  - resourceclaims
   verbs:
   - get
   - list

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -335,6 +335,7 @@ rules:
   - resource.k8s.io
   resources:
   - deviceclasses
+  - resourceclaims
   verbs:
   - get
   - list

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -317,6 +317,7 @@ rules:
   - resource.k8s.io
   resources:
   - deviceclasses
+  - resourceclaims
   verbs:
   - get
   - list

--- a/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
+++ b/deploy/operator/internal/controller/dgd_checkpoints_reconciler.go
@@ -556,8 +556,9 @@ func (r *dgdCheckpointsReconciler) buildCheckpointJobPodTemplate(
 		r.config,
 		consts.MultinodeDeploymentTypeGrove, // Use Grove (single-node backends return early)
 		componentName,
-		nil, // No checkpoint info for checkpoint creation jobs
-		nil, // Use default deployer
+		nil,                                     // No checkpoint info for checkpoint creation jobs
+		nil,                                     // Use default deployer
+		func() (int64, error) { return 0, nil }, // Checkpoint jobs are single-node
 	)
 	if err != nil {
 		return corev1.PodTemplateSpec{}, fmt.Errorf("failed to generate base pod spec: %w", err)

--- a/deploy/operator/internal/controller/dra_claim_dependencies.go
+++ b/deploy/operator/internal/controller/dra_claim_dependencies.go
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	resourcev1 "k8s.io/api/resource/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims,verbs=get;list;watch
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=get;list;watch
+
+func deploymentEventFilter(
+	config *configv1alpha1.OperatorConfiguration,
+	runtimeConfig *commonController.RuntimeConfig,
+) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		if _, ok := obj.(*resourcev1.DeviceClass); ok {
+			return true
+		}
+		return commonController.NamespaceAllowed(config, runtimeConfig, obj, obj.GetNamespace())
+	})
+}
+
+func componentReferencesDRAClaim(
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	objectName string,
+	template bool,
+) bool {
+	if component == nil || !component.IsMultinode() || component.PodTemplate == nil {
+		return false
+	}
+	mainContainer := dynamo.GetMainContainer(component)
+	if mainContainer == nil || len(mainContainer.Resources.Claims) == 0 {
+		return false
+	}
+
+	containerClaimNames := make(map[string]struct{}, len(mainContainer.Resources.Claims))
+	for _, claim := range mainContainer.Resources.Claims {
+		containerClaimNames[claim.Name] = struct{}{}
+	}
+
+	for _, podClaim := range component.PodTemplate.Spec.ResourceClaims {
+		if _, ok := containerClaimNames[podClaim.Name]; !ok {
+			continue
+		}
+		if template && podClaim.ResourceClaimTemplateName != nil && *podClaim.ResourceClaimTemplateName == objectName {
+			return true
+		}
+		if !template && podClaim.ResourceClaimName != nil && *podClaim.ResourceClaimName == objectName {
+			return true
+		}
+	}
+	return false
+}
+
+func componentUsesDRAClaims(component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) bool {
+	return component != nil && component.IsMultinode() && len(dynamo.GetMainContainerResources(component).Claims) > 0
+}
+
+func (r *DynamoComponentDeploymentReconciler) mapResourceClaimToDCDRequests(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	return r.mapDRAClaimToDCDRequests(ctx, obj, false)
+}
+
+func (r *DynamoComponentDeploymentReconciler) mapResourceClaimTemplateToDCDRequests(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	return r.mapDRAClaimToDCDRequests(ctx, obj, true)
+}
+
+func (r *DynamoComponentDeploymentReconciler) mapDRAClaimToDCDRequests(
+	ctx context.Context,
+	obj client.Object,
+	template bool,
+) []ctrl.Request {
+	deployments := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	if err := r.List(ctx, deployments, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list DynamoComponentDeployments for DRA claim event")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0)
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		if componentReferencesDRAClaim(&deployment.Spec.DynamoComponentDeploymentSharedSpec, obj.GetName(), template) {
+			requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{
+				Namespace: deployment.Namespace,
+				Name:      deployment.Name,
+			}})
+		}
+	}
+	return requests
+}
+
+func (r *DynamoComponentDeploymentReconciler) mapDeviceClassToDCDRequests(
+	ctx context.Context,
+	_ client.Object,
+) []ctrl.Request {
+	deployments := &nvidiacomv1beta1.DynamoComponentDeploymentList{}
+	if err := r.List(ctx, deployments); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list DynamoComponentDeployments for DeviceClass event")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0)
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		if commonController.NamespaceAllowed(r.Config, r.RuntimeConfig, deployment, deployment.Namespace) &&
+			componentUsesDRAClaims(&deployment.Spec.DynamoComponentDeploymentSharedSpec) {
+			requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{
+				Namespace: deployment.Namespace,
+				Name:      deployment.Name,
+			}})
+		}
+	}
+	return requests
+}
+
+func (r *DynamoGraphDeploymentReconciler) mapResourceClaimToDGDRequests(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	return r.mapDRAClaimToDGDRequests(ctx, obj, false)
+}
+
+func (r *DynamoGraphDeploymentReconciler) mapResourceClaimTemplateToDGDRequests(
+	ctx context.Context,
+	obj client.Object,
+) []ctrl.Request {
+	return r.mapDRAClaimToDGDRequests(ctx, obj, true)
+}
+
+func (r *DynamoGraphDeploymentReconciler) mapDRAClaimToDGDRequests(
+	ctx context.Context,
+	obj client.Object,
+	template bool,
+) []ctrl.Request {
+	deployments := &nvidiacomv1beta1.DynamoGraphDeploymentList{}
+	if err := r.List(ctx, deployments, client.InNamespace(obj.GetNamespace())); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list DynamoGraphDeployments for DRA claim event")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0)
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		if !r.isGrovePathway(deployment) {
+			continue
+		}
+		for componentIndex := range deployment.Spec.Components {
+			if componentReferencesDRAClaim(&deployment.Spec.Components[componentIndex], obj.GetName(), template) {
+				requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{
+					Namespace: deployment.Namespace,
+					Name:      deployment.Name,
+				}})
+				break
+			}
+		}
+	}
+	return requests
+}
+
+func (r *DynamoGraphDeploymentReconciler) mapDeviceClassToDGDRequests(
+	ctx context.Context,
+	_ client.Object,
+) []ctrl.Request {
+	deployments := &nvidiacomv1beta1.DynamoGraphDeploymentList{}
+	if err := r.List(ctx, deployments); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to list DynamoGraphDeployments for DeviceClass event")
+		return nil
+	}
+
+	requests := make([]ctrl.Request, 0)
+	for i := range deployments.Items {
+		deployment := &deployments.Items[i]
+		if !commonController.NamespaceAllowed(r.Config, r.RuntimeConfig, deployment, deployment.Namespace) ||
+			!r.isGrovePathway(deployment) {
+			continue
+		}
+		for componentIndex := range deployment.Spec.Components {
+			if componentUsesDRAClaims(&deployment.Spec.Components[componentIndex]) {
+				requests = append(requests, ctrl.Request{NamespacedName: types.NamespacedName{
+					Namespace: deployment.Namespace,
+					Name:      deployment.Name,
+				}})
+				break
+			}
+		}
+	}
+	return requests
+}

--- a/deploy/operator/internal/controller/dra_claim_dependencies_test.go
+++ b/deploy/operator/internal/controller/dra_claim_dependencies_test.go
@@ -1,0 +1,208 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func testDRAClaimComponent(objectName string, template bool) nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec {
+	podClaim := corev1.PodResourceClaim{Name: "accelerators"}
+	if template {
+		podClaim.ResourceClaimTemplateName = ptr.To(objectName)
+	} else {
+		podClaim.ResourceClaimName = ptr.To(objectName)
+	}
+
+	return nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+		ComponentName: "worker",
+		Multinode:     &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2},
+		PodTemplate: &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				ResourceClaims: []corev1.PodResourceClaim{podClaim},
+				Containers: []corev1.Container{{
+					Name: commonconsts.MainContainerName,
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "accelerators"}},
+					},
+				}},
+			},
+		},
+	}
+}
+
+func TestMapResourceClaimToDCDRequests(t *testing.T) {
+	t.Log("Create one matching and one unrelated component deployment")
+	matching := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: "default"},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: testDRAClaimComponent("gpu-claim", false),
+		},
+	}
+	unrelated := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "default"},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: testDRAClaimComponent("gpu-claim", false),
+		},
+	}
+	unrelated.Spec.Multinode = nil
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, unrelated).Build(),
+	}
+
+	t.Log("Map a ResourceClaim event to its dependent component deployment")
+	requests := reconciler.mapResourceClaimToDCDRequests(context.Background(), &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim", Namespace: "default"},
+	})
+
+	assert.Equal(t, []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: "default", Name: "matching"}}}, requests)
+}
+
+func TestMapResourceClaimTemplateToDGDRequests(t *testing.T) {
+	t.Log("Create one matching and one unrelated graph deployment")
+	matching := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "matching", Namespace: "default"},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "frontend"},
+				testDRAClaimComponent("gpu-template", true),
+			},
+		},
+	}
+	unrelated := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "default"},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				testDRAClaimComponent("gpu-template", true),
+			},
+		},
+	}
+	unrelated.Spec.Components[0].Multinode = nil
+	lws := matching.DeepCopy()
+	lws.Name = "lws"
+	lws.Annotations = map[string]string{commonconsts.KubeAnnotationEnableGrove: commonconsts.KubeLabelValueFalse}
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme).WithObjects(matching, unrelated, lws).Build(),
+		RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: true}},
+	}
+
+	t.Log("Map a ResourceClaimTemplate event to its dependent graph deployment")
+	requests := reconciler.mapResourceClaimTemplateToDGDRequests(context.Background(), &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu-template", Namespace: "default"},
+	})
+
+	assert.Equal(t, []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: "default", Name: "matching"}}}, requests)
+}
+
+func TestMapDeviceClassToDCDRequests(t *testing.T) {
+	t.Log("Create DRA-backed component deployments inside and outside the restricted namespace")
+	draBacked := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dra-backed", Namespace: "dra-workloads"},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: testDRAClaimComponent("gpu-template", true),
+		},
+	}
+	draBackedOutsideScope := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "outside-scope", Namespace: "other-workloads"},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: testDRAClaimComponent("gpu-template", true),
+		},
+	}
+	scalarGPU := &nvidiacomv1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "scalar-gpu", Namespace: "dra-workloads"},
+		Spec: nvidiacomv1beta1.DynamoComponentDeploymentSpec{
+			DynamoComponentDeploymentSharedSpec: nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "worker",
+			},
+		},
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme).WithObjects(draBacked, draBackedOutsideScope, scalarGPU).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{Namespace: configv1alpha1.NamespaceConfiguration{Restricted: "dra-workloads"}},
+		RuntimeConfig: &commonController.RuntimeConfig{},
+	}
+
+	t.Log("Map a cluster-scoped DeviceClass event to every DRA-backed component deployment")
+	requests := reconciler.mapDeviceClassToDCDRequests(context.Background(), &resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"},
+	})
+
+	assert.Equal(t, []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: "dra-workloads", Name: "dra-backed"}}}, requests)
+}
+
+func TestMapDeviceClassToDGDRequests(t *testing.T) {
+	t.Log("Create DRA-backed graph deployments inside and outside the restricted namespace")
+	draBacked := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dra-backed", Namespace: "dra-workloads"},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{
+				{ComponentName: "frontend"},
+				testDRAClaimComponent("gpu-template", true),
+			},
+		},
+	}
+	draBackedOutsideScope := draBacked.DeepCopy()
+	draBackedOutsideScope.Name = "outside-scope"
+	draBackedOutsideScope.Namespace = "other-workloads"
+	unrelated := &nvidiacomv1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "unrelated", Namespace: "dra-workloads"},
+		Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+			Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{{ComponentName: "frontend"}},
+		},
+	}
+	scheme := runtime.NewScheme()
+	require.NoError(t, nvidiacomv1beta1.AddToScheme(scheme))
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:        fake.NewClientBuilder().WithScheme(scheme).WithObjects(draBacked, draBackedOutsideScope, unrelated).Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{Namespace: configv1alpha1.NamespaceConfiguration{Restricted: "dra-workloads"}},
+		RuntimeConfig: &commonController.RuntimeConfig{Gate: features.Gates{Grove: true}},
+	}
+
+	t.Log("Map a cluster-scoped DeviceClass event to every DRA-backed graph deployment")
+	requests := reconciler.mapDeviceClassToDGDRequests(context.Background(), &resourcev1.DeviceClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"},
+	})
+
+	assert.Equal(t, []ctrl.Request{{NamespacedName: types.NamespacedName{Namespace: "dra-workloads", Name: "dra-backed"}}}, requests)
+}
+
+func TestDeploymentEventFilterAllowsClusterScopedDeviceClasses(t *testing.T) {
+	filter := deploymentEventFilter(
+		&configv1alpha1.OperatorConfiguration{Namespace: configv1alpha1.NamespaceConfiguration{Restricted: "dra-workloads"}},
+		&commonController.RuntimeConfig{},
+	)
+
+	t.Log("Allow cluster-scoped DeviceClass events so their mapper can select in-scope deployments")
+	assert.True(t, filter.Create(event.CreateEvent{Object: &resourcev1.DeviceClass{}}))
+
+	t.Log("Continue filtering namespaced dependency events at their source")
+	assert.True(t, filter.Create(event.CreateEvent{Object: &resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Namespace: "dra-workloads"}}}))
+	assert.False(t, filter.Create(event.CreateEvent{Object: &resourcev1.ResourceClaim{ObjectMeta: metav1.ObjectMeta{Namespace: "other-workloads"}}}))
+}

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -30,6 +30,7 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"emperror.dev/errors"
@@ -53,6 +54,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -814,8 +816,10 @@ func (r *DynamoComponentDeploymentReconciler) generateDeployment(ctx context.Con
 		},
 	}
 
+	renderer := r.workloadRenderer()
+	containerGPUs := renderer.containerGPUCount(ctx, opt.dynamoComponentDeployment)
 	// nolint: gosimple
-	podTemplateSpec, err := r.workloadRenderer().generatePodTemplateSpec(ctx, opt.dynamoComponentDeployment, dynamo.RoleMain)
+	podTemplateSpec, err := renderer.generatePodTemplateSpec(ctx, opt.dynamoComponentDeployment, dynamo.RoleMain, containerGPUs)
 	if err != nil {
 		return
 	}
@@ -908,7 +912,23 @@ func (r *DynamoComponentDeploymentReconciler) SetupWithManager(mgr ctrl.Manager)
 		})).
 		Owns(&corev1.Service{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Owns(&networkingv1.Ingress{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		WithEventFilter(commonController.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig))
+		WithEventFilter(deploymentEventFilter(r.Config, r.RuntimeConfig))
+
+	if r.RuntimeConfig.Gate.Enabled(features.DRA) {
+		m = m.Watches(
+			&resourcev1.ResourceClaim{},
+			handler.EnqueueRequestsFromMapFunc(r.mapResourceClaimToDCDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).Watches(
+			&resourcev1.ResourceClaimTemplate{},
+			handler.EnqueueRequestsFromMapFunc(r.mapResourceClaimTemplateToDCDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).Watches(
+			&resourcev1.DeviceClass{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDeviceClassToDCDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	}
 
 	if r.RuntimeConfig.Gate.Enabled(features.LWS) {
 		m.Owns(&leaderworkersetv1.LeaderWorkerSet{}, builder.WithPredicates(predicate.Funcs{

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/common"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
@@ -99,6 +100,7 @@ type DynamoComponentDeploymentReconciler struct {
 
 // +kubebuilder:rbac:groups=scheduling.volcano.sh,resources=podgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceclaims;resourceclaimtemplates,verbs=get;list;watch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -928,14 +930,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 	podAnnotations := dynamo.GetDCDKubeAnnotations(dcd)
 	kubeName := dcd.Name
 
-	// Convert user-provided metrics annotation into controller-managed label
-	// By default (no annotation), metrics are enabled
-	if podAnnotations[commonconsts.KubeAnnotationEnableMetrics] == commonconsts.KubeLabelValueFalse {
-		// Explicitly disabled, don't add the label
-	} else {
-		// Any other value (including empty) enables metrics
-		podLabels[commonconsts.KubeLabelMetricsEnabled] = commonconsts.KubeLabelValueTrue
-	}
+	applyMetricsLabel(podLabels, podAnnotations)
 
 	if parentName := dcd.GetLabels()[commonconsts.KubeLabelDynamoGraphDeploymentName]; parentName != "" {
 		podLabels[commonconsts.KubeLabelDynamoGraphDeploymentName] = parentName
@@ -974,6 +969,11 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		}
 	}
 
+	gpusPerNode, err := r.resolveGPUsPerNode(ctx, dcd, component)
+	if err != nil {
+		return nil, err
+	}
+
 	podSpec, err := dynamo.GenerateBasePodSpecForController(
 		dcd,
 		r.DockerSecretRetriever,
@@ -983,6 +983,7 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		checkpointInfo,
 		dynamo.GenerateBasePodSpecForControllerOptions{
 			WorkloadComponentType: nvidiacomv1beta1.ComponentType(componentType),
+			GPUsPerNode:           gpusPerNode,
 		},
 	)
 	if err != nil {
@@ -1056,6 +1057,43 @@ func (r *DynamoComponentDeploymentReconciler) generatePodTemplateSpec(ctx contex
 		},
 		Spec: *podSpec,
 	}, nil
+}
+
+func applyMetricsLabel(podLabels, podAnnotations map[string]string) {
+	// Metrics are enabled unless the pod annotation explicitly disables them.
+	if podAnnotations[commonconsts.KubeAnnotationEnableMetrics] != commonconsts.KubeLabelValueFalse {
+		podLabels[commonconsts.KubeLabelMetricsEnabled] = commonconsts.KubeLabelValueTrue
+	}
+}
+
+func (r *DynamoComponentDeploymentReconciler) resolveGPUsPerNode(
+	ctx context.Context,
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+	component *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+) (int64, error) {
+	backendFramework, err := dynamo.GetBackendFrameworkFromDynamoComponent(dcd)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to determine backend framework")
+	}
+	if backendFramework != dynamo.BackendFrameworkVLLM || component.GetNumberOfNodes() <= 1 {
+		return 0, nil
+	}
+
+	claimPodSpec := &corev1.PodSpec{}
+	if component.PodTemplate != nil {
+		claimPodSpec = &component.PodTemplate.Spec
+	}
+	gpuCount, err := dra.ResolveGPUCount(
+		ctx,
+		r.Client,
+		dcd.Namespace,
+		claimPodSpec,
+		dynamo.GetMainContainerResources(component),
+	)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to resolve GPUs per node")
+	}
+	return int64(gpuCount), nil
 }
 
 func (r *DynamoComponentDeploymentReconciler) generateService(ctx context.Context, opt generateResourceOption) (*corev1.Service, bool, error) {

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -61,8 +61,8 @@ import (
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
 
-func staticContainerGPUCount(count int64) dynamo.ContainerGPUCount {
-	return func() (int64, error) { return count, nil }
+func noContainerGPUs() dynamo.ContainerGPUCount {
+	return func() (int64, error) { return 0, nil }
 }
 
 const (
@@ -891,7 +891,7 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 		context.Background(),
 		dcd,
 		dynamo.RoleMain,
-		staticContainerGPUCount(0),
+		noContainerGPUs(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, commonconsts.ComponentTypeWorker, podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType])
@@ -1067,7 +1067,7 @@ func TestDynamoComponentDeploymentReconciler_BetaPrefillWorkloadComponentType(t 
 		context.Background(),
 		dcd,
 		dynamo.RoleMain,
-		staticContainerGPUCount(0),
+		noContainerGPUs(),
 	)
 	require.NoError(t, err)
 	require.Equal(t, commonconsts.ComponentTypePrefill, podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType])
@@ -1883,7 +1883,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -1944,7 +1944,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2024,7 +2024,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "gpuMemoryService restore requires resolved checkpoint")
@@ -2067,7 +2067,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2113,7 +2113,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2175,7 +2175,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2219,7 +2219,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
-			staticContainerGPUCount(0),
+			noContainerGPUs(),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -3594,7 +3594,7 @@ func TestGenerateWorkerPodTemplateSpecDoesNotRequireGPUResource(t *testing.T) {
 		context.Background(),
 		dcd,
 		map[string]string{"app": "demo"},
-		staticContainerGPUCount(0),
+		noContainerGPUs(),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, got)

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -38,12 +38,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	istioNetworking "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -58,6 +60,10 @@ import (
 	leaderworkersetv1 "sigs.k8s.io/lws/api/leaderworkerset/v1"
 	volcanov1beta1 "volcano.sh/apis/pkg/apis/scheduling/v1beta1"
 )
+
+func staticContainerGPUCount(count int64) dynamo.ContainerGPUCount {
+	return func() (int64, error) { return count, nil }
+}
 
 const (
 	testDottedDCDName     = "service.1"
@@ -885,6 +891,7 @@ func TestDynamoComponentDeploymentReconciler_LegacyAlphaWorkloadComponentType(t 
 		context.Background(),
 		dcd,
 		dynamo.RoleMain,
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 	require.Equal(t, commonconsts.ComponentTypeWorker, podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType])
@@ -1060,6 +1067,7 @@ func TestDynamoComponentDeploymentReconciler_BetaPrefillWorkloadComponentType(t 
 		context.Background(),
 		dcd,
 		dynamo.RoleMain,
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 	require.Equal(t, commonconsts.ComponentTypePrefill, podTemplate.Labels[commonconsts.KubeLabelDynamoComponentType])
@@ -1875,6 +1883,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -1935,6 +1944,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2014,6 +2024,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "gpuMemoryService restore requires resolved checkpoint")
@@ -2056,6 +2067,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2101,6 +2113,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2162,6 +2175,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -2205,6 +2219,7 @@ func TestDynamoComponentDeploymentReconciler_generatePodTemplateSpec_RestoreLabe
 			context.Background(),
 			dcd,
 			dynamo.RoleMain,
+			staticContainerGPUCount(0),
 		)
 		if err != nil {
 			t.Fatalf("generatePodTemplateSpec failed: %v", err)
@@ -3579,9 +3594,117 @@ func TestGenerateWorkerPodTemplateSpecDoesNotRequireGPUResource(t *testing.T) {
 		context.Background(),
 		dcd,
 		map[string]string{"app": "demo"},
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, "worker", got.Labels["role"])
 	require.Equal(t, commonconsts.MainContainerName, got.Spec.Containers[0].Name)
+}
+
+type draReadCounter struct {
+	client.Reader
+	claimTemplateGets int
+	deviceClassGets   int
+}
+
+func (r *draReadCounter) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	switch obj.(type) {
+	case *resourcev1.ResourceClaimTemplate:
+		r.claimTemplateGets++
+	case *resourcev1.DeviceClass:
+		r.deviceClassGets++
+	}
+	return r.Reader.Get(ctx, key, obj, opts...)
+}
+
+func TestRenderMultinodePodTemplateSpecs_VLLMMultinodeDRA(t *testing.T) {
+	t.Log("Create a one-GPU ResourceClaimTemplate")
+	s := scheme.Scheme
+	require.NoError(t, resourcev1.AddToScheme(s))
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-gpu", Namespace: "default"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					}},
+				},
+			},
+		},
+	}
+	deviceClass := &resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "gpu.nvidia.com"}}
+
+	t.Log("Create an LWS-backed two-node TP=2 vLLM component using only DRA")
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dra-test-agg", Namespace: "default"},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "agg",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+						},
+					},
+					Spec: corev1.PodSpec{
+						ResourceClaims: []corev1.PodResourceClaim{{
+							Name:                      "gpu",
+							ResourceClaimTemplateName: ptr.To("one-gpu"),
+						}},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "vllm-test",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm", "--tensor-parallel-size", "2"},
+							Resources: corev1.ResourceRequirements{
+								Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dcd, claimTemplate, deviceClass).
+			Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return nil, nil
+			},
+		},
+	}
+	t.Log("Resolve DRA once and render both LWS roles")
+	reader := &draReadCounter{Reader: reconciler.Client}
+	renderer := reconciler.workloadRenderer()
+	renderer.reader = reader
+	leaderTemplate, workerTemplate, err := renderer.renderMultinodePodTemplateSpecs(t.Context(), dcd)
+	require.NoError(t, err)
+	assert.Equal(t, 1, reader.claimTemplateGets)
+	assert.Equal(t, 1, reader.deviceClassGets)
+
+	t.Log("Verify role-specific MP launch flags and preserved DRA claims")
+	leader := leaderTemplate.Spec.Containers[0]
+	worker := workerTemplate.Spec.Containers[0]
+	assert.Contains(t, leader.Args, "--nnodes")
+	assert.Contains(t, leader.Args, "--node-rank")
+	assert.Contains(t, leader.Args, "0")
+	assert.Contains(t, worker.Args, "--headless")
+	assert.Contains(t, worker.Args, "$(LWS_WORKER_INDEX)")
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, leader.Resources.Claims)
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, worker.Resources.Claims)
 }

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_controller_test.go
@@ -38,12 +38,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/format"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	istioNetworking "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -3477,4 +3479,93 @@ func TestGenerateWorkerPodTemplateSpecDoesNotRequireGPUResource(t *testing.T) {
 	require.NotNil(t, got)
 	require.Equal(t, "worker", got.Labels["role"])
 	require.Equal(t, commonconsts.MainContainerName, got.Spec.Containers[0].Name)
+}
+
+func TestGeneratePodTemplateSpec_VLLMMultinodeDRA(t *testing.T) {
+	t.Log("Create a one-GPU ResourceClaimTemplate")
+	s := scheme.Scheme
+	require.NoError(t, resourcev1.AddToScheme(s))
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-gpu", Namespace: "default"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	t.Log("Create an LWS-backed two-node TP=2 vLLM component using only DRA")
+	dcd := &v1beta1.DynamoComponentDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dra-test-agg", Namespace: "default"},
+		Spec: v1beta1.DynamoComponentDeploymentSpec{
+			BackendFramework: string(dynamo.BackendFrameworkVLLM),
+			DynamoComponentDeploymentSharedSpec: v1beta1.DynamoComponentDeploymentSharedSpec{
+				ComponentName: "agg",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+						},
+					},
+					Spec: corev1.PodSpec{
+						ResourceClaims: []corev1.PodResourceClaim{{
+							Name:                      "gpu",
+							ResourceClaimTemplateName: ptr.To("one-gpu"),
+						}},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "vllm-test",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm", "--tensor-parallel-size", "2"},
+							Resources: corev1.ResourceRequirements{
+								Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	reconciler := &DynamoComponentDeploymentReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(dcd, claimTemplate).
+			Build(),
+		Config:        &configv1alpha1.OperatorConfiguration{},
+		RuntimeConfig: &controller_common.RuntimeConfig{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return nil, nil
+			},
+		},
+	}
+	opt := generateResourceOption{dynamoComponentDeployment: dcd}
+
+	t.Log("Render both LWS roles")
+	leaderTemplate, err := reconciler.generatePodTemplateSpec(context.Background(), opt, dynamo.RoleLeader)
+	require.NoError(t, err)
+	workerTemplate, err := reconciler.generatePodTemplateSpec(context.Background(), opt, dynamo.RoleWorker)
+	require.NoError(t, err)
+
+	t.Log("Verify role-specific MP launch flags and preserved DRA claims")
+	leader := leaderTemplate.Spec.Containers[0]
+	worker := workerTemplate.Spec.Containers[0]
+	assert.Contains(t, leader.Args, "--nnodes")
+	assert.Contains(t, leader.Args, "--node-rank")
+	assert.Contains(t, leader.Args, "0")
+	assert.Contains(t, worker.Args, "--headless")
+	assert.Contains(t, worker.Args, "$(LWS_WORKER_INDEX)")
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, leader.Resources.Claims)
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, worker.Resources.Claims)
 }

--- a/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
+++ b/deploy/operator/internal/controller/dynamocomponentdeployment_renderer.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sync"
 
 	"emperror.dev/errors"
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
@@ -86,17 +87,18 @@ func (r *dcdWorkloadRenderer) renderMultinodePodTemplateSpecs(
 	if err != nil {
 		return nil, nil, err
 	}
+	containerGPUs := r.containerGPUCount(ctx, dcd)
 
 	leaderLabels := make(map[string]string, len(podLabels))
 	maps.Copy(leaderLabels, podLabels)
-	leaderPodTemplateSpec, err := r.generateLeaderPodTemplateSpec(ctx, dcd, leaderLabels)
+	leaderPodTemplateSpec, err := r.generateLeaderPodTemplateSpec(ctx, dcd, leaderLabels, containerGPUs)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	workerLabels := make(map[string]string, len(podLabels))
 	maps.Copy(workerLabels, podLabels)
-	workerPodTemplateSpec, err := r.generateWorkerPodTemplateSpec(ctx, dcd, workerLabels)
+	workerPodTemplateSpec, err := r.generateWorkerPodTemplateSpec(ctx, dcd, workerLabels, containerGPUs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -104,12 +106,22 @@ func (r *dcdWorkloadRenderer) renderMultinodePodTemplateSpecs(
 	return leaderPodTemplateSpec, workerPodTemplateSpec, nil
 }
 
+func (r *dcdWorkloadRenderer) containerGPUCount(
+	ctx context.Context,
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+) dynamo.ContainerGPUCount {
+	return sync.OnceValues(func() (int64, error) {
+		return dynamo.ResolveContainerGPUs(ctx, r.reader, dcd.Namespace, &dcd.Spec.DynamoComponentDeploymentSharedSpec)
+	})
+}
+
 func (r *dcdWorkloadRenderer) generateLeaderPodTemplateSpec(
 	ctx context.Context,
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 	labels map[string]string,
+	containerGPUs dynamo.ContainerGPUCount,
 ) (*corev1.PodTemplateSpec, error) {
-	leaderPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, dcd, dynamo.RoleLeader)
+	leaderPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, dcd, dynamo.RoleLeader, containerGPUs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate leader pod template")
 	}
@@ -129,8 +141,9 @@ func (r *dcdWorkloadRenderer) generateWorkerPodTemplateSpec(
 	ctx context.Context,
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 	labels map[string]string,
+	containerGPUs dynamo.ContainerGPUCount,
 ) (*corev1.PodTemplateSpec, error) {
-	workerPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, dcd, dynamo.RoleWorker)
+	workerPodTemplateSpec, err := r.generatePodTemplateSpec(ctx, dcd, dynamo.RoleWorker, containerGPUs)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to generate worker pod template")
 	}
@@ -150,6 +163,7 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 	ctx context.Context,
 	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
 	role dynamo.Role,
+	containerGPUs dynamo.ContainerGPUCount,
 ) (*corev1.PodTemplateSpec, error) {
 	component := &dcd.Spec.DynamoComponentDeploymentSharedSpec
 	componentType, err := r.getDCDWorkloadComponentType(ctx, dcd)
@@ -216,6 +230,7 @@ func (r *dcdWorkloadRenderer) generatePodTemplateSpec(
 		role,
 		commonconsts.MultinodeDeploymentTypeLWS,
 		checkpointInfo,
+		containerGPUs,
 		dynamo.GenerateBasePodSpecForControllerOptions{
 			WorkloadComponentType: nvidiacomv1beta1.ComponentType(componentType),
 		},

--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -27,6 +27,7 @@ import (
 
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/scale"
@@ -262,7 +263,22 @@ func (r *DynamoGraphDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) err
 			UpdateFunc:  func(de event.UpdateEvent) bool { return true },
 			GenericFunc: func(ge event.GenericEvent) bool { return true },
 		})).
-		WithEventFilter(commoncontroller.EphemeralDeploymentEventFilter(r.Config, r.RuntimeConfig))
+		WithEventFilter(deploymentEventFilter(r.Config, r.RuntimeConfig))
+	if r.RuntimeConfig.Gate.Enabled(features.DRA) {
+		ctrlBuilder = ctrlBuilder.Watches(
+			&resourcev1.ResourceClaim{},
+			handler.EnqueueRequestsFromMapFunc(r.mapResourceClaimToDGDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).Watches(
+			&resourcev1.ResourceClaimTemplate{},
+			handler.EnqueueRequestsFromMapFunc(r.mapResourceClaimTemplateToDGDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		).Watches(
+			&resourcev1.DeviceClass{},
+			handler.EnqueueRequestsFromMapFunc(r.mapDeviceClassToDGDRequests),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	}
 	if r.RuntimeConfig.Gate.Enabled(features.Istio) {
 		ctrlBuilder = ctrlBuilder.Owns(&networkingv1beta1.DestinationRule{}, builder.WithPredicates(predicate.Funcs{
 			CreateFunc:  func(ce event.CreateEvent) bool { return false },

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -8,6 +8,7 @@ package dra
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -31,6 +32,11 @@ const (
 	// source of truth for this string across the operator.
 	DefaultDeviceClassName = "gpu.nvidia.com"
 )
+
+// deviceDriverEqualityPattern extracts positive device.driver equality constraints
+// from CEL conjunctions. classifyDeviceClass deliberately ignores disjunctions,
+// where one matching branch does not classify every device selected by the class.
+var deviceDriverEqualityPattern = regexp.MustCompile(`(?:^|&&)\s*\(*\s*device\.driver\s*==\s*["']([^"']+)["']`)
 
 // ApplyClaim replaces the first container's scalar GPU resources with a shared
 // DRA ResourceClaim. Every container that references this claim name will share
@@ -102,6 +108,255 @@ func ExtractGPUCountFromResourceRequirements(resources corev1.ResourceRequiremen
 		return gpuCountFromQuantity(name, q)
 	}
 	return 0, nil
+}
+
+// ResolveGPUCount returns the number of GPUs requested by a container, including
+// devices requested through DRA ResourceClaims. Scalar resources take precedence
+// because operator-managed DRA paths intentionally retain them until rendering.
+func ResolveGPUCount(
+	ctx context.Context,
+	cl client.Reader,
+	namespace string,
+	podSpec *corev1.PodSpec,
+	resources corev1.ResourceRequirements,
+) (int, error) {
+	scalarCount, err := ExtractGPUCountFromResourceRequirements(resources)
+	if err != nil || scalarCount > 0 || len(resources.Claims) == 0 {
+		return scalarCount, err
+	}
+	if cl == nil {
+		return 0, fmt.Errorf("cannot resolve GPU ResourceClaims without a Kubernetes client")
+	}
+	if podSpec == nil {
+		return 0, fmt.Errorf("cannot resolve GPU ResourceClaims without a pod spec")
+	}
+
+	podClaims := make(map[string]corev1.PodResourceClaim, len(podSpec.ResourceClaims))
+	for _, claim := range podSpec.ResourceClaims {
+		podClaims[claim.Name] = claim
+	}
+
+	total := 0
+	seen := make(map[string]struct{}, len(resources.Claims))
+	deviceClasses := newDeviceClassResolver(cl)
+	for _, containerClaim := range resources.Claims {
+		key := containerClaim.Name + "\x00" + containerClaim.Request
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		podClaim, ok := podClaims[containerClaim.Name]
+		if !ok {
+			return 0, fmt.Errorf("container ResourceClaim %q has no matching pod resourceClaim", containerClaim.Name)
+		}
+		claimSpec, err := getClaimSpec(ctx, cl, namespace, podClaim)
+		if err != nil {
+			return 0, err
+		}
+		count, err := gpuCountFromClaimSpec(ctx, deviceClasses, claimSpec, containerClaim.Request)
+		if err != nil {
+			return 0, fmt.Errorf("cannot determine GPU count for ResourceClaim %q: %w", containerClaim.Name, err)
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func getClaimSpec(
+	ctx context.Context,
+	cl client.Reader,
+	namespace string,
+	podClaim corev1.PodResourceClaim,
+) (*resourcev1.ResourceClaimSpec, error) {
+	switch {
+	case podClaim.ResourceClaimTemplateName != nil && *podClaim.ResourceClaimTemplateName != "":
+		name := *podClaim.ResourceClaimTemplateName
+		template := &resourcev1.ResourceClaimTemplate{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, template); err != nil {
+			return nil, fmt.Errorf("failed to get ResourceClaimTemplate %s/%s: %w", namespace, name, err)
+		}
+		return &template.Spec.Spec, nil
+	case podClaim.ResourceClaimName != nil && *podClaim.ResourceClaimName != "":
+		name := *podClaim.ResourceClaimName
+		claim := &resourcev1.ResourceClaim{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, claim); err != nil {
+			return nil, fmt.Errorf("failed to get ResourceClaim %s/%s: %w", namespace, name, err)
+		}
+		return &claim.Spec, nil
+	default:
+		return nil, fmt.Errorf("pod resourceClaim %q does not reference a ResourceClaim or ResourceClaimTemplate", podClaim.Name)
+	}
+}
+
+func gpuCountFromClaimSpec(
+	ctx context.Context,
+	deviceClasses *deviceClassResolver,
+	spec *resourcev1.ResourceClaimSpec,
+	requestName string,
+) (int, error) {
+	total := 0
+	foundRequest := requestName == ""
+	for _, request := range spec.Devices.Requests {
+		if requestName != "" && request.Name != requestName {
+			continue
+		}
+		foundRequest = true
+
+		count, isGPU, err := gpuCountFromDeviceRequest(ctx, deviceClasses, request)
+		if err != nil {
+			return 0, err
+		}
+		if isGPU {
+			total += count
+		}
+	}
+	if !foundRequest {
+		return 0, fmt.Errorf("device request %q was not found", requestName)
+	}
+	return total, nil
+}
+
+func gpuCountFromDeviceRequest(
+	ctx context.Context,
+	deviceClasses *deviceClassResolver,
+	request resourcev1.DeviceRequest,
+) (int, bool, error) {
+	if request.Exactly != nil {
+		isGPU, err := deviceClasses.isGPU(ctx, request.Exactly.DeviceClassName)
+		if err != nil {
+			return 0, false, err
+		}
+		if !isGPU {
+			return 0, false, nil
+		}
+		count, err := exactDeviceCount(request.Exactly.AllocationMode, request.Exactly.Count)
+		return count, true, err
+	}
+	if len(request.FirstAvailable) == 0 {
+		return 0, false, fmt.Errorf("device request %q must set exactly or firstAvailable", request.Name)
+	}
+
+	var count int
+	var hasGPU, hasNonGPU bool
+	for _, subRequest := range request.FirstAvailable {
+		isGPU, err := deviceClasses.isGPU(ctx, subRequest.DeviceClassName)
+		if err != nil {
+			return 0, false, err
+		}
+		if !isGPU {
+			hasNonGPU = true
+			continue
+		}
+		candidateCount, err := exactDeviceCount(subRequest.AllocationMode, subRequest.Count)
+		if err != nil {
+			return 0, false, err
+		}
+		if hasGPU && candidateCount != count {
+			return 0, false, fmt.Errorf("GPU device request %q has firstAvailable alternatives with different counts", request.Name)
+		}
+		count = candidateCount
+		hasGPU = true
+	}
+	if hasGPU && hasNonGPU {
+		return 0, false, fmt.Errorf("device request %q mixes GPU and non-GPU firstAvailable alternatives", request.Name)
+	}
+	return count, hasGPU, nil
+}
+
+func exactDeviceCount(mode resourcev1.DeviceAllocationMode, count int64) (int, error) {
+	switch mode {
+	case "", resourcev1.DeviceAllocationModeExactCount:
+		if count == 0 {
+			return 1, nil
+		}
+		if count < 0 {
+			return 0, fmt.Errorf("GPU device count must be positive")
+		}
+		return int(count), nil
+	case resourcev1.DeviceAllocationModeAll:
+		return 0, fmt.Errorf("GPU allocationMode %q has no deterministic per-node device count", mode)
+	default:
+		return 0, fmt.Errorf("unsupported GPU allocationMode %q", mode)
+	}
+}
+
+func looksLikeGPUIdentifier(name string) bool {
+	normalized := strings.ToLower(name)
+	return normalized == "gpu" ||
+		strings.HasPrefix(normalized, "gpu.") ||
+		strings.HasPrefix(normalized, "gpu/") ||
+		strings.HasSuffix(normalized, "/gpu") ||
+		strings.Contains(normalized, "/gpu.") ||
+		strings.Contains(normalized, "/gpu-")
+}
+
+type deviceClassResolver struct {
+	reader client.Reader
+	cache  map[string]bool
+}
+
+func newDeviceClassResolver(reader client.Reader) *deviceClassResolver {
+	return &deviceClassResolver{
+		reader: reader,
+		cache:  map[string]bool{},
+	}
+}
+
+func (r *deviceClassResolver) isGPU(ctx context.Context, name string) (bool, error) {
+	if isGPU, ok := r.cache[name]; ok {
+		return isGPU, nil
+	}
+
+	deviceClass := &resourcev1.DeviceClass{}
+	if err := r.reader.Get(ctx, types.NamespacedName{Name: name}, deviceClass); err != nil {
+		return false, fmt.Errorf("failed to get DeviceClass %q: %w", name, err)
+	}
+
+	isGPU, known, err := classifyDeviceClass(deviceClass)
+	if err != nil {
+		return false, err
+	}
+	if !known {
+		return false, fmt.Errorf(
+			"cannot determine whether DeviceClass %q provides GPUs: set spec.extendedResourceName or constrain device.driver in a CEL selector",
+			name,
+		)
+	}
+	r.cache[name] = isGPU
+	return isGPU, nil
+}
+
+func classifyDeviceClass(deviceClass *resourcev1.DeviceClass) (bool, bool, error) {
+	if deviceClass.Spec.ExtendedResourceName != nil {
+		return isGPUResourceName(corev1.ResourceName(*deviceClass.Spec.ExtendedResourceName)), true, nil
+	}
+
+	var isGPU, hasDriver bool
+	for _, selector := range deviceClass.Spec.Selectors {
+		if selector.CEL == nil || strings.Contains(selector.CEL.Expression, "||") {
+			continue
+		}
+		matches := deviceDriverEqualityPattern.FindAllStringSubmatch(selector.CEL.Expression, -1)
+		for _, match := range matches {
+			candidateIsGPU := looksLikeGPUIdentifier(match[1])
+			if hasDriver && candidateIsGPU != isGPU {
+				return false, false, fmt.Errorf("DeviceClass %q constrains device.driver to both GPU and non-GPU drivers", deviceClass.Name)
+			}
+			isGPU = candidateIsGPU
+			hasDriver = true
+		}
+	}
+	if hasDriver {
+		return isGPU, true, nil
+	}
+	// Keep canonical GPU class names working only when the class has no selectors.
+	// A present but unsupported selector must remain unclassified instead of being
+	// overridden by a suggestive class name.
+	if len(deviceClass.Spec.Selectors) == 0 && looksLikeGPUIdentifier(deviceClass.Name) {
+		return true, true, nil
+	}
+	return false, false, nil
 }
 
 // RemoveGPUResources deletes all scalar GPU resource entries from a resource list.

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -223,7 +223,7 @@ func gpuCountFromDeviceRequest(
 	request resourcev1.DeviceRequest,
 ) (int, bool, error) {
 	if request.Exactly != nil {
-		isGPU, err := deviceClasses.isGPU(ctx, request.Exactly.DeviceClassName)
+		isGPU, err := deviceClasses.isGPU(ctx, request.Exactly.DeviceClassName, request.Exactly.Selectors)
 		if err != nil {
 			return 0, false, err
 		}
@@ -240,7 +240,7 @@ func gpuCountFromDeviceRequest(
 	var count int
 	var hasGPU, hasNonGPU bool
 	for _, subRequest := range request.FirstAvailable {
-		isGPU, err := deviceClasses.isGPU(ctx, subRequest.DeviceClassName)
+		isGPU, err := deviceClasses.isGPU(ctx, subRequest.DeviceClassName, subRequest.Selectors)
 		if err != nil {
 			return 0, false, err
 		}
@@ -293,47 +293,46 @@ func looksLikeGPUIdentifier(name string) bool {
 
 type deviceClassResolver struct {
 	reader client.Reader
-	cache  map[string]bool
+	cache  map[string]*resourcev1.DeviceClass
 }
 
 func newDeviceClassResolver(reader client.Reader) *deviceClassResolver {
 	return &deviceClassResolver{
 		reader: reader,
-		cache:  map[string]bool{},
+		cache:  map[string]*resourcev1.DeviceClass{},
 	}
 }
 
-func (r *deviceClassResolver) isGPU(ctx context.Context, name string) (bool, error) {
-	if isGPU, ok := r.cache[name]; ok {
-		return isGPU, nil
+func (r *deviceClassResolver) isGPU(ctx context.Context, name string, requestSelectors []resourcev1.DeviceSelector) (bool, error) {
+	deviceClass, ok := r.cache[name]
+	if !ok {
+		deviceClass = &resourcev1.DeviceClass{}
+		if err := r.reader.Get(ctx, types.NamespacedName{Name: name}, deviceClass); err != nil {
+			return false, fmt.Errorf("failed to get DeviceClass %q: %w", name, err)
+		}
+		r.cache[name] = deviceClass
 	}
 
-	deviceClass := &resourcev1.DeviceClass{}
-	if err := r.reader.Get(ctx, types.NamespacedName{Name: name}, deviceClass); err != nil {
-		return false, fmt.Errorf("failed to get DeviceClass %q: %w", name, err)
-	}
-
-	isGPU, known, err := classifyDeviceClass(deviceClass)
+	isGPU, known, err := classifyDeviceRequest(deviceClass, requestSelectors)
 	if err != nil {
 		return false, err
 	}
 	if !known {
 		return false, fmt.Errorf(
-			"cannot determine whether DeviceClass %q provides GPUs: set spec.extendedResourceName or constrain device.driver in a CEL selector",
+			"cannot determine whether DeviceClass %q provides GPUs: set spec.extendedResourceName or constrain device.driver in a DeviceClass or request CEL selector",
 			name,
 		)
 	}
-	r.cache[name] = isGPU
 	return isGPU, nil
 }
 
-func classifyDeviceClass(deviceClass *resourcev1.DeviceClass) (bool, bool, error) {
-	if deviceClass.Spec.ExtendedResourceName != nil {
-		return isGPUResourceName(corev1.ResourceName(*deviceClass.Spec.ExtendedResourceName)), true, nil
-	}
-
+func classifyDeviceRequest(deviceClass *resourcev1.DeviceClass, requestSelectors []resourcev1.DeviceSelector) (bool, bool, error) {
+	// Kubernetes requires both DeviceClass and request selectors to match.
+	selectors := make([]resourcev1.DeviceSelector, 0, len(deviceClass.Spec.Selectors)+len(requestSelectors))
+	selectors = append(selectors, deviceClass.Spec.Selectors...)
+	selectors = append(selectors, requestSelectors...)
 	var isGPU, hasDriver bool
-	for _, selector := range deviceClass.Spec.Selectors {
+	for _, selector := range selectors {
 		if selector.CEL == nil || strings.Contains(selector.CEL.Expression, "||") {
 			continue
 		}
@@ -341,7 +340,7 @@ func classifyDeviceClass(deviceClass *resourcev1.DeviceClass) (bool, bool, error
 		for _, match := range matches {
 			candidateIsGPU := looksLikeGPUIdentifier(match[1])
 			if hasDriver && candidateIsGPU != isGPU {
-				return false, false, fmt.Errorf("DeviceClass %q constrains device.driver to both GPU and non-GPU drivers", deviceClass.Name)
+				return false, false, fmt.Errorf("DeviceClass %q and its request selectors constrain device.driver to both GPU and non-GPU drivers", deviceClass.Name)
 			}
 			isGPU = candidateIsGPU
 			hasDriver = true
@@ -350,10 +349,13 @@ func classifyDeviceClass(deviceClass *resourcev1.DeviceClass) (bool, bool, error
 	if hasDriver {
 		return isGPU, true, nil
 	}
+	if deviceClass.Spec.ExtendedResourceName != nil {
+		return isGPUResourceName(corev1.ResourceName(*deviceClass.Spec.ExtendedResourceName)), true, nil
+	}
 	// Keep canonical GPU class names working only when the class has no selectors.
-	// A present but unsupported selector must remain unclassified instead of being
-	// overridden by a suggestive class name.
-	if len(deviceClass.Spec.Selectors) == 0 && looksLikeGPUIdentifier(deviceClass.Name) {
+	// A present but unsupported class or request selector must remain unclassified
+	// instead of being overridden by a suggestive class name.
+	if len(selectors) == 0 && looksLikeGPUIdentifier(deviceClass.Name) {
 		return true, true, nil
 	}
 	return false, false, nil

--- a/deploy/operator/internal/dra/dra.go
+++ b/deploy/operator/internal/dra/dra.go
@@ -104,6 +104,166 @@ func ExtractGPUCountFromResourceRequirements(resources corev1.ResourceRequiremen
 	return 0, nil
 }
 
+// ResolveGPUCount returns the number of GPUs requested by a container, including
+// devices requested through DRA ResourceClaims. Scalar resources take precedence
+// because operator-managed DRA paths intentionally retain them until rendering.
+func ResolveGPUCount(
+	ctx context.Context,
+	cl client.Reader,
+	namespace string,
+	podSpec *corev1.PodSpec,
+	resources corev1.ResourceRequirements,
+) (int, error) {
+	scalarCount, err := ExtractGPUCountFromResourceRequirements(resources)
+	if err != nil || scalarCount > 0 || len(resources.Claims) == 0 {
+		return scalarCount, err
+	}
+	if cl == nil {
+		return 0, fmt.Errorf("cannot resolve GPU ResourceClaims without a Kubernetes client")
+	}
+	if podSpec == nil {
+		return 0, fmt.Errorf("cannot resolve GPU ResourceClaims without a pod spec")
+	}
+
+	podClaims := make(map[string]corev1.PodResourceClaim, len(podSpec.ResourceClaims))
+	for _, claim := range podSpec.ResourceClaims {
+		podClaims[claim.Name] = claim
+	}
+
+	total := 0
+	seen := make(map[string]struct{}, len(resources.Claims))
+	for _, containerClaim := range resources.Claims {
+		key := containerClaim.Name + "\x00" + containerClaim.Request
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		podClaim, ok := podClaims[containerClaim.Name]
+		if !ok {
+			return 0, fmt.Errorf("container ResourceClaim %q has no matching pod resourceClaim", containerClaim.Name)
+		}
+		claimSpec, err := getClaimSpec(ctx, cl, namespace, podClaim)
+		if err != nil {
+			return 0, err
+		}
+		count, err := gpuCountFromClaimSpec(claimSpec, containerClaim.Request)
+		if err != nil {
+			return 0, fmt.Errorf("cannot determine GPU count for ResourceClaim %q: %w", containerClaim.Name, err)
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func getClaimSpec(
+	ctx context.Context,
+	cl client.Reader,
+	namespace string,
+	podClaim corev1.PodResourceClaim,
+) (*resourcev1.ResourceClaimSpec, error) {
+	switch {
+	case podClaim.ResourceClaimTemplateName != nil && *podClaim.ResourceClaimTemplateName != "":
+		name := *podClaim.ResourceClaimTemplateName
+		template := &resourcev1.ResourceClaimTemplate{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, template); err != nil {
+			return nil, fmt.Errorf("failed to get ResourceClaimTemplate %s/%s: %w", namespace, name, err)
+		}
+		return &template.Spec.Spec, nil
+	case podClaim.ResourceClaimName != nil && *podClaim.ResourceClaimName != "":
+		name := *podClaim.ResourceClaimName
+		claim := &resourcev1.ResourceClaim{}
+		if err := cl.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, claim); err != nil {
+			return nil, fmt.Errorf("failed to get ResourceClaim %s/%s: %w", namespace, name, err)
+		}
+		return &claim.Spec, nil
+	default:
+		return nil, fmt.Errorf("pod resourceClaim %q does not reference a ResourceClaim or ResourceClaimTemplate", podClaim.Name)
+	}
+}
+
+func gpuCountFromClaimSpec(spec *resourcev1.ResourceClaimSpec, requestName string) (int, error) {
+	total := 0
+	foundRequest := requestName == ""
+	for _, request := range spec.Devices.Requests {
+		if requestName != "" && request.Name != requestName {
+			continue
+		}
+		foundRequest = true
+
+		count, isGPU, err := gpuCountFromDeviceRequest(request)
+		if err != nil {
+			return 0, err
+		}
+		if isGPU {
+			total += count
+		}
+	}
+	if !foundRequest {
+		return 0, fmt.Errorf("device request %q was not found", requestName)
+	}
+	return total, nil
+}
+
+func gpuCountFromDeviceRequest(request resourcev1.DeviceRequest) (int, bool, error) {
+	if request.Exactly != nil {
+		if !isGPUDeviceClassName(request.Exactly.DeviceClassName) {
+			return 0, false, nil
+		}
+		count, err := exactDeviceCount(request.Exactly.AllocationMode, request.Exactly.Count)
+		return count, true, err
+	}
+
+	var count int
+	var hasGPU, hasNonGPU bool
+	for _, subRequest := range request.FirstAvailable {
+		if !isGPUDeviceClassName(subRequest.DeviceClassName) {
+			hasNonGPU = true
+			continue
+		}
+		candidateCount, err := exactDeviceCount(subRequest.AllocationMode, subRequest.Count)
+		if err != nil {
+			return 0, false, err
+		}
+		if hasGPU && candidateCount != count {
+			return 0, false, fmt.Errorf("GPU device request %q has firstAvailable alternatives with different counts", request.Name)
+		}
+		count = candidateCount
+		hasGPU = true
+	}
+	if hasGPU && hasNonGPU {
+		return 0, false, fmt.Errorf("device request %q mixes GPU and non-GPU firstAvailable alternatives", request.Name)
+	}
+	return count, hasGPU, nil
+}
+
+func exactDeviceCount(mode resourcev1.DeviceAllocationMode, count int64) (int, error) {
+	switch mode {
+	case "", resourcev1.DeviceAllocationModeExactCount:
+		if count == 0 {
+			return 1, nil
+		}
+		if count < 0 {
+			return 0, fmt.Errorf("GPU device count must be positive")
+		}
+		return int(count), nil
+	case resourcev1.DeviceAllocationModeAll:
+		return 0, fmt.Errorf("GPU allocationMode %q has no deterministic per-node device count", mode)
+	default:
+		return 0, fmt.Errorf("unsupported GPU allocationMode %q", mode)
+	}
+}
+
+func isGPUDeviceClassName(name string) bool {
+	normalized := strings.ToLower(name)
+	return normalized == "gpu" ||
+		strings.HasPrefix(normalized, "gpu.") ||
+		strings.HasPrefix(normalized, "gpu/") ||
+		strings.HasSuffix(normalized, "/gpu") ||
+		strings.Contains(normalized, "/gpu.") ||
+		strings.Contains(normalized, "/gpu-")
+}
+
 // RemoveGPUResources deletes all scalar GPU resource entries from a resource list.
 func RemoveGPUResources(resources corev1.ResourceList) {
 	for _, name := range gpuResourceNames(resources) {

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -170,6 +170,11 @@ func TestExtractGPUCountFromResourceRequirements_RejectsFractionalGPU(t *testing
 }
 
 func TestResolveGPUCountFromResourceClaims(t *testing.T) {
+	driverSelectors := func(driver string) []resourcev1.DeviceSelector {
+		return []resourcev1.DeviceSelector{{
+			CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == '" + driver + "'"},
+		}}
+	}
 	exactRequest := func(name, deviceClass string, count int64, mode resourcev1.DeviceAllocationMode) resourcev1.DeviceRequest {
 		return resourcev1.DeviceRequest{
 			Name: name,
@@ -179,6 +184,11 @@ func TestResolveGPUCountFromResourceClaims(t *testing.T) {
 				Count:           count,
 			},
 		}
+	}
+	exactRequestWithDriver := func(name, deviceClass, driver string, count int64) resourcev1.DeviceRequest {
+		request := exactRequest(name, deviceClass, count, resourcev1.DeviceAllocationModeExactCount)
+		request.Exactly.Selectors = driverSelectors(driver)
+		return request
 	}
 	claimTemplate := func(name string, requests ...resourcev1.DeviceRequest) client.Object {
 		return &resourcev1.ResourceClaimTemplate{
@@ -208,9 +218,7 @@ func TestResolveGPUCountFromResourceClaims(t *testing.T) {
 		return &resourcev1.DeviceClass{
 			ObjectMeta: metav1.ObjectMeta{Name: name},
 			Spec: resourcev1.DeviceClassSpec{
-				Selectors: []resourcev1.DeviceSelector{{
-					CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == '" + driver + "'"},
-				}},
+				Selectors: driverSelectors(driver),
 			},
 		}
 	}
@@ -290,6 +298,55 @@ func TestResolveGPUCountFromResourceClaims(t *testing.T) {
 			want:     4,
 		},
 		{
+			name: "request selector overrides a GPU-like empty DeviceClass",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"}},
+				claimTemplate(
+					"network-template",
+					exactRequestWithDriver("network", "gpu.example.com", "dra.net.example.com", 1),
+				),
+			},
+			podClaim: templatePodClaim("network", "network-template"),
+			want:     0,
+		},
+		{
+			name: "request selector classifies an otherwise unknown DeviceClass as GPU",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "accelerators.example.com"}},
+				claimTemplate(
+					"gpu-template",
+					exactRequestWithDriver("gpus", "accelerators.example.com", "gpu.nvidia.com", 2),
+				),
+			},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     2,
+		},
+		{
+			name: "same DeviceClass is classified independently for each request",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "devices.example.com"}},
+				claimTemplate(
+					"devices-template",
+					exactRequestWithDriver("gpus", "devices.example.com", "gpu.nvidia.com", 2),
+					exactRequestWithDriver("network", "devices.example.com", "dra.net.example.com", 1),
+				),
+			},
+			podClaim: templatePodClaim("devices", "devices-template"),
+			want:     2,
+		},
+		{
+			name: "conflicting class and request driver selectors are rejected",
+			objects: []client.Object{
+				deviceClass("shared-gpus.example.com", "gpu.nvidia.com"),
+				claimTemplate(
+					"conflicting-template",
+					exactRequestWithDriver("devices", "shared-gpus.example.com", "dra.net.example.com", 1),
+				),
+			},
+			podClaim: templatePodClaim("devices", "conflicting-template"),
+			wantErr:  "constrain device.driver to both GPU and non-GPU drivers",
+		},
+		{
 			name: "non-GPU claim is ignored",
 			objects: []client.Object{claimTemplate(
 				"network-template",
@@ -324,16 +381,20 @@ func TestResolveGPUCountFromResourceClaims(t *testing.T) {
 		},
 		{
 			name: "equal-count GPU firstAvailable alternatives are supported",
-			objects: []client.Object{claimTemplate(
-				"gpu-template",
-				resourcev1.DeviceRequest{
-					Name: "gpus",
-					FirstAvailable: []resourcev1.DeviceSubRequest{
-						{Name: "nvidia", DeviceClassName: "gpu.nvidia.com", Count: 2},
-						{Name: "intel", DeviceClassName: "gpu.intel.com", Count: 2},
+			objects: []client.Object{
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "nvidia.example.com"}},
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "intel.example.com"}},
+				claimTemplate(
+					"gpu-template",
+					resourcev1.DeviceRequest{
+						Name: "gpus",
+						FirstAvailable: []resourcev1.DeviceSubRequest{
+							{Name: "nvidia", DeviceClassName: "nvidia.example.com", Selectors: driverSelectors("gpu.nvidia.com"), Count: 2},
+							{Name: "intel", DeviceClassName: "intel.example.com", Selectors: driverSelectors("gpu.intel.com"), Count: 2},
+						},
 					},
-				},
-			)},
+				),
+			},
 			podClaim: templatePodClaim("accelerators", "gpu-template"),
 			want:     2,
 		},

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -13,8 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func basePodSpec() corev1.PodSpec {
@@ -138,6 +144,18 @@ func TestExtractGPUCountFromResourceRequirements_DeterministicResourceSelection(
 	assert.Equal(t, 4, gpuCount)
 }
 
+func TestExtractGPUCountFromResourceRequirements_MIGResource(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceName("nvidia.com/mig-3g.20gb"): resource.MustParse("2"),
+		},
+	}
+
+	gpuCount, err := ExtractGPUCountFromResourceRequirements(resources)
+	require.NoError(t, err)
+	assert.Equal(t, 2, gpuCount)
+}
+
 func TestExtractGPUCountFromResourceRequirements_RejectsFractionalGPU(t *testing.T) {
 	resources := corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -149,6 +167,275 @@ func TestExtractGPUCountFromResourceRequirements_RejectsFractionalGPU(t *testing
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be a whole number")
 	assert.Contains(t, err.Error(), "500m")
+}
+
+func TestResolveGPUCountFromResourceClaims(t *testing.T) {
+	exactRequest := func(name, deviceClass string, count int64, mode resourcev1.DeviceAllocationMode) resourcev1.DeviceRequest {
+		return resourcev1.DeviceRequest{
+			Name: name,
+			Exactly: &resourcev1.ExactDeviceRequest{
+				DeviceClassName: deviceClass,
+				AllocationMode:  mode,
+				Count:           count,
+			},
+		}
+	}
+	claimTemplate := func(name string, requests ...resourcev1.DeviceRequest) client.Object {
+		return &resourcev1.ResourceClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: resourcev1.ResourceClaimTemplateSpec{
+				Spec: resourcev1.ResourceClaimSpec{
+					Devices: resourcev1.DeviceClaim{Requests: requests},
+				},
+			},
+		}
+	}
+	claim := func(name string, requests ...resourcev1.DeviceRequest) client.Object {
+		return &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{Requests: requests},
+			},
+		}
+	}
+	templatePodClaim := func(claimName, templateName string) corev1.PodResourceClaim {
+		return corev1.PodResourceClaim{
+			Name:                      claimName,
+			ResourceClaimTemplateName: ptr.To(templateName),
+		}
+	}
+	deviceClass := func(name, driver string) client.Object {
+		return &resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: resourcev1.DeviceClassSpec{
+				Selectors: []resourcev1.DeviceSelector{{
+					CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == '" + driver + "'"},
+				}},
+			},
+		}
+	}
+	deviceClasses := []client.Object{
+		deviceClass("gpu.nvidia.com", "gpu.nvidia.com"),
+		deviceClass("gpu.intel.com", "gpu.intel.com"),
+		deviceClass("rdma-dranet", "dra.net.example.com"),
+	}
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		podClaim    corev1.PodResourceClaim
+		requestName string
+		want        int
+		wantErr     string
+	}{
+		{
+			name: "ResourceClaimTemplate exact NVIDIA GPU count",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 4, resourcev1.DeviceAllocationModeExactCount),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     4,
+		},
+		{
+			name: "ResourceClaim request selector excludes non-GPU devices",
+			objects: []client.Object{claim(
+				"devices",
+				exactRequest("gpus", "gpu.intel.com", 2, ""),
+				exactRequest("network", "rdma-dranet", 1, ""),
+			)},
+			podClaim: corev1.PodResourceClaim{
+				Name:              "accelerators",
+				ResourceClaimName: ptr.To("devices"),
+			},
+			requestName: "gpus",
+			want:        2,
+		},
+		{
+			name: "default exact count is one",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 0, ""),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     1,
+		},
+		{
+			name: "custom DeviceClass name uses its GPU driver selector",
+			objects: []client.Object{
+				deviceClass("shared-h100.example.com", "gpu.nvidia.com"),
+				claimTemplate(
+					"gpu-template",
+					exactRequest("gpus", "shared-h100.example.com", 8, resourcev1.DeviceAllocationModeExactCount),
+				),
+			},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     8,
+		},
+		{
+			name: "custom DeviceClass name uses its extended GPU resource",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "shared-gpus.example.com"},
+					Spec: resourcev1.DeviceClassSpec{
+						ExtendedResourceName: ptr.To(commonconsts.KubeResourceGPUNvidia),
+					},
+				},
+				claimTemplate(
+					"gpu-template",
+					exactRequest("gpus", "shared-gpus.example.com", 4, resourcev1.DeviceAllocationModeExactCount),
+				),
+			},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     4,
+		},
+		{
+			name: "non-GPU claim is ignored",
+			objects: []client.Object{claimTemplate(
+				"network-template",
+				exactRequest("network", "rdma-dranet", 1, ""),
+			)},
+			podClaim: templatePodClaim("network", "network-template"),
+			want:     0,
+		},
+		{
+			name: "allocation mode All is rejected",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 0, resourcev1.DeviceAllocationModeAll),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			wantErr:  "has no deterministic per-node device count",
+		},
+		{
+			name: "mixed firstAvailable alternatives are rejected",
+			objects: []client.Object{claimTemplate(
+				"mixed-template",
+				resourcev1.DeviceRequest{
+					Name: "devices",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "gpu", DeviceClassName: "gpu.nvidia.com", Count: 1},
+						{Name: "network", DeviceClassName: "rdma-dranet", Count: 1},
+					},
+				},
+			)},
+			podClaim: templatePodClaim("devices", "mixed-template"),
+			wantErr:  "mixes GPU and non-GPU",
+		},
+		{
+			name: "equal-count GPU firstAvailable alternatives are supported",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				resourcev1.DeviceRequest{
+					Name: "gpus",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "nvidia", DeviceClassName: "gpu.nvidia.com", Count: 2},
+						{Name: "intel", DeviceClassName: "gpu.intel.com", Count: 2},
+					},
+				},
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     2,
+		},
+		{
+			name: "unclassifiable DeviceClass is actionable",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "accelerators.example.com"}},
+				claimTemplate(
+					"accelerator-template",
+					exactRequest("accelerators", "accelerators.example.com", 1, ""),
+				),
+			},
+			podClaim: templatePodClaim("accelerators", "accelerator-template"),
+			wantErr:  "cannot determine whether DeviceClass \"accelerators.example.com\" provides GPUs",
+		},
+		{
+			name: "unsupported selector does not fall back to GPU-like class name",
+			objects: []client.Object{
+				&resourcev1.DeviceClass{
+					ObjectMeta: metav1.ObjectMeta{Name: "gpu.example.com"},
+					Spec: resourcev1.DeviceClassSpec{
+						Selectors: []resourcev1.DeviceSelector{{CEL: &resourcev1.CELDeviceSelector{
+							Expression: `device.driver != "cpu.example.com"`,
+						}}},
+					},
+				},
+				claimTemplate(
+					"gpu-template",
+					exactRequest("gpus", "gpu.example.com", 1, ""),
+				),
+			},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			wantErr:  "cannot determine whether DeviceClass \"gpu.example.com\" provides GPUs",
+		},
+		{
+			name: "missing DeviceClass is actionable",
+			objects: []client.Object{claimTemplate(
+				"missing-class-template",
+				exactRequest("accelerators", "missing.example.com", 1, ""),
+			)},
+			podClaim: templatePodClaim("accelerators", "missing-class-template"),
+			wantErr:  "failed to get DeviceClass \"missing.example.com\"",
+		},
+		{
+			name: "request without a supported shape is rejected",
+			objects: []client.Object{claimTemplate(
+				"invalid-template",
+				resourcev1.DeviceRequest{Name: "devices"},
+			)},
+			podClaim: templatePodClaim("devices", "invalid-template"),
+			wantErr:  "must set exactly or firstAvailable",
+		},
+		{
+			name:     "missing ResourceClaimTemplate is actionable",
+			podClaim: templatePodClaim("accelerators", "missing"),
+			wantErr:  "failed to get ResourceClaimTemplate default/missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Create a client containing the claim source")
+			scheme := runtime.NewScheme()
+			require.NoError(t, resourcev1.AddToScheme(scheme))
+			objects := append([]client.Object{}, deviceClasses...)
+			objects = append(objects, tt.objects...)
+			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+
+			t.Log("Reference the pod claim from the main container")
+			podSpec := &corev1.PodSpec{ResourceClaims: []corev1.PodResourceClaim{tt.podClaim}}
+			resources := corev1.ResourceRequirements{
+				Claims: []corev1.ResourceClaim{{
+					Name:    tt.podClaim.Name,
+					Request: tt.requestName,
+				}},
+			}
+
+			t.Log("Resolve the exact GPU count")
+			got, err := ResolveGPUCount(context.Background(), kubeClient, "default", podSpec, resources)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveGPUCountPrefersScalarResources(t *testing.T) {
+	t.Log("Combine a scalar GPU request with an unresolved ResourceClaim")
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("8"),
+		},
+		Claims: []corev1.ResourceClaim{{Name: "missing"}},
+	}
+
+	t.Log("Resolve without a Kubernetes client")
+	got, err := ResolveGPUCount(context.Background(), nil, "default", nil, resources)
+	require.NoError(t, err)
+	assert.Equal(t, 8, got)
 }
 
 func TestGenerateResourceClaimTemplate_Enabled(t *testing.T) {

--- a/deploy/operator/internal/dra/dra_test.go
+++ b/deploy/operator/internal/dra/dra_test.go
@@ -13,8 +13,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func basePodSpec() corev1.PodSpec {
@@ -149,6 +155,180 @@ func TestExtractGPUCountFromResourceRequirements_RejectsFractionalGPU(t *testing
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be a whole number")
 	assert.Contains(t, err.Error(), "500m")
+}
+
+func TestResolveGPUCountFromResourceClaims(t *testing.T) {
+	exactRequest := func(name, deviceClass string, count int64, mode resourcev1.DeviceAllocationMode) resourcev1.DeviceRequest {
+		return resourcev1.DeviceRequest{
+			Name: name,
+			Exactly: &resourcev1.ExactDeviceRequest{
+				DeviceClassName: deviceClass,
+				AllocationMode:  mode,
+				Count:           count,
+			},
+		}
+	}
+	claimTemplate := func(name string, requests ...resourcev1.DeviceRequest) client.Object {
+		return &resourcev1.ResourceClaimTemplate{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: resourcev1.ResourceClaimTemplateSpec{
+				Spec: resourcev1.ResourceClaimSpec{
+					Devices: resourcev1.DeviceClaim{Requests: requests},
+				},
+			},
+		}
+	}
+	claim := func(name string, requests ...resourcev1.DeviceRequest) client.Object {
+		return &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{Requests: requests},
+			},
+		}
+	}
+	templatePodClaim := func(claimName, templateName string) corev1.PodResourceClaim {
+		return corev1.PodResourceClaim{
+			Name:                      claimName,
+			ResourceClaimTemplateName: ptr.To(templateName),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		podClaim    corev1.PodResourceClaim
+		requestName string
+		want        int
+		wantErr     string
+	}{
+		{
+			name: "ResourceClaimTemplate exact NVIDIA GPU count",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 4, resourcev1.DeviceAllocationModeExactCount),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     4,
+		},
+		{
+			name: "ResourceClaim request selector excludes non-GPU devices",
+			objects: []client.Object{claim(
+				"devices",
+				exactRequest("gpus", "gpu.intel.com", 2, ""),
+				exactRequest("network", "rdma-dranet", 1, ""),
+			)},
+			podClaim: corev1.PodResourceClaim{
+				Name:              "accelerators",
+				ResourceClaimName: ptr.To("devices"),
+			},
+			requestName: "gpus",
+			want:        2,
+		},
+		{
+			name: "default exact count is one",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 0, ""),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     1,
+		},
+		{
+			name: "non-GPU claim is ignored",
+			objects: []client.Object{claimTemplate(
+				"network-template",
+				exactRequest("network", "rdma-dranet", 1, ""),
+			)},
+			podClaim: templatePodClaim("network", "network-template"),
+			want:     0,
+		},
+		{
+			name: "allocation mode All is rejected",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				exactRequest("gpus", "gpu.nvidia.com", 0, resourcev1.DeviceAllocationModeAll),
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			wantErr:  "has no deterministic per-node device count",
+		},
+		{
+			name: "mixed firstAvailable alternatives are rejected",
+			objects: []client.Object{claimTemplate(
+				"mixed-template",
+				resourcev1.DeviceRequest{
+					Name: "devices",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "gpu", DeviceClassName: "gpu.nvidia.com", Count: 1},
+						{Name: "network", DeviceClassName: "rdma-dranet", Count: 1},
+					},
+				},
+			)},
+			podClaim: templatePodClaim("devices", "mixed-template"),
+			wantErr:  "mixes GPU and non-GPU",
+		},
+		{
+			name: "equal-count GPU firstAvailable alternatives are supported",
+			objects: []client.Object{claimTemplate(
+				"gpu-template",
+				resourcev1.DeviceRequest{
+					Name: "gpus",
+					FirstAvailable: []resourcev1.DeviceSubRequest{
+						{Name: "nvidia", DeviceClassName: "gpu.nvidia.com", Count: 2},
+						{Name: "intel", DeviceClassName: "gpu.intel.com", Count: 2},
+					},
+				},
+			)},
+			podClaim: templatePodClaim("accelerators", "gpu-template"),
+			want:     2,
+		},
+		{
+			name:     "missing ResourceClaimTemplate is actionable",
+			podClaim: templatePodClaim("accelerators", "missing"),
+			wantErr:  "failed to get ResourceClaimTemplate default/missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Create a client containing the claim source")
+			scheme := runtime.NewScheme()
+			require.NoError(t, resourcev1.AddToScheme(scheme))
+			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(tt.objects...).Build()
+
+			t.Log("Reference the pod claim from the main container")
+			podSpec := &corev1.PodSpec{ResourceClaims: []corev1.PodResourceClaim{tt.podClaim}}
+			resources := corev1.ResourceRequirements{
+				Claims: []corev1.ResourceClaim{{
+					Name:    tt.podClaim.Name,
+					Request: tt.requestName,
+				}},
+			}
+
+			t.Log("Resolve the exact GPU count")
+			got, err := ResolveGPUCount(context.Background(), kubeClient, "default", podSpec, resources)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveGPUCountPrefersScalarResources(t *testing.T) {
+	t.Log("Combine a scalar GPU request with an unresolved ResourceClaim")
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceName(commonconsts.KubeResourceGPUNvidia): resource.MustParse("8"),
+		},
+		Claims: []corev1.ResourceClaim{{Name: "missing"}},
+	}
+
+	t.Log("Resolve without a Kubernetes client")
+	got, err := ResolveGPUCount(context.Background(), nil, "default", nil, resources)
+	require.NoError(t, err)
+	assert.Equal(t, 8, got)
 }
 
 func TestGenerateResourceClaimTemplate_Enabled(t *testing.T) {

--- a/deploy/operator/internal/dynamo/backend_sglang.go
+++ b/deploy/operator/internal/dynamo/backend_sglang.go
@@ -26,7 +26,7 @@ func isPythonCommand(cmd string) bool {
 	return matched
 }
 
-func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
+func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, _ ContainerGPUCount) error {
 	if component.CompilationCache != nil {
 		logger := log.Log.WithName("sglang-backend")
 		logger.Info("Compilation cache configured for SGLang but not yet fully supported",
@@ -39,7 +39,7 @@ func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNod
 
 	// For single node, nothing to do
 	if numberOfNodes <= 1 {
-		return
+		return nil
 	}
 
 	// Remove probes for multinode worker
@@ -52,10 +52,11 @@ func (b *SGLangBackend) UpdateContainer(container *corev1.Container, numberOfNod
 	// Generate the flags to add
 	flags, needsShell := b.getMultinodeFlags(numberOfNodes, role, serviceName, multinodeDeployer)
 	if flags == "" {
-		return
+		return nil
 	}
 
 	injectFlagsIntoContainerCommand(container, flags, needsShell, "sglang")
+	return nil
 }
 
 func (b *SGLangBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {

--- a/deploy/operator/internal/dynamo/backend_sglang_test.go
+++ b/deploy/operator/internal/dynamo/backend_sglang_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -228,7 +229,7 @@ func TestSGLangBackend_PythonCommandInjection(t *testing.T) {
 				Args:    append([]string{}, tt.initialArgs...),
 			}
 
-			backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer)
+			require.NoError(t, backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer, staticContainerGPUCount(0)))
 
 			if !reflect.DeepEqual(container.Command, tt.expectedCommand) {
 				t.Errorf("UpdateContainer() command = %v, want %v", container.Command, tt.expectedCommand)
@@ -353,7 +354,7 @@ func TestSGLangBackend_ShellCommandInjection(t *testing.T) {
 				Args:    append([]string{}, tt.initialArgs...),
 			}
 
-			backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer)
+			require.NoError(t, backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer, staticContainerGPUCount(0)))
 
 			if !reflect.DeepEqual(container.Args, tt.expectedArgs) {
 				t.Errorf("UpdateContainer() args = %v, want %v", container.Args, tt.expectedArgs)
@@ -527,7 +528,7 @@ func TestSGLangBackend_ProbeRemoval(t *testing.T) {
 				StartupProbe:   startupProbe,
 			}
 
-			backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer)
+			require.NoError(t, backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{}), "test-service", tt.multinodeDeployer, staticContainerGPUCount(0)))
 
 			if tt.expectProbesRemoved {
 				if container.LivenessProbe != nil {
@@ -631,7 +632,7 @@ func TestSGLangBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 			originalEnvCount := len(container.Env)
 
 			// Call UpdateContainer (single node to avoid multinode logic)
-			backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{})
+			require.NoError(t, backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{}, staticContainerGPUCount(0)))
 
 			if tt.expectNoEnvVarChanges {
 				// Check that no new environment variables were added

--- a/deploy/operator/internal/dynamo/backend_trtllm.go
+++ b/deploy/operator/internal/dynamo/backend_trtllm.go
@@ -20,7 +20,7 @@ type TRTLLMBackend struct {
 // For single-node deployments it is a no-op. For multinode, it mounts the SSH
 // keypair secret and injects the appropriate SSH setup and launch commands for
 // leader (mpirun) and worker (sshd) roles.
-func (b *TRTLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
+func (b *TRTLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUCount ContainerGPUCount) error {
 	if component.CompilationCache != nil {
 		logger := log.Log.WithName("trtllm-backend")
 		logger.Info("Compilation cache configured for TensorRT-LLM but not yet fully supported",
@@ -32,7 +32,7 @@ func (b *TRTLLMBackend) UpdateContainer(container *corev1.Container, numberOfNod
 
 	// For single node, nothing to do
 	if numberOfNodes <= 1 {
-		return
+		return nil
 	}
 
 	// Configure probes for multinode deployments
@@ -67,10 +67,16 @@ func (b *TRTLLMBackend) UpdateContainer(container *corev1.Container, numberOfNod
 	// Update container command based on role
 	switch role {
 	case RoleLeader:
-		b.setupLeaderContainer(container, numberOfNodes, serviceName, component, multinodeDeployer)
+		containerGPUs, err := containerGPUCount()
+		if err != nil {
+			return fmt.Errorf("failed to resolve container GPUs: %w", err)
+		}
+		b.setupLeaderContainer(container, numberOfNodes, serviceName, multinodeDeployer, containerGPUs)
 	case RoleWorker:
 		b.setupWorkerContainer(container)
 	}
+
+	return nil
 }
 
 // UpdatePodSpec injects the SSH keypair volume into the pod spec for TRT-LLM
@@ -102,7 +108,7 @@ func (b *TRTLLMBackend) addSSHVolumeMount(container *corev1.Container) {
 }
 
 // setupLeaderContainer configures the leader node with SSH setup and mpirun command
-func (b *TRTLLMBackend) setupLeaderContainer(container *corev1.Container, numberOfNodes int32, serviceName string, component *v1beta1.DynamoComponentDeploymentSharedSpec, multinodeDeployer MultinodeDeployer) {
+func (b *TRTLLMBackend) setupLeaderContainer(container *corev1.Container, numberOfNodes int32, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUs int64) {
 	// Generate the list of all hostnames
 	hostNamesList := b.hostNamesList(numberOfNodes, serviceName, multinodeDeployer)
 	allHostnames := strings.Join(hostNamesList, ",")
@@ -144,13 +150,8 @@ func (b *TRTLLMBackend) setupLeaderContainer(container *corev1.Container, number
 		fmt.Sprintf("printf 'Host *\\nIdentityFile '$HOME'/.ssh/id_rsa\\nStrictHostKeyChecking no\\nPort %d\\n' > $HOME/.ssh/config", commonconsts.MpiRunSshPort),
 	}
 
-	// Calculate total number of GPUs across all nodes. In the normal pod
-	// generation path container.Resources has already been merged from the
-	// component podTemplate; keep the component fallback for direct backend
-	// callers and focused unit tests.
-	resources := resourceRequirementsWithFallback(container.Resources, GetMainContainerResources(component))
-	gpusPerNode := getGPUsPerNode(&resources)
-	totalGPUs := numberOfNodes * gpusPerNode
+	// Calculate total GPUs from the scalar or DRA-resolved main-container count.
+	totalGPUs := int64(numberOfNodes) * containerGPUs
 
 	// Build mpirun command with explicit SSH configuration and environment variables
 	// Wrap the entire command (trtllm-llmapi-launch + original command) in bash -c for proper shell interpretation
@@ -229,14 +230,6 @@ func (b *TRTLLMBackend) setupWorkerContainer(container *corev1.Container) {
 // hostNamesList generates the list of hostnames for all nodes in the multinode deployment
 func (b *TRTLLMBackend) hostNamesList(numberOfNodes int32, serviceName string, multinodeDeployer MultinodeDeployer) []string {
 	return multinodeDeployer.GetHostNames(serviceName, numberOfNodes)
-}
-
-// getGPUsPerNode extracts the number of GPUs per node from resources
-func getGPUsPerNode(resources *corev1.ResourceRequirements) int32 {
-	if resources == nil {
-		return 0
-	}
-	return int32(getGPUQuantity(resources))
 }
 
 // getCommonTRTLLMEnvVars returns a map of common environment variables for TRTLLM deployments

--- a/deploy/operator/internal/dynamo/backend_trtllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_trtllm_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -89,7 +90,7 @@ func TestShellQuoteForBashC_InLeaderCommand(t *testing.T) {
 		},
 	}
 
-	backend.setupLeaderContainer(container, 2, "dec", betaComponent(t, component), &GroveMultinodeDeployer{})
+	backend.setupLeaderContainer(container, 2, "dec", &GroveMultinodeDeployer{}, resolveTestContainerGPUs(t, betaComponent(t, component)))
 
 	if len(container.Args) != 1 {
 		t.Fatalf("expected 1 arg, got %d", len(container.Args))
@@ -238,7 +239,16 @@ func TestTRTLLMBackend_UpdateContainer(t *testing.T) {
 				StartupProbe:   &corev1.Probe{},
 			}
 
-			backend.UpdateContainer(container, tt.numberOfNodes, tt.role, betaComponent(t, tt.component), "test-service", tt.multinodeDeployer)
+			component := betaComponent(t, tt.component)
+			require.NoError(t, backend.UpdateContainer(
+				container,
+				tt.numberOfNodes,
+				tt.role,
+				component,
+				"test-service",
+				tt.multinodeDeployer,
+				staticContainerGPUCount(resolveTestContainerGPUs(t, component)),
+			))
 
 			validateVolumeMounts(t, container, tt.expectedVolumeMounts)
 			validateCommand(t, container, tt.expectedCommand)
@@ -769,7 +779,14 @@ func TestTRTLLMBackend_setupLeaderContainer(t *testing.T) {
 				}
 			}
 
-			backend.setupLeaderContainer(container, tt.numberOfNodes, tt.serviceName, betaComponent(t, tt.component), tt.multinodeDeployer)
+			component := betaComponent(t, tt.component)
+			backend.setupLeaderContainer(
+				container,
+				tt.numberOfNodes,
+				tt.serviceName,
+				tt.multinodeDeployer,
+				resolveTestContainerGPUs(t, component),
+			)
 
 			// Check that command is set correctly
 			expectedCommand := []string{"/bin/sh", "-c"}
@@ -852,82 +869,6 @@ func TestTRTLLMBackend_setupWorkerContainer(t *testing.T) {
 	}
 }
 
-func TestTRTLLMBackend_getGPUsPerNode(t *testing.T) {
-	tests := []struct {
-		name      string
-		resources *v1alpha1.Resources
-		expected  int32
-	}{
-		{
-			name:      "No resources - default to 0",
-			resources: nil,
-			expected:  0,
-		},
-		{
-			name:      "Empty resources - default to 0",
-			resources: &v1alpha1.Resources{},
-			expected:  0,
-		},
-		{
-			name: "GPU in requests",
-			resources: &v1alpha1.Resources{
-				Requests: &v1alpha1.ResourceItem{
-					GPU: "2",
-				},
-			},
-			expected: 2,
-		},
-		{
-			name: "GPU in limits",
-			resources: &v1alpha1.Resources{
-				Limits: &v1alpha1.ResourceItem{
-					GPU: "4",
-				},
-			},
-			expected: 4,
-		},
-		{
-			name: "GPU in both requests and limits - requests takes precedence",
-			resources: &v1alpha1.Resources{
-				Requests: &v1alpha1.ResourceItem{
-					GPU: "3",
-				},
-				Limits: &v1alpha1.ResourceItem{
-					GPU: "8",
-				},
-			},
-			expected: 3,
-		},
-		{
-			name: "Invalid GPU value - default to 0",
-			resources: &v1alpha1.Resources{
-				Requests: &v1alpha1.ResourceItem{
-					GPU: "invalid",
-				},
-			},
-			expected: 0,
-		},
-		{
-			name: "Empty GPU string - default to 0",
-			resources: &v1alpha1.Resources{
-				Requests: &v1alpha1.ResourceItem{
-					GPU: "",
-				},
-			},
-			expected: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := getGPUsPerNode(betaResourceRequirements(t, tt.resources))
-			if result != tt.expected {
-				t.Errorf("getGPUsPerNode() = %d, want %d", result, tt.expected)
-			}
-		})
-	}
-}
-
 func TestTRTLLMBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 	backend := &TRTLLMBackend{}
 
@@ -1005,7 +946,7 @@ func TestTRTLLMBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 			originalEnvCount := len(container.Env)
 
 			// Call UpdateContainer (single node to avoid multinode logic)
-			backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{})
+			require.NoError(t, backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{}, staticContainerGPUCount(0)))
 
 			if tt.expectNoEnvVarChanges {
 				// Check that no new environment variables were added

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -34,7 +34,7 @@ type VLLMBackend struct {
 	ParentGraphDeploymentName string
 }
 
-func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
+func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUCount ContainerGPUCount) error {
 	// The inter-pod GMS layout (with or without failover) requires the engine
 	// to load weights from the dedicated GMS weight-server pod rather than
 	// from disk.
@@ -55,9 +55,13 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 	annotations := GetPodTemplateAnnotations(component)
 
 	if isMultinode {
-		resources := resourceRequirementsWithFallback(container.Resources, GetMainContainerResources(component))
+		containerGPUs, err := containerGPUCount()
+		if err != nil {
+			return fmt.Errorf("failed to resolve container GPUs: %w", err)
+		}
+
 		// Apply multinode-specific argument modifications
-		updateVLLMMultinodeArgs(container, role, serviceName, multinodeDeployer, &resources, numberOfNodes, annotations)
+		updateVLLMMultinodeArgs(container, role, serviceName, multinodeDeployer, containerGPUs, numberOfNodes, annotations)
 
 		if shouldUseMpBackend(annotations) {
 			container.Env = append(container.Env, corev1.EnvVar{
@@ -133,6 +137,8 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 			"env-vars-set", true,
 			"env-vars", "VLLM_CACHE_ROOT")
 	}
+
+	return nil
 }
 
 const (
@@ -303,9 +309,9 @@ func (b *VLLMBackend) shouldInjectVLLMMpWaitLeaderInit(podSpec *corev1.PodSpec, 
 
 // updateVLLMMultinodeArgs dispatches to the appropriate injection function based on
 // parallelism strategy (TP/PP distributed vs data-parallel) and executor backend (mp vs ray).
-func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *corev1.ResourceRequirements, numberOfNodes int32, annotations map[string]string) {
+func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUs int64, numberOfNodes int32, annotations map[string]string) {
 	expandedArgs := getExpandedArgs(container)
-	needsDistributed := needsTensorParallelMultinodeLaunch(expandedArgs, resources)
+	needsDistributed := needsTensorParallelMultinodeLaunch(expandedArgs, containerGPUs)
 
 	if needsDistributed && shouldUseMpBackend(annotations) {
 		injectMpDistributedLaunchFlags(container, role, serviceName, multinodeDeployer, numberOfNodes)
@@ -323,8 +329,8 @@ func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName
 		// only the leader node is in the Ray cluster when create_dp_placement_groups runs,
 		// so vLLM naturally places all initial DP workers on the leader node.
 		injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer)
-	} else if needsDataParallelMultinodeLaunch(expandedArgs, resources) {
-		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, resources, numberOfNodes)
+	} else if needsDataParallelMultinodeLaunch(expandedArgs, containerGPUs) {
+		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, containerGPUs, numberOfNodes)
 	} else {
 		logger := log.Log.WithName("vllm-backend")
 		logger.Info("No need to inject tensor or data parallel flags for multinode deployments", "args", strings.Join(container.Args, " "))
@@ -591,12 +597,11 @@ func hasFlag(expandedArgs []string, flag string) bool {
 	return false
 }
 
-func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *corev1.ResourceRequirements, numberOfNodes int32) {
+func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUs int64, numberOfNodes int32) {
 	expandedArgs := getExpandedArgs(container)
 	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
 
 	// Calculate engines per node
-	containerGPUs := getContainerGPUs(resources)
 	worldSize := getWorldSize(expandedArgs) // TP * PP per engine
 	dataParallelSizeLocal := containerGPUs / worldSize
 
@@ -649,9 +654,8 @@ func injectDataParallelLaunchFlags(container *corev1.Container, role Role, servi
 }
 
 // needsMultinodeDistributedLaunch returns true when the model's world size (TP * PP)
-// exceeds the GPU count of a single node, requiring multi-node distribution (via mp or ray).
-func needsTensorParallelMultinodeLaunch(expandedArgs []string, resources *corev1.ResourceRequirements) bool {
-	containerGPUs := getContainerGPUs(resources)
+// exceeds the GPU count of one engine container, requiring multi-node distribution (via mp or ray).
+func needsTensorParallelMultinodeLaunch(expandedArgs []string, containerGPUs int64) bool {
 	if containerGPUs == 0 {
 		return false
 	}
@@ -665,9 +669,8 @@ func getWorldSize(expandedArgs []string) int64 {
 }
 
 // if world size across all DP ranks > GPU count, then we need to inject data parallel multinode coordination
-func needsDataParallelMultinodeLaunch(expandedArgs []string, resources *corev1.ResourceRequirements) bool {
+func needsDataParallelMultinodeLaunch(expandedArgs []string, containerGPUs int64) bool {
 	dataParallelSize := getFlagValue(expandedArgs, dataParallelSizeFlag)
-	containerGPUs := getContainerGPUs(resources)
 	if containerGPUs == 0 {
 		return false
 	}
@@ -686,56 +689,4 @@ func getFlagValue(expandedArgs []string, flag string) int64 {
 		}
 	}
 	return flagValue
-}
-
-func getContainerGPUs(resources *corev1.ResourceRequirements) int64 {
-	return getGPUQuantity(resources)
-}
-
-func getGPUQuantity(resources *corev1.ResourceRequirements) int64 {
-	if resources == nil {
-		return 0
-	}
-	if value, ok := resourceListGPUValue(resources.Requests); ok {
-		return value
-	}
-	if value, ok := resourceListGPUValue(resources.Limits); ok {
-		return value
-	}
-	return 0
-}
-
-func resourceListGPUValue(resources corev1.ResourceList) (int64, bool) {
-	if q, ok := resources[corev1.ResourceName(commonconsts.KubeResourceGPUNvidia)]; ok {
-		return q.Value(), true
-	}
-	for name, q := range resources {
-		if resourceNameIsGPU(name) {
-			return q.Value(), true
-		}
-	}
-	return 0, false
-}
-
-func resourceNameIsGPU(name corev1.ResourceName) bool {
-	normalized := strings.ToLower(string(name))
-	return normalized == "gpu" ||
-		normalized == "nvidia/gpu" ||
-		strings.HasSuffix(normalized, "/gpu") ||
-		strings.Contains(normalized, ".com/gpu") ||
-		strings.HasPrefix(normalized, "mig-") ||
-		strings.Contains(normalized, "/mig-")
-}
-
-func resourceRequirementsWithFallback(resources, fallback corev1.ResourceRequirements) corev1.ResourceRequirements {
-	if len(resources.Requests) == 0 {
-		resources.Requests = fallback.Requests
-	}
-	if len(resources.Limits) == 0 {
-		resources.Limits = fallback.Limits
-	}
-	if len(resources.Claims) == 0 {
-		resources.Claims = fallback.Claims
-	}
-	return resources
 }

--- a/deploy/operator/internal/dynamo/backend_vllm.go
+++ b/deploy/operator/internal/dynamo/backend_vllm.go
@@ -27,6 +27,7 @@ const (
 
 type VLLMBackend struct {
 	ParentGraphDeploymentName string
+	GPUsPerNode               int64
 }
 
 func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
@@ -51,8 +52,13 @@ func (b *VLLMBackend) UpdateContainer(container *corev1.Container, numberOfNodes
 
 	if isMultinode {
 		resources := resourceRequirementsWithFallback(container.Resources, GetMainContainerResources(component))
+		gpusPerNode := b.GPUsPerNode
+		if gpusPerNode == 0 {
+			gpusPerNode = getContainerGPUs(&resources)
+		}
+
 		// Apply multinode-specific argument modifications
-		updateVLLMMultinodeArgs(container, role, serviceName, multinodeDeployer, &resources, numberOfNodes, annotations)
+		updateVLLMMultinodeArgs(container, role, serviceName, multinodeDeployer, gpusPerNode, numberOfNodes, annotations)
 
 		if shouldUseMpBackend(annotations) {
 			container.Env = append(container.Env, corev1.EnvVar{
@@ -266,9 +272,9 @@ func (b *VLLMBackend) shouldInjectVLLMMpWaitLeaderInit(podSpec *corev1.PodSpec, 
 
 // updateVLLMMultinodeArgs dispatches to the appropriate injection function based on
 // parallelism strategy (TP/PP distributed vs data-parallel) and executor backend (mp vs ray).
-func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *corev1.ResourceRequirements, numberOfNodes int32, annotations map[string]string) {
+func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, gpusPerNode int64, numberOfNodes int32, annotations map[string]string) {
 	expandedArgs := getExpandedArgs(container)
-	needsDistributed := needsTensorParallelMultinodeLaunch(expandedArgs, resources)
+	needsDistributed := needsTensorParallelMultinodeLaunch(expandedArgs, gpusPerNode)
 
 	if needsDistributed && shouldUseMpBackend(annotations) {
 		injectMpDistributedLaunchFlags(container, role, serviceName, multinodeDeployer, numberOfNodes)
@@ -286,8 +292,8 @@ func updateVLLMMultinodeArgs(container *corev1.Container, role Role, serviceName
 		// only the leader node is in the Ray cluster when create_dp_placement_groups runs,
 		// so vLLM naturally places all initial DP workers on the leader node.
 		injectElasticEPRayLaunchFlags(container, role, serviceName, multinodeDeployer)
-	} else if needsDataParallelMultinodeLaunch(expandedArgs, resources) {
-		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, resources, numberOfNodes)
+	} else if needsDataParallelMultinodeLaunch(expandedArgs, gpusPerNode) {
+		injectDataParallelLaunchFlags(container, role, serviceName, multinodeDeployer, gpusPerNode, numberOfNodes)
 	} else {
 		logger := log.Log.WithName("vllm-backend")
 		logger.Info("No need to inject tensor or data parallel flags for multinode deployments", "args", strings.Join(container.Args, " "))
@@ -474,14 +480,13 @@ func hasFlag(expandedArgs []string, flag string) bool {
 	return false
 }
 
-func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, resources *corev1.ResourceRequirements, numberOfNodes int32) {
+func injectDataParallelLaunchFlags(container *corev1.Container, role Role, serviceName string, multinodeDeployer MultinodeDeployer, gpusPerNode int64, numberOfNodes int32) {
 	expandedArgs := getExpandedArgs(container)
 	leaderHostname := multinodeDeployer.GetLeaderHostname(serviceName)
 
 	// Calculate engines per node
-	containerGPUs := getContainerGPUs(resources)
 	worldSize := getWorldSize(expandedArgs) // TP * PP per engine
-	dataParallelSizeLocal := containerGPUs / worldSize
+	dataParallelSizeLocal := gpusPerNode / worldSize
 
 	// Get total DP size from args, or calculate from nodes
 	totalDPSize := getFlagValue(expandedArgs, dataParallelSizeFlag)
@@ -533,12 +538,11 @@ func injectDataParallelLaunchFlags(container *corev1.Container, role Role, servi
 
 // needsMultinodeDistributedLaunch returns true when the model's world size (TP * PP)
 // exceeds the GPU count of a single node, requiring multi-node distribution (via mp or ray).
-func needsTensorParallelMultinodeLaunch(expandedArgs []string, resources *corev1.ResourceRequirements) bool {
-	containerGPUs := getContainerGPUs(resources)
-	if containerGPUs == 0 {
+func needsTensorParallelMultinodeLaunch(expandedArgs []string, gpusPerNode int64) bool {
+	if gpusPerNode == 0 {
 		return false
 	}
-	return getWorldSize(expandedArgs) > containerGPUs
+	return getWorldSize(expandedArgs) > gpusPerNode
 }
 
 func getWorldSize(expandedArgs []string) int64 {
@@ -548,13 +552,12 @@ func getWorldSize(expandedArgs []string) int64 {
 }
 
 // if world size across all DP ranks > GPU count, then we need to inject data parallel multinode coordination
-func needsDataParallelMultinodeLaunch(expandedArgs []string, resources *corev1.ResourceRequirements) bool {
+func needsDataParallelMultinodeLaunch(expandedArgs []string, gpusPerNode int64) bool {
 	dataParallelSize := getFlagValue(expandedArgs, dataParallelSizeFlag)
-	containerGPUs := getContainerGPUs(resources)
-	if containerGPUs == 0 {
+	if gpusPerNode == 0 {
 		return false
 	}
-	return getWorldSize(expandedArgs)*dataParallelSize > containerGPUs
+	return getWorldSize(expandedArgs)*dataParallelSize > gpusPerNode
 }
 
 func getFlagValue(expandedArgs []string, flag string) int64 {

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // TestShellQuotePOSIX_ArgvRoundTrip re-parses the quoted tokens through a real
@@ -61,21 +61,7 @@ func findEnvVar(env []corev1.EnvVar, name string) *corev1.EnvVar {
 	return nil
 }
 
-func TestGetContainerGPUsRecognizesMIGResources(t *testing.T) {
-	resources := &corev1.ResourceRequirements{
-		Requests: corev1.ResourceList{
-			corev1.ResourceName("nvidia.com/mig-3g.20gb"): resource.MustParse("2"),
-		},
-	}
-
-	if got := getContainerGPUs(resources); got != 2 {
-		t.Fatalf("getContainerGPUs() = %d, want 2", got)
-	}
-}
-
 func TestVLLMBackend_UpdateContainer(t *testing.T) {
-	backend := &VLLMBackend{}
-
 	tests := []struct {
 		name                string
 		numberOfNodes       int32
@@ -83,7 +69,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 		component           *v1alpha1.DynamoComponentDeploymentSharedSpec
 		multinodeDeployer   MultinodeDeployer
 		initialContainer    *corev1.Container
-		gpuCount            int64 // GPU count for the test case
+		containerGPUs       int64
 		expectedArgs        []string
 		expectNotModified   bool // If true, container args should not change
 		expectProbesRemoved bool // If true, probes should be nil
@@ -97,7 +83,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm"}},
-			gpuCount:          0,
+			containerGPUs:     0,
 			expectNotModified: true,
 		},
 		{
@@ -107,7 +93,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:           &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "test", tensorParallelSizeFlag, "8"}},
-			gpuCount:            4,
+			containerGPUs:       4,
 			expectedArgs:        []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm --model test %s 8 --distributed-executor-backend ray", VLLMPort, tensorParallelSizeFlag)},
 			expectProbesRemoved: true,
 		},
@@ -125,7 +111,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 					`{"kv_connector": "NixlConnector", "kv_role": "kv_both"}`,
 				},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s && python3 -m dynamo.vllm --model test %s 8 --kv-transfer-config "{\"kv_connector\": \"NixlConnector\", \"kv_role\": \"kv_both\"}" --distributed-executor-backend ray`,
 				VLLMPort, tensorParallelSizeFlag,
@@ -139,7 +125,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:           &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", "--model", "test", tensorParallelSizeFlag, "8"}},
-			gpuCount:            4,
+			containerGPUs:       4,
 			expectedArgs:        []string{"ray start --address=$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE):6379 --block"},
 			expectProbesRemoved: true,
 		},
@@ -150,7 +136,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:           &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer:   &LWSMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Args: []string{"python3", "-m", "dynamo.vllm", tensorParallelSizeFlag, "8"}},
-			gpuCount:            4,
+			containerGPUs:       4,
 			expectedArgs:        []string{"ray start --address=$(LWS_LEADER_ADDRESS):6379 --block"},
 			expectProbesRemoved: true,
 		},
@@ -161,7 +147,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Args: []string{}},
-			gpuCount:          0,
+			containerGPUs:     0,
 			expectNotModified: true, // Should not modify empty args
 		},
 		{
@@ -171,7 +157,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			component:         &v1alpha1.DynamoComponentDeploymentSharedSpec{},
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Args: []string{"python3", "-m", "dynamo.frontend"}},
-			gpuCount:          0,
+			containerGPUs:     0,
 			expectNotModified: true,
 		},
 		{
@@ -185,7 +171,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
-			gpuCount:            8,
+			containerGPUs:       8,
 			expectedArgs:        []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16", "--distributed-executor-backend", "mp", "--nnodes", "2", "--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)", "--master-port", commonconsts.VLLMMpMasterPort, "--node-rank", "0"},
 			expectProbesRemoved: true,
 		},
@@ -200,7 +186,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			multinodeDeployer: &GroveMultinodeDeployer{},
 			initialContainer:  &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
-			gpuCount:          8,
+			containerGPUs:     8,
 			expectedArgs: []string{fmt.Sprintf(
 				"exec python3 -m dynamo.vllm %s 16 --distributed-executor-backend mp --nnodes 2 --master-addr $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --master-port %s --node-rank $((GROVE_PCLQ_POD_INDEX + 1)) --headless",
 				tensorParallelSizeFlag, commonconsts.VLLMMpMasterPort)},
@@ -218,7 +204,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3", "-m", "dynamo.vllm"}, Args: []string{"--model", "test", tensorParallelSizeFlag, "8"}},
-			gpuCount:            4,
+			containerGPUs:       4,
 			expectedArgs:        []string{fmt.Sprintf("ray start --head --port=%s && python3 -m dynamo.vllm --model test %s 8 --distributed-executor-backend ray", VLLMPort, tensorParallelSizeFlag)},
 			expectProbesRemoved: true,
 		},
@@ -233,7 +219,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			},
 			multinodeDeployer:   &GroveMultinodeDeployer{},
 			initialContainer:    &corev1.Container{Command: []string{"python3"}, Args: []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16"}},
-			gpuCount:            8,
+			containerGPUs:       8,
 			expectedArgs:        []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16", "--distributed-executor-backend", "mp", "--nnodes", "2", "--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)", "--master-port", commonconsts.VLLMMpMasterPort, "--node-rank", "0"},
 			expectProbesRemoved: true,
 		},
@@ -252,7 +238,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{},
 				StartupProbe:   &corev1.Probe{},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
@@ -276,7 +262,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{},
 				StartupProbe:   &corev1.Probe{},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test --data-parallel-backend=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
@@ -300,7 +286,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{},
 				StartupProbe:   &corev1.Probe{},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
@@ -321,7 +307,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{},
 				StartupProbe:   &corev1.Probe{},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --model test -dpb=ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
@@ -343,7 +329,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				ReadinessProbe: &corev1.Probe{},
 				StartupProbe:   &corev1.Probe{},
 			},
-			gpuCount: 4,
+			containerGPUs: 4,
 			expectedArgs: []string{fmt.Sprintf(
 				`ray start --head --port=%s --node-ip-address="$POD_IP" --block & i=0; until python3 -c "import socket; s=socket.create_connection(('127.0.0.1',%s),timeout=1); s.close()" 2>/dev/null; do i=$((i+1)); [ "$i" -ge 150 ] && { echo "ERROR: Ray head did not start within 300s" >&2; exit 1; }; sleep 2; done && exec python3 -m dynamo.vllm --data-parallel-backend ray %s`,
 				VLLMPort, VLLMPort, enableElasticEPFlag,
@@ -364,7 +350,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			initialContainer: &corev1.Container{
 				Args: []string{"--model", "test", "--data-parallel-backend", "ray", enableElasticEPFlag},
 			},
-			gpuCount:          4,
+			containerGPUs:     4,
 			expectNotModified: true,
 		},
 		{
@@ -377,7 +363,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				Command: []string{"python3", "-m", "dynamo.vllm"},
 				Args:    []string{"--model", "test", "--data-parallel-backend", "ray"},
 			},
-			gpuCount:          4,
+			containerGPUs:     4,
 			expectNotModified: true,
 		},
 		// moe_agg.yaml and moe_disagg.yaml pass --enable-elastic-ep on the default
@@ -393,7 +379,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				Command: []string{"python3", "-m", "dynamo.vllm"},
 				Args:    []string{"--model", "test", enableElasticEPFlag},
 			},
-			gpuCount:          2,
+			containerGPUs:     2,
 			expectNotModified: true,
 		},
 		{
@@ -406,28 +392,69 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 				Command: []string{"python3", "-m", "dynamo.vllm"},
 				Args:    []string{"--model", "test", "--data-parallel-backend", "mp", enableElasticEPFlag},
 			},
-			gpuCount:          2,
+			containerGPUs:     2,
 			expectNotModified: true,
+		},
+		{
+			name:          "multinode leader uses GPU count resolved from DRA",
+			numberOfNodes: 2,
+			role:          RoleLeader,
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				Annotations: map[string]string{
+					commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+				},
+				Resources: &v1alpha1.Resources{
+					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+				},
+			},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "2"},
+			},
+			containerGPUs: 1,
+			expectedArgs: []string{
+				"-m", "dynamo.vllm", tensorParallelSizeFlag, "2",
+				"--distributed-executor-backend", "mp",
+				"--nnodes", "2",
+				"--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)",
+				"--master-port", commonconsts.VLLMMpMasterPort,
+				"--node-rank", "0",
+			},
+			expectProbesRemoved: true,
+		},
+		{
+			name:          "multinode worker computes data parallel ranks from DRA GPU count",
+			numberOfNodes: 2,
+			role:          RoleWorker,
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				Resources: &v1alpha1.Resources{
+					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+				},
+			},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "2"},
+			},
+			containerGPUs: 1,
+			expectedArgs: []string{fmt.Sprintf(
+				"exec python3 -m dynamo.vllm %s 2 --data-parallel-hybrid-lb --data-parallel-size-local 1 --data-parallel-start-rank $(( 1 * $((GROVE_PCLQ_POD_INDEX + 1)) )) --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445",
+				dataParallelSizeFlag,
+			)},
+			expectProbesRemoved: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
+			backend := &VLLMBackend{}
 
 			initialContainerArgs := append([]string{}, tt.initialContainer.Args...)
 
-			// Create resources from GPU count and set in component
-			if tt.gpuCount > 0 {
-				tt.component.Resources = &v1alpha1.Resources{
-					Limits: &v1alpha1.ResourceItem{
-						GPU: strconv.FormatInt(tt.gpuCount, 10),
-					},
-				}
-			}
-
 			// Call UpdateContainer
-			backend.UpdateContainer(tt.initialContainer, tt.numberOfNodes, tt.role, betaComponent(t, tt.component), "test-service", tt.multinodeDeployer)
+			require.NoError(t, backend.UpdateContainer(tt.initialContainer, tt.numberOfNodes, tt.role, betaComponent(t, tt.component), "test-service", tt.multinodeDeployer, staticContainerGPUCount(tt.containerGPUs)))
 
 			if tt.expectNotModified {
 				// Args should not have changed
@@ -551,7 +578,7 @@ func TestVLLMBackend_ShellCommandInjection(t *testing.T) {
 				}
 			}
 
-			backend.UpdateContainer(tt.initialContainer, tt.numberOfNodes, tt.role, betaComponent(t, component), "test-service", tt.multinodeDeployer)
+			require.NoError(t, backend.UpdateContainer(tt.initialContainer, tt.numberOfNodes, tt.role, betaComponent(t, component), "test-service", tt.multinodeDeployer, staticContainerGPUCount(tt.gpuCount)))
 
 			if !reflect.DeepEqual(tt.initialContainer.Args, tt.expectedArgs) {
 				t.Errorf("UpdateContainer() args = %v, want %v", tt.initialContainer.Args, tt.expectedArgs)
@@ -641,7 +668,7 @@ func TestVLLMBackend_UpdateContainer_UseAsCompilationCache(t *testing.T) {
 			}
 
 			// Call UpdateContainer
-			backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{})
+			require.NoError(t, backend.UpdateContainer(container, 1, RoleMain, betaComponent(t, tt.component), "test-service", &GroveMultinodeDeployer{}, staticContainerGPUCount(0)))
 
 			if tt.expectCacheEnvVar {
 				// Check that the VLLM_CACHE_ROOT environment variable is set
@@ -920,18 +947,8 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 
 			initialContainerArgs := append([]string{}, tt.initialContainer.Args...)
 
-			// Create resources from GPU count
-			var resources *v1alpha1.Resources
-			if tt.gpuCount > 0 {
-				resources = &v1alpha1.Resources{
-					Limits: &v1alpha1.ResourceItem{
-						GPU: strconv.FormatInt(tt.gpuCount, 10),
-					},
-				}
-			}
-
 			// Call updateVLLMMultinodeArgs with annotations
-			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, betaResourceRequirements(t, resources), 2, tt.annotations)
+			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, tt.gpuCount, 2, tt.annotations)
 
 			if tt.expectNotModified {
 				// Args should not have changed
@@ -1308,7 +1325,7 @@ func TestVLLMBackend_UpdateContainer_InterPodGMS(t *testing.T) {
 				Args:    []string{"-m", "dynamo.vllm"},
 			}
 
-			backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
+			require.NoError(t, backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{}, staticContainerGPUCount(0)))
 
 			if got := containerHasArg(container, "--load-format", "gms"); got != tt.wantLoadFormat {
 				t.Errorf("containerHasArg(--load-format gms) = %v, want %v; args=%v", got, tt.wantLoadFormat, container.Args)
@@ -1344,7 +1361,7 @@ func TestVLLMBackend_UpdateContainer_NoInterPodGMS(t *testing.T) {
 		Args:    []string{"-m", "dynamo.vllm"},
 	}
 
-	backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{})
+	require.NoError(t, backend.UpdateContainer(container, 1, RoleMain, component, "svc", &GroveMultinodeDeployer{}, staticContainerGPUCount(0)))
 
 	if containerHasArg(container, "--load-format", "gms") {
 		t.Errorf("--load-format gms must not be injected when inter-pod GMS is disabled")

--- a/deploy/operator/internal/dynamo/backend_vllm_test.go
+++ b/deploy/operator/internal/dynamo/backend_vllm_test.go
@@ -26,8 +26,6 @@ func TestGetContainerGPUsRecognizesMIGResources(t *testing.T) {
 }
 
 func TestVLLMBackend_UpdateContainer(t *testing.T) {
-	backend := &VLLMBackend{}
-
 	tests := []struct {
 		name                string
 		numberOfNodes       int32
@@ -36,6 +34,7 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 		multinodeDeployer   MultinodeDeployer
 		initialContainer    *corev1.Container
 		gpuCount            int64 // GPU count for the test case
+		resolvedGPUCount    int64
 		expectedArgs        []string
 		expectNotModified   bool // If true, container args should not change
 		expectProbesRemoved bool // If true, probes should be nil
@@ -187,11 +186,61 @@ func TestVLLMBackend_UpdateContainer(t *testing.T) {
 			expectedArgs:        []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "16", "--distributed-executor-backend", "mp", "--nnodes", "2", "--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)", "--master-port", commonconsts.VLLMMpMasterPort, "--node-rank", "0"},
 			expectProbesRemoved: true,
 		},
+		{
+			name:          "multinode leader uses GPU count resolved from DRA",
+			numberOfNodes: 2,
+			role:          RoleLeader,
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				Annotations: map[string]string{
+					commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+				},
+				Resources: &v1alpha1.Resources{
+					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+				},
+			},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "2"},
+			},
+			resolvedGPUCount: 1,
+			expectedArgs: []string{
+				"-m", "dynamo.vllm", tensorParallelSizeFlag, "2",
+				"--distributed-executor-backend", "mp",
+				"--nnodes", "2",
+				"--master-addr", "$(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE)",
+				"--master-port", commonconsts.VLLMMpMasterPort,
+				"--node-rank", "0",
+			},
+			expectProbesRemoved: true,
+		},
+		{
+			name:          "multinode worker computes data parallel ranks from DRA GPU count",
+			numberOfNodes: 2,
+			role:          RoleWorker,
+			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
+				Resources: &v1alpha1.Resources{
+					Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+				},
+			},
+			multinodeDeployer: &GroveMultinodeDeployer{},
+			initialContainer: &corev1.Container{
+				Command: []string{"python3"},
+				Args:    []string{"-m", "dynamo.vllm", dataParallelSizeFlag, "2"},
+			},
+			resolvedGPUCount: 1,
+			expectedArgs: []string{fmt.Sprintf(
+				"exec python3 -m dynamo.vllm %s 2 --data-parallel-hybrid-lb --data-parallel-size-local 1 --data-parallel-start-rank $(( 1 * $((GROVE_PCLQ_POD_INDEX + 1)) )) --data-parallel-address $(GROVE_PCSG_NAME)-$(GROVE_PCSG_INDEX)-test-service-ldr-0.$(GROVE_HEADLESS_SERVICE) --data-parallel-rpc-port 13445",
+				dataParallelSizeFlag,
+			)},
+			expectProbesRemoved: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := gomega.NewGomegaWithT(t)
+			backend := &VLLMBackend{GPUsPerNode: tt.resolvedGPUCount}
 
 			initialContainerArgs := append([]string{}, tt.initialContainer.Args...)
 
@@ -656,18 +705,8 @@ func TestUpdateVLLMMultinodeArgs(t *testing.T) {
 
 			initialContainerArgs := append([]string{}, tt.initialContainer.Args...)
 
-			// Create resources from GPU count
-			var resources *v1alpha1.Resources
-			if tt.gpuCount > 0 {
-				resources = &v1alpha1.Resources{
-					Limits: &v1alpha1.ResourceItem{
-						GPU: strconv.FormatInt(tt.gpuCount, 10),
-					},
-				}
-			}
-
 			// Call updateVLLMMultinodeArgs with annotations
-			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, betaResourceRequirements(t, resources), 2, tt.annotations)
+			updateVLLMMultinodeArgs(tt.initialContainer, tt.role, "test-service", tt.multinodeDeployer, tt.gpuCount, 2, tt.annotations)
 
 			if tt.expectNotModified {
 				// Args should not have changed

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1550,6 +1550,8 @@ func applyDefaultSecurityContext(podSpec *corev1.PodSpec) {
 // Includes standard environment variables (DYNAMO_PORT, NATS_SERVER, ETCD_ENDPOINTS)
 // Deployment-specific environment merging should be handled by the caller
 // containerGPUs lazily resolves the main container's scalar or DRA-backed GPU count.
+//
+//nolint:gocyclo
 func GenerateBasePodSpec(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	backendFramework BackendFramework,

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -27,6 +27,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -1403,18 +1404,23 @@ func ParseBackendFramework(framework string) (BackendFramework, error) {
 	}
 }
 
+// ContainerGPUCount lazily resolves the main container's scalar or DRA-backed
+// GPU count. The same resolver can be shared across all roles of a component.
+type ContainerGPUCount func() (int64, error)
+
 // Backend interface for modular backend logic
 // Each backend (SGLang, VLLM, etc.) implements this interface
 type Backend interface {
-	UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer)
+	UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, containerGPUs ContainerGPUCount) error
 	UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer)
 }
 
 // NoopBackend does no processing - used for non-worker components like frontend, planner, router
 type NoopBackend struct{}
 
-func (b *NoopBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
+func (b *NoopBackend) UpdateContainer(container *corev1.Container, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer, _ ContainerGPUCount) error {
 	// No-op: frontend, planner, router, etc. don't need backend-specific processing
+	return nil
 }
 
 func (b *NoopBackend) UpdatePodSpec(podSpec *corev1.PodSpec, numberOfNodes int32, role Role, component *v1beta1.DynamoComponentDeploymentSharedSpec, serviceName string, multinodeDeployer MultinodeDeployer) {
@@ -1543,8 +1549,7 @@ func applyDefaultSecurityContext(podSpec *corev1.PodSpec) {
 // GenerateBasePodSpec creates a basic PodSpec with common logic shared between controller and grove
 // Includes standard environment variables (DYNAMO_PORT, NATS_SERVER, ETCD_ENDPOINTS)
 // Deployment-specific environment merging should be handled by the caller
-//
-//nolint:gocyclo
+// containerGPUs lazily resolves the main container's scalar or DRA-backed GPU count.
 func GenerateBasePodSpec(
 	component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	backendFramework BackendFramework,
@@ -1558,6 +1563,7 @@ func GenerateBasePodSpec(
 	serviceName string,
 	checkpointInfo *checkpoint.CheckpointInfo, // Optional checkpoint info (resolved by ResolveCheckpointForService)
 	deployerOverride MultinodeDeployer, // Optional: overrides factory-created deployer when non-nil
+	containerGPUs ContainerGPUCount,
 ) (*corev1.PodSpec, error) {
 	// Start with base container generated per component type
 	annotations := GetPodTemplateAnnotations(component)
@@ -1596,7 +1602,9 @@ func GenerateBasePodSpec(
 	if backend == nil {
 		return nil, fmt.Errorf("unsupported backend framework: %s", backendFramework)
 	}
-	backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer)
+	if err := backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer, containerGPUs); err != nil {
+		return nil, fmt.Errorf("failed to update container for backend %s: %w", backendFramework, err)
+	}
 	applyCheckpointProbeCadence(&container, component, checkpointInfo)
 
 	// get base podspec from component
@@ -1970,11 +1978,12 @@ func GeneratePodSpecForComponent(
 	serviceName string,
 	checkpointInfo *checkpoint.CheckpointInfo,
 	deployerOverride MultinodeDeployer,
+	containerGPUs ContainerGPUCount,
 ) (*corev1.PodSpec, error) {
 	return generatePodSpecForComponent(
 		component, backendFramework, secretsRetriever, dynamoDeployment,
 		role, numberOfNodes, operatorConfig, multinodeDeploymentType,
-		serviceName, checkpointInfo, deployerOverride, nil,
+		serviceName, checkpointInfo, deployerOverride, nil, containerGPUs,
 	)
 }
 
@@ -1991,6 +2000,7 @@ func generatePodSpecForComponent(
 	checkpointInfo *checkpoint.CheckpointInfo,
 	deployerOverride MultinodeDeployer,
 	groveClusterTopologyDomains []v1beta1.TopologyDomain,
+	containerGPUs ContainerGPUCount,
 ) (*corev1.PodSpec, error) {
 	if component == nil {
 		return nil, fmt.Errorf("component is nil")
@@ -2004,11 +2014,40 @@ func generatePodSpecForComponent(
 		operatorConfig = &configv1alpha1.OperatorConfiguration{}
 	}
 
-	podSpec, err := GenerateBasePodSpec(component, backendFramework, secretsRetriever, dynamoDeployment.Name, dynamoDeployment.Namespace, role, numberOfNodes, operatorConfig, multinodeDeploymentType, serviceName, checkpointInfo, deployerOverride)
+	podSpec, err := GenerateBasePodSpec(component, backendFramework, secretsRetriever, dynamoDeployment.Name, dynamoDeployment.Namespace, role, numberOfNodes, operatorConfig, multinodeDeploymentType, serviceName, checkpointInfo, deployerOverride, containerGPUs)
 	if err != nil {
 		return nil, err
 	}
 	return podSpec, nil
+}
+
+// ResolveContainerGPUs returns the GPU count requested by the main container,
+// whether expressed as scalar resources or DRA ResourceClaims.
+func ResolveContainerGPUs(
+	ctx context.Context,
+	reader ctrlclient.Reader,
+	namespace string,
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+) (int64, error) {
+	if component == nil {
+		return 0, fmt.Errorf("component is nil")
+	}
+
+	podSpec := &corev1.PodSpec{}
+	if component.PodTemplate != nil {
+		podSpec = &component.PodTemplate.Spec
+	}
+	gpuCount, err := dra.ResolveGPUCount(
+		ctx,
+		reader,
+		namespace,
+		podSpec,
+		GetMainContainerResources(component),
+	)
+	if err != nil {
+		return 0, err
+	}
+	return int64(gpuCount), nil
 }
 
 func applyDGDTemplateDefaults(
@@ -2210,6 +2249,7 @@ type cliqueParams struct {
 	validatedQueueName          string
 	checkpointRestore           *checkpoint.ResolvedPodSpecRestore
 	groveClusterTopologyDomains []v1beta1.TopologyDomain
+	containerGPUs               ContainerGPUCount
 }
 
 // buildCliqueForRole generates a single PodCliqueTemplateSpec for the given role,
@@ -2220,7 +2260,7 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 	podSpec, err := generatePodSpecForRole(
 		p.r, p.component, p.backendFramework, p.secretsRetriever,
 		p.dynamoDeployment, p.numberOfNodes, p.operatorConfig, p.componentName, p.checkpointInfo,
-		p.groveClusterTopologyDomains,
+		p.groveClusterTopologyDomains, p.containerGPUs,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", p.r.Name, err)
@@ -2545,6 +2585,9 @@ func GenerateGrovePodCliqueSet(
 
 		numberOfNodes := component.GetNumberOfNodes()
 		isMultinode := numberOfNodes > 1
+		containerGPUs := sync.OnceValues(func() (int64, error) {
+			return ResolveContainerGPUs(ctx, reader, dynamoDeployment.Namespace, component)
+		})
 		isInterPodGMS := component.IsInterPodGMSEnabled()
 		isInterPodFailover := component.IsInterPodFailoverEnabled()
 		usesPCSG := component.UsesPCSG()
@@ -2574,6 +2617,7 @@ func GenerateGrovePodCliqueSet(
 				validatedQueueName:          validatedQueueName,
 				checkpointRestore:           checkpointRestore,
 				groveClusterTopologyDomains: groveClusterTopologyDomains,
+				containerGPUs:               containerGPUs,
 			})
 			if err != nil {
 				return nil, err
@@ -2688,6 +2732,7 @@ func generatePodSpecForRole(
 	serviceName string,
 	checkpointInfo *checkpoint.CheckpointInfo,
 	groveClusterTopologyDomains []v1beta1.TopologyDomain,
+	containerGPUs ContainerGPUCount,
 ) (*corev1.PodSpec, error) {
 	isInterPodGMS := component.IsInterPodGMSEnabled()
 
@@ -2697,7 +2742,7 @@ func generatePodSpecForRole(
 			component, backendFramework, secretsRetriever, dynamoDeployment,
 			RoleMain, 1, operatorConfig,
 			commonconsts.MultinodeDeploymentTypeGrove, serviceName, checkpointInfo, nil,
-			groveClusterTopologyDomains,
+			groveClusterTopologyDomains, containerGPUs,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate base podSpec for GMS: %w", err)
@@ -2719,7 +2764,7 @@ func generatePodSpecForRole(
 		component, backendFramework, secretsRetriever, dynamoDeployment,
 		r.Role, numberOfNodes, operatorConfig,
 		commonconsts.MultinodeDeploymentTypeGrove, serviceName, checkpointInfo, deployer,
-		groveClusterTopologyDomains,
+		groveClusterTopologyDomains, containerGPUs,
 	)
 	if err != nil {
 		return nil, err
@@ -3034,6 +3079,7 @@ func GenerateBasePodSpecForController(
 	role Role,
 	multinodeDeploymentType commonconsts.MultinodeDeploymentType,
 	checkpointInfo *checkpoint.CheckpointInfo, // Optional checkpoint info (resolved by caller)
+	containerGPUs ContainerGPUCount,
 	options GenerateBasePodSpecForControllerOptions,
 ) (*corev1.PodSpec, error) {
 	// Convert to our interface
@@ -3073,6 +3119,7 @@ func GenerateBasePodSpecForController(
 		componentName,
 		checkpointInfo,
 		nil, // use default deployer
+		containerGPUs,
 	)
 	if err != nil {
 		return nil, err

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1362,6 +1362,10 @@ type MultinodeDeployer interface {
 	NeedsDNSWait() bool          // returns true if DNS wait is needed to launch multinode components
 }
 
+type backendRenderContext struct {
+	GPUsPerNode int64
+}
+
 // BackendFactory creates backend instances based on the framework type
 func BackendFactory(backendFramework BackendFramework, operatorConfig *configv1alpha1.OperatorConfiguration, parentGraphDeploymentName string) Backend {
 	switch backendFramework {
@@ -1493,6 +1497,42 @@ func GenerateBasePodSpec(
 	checkpointInfo *checkpoint.CheckpointInfo, // Optional checkpoint info (resolved by ResolveCheckpointForService)
 	deployerOverride MultinodeDeployer, // Optional: overrides factory-created deployer when non-nil
 ) (*corev1.PodSpec, error) {
+	return generateBasePodSpec(
+		component,
+		backendFramework,
+		secretsRetriever,
+		parentGraphDeploymentName,
+		namespace,
+		role,
+		numberOfNodes,
+		operatorConfig,
+		multinodeDeploymentType,
+		serviceName,
+		checkpointInfo,
+		deployerOverride,
+		backendRenderContext{},
+	)
+}
+
+// generateBasePodSpec accepts controller-resolved resource information while
+// preserving GenerateBasePodSpec as the client-independent rendering entrypoint.
+//
+//nolint:gocyclo
+func generateBasePodSpec(
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework BackendFramework,
+	secretsRetriever SecretsRetriever,
+	parentGraphDeploymentName string,
+	namespace string,
+	role Role,
+	numberOfNodes int32,
+	operatorConfig *configv1alpha1.OperatorConfiguration,
+	multinodeDeploymentType commonconsts.MultinodeDeploymentType,
+	serviceName string,
+	checkpointInfo *checkpoint.CheckpointInfo,
+	deployerOverride MultinodeDeployer,
+	renderContext backendRenderContext,
+) (*corev1.PodSpec, error) {
 	// Start with base container generated per component type
 	annotations := GetPodTemplateAnnotations(component)
 	componentContext := generateComponentContext(component, parentGraphDeploymentName, namespace, numberOfNodes, NewDiscoveryContext(operatorConfig.Discovery.Backend, annotations))
@@ -1529,6 +1569,9 @@ func GenerateBasePodSpec(
 	backend := BackendFactory(backendFramework, operatorConfig, parentGraphDeploymentName)
 	if backend == nil {
 		return nil, fmt.Errorf("unsupported backend framework: %s", backendFramework)
+	}
+	if vllmBackend, ok := backend.(*VLLMBackend); ok {
+		vllmBackend.GPUsPerNode = renderContext.GPUsPerNode
 	}
 	backend.UpdateContainer(&container, numberOfNodes, role, component, serviceName, multinodeDeployer)
 	applyCheckpointProbeCadence(&container, component, checkpointInfo)
@@ -1902,7 +1945,7 @@ func GeneratePodSpecForComponent(
 	return generatePodSpecForComponent(
 		component, backendFramework, secretsRetriever, dynamoDeployment,
 		role, numberOfNodes, operatorConfig, multinodeDeploymentType,
-		serviceName, checkpointInfo, deployerOverride, nil,
+		serviceName, checkpointInfo, deployerOverride, nil, backendRenderContext{},
 	)
 }
 
@@ -1919,6 +1962,7 @@ func generatePodSpecForComponent(
 	checkpointInfo *checkpoint.CheckpointInfo,
 	deployerOverride MultinodeDeployer,
 	groveClusterTopologyDomains []v1beta1.TopologyDomain,
+	renderContext backendRenderContext,
 ) (*corev1.PodSpec, error) {
 	if component == nil {
 		return nil, fmt.Errorf("component is nil")
@@ -1932,11 +1976,37 @@ func generatePodSpecForComponent(
 		operatorConfig = &configv1alpha1.OperatorConfiguration{}
 	}
 
-	podSpec, err := GenerateBasePodSpec(component, backendFramework, secretsRetriever, dynamoDeployment.Name, dynamoDeployment.Namespace, role, numberOfNodes, operatorConfig, multinodeDeploymentType, serviceName, checkpointInfo, deployerOverride)
+	podSpec, err := generateBasePodSpec(component, backendFramework, secretsRetriever, dynamoDeployment.Name, dynamoDeployment.Namespace, role, numberOfNodes, operatorConfig, multinodeDeploymentType, serviceName, checkpointInfo, deployerOverride, renderContext)
 	if err != nil {
 		return nil, err
 	}
 	return podSpec, nil
+}
+
+func resolveBackendRenderContext(
+	ctx context.Context,
+	kubeClient ctrlclient.Client,
+	namespace string,
+	component *v1beta1.DynamoComponentDeploymentSharedSpec,
+	backendFramework BackendFramework,
+	numberOfNodes int32,
+) (backendRenderContext, error) {
+	if backendFramework != BackendFrameworkVLLM || numberOfNodes <= 1 {
+		return backendRenderContext{}, nil
+	}
+
+	podTemplate := ensurePodTemplate(component)
+	gpuCount, err := dra.ResolveGPUCount(
+		ctx,
+		kubeClient,
+		namespace,
+		&podTemplate.Spec,
+		GetMainContainerResources(component),
+	)
+	if err != nil {
+		return backendRenderContext{}, err
+	}
+	return backendRenderContext{GPUsPerNode: int64(gpuCount)}, nil
 }
 
 func applyDGDTemplateDefaults(
@@ -2140,6 +2210,7 @@ type cliqueParams struct {
 	kubeClient                  ctrlclient.Client
 	ctx                         context.Context
 	groveClusterTopologyDomains []v1beta1.TopologyDomain
+	renderContext               backendRenderContext
 }
 
 // buildCliqueForRole generates a single PodCliqueTemplateSpec for the given role,
@@ -2150,7 +2221,7 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 	podSpec, err := generatePodSpecForRole(
 		p.r, p.component, p.backendFramework, p.secretsRetriever,
 		p.dynamoDeployment, p.numberOfNodes, p.operatorConfig, p.componentName, p.checkpointInfo,
-		p.groveClusterTopologyDomains,
+		p.groveClusterTopologyDomains, p.renderContext,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate podSpec for role %s: %w", p.r.Name, err)
@@ -2436,6 +2507,17 @@ func GenerateGrovePodCliqueSet(
 
 		numberOfNodes := component.GetNumberOfNodes()
 		isMultinode := numberOfNodes > 1
+		renderContext, err := resolveBackendRenderContext(
+			ctx,
+			kubeClient,
+			dynamoDeployment.Namespace,
+			component,
+			backendFramework,
+			numberOfNodes,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve resources for component %s: %w", componentName, err)
+		}
 		isInterPodGMS := component.IsInterPodGMSEnabled()
 		isInterPodFailover := component.IsInterPodFailoverEnabled()
 		usesPCSG := isMultinode || isInterPodGMS
@@ -2466,6 +2548,7 @@ func GenerateGrovePodCliqueSet(
 				kubeClient:                  kubeClient,
 				ctx:                         ctx,
 				groveClusterTopologyDomains: groveClusterTopologyDomains,
+				renderContext:               renderContext,
 			})
 			if err != nil {
 				return nil, err
@@ -2580,6 +2663,7 @@ func generatePodSpecForRole(
 	serviceName string,
 	checkpointInfo *checkpoint.CheckpointInfo,
 	groveClusterTopologyDomains []v1beta1.TopologyDomain,
+	renderContext backendRenderContext,
 ) (*corev1.PodSpec, error) {
 	isInterPodGMS := component.IsInterPodGMSEnabled()
 
@@ -2589,7 +2673,7 @@ func generatePodSpecForRole(
 			component, backendFramework, secretsRetriever, dynamoDeployment,
 			RoleMain, 1, operatorConfig,
 			commonconsts.MultinodeDeploymentTypeGrove, serviceName, checkpointInfo, nil,
-			groveClusterTopologyDomains,
+			groveClusterTopologyDomains, renderContext,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate base podSpec for GMS: %w", err)
@@ -2611,7 +2695,7 @@ func generatePodSpecForRole(
 		component, backendFramework, secretsRetriever, dynamoDeployment,
 		r.Role, numberOfNodes, operatorConfig,
 		commonconsts.MultinodeDeploymentTypeGrove, serviceName, checkpointInfo, deployer,
-		groveClusterTopologyDomains,
+		groveClusterTopologyDomains, renderContext,
 	)
 	if err != nil {
 		return nil, err
@@ -2915,6 +2999,10 @@ type GenerateBasePodSpecForControllerOptions struct {
 	// WorkloadComponentType overrides the component type used for pod workload
 	// defaults and env vars. Empty means use dynComponent.Spec.ComponentType.
 	WorkloadComponentType v1beta1.ComponentType
+
+	// GPUsPerNode is the controller-resolved GPU count for claims whose device
+	// count cannot be read from scalar container resources.
+	GPUsPerNode int64
 }
 
 // GenerateBasePodSpecForController generates a PodSpec using backend logic for controller usage
@@ -2952,7 +3040,7 @@ func GenerateBasePodSpecForController(
 
 	// Generate base PodSpec with standard env vars using merged component envs
 	componentName := GetDCDComponentName(dynComponent)
-	podSpec, err := GenerateBasePodSpec(
+	podSpec, err := generateBasePodSpec(
 		componentSpec,
 		backendFramework,
 		secretsRetriever,
@@ -2965,6 +3053,7 @@ func GenerateBasePodSpecForController(
 		componentName,
 		checkpointInfo,
 		nil, // use default deployer
+		backendRenderContext{GPUsPerNode: options.GPUsPerNode},
 	)
 	if err != nil {
 		return nil, err

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -43,6 +43,7 @@ import (
 	istioNetworking "istio.io/api/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -4468,6 +4469,225 @@ func sortEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
 	return sorted
 }
 
+func oneGPUDRAObjects() (*resourcev1.ResourceClaimTemplate, *resourcev1.DeviceClass) {
+	return &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-gpu", Namespace: "default"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					}},
+				},
+			},
+		},
+	}, &resourcev1.DeviceClass{ObjectMeta: metav1.ObjectMeta{Name: "gpu.nvidia.com"}}
+}
+
+func TestGenerateGrovePodCliqueSet_DoesNotResolveUnusedContainerGPUCount(t *testing.T) {
+	tests := []struct {
+		name             string
+		backendFramework BackendFramework
+		numberOfNodes    int32
+		module           string
+	}{
+		{name: "multinode SGLang", backendFramework: BackendFrameworkSGLang, numberOfNodes: 2, module: "dynamo.sglang"},
+		{name: "single-node vLLM", backendFramework: BackendFrameworkVLLM, numberOfNodes: 1, module: "dynamo.vllm"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dgd := &v1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "dra-test", Namespace: "default"},
+				Spec: v1beta1.DynamoGraphDeploymentSpec{
+					BackendFramework: string(tt.backendFramework),
+					Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+						ComponentName: "worker",
+						ComponentType: v1beta1.ComponentTypeWorker,
+						Multinode:     &v1beta1.MultinodeSpec{NodeCount: tt.numberOfNodes},
+						PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							ResourceClaims: []corev1.PodResourceClaim{{
+								Name:                      "network",
+								ResourceClaimTemplateName: ptr.To("missing-network-template"),
+							}},
+							Containers: []corev1.Container{{
+								Name:    commonconsts.MainContainerName,
+								Image:   "backend-test",
+								Command: []string{"python3"},
+								Args:    []string{"-m", tt.module},
+								Resources: corev1.ResourceRequirements{
+									Claims: []corev1.ResourceClaim{{Name: "network"}},
+								},
+							}},
+						}},
+					}},
+				},
+			}
+
+			got, err := GenerateGrovePodCliqueSet(
+				t.Context(),
+				dgd,
+				&configv1alpha1.OperatorConfiguration{},
+				&controller_common.RuntimeConfig{},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+		})
+	}
+}
+
+func TestGenerateGrovePodCliqueSet_VLLMMultinodeDRA(t *testing.T) {
+	t.Log("Create a one-GPU ResourceClaimTemplate")
+	scheme := runtime.NewScheme()
+	require.NoError(t, resourcev1.AddToScheme(scheme))
+	claimTemplate, deviceClass := oneGPUDRAObjects()
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claimTemplate, deviceClass).Build()
+
+	t.Log("Render a two-node TP=2 vLLM component using only the DRA claim")
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dra-test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(BackendFrameworkVLLM),
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "agg",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ResourceClaims: []corev1.PodResourceClaim{{
+							Name:                      "gpu",
+							ResourceClaimTemplateName: ptr.To("one-gpu"),
+						}},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "vllm-test",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "2"},
+							Resources: corev1.ResourceRequirements{
+								Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	got, err := GenerateGrovePodCliqueSet(
+		context.Background(),
+		dgd,
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		kubeClient,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	t.Log("Verify the leader and worker receive role-specific MP launch flags")
+	cliques := make(map[string]*grovev1alpha1.PodCliqueTemplateSpec, len(got.Spec.Template.Cliques))
+	for _, clique := range got.Spec.Template.Cliques {
+		cliques[clique.Name] = clique
+	}
+	require.Contains(t, cliques, "agg-ldr")
+	require.Contains(t, cliques, "agg-wkr")
+	leader := cliques["agg-ldr"].Spec.PodSpec.Containers[0]
+	worker := cliques["agg-wkr"].Spec.PodSpec.Containers[0]
+	assert.Contains(t, leader.Args, distributedExecutorFlag)
+	assert.Contains(t, leader.Args, "--nnodes")
+	assert.Contains(t, leader.Args, "--node-rank")
+	assert.Contains(t, leader.Args, "0")
+	require.Len(t, worker.Args, 1)
+	assert.Contains(t, worker.Args[0], "--node-rank $((GROVE_PCLQ_POD_INDEX + 1))")
+	assert.Contains(t, worker.Args[0], "--headless")
+
+	t.Log("Verify rendering preserves DRA without adding a scalar GPU allocation")
+	for _, container := range []corev1.Container{leader, worker} {
+		assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, container.Resources.Claims)
+		assert.NotContains(t, container.Resources.Limits, corev1.ResourceName(commonconsts.KubeResourceGPUNvidia))
+		assert.NotContains(t, container.Resources.Requests, corev1.ResourceName(commonconsts.KubeResourceGPUNvidia))
+	}
+}
+
+func TestGenerateGrovePodCliqueSet_TRTLLMMultinodeDRA(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, resourcev1.AddToScheme(scheme))
+	claimTemplate, deviceClass := oneGPUDRAObjects()
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claimTemplate, deviceClass).Build()
+
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "dra-test", Namespace: "default"},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(BackendFrameworkTRTLLM),
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "agg",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ResourceClaims: []corev1.PodResourceClaim{{
+							Name:                      "gpu",
+							ResourceClaimTemplateName: ptr.To("one-gpu"),
+						}},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "trtllm-test",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.trtllm"},
+							Resources: corev1.ResourceRequirements{
+								Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+
+	got, err := GenerateGrovePodCliqueSet(
+		t.Context(),
+		dgd,
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		kubeClient,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	cliques := make(map[string]*grovev1alpha1.PodCliqueTemplateSpec, len(got.Spec.Template.Cliques))
+	for _, clique := range got.Spec.Template.Cliques {
+		cliques[clique.Name] = clique
+	}
+	require.Contains(t, cliques, "agg-ldr")
+	require.Contains(t, cliques, "agg-wkr")
+	leader := cliques["agg-ldr"].Spec.PodSpec.Containers[0]
+	worker := cliques["agg-wkr"].Spec.PodSpec.Containers[0]
+	require.Len(t, leader.Args, 1)
+	assert.Contains(t, leader.Args[0], "--oversubscribe -n 2 ")
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, leader.Resources.Claims)
+	assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, worker.Resources.Claims)
+}
+
 func Test_GeneratePodCliqueSetGlobalDynamoNamespace(t *testing.T) {
 	dynamoDeployment := &v1alpha1.DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -4652,8 +4872,9 @@ func TestGeneratePodSpecForComponent_SGLang(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"worker",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // SGLang does not use the resolved GPU count
 			)
 
 			if tt.expectError {
@@ -4801,8 +5022,9 @@ func TestGeneratePodSpecForComponent_VLLM(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			component := betaComponent(t, tt.component)
 			podSpec, err := GeneratePodSpecForComponent(
-				betaComponent(t, tt.component),
+				component,
 				tt.backendFramework,
 				secretsRetriever,
 				betaDGD(t, dynamoDeployment),
@@ -4813,6 +5035,7 @@ func TestGeneratePodSpecForComponent_VLLM(t *testing.T) {
 				"worker",
 				nil, // No checkpoint info in tests
 				nil, // Use default deployer
+				staticContainerGPUCount(resolveTestContainerGPUs(t, component)),
 			)
 
 			if tt.expectError {
@@ -4901,6 +5124,7 @@ func TestGeneratePodSpecForComponent_UnsupportedBackend(t *testing.T) {
 				"worker",
 				nil, // No checkpoint info in tests
 				nil, // Use default deployer
+				staticContainerGPUCount(0),
 			)
 
 			if tt.expectError {
@@ -5886,8 +6110,9 @@ func TestGenerateBasePodSpec_Frontend(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if (err != nil) != tt.wantErr {
@@ -5963,8 +6188,9 @@ func TestGenerateBasePodSpec_PlannerServiceAccount(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if err != nil {
@@ -6087,8 +6313,9 @@ func TestGenerateBasePodSpec_DisableImagePullSecretDiscovery(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if err != nil {
@@ -6194,8 +6421,9 @@ func TestGenerateBasePodSpec_DiscoverBackend(t *testing.T) {
 				tt.controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 			if !assert.NoError(t, err) {
 				return
@@ -6365,8 +6593,9 @@ func TestGenerateBasePodSpec_Worker(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if err != nil {
@@ -6422,6 +6651,7 @@ func TestGenerateBasePodSpec_GPUMemoryServiceExtraClientContainers(t *testing.T)
 		"worker",
 		nil,
 		nil,
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 
@@ -6483,6 +6713,7 @@ func TestGenerateBasePodSpec_GPUMemoryServiceRejectsMissingExtraClientContainers
 		"worker",
 		nil,
 		nil,
+		staticContainerGPUCount(0),
 	)
 
 	t.Log("Verify rendering fails with every unresolved client named")
@@ -6652,8 +6883,9 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if tt.expectError {
@@ -6741,6 +6973,7 @@ func TestGenerateBasePodSpec_TRTLLMSSHMountUsesSecretVolume(t *testing.T) {
 		"worker",
 		nil,
 		nil,
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 
@@ -6937,8 +7170,9 @@ func TestGenerateBasePodSpec_ResourceClaims(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if tt.expectError {
@@ -7150,8 +7384,9 @@ func TestGenerateBasePodSpec_UseAsCompilationCache_BackendSupport(t *testing.T) 
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if tt.expectError {
@@ -7234,6 +7469,7 @@ func TestGenerateBasePodSpec_ConvertedCompilationCacheMountIsNotDuplicated(t *te
 				"test-service",
 				nil,
 				nil,
+				staticContainerGPUCount(0),
 			)
 			require.NoError(t, err)
 			require.NotEmpty(t, podSpec.Containers)
@@ -7274,6 +7510,7 @@ func TestGenerateBasePodSpec_ConvertedCompilationCacheUsesDefaultMount(t *testin
 		"test-service",
 		nil,
 		nil,
+		staticContainerGPUCount(0),
 	)
 	require.NoError(t, err)
 	require.NotEmpty(t, podSpec.Containers)
@@ -7633,8 +7870,9 @@ func TestGenerateBasePodSpec_SecurityContext(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // No checkpoint info in tests
-				nil, // Use default deployer
+				nil,                        // No checkpoint info in tests
+				nil,                        // Use default deployer
+				staticContainerGPUCount(0), // No GPUs needed by this test
 			)
 
 			if err != nil {
@@ -9543,8 +9781,9 @@ func TestGenerateBasePodSpec_FrontendSidecar(t *testing.T) {
 				controllerConfig,
 				commonconsts.MultinodeDeploymentTypeGrove,
 				"test-service",
-				nil, // checkpointInfo
-				nil, // deployerOverride
+				nil,                        // checkpointInfo
+				nil,                        // deployerOverride
+				staticContainerGPUCount(0), // containerGPUs
 			)
 
 			if (err != nil) != tt.wantErr {
@@ -10574,7 +10813,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 		require.Len(t, podSpec.Containers, 1)
@@ -10608,7 +10847,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10661,7 +10900,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10695,7 +10934,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkSGLang, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "frontend", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "frontend", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10721,7 +10960,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10748,7 +10987,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10781,7 +11020,7 @@ func TestGeneratePodSpecForComponent_KvTransferPolicyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10855,7 +11094,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10912,7 +11151,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkSGLang, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "frontend", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "frontend", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10935,7 +11174,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10959,7 +11198,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 
@@ -10988,7 +11227,7 @@ func TestGeneratePodSpecForComponent_WorkerTopologyEnvVars(t *testing.T) {
 		component := dgd.Spec.Components[0].DeepCopy()
 		podSpec, err := GeneratePodSpecForComponent(
 			component, BackendFrameworkVLLM, secretsRetriever, dgd, RoleMain, 1,
-			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil,
+			controllerConfig, commonconsts.MultinodeDeploymentTypeGrove, "worker", nil, nil, staticContainerGPUCount(0),
 		)
 		require.NoError(t, err)
 

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -43,6 +43,7 @@ import (
 	istioNetworking "istio.io/api/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -4387,6 +4388,102 @@ func sortEnvVars(envs []corev1.EnvVar) []corev1.EnvVar {
 		return sorted[i].Name < sorted[j].Name
 	})
 	return sorted
+}
+
+func TestGenerateGrovePodCliqueSet_VLLMMultinodeDRA(t *testing.T) {
+	t.Log("Create a one-GPU ResourceClaimTemplate")
+	scheme := runtime.NewScheme()
+	require.NoError(t, resourcev1.AddToScheme(scheme))
+	claimTemplate := &resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "one-gpu", Namespace: "default"},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name: "gpu",
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: "gpu.nvidia.com",
+							AllocationMode:  resourcev1.DeviceAllocationModeExactCount,
+							Count:           1,
+						},
+					}},
+				},
+			},
+		},
+	}
+	kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(claimTemplate).Build()
+
+	t.Log("Render a two-node TP=2 vLLM component using only the DRA claim")
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dra-test",
+			Namespace: "default",
+			Annotations: map[string]string{
+				commonconsts.KubeAnnotationVLLMDistributedExecutorBackend: "mp",
+			},
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: string(BackendFrameworkVLLM),
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{{
+				ComponentName: "agg",
+				ComponentType: v1beta1.ComponentTypeWorker,
+				Multinode:     &v1beta1.MultinodeSpec{NodeCount: 2},
+				PodTemplate: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						ResourceClaims: []corev1.PodResourceClaim{{
+							Name:                      "gpu",
+							ResourceClaimTemplateName: ptr.To("one-gpu"),
+						}},
+						Containers: []corev1.Container{{
+							Name:    commonconsts.MainContainerName,
+							Image:   "vllm-test",
+							Command: []string{"python3"},
+							Args:    []string{"-m", "dynamo.vllm", tensorParallelSizeFlag, "2"},
+							Resources: corev1.ResourceRequirements{
+								Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+							},
+						}},
+					},
+				},
+			}},
+		},
+	}
+	got, err := GenerateGrovePodCliqueSet(
+		context.Background(),
+		dgd,
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		kubeClient,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	t.Log("Verify the leader and worker receive role-specific MP launch flags")
+	cliques := make(map[string]*grovev1alpha1.PodCliqueTemplateSpec, len(got.Spec.Template.Cliques))
+	for _, clique := range got.Spec.Template.Cliques {
+		cliques[clique.Name] = clique
+	}
+	require.Contains(t, cliques, "agg-ldr")
+	require.Contains(t, cliques, "agg-wkr")
+	leader := cliques["agg-ldr"].Spec.PodSpec.Containers[0]
+	worker := cliques["agg-wkr"].Spec.PodSpec.Containers[0]
+	assert.Contains(t, leader.Args, distributedExecutorFlag)
+	assert.Contains(t, leader.Args, "--nnodes")
+	assert.Contains(t, leader.Args, "--node-rank")
+	assert.Contains(t, leader.Args, "0")
+	require.Len(t, worker.Args, 1)
+	assert.Contains(t, worker.Args[0], "--node-rank $((GROVE_PCLQ_POD_INDEX + 1))")
+	assert.Contains(t, worker.Args[0], "--headless")
+
+	t.Log("Verify rendering preserves DRA without adding a scalar GPU allocation")
+	for _, container := range []corev1.Container{leader, worker} {
+		assert.Equal(t, []corev1.ResourceClaim{{Name: "gpu"}}, container.Resources.Claims)
+		assert.NotContains(t, container.Resources.Limits, corev1.ResourceName(commonconsts.KubeResourceGPUNvidia))
+		assert.NotContains(t, container.Resources.Requests, corev1.ResourceName(commonconsts.KubeResourceGPUNvidia))
+	}
 }
 
 func Test_GeneratePodCliqueSetGlobalDynamoNamespace(t *testing.T) {

--- a/deploy/operator/internal/dynamo/test_beta_helpers_test.go
+++ b/deploy/operator/internal/dynamo/test_beta_helpers_test.go
@@ -11,6 +11,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func staticContainerGPUCount(count int64) ContainerGPUCount {
+	return func() (int64, error) { return count, nil }
+}
+
 func betaComponent(t testing.TB, src *v1alpha1.DynamoComponentDeploymentSharedSpec) *v1beta1.DynamoComponentDeploymentSharedSpec {
 	t.Helper()
 	if src == nil {
@@ -134,6 +138,15 @@ func betaResourceRequirements(t testing.TB, src *v1alpha1.Resources) *corev1.Res
 	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{Resources: src})
 	resources := GetMainContainerResources(component)
 	return &resources
+}
+
+func resolveTestContainerGPUs(t testing.TB, component *v1beta1.DynamoComponentDeploymentSharedSpec) int64 {
+	t.Helper()
+	containerGPUs, err := ResolveContainerGPUs(t.Context(), nil, "", component)
+	if err != nil {
+		t.Fatalf("resolve test container GPUs: %v", err)
+	}
+	return containerGPUs
 }
 
 func applyAlphaMetadataToBetaComponent(component *v1beta1.DynamoComponentDeploymentSharedSpec, annotations, labels map[string]string) {

--- a/deploy/operator/internal/dynamo/test_beta_helpers_test.go
+++ b/deploy/operator/internal/dynamo/test_beta_helpers_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	corev1 "k8s.io/api/core/v1"
 )
 
 func staticContainerGPUCount(count int64) ContainerGPUCount {
@@ -128,16 +127,6 @@ func betaRestartStatus(src *v1alpha1.RestartStatus) *v1beta1.RestartStatus {
 		Phase:      v1beta1.RestartPhase(src.Phase),
 		InProgress: append([]string(nil), src.InProgress...),
 	}
-}
-
-func betaResourceRequirements(t testing.TB, src *v1alpha1.Resources) *corev1.ResourceRequirements {
-	t.Helper()
-	if src == nil {
-		return nil
-	}
-	component := betaComponent(t, &v1alpha1.DynamoComponentDeploymentSharedSpec{Resources: src})
-	resources := GetMainContainerResources(component)
-	return &resources
 }
 
 func resolveTestContainerGPUs(t testing.TB, component *v1beta1.DynamoComponentDeploymentSharedSpec) int64 {


### PR DESCRIPTION
## Summary

* Resolve a component's per-node GPU count from user-supplied `ResourceClaim` and `ResourceClaimTemplate` objects when no scalar GPU resource is present.
* Pass the lazy, memoized count through both Grove and LeaderWorkerSet rendering. vLLM consumes it for multinode MP/Ray and hybrid-DP launch flags; TensorRT-LLM consumes it for the multinode leader's `mpirun` world size.
* Preserve pure DRA allocation: the operator reads claim metadata for launch planning but never adds a synthetic `nvidia.com/gpu` request or limit.
* Watch referenced `ResourceClaim` and `ResourceClaimTemplate` objects and relevant cluster-scoped `DeviceClass` objects so dependency changes re-render existing workloads.
* Add the required ResourceClaim and DeviceClass read/watch RBAC and regenerate the operator and Helm RBAC manifests.
* Reject ambiguous or non-deterministic device requests instead of silently rendering broken distributed launch flags.

Fixes ai-dynamo/dynamo#12164

## Root cause

The multinode backend logic derived the per-container GPU count only from scalar entries in `resources.requests` and `resources.limits`. A pure-DRA container has `resources.claims` instead, so vLLM saw a count of zero and skipped the normal multinode launch setup. Leader and worker could consequently receive effectively identical commands.

Operator-managed GMS DRA did not expose this gap because its scalar GPU count remains present while backend arguments are rendered and is converted to a claim afterward. User-supplied DRA has no temporary scalar count.

## Implementation

`dra.ResolveGPUCount` keeps scalar resources authoritative for compatibility. When no scalar GPU is present, it maps the main container's claim references to the pod's `resourceClaims` and reads the referenced `resource.k8s.io/v1` `ResourceClaim` or `ResourceClaimTemplate`.

The resolver:

* supports deterministic `ExactCount` GPU requests, including Kubernetes' default count of one;
* supports `firstAvailable` when every alternative is a GPU class and all alternatives request the same count;
* respects the optional container request selector and deduplicates repeated claim/request references;
* ignores requests that are deterministically non-GPU;
* rejects `allocationMode: All`, mixed GPU/non-GPU alternatives, differing alternative counts, missing request names, missing claim objects, and unclassifiable DeviceClasses with actionable reconciliation errors;
* classifies DeviceClasses by `extendedResourceName`, unambiguous conjunctive `device.driver == ...` selectors, or a conventional GPU class name only when no selectors are present.

Rendering passes a `ContainerGPUCount` closure rather than eagerly resolving every component. `sync.OnceValues` shares the result and error across all roles of one component:

* multinode vLLM resolves it when producing distributed launch flags;
* multinode TensorRT-LLM resolves it only for the leader;
* SGLang, Noop, and single-node vLLM do not resolve it because they do not consume the count.

DCD and DGD controllers watch DRA dependencies. Claim/template events enqueue only multinode components that reference the changed object; DeviceClass events enqueue relevant DRA-backed multinode workloads. DGD dependency watches are limited to the Grove pathway because LWS rendering is owned by the DCD controller.

For two nodes with one DRA GPU each and `--tensor-parallel-size 2`, vLLM now enters the same MP/Ray launch path as two scalar-GPU pods. With MP selected, the leader receives `--nnodes 2`, `--node-rank 0`, and rendezvous flags; the worker receives its computed nonzero rank plus `--headless`. Hybrid-DP similarly derives `--data-parallel-size-local` and the per-node start rank from the resolved count.

## RBAC

The generated operator and Helm roles include:

* `get/list/watch` for `resourceclaims`;
* `get/list/watch` for cluster-scoped `deviceclasses`;
* `get/list/watch` for `resourceclaimtemplates` in addition to the existing lifecycle permissions required by operator-managed templates.

## Validation

After rebasing onto `e523f7ceb9`:

* `go test ./internal/dra ./internal/dynamo`
* `go test ./internal/controller -run '^(TestRenderMultinodePodTemplateSpecs_VLLMMultinodeDRA|TestGenerateWorkerPodTemplateSpecDoesNotRequireGPUResource|TestDynamoComponentDeploymentReconciler_.*WorkloadComponentType)$'`
* `git diff --check`

Coverage includes direct ResourceClaim and ResourceClaimTemplate resolution, request filtering and deduplication, default counts, DeviceClass classification, ambiguous request rejection, scalar precedence, lazy backend consumption, dependency event mapping, Grove TP/MP rendering, LeaderWorkerSet TP/MP rendering, TensorRT-LLM world-size calculation, and hybrid-DP flag injection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPU-aware multinode vLLM workloads using Device Resource Allocation (DRA).
  * Preserved resource claims while generating leader and worker pod configurations.
  * Added support for resolving GPU counts from resource claims when scalar GPU resources are unavailable.

* **Bug Fixes**
  * Improved multinode launch and parallelism configuration when GPUs are provisioned through DRA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->