### PR TITLE
feat(gms): read-mode MoE-kernel rebuild for NVFP4 GMS shadow failover (vLLM 0.25.1)

### DIFF
--- a/failover-kimi/EPOCH-0251-PORT.md
+++ b/failover-kimi/EPOCH-0251-PORT.md
@@ -14,6 +14,7 @@ close version-drift deltas,"** not "re-land our stack."
 
 ## Status board
 - [x] **L0 — RW→RO weight commit/import** (no shadow, no scratch-KV) — **GREEN** 2026-07-25
+- [x] **L0 hardening** — backend fail-fast guard + logprobs A/B (RW vs RO bit-identical) — **DONE** 2026-07-25
 - [ ] **L1 — scratch-KV routing** (shadow reaches standby, KV routed to scratch pool)
 - [ ] **L2 — two-engine failover** (kill active → shadow promotes → serves; eager + graphs)
 
@@ -34,6 +35,17 @@ RO  registered +139s | rebuilt 60 MoE kernels/worker (all 8 TP) | 0 tracebacks/a
     imported 71.41 GiB/worker | infer 200 "Paris. Paris is a major European city…" (byte-identical to RW)
 ```
 Harness: `failover-kimi/kimi_rwro.sh`. Raw logs on pod: `/tmp/kimi_rwro/logs/`.
+
+### L0 hardening (2026-07-25)
+- **Backend fail-fast guard** (`_rebuild_ro_moe_kernels`): logs the selected NVFP4 backend and
+  **refuses to serve** on any backend outside `_RO_VALIDATED_NVFP4_BACKENDS = {FLASHINFER_TRTLLM,
+  FLASHINFER_CUTLASS}` (override `DYN_GMS_ALLOW_UNVALIDATED_MOE_BACKEND=1`). Confirmed it logs
+  `rebuilding MoE kernels for NVFP4 backend FLASHINFER_TRTLLM` and serves. → **R1 mitigated** (silent-wrong on
+  a backend swap is now a loud, actionable error).
+- **Logprobs A/B** (`kimi_rwro_ab.sh`, 4 diverse-margin prompts, `logprobs:5`): RW vs RO tokens all match and
+  **worst max |Δlogprob| = 0.000e+00 — bit-identical**. Prompts: capital-of-France (high), gold→"Au…79"
+  (factual), two-plus-two (numeric), favorite-season (open/low-margin). → **R3 closed** (numerically exact,
+  not just argmax-equivalent).
 
 ---
 

--- a/failover-kimi/EPOCH-0251-PORT.md
+++ b/failover-kimi/EPOCH-0251-PORT.md
@@ -16,7 +16,9 @@ close version-drift deltas,"** not "re-land our stack."
 - [x] **L0 — RW→RO weight commit/import** (no shadow, no scratch-KV) — **GREEN** 2026-07-25
 - [x] **L0 hardening** — backend fail-fast guard + logprobs A/B (RW vs RO bit-identical) — **DONE** 2026-07-25
 - [x] **L1 — scratch-KV routing** — shadow reaches standby, single-block scratch, fail-closed guard never fires — **GREEN** 2026-07-25
-- [~] **L2 — two-engine failover** — **eager GREEN** (promote +8s, post-failover 200 +5s); graphs pass running
+- [x] **L2 — two-engine failover** — **GREEN eager+graphs** (promote +8s/+9s, post-failover 200 +5s)
+- [x] **Concurrent cold-init** — both engines at once converge, peak 152 GiB (flock+sleep prevents double-peak) — **GREEN**
+- [x] **Post-failover replenishment (fail-twice loop)** — failover-1 → new shadow parks beside live active → failover-2 → 200 — **GREEN** 2026-07-25
 
 ## Deltas layered on main (the 5 port patches)
 | # | Patch | File | Why 0.25.1 needs it |
@@ -84,6 +86,56 @@ for a single 1s sample at +4s post-kill. Eager showed no such spike (stayed ≤1
 graphs lifecycle is promotion, not init/colocation. Worth a headroom margin (lower `--gpu-memory-utilization`, or
 free the dying active's KV before the swap) before trusting graphs-mode promotion on larger models. Compare 0.23.0
 baseline: eager colocated peak 149 / graphs 160 GiB.
+
+## Post-failover shadow replenishment — GREEN (2026-07-25, `kimi_replenish.sh`, eager)
+Lifts the TRTLLM prior-art **"fail-once, no replenishment"** limitation. Full loop, deterministic serialized launches:
+```
+P2  e0 ACTIVE (+224s) + e1 SHADOW parked (+141s)            colocated 151,721; serve 200
+P3  FAILOVER-1: kill e0 -> e1 PROMOTED +7s                  serve 200
+P4  REPLENISH: launch engineC (ENGINE_ID=0 reused) -> it races the live active's flock, loses,
+    imports RO weights, sets up scratch-KV, PARKS +137s     colocated 151,783; e1 still serving 200
+P5  FAILOVER-2: kill e1 -> engineC PROMOTED +8s             serve 200
+=> KIMI_REPLENISH_DONE failover1=200 replenish_parked=yes failover2=200
+```
+**The previously-untested crux works:** a *fresh* shadow acquires a scratch-KV grant + RO weights from the
+still-alive GMS servers **after** a promotion (active holds `kv_cache` RW), parks, and is itself promotable.
+Replenished shadow's routing confirmed: fail-closed scratch guard fired **0×**; KVROUTE + MoE-kernel-rebuild +
+sleep markers all present. **Memory stays bounded across the whole cycle** (per-GPU): colocated_1 155,859 /
+failover-1 promo 157,633 / **replenish bring-up 155,921** / colocated_2 (replenished) 155,921 / failover-2 promo
+151,039 → **worst-GPU overall peak 157,633 MiB (~25.7 GiB headroom)**. No growth across the cycle (replenish
+colocated ≈ initial colocated → no leak). Harness: `failover-kimi/kimi_replenish.sh`, analysis
+`analyze_replenish.py`. (Eager only; graphs replenishment not yet run — expect the same graphs promotion-transient
+caveat as L2.)
+
+## Deployment (real DGD via operator) — scoping (2026-07-25)
+**The operator already supports this topology as a first-class feature — deploying it is config, not a build
+(classification "a").** A worker component with:
+```yaml
+experimental:
+  gpuMemoryService: { mode: IntraPod }
+  failover:         { mode: IntraPod, numShadows: 1 }   # numShadows Maximum=1 today
+```
+(+ DGD annotation `nvidia.com/dynamo-kube-discovery-mode: container`) makes the operator auto-render the pod I
+hand-roll: a **GMS sidecar** (`python3 -m gpu_memory_service.cli.server` — one supervisor that fans out one server
+per-GPU-per-tag, collapsing my 16 processes), **cloned `engine-0`/`engine-1`** racing a flock at
+`FAILOVER_LOCK_PATH=/gms-intrapod-control/failover.lock` in a shared emptyDir, auto-injected `ENGINE_ID`,
+`DYN_SYSTEM_PORT`, `VLLM_NIXL_SIDE_CHANNEL_PORT`, `DYN_VLLM_KV_EVENT_PORT`, `DYN_VLLM_GMS_SHADOW_MODE=true`, plus a
+`frontend` component. Key code: `deploy/operator/internal/gms/gms.go`, `internal/dynamo/failover.go` +
+`failover_vllm.go` + `backend_vllm.go`, `internal/controller/failover_cascade_controller.go` (inter-pod only). CRD:
+`api/v1beta1/common.go` (`GPUMemoryServiceSpec`, `FailoverSpec`). Sample: `deploy/operator/samples/v1beta1/dgd-gms-failover.yaml`.
+
+**Config-only gaps (add to the worker container spec, NOT a build):** `--load-format gms` in `args` (auto-injected
+only for inter-pod), and `DYN_GMS_SCRATCH_SINGLE_BLOCK` / `DYN_NO_AUTOTUNE` / `DYN_GMS_KVROUTE_V1` in `env` (operator
+has no refs to these).
+
+**⚠️ The real blocker for deploying MY validated build:** the 5 port fixes are currently **manually overlaid onto the
+pod's site-packages** — they are NOT in any image. A real DGD uses the container image (`daf44c6bf1…-vllm-runtime` =
+latest main, WITHOUT the fixes). So a DGD deploy needs the fixes in the image OR an overlay: (i) `model_loader.py`
+(RO MoE-kernel rebuild + backend guard) and (ii) `module.py` (shape-adopt) are dynamo files → land them in main and
+rebuild, or overlay; (iii) `kimi_k25.py` meta-safety is a **vLLM** change → upstream or overlay; (iv) `dyn_kvroute.py`
++ `dyn_noautotune.py` are sitecustomize overlays → ship via ConfigMap+initContainer or bake in. The operator's
+schemaless `podTemplate.spec` accepts `initContainers`/`volumes`, so an overlay-init-container is a viable no-rebuild
+path. **Net: operator topology = ready; the work is getting the patches into a deployable image/overlay.**
 
 ---
 

--- a/failover-kimi/EPOCH-0251-PORT.md
+++ b/failover-kimi/EPOCH-0251-PORT.md
@@ -1,0 +1,98 @@
+# Kimi-K2.6 GMS Shadow-Failover — vLLM 0.25.1 Port (Epoch Log)
+
+Running milestone + findings log for porting the Kimi-K2.6-NVFP4 GMS shadow-failover
+setup from vLLM 0.23.0 to 0.25.1 (latest dynamo `main`). Append as we iterate.
+
+- **Branch:** `kimi-failover-0251` (worktree `~/repos/dynamo-kimi-0251`, off latest main)
+- **Pod:** `kimi-failover` / ns `mohammed-dev` / node `tx5tk` (tainted `mohammed`) / image `daf44c6bf1…-vllm-runtime`
+- **Model:** `/tmp/kimi-k2.6-nvfp4`, TP8, MoE backend **FLASHINFER_TRTLLM**, attention FLASHINFER_MLA
+
+## The reframe
+Most of the failover feature is **already merged into `main`** (single-block scratch #11911,
+GMS failover #6818, materialization/#9854, kimi_k25 in vLLM). This port is **"validate main +
+close version-drift deltas,"** not "re-land our stack."
+
+## Status board
+- [x] **L0 — RW→RO weight commit/import** (no shadow, no scratch-KV) — **GREEN** 2026-07-25
+- [ ] **L1 — scratch-KV routing** (shadow reaches standby, KV routed to scratch pool)
+- [ ] **L2 — two-engine failover** (kill active → shadow promotes → serves; eager + graphs)
+
+## Deltas layered on main (the 5 port patches)
+| # | Patch | File | Why 0.25.1 needs it |
+|---|-------|------|---------------------|
+| 1 | meta-safety guard | vLLM `models/kimi_k25.py` (`_on_meta`) | 0.25.1 still does unconditional `.to(device)` on vision_tower/mm_projector → faults building the RO model on meta. Copy: `failover-kimi/kimi_k25_0251-metasafe.py`. |
+| 2 | scratch-KV V1 routing | `failover-kimi/dyn_kvroute.py` (gate `DYN_GMS_KVROUTE_V1=1`) | 0.25.1 split the model runner into V1/V2. Main's `patch_kv_cache_pool_scope` targets a V2 symbol that doesn't exist → silent no-op on the default V1 runner. Wraps V1 `_allocate_kv_cache_tensors` in `gms_use_mem_pool("kv_cache")`. |
+| 3 | materialize shape-adopt | `lib/gpu_memory_service/client/torch/module.py` | RW reduces NVFP4 MoE scales `(E,2)→(E,)` and commits that shape; RO meta param keeps `(E,2)`. Adopt the committed (authoritative) tensor instead of asserting. |
+| 4 | RO MoE-kernel rebuild | `lib/gpu_memory_service/integrations/vllm/model_loader.py` (`_rebuild_ro_moe_kernels`) | RO materializes committed weights but never runs `process_weights_after_loading`, so `quant_method.moe_kernel is None` → MoE forward asserts. Rebuild **only** the kernel object (`get_fused_moe_quant_config` + `make_nvfp4_moe_kernel`); skip the weight re-transform + `fused_experts.process_weights` the writer already committed. Analog of 0.23.0 `66850a4`. |
+| 5 | harness GMS-ready string | `failover-kimi/*.sh` | GMS server ready-log changed to "Server started"; old wait string burned a 12-min timeout → now ~9s. |
+
+## L0 evidence (2026-07-25, eager, TP8)
+```
+RW  registered +223s | mem 141746 MiB/GPU | infer 200 "Paris. Paris is a major European city…"
+kill A → weights persist in GMS servers: 73124 MiB/GPU
+RO  registered +139s | rebuilt 60 MoE kernels/worker (all 8 TP) | 0 tracebacks/asserts
+    imported 71.41 GiB/worker | infer 200 "Paris. Paris is a major European city…" (byte-identical to RW)
+```
+Harness: `failover-kimi/kimi_rwro.sh`. Raw logs on pod: `/tmp/kimi_rwro/logs/`.
+
+---
+
+## Test coverage & known risks  ⚠️ read before trusting the RO path broadly
+L0 is a **happy-path smoke test**: one prompt, greedy (temperature 0), eager, batch-1, ~6 in / 12 out.
+It proves the RW→RO weight-sharing plumbing and the kernel rebuild *for this backend/config*. It does
+**not** prove general correctness. Grounded findings from reading the 0.25.1 MoE code:
+
+### R1 — RO kernel rebuild is backend-specific (audited: TRTLLM only)
+L0 ran **FLASHINFER_TRTLLM**. Its `process_weights_after_loading` (step-5) does: (a) an **in-place fuse**
+`w13_weight_scale_2.mul_(w13_input_scale)`, and (b) recompute `g1_scale_c` + register EPLB layer params.
+- **Why skip-step-5 is correct here (by construction, not luck):** RW commits the *post-fuse* scales, so
+  RO materializes already-fused `w13_weight_scale_2`. The experts `__init__` (called by
+  `make_nvfp4_moe_kernel`) recomputes `self.g1_scale_c = quant_config.g1_alphas * a2_gscale` from those
+  already-fused scales → correct value with no step-5 needed. Re-running step-5 would **double-fuse** →
+  wrong. So skipping is both necessary and sufficient for inference here.
+- **Residual risk:** only TRTLLM (+ flashinfer_cutlass by inspection) audited. The other 6 selectable
+  backends (CUTEDSL, CUTEDSL_BATCHED, VLLM_CUTLASS, MARLIN, HUMMING, EMULATION, B12x) are **not audited**.
+  A backend whose step-5 does work not reproduced by the experts `__init__` (workspace alloc, non-idempotent
+  transform) would **break silently** if backend selection ever changes (different GPU / vLLM version /
+  `VLLM_*` flag).
+- **EPLB:** the skipped `register_parameter` for `g1_scale_c`/`gemm1_clamp_limit`/`gemm1_beta` means
+  expert-parallel load-balancing rearrangement would miss them. Safe **only** while EPLB is off.
+
+### R2 — 244 meta attention scales unmaterialized on RO
+RO logs `244 meta tensors not in metadata`: `mla_attn.{q,k,v,prob}_scale` across all layers. These fp8 MLA
+attention scales are left on the meta device (not committed by RW). L0 still served correctly (likely
+defaulted/recomputed at runtime for this config), but this is an unexplained, pre-existing RO-path gap that
+could bite a config where those scales are load-bearing.
+
+### R3 — numerical check is argmax-only
+Byte-identical greedy output on a *high-confidence* prompt is consistent with correctness but doesn't prove
+bit-accuracy — argmax masks small scale errors. Need a **logprobs A/B (RW vs RO)** on a few diverse /
+low-margin prompts.
+
+### R4 — untested execution paths
+- **Scratch-KV routing + sleep/wake** (patch #2): L0 has no shadow mode → completely unexercised. → L1/L2.
+- **CUDA graphs:** L0 eager-only. Rebuilt kernel under graph capture untested. → L2 graphs pass.
+- **Concurrency / long sequences / continuous batching:** L0 was batch-1. MoE grouped-GEMM has
+  size-dependent paths.
+- **Multimodal (vision) path:** text-only; patch #1 touches vision_tower/mm_projector but they're unexercised.
+- **Other quant methods:** `_rebuild_ro_moe_kernels` only handles NVFP4; an FP8-MoE model would silently
+  skip the guard and hit the same `moe_kernel is None` assert.
+- **shape-adopt is permissive:** adopts *any* shape/dtype mismatch; a genuinely corrupt commit would be
+  silently accepted rather than flagged.
+
+### Recommended hardening (cheap → do first)
+1. **Log + fail-fast** the selected NVFP4 backend in `_rebuild_ro_moe_kernels`; refuse (don't serve)
+   unaudited backends. Turns silent-wrong into a loud error.
+2. **Logprobs A/B** RW vs RO on several prompts (upgrade "Paris matched" → "numerically equivalent").
+3. Investigate R2 (are the 244 meta scales actually load-bearing? default vs recompute?).
+4. (later / for upstream) re-cache experts-object derived state + handle EPLB, or option-c
+   (commit raw weights, run symmetric `process_weights` on RO) for backend-agnostic generality.
+
+## Repro
+```bash
+# on pod kimi-failover / ns mohammed-dev / container dev
+bash /tmp/kimi_rwro.sh      # L0 (RW→RO)
+bash /tmp/kimi_failover.sh  # L2 (EAGER=1 then EAGER=0)
+```
+Overlays live in `/usr/local/lib/python3.12/dist-packages/` (`dyn_noautotune.py`, `dyn_kvroute.py`),
+auto-loaded by `sitecustomize.py` when `DYN_NO_AUTOTUNE=1` / `DYN_GMS_KVROUTE_V1=1`.

--- a/failover-kimi/EPOCH-0251-PORT.md
+++ b/failover-kimi/EPOCH-0251-PORT.md
@@ -15,8 +15,8 @@ close version-drift deltas,"** not "re-land our stack."
 ## Status board
 - [x] **L0 — RW→RO weight commit/import** (no shadow, no scratch-KV) — **GREEN** 2026-07-25
 - [x] **L0 hardening** — backend fail-fast guard + logprobs A/B (RW vs RO bit-identical) — **DONE** 2026-07-25
-- [ ] **L1 — scratch-KV routing** (shadow reaches standby, KV routed to scratch pool)
-- [ ] **L2 — two-engine failover** (kill active → shadow promotes → serves; eager + graphs)
+- [x] **L1 — scratch-KV routing** — shadow reaches standby, single-block scratch, fail-closed guard never fires — **GREEN** 2026-07-25
+- [~] **L2 — two-engine failover** — **eager GREEN** (promote +8s, post-failover 200 +5s); graphs pass running
 
 ## Deltas layered on main (the 5 port patches)
 | # | Patch | File | Why 0.25.1 needs it |
@@ -46,6 +46,44 @@ Harness: `failover-kimi/kimi_rwro.sh`. Raw logs on pod: `/tmp/kimi_rwro/logs/`.
   **worst max |Δlogprob| = 0.000e+00 — bit-identical**. Prompts: capital-of-France (high), gold→"Au…79"
   (factual), two-plus-two (numeric), favorite-season (open/low-margin). → **R3 closed** (numerically exact,
   not just argmax-equivalent).
+
+## L1 + L2 results (2026-07-25, TP8, `kimi_failover.sh`)
+Two-engine intra-pod shadow failover: engine0 ACTIVE + engine1 SHADOW share GMS weights, kill engine0 → shadow
+promotes and serves. Env: `DYN_GMS_SCRATCH_SINGLE_BLOCK=1 DYN_NO_AUTOTUNE=1 DYN_GMS_KVROUTE_V1=1`.
+
+- **L1 (scratch-KV routing):** `[KVROUTE] loaded` on all 8 workers; shadow reached **standby +139s**; the
+  scratch fail-closed guard (`no KV allocation was routed through scratch`) fired **0 times**. The `dyn_kvroute.py`
+  V1 fix works. Definitive corroboration: shadow overhead is only **+4.3 GiB** (single-block scratch 0.5 GiB) —
+  real KV would be ~65 GiB → OOM, per-layer scratch ~30 GiB.
+- **L2 eager:** ACTIVE serves 200 → kill whole engine0 → **SHADOW PROMOTED +8s** → **post-failover 200 at +5s**
+  ("Paris…"). The +5s is the frontend evicting the dead active's discovery entry (retry-with-backoff, expected).
+
+### Memory / concurrency study (answers: can we bring up a shadow next to a live active?)
+Ceiling = **183,359 MiB** (B200). 1 Hz all-GPU sampler (`dev_mem.csv`) + phase markers (`phases.csv`),
+analyzed by `analyze_mem.py`. Per-GPU (uniform across all 8):
+
+| metric | eager | graphs |
+|---|---|---|
+| active resting (weights 73 shared + real KV + rt) | 147,359 MiB (143.9 GiB) | 147,477 MiB |
+| colocated resting (active + resting shadow) | 151,721 MiB | 154,071 MiB |
+| **Q1 — shadow steady overhead** (coloc − active) | **+4,362 MiB (~4.3 GiB)** | **+6,594 MiB (~6.4 GiB)** |
+| **Q2 — replenishment bring-up peak** (shadow init w/ live active) | **155,859 MiB (152.2 GiB)** | **157,397 MiB (153.7 GiB)** |
+| headroom at replenishment peak | **27,500 MiB (~26.9 GiB)** | **25,962 MiB (~25.4 GiB)** |
+| **failover promotion transient peak** (scratch→real KV swap) | ≤155,859 (no spike) | **182,069 MiB (177.8 GiB) on 2/8 GPUs — 1s** |
+| headroom at promotion | ~27 GiB | **~1,290 MiB (~1.3 GiB)** ⚠️ |
+| replenishment verdict | **FITS** | **FITS** |
+
+**Takeaways:** (1) The resting shadow is cheap — **~4.3 GiB eager / ~6.4 GiB graphs** on top of a live active (it
+shares the 73 GiB weights via GMS and holds *scratch*-KV, not real KV; graphs costs ~2 GiB more for capture
+residency). (2) **Replenishment** (bring a shadow up beside a serving active) peaks only ~4–6 GiB above colocated
+resting — autotune-off killed the warmup burst, single-block scratch keeps scratch at 0.5 GiB — so it fits with
+**~25–27 GiB to spare** in both modes. Green-light for shadow replenishment on promotion (the TRTLLM "fail-once"
+limitation). (3) ⚠️ **New risk (graphs only): the failover PROMOTION transient** — the scratch→real KV swap
+(`reallocate_all_handles`) — briefly spiked to **177.8 GiB on 2/8 GPUs (GPU1, GPU7), ~1.3 GiB from the ceiling**,
+for a single 1s sample at +4s post-kill. Eager showed no such spike (stayed ≤152). So the tightest point in the
+graphs lifecycle is promotion, not init/colocation. Worth a headroom margin (lower `--gpu-memory-utilization`, or
+free the dying active's KV before the swap) before trusting graphs-mode promotion on larger models. Compare 0.23.0
+baseline: eager colocated peak 149 / graphs 160 GiB.
 
 ---
 

--- a/failover-kimi/analyze_mem.py
+++ b/failover-kimi/analyze_mem.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Shadow memory-overhead + concurrent bring-up peak from a kimi_failover run.
+
+Consumes the 1 Hz all-GPU sampler (dev_mem.csv: ts,gpu,mem_mib) and the
+epoch-stamped phase boundaries (phases.csv: epoch,label). Reports, per GPU:
+  - active_resting     : mem with only the ACTIVE engine up (resting)
+  - colocated_resting  : mem with ACTIVE + resting SHADOW
+  - shadow_overhead    : colocated_resting - active_resting  (Q1)
+  - bringup_peak       : max mem during [shadow_launch, shadow_standby] (Q2 —
+                         the concurrent bring-up peak, shadow init w/ live active)
+  - overall_peak       : max mem over the whole run
+and headroom vs the card ceiling.
+
+Usage: analyze_mem.py DEV_MEM_CSV PHASES_CSV [--ceiling-mib N]
+"""
+import csv
+import sys
+
+
+def load_dev(path):
+    g = {}
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            try:
+                gpu = int(row["gpu"])
+                g.setdefault(gpu, []).append((float(row["ts"]), float(row["mem_mib"])))
+            except (ValueError, KeyError):
+                continue
+    for gpu in g:
+        g[gpu].sort()
+    return g
+
+
+def load_phases(path):
+    ph = {}
+    try:
+        with open(path) as f:
+            for row in csv.DictReader(f):
+                ph[row["label"]] = float(row["epoch"])  # last occurrence wins
+    except FileNotFoundError:
+        pass
+    return ph
+
+
+def val_at(series, t):
+    # nearest sample to t
+    return min(series, key=lambda x: abs(x[0] - t))[1]
+
+
+def peak_in(series, t0, t1):
+    vals = [m for (ts, m) in series if t0 <= ts <= t1]
+    return max(vals) if vals else float("nan")
+
+
+def main():
+    dev_csv, phases_csv = sys.argv[1], sys.argv[2]
+    ceiling = None
+    if "--ceiling-mib" in sys.argv:
+        ceiling = float(sys.argv[sys.argv.index("--ceiling-mib") + 1])
+    dev = load_dev(dev_csv)
+    ph = load_phases(phases_csv)
+
+    p_active = ph.get("active_resting", ph.get("active_registered"))
+    p_coloc = ph.get("colocated_resting", ph.get("shadow_standby"))
+    p_sl = ph.get("shadow_launch")
+    p_ss = ph.get("shadow_standby")
+    miss = [n for n, v in [("active", p_active), ("coloc", p_coloc),
+                            ("shadow_launch", p_sl), ("shadow_standby", p_ss)] if v is None]
+    if miss:
+        print(f"WARN missing phase markers: {miss} (labels present: {sorted(ph)})")
+
+    hdr = f"{'gpu':>3} {'active':>9} {'coloc':>9} {'sh_over':>8} {'bringup_pk':>11} {'overall_pk':>11}"
+    if ceiling:
+        hdr += f" {'headroom':>9}"
+    print(hdr)
+    worst_over = worst_peak = 0.0
+    for gpu in sorted(dev):
+        s = dev[gpu]
+        a = val_at(s, p_active) if p_active else float("nan")
+        c = val_at(s, p_coloc) if p_coloc else float("nan")
+        over = c - a
+        bpk = peak_in(s, p_sl, p_ss) if (p_sl and p_ss) else float("nan")
+        opk = max(m for _, m in s)
+        worst_over = max(worst_over, over if over == over else 0)
+        worst_peak = max(worst_peak, bpk if bpk == bpk else 0)
+        line = f"{gpu:>3} {a:>9.0f} {c:>9.0f} {over:>8.0f} {bpk:>11.0f} {opk:>11.0f}"
+        if ceiling:
+            line += f" {ceiling - opk:>9.0f}"
+        print(line)
+    print(f"\nWORST-GPU  shadow_overhead={worst_over:.0f} MiB  "
+          f"concurrent_bringup_peak={worst_peak:.0f} MiB", end="")
+    if ceiling:
+        print(f"  headroom_at_peak={ceiling - worst_peak:.0f} MiB (ceiling {ceiling:.0f})")
+        print(f"VERDICT: concurrent shadow bring-up "
+              f"{'FITS' if worst_peak < ceiling else 'EXCEEDS'} the ceiling")
+    else:
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/failover-kimi/analyze_replenish.py
+++ b/failover-kimi/analyze_replenish.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Per-phase memory peaks for the replenishment cycle (kimi_replenish.sh).
+
+Usage: analyze_replenish.py OUT_DIR [--ceiling-mib N]
+Reads OUT_DIR/dev_mem.csv + OUT_DIR/phases.csv.
+"""
+import csv
+import sys
+
+O = sys.argv[1]
+ceiling = 183359
+if "--ceiling-mib" in sys.argv:
+    ceiling = float(sys.argv[sys.argv.index("--ceiling-mib") + 1])
+
+dev = {}
+for r in csv.DictReader(open(f"{O}/dev_mem.csv")):
+    dev.setdefault(int(r["gpu"]), []).append((float(r["ts"]), float(r["mem_mib"])))
+ph = {r["label"]: float(r["epoch"]) for r in csv.DictReader(open(f"{O}/phases.csv"))}
+
+
+def peak(a, b):
+    return max(max((m for t, m in dev[g] if a <= t <= b), default=0) for g in dev)
+
+
+def val(lbl):
+    t = ph[lbl]
+    return max(min(dev[g], key=lambda x: abs(x[0] - t))[1] for g in dev)
+
+
+rows = [
+    ("colocated_1 (e0 active + e1 shadow)", val("colocated_1")),
+    ("failover-1 promotion peak [kill..promote]", peak(ph["failover1_kill"], ph["e1_promoted"])),
+    ("REPLENISH bring-up peak [launch..standby]", peak(ph["replenish_launch"], ph["colocated_2"])),
+    ("colocated_2 (e1 active + eC shadow) REPLENISHED", val("colocated_2")),
+    ("failover-2 promotion peak [kill..promote]", peak(ph["failover2_kill"], ph["eC_promoted"])),
+]
+for name, v in rows:
+    print(f"  {name:50s}: {v:7.0f} MiB")
+w = max(max(m for _, m in dev[g]) for g in dev)
+print(f"  {'WORST-GPU overall peak':50s}: {w:7.0f} MiB  (headroom {ceiling - w:.0f})")

--- a/failover-kimi/dyn_kvroute.py
+++ b/failover-kimi/dyn_kvroute.py
@@ -1,0 +1,79 @@
+"""Route the V1 model-runner's KV allocation through the GMS scratch mempool.
+
+vLLM 0.25.1 split the model runner into V1 (vllm.v1.worker.gpu_model_runner,
+DEFAULT: use_v2_model_runner=False) and V2 (vllm.v1.worker.gpu.model_runner).
+Main's patch_kv_cache_pool_scope() wraps `vllm.v1.worker.gpu.model_runner.init_kv_cache`
+— a symbol that does not exist in this vLLM — so its `except AttributeError` makes
+it a silent no-op on the default V1 runner. Result: the shadow's KV torch.zeros
+never lands in the scratch pool -> worker.py fail-closed guard fires
+("Scratch-KV enabled but no KV allocation was routed through scratch").
+
+Fix: wrap V1's `_allocate_kv_cache_tensors` (the fn that emits the raw KV buffer,
+scoped to KV tensors only — not block tables) in gms_use_mem_pool("kv_cache").
+Guarded to only engage when the kv_cache scratch pool is actually registered
+(shadow mode), so it's a no-op otherwise. Gate: DYN_GMS_KVROUTE_V1=1.
+
+This is a runtime stand-in for the proper upstream fix (correct
+patch_kv_cache_pool_scope to target the V1 runner + V2's real method).
+"""
+import importlib.abc
+import sys
+
+_T = "vllm.v1.worker.gpu_model_runner"
+
+
+def _patch():
+    mod = sys.modules.get(_T)
+    if mod is None:
+        return
+    R = getattr(mod, "GPUModelRunner", None)
+    if R is None:
+        return
+    orig = getattr(R, "_allocate_kv_cache_tensors", None)
+    if orig is None or getattr(orig, "_kvroute", False):
+        return
+    import torch
+    from gpu_memory_service.client.torch.allocator import (
+        get_gms_client_memory_manager,
+        gms_use_mem_pool,
+    )
+
+    def patched(self, *a, **k):
+        # Only route when the kv_cache scratch pool exists (shadow mode); else no-op.
+        if get_gms_client_memory_manager("kv_cache") is not None:
+            device = torch.device("cuda", torch.cuda.current_device())
+            with gms_use_mem_pool("kv_cache", device):
+                return orig(self, *a, **k)
+        return orig(self, *a, **k)
+
+    patched._kvroute = True
+    R._allocate_kv_cache_tensors = patched
+    print(
+        "[KVROUTE] wrapped V1 GPUModelRunner._allocate_kv_cache_tensors in kv_cache pool",
+        flush=True,
+    )
+
+
+class _F(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if name != _T:
+            return None
+        for f in list(sys.meta_path):
+            if f is self:
+                continue
+            spec = f.find_spec(name, path, target)
+            if spec and spec.loader:
+                oe = spec.loader.exec_module
+
+                def ex(m, _oe=oe):
+                    _oe(m)
+                    _patch()
+
+                spec.loader.exec_module = ex
+                return spec
+        return None
+
+
+sys.meta_path.insert(0, _F())
+_patch()
+print("[KVROUTE] loaded (V1 KV-alloc scratch routing)", flush=True)

--- a/failover-kimi/dyn_noautotune.py
+++ b/failover-kimi/dyn_noautotune.py
@@ -1,0 +1,57 @@
+"""Minimal: no-op FlashInfer autotune when DYN_NO_AUTOTUNE=1.
+
+FlashInfer autotune is the source of the GMS warmup memory burst (workspaces
+not reused under the split-pool layout -> +25 GiB / peak 178 / 15 alloc-retries).
+Skipping it drops the GMS bring-up peak to ~145 (below vanilla) — the headroom
+lever for two-engine colocation / replenishment.
+
+This module does NOTHING else (no _dummy_run wrapping, no cuda.synchronize), so
+it is safe under cudagraph capture (non-eager). Loaded via sitecustomize, so it
+reaches every TP worker process.
+"""
+import importlib.abc
+import sys
+
+_T = "vllm.model_executor.warmup.kernel_warmup"
+
+
+def _patch():
+    mod = sys.modules.get(_T)
+    if mod is None:
+        return
+    fn = getattr(mod, "flashinfer_autotune", None)
+    if fn is None or getattr(fn, "_noat", False):
+        return
+
+    def noop(*a, **k):
+        print("[NOAT] flashinfer_autotune skipped (DYN_NO_AUTOTUNE=1)", flush=True)
+        return None
+
+    noop._noat = True
+    mod.flashinfer_autotune = noop
+    print("[NOAT] patched flashinfer_autotune -> noop", flush=True)
+
+
+class _F(importlib.abc.MetaPathFinder):
+    def find_spec(self, name, path, target=None):
+        if name != _T:
+            return None
+        for f in list(sys.meta_path):
+            if f is self:
+                continue
+            spec = f.find_spec(name, path, target)
+            if spec and spec.loader:
+                oe = spec.loader.exec_module
+
+                def ex(m, _oe=oe):
+                    _oe(m)
+                    _patch()
+
+                spec.loader.exec_module = ex
+                return spec
+        return None
+
+
+sys.meta_path.insert(0, _F())
+_patch()
+print("[NOAT] no-autotune module loaded", flush=True)

--- a/failover-kimi/kimi_failover.sh
+++ b/failover-kimi/kimi_failover.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Kimi-K2.6 TP8 two-engine intra-pod shadow failover (single-block scratch + autotune off).
+# engine0 ACTIVE (holds flock, serves) + engine1 SHADOW (scratch-KV, STANDBY), both TP8
+# on the same 8 GPUs, sharing GMS weights. Kill engine0 (WHOLE engine) -> engine1 wakes,
+# remaps real KV, promotes, serves. EAGER=1 first pass, EAGER=0 (cudagraphs) second.
+set -u
+source /opt/dynamo/venv/bin/activate 2>/dev/null || true
+export HF_HOME=/tmp/hf HF_HUB_OFFLINE=0   # writable for Kimi trust-remote-code dynamic modules
+mkdir -p /tmp/hf
+MODEL=${MODEL:-/tmp/kimi-k2.6-nvfp4}; SERVED=${SERVED:-kimi-k2.6}
+TP=${TP:-8}; MML=${MML:-4096}; UTIL=${UTIL:-0.8}
+SINGLE=${DYN_GMS_SCRATCH_SINGLE_BLOCK:-1}; NOAT=${DYN_NO_AUTOTUNE:-1}; EAGER=${EAGER:-1}
+ACT_TO=${ACT_TO:-900}; SHA_TO=${SHA_TO:-900}; PROMO_TO=${PROMO_TO:-400}
+EAGER_FLAG=""; [ "$EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"
+TAG=${TAG:-$( [ "$EAGER" = "1" ] && echo eager || echo graphs )}
+OUT=/tmp/kimi_failover-$TAG; rm -rf "$OUT"; mkdir -p "$OUT/logs"; LOCK=$OUT/failover.lock
+have(){ grep -aq "$2" "$1" 2>/dev/null; }
+log(){ echo "[kimi_failover $(date +%T)] $*"; }
+mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
+cleanup(){ log "cleanup"; [ "${SAMP:-0}" != "0" ] && kill -9 "$SAMP" 2>/dev/null
+  pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
+  pkill -9 -f "[E]ngineCore" 2>/dev/null; pkill -9 -f "[g]pu_memory_service" 2>/dev/null; sleep 2
+  for p in $(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null); do kill -9 "$p" 2>/dev/null; done
+  rm -f /tmp/gms_*.sock; cp "$OUT"/logs/*.log "$OUT/" 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 4
+
+# verify clean baseline
+for a in $(seq 1 10); do
+  dirty=$(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | awk -F', ' '$2+0>512{print}')
+  [ -z "$dirty" ] && break; log "GPUs not clean, retry $a"; pkill -9 -f "[E]ngineCore" 2>/dev/null; sleep 5
+done
+log "baseline: $(mem)"
+
+# 1s device sampler (all GPUs)
+( echo "ts,gpu,mem_mib" > "$OUT/dev_mem.csv"
+  while true; do ts=$(date +%s.%N)
+    nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits 2>/dev/null \
+      | awk -F', ' -v t="$ts" '{print t","$1","$2}' >> "$OUT/dev_mem.csv"; sleep 1; done ) & SAMP=$!
+
+infer(){ curl -s -o "$OUT/infer_$1.json" -w "%{http_code}" -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$SERVED\",\"prompt\":\"The capital of France is\",\"max_tokens\":12,\"temperature\":0}"; }
+
+launch(){ DYN_GMS_SCRATCH_SINGLE_BLOCK=$SINGLE DYN_NO_AUTOTUNE=$NOAT DYN_GMS_KVROUTE_V1=1 \
+  ENGINE_ID=$1 FAILOVER_LOCK_PATH=$LOCK DYN_SYSTEM_PORT=$((8100+$1)) \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$((5600+$1)) DYN_VLLM_KV_EVENT_PORT=$((20080+$1)) \
+  nohup python3 -m dynamo.vllm --model "$MODEL" --served-model-name "$SERVED" -tp "$TP" \
+  --trust-remote-code --max-model-len "$MML" --gpu-memory-utilization "$UTIL" $EAGER_FLAG \
+  --load-format gms --gms-shadow-mode > "$2" 2>&1 & echo $!; }
+
+log "GMS weights+kv servers (TP=$TP)"
+for d in $(seq 0 $((TP-1))); do
+  python3 -m gpu_memory_service --device $d --tag weights  > "$OUT/logs/gms_w$d.log"  2>&1 &
+  python3 -m gpu_memory_service --device $d --tag kv_cache > "$OUT/logs/gms_kv$d.log" 2>&1 &
+done
+for d in $(seq 0 $((TP-1))); do for i in $(seq 1 60); do have "$OUT/logs/gms_w$d.log" "Server started" && break; sleep 1; done; done
+nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
+
+log "engine0 ACTIVE launching (single_block=$SINGLE no_autotune=$NOAT eager=$EAGER)"
+A=$(launch 0 "$OUT/logs/engine0.log"); log "engine0 pid $A"
+for i in $(seq 1 $ACT_TO); do have "$OUT/logs/engine0.log" "Registered endpoint" && { log "ACTIVE registered +${i}s"; break; }
+  kill -0 $A 2>/dev/null || { log "engine0 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|non-positive" "$OUT/logs/engine0.log"|tail -10; exit 1; }; sleep 1; done
+have "$OUT/logs/engine0.log" "Registered endpoint" || { log "ACTIVE never registered (timeout)"; exit 1; }
+log "mem after ACTIVE: $(mem)"
+
+log "engine1 SHADOW launching"
+B=$(launch 1 "$OUT/logs/engine1.log"); log "engine1 pid $B"
+for i in $(seq 1 $SHA_TO); do have "$OUT/logs/engine1.log" "waiting for lock" && { log "SHADOW standby +${i}s"; break; }
+  kill -0 $B 2>/dev/null || { log "engine1 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|non-positive" "$OUT/logs/engine1.log"|tail -10; exit 1; }; sleep 1; done
+have "$OUT/logs/engine1.log" "waiting for lock" || { log "SHADOW never reached standby (timeout)"; grep -anE "Error|OutOfMemory|Traceback" "$OUT/logs/engine1.log"|tail -10; exit 1; }
+echo "=== shadow [D3] scratch_map (expect 1 granule/GPU) ==="; grep -a "\[D3\] scratch_map" "$OUT/logs/engine1.log" | head -3
+log "MEM COLOCATED (active+shadow): $(mem)"
+
+for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
+log "infer ACTIVE: HTTP $(infer active) :: $(head -c 120 "$OUT/infer_active.json")"
+
+log "KILL engine0 (whole engine: children first, then parent) -> FAILOVER"
+pkill -9 -P "$A" 2>/dev/null; kill -9 "$A" 2>/dev/null
+for i in $(seq 1 $PROMO_TO); do have "$OUT/logs/engine1.log" "Registered endpoint" && { log "SHADOW PROMOTED +${i}s"; break; }
+  kill -0 $B 2>/dev/null || { log "engine1 DIED on promotion"; grep -anE "Error|OutOfMemory|Traceback|CUDA error" "$OUT/logs/engine1.log"|tail -10; break; }; sleep 1; done
+log "MEM after failover: $(mem)"
+# Post-failover inference: the frontend must evict the dead active's discovery
+# entry and route to the promoted engine. Retry with backoff (connection-refused
+# to the dead active is expected for the first few seconds).
+PF=000; PFR=0
+for r in $(seq 1 18); do
+  sleep 5
+  code=$(infer postfail)
+  log "  post-failover retry $r (+$((r*5))s): HTTP $code :: $(head -c 90 "$OUT/infer_postfail.json")"
+  [ "$code" = "200" ] && { PF=200; PFR=$((r*5)); log "POST-FAILOVER 200 at +${PFR}s after promotion"; break; }
+done
+log "MEM final: $(mem)"
+echo "KIMI_FAILOVER_DONE tag=$TAG single_block=$SINGLE no_autotune=$NOAT eager=$EAGER postfail=$PF postfail_secs=$PFR"

--- a/failover-kimi/kimi_failover.sh
+++ b/failover-kimi/kimi_failover.sh
@@ -16,6 +16,7 @@ TAG=${TAG:-$( [ "$EAGER" = "1" ] && echo eager || echo graphs )}
 OUT=/tmp/kimi_failover-$TAG; rm -rf "$OUT"; mkdir -p "$OUT/logs"; LOCK=$OUT/failover.lock
 have(){ grep -aq "$2" "$1" 2>/dev/null; }
 log(){ echo "[kimi_failover $(date +%T)] $*"; }
+phase(){ echo "$(date +%s.%N),$1" >> "$OUT/phases.csv"; }   # epoch-stamped phase boundaries for mem windowing
 mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
 cleanup(){ log "cleanup"; [ "${SAMP:-0}" != "0" ] && kill -9 "$SAMP" 2>/dev/null
   pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
@@ -32,6 +33,7 @@ for a in $(seq 1 10); do
 done
 log "baseline: $(mem)"
 
+echo "epoch,label" > "$OUT/phases.csv"; phase baseline
 # 1s device sampler (all GPUs)
 ( echo "ts,gpu,mem_mib" > "$OUT/dev_mem.csv"
   while true; do ts=$(date +%s.%N)
@@ -58,27 +60,34 @@ for d in $(seq 0 $((TP-1))); do for i in $(seq 1 60); do have "$OUT/logs/gms_w$d
 nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
 
 log "engine0 ACTIVE launching (single_block=$SINGLE no_autotune=$NOAT eager=$EAGER)"
+phase active_launch
 A=$(launch 0 "$OUT/logs/engine0.log"); log "engine0 pid $A"
 for i in $(seq 1 $ACT_TO); do have "$OUT/logs/engine0.log" "Registered endpoint" && { log "ACTIVE registered +${i}s"; break; }
   kill -0 $A 2>/dev/null || { log "engine0 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|non-positive" "$OUT/logs/engine0.log"|tail -10; exit 1; }; sleep 1; done
 have "$OUT/logs/engine0.log" "Registered endpoint" || { log "ACTIVE never registered (timeout)"; exit 1; }
+phase active_registered; sleep 3; phase active_resting
 log "mem after ACTIVE: $(mem)"
 
 log "engine1 SHADOW launching"
+phase shadow_launch
 B=$(launch 1 "$OUT/logs/engine1.log"); log "engine1 pid $B"
 for i in $(seq 1 $SHA_TO); do have "$OUT/logs/engine1.log" "waiting for lock" && { log "SHADOW standby +${i}s"; break; }
   kill -0 $B 2>/dev/null || { log "engine1 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|non-positive" "$OUT/logs/engine1.log"|tail -10; exit 1; }; sleep 1; done
 have "$OUT/logs/engine1.log" "waiting for lock" || { log "SHADOW never reached standby (timeout)"; grep -anE "Error|OutOfMemory|Traceback" "$OUT/logs/engine1.log"|tail -10; exit 1; }
+phase shadow_standby
 echo "=== shadow [D3] scratch_map (expect 1 granule/GPU) ==="; grep -a "\[D3\] scratch_map" "$OUT/logs/engine1.log" | head -3
+sleep 3; phase colocated_resting
 log "MEM COLOCATED (active+shadow): $(mem)"
 
 for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
 log "infer ACTIVE: HTTP $(infer active) :: $(head -c 120 "$OUT/infer_active.json")"
 
 log "KILL engine0 (whole engine: children first, then parent) -> FAILOVER"
+phase active_kill
 pkill -9 -P "$A" 2>/dev/null; kill -9 "$A" 2>/dev/null
 for i in $(seq 1 $PROMO_TO); do have "$OUT/logs/engine1.log" "Registered endpoint" && { log "SHADOW PROMOTED +${i}s"; break; }
   kill -0 $B 2>/dev/null || { log "engine1 DIED on promotion"; grep -anE "Error|OutOfMemory|Traceback|CUDA error" "$OUT/logs/engine1.log"|tail -10; break; }; sleep 1; done
+phase shadow_promoted
 log "MEM after failover: $(mem)"
 # Post-failover inference: the frontend must evict the dead active's discovery
 # entry and route to the promoted engine. Retry with backoff (connection-refused
@@ -90,5 +99,5 @@ for r in $(seq 1 18); do
   log "  post-failover retry $r (+$((r*5))s): HTTP $code :: $(head -c 90 "$OUT/infer_postfail.json")"
   [ "$code" = "200" ] && { PF=200; PFR=$((r*5)); log "POST-FAILOVER 200 at +${PFR}s after promotion"; break; }
 done
-log "MEM final: $(mem)"
+phase final; log "MEM final: $(mem)"
 echo "KIMI_FAILOVER_DONE tag=$TAG single_block=$SINGLE no_autotune=$NOAT eager=$EAGER postfail=$PF postfail_secs=$PFR"

--- a/failover-kimi/kimi_failover_concurrent.sh
+++ b/failover-kimi/kimi_failover_concurrent.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# CONCURRENT COLD-INIT — both engines launched at the SAME time (both shadow-mode).
+# They race the flock: winner=ACTIVE (disk->GMS->commit->KV->warmup->register),
+# loser=SHADOW (waits for committed weights -> RO import -> scratch-KV -> warmup ->
+# standby). Unlike kimi_failover.sh (which serializes: active fully up THEN shadow),
+# this measures the TRUE concurrent bring-up peak — the 0.23.0 risk case (each engine
+# warmup-peaked ~178 GiB; two at once would blow the 183 ceiling). With autotune-off +
+# single-block scratch, does concurrent cold-init now fit? Measure, don't assume.
+set -u
+source /opt/dynamo/venv/bin/activate 2>/dev/null || true
+export HF_HOME=/tmp/hf HF_HUB_OFFLINE=0; mkdir -p /tmp/hf
+MODEL=${MODEL:-/tmp/kimi-k2.6-nvfp4}; SERVED=${SERVED:-kimi-k2.6}
+TP=${TP:-8}; MML=${MML:-4096}; UTIL=${UTIL:-0.8}
+SINGLE=${DYN_GMS_SCRATCH_SINGLE_BLOCK:-1}; NOAT=${DYN_NO_AUTOTUNE:-1}; EAGER=${EAGER:-1}
+CO_TO=${CO_TO:-1400}; PROMO_TO=${PROMO_TO:-400}
+EAGER_FLAG=""; [ "$EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"
+TAG=${TAG:-concurrent-$( [ "$EAGER" = "1" ] && echo eager || echo graphs )}
+OUT=/tmp/kimi_failover-$TAG; rm -rf "$OUT"; mkdir -p "$OUT/logs"; LOCK=$OUT/failover.lock
+have(){ grep -aq "$2" "$1" 2>/dev/null; }
+log(){ echo "[concurrent $(date +%T)] $*"; }
+phase(){ echo "$(date +%s.%N),$1" >> "$OUT/phases.csv"; }
+mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
+cleanup(){ log "cleanup"; [ "${SAMP:-0}" != "0" ] && kill -9 "$SAMP" 2>/dev/null
+  pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
+  pkill -9 -f "[E]ngineCore" 2>/dev/null; pkill -9 -f "[g]pu_memory_service" 2>/dev/null; sleep 2
+  for p in $(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null); do kill -9 "$p" 2>/dev/null; done
+  rm -f /tmp/gms_*.sock; cp "$OUT"/logs/*.log "$OUT/" 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 4
+for a in $(seq 1 10); do
+  dirty=$(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | awk -F', ' '$2+0>512{print}')
+  [ -z "$dirty" ] && break; log "GPUs not clean, retry $a"; pkill -9 -f "[E]ngineCore" 2>/dev/null; sleep 5
+done
+echo "epoch,label" > "$OUT/phases.csv"; phase baseline
+log "baseline: $(mem)"
+( echo "ts,gpu,mem_mib" > "$OUT/dev_mem.csv"
+  while true; do ts=$(date +%s.%N)
+    nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits 2>/dev/null \
+      | awk -F', ' -v t="$ts" '{print t","$1","$2}' >> "$OUT/dev_mem.csv"; sleep 1; done ) & SAMP=$!
+
+infer(){ curl -s -o "$OUT/infer_$1.json" -w "%{http_code}" -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$SERVED\",\"prompt\":\"The capital of France is\",\"max_tokens\":12,\"temperature\":0}"; }
+launch(){ DYN_GMS_SCRATCH_SINGLE_BLOCK=$SINGLE DYN_NO_AUTOTUNE=$NOAT DYN_GMS_KVROUTE_V1=1 \
+  ENGINE_ID=$1 FAILOVER_LOCK_PATH=$LOCK DYN_SYSTEM_PORT=$((8100+$1)) \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$((5600+$1)) DYN_VLLM_KV_EVENT_PORT=$((20080+$1)) \
+  nohup python3 -m dynamo.vllm --model "$MODEL" --served-model-name "$SERVED" -tp "$TP" \
+  --trust-remote-code --max-model-len "$MML" --gpu-memory-utilization "$UTIL" $EAGER_FLAG \
+  --load-format gms --gms-shadow-mode > "$2" 2>&1 & echo $!; }
+
+log "GMS weights+kv servers (TP=$TP)"
+for d in $(seq 0 $((TP-1))); do
+  python3 -m gpu_memory_service --device $d --tag weights  > "$OUT/logs/gms_w$d.log"  2>&1 &
+  python3 -m gpu_memory_service --device $d --tag kv_cache > "$OUT/logs/gms_kv$d.log" 2>&1 &
+done
+for d in $(seq 0 $((TP-1))); do for i in $(seq 1 60); do have "$OUT/logs/gms_w$d.log" "Server started" && break; sleep 1; done; done
+nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
+
+log "*** CONCURRENT LAUNCH: engine0 + engine1 at once (single_block=$SINGLE no_autotune=$NOAT eager=$EAGER) ***"
+phase concurrent_launch
+P0=$(launch 0 "$OUT/logs/engine0.log"); P1=$(launch 1 "$OUT/logs/engine1.log")
+log "engine0 pid $P0 ; engine1 pid $P1 (racing flock)"
+
+L0=$OUT/logs/engine0.log; L1=$OUT/logs/engine1.log
+ACTIVE_LOG=""; SHADOW_LOG=""; ACTIVE_PID=""; SHADOW_PID=""
+for i in $(seq 1 $CO_TO); do
+  # resolve roles from logs (flock winner registers; loser waits for lock)
+  if [ -z "$ACTIVE_LOG" ]; then
+    if have "$L0" "waiting for lock"; then SHADOW_LOG=$L0; SHADOW_PID=$P0; ACTIVE_LOG=$L1; ACTIVE_PID=$P1; log "roles: engine1 ACTIVE, engine0 SHADOW (+${i}s)"
+    elif have "$L1" "waiting for lock"; then SHADOW_LOG=$L1; SHADOW_PID=$P1; ACTIVE_LOG=$L0; ACTIVE_PID=$P0; log "roles: engine0 ACTIVE, engine1 SHADOW (+${i}s)"; fi
+  fi
+  areg=0; sstb=0
+  [ -n "$ACTIVE_LOG" ] && have "$ACTIVE_LOG" "Registered endpoint" && areg=1
+  [ -n "$SHADOW_LOG" ] && have "$SHADOW_LOG" "waiting for lock" && sstb=1
+  [ "$areg" = 1 ] && [ "$sstb" = 1 ] && { log "BOTH READY (active registered + shadow standby) +${i}s"; break; }
+  kill -0 $P0 2>/dev/null || { log "engine0 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|not validated|non-positive|routed through scratch" "$L0"|tail -12; exit 1; }
+  kill -0 $P1 2>/dev/null || { log "engine1 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|not validated|non-positive|routed through scratch" "$L1"|tail -12; exit 1; }
+  sleep 1
+done
+phase concurrent_ready
+[ -n "$ACTIVE_LOG" ] && have "$ACTIVE_LOG" "Registered endpoint" || { log "concurrent bring-up did not converge (timeout)"; exit 1; }
+log "MEM after concurrent bring-up (active+shadow): $(mem)"
+sleep 3; phase concurrent_settled; log "MEM settled: $(mem)"
+
+for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
+log "infer ACTIVE: HTTP $(infer active) :: $(head -c 90 "$OUT/infer_active.json")"
+
+# failover for completeness (kill whichever won active)
+log "KILL active engine -> FAILOVER"; phase active_kill
+pkill -9 -P "$ACTIVE_PID" 2>/dev/null; kill -9 "$ACTIVE_PID" 2>/dev/null
+for i in $(seq 1 $PROMO_TO); do have "$SHADOW_LOG" "Registered endpoint" && { log "SHADOW PROMOTED +${i}s"; break; }
+  kill -0 $SHADOW_PID 2>/dev/null || { log "shadow DIED on promotion"; grep -anE "Error|Traceback|CUDA error" "$SHADOW_LOG"|tail -10; break; }; sleep 1; done
+phase shadow_promoted; log "MEM after failover: $(mem)"
+PF=000; PFR=0
+for r in $(seq 1 18); do sleep 5; code=$(infer postfail)
+  log "  post-failover retry $r (+$((r*5))s): HTTP $code"; [ "$code" = "200" ] && { PF=200; PFR=$((r*5)); break; }; done
+phase final; log "MEM final: $(mem)"
+echo "KIMI_CONCURRENT_DONE tag=$TAG eager=$EAGER postfail=$PF postfail_secs=$PFR"

--- a/failover-kimi/kimi_failover_concurrent.sh
+++ b/failover-kimi/kimi_failover_concurrent.sh
@@ -64,14 +64,16 @@ log "engine0 pid $P0 ; engine1 pid $P1 (racing flock)"
 L0=$OUT/logs/engine0.log; L1=$OUT/logs/engine1.log
 ACTIVE_LOG=""; SHADOW_LOG=""; ACTIVE_PID=""; SHADOW_PID=""
 for i in $(seq 1 $CO_TO); do
-  # resolve roles from logs (flock winner registers; loser waits for lock)
-  if [ -z "$ACTIVE_LOG" ]; then
-    if have "$L0" "waiting for lock"; then SHADOW_LOG=$L0; SHADOW_PID=$P0; ACTIVE_LOG=$L1; ACTIVE_PID=$P1; log "roles: engine1 ACTIVE, engine0 SHADOW (+${i}s)"
-    elif have "$L1" "waiting for lock"; then SHADOW_LOG=$L1; SHADOW_PID=$P1; ACTIVE_LOG=$L0; ACTIVE_PID=$P0; log "roles: engine0 ACTIVE, engine1 SHADOW (+${i}s)"; fi
+  # resolve roles: the flock LOSER is the only one that sleeps ("Engine sleeping"),
+  # so it is unambiguously the SHADOW; the other is ACTIVE. (Both transiently log
+  # "waiting for lock" during the race, so that string cannot distinguish them.)
+  if [ -z "$SHADOW_LOG" ]; then
+    if have "$L0" "Engine sleeping"; then SHADOW_LOG=$L0; SHADOW_PID=$P0; ACTIVE_LOG=$L1; ACTIVE_PID=$P1; log "roles: engine1 ACTIVE, engine0 SHADOW (+${i}s)"
+    elif have "$L1" "Engine sleeping"; then SHADOW_LOG=$L1; SHADOW_PID=$P1; ACTIVE_LOG=$L0; ACTIVE_PID=$P0; log "roles: engine0 ACTIVE, engine1 SHADOW (+${i}s)"; fi
   fi
   areg=0; sstb=0
+  [ -n "$SHADOW_LOG" ] && sstb=1   # shadow has slept -> standby
   [ -n "$ACTIVE_LOG" ] && have "$ACTIVE_LOG" "Registered endpoint" && areg=1
-  [ -n "$SHADOW_LOG" ] && have "$SHADOW_LOG" "waiting for lock" && sstb=1
   [ "$areg" = 1 ] && [ "$sstb" = 1 ] && { log "BOTH READY (active registered + shadow standby) +${i}s"; break; }
   kill -0 $P0 2>/dev/null || { log "engine0 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|not validated|non-positive|routed through scratch" "$L0"|tail -12; exit 1; }
   kill -0 $P1 2>/dev/null || { log "engine1 DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|not validated|non-positive|routed through scratch" "$L1"|tail -12; exit 1; }

--- a/failover-kimi/kimi_k25_0251-metasafe.py
+++ b/failover-kimi/kimi_k25_0251-metasafe.py
@@ -1,0 +1,487 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Kimi-K2.5 Model Implementation for vLLM.
+
+Kimi-K2.5 extends Kimi-K2 with vision support.
+"""
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal
+
+import torch
+from torch import nn
+from transformers import BatchFeature
+
+from vllm.config import VllmConfig
+from vllm.config.multimodal import BaseDummyOptions
+from vllm.inputs import MultiModalDataDict
+from vllm.logger import init_logger
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.compressed_tensors import (
+    compressed_tensors,
+)
+from vllm.model_executor.models.interfaces import (
+    SupportsEagle,
+    SupportsEagle3,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+)
+from vllm.model_executor.models.kimi_k25_vit import (
+    KimiK25MultiModalProjector,
+    MoonViT3dPretrainedModel,
+    vision_tower_forward,
+)
+from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.inputs import (
+    MultiModalFieldConfig,
+    MultiModalKwargsItems,
+    NestedTensors,
+    VisionChunkImage,
+    VisionChunkVideo,
+)
+from vllm.multimodal.parse import MultiModalDataItems, VisionChunkProcessorItems
+from vllm.multimodal.processing import (
+    BaseDummyInputsBuilder,
+    BaseMultiModalProcessor,
+    BaseProcessingInfo,
+    InputProcessingContext,
+    PromptReplacement,
+    PromptUpdate,
+)
+from vllm.platforms import current_platform
+from vllm.sequence import IntermediateTensors
+from vllm.transformers_utils.configs.kimi_k25 import KimiK25Config
+from vllm.transformers_utils.processor import cached_get_image_processor
+from vllm.transformers_utils.processors.kimi_k25 import KimiK25Processor
+from vllm.transformers_utils.processors.kimi_k25_vision_fused import (
+    KimiK25FusedVisionProcessor,
+)
+from vllm.utils.import_utils import is_numba_available
+from vllm.utils.tensor_schema import TensorSchema, TensorShape
+
+from .utils import (
+    AutoWeightsLoader,
+    WeightsMapper,
+    init_vllm_registered_model,
+    maybe_prefix,
+)
+
+logger = init_logger(__name__)
+
+
+# Dummy input dimensions for profiling.
+@dataclass
+class MaxImageTokenMeta:
+    width: int = 3000
+    height: int = 3000
+
+
+class KimiK25MediaPixelInputs(TensorSchema):
+    """
+    Media input schema for K2-VL model.
+
+    Dimensions:
+        - np: Number of patches (flattened from all media items)
+        - ps: Patch size
+        - nm: Number of media items
+    """
+
+    type: Literal["pixel_values"] = "pixel_values"
+
+    pixel_values: Annotated[
+        torch.Tensor | list[torch.Tensor],
+        TensorShape("np", 3, "ps", "ps"),
+    ]
+
+    grid_thws: Annotated[torch.Tensor, TensorShape("nm", 3)]
+
+
+class KimiK25ProcessingInfo(BaseProcessingInfo):
+    """Processing information for Kimi-K2.5 model.
+
+    Provides configuration and utilities for processing both
+    images and video-chunks.
+    """
+
+    def __init__(self, ctx: InputProcessingContext) -> None:
+        super().__init__(ctx)
+
+        self.hf_config = hf_config = self.get_hf_config()
+
+        tokenizer = self.get_tokenizer()
+        processor_cls = KimiK25FusedVisionProcessor if is_numba_available() else None
+        logger.info_once(
+            "Using %s image preprocessing for Kimi-K2.5/K2.6 vision chunks.",
+            "fused CPU" if processor_cls is not None else "remote HF",
+        )
+        image_processor = cached_get_image_processor(
+            self.ctx.model_config.model,
+            revision=self.ctx.model_config.revision,
+            trust_remote_code=self.ctx.model_config.trust_remote_code,
+            processor_cls_overrides=processor_cls,
+        )
+
+        # Resolve token ID from the tokenizer because transformers v5
+        # may remap token IDs vs config.json.
+        config_token_id = hf_config.media_placeholder_token_id
+        resolved_token_id = tokenizer.convert_tokens_to_ids("<|media_pad|>")
+        is_valid_resolved = isinstance(resolved_token_id, int) and (
+            tokenizer.unk_token_id is None
+            or resolved_token_id != tokenizer.unk_token_id
+        )
+        if is_valid_resolved and resolved_token_id != config_token_id:
+            logger.warning_once(
+                "Kimi-K2.5 config.media_placeholder_token_id (%d) disagrees "
+                "with tokenizer mapping for <|media_pad|> (%d). "
+                "Using tokenizer value.",
+                config_token_id,
+                resolved_token_id,
+            )
+            media_token_id = resolved_token_id
+            # Patch config so downstream code also sees the correct ID.
+            hf_config.media_placeholder_token_id = resolved_token_id
+        else:
+            media_token_id = config_token_id
+
+        self.media_token_id = media_token_id
+        self.media_token = tokenizer.decode(media_token_id)
+
+        self.image_processor = image_processor
+        self.hf_processor = KimiK25Processor(
+            tokenizer=tokenizer,
+            image_processor=image_processor,
+            media_token_id=media_token_id,
+        )
+        self.media_tokens_calculator = image_processor.media_tokens_calculator
+
+    def get_hf_processor(self):
+        return self.hf_processor
+
+    def get_hf_config(self):
+        return self.ctx.get_hf_config(KimiK25Config)
+
+    def get_supported_mm_limits(self) -> Mapping[str, int | None]:
+        # None means unlimited
+        return {"vision_chunk": None}
+
+
+class KimiK25DummyInputsBuilder(BaseDummyInputsBuilder[KimiK25ProcessingInfo]):
+    """Builds dummy inputs for Kimi-K2.5 model profiling."""
+
+    def get_dummy_text(self, mm_counts: Mapping[str, int]) -> str:
+        num_media = mm_counts.get("vision_chunk", 0)
+        return self.info.media_token * num_media
+
+    def get_dummy_mm_items(self):
+        dummy_videos = self._get_dummy_images(
+            height=MaxImageTokenMeta.height,
+            width=MaxImageTokenMeta.width,
+            num_images=self.info.image_processor.num_frames_per_chunk,
+        )
+
+        video_chunk_dummy_item = VisionChunkVideo(
+            type="video_chunk", video_chunk=dummy_videos
+        )
+        video_chunk_num_tokens = self.info.media_tokens_calculator(
+            video_chunk_dummy_item
+        )
+
+        image_dummy_item = VisionChunkImage(
+            type="image",
+            image=self._get_dummy_images(
+                height=MaxImageTokenMeta.height,
+                width=MaxImageTokenMeta.width,
+                num_images=1,
+            )[0],
+        )
+        image_num_tokens = self.info.media_tokens_calculator(image_dummy_item)
+        # return the larger one
+        if video_chunk_num_tokens >= image_num_tokens:
+            return [video_chunk_dummy_item]
+        else:
+            return [image_dummy_item]
+
+    def get_dummy_mm_data(
+        self,
+        seq_len: int,
+        mm_counts: Mapping[str, int],
+        mm_options: Mapping[str, BaseDummyOptions],
+    ) -> MultiModalDataDict:
+        # TODO: Support mm_options for vision_chunk to allow user configuration
+        dummy_items = self.get_dummy_mm_items()
+        return {"vision_chunk": dummy_items}
+
+
+class KimiK25MultiModalProcessor(BaseMultiModalProcessor[KimiK25ProcessingInfo]):
+    """Multi-modal processor for Kimi-K2.5.
+
+    Handles both image and video-chunk modalities.
+    """
+
+    def _get_mm_fields_config(
+        self,
+        hf_inputs: BatchFeature,
+        hf_processor_mm_kwargs: Mapping[str, object],
+    ) -> Mapping[str, MultiModalFieldConfig]:
+        """Indicates how to slice media input into multiple items.
+
+        pixel_values: [N, 3, patch_size, patch_size],
+          all patches collected from B medias
+        grid_thws: [B,3], each item: [N_t, N_h ,N_w],
+          indicates the grid size in time/height/width direction for current item.
+
+        by multiplying [N_t, N_h ,N_w], we get the number of patches
+        for each media item, thus we can slice pixel_values by
+        pixel_values[start:start + N_t*N_h*N_w] to get patches of one item.
+
+        """
+        grid_thws = hf_inputs.get("grid_thws", torch.empty((0, 3)))
+        grid_sizes = grid_thws.prod(-1)
+
+        return dict(
+            pixel_values=MultiModalFieldConfig.flat_from_sizes(
+                "vision_chunk", grid_sizes
+            ),
+            grid_thws=MultiModalFieldConfig.batched("vision_chunk", keep_on_cpu=True),
+        )
+
+    def _call_hf_processor(
+        self,
+        prompt: str,
+        mm_data: Mapping[str, object],
+        mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
+    ) -> BatchFeature:
+        # Override to use the text path instead of token path because vision chunk
+        # is not considered
+        return super()._call_hf_processor(prompt, mm_data, mm_kwargs, tok_kwargs)
+
+    def _get_prompt_updates(
+        self,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, Any],
+        out_mm_kwargs: MultiModalKwargsItems,
+    ) -> Sequence[PromptUpdate]:
+        media_token_id = self.info.media_token_id
+
+        def get_replacement(item_idx: int):
+            media = mm_items.get_items("vision_chunk", (VisionChunkProcessorItems,))
+            num_media_token = self.info.media_tokens_calculator(media[item_idx])
+            return [media_token_id] * num_media_token
+
+        return [
+            PromptReplacement(
+                modality="vision_chunk",
+                target=[media_token_id],
+                replacement=get_replacement,
+            ),
+        ]
+
+
+@MULTIMODAL_REGISTRY.register_processor(
+    KimiK25MultiModalProcessor,
+    info=KimiK25ProcessingInfo,
+    dummy_inputs=KimiK25DummyInputsBuilder,
+)
+class KimiK25ForConditionalGeneration(
+    nn.Module,
+    SupportsMultiModal,
+    SupportsPP,
+    SupportsQuant,
+    SupportsEagle,
+    SupportsEagle3,
+):
+    """Kimi-K2.5 model for conditional generation.
+
+    Supports both image and video-chunk modalities.
+    Video-chunks are temporal segments (typically 4 frames) that are
+    processed with temporal pooling.
+    """
+
+    supports_encoder_tp_data = True
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            # For legacy NVFP4 checkpoint compatibility:
+            # see https://github.com/vllm-project/vllm/pull/33346#issuecomment-3851475033
+            "language_model.layers.": "language_model.model.layers.",
+            # mm projector
+            "mm_projector.proj.0": "mm_projector.linear_1",
+            "mm_projector.proj.2": "mm_projector.linear_2",
+        }
+    )
+
+    @classmethod
+    def get_placeholder_str(cls, modality: str, i: int) -> str | None:
+        # Kimi-K2.5 uses video_chunk for all media types
+        if modality == "image":
+            return "<|media_begin|>image<|media_content|><|media_pad|><|media_end|>"
+        elif modality == "video":
+            # return a placeholder, to be replaced in the future.
+            return "<|kimi_k25_video_placeholder|>"
+
+        raise ValueError(f"Unsupported modality: {modality}")
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        model_config = vllm_config.model_config
+        config: KimiK25Config = model_config.hf_config
+        self.config = config
+        quant_config = vllm_config.quant_config
+
+        # Check for MoonViT config compatibility
+        self.use_data_parallel = (
+            model_config.multimodal_config.mm_encoder_tp_mode == "data"
+        )
+        self.hidden_size = config.text_config.hidden_size
+        self.device = current_platform.current_device()
+        # Build vision tower directly with KimiK25VisionConfig
+        with self._mark_tower_model(vllm_config, "vision_chunk"):
+            self.vision_tower = MoonViT3dPretrainedModel(
+                config.vision_config,
+                quant_config=self._maybe_ignore_quant_config(quant_config),
+                prefix=maybe_prefix(prefix, "vision_tower"),
+            )
+            # Meta-safe device move: under GMS RO/shadow construction the model is
+            # built on the meta device; moving meta tensors with .to(device) raises
+            # "Cannot copy out of meta tensor". Keep submodules on meta in that case
+            # — their weights are materialized from GMS afterward.
+            def _on_meta(module) -> bool:
+                return any(t.is_meta for t in module.parameters()) or any(
+                    t.is_meta for t in module.buffers()
+                )
+
+            if _on_meta(self.vision_tower):
+                pass
+            elif self._maybe_ignore_quant_config(quant_config) is not None:
+                self.vision_tower = self.vision_tower.to(device=self.device)
+            else:
+                self.vision_tower = self.vision_tower.to(
+                    device=self.device, dtype=model_config.dtype
+                )
+
+            self.mm_projector = KimiK25MultiModalProjector(
+                config=config.vision_config,
+                use_data_parallel=self.use_data_parallel,
+                quant_config=self._maybe_ignore_quant_config(quant_config),
+                prefix=maybe_prefix(prefix, "mm_projector"),
+            )
+            if not _on_meta(self.mm_projector):
+                self.mm_projector = self.mm_projector.to(
+                    device=self.device, dtype=model_config.dtype
+                )
+
+        self.quant_config = quant_config
+        with self._mark_language_model(vllm_config):
+            self.language_model = init_vllm_registered_model(
+                vllm_config=vllm_config,
+                hf_config=config.text_config,
+                prefix=maybe_prefix(prefix, "language_model"),
+                architectures=["DeepseekV2ForCausalLM"],
+            )
+        self.make_empty_intermediate_tensors = (
+            self.language_model.make_empty_intermediate_tensors
+        )
+        self.media_placeholder: int = self.config.media_placeholder_token_id
+
+    def _maybe_ignore_quant_config(self, quant_config: QuantizationConfig):
+        if isinstance(quant_config, compressed_tensors.CompressedTensorsConfig):
+            return None
+        return quant_config
+
+    def _parse_and_validate_media_input(
+        self, **kwargs: object
+    ) -> KimiK25MediaPixelInputs | None:
+        pixel_values = kwargs.pop("pixel_values", None)
+        grid_thws = kwargs.pop("grid_thws", None)
+        if pixel_values is None:
+            return None
+
+        if isinstance(pixel_values, list):
+            pixel_values = torch.cat(pixel_values, dim=0)
+
+        if len(pixel_values.shape) == 5 or len(pixel_values.shape) == 3:
+            pixel_values = pixel_values.reshape(
+                pixel_values.shape[0] * pixel_values.shape[1], *pixel_values.shape[2:]
+            )
+
+        # The batch dimension of pixel_values has been flattened into shape[0]
+        target_dtype = next(self.vision_tower.parameters()).dtype
+        pixel_values = pixel_values.to(target_dtype)
+        assert isinstance(grid_thws, torch.Tensor), (
+            f"expect grid_thws to be a tensor, got {type(grid_thws)}"
+        )
+        # In some cases (e.g. with merger), grid_thws has an extra middle dimension
+        grid_thws = grid_thws.reshape(-1, grid_thws.shape[-1])
+        assert grid_thws.ndim == 2 and grid_thws.size(1) == 3, (
+            f"unexpected shape for grid_thws: {grid_thws.shape}"
+        )
+
+        return KimiK25MediaPixelInputs(
+            type="pixel_values",
+            pixel_values=pixel_values,
+            grid_thws=grid_thws,
+        )
+
+    def _process_media_input(
+        self, media_input: KimiK25MediaPixelInputs
+    ) -> list[torch.Tensor]:
+        # NOTE(moyan): This forward will automatically batch the forward pass internally
+        media_features = vision_tower_forward(
+            self.vision_tower,
+            media_input["pixel_values"],
+            media_input["grid_thws"],
+            mm_projector=self.mm_projector,
+            use_data_parallel=self.use_data_parallel,
+        )
+        return media_features
+
+    def embed_multimodal(self, **kwargs: object) -> NestedTensors | None:
+        # Validate the multimodal input keyword arguments
+        media_input = self._parse_and_validate_media_input(**kwargs)
+        if media_input is None:
+            return None
+
+        # Run multimodal inputs through encoder and projector
+        vision_embeddings = self._process_media_input(media_input)
+        return vision_embeddings
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs: object,
+    ) -> IntermediateTensors:
+        if intermediate_tensors is not None:
+            inputs_embeds = None
+        hidden_states = self.language_model(
+            input_ids=input_ids,
+            positions=positions,
+            intermediate_tensors=intermediate_tensors,
+            inputs_embeds=inputs_embeds,
+        )
+
+        return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor, **kwargs) -> torch.Tensor:
+        logits = self.language_model.compute_logits(hidden_states)
+        return logits
+
+    def set_aux_hidden_state_layers(self, layers: tuple[int, ...]) -> None:
+        self.language_model.set_aux_hidden_state_layers(layers)
+
+    def get_eagle3_aux_hidden_state_layers(self) -> tuple[int, ...]:
+        return self.language_model.get_eagle3_aux_hidden_state_layers()
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)

--- a/failover-kimi/kimi_replenish.sh
+++ b/failover-kimi/kimi_replenish.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# POST-FAILOVER SHADOW REPLENISHMENT — fix the "fail-once" limitation.
+# Sequence (TP8, deterministic serialized launches so roles are unambiguous):
+#   P2  engine0 ACTIVE + engine1 SHADOW (parked at standby)         -> 1a+1s
+#   P3  FAILOVER-1: kill engine0 -> engine1 PROMOTES -> serves 200  -> 1a (no shadow)
+#   P4  REPLENISH: launch engineC (ENGINE_ID=0 reused) -> it races the flock, loses
+#       to the live active (engine1), imports RO weights, sets up scratch-KV, PARKS
+#       at standby -> restores 1a+1s WHILE engine1 keeps serving
+#   P5  FAILOVER-2: kill engine1 -> engineC PROMOTES -> serves 200  -> proves a 2nd
+#       failover works on the replenished shadow
+# The untested crux = can a NEW shadow acquire a scratch-KV grant + RO weights from
+# the still-alive GMS servers AFTER a promotion (active holds kv_cache RW).
+set -u
+source /opt/dynamo/venv/bin/activate 2>/dev/null || true
+export HF_HOME=/tmp/hf HF_HUB_OFFLINE=0; mkdir -p /tmp/hf
+MODEL=${MODEL:-/tmp/kimi-k2.6-nvfp4}; SERVED=${SERVED:-kimi-k2.6}
+TP=${TP:-8}; MML=${MML:-4096}; UTIL=${UTIL:-0.8}
+SINGLE=${DYN_GMS_SCRATCH_SINGLE_BLOCK:-1}; NOAT=${DYN_NO_AUTOTUNE:-1}; EAGER=${EAGER:-1}
+ACT_TO=${ACT_TO:-900}; SHA_TO=${SHA_TO:-900}; PROMO_TO=${PROMO_TO:-400}
+EAGER_FLAG=""; [ "$EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"
+TAG=${TAG:-replenish-$( [ "$EAGER" = "1" ] && echo eager || echo graphs )}
+OUT=/tmp/kimi_failover-$TAG; rm -rf "$OUT"; mkdir -p "$OUT/logs"; LOCK=$OUT/failover.lock
+have(){ grep -aq "$2" "$1" 2>/dev/null; }
+log(){ echo "[replenish $(date +%T)] $*"; }
+phase(){ echo "$(date +%s.%N),$1" >> "$OUT/phases.csv"; }
+mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
+cleanup(){ log "cleanup"; [ "${SAMP:-0}" != "0" ] && kill -9 "$SAMP" 2>/dev/null
+  pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
+  pkill -9 -f "[E]ngineCore" 2>/dev/null; pkill -9 -f "[g]pu_memory_service" 2>/dev/null; sleep 2
+  for p in $(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null); do kill -9 "$p" 2>/dev/null; done
+  rm -f /tmp/gms_*.sock; cp "$OUT"/logs/*.log "$OUT/" 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 4
+for a in $(seq 1 10); do
+  dirty=$(nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | awk -F', ' '$2+0>512{print}')
+  [ -z "$dirty" ] && break; log "GPUs not clean, retry $a"; pkill -9 -f "[E]ngineCore" 2>/dev/null; sleep 5
+done
+echo "epoch,label" > "$OUT/phases.csv"; phase baseline
+log "baseline: $(mem)"
+( echo "ts,gpu,mem_mib" > "$OUT/dev_mem.csv"
+  while true; do ts=$(date +%s.%N)
+    nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits 2>/dev/null \
+      | awk -F', ' -v t="$ts" '{print t","$1","$2}' >> "$OUT/dev_mem.csv"; sleep 1; done ) & SAMP=$!
+
+infer(){ curl -s -o "$OUT/infer_$1.json" -w "%{http_code}" -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$SERVED\",\"prompt\":\"The capital of France is\",\"max_tokens\":12,\"temperature\":0}"; }
+launch(){ DYN_GMS_SCRATCH_SINGLE_BLOCK=$SINGLE DYN_NO_AUTOTUNE=$NOAT DYN_GMS_KVROUTE_V1=1 \
+  ENGINE_ID=$1 FAILOVER_LOCK_PATH=$LOCK DYN_SYSTEM_PORT=$((8100+$1)) \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$((5600+$1)) DYN_VLLM_KV_EVENT_PORT=$((20080+$1)) \
+  nohup python3 -m dynamo.vllm --model "$MODEL" --served-model-name "$SERVED" -tp "$TP" \
+  --trust-remote-code --max-model-len "$MML" --gpu-memory-utilization "$UTIL" $EAGER_FLAG \
+  --load-format gms --gms-shadow-mode > "$2" 2>&1 & echo $!; }
+# wait for a marker in a log, dying-engine aware. $1=log $2=marker $3=timeout $4=pid $5=label
+wait_for(){ local L=$1 M=$2 TO=$3 PID=$4 LB=$5
+  for i in $(seq 1 $TO); do have "$L" "$M" && { log "$LB +${i}s"; return 0; }
+    kill -0 "$PID" 2>/dev/null || { log "$LB: ENGINE DIED"; grep -anE "Error|OutOfMemory|Traceback|CUDA error|not validated|non-positive|routed through scratch" "$L"|tail -12; return 1; }
+    sleep 1; done; log "$LB: TIMEOUT waiting '$M'"; return 1; }
+kill_engine(){ pkill -9 -P "$1" 2>/dev/null; kill -9 "$1" 2>/dev/null; }
+
+log "GMS weights+kv servers (TP=$TP)"
+for d in $(seq 0 $((TP-1))); do
+  python3 -m gpu_memory_service --device $d --tag weights  > "$OUT/logs/gms_w$d.log"  2>&1 &
+  python3 -m gpu_memory_service --device $d --tag kv_cache > "$OUT/logs/gms_kv$d.log" 2>&1 &
+done
+for d in $(seq 0 $((TP-1))); do for i in $(seq 1 60); do have "$OUT/logs/gms_w$d.log" "Server started" && break; sleep 1; done; done
+nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
+for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
+
+# ---- P2: engine0 ACTIVE + engine1 SHADOW ----
+log "P2 engine0 ACTIVE launching"; phase e0_launch
+A=$(launch 0 "$OUT/logs/engine0.log")
+wait_for "$OUT/logs/engine0.log" "Registered endpoint" $ACT_TO "$A" "ACTIVE(e0) registered" || exit 1
+phase e0_active; log "mem after e0 ACTIVE: $(mem)"
+log "P2 engine1 SHADOW launching"; phase e1_launch
+B=$(launch 1 "$OUT/logs/engine1.log")
+wait_for "$OUT/logs/engine1.log" "Engine sleeping" $SHA_TO "$B" "SHADOW(e1) standby" || exit 1
+phase colocated_1; log "MEM COLOCATED (e0 active + e1 shadow): $(mem)"
+log "infer (e0 active): HTTP $(infer p2) :: $(head -c 80 "$OUT/infer_p2.json")"
+
+# ---- P3: FAILOVER-1 (kill e0 -> e1 promotes) ----
+log "P3 FAILOVER-1: kill engine0"; phase failover1_kill
+kill_engine "$A"
+wait_for "$OUT/logs/engine1.log" "Registered endpoint" $PROMO_TO "$B" "e1 PROMOTED" || exit 1
+phase e1_promoted; log "MEM after failover-1 (e1 sole active): $(mem)"
+PF=000; for r in $(seq 1 12); do sleep 5; c=$(infer p3); log "  post-failover-1 retry $r: HTTP $c"; [ "$c" = "200" ] && { PF=200; break; }; done
+[ "$PF" = "200" ] || { log "FAILOVER-1 never served 200"; exit 1; }
+
+# ---- P4: REPLENISH (launch engineC as new shadow beside live e1) ----
+log "P4 REPLENISH: launch engineC (ENGINE_ID=0 reused) beside live active e1"; phase replenish_launch
+C=$(launch 0 "$OUT/logs/engine0b.log")
+wait_for "$OUT/logs/engine0b.log" "Engine sleeping" $SHA_TO "$C" "REPLENISH shadow(eC) standby" || { log "REPLENISH FAILED to park"; exit 1; }
+phase colocated_2; log "MEM COLOCATED (e1 active + eC shadow) — REPLENISHED: $(mem)"
+log "infer (e1 still active, eC parked): HTTP $(infer p4) :: $(head -c 80 "$OUT/infer_p4.json")"
+
+# ---- P5: FAILOVER-2 (kill e1 -> eC promotes) ----
+log "P5 FAILOVER-2: kill engine1 (now active)"; phase failover2_kill
+kill_engine "$B"
+wait_for "$OUT/logs/engine0b.log" "Registered endpoint" $PROMO_TO "$C" "eC PROMOTED" || exit 1
+phase eC_promoted; log "MEM after failover-2 (eC sole active): $(mem)"
+PF2=000; for r in $(seq 1 12); do sleep 5; c=$(infer p5); log "  post-failover-2 retry $r: HTTP $c :: $(head -c 70 "$OUT/infer_p5.json")"; [ "$c" = "200" ] && { PF2=200; break; }; done
+phase final
+echo "KIMI_REPLENISH_DONE tag=$TAG failover1=$PF replenish_parked=yes failover2=$PF2"

--- a/failover-kimi/kimi_rwro.sh
+++ b/failover-kimi/kimi_rwro.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# LAYER 0 — GMS RW->RO weight commit/import in isolation (no shadow, no scratch-KV,
+# no flock, no failover). Validates the weight-sharing half of failover:
+#   A) engine A (--load-format gms) loads disk weights -> GMS -> commits -> serves 200
+#   B) kill A (weights persist in GMS servers)
+#   C) engine B (--load-format gms) connects RO -> materializes committed weights -> serves 200
+# Needs only the meta-safety fix (RO meta-construction). Kimi-K2.6 TP8.
+set -u
+source /opt/dynamo/venv/bin/activate 2>/dev/null || true
+export HF_HOME=/tmp/hf HF_HUB_OFFLINE=0; mkdir -p /tmp/hf
+MODEL=/tmp/kimi-k2.6-nvfp4; SERVED=kimi-k2.6; TP=8; MML=4096; UTIL=0.8
+NOAT=${DYN_NO_AUTOTUNE:-1}; EAGER=${EAGER:-1}
+EAGER_FLAG=""; [ "$EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"
+OUT=/tmp/kimi_rwro; rm -rf "$OUT"; mkdir -p "$OUT/logs"
+have(){ grep -aq "$2" "$1" 2>/dev/null; }
+log(){ echo "[rwro $(date +%T)] $*"; }
+mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
+cleanup(){ pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
+  pkill -9 -f "[E]ngineCore" 2>/dev/null; pkill -9 -f "[g]pu_memory_service" 2>/dev/null; sleep 2
+  for p in $(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null); do kill -9 "$p" 2>/dev/null; done
+  rm -f /tmp/gms_*.sock; cp "$OUT"/logs/*.log "$OUT/" 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 4
+infer(){ curl -s -o "$OUT/infer_$1.json" -w "%{http_code}" -X POST http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"$SERVED\",\"prompt\":\"The capital of France is\",\"max_tokens\":12,\"temperature\":0}"; }
+launch(){ DYN_NO_AUTOTUNE=$NOAT DYN_SYSTEM_PORT=$((8100+$1)) \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$((5600+$1)) DYN_VLLM_KV_EVENT_PORT=$((20080+$1)) \
+  nohup python3 -m dynamo.vllm --model "$MODEL" --served-model-name "$SERVED" -tp "$TP" \
+  --trust-remote-code --max-model-len "$MML" --gpu-memory-utilization "$UTIL" $EAGER_FLAG \
+  --load-format gms > "$2" 2>&1 & echo $!; }
+
+log "GMS weights servers (TP=$TP)"
+for d in $(seq 0 $((TP-1))); do python3 -m gpu_memory_service --device $d --tag weights > "$OUT/logs/gms_w$d.log" 2>&1 & done
+for d in $(seq 0 $((TP-1))); do for i in $(seq 1 90); do have "$OUT/logs/gms_w$d.log" "Server started" && break; sleep 1; done; done
+nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
+
+log "=== A) RW engine: disk -> GMS -> commit -> serve ==="
+A=$(launch 0 "$OUT/logs/engineA.log"); log "engineA pid $A"
+for i in $(seq 1 700); do have "$OUT/logs/engineA.log" "Registered endpoint" && { log "RW registered +${i}s"; break; }
+  kill -0 $A 2>/dev/null || { log "engineA DIED"; grep -anE "Error|Traceback|Cannot copy|meta tensor|non-positive|routed through scratch" "$OUT/logs/engineA.log" | tail -10; exit 1; }; sleep 1; done
+have "$OUT/logs/engineA.log" "Registered endpoint" || { log "RW never registered"; exit 1; }
+for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
+log "RW mem: $(mem)"
+log "RW infer: HTTP $(infer rw) :: $(head -c 120 "$OUT/infer_rw.json")"
+
+log "=== kill A (committed weights must survive in GMS servers) ==="
+pkill -9 -P "$A" 2>/dev/null; kill -9 "$A" 2>/dev/null; sleep 8
+log "post-kill mem (weights held by GMS servers): $(mem)"
+
+log "=== B) RO engine: import committed weights -> serve ==="
+B=$(launch 1 "$OUT/logs/engineB.log"); log "engineB pid $B"
+for i in $(seq 1 700); do have "$OUT/logs/engineB.log" "Registered endpoint" && { log "RO registered +${i}s"; break; }
+  kill -0 $B 2>/dev/null || { log "engineB DIED"; grep -anE "Error|Traceback|Cannot copy|meta tensor|non-positive|Stale|routed through scratch" "$OUT/logs/engineB.log" | tail -12; exit 1; }; sleep 1; done
+have "$OUT/logs/engineB.log" "Registered endpoint" || { log "RO never registered"; exit 1; }
+sleep 3
+log "RO mem: $(mem)"
+log "RO infer: HTTP $(infer ro) :: $(head -c 120 "$OUT/infer_ro.json")"
+echo "KIMI_RWRO_DONE (RW=$(cat $OUT/infer_rw.json 2>/dev/null | head -c 0)rw ro)"

--- a/failover-kimi/kimi_rwro_ab.sh
+++ b/failover-kimi/kimi_rwro_ab.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# LAYER 0 + numerical A/B — GMS RW->RO in isolation, then compare RW vs RO
+# logprobs across several diverse-margin prompts (not just greedy argmax on one
+# high-confidence prompt). Confirms the RO MoE-kernel rebuild is numerically
+# equivalent, not merely argmax-equivalent. Kimi-K2.6 TP8.
+set -u
+source /opt/dynamo/venv/bin/activate 2>/dev/null || true
+export HF_HOME=/tmp/hf HF_HUB_OFFLINE=0; mkdir -p /tmp/hf
+MODEL=/tmp/kimi-k2.6-nvfp4; SERVED=kimi-k2.6; TP=8; MML=4096; UTIL=0.8
+NOAT=${DYN_NO_AUTOTUNE:-1}; EAGER=${EAGER:-1}
+EAGER_FLAG=""; [ "$EAGER" = "1" ] && EAGER_FLAG="--enforce-eager"
+OUT=/tmp/kimi_rwro_ab; rm -rf "$OUT"; mkdir -p "$OUT/logs"
+have(){ grep -aq "$2" "$1" 2>/dev/null; }
+log(){ echo "[rwroab $(date +%T)] $*"; }
+mem(){ nvidia-smi --query-gpu=index,memory.used --format=csv,noheader,nounits | head -"$TP" | tr '\n' ' '; echo; }
+cleanup(){ pkill -9 -f "[d]ynamo.vllm" 2>/dev/null; pkill -9 -f "[d]ynamo.frontend" 2>/dev/null
+  pkill -9 -f "[E]ngineCore" 2>/dev/null; pkill -9 -f "[g]pu_memory_service" 2>/dev/null; sleep 2
+  for p in $(nvidia-smi --query-compute-apps=pid --format=csv,noheader 2>/dev/null); do kill -9 "$p" 2>/dev/null; done
+  rm -f /tmp/gms_*.sock; cp "$OUT"/logs/*.log "$OUT/" 2>/dev/null; }
+trap cleanup EXIT
+cleanup; sleep 4
+
+# diverse-margin prompts: high-confidence factual -> open-ended (lower margin)
+PROMPTS=(
+  "The capital of France is"
+  "The chemical symbol for gold is"
+  "Two plus two equals"
+  "My favorite season of the year is"
+)
+# JSON-safe POST: phase idx prompt -> $OUT/${phase}_${idx}.json ; echo http code
+infer(){ local phase=$1 idx=$2 p=$3
+  python3 - "$SERVED" "$p" "$OUT/${phase}_${idx}.json" <<'PY'
+import json,sys,urllib.request
+served,prompt,outfile=sys.argv[1],sys.argv[2],sys.argv[3]
+body=json.dumps({"model":served,"prompt":prompt,"max_tokens":10,"temperature":0,"logprobs":5}).encode()
+req=urllib.request.Request("http://localhost:8000/v1/completions",data=body,headers={"Content-Type":"application/json"})
+try:
+    r=urllib.request.urlopen(req,timeout=60); d=json.load(r); open(outfile,"w").write(json.dumps(d)); print(200)
+except Exception as e:
+    open(outfile,"w").write(json.dumps({"error":str(e)})); print("ERR")
+PY
+}
+run_all(){ local phase=$1 i=0
+  for p in "${PROMPTS[@]}"; do i=$((i+1)); local code; code=$(infer "$phase" "$i" "$p")
+    log "  $phase[$i] HTTP $code :: $(python3 -c "import json;d=json.load(open('$OUT/${phase}_${i}.json'));print(''.join(d['choices'][0]['logprobs']['tokens'])[:60])" 2>/dev/null)"
+  done; }
+
+launch(){ DYN_NO_AUTOTUNE=$NOAT DYN_SYSTEM_PORT=$((8100+$1)) \
+  VLLM_NIXL_SIDE_CHANNEL_PORT=$((5600+$1)) DYN_VLLM_KV_EVENT_PORT=$((20080+$1)) \
+  nohup python3 -m dynamo.vllm --model "$MODEL" --served-model-name "$SERVED" -tp "$TP" \
+  --trust-remote-code --max-model-len "$MML" --gpu-memory-utilization "$UTIL" $EAGER_FLAG \
+  --load-format gms > "$2" 2>&1 & echo $!; }
+
+log "GMS weights servers (TP=$TP)"
+for d in $(seq 0 $((TP-1))); do python3 -m gpu_memory_service --device $d --tag weights > "$OUT/logs/gms_w$d.log" 2>&1 & done
+for d in $(seq 0 $((TP-1))); do for i in $(seq 1 90); do have "$OUT/logs/gms_w$d.log" "Server started" && break; sleep 1; done; done
+nohup python3 -m dynamo.frontend > "$OUT/logs/frontend.log" 2>&1 &
+
+log "=== A) RW engine: disk -> GMS -> commit -> serve ==="
+A=$(launch 0 "$OUT/logs/engineA.log"); log "engineA pid $A"
+for i in $(seq 1 700); do have "$OUT/logs/engineA.log" "Registered endpoint" && { log "RW registered +${i}s"; break; }
+  kill -0 $A 2>/dev/null || { log "engineA DIED"; grep -anE "Error|Traceback|Cannot copy|meta tensor|not validated" "$OUT/logs/engineA.log" | tail -10; exit 1; }; sleep 1; done
+have "$OUT/logs/engineA.log" "Registered endpoint" || { log "RW never registered"; exit 1; }
+for i in $(seq 1 60); do have "$OUT/logs/frontend.log" "Completions is ready" && break; sleep 1; done
+log "RW mem: $(mem)"; run_all rw
+
+log "=== kill A (committed weights must survive in GMS servers) ==="
+pkill -9 -P "$A" 2>/dev/null; kill -9 "$A" 2>/dev/null; sleep 8
+log "post-kill mem: $(mem)"
+
+log "=== B) RO engine: import committed weights + rebuild MoE kernel -> serve ==="
+B=$(launch 1 "$OUT/logs/engineB.log"); log "engineB pid $B"
+for i in $(seq 1 700); do have "$OUT/logs/engineB.log" "Registered endpoint" && { log "RO registered +${i}s"; break; }
+  kill -0 $B 2>/dev/null || { log "engineB DIED"; grep -anE "Error|Traceback|Cannot copy|meta tensor|not validated|moe_kernel" "$OUT/logs/engineB.log" | tail -12; exit 1; }; sleep 1; done
+have "$OUT/logs/engineB.log" "Registered endpoint" || { log "RO never registered"; exit 1; }
+sleep 3
+log "RO mem: $(mem)"; run_all ro
+grep -a "rebuilt .* MoE kernel\|NVFP4 backend" "$OUT/logs/engineB.log" | head -2
+
+log "=== NUMERICAL A/B: RW vs RO logprobs per prompt ==="
+python3 - "$OUT" "${#PROMPTS[@]}" <<'PY'
+import json,sys
+out,n=sys.argv[1],int(sys.argv[2])
+worst=0.0; anymismatch=False
+for i in range(1,n+1):
+    try:
+        rw=json.load(open(f"{out}/rw_{i}.json")); ro=json.load(open(f"{out}/ro_{i}.json"))
+        rwl=rw["choices"][0]["logprobs"]; rol=ro["choices"][0]["logprobs"]
+        rwt,rot=rwl["tokens"],rol["tokens"]; rwp,rop=rwl["token_logprobs"],rol["token_logprobs"]
+        tok_match=(rwt==rot)
+        m=max((abs((a or 0)-(b or 0)) for a,b in zip(rwp,rop)), default=0.0)
+        worst=max(worst,m); anymismatch=anymismatch or (not tok_match)
+        print(f"  prompt {i}: tokens_match={tok_match}  max|dlogprob|={m:.2e}  RW='{''.join(rwt)[:40]}'")
+        if not tok_match:
+            print(f"     RW tokens: {rwt}")
+            print(f"     RO tokens: {rot}")
+    except Exception as e:
+        print(f"  prompt {i}: COMPARE FAILED {e}")
+verdict = "PASS" if (not anymismatch and worst < 1e-2) else "REVIEW"
+print(f"AB_VERDICT={verdict} worst_max_abs_dlogprob={worst:.3e} token_mismatch={anymismatch}")
+PY
+echo "KIMI_RWRO_AB_DONE"

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -196,11 +196,24 @@ def materialize_module_from_gms(
             param = mod._parameters[attr]
             if param is not None:
                 if param.shape != tensor.shape or param.dtype != tensor.dtype:
-                    raise RuntimeError(
-                        f"Shape/dtype mismatch for {name}: "
-                        f"param={tuple(param.shape)}/{param.dtype}, "
-                        f"gms={tuple(tensor.shape)}/{tensor.dtype}"
+                    # Post-load weight transforms (e.g. NVFP4 MoE
+                    # w13_input_scale (E,2)->(E,)) give the RW writer a
+                    # different shape than the RO meta param, which skips
+                    # post-load hooks. The committed tensor is authoritative
+                    # (the writer served at that shape), so adopt it.
+                    logger.debug(
+                        "[GMS] Adopting committed shape for %s: "
+                        "meta=%s/%s -> gms=%s/%s",
+                        name,
+                        tuple(param.shape),
+                        param.dtype,
+                        tuple(tensor.shape),
+                        tensor.dtype,
                     )
+                    mod._parameters[attr] = torch.nn.Parameter(
+                        tensor, requires_grad=param.requires_grad
+                    )
+                    continue
                 if param.is_meta or param.device != tensor.device:
                     mod._parameters[attr] = torch.nn.Parameter(
                         tensor, requires_grad=param.requires_grad

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -245,6 +245,67 @@ def register_gms_loader(load_format: str = "gms") -> None:
 # =============================================================================
 
 
+def _rebuild_ro_moe_kernels(model: torch.nn.Module) -> int:
+    """Rebuild modular-MoE kernel objects on the RO (import) path.
+
+    The RW writer commits weights *after* the quant method's
+    ``process_weights_after_loading`` has run — i.e. the committed tensors are
+    already in final kernel format. The RO path builds the model on meta and
+    materializes those committed tensors, but the meta-side
+    ``process_weights_after_loading`` aborts on the first MoE layer (meta
+    tensors are unsupported), so every FusedMoE quant method is left with
+    ``moe_kernel is None`` and the MoE forward asserts.
+
+    Re-running the full ``process_weights_after_loading`` on RO would
+    double-transform the already-final weights. Instead we rebuild *only* the
+    kernel object (``get_fused_moe_quant_config`` + ``make_nvfp4_moe_kernel``)
+    from the materialized weights, and deliberately skip the weight
+    (re-)transform and the ``fused_experts.process_weights_after_loading``
+    repack the writer already committed. Analog of the 0.23.0 RO MoE-kernel
+    rebuild, adapted to 0.25.1's modular MoE.
+    """
+    try:
+        from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+            make_nvfp4_moe_kernel,
+        )
+    except Exception as e:
+        logger.debug("[GMS] No NVFP4 modular-MoE kernel builder available: %s", e)
+        return 0
+
+    built = 0
+    for layer in model.modules():
+        qm = getattr(layer, "quant_method", None)
+        if qm is None or getattr(qm, "moe_kernel", "missing") is not None:
+            # Not a quant method, or kernel already built.
+            continue
+        # NVFP4 modular FusedMoE method exposes these; skip everything else.
+        if not (
+            hasattr(qm, "nvfp4_backend")
+            and hasattr(qm, "experts_cls")
+            and hasattr(qm, "get_fused_moe_quant_config")
+        ):
+            continue
+        try:
+            qm.moe_quant_config = qm.get_fused_moe_quant_config(layer)
+            qm.moe_kernel = make_nvfp4_moe_kernel(
+                moe_quant_config=qm.moe_quant_config,
+                moe_config=qm.moe,
+                experts_cls=qm.experts_cls,
+                backend=qm.nvfp4_backend,
+                routing_tables=layer._expert_routing_tables(),
+                layer=layer,
+            )
+            built += 1
+        except Exception:
+            logger.exception(
+                "[GMS] RO moe_kernel rebuild failed for %s",
+                layer.__class__.__name__,
+            )
+    if built:
+        logger.info("[GMS] Read mode: rebuilt %d MoE kernel(s)", built)
+    return built
+
+
 def _load_read_mode(
     gms_client: "GMSClientMemoryManager",
     vllm_config,
@@ -261,6 +322,11 @@ def _load_read_mode(
     try:
         model = _create_meta_model(vllm_config, model_config)
         materialize_module_from_gms(gms_client, model, device_index=device_index)
+
+        # Modular-MoE kernels are not committed (they are runtime objects, not
+        # weights); rebuild them from the materialized weights. See
+        # _rebuild_ro_moe_kernels for why we skip the weight re-transform.
+        _rebuild_ro_moe_kernels(model)
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -245,6 +245,21 @@ def register_gms_loader(load_format: str = "gms") -> None:
 # =============================================================================
 
 
+# NVFP4 MoE backends whose step-5 (fused_experts.process_weights_after_loading)
+# is a pure in-place activation-scale fuse that the RW writer captures in the
+# committed weights, so the RO kernel rebuild (which skips step-5) is provably
+# correct: the experts __init__ recomputes any derived scales from the already
+# fused, committed quant config. FLASHINFER_TRTLLM is validated end-to-end;
+# FLASHINFER_CUTLASS is audited by inspection. Any other backend may do work
+# (workspace alloc, non-idempotent transforms, EPLB param registration) the RO
+# path does not reproduce -> refuse rather than silently serve wrong weights.
+# See failover-kimi/EPOCH-0251-PORT.md (R1). Override at your own risk with
+# DYN_GMS_ALLOW_UNVALIDATED_MOE_BACKEND=1.
+_RO_VALIDATED_NVFP4_BACKENDS = frozenset(
+    {"FLASHINFER_TRTLLM", "FLASHINFER_CUTLASS"}
+)
+
+
 def _rebuild_ro_moe_kernels(model: torch.nn.Module) -> int:
     """Rebuild modular-MoE kernel objects on the RO (import) path.
 
@@ -285,6 +300,25 @@ def _rebuild_ro_moe_kernels(model: torch.nn.Module) -> int:
             and hasattr(qm, "get_fused_moe_quant_config")
         ):
             continue
+        backend_name = getattr(qm.nvfp4_backend, "name", str(qm.nvfp4_backend))
+        if (
+            backend_name not in _RO_VALIDATED_NVFP4_BACKENDS
+            and os.environ.get("DYN_GMS_ALLOW_UNVALIDATED_MOE_BACKEND") != "1"
+        ):
+            raise RuntimeError(
+                f"[GMS] RO MoE-kernel rebuild is not validated for NVFP4 backend "
+                f"{backend_name!r} (validated: {sorted(_RO_VALIDATED_NVFP4_BACKENDS)}). "
+                f"The RO path skips fused_experts.process_weights_after_loading, which "
+                f"is only proven safe when step-5 is an in-place scale fuse captured in "
+                f"the commit. Set DYN_GMS_ALLOW_UNVALIDATED_MOE_BACKEND=1 to override at "
+                f"your own risk (may serve numerically wrong weights). See "
+                f"failover-kimi/EPOCH-0251-PORT.md (R1)."
+            )
+        if built == 0:
+            logger.info(
+                "[GMS] Read mode: rebuilding MoE kernels for NVFP4 backend %s",
+                backend_name,
+            )
         try:
             qm.moe_quant_config = qm.get_fused_moe_quant_config(layer)
             qm.moe_kernel = make_nvfp4_moe_kernel(


### PR DESCRIPTION
## Summary

Ports the GMS shadow-failover setup to **vLLM 0.25.1** and adds the read-mode (RO) MoE-kernel rebuild needed for NVFP4 MoE models.

Product changes (`lib/gpu_memory_service/`):
- **`model_loader.py`** — `_rebuild_ro_moe_kernels()` rebuilds the modular-MoE kernel object on the RO import path (`get_fused_moe_quant_config` + `make_nvfp4_moe_kernel`), skipping the weight re-transform the RW writer already committed. Fixes `assert moe_kernel is not None` on shadow/RO engines. Includes a fail-fast guard that refuses NVFP4 backends outside the validated set (override via `DYN_GMS_ALLOW_UNVALIDATED_MOE_BACKEND=1`), so a backend swap fails loud instead of serving wrong weights.
- **`module.py`** — `materialize_module_from_gms` adopts the committed tensor shape/dtype when post-load MoE scale transforms (e.g. `(E,2)→(E,)`) diverge from the RO meta param.

The `failover-kimi/` directory holds the validation harness + an epoch log (`EPOCH-0251-PORT.md`) documenting the full bring-up and memory study.

## Validation

On vLLM 0.25.1, NVFP4 MoE, TP8:
- **L0 RW→RO**: RW commits+serves; weights persist after kill; RO imports + rebuilds 60 MoE kernels/worker and serves. RW vs RO logprobs **bit-identical** (worst Δ=0) across 4 diverse-margin prompts.
- **L1** scratch-KV routing; **L2** two-engine failover (eager+graphs): promote +8/+9s, post-failover 200.
- **Concurrent cold-init** fits; **post-failover shadow replenishment** (fail-twice loop) works — lifts the "fail-once" limitation.
- **Memory**: shadow steady overhead +4.3/+6.4 GiB; replenishment/concurrent peak ~152–158 GiB — fits under the 183 GiB ceiling with ~25 GiB headroom.

See `failover-kimi/EPOCH-0251-PORT.md` for the full narrative, per-backend analysis, and known risks.

> Draft: the RO MoE-kernel rebuild is validated for the FlashInfer NVFP4 backends (guarded); broader backend coverage + upstreaming the meta-safety fix are follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
