### PR TITLE
docs: update Fern CLI link [DYN-3853]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -356,7 +356,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/cli-api/overview). This is useful
+[Fern CLI](https://buildwithfern.com/learn/cli-api-reference/cli-reference/overview). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites


### PR DESCRIPTION
## Summary

- Replace the retired Fern CLI overview URL in `docs/README.md` with Fern's current official CLI reference.
- The old URL now permanently returns 404 and causes the external Lychee link check to fail on both PRs and `main`.

## Validation

- Confirmed the old URL returns HTTP 404 and the replacement returns HTTP 200.
- `git diff --check`
- Pre-commit hooks on `docs/README.md`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fern CLI link in the “Running Locally” section to point to the current CLI reference overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->