### PR TITLE
feat(kv-router): extensible event-kind index registry and cache-group event tag

### DIFF
--- a/lib/bench/kv_router/common/dc_ckf_parity.rs
+++ b/lib/bench/kv_router/common/dc_ckf_parity.rs
@@ -319,6 +319,7 @@ mod tests {
         RouterEvent::new(
             worker,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -338,6 +339,7 @@ mod tests {
         RouterEvent::new(
             worker,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(hash)],

--- a/lib/bench/kv_router/mooncake_open_loop.rs
+++ b/lib/bench/kv_router/mooncake_open_loop.rs
@@ -1709,6 +1709,7 @@ mod tests {
             payload: DispatchPayload::Event(RouterEvent::new(
                 u64::from(id),
                 dynamo_kv_router::protocols::KvCacheEvent {
+                    cache_group: None,
                     event_id: u64::from(id),
                     data: KvCacheEventData::Cleared,
                     dp_rank: 0,

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -998,6 +998,7 @@ fn open_loop_preparation_preserves_query_first_ties_and_removed_blocks() -> anyh
         kv_events: vec![
             ReplayTimedKvEvent {
                 event: KvCacheEvent {
+                    cache_group: None,
                     event_id: 7,
                     data: KvCacheEventData::Removed(KvCacheRemoveData {
                         block_hashes: vec![
@@ -1013,6 +1014,7 @@ fn open_loop_preparation_preserves_query_first_ties_and_removed_blocks() -> anyh
             },
             ReplayTimedKvEvent {
                 event: KvCacheEvent {
+                    cache_group: None,
                     event_id: 8,
                     data: KvCacheEventData::Stored(KvCacheStoreData {
                         parent_hash: None,

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -308,6 +308,7 @@ fn kv_event_create_stored_from_parts(
     }
 
     KvCacheEvent {
+        cache_group: None,
         data: KvCacheEventData::Stored(KvCacheStoreData {
             blocks,
             parent_hash: kv_params.parent_hash.map(ExternalSequenceBlockHash),
@@ -330,6 +331,7 @@ fn kv_event_create_removed_from_parts(
             .map(|&v| ExternalSequenceBlockHash(v))
             .collect();
     KvCacheEvent {
+        cache_group: None,
         event_id,
         data: KvCacheEventData::Removed(KvCacheRemoveData { block_hashes }),
         dp_rank: 0,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1092,6 +1092,7 @@ impl KvEventPublisher {
     ) -> KvCacheEvent {
         let block_hashes_u64: Vec<u64> = block_hashes.iter().map(|&hash| hash as u64).collect();
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: parent_hash.map(ExternalSequenceBlockHash::from),
@@ -1115,6 +1116,7 @@ impl KvEventPublisher {
 
     fn removed_event(&self, event_id: u64, block_hashes: Vec<i64>) -> KvCacheEvent {
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: block_hashes

--- a/lib/kv-router/src/indexer/branch_sharded.rs
+++ b/lib/kv-router/src/indexer/branch_sharded.rs
@@ -565,6 +565,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 events.push(RouterEvent::new(
                     worker.worker_id,
                     KvCacheEvent {
+                        cache_group: None,
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {
                             parent_hash,
@@ -681,6 +682,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                 worker_id: event.worker_id,
                 storage_tier: event.storage_tier,
                 event: KvCacheEvent {
+                    cache_group: None,
                     event_id: event.event.event_id,
                     dp_rank: event.event.dp_rank,
                     data: KvCacheEventData::Removed(KvCacheRemoveData {
@@ -700,6 +702,7 @@ impl<S: AsyncShardHandle> BranchShardedIndexer<S> {
                     worker_id: event.worker_id,
                     storage_tier: event.storage_tier,
                     event: KvCacheEvent {
+                        cache_group: None,
                         event_id: event.event.event_id,
                         dp_rank: event.event.dp_rank,
                         data: KvCacheEventData::Removed(KvCacheRemoveData {

--- a/lib/kv-router/src/indexer/compressed_radix.rs
+++ b/lib/kv-router/src/indexer/compressed_radix.rs
@@ -46,6 +46,7 @@ fn dump_event(
     RouterEvent::new(
         worker.worker_id,
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -517,6 +517,7 @@ impl ConcurrentRadixTree {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
                     event: KvCacheEvent {
+                        cache_group: None,
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {
                             parent_hash,

--- a/lib/kv-router/src/indexer/cuckoo/adapter.rs
+++ b/lib/kv-router/src/indexer/cuckoo/adapter.rs
@@ -472,6 +472,7 @@ mod tests {
         RouterEvent::new(
             1,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -491,6 +492,7 @@ mod tests {
         RouterEvent::new(
             1,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(hash)],

--- a/lib/kv-router/src/indexer/cuckoo/dc.rs
+++ b/lib/kv-router/src/indexer/cuckoo/dc.rs
@@ -869,6 +869,7 @@ mod tests {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -892,6 +893,7 @@ mod tests {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: hashes
@@ -909,6 +911,7 @@ mod tests {
         RouterEvent::new(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Cleared,
                 dp_rank,

--- a/lib/kv-router/src/indexer/cuckoo/publication.rs
+++ b/lib/kv-router/src/indexer/cuckoo/publication.rs
@@ -251,6 +251,7 @@ mod tests {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/kv-router/src/indexer/kv_indexer.rs
+++ b/lib/kv-router/src/indexer/kv_indexer.rs
@@ -69,6 +69,7 @@ fn apply_routing_decision_with_prune_tracking(
     let event = RouterEvent::new(
         routing_req.worker.worker_id,
         KvCacheEvent {
+            cache_group: None,
             event_id: *event_id_counter,
             data: stored_event,
             dp_rank: routing_req.worker.dp_rank,
@@ -107,6 +108,7 @@ fn apply_prune_removes(trie: &mut RadixTree, entries: Vec<BlockEntry>, event_id_
         let event = RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id: *event_id_counter,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: entries.into_iter().map(|entry| entry.key).collect(),

--- a/lib/kv-router/src/indexer/local.rs
+++ b/lib/kv-router/src/indexer/local.rs
@@ -823,6 +823,7 @@ mod tests {
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: Some(ExternalSequenceBlockHash(parent_hash)),
@@ -997,6 +998,7 @@ mod tests {
             .apply_event_with_buffer(RouterEvent::with_storage_tier(
                 11,
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: 3,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 0,

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -347,6 +347,7 @@ impl LowerTierIndexer {
                 events.push(RouterEvent::new(
                     worker.worker_id,
                     KvCacheEvent {
+                        cache_group: None,
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {
                             parent_hash: key.parent_hash,

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -528,6 +528,7 @@ impl PositionalIndexer {
                     worker_id: worker.worker_id,
                     storage_tier: crate::protocols::StorageTier::Device,
                     event: KvCacheEvent {
+                        cache_group: None,
                         event_id,
                         data: KvCacheEventData::Stored(KvCacheStoreData {
                             parent_hash: None,

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -2459,6 +2459,7 @@ mod local_indexer_tests {
         RouterEvent::new(
             0,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -2478,6 +2479,7 @@ mod local_indexer_tests {
         RouterEvent::new(
             0,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: block_hashes
@@ -2495,6 +2497,7 @@ mod local_indexer_tests {
         RouterEvent::new(
             0,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Cleared,
                 dp_rank: 0,
@@ -2517,6 +2520,7 @@ mod local_indexer_tests {
             RouterEvent::new(
                 0,
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: id,
                     data: KvCacheEventData::Stored(KvCacheStoreData {
                         parent_hash: None,
@@ -2711,6 +2715,7 @@ mod local_indexer_tests {
         let test_event = RouterEvent::new(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id: 1,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -2768,6 +2773,7 @@ mod local_indexer_tests {
         let test_event = RouterEvent::new(
             7,
             KvCacheEvent {
+                cache_group: None,
                 event_id: 1,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -664,6 +664,7 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -694,6 +695,7 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             let event = RouterEvent::new(
                 worker.worker_id,
                 KvCacheEvent {
+                    cache_group: None,
                     event_id,
                     data: KvCacheEventData::Removed(KvCacheRemoveData {
                         block_hashes: hashes.into_iter().collect(),

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -769,6 +769,23 @@ pub struct KvCacheEvents {
     pub shutdown: bool,
 }
 
+/// Classifies which kind of KV-cache group produced an event, so consumers
+/// can route recurrent-state (SSM / linear-attention) events separately from
+/// paged-attention events.
+///
+/// `None` on [`KvCacheEvent::cache_group`] means attention: every event
+/// predating this tag, and every producer that only indexes attention groups,
+/// omits it, and absence must preserve that behavior.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CacheGroupClass {
+    /// Paged attention KV blocks (full / MLA / sink attention groups).
+    Attention,
+    /// Recurrent-state checkpoints (Mamba / Gated DeltaNet / KDA groups).
+    /// No producer emits this yet; reserved for hybrid-model indexing.
+    Recurrent,
+}
+
 /// Represents a single cache event with an ID and associated data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct KvCacheEvent {
@@ -779,6 +796,10 @@ pub struct KvCacheEvent {
     /// The data parallel rank of the worker emitting this event (0 if DP not enabled).
     #[serde(default)]
     pub dp_rank: DpRank,
+    /// Which cache-group class produced this event. `None` means attention
+    /// (the pre-tag legacy default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_group: Option<CacheGroupClass>,
 }
 
 /// Represents the data associated with a cache event.
@@ -1331,6 +1352,7 @@ mod tests {
     fn test_router_event_new() {
         let worker_id = 0;
         let kv_cache_event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -1357,6 +1379,61 @@ mod tests {
         } else {
             panic!("Expected KvCacheEventData::Stored");
         }
+    }
+
+    /// `cache_group: None` must leave the field-named msgpack wire bytes
+    /// byte-identical to the pre-tag encoding, so a fleet can mix producers
+    /// and consumers across this change.
+    #[test]
+    fn kv_cache_event_none_cache_group_keeps_legacy_wire_bytes() {
+        #[derive(Serialize)]
+        struct LegacyKvCacheEvent {
+            event_id: u64,
+            data: KvCacheEventData,
+            dp_rank: DpRank,
+        }
+
+        let data = KvCacheEventData::Removed(KvCacheRemoveData {
+            block_hashes: vec![ExternalSequenceBlockHash(42)],
+        });
+        let legacy = LegacyKvCacheEvent {
+            event_id: 7,
+            data: data.clone(),
+            dp_rank: 1,
+        };
+        let tagged = KvCacheEvent {
+            event_id: 7,
+            data,
+            dp_rank: 1,
+            cache_group: None,
+        };
+
+        let legacy_bytes = rmp_serde::to_vec_named(&legacy).unwrap();
+        let tagged_bytes = rmp_serde::to_vec_named(&tagged).unwrap();
+        assert_eq!(legacy_bytes, tagged_bytes);
+
+        // Old payloads (no `cache_group` key) decode with the legacy default.
+        let decoded: KvCacheEvent = rmp_serde::from_slice(&legacy_bytes).unwrap();
+        assert_eq!(decoded.cache_group, None);
+        assert_eq!(decoded, tagged);
+    }
+
+    #[test]
+    fn kv_cache_event_cache_group_round_trips() {
+        let event = KvCacheEvent {
+            event_id: 9,
+            data: KvCacheEventData::Cleared,
+            dp_rank: 0,
+            cache_group: Some(CacheGroupClass::Recurrent),
+        };
+
+        let named: KvCacheEvent =
+            rmp_serde::from_slice(&rmp_serde::to_vec_named(&event).unwrap()).unwrap();
+        assert_eq!(named, event);
+
+        let json: KvCacheEvent =
+            serde_json::from_str(&serde_json::to_string(&event).unwrap()).unwrap();
+        assert_eq!(json, event);
     }
 
     #[rstest]

--- a/lib/kv-router/src/services/indexer/backend.rs
+++ b/lib/kv-router/src/services/indexer/backend.rs
@@ -281,6 +281,7 @@ pub(crate) mod test_util {
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash,

--- a/lib/kv-router/src/test_utils.rs
+++ b/lib/kv-router/src/test_utils.rs
@@ -22,6 +22,7 @@ pub fn router_event(
     RouterEvent::new(
         worker_id,
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data,
             dp_rank,

--- a/lib/kv-router/src/zmq_wire/convert.rs
+++ b/lib/kv-router/src/zmq_wire/convert.rs
@@ -63,6 +63,7 @@ pub fn convert_event(
                     return Some(PlacementEvent::new(
                         Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
                         KvCacheEvent {
+                            cache_group: None,
                             event_id,
                             data: KvCacheEventData::Removed(KvCacheRemoveData {
                                 block_hashes: vec![],
@@ -79,6 +80,7 @@ pub fn convert_event(
                 .map(BlockHashValue::into_u64)
                 .collect();
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: parent_block_hash
@@ -108,6 +110,7 @@ pub fn convert_event(
                 .map(ExternalSequenceBlockHash::from)
                 .collect();
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: hashes,
@@ -116,6 +119,7 @@ pub fn convert_event(
             }
         }
         RawKvEvent::AllBlocksCleared => KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Cleared,
             dp_rank,

--- a/lib/kv-router/src/zmq_wire/filter.rs
+++ b/lib/kv-router/src/zmq_wire/filter.rs
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 
-use crate::protocols::BlockExtraInfo;
+use crate::protocols::{BlockExtraInfo, CacheGroupClass};
 
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
@@ -21,7 +22,7 @@ pub(super) enum BlockStoredTrailingField {
     BlockMmInfos(Vec<Option<BlockExtraInfo>>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KvCacheSpecKind {
     FullAttention,
     MlaAttention,
@@ -71,12 +72,69 @@ impl KvCacheSpecKind {
             Self::Unknown => "unknown",
         }
     }
+}
 
-    pub(crate) fn is_main_attention(self) -> bool {
-        matches!(
-            self,
-            Self::FullAttention | Self::MlaAttention | Self::SinkFullAttention
-        )
+/// How the router indexes KV events for one [`KvCacheSpecKind`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexStrategy {
+    /// Index into the attention (radix) block index.
+    Attention,
+    /// Index as recurrent-state checkpoints. No kind maps to this yet;
+    /// admitting a recurrent kind is a registry change, not a filter edit.
+    Recurrent,
+    /// Drop the event before indexing.
+    Drop,
+}
+
+/// Maps each [`KvCacheSpecKind`] to an [`IndexStrategy`].
+///
+/// The default map reproduces the historical main-attention allow-list:
+/// `FullAttention`, `MlaAttention`, and `SinkFullAttention` index as
+/// attention; every other kind (including `Unknown` and unregistered kinds)
+/// drops. Adding or removing an indexable kind is a registration change via
+/// [`IndexStrategyRegistry::with_strategy`].
+#[derive(Debug, Clone)]
+pub struct IndexStrategyRegistry {
+    strategies: FxHashMap<KvCacheSpecKind, IndexStrategy>,
+}
+
+impl Default for IndexStrategyRegistry {
+    fn default() -> Self {
+        let mut strategies = FxHashMap::default();
+        for kind in [
+            KvCacheSpecKind::FullAttention,
+            KvCacheSpecKind::MlaAttention,
+            KvCacheSpecKind::SinkFullAttention,
+        ] {
+            strategies.insert(kind, IndexStrategy::Attention);
+        }
+        Self { strategies }
+    }
+}
+
+impl IndexStrategyRegistry {
+    /// The strategy for `kind`; unregistered kinds drop.
+    pub fn strategy(&self, kind: KvCacheSpecKind) -> IndexStrategy {
+        self.strategies
+            .get(&kind)
+            .copied()
+            .unwrap_or(IndexStrategy::Drop)
+    }
+
+    /// Register or override the strategy for one kind.
+    pub fn with_strategy(mut self, kind: KvCacheSpecKind, strategy: IndexStrategy) -> Self {
+        self.strategies.insert(kind, strategy);
+        self
+    }
+
+    /// The cache-group class stamped on events of `kind`, `None` for dropped
+    /// kinds.
+    pub(crate) fn cache_group(&self, kind: KvCacheSpecKind) -> Option<CacheGroupClass> {
+        match self.strategy(kind) {
+            IndexStrategy::Attention => Some(CacheGroupClass::Attention),
+            IndexStrategy::Recurrent => Some(CacheGroupClass::Recurrent),
+            IndexStrategy::Drop => None,
+        }
     }
 }
 
@@ -104,6 +162,8 @@ pub(crate) struct KvCacheEventMetadata {
     pub(crate) group_idx: Option<u32>,
     pub(crate) kv_cache_spec_kind: Option<KvCacheSpecKind>,
     pub(crate) kv_cache_spec_sliding_window: Option<u32>,
+    /// Event-declared block size in tokens; only `BlockStored` carries it.
+    pub(crate) block_size: Option<u32>,
 }
 
 impl KvCacheEventMetadata {

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -29,9 +29,10 @@ pub use convert::{
 pub use extra_keys::{
     extra_keys_to_block_mm_infos, extra_keys_to_cache_namespace, parse_mm_hash_from_extra_key,
 };
-pub use filter::KvCacheSpecKind;
+pub use filter::{IndexStrategy, IndexStrategyRegistry, KvCacheSpecKind};
 pub use types::{BlockHashValue, ExtraKeyItem, KvEventBatch, KvTokenIds, RawKvEvent};
 
+use crate::protocols::CacheGroupClass;
 use filter::KvCacheEventMetadata;
 
 pub fn decode_event_batch(payload: &[u8]) -> Result<KvEventBatch, rmps::decode::Error> {
@@ -46,6 +47,7 @@ pub struct ZmqEventNormalizer {
     /// pad_value scheme. `None` for text-only models / non-MM deployments.
     image_token_id: Option<u32>,
     warning_count: Arc<AtomicU32>,
+    strategies: IndexStrategyRegistry,
     group_metadata: FxHashMap<(DpRank, u32), KvCacheGroupMetadata>,
     cache_namespaces: FxHashMap<(WorkerWithDpRank, u64), CacheNamespaceState>,
 }
@@ -56,10 +58,12 @@ enum CacheNamespaceState {
     Ambiguous,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct KvCacheGroupMetadata {
     kind: KvCacheSpecKind,
     sliding_window: Option<u32>,
+    /// Block size in tokens declared by this group's `BlockStored` events.
+    block_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -91,6 +95,7 @@ impl ZmqEventNormalizer {
             kv_block_size,
             image_token_id: None,
             warning_count: Arc::new(AtomicU32::new(0)),
+            strategies: IndexStrategyRegistry::default(),
             group_metadata: FxHashMap::default(),
             cache_namespaces: FxHashMap::default(),
         }
@@ -101,9 +106,23 @@ impl ZmqEventNormalizer {
             kv_block_size,
             image_token_id: None,
             warning_count,
+            strategies: IndexStrategyRegistry::default(),
             group_metadata: FxHashMap::default(),
             cache_namespaces: FxHashMap::default(),
         }
+    }
+
+    /// Override the kind → index-strategy registry. The default reproduces
+    /// the historical main-attention allow-list; composition roots use this
+    /// to admit additional kinds.
+    ///
+    /// Admitted kinds still convert with the attention `kv_block_size`:
+    /// blocks of a different size are rejected at conversion, so registering
+    /// a `Recurrent` kind only tags its events — dedicated recurrent-state
+    /// indexing does not exist yet.
+    pub fn with_index_strategies(mut self, strategies: IndexStrategyRegistry) -> Self {
+        self.strategies = strategies;
+        self
     }
 
     /// Set the model's image placeholder token id so vLLM BlockStored events
@@ -144,14 +163,17 @@ impl ZmqEventNormalizer {
         event_id: u64,
         worker: WorkerWithDpRank,
     ) -> Option<PlacementEvent> {
-        convert_event(
+        let cache_group = self.cache_group_for(raw.metadata(), worker.dp_rank);
+        let mut placement_event = convert_event(
             raw,
             event_id,
             self.kv_block_size,
             worker,
             &self.warning_count,
             self.image_token_id,
-        )
+        )?;
+        placement_event.event.cache_group = cache_group;
+        Some(placement_event)
     }
 
     pub fn normalize(
@@ -170,13 +192,31 @@ impl ZmqEventNormalizer {
             return;
         };
 
-        self.group_metadata.insert(
-            (dp_rank, group_idx),
-            KvCacheGroupMetadata {
-                kind,
-                sliding_window: metadata.kv_cache_spec_sliding_window,
-            },
-        );
+        let learned = KvCacheGroupMetadata {
+            kind,
+            sliding_window: metadata.kv_cache_spec_sliding_window,
+            block_size: metadata.block_size,
+        };
+        let previous = self.group_metadata.insert((dp_rank, group_idx), learned);
+
+        // An attention group whose event block size disagrees with the
+        // configured router block size will have every stored block rejected
+        // at conversion. Surface that once per (group, size) instead of
+        // letting the per-block conversion warning cap hide it.
+        if previous != Some(learned)
+            && self.strategies.strategy(kind) == IndexStrategy::Attention
+            && let Some(block_size) = learned.block_size
+            && block_size != self.kv_block_size
+        {
+            tracing::warn!(
+                dp_rank,
+                group_idx,
+                kind = kind.as_wire(),
+                event_block_size = block_size,
+                configured_block_size = self.kv_block_size,
+                "KV event block size for this cache group differs from the configured block size; its stored blocks will not be indexed"
+            );
+        }
     }
 
     fn propagate_cache_namespace(
@@ -285,26 +325,15 @@ impl ZmqEventNormalizer {
         dp_rank: DpRank,
     ) -> Option<ZmqEventFilterReason> {
         if let Some(kind) = metadata.kv_cache_spec_kind {
-            if kind.is_main_attention() {
-                return None;
-            }
-            if kind == KvCacheSpecKind::Unknown {
-                return Some(ZmqEventFilterReason::UnknownKind);
-            }
-            return Some(ZmqEventFilterReason::NonMainAttentionKind);
+            return self.kind_filter_reason(kind, ZmqEventFilterReason::NonMainAttentionKind);
         }
 
         let group_idx = metadata.group_idx?;
 
         if let Some(metadata) = self.group_metadata.get(&(dp_rank, group_idx)) {
             let _sliding_window = metadata.sliding_window;
-            if metadata.kind.is_main_attention() {
-                return None;
-            }
-            if metadata.kind == KvCacheSpecKind::Unknown {
-                return Some(ZmqEventFilterReason::UnknownKind);
-            }
-            return Some(ZmqEventFilterReason::NonMainAttentionGroup);
+            return self
+                .kind_filter_reason(metadata.kind, ZmqEventFilterReason::NonMainAttentionGroup);
         }
 
         if group_idx == 0 {
@@ -312,5 +341,36 @@ impl ZmqEventNormalizer {
         } else {
             Some(ZmqEventFilterReason::UnlearnedGroupIdx)
         }
+    }
+
+    fn kind_filter_reason(
+        &self,
+        kind: KvCacheSpecKind,
+        drop_reason: ZmqEventFilterReason,
+    ) -> Option<ZmqEventFilterReason> {
+        match self.strategies.strategy(kind) {
+            IndexStrategy::Attention | IndexStrategy::Recurrent => None,
+            IndexStrategy::Drop if kind == KvCacheSpecKind::Unknown => {
+                Some(ZmqEventFilterReason::UnknownKind)
+            }
+            IndexStrategy::Drop => Some(drop_reason),
+        }
+    }
+
+    /// The cache-group class for an event, resolved from its inline kind or
+    /// the learned group metadata. `None` for kindless events (legacy /
+    /// non-vLLM producers), which consumers treat as attention.
+    fn cache_group_for(
+        &self,
+        metadata: KvCacheEventMetadata,
+        dp_rank: DpRank,
+    ) -> Option<CacheGroupClass> {
+        let kind = metadata.kv_cache_spec_kind.or_else(|| {
+            let group_idx = metadata.group_idx?;
+            self.group_metadata
+                .get(&(dp_rank, group_idx))
+                .map(|metadata| metadata.kind)
+        })?;
+        self.strategies.cache_group(kind)
     }
 }

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -874,3 +874,129 @@ fn cpu_event_with_full_payload_is_indexable() {
     }
     assert_eq!(warning_count.load(Ordering::Relaxed), 0);
 }
+
+#[test]
+fn test_registry_default_matches_legacy_main_attention_filter() {
+    let registry = IndexStrategyRegistry::default();
+    for (kind, expected) in [
+        (KvCacheSpecKind::FullAttention, IndexStrategy::Attention),
+        (KvCacheSpecKind::MlaAttention, IndexStrategy::Attention),
+        (KvCacheSpecKind::SinkFullAttention, IndexStrategy::Attention),
+        (KvCacheSpecKind::SlidingWindow, IndexStrategy::Drop),
+        (KvCacheSpecKind::SlidingWindowMla, IndexStrategy::Drop),
+        (KvCacheSpecKind::Mamba, IndexStrategy::Drop),
+        (KvCacheSpecKind::ChunkedLocalAttention, IndexStrategy::Drop),
+        (KvCacheSpecKind::EncoderOnlyAttention, IndexStrategy::Drop),
+        (KvCacheSpecKind::CrossAttention, IndexStrategy::Drop),
+        (KvCacheSpecKind::Unknown, IndexStrategy::Drop),
+    ] {
+        assert_eq!(registry.strategy(kind), expected, "kind {kind:?}");
+    }
+}
+
+#[test]
+fn test_normalizer_drops_recurrent_and_unknown_kinds_by_default() {
+    let mut normalizer = ZmqEventNormalizer::new(2);
+    let worker = WorkerWithDpRank::new(3, 0);
+
+    let mamba: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+        TestEventKind::BlockStored,
+        Some(1),
+        "mamba",
+    ))
+    .expect("valid mamba event");
+    assert_eq!(
+        normalizer
+            .preprocess_with_reason(mamba, worker)
+            .unwrap_err(),
+        ZmqEventFilterReason::NonMainAttentionKind
+    );
+
+    // A future recurrent kind the wire enum does not know yet.
+    let kda: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+        TestEventKind::BlockStored,
+        Some(1),
+        "kda",
+    ))
+    .expect("valid kda event");
+    assert_eq!(
+        normalizer.preprocess_with_reason(kda, worker).unwrap_err(),
+        ZmqEventFilterReason::UnknownKind
+    );
+}
+
+#[test]
+fn test_registered_recurrent_kind_passes_and_stamps_cache_group() {
+    let registry = IndexStrategyRegistry::default()
+        .with_strategy(KvCacheSpecKind::Mamba, IndexStrategy::Recurrent);
+    let mut normalizer = ZmqEventNormalizer::new(2).with_index_strategies(registry);
+    let worker = WorkerWithDpRank::new(3, 0);
+
+    let mamba: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+        TestEventKind::BlockStored,
+        Some(1),
+        "mamba",
+    ))
+    .expect("valid mamba event");
+    let placement = normalizer
+        .normalize(mamba, 7, worker)
+        .expect("registered kind must pass the filter");
+
+    assert_eq!(
+        placement.event.cache_group,
+        Some(crate::protocols::CacheGroupClass::Recurrent)
+    );
+    assert!(matches!(placement.event.data, KvCacheEventData::Stored(_)));
+}
+
+#[test]
+fn test_normalizer_stamps_attention_cache_group_and_leaves_kindless_untagged() {
+    let mut normalizer = ZmqEventNormalizer::new(2);
+    let worker = WorkerWithDpRank::new(3, 0);
+
+    let attention: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+        TestEventKind::BlockStored,
+        Some(0),
+        "full_attention",
+    ))
+    .expect("valid attention event");
+    let placement = normalizer
+        .normalize(attention, 7, worker)
+        .expect("attention event must pass");
+    assert_eq!(
+        placement.event.cache_group,
+        Some(crate::protocols::CacheGroupClass::Attention)
+    );
+
+    // Kindless events (legacy / non-vLLM producers) stay untagged.
+    let kindless: RawKvEvent =
+        from_slice(&block_stored_sequence(None, None)).expect("valid kindless event");
+    let placement = normalizer
+        .normalize(kindless, 8, worker)
+        .expect("kindless event must pass");
+    assert_eq!(placement.event.cache_group, None);
+}
+
+#[test]
+fn test_normalizer_learns_group_block_size() {
+    let mut normalizer = ZmqEventNormalizer::new(16);
+    let worker = WorkerWithDpRank::new(3, 0);
+
+    // The shared fixture declares block_size = 2, which differs from the
+    // configured 16: the metadata must still be learned (and the mismatch
+    // warned about) so the misconfiguration is observable.
+    let store: RawKvEvent = from_slice(&sequence_with_cache_spec_kind(
+        TestEventKind::BlockStored,
+        Some(3),
+        "full_attention",
+    ))
+    .expect("valid store event");
+    assert!(normalizer.preprocess(store, worker).is_some());
+
+    let learned = normalizer
+        .group_metadata
+        .get(&(0, 3))
+        .expect("group metadata must be learned from BlockStored");
+    assert_eq!(learned.kind, KvCacheSpecKind::FullAttention);
+    assert_eq!(learned.block_size, Some(2));
+}

--- a/lib/kv-router/src/zmq_wire/types.rs
+++ b/lib/kv-router/src/zmq_wire/types.rs
@@ -124,9 +124,15 @@ impl RawKvEvent {
                 group_idx,
                 kv_cache_spec_kind,
                 kv_cache_spec_sliding_window,
+                block_size,
                 ..
-            }
-            | Self::BlockRemoved {
+            } => KvCacheEventMetadata {
+                group_idx: *group_idx,
+                kv_cache_spec_kind: *kv_cache_spec_kind,
+                kv_cache_spec_sliding_window: *kv_cache_spec_sliding_window,
+                block_size: u32::try_from(*block_size).ok(),
+            },
+            Self::BlockRemoved {
                 group_idx,
                 kv_cache_spec_kind,
                 kv_cache_spec_sliding_window,
@@ -135,6 +141,7 @@ impl RawKvEvent {
                 group_idx: *group_idx,
                 kv_cache_spec_kind: *kv_cache_spec_kind,
                 kv_cache_spec_sliding_window: *kv_cache_spec_sliding_window,
+                block_size: None,
             },
             Self::AllBlocksCleared | Self::Ignored => KvCacheEventMetadata::default(),
         }

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -67,6 +67,7 @@ fn store_event(
     RouterEvent::with_storage_tier(
         worker_id,
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash,

--- a/lib/llm/src/kv_dc_relay/actor.rs
+++ b/lib/llm/src/kv_dc_relay/actor.rs
@@ -1346,6 +1346,7 @@ mod tests {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -393,6 +393,7 @@ pub(super) mod test_util {
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash,

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -1416,6 +1416,7 @@ mod tests {
         RouterEvent::new(
             42,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -1435,6 +1436,7 @@ mod tests {
         RouterEvent::new(
             worker.worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Cleared,
                 dp_rank: worker.dp_rank,

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs
@@ -278,6 +278,7 @@ mod tests {
         RouterEvent::new(
             1,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/llm/src/kv_router/publisher/batching.rs
+++ b/lib/llm/src/kv_router/publisher/batching.rs
@@ -6,7 +6,8 @@ use std::time::{Duration, Instant};
 
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, RouterEvent, StorageTier,
+    CacheGroupClass, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
+    RouterEvent, StorageTier,
 };
 
 use super::dedup::EventDedupFilter;
@@ -21,6 +22,7 @@ pub(super) struct BatchingState {
     pub(super) next_publish_id: u64,
     pub(super) last_dp_rank: u32,
     pub(super) last_storage_tier: StorageTier,
+    pub(super) last_cache_group: Option<CacheGroupClass>,
     pub(super) last_flush_time: Instant,
 }
 
@@ -32,6 +34,7 @@ impl BatchingState {
             next_publish_id: 1,
             last_dp_rank: 0,
             last_storage_tier: StorageTier::Device,
+            last_cache_group: None,
             last_flush_time: Instant::now(),
         }
     }
@@ -90,6 +93,7 @@ impl BatchingState {
                 worker_id,
                 self.last_storage_tier,
                 KvCacheEvent {
+                    cache_group: self.last_cache_group,
                     event_id: self.next_publish_id,
                     data: KvCacheEventData::Removed(filtered),
                     dp_rank,
@@ -106,6 +110,7 @@ impl BatchingState {
                 worker_id,
                 self.last_storage_tier,
                 KvCacheEvent {
+                    cache_group: self.last_cache_group,
                     event_id: self.next_publish_id,
                     data: KvCacheEventData::Stored(data),
                     dp_rank,

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -88,12 +88,15 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                         batching_state.has_pending() && event.dp_rank != batching_state.last_dp_rank;
                     let storage_tier_changed = batching_state.has_pending()
                         && storage_tier != batching_state.last_storage_tier;
+                    let cache_group_changed = batching_state.has_pending()
+                        && event.cache_group != batching_state.last_cache_group;
 
                     match event.data {
                         KvCacheEventData::Removed(data) => {
                             if batching_state.pending_stored.is_some()
                                 || dp_rank_changed
                                 || storage_tier_changed
+                                || cache_group_changed
                             {
                                 batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                             }
@@ -107,6 +110,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                         KvCacheEventData::Stored(data) => {
                             let should_flush = dp_rank_changed
                                 || storage_tier_changed
+                                || cache_group_changed
                                 || batching_state.pending_removed.is_some()
                                 || batching_state.pending_stored.as_ref().is_some_and(|p| {
                                     data.parent_hash != p.blocks.last().map(|b| b.block_hash)
@@ -129,6 +133,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
                                 worker_id,
                                 storage_tier,
                                 KvCacheEvent {
+                                    cache_group: event.cache_group,
                                     event_id: batching_state.next_publish_id,
                                     data: KvCacheEventData::Cleared,
                                     dp_rank: event.dp_rank,
@@ -142,6 +147,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
 
                     batching_state.last_dp_rank = event.dp_rank;
                     batching_state.last_storage_tier = storage_tier;
+                    batching_state.last_cache_group = event.cache_group;
 
                     // Bound coalesced output without splitting an individual source
                     // event or returning to `select!` midway through the native list.

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -41,11 +41,13 @@ mod test_event_processing {
         publisher
             .publish_batch(vec![
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: 8,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 1,
                 },
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: 9,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 2,
@@ -76,11 +78,13 @@ mod test_event_processing {
         let error = publisher
             .publish_batch(vec![
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: 8,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 1,
                 },
                 KvCacheEvent {
+                    cache_group: None,
                     event_id: 9,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 2,
@@ -109,6 +113,7 @@ mod test_event_processing {
 
         publisher
             .publish(KvCacheEvent {
+                cache_group: None,
                 event_id: 10,
                 data: KvCacheEventData::Cleared,
                 dp_rank: 2,
@@ -123,6 +128,7 @@ mod test_event_processing {
             .publish_batch_with_storage_tiers(vec![
                 (
                     KvCacheEvent {
+                        cache_group: None,
                         event_id: 10,
                         data: KvCacheEventData::Cleared,
                         dp_rank: 2,
@@ -131,6 +137,7 @@ mod test_event_processing {
                 ),
                 (
                     KvCacheEvent {
+                        cache_group: None,
                         event_id: 11,
                         data: KvCacheEventData::Cleared,
                         dp_rank: 3,
@@ -881,6 +888,7 @@ mod tests_startup_helpers {
         let (component, published) = MockComponent::new();
 
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(1), ExternalSequenceBlockHash(2)],
@@ -927,6 +935,7 @@ mod tests_startup_helpers {
 
         // Create BlockStored event
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -1020,6 +1029,7 @@ mod tests_startup_helpers {
 
         // First, store a block
         let store_event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -1048,6 +1058,7 @@ mod tests_startup_helpers {
 
         // Then remove same event
         let remove_event = KvCacheEvent {
+            cache_group: None,
             event_id: 2,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(100)],
@@ -1103,6 +1114,7 @@ mod tests_startup_helpers {
 
         // Store a block
         let store_event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -1121,6 +1133,7 @@ mod tests_startup_helpers {
 
         // Clear all blocks
         let clear_event = KvCacheEvent {
+            cache_group: None,
             event_id: 2,
             data: KvCacheEventData::Cleared,
             dp_rank: 0,
@@ -1186,6 +1199,7 @@ mod tests_startup_helpers {
         token.cancel();
 
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(1)],
@@ -1576,6 +1590,7 @@ mod tests_startup_helpers {
 
         // === STEP 1: Normal Operation ===
         let event_1 = KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -1649,6 +1664,7 @@ mod tests_startup_helpers {
 
         // === STEP 2 & 3: Simulate Outage - Stop forwarding to router ===
         let event_2 = KvCacheEvent {
+            cache_group: None,
             event_id: 2,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -2238,6 +2254,7 @@ mod event_processor_tests {
         dp_rank: u32,
     ) -> KvCacheEvent {
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: parent_hash.map(ExternalSequenceBlockHash),
@@ -2254,6 +2271,7 @@ mod event_processor_tests {
 
     fn removed_event(event_id: u64, block_hash: u64, dp_rank: u32) -> KvCacheEvent {
         KvCacheEvent {
+            cache_group: None,
             event_id,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(block_hash)],
@@ -2291,6 +2309,60 @@ mod event_processor_tests {
             panic!("expected stored event");
         };
         assert_eq!(data.blocks.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_cache_group_survives_batching_and_splits_on_change() {
+        let (tx, rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
+        let publisher = MockPublisher::new();
+        let handle = tokio::spawn(run_event_processor_loop(
+            publisher.clone(),
+            1,
+            CancellationToken::new(),
+            rx,
+            None,
+            None,
+            DEFAULT_MAX_BATCH_BLOCKS,
+        ));
+
+        let tagged = |mut event: KvCacheEvent, group| {
+            event.cache_group = group;
+            event
+        };
+        // The third store chains off the second, so without the tag change it
+        // would coalesce into the same batch.
+        tx.send(local_gpu_batch(vec![
+            tagged(
+                stored_event(0, None, 10, 0),
+                Some(CacheGroupClass::Attention),
+            ),
+            tagged(
+                stored_event(1, Some(10), 11, 0),
+                Some(CacheGroupClass::Attention),
+            ),
+            tagged(
+                stored_event(2, Some(11), 12, 0),
+                Some(CacheGroupClass::Recurrent),
+            ),
+        ]))
+        .unwrap();
+        drop(tx);
+        handle.await.unwrap();
+
+        let events = publisher.get_events();
+        assert_eq!(events.len(), 2, "tag change must split the batch");
+        assert_eq!(
+            events[0].event.cache_group,
+            Some(CacheGroupClass::Attention)
+        );
+        let KvCacheEventData::Stored(first) = &events[0].event.data else {
+            panic!("expected stored event");
+        };
+        assert_eq!(first.blocks.len(), 2);
+        assert_eq!(
+            events[1].event.cache_group,
+            Some(CacheGroupClass::Recurrent)
+        );
     }
 
     #[tokio::test]
@@ -2343,6 +2415,7 @@ mod event_processor_tests {
 
         let host_removed = removed_event(5, 51, 1);
         let clear = KvCacheEvent {
+            cache_group: None,
             event_id: 6,
             data: KvCacheEventData::Cleared,
             dp_rank: 1,
@@ -2537,6 +2610,7 @@ mod event_processor_tests {
 
         let block_count = DEFAULT_MAX_BATCH_BLOCKS + 1;
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -2607,6 +2681,7 @@ mod event_processor_tests {
 
         for i in 0..event_count {
             let event = KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -2711,6 +2786,7 @@ mod event_processor_tests {
             };
 
             let event = KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash,
@@ -2804,6 +2880,7 @@ mod event_processor_tests {
 
         for i in 0..3 {
             let event = KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: Some(ExternalSequenceBlockHash((i + 1) as u64 * 100)),
@@ -2871,6 +2948,7 @@ mod event_processor_tests {
         });
 
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,
@@ -2887,6 +2965,7 @@ mod event_processor_tests {
         tokio::task::yield_now().await;
 
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(1)),
@@ -2903,6 +2982,7 @@ mod event_processor_tests {
         tokio::task::yield_now().await;
 
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 2,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(1)),
@@ -3012,6 +3092,7 @@ mod event_processor_tests {
         // Since timeout is <= 0.2ms, each event should timeout and be sent individually
         for i in 0..5 {
             let event = KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -3083,6 +3164,7 @@ mod event_processor_tests {
 
         // Send a Removed event
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(0)],
@@ -3096,6 +3178,7 @@ mod event_processor_tests {
 
         // Send a Stored event (should cause flush of the Removed event)
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(0)),
@@ -3147,6 +3230,7 @@ mod event_processor_tests {
         });
 
         tx.send(local_host_event(KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(42)],
@@ -3195,6 +3279,7 @@ mod event_processor_tests {
         });
 
         tx.send(local_host_event(KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(1)],
@@ -3205,6 +3290,7 @@ mod event_processor_tests {
         tokio::task::yield_now().await;
 
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Removed(KvCacheRemoveData {
                 block_hashes: vec![ExternalSequenceBlockHash(2)],
@@ -3252,6 +3338,7 @@ mod event_processor_tests {
         // Send events with dp_rank=0
         for i in 0..3 {
             tx.send(local_gpu_event(KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -3265,6 +3352,7 @@ mod event_processor_tests {
         // Send events with dp_rank=1 (should cause flush of previous batch)
         for i in 3..6 {
             tx.send(local_gpu_event(KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -3344,6 +3432,7 @@ mod event_processor_tests {
         // Send first batch: 3 events with dp_rank=0, event_ids 10-12
         for i in 0..3 {
             tx.send(local_gpu_event(KvCacheEvent {
+                cache_group: None,
                 event_id: 10 + i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -3358,6 +3447,7 @@ mod event_processor_tests {
         // This should flush the first batch with dp_rank=0
         for i in 0..2 {
             tx.send(local_gpu_event(KvCacheEvent {
+                cache_group: None,
                 event_id: 20 + i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash((i + 3) as u64)],
@@ -3434,6 +3524,7 @@ mod event_processor_tests {
         // remaining 2 should batch together
         for i in 0..3 {
             tx.send(local_gpu_event(KvCacheEvent {
+                cache_group: None,
                 event_id: i as u64,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: vec![ExternalSequenceBlockHash(i as u64)],
@@ -3499,6 +3590,7 @@ mod event_processor_tests {
 
         // Send first batch: 2 sequential stored events with dp_rank=0, event_ids 100-101
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 100,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(0)),
@@ -3515,6 +3607,7 @@ mod event_processor_tests {
         tokio::task::yield_now().await;
 
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 101,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(1)),
@@ -3533,6 +3626,7 @@ mod event_processor_tests {
         // Send second batch: 1 event with dp_rank=1, event_id=200
         // This should flush the first batch with dp_rank=0, event_id=101
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 200,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(0)),
@@ -3619,6 +3713,7 @@ mod event_processor_tests {
 
         // First event: parent_hash=None, block_hash=1
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 0,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None, // Root block with no parent
@@ -3636,6 +3731,7 @@ mod event_processor_tests {
 
         // Second event: parent_hash=Some(1), block_hash=2 (sequential)
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(1)), // Points to previous block
@@ -3653,6 +3749,7 @@ mod event_processor_tests {
 
         // Third event: parent_hash=Some(2), block_hash=3 (sequential)
         tx.send(local_gpu_event(KvCacheEvent {
+            cache_group: None,
             event_id: 2,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: Some(ExternalSequenceBlockHash(2)),
@@ -3726,6 +3823,7 @@ mod event_plane_batch_tests {
         RouterEvent::new(
             7,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
                     block_hashes: (0..block_count)
@@ -3749,6 +3847,7 @@ mod event_plane_batch_tests {
         RouterEvent::new(
             7,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,
@@ -3798,6 +3897,7 @@ mod event_plane_batch_tests {
         RouterEvent::new(
             7,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Cleared,
                 dp_rank: (event_id % 2) as u32,

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1522,6 +1522,7 @@ mod tests {
                 (1..=3)
                     .map(|event_id| RawKvEvent {
                         event: KvCacheEvent {
+                            cache_group: None,
                             event_id,
                             data: dynamo_kv_router::protocols::KvCacheEventData::Cleared,
                             dp_rank: 0,

--- a/lib/mocker/src/kv_manager/kvbm_backend.rs
+++ b/lib/mocker/src/kv_manager/kvbm_backend.rs
@@ -858,6 +858,7 @@ impl KvManager {
         self.next_event_id += 1;
 
         let event = KvCacheEvent {
+            cache_group: None,
             event_id,
             data: event_data,
             dp_rank: self.dp_rank,

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -839,6 +839,7 @@ impl SglangKvManager {
             .collect();
 
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: self.next_event_id,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash,
@@ -891,6 +892,7 @@ impl SglangKvManager {
         }
 
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: self.next_event_id,
             data: KvCacheEventData::Removed(KvCacheRemoveData { block_hashes }),
             dp_rank: self.dp_rank,

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -838,6 +838,7 @@ impl VllmKvManager {
             })
         };
         let event = KvCacheEvent {
+            cache_group: None,
             event_id: self.next_event_id,
             data,
             dp_rank: self.dp_rank,

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -1055,6 +1055,7 @@ mod tests {
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -622,6 +622,7 @@ policy_classes:
         RouterEvent::with_storage_tier(
             worker_id,
             KvCacheEvent {
+                cache_group: None,
                 event_id,
                 data: KvCacheEventData::Stored(KvCacheStoreData {
                     parent_hash: None,

--- a/lib/mocker/src/scheduler/kv_event_sink.rs
+++ b/lib/mocker/src/scheduler/kv_event_sink.rs
@@ -311,6 +311,7 @@ mod tests {
                 .into_iter()
                 .map(|event_id| DeferredKvPublish {
                     event: KvCacheEvent {
+                        cache_group: None,
                         event_id,
                         data: stored_data.clone(),
                         dp_rank: 0,

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -25,6 +25,7 @@ impl FakeCore {
         self.publishers
             .publish(
                 KvCacheEvent {
+                    cache_group: None,
                     event_id,
                     data: KvCacheEventData::Cleared,
                     dp_rank: 0,

--- a/lib/mocker/src/services/zmq_events.rs
+++ b/lib/mocker/src/services/zmq_events.rs
@@ -386,6 +386,7 @@ mod tests {
 
     fn stored_event() -> KvCacheEvent {
         KvCacheEvent {
+            cache_group: None,
             event_id: 1,
             data: KvCacheEventData::Stored(KvCacheStoreData {
                 parent_hash: None,


### PR DESCRIPTION
## Summary

Groundwork for DEP #12169 (KV-router indexing for linear-attention / recurrent-state cache groups: Kimi-Linear KDA, Mamba hybrids). **No routing behavior changes** — every piece here is behavior-preserving substrate that the recurrent-state indexing work can build on:

1. **Extensible event-kind registry.** Replaces the hard-coded `is_main_attention()` allow-list in the ZMQ event filter with an `IndexStrategyRegistry` mapping each `KvCacheSpecKind` to an index strategy (`Attention` | `Recurrent` | `Drop`). The default registry reproduces the historical filter exactly (asserted kind-by-kind in a test). Admitting a new kind — e.g. a recurrent `mamba`/`kda` cache group — becomes a registration change at a composition root instead of a predicate edit, without a wire-format break.

2. **Per-group block-size learning (partial #9376).** `KvCacheGroupMetadata` now learns the event-declared `block_size` per `(dp_rank, group_idx)`, and the normalizer warns once per group when an attention group's block size disagrees with the configured router block size. Previously that misconfiguration only surfaced as a capped per-block conversion warning while every stored block was silently rejected.

3. **Optional `cache_group` tag on `KvCacheEvent`.** A `#[serde(default, skip_serializing_if)]` `Option<CacheGroupClass>` (`attention` | `recurrent`) so consumers can eventually route recurrent-state events to a dedicated index. Compatibility is explicit and tested:
   - `None` keeps the field-named msgpack wire bytes **byte-identical** to the pre-tag encoding (byte-equality test against a legacy-shaped struct);
   - legacy payloads without the key decode to `None`, which means attention — today's behavior — so mixed-version fleets degrade to current routing, never corruption;
   - all production surfaces for this struct (event plane codec, replica sync) use `rmp_serde::to_vec_named`, i.e. field-named encoding.

   The normalizer stamps the tag from the event's resolved kind; kindless producers (e.g. TRT-LLM-style events without `kv_cache_spec_kind`) stay untagged.

The remaining ~100 changed lines outside `lib/kv-router/src/zmq_wire` are mechanical `cache_group: None,` insertions at existing `KvCacheEvent` initializers.

Related: #9376 (block-size fallback; item 2 is the detection half), #11726 (mocker hybrid cache groups), #10741 (disagg hybrid Mamba — out of scope here).

## Validation

- `cargo test -p dynamo-kv-router` — 856 passed (includes new tests: registry-default parity with the legacy filter for every kind, `mamba`/future-`kda` drop reasons unchanged, registered recurrent kind passes and stamps `cache_group`, kindless events stay untagged, group block-size learning, wire-byte equality for `None`, tag round-trip over named msgpack + JSON)
- `cargo test -p dynamo-llm --lib kv_router` — 210 passed
- `cargo test -p dynamo-mocker` — 636 passed
- `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` — clean
- `lib/bindings/python`, `lib/bindings/c` — compile clean
- `cargo fmt --all` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache-group classification (Attention vs Recurrent) and an optional `cache_group` on KV cache events.
  * Introduced configurable indexing strategies for cache kinds, with normalization now stamping placement using learned and/or configured cache-group metadata.
  * Event batching now preserves cache groups and splits output when the cache group changes.

* **Bug Fixes**
  * Improved filtering/normalization behavior for recurrent, unknown, and legacy cache events while maintaining wire compatibility when `cache_group` is omitted.

* **Tests**
  * Added/updated coverage for cache-group serialization, metadata learning, normalization filtering/stamping, and batching/coalescing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->