### PR TITLE
fix(thunderagent): support topology-only wrapped backends

### DIFF
--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -266,7 +266,10 @@ class DynamoRuntimeArgGroup(ArgGroup):
             env_var="DYN_ENDPOINT_TYPES",
             default="chat,completions",
             obsolete_flag="--dyn-endpoint-types",
-            help="Comma-separated list of endpoint types to enable. Options: 'chat', 'completions'. Use 'completions' for models without chat templates.",
+            help="Comma-separated list of endpoint types to enable. Options: "
+            "'chat', 'completions', or 'none'. Use 'completions' for models "
+            "without chat templates. Use 'none' for topology-only workers "
+            "fronted by another Dynamo service.",
         )
 
         add_argument(

--- a/components/src/dynamo/common/utils/endpoint_types.py
+++ b/components/src/dynamo/common/utils/endpoint_types.py
@@ -11,14 +11,15 @@ def parse_endpoint_types(endpoint_types_str: str) -> ModelType:
 
     Args:
         endpoint_types_str: Comma-separated list of endpoint types.
-                          Valid values: 'chat', 'completions'
-                          Examples: 'chat', 'completions', 'chat,completions'
+                          Valid values: 'chat', 'completions', or 'none'
+                          Examples: 'chat', 'completions', 'chat,completions', 'none'
 
     Returns:
         ModelType flags combined with bitwise OR
 
     Raises:
-        ValueError: If any invalid endpoint type is provided or string is empty
+        ValueError: If any invalid endpoint type is provided, 'none' is mixed
+            with other endpoint types, or the string is empty
 
     Examples:
         >>> parse_endpoint_types("chat")
@@ -27,6 +28,8 @@ def parse_endpoint_types(endpoint_types_str: str) -> ModelType:
         ModelType.Completions
         >>> parse_endpoint_types("chat,completions")
         ModelType.Chat | ModelType.Completions
+        >>> parse_endpoint_types("none")
+        ModelType.Empty
     """
     if not endpoint_types_str or not endpoint_types_str.strip():
         raise ValueError("Endpoint types string cannot be empty")
@@ -36,6 +39,13 @@ def parse_endpoint_types(endpoint_types_str: str) -> ModelType:
     if not types:
         raise ValueError("No valid endpoint types provided")
 
+    if "none" in types:
+        if len(types) > 1:
+            raise ValueError(
+                "Endpoint type 'none' cannot be combined with other endpoint types"
+            )
+        return ModelType.Empty
+
     result: ModelType | None = None
     for t in types:
         if t == "chat":
@@ -44,7 +54,8 @@ def parse_endpoint_types(endpoint_types_str: str) -> ModelType:
             flag = ModelType.Completions
         else:
             raise ValueError(
-                f"Invalid endpoint type: '{t}'. Valid options: 'chat', 'completions'"
+                f"Invalid endpoint type: '{t}'. Valid options: "
+                "'chat', 'completions', 'none'"
             )
 
         result = flag if result is None else result | flag

--- a/components/src/dynamo/common/utils/tests/test_endpoint_types.py
+++ b/components/src/dynamo/common/utils/tests/test_endpoint_types.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for endpoint type parsing."""
+
+import pytest
+
+from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.llm import ModelType
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_parse_endpoint_types_allows_topology_only_workers():
+    assert parse_endpoint_types("none") == ModelType.Empty
+
+
+@pytest.mark.parametrize("value", ["chat,none", "none,completions"])
+def test_parse_endpoint_types_rejects_mixing_none_with_public_surfaces(value):
+    with pytest.raises(ValueError, match="'none' cannot be combined"):
+        parse_endpoint_types(value)
+
+
+@pytest.mark.parametrize("value", ["", "   ", ",,,"])
+def test_parse_endpoint_types_rejects_empty_input(value):
+    with pytest.raises(ValueError):
+        parse_endpoint_types(value)
+
+
+def test_parse_endpoint_types_invalid_option_lists_none():
+    with pytest.raises(ValueError, match="'chat', 'completions', 'none'"):
+        parse_endpoint_types("responses")

--- a/components/src/dynamo/thunderagent_router/README.md
+++ b/components/src/dynamo/thunderagent_router/README.md
@@ -36,6 +36,7 @@ uv pip install -e .
 # 1. Start your Dynamo workers (vLLM example, with KV events on)
 python -m dynamo.vllm \
     --model <model> --tensor-parallel-size <N> \
+    --endpoint-types none \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events",
                          "endpoint":"tcp://*:20080",
                          "enable_kv_cache_events":true}'
@@ -50,6 +51,12 @@ python -m dynamo.thunderagent_router \
 #    a model handler, which our service registered)
 python -m dynamo.frontend --router-mode round-robin
 ```
+
+Use `--endpoint-types none` on workers wrapped by ThunderAgent so they register
+only for topology and readiness. ThunderAgent registers the public
+chat/completions surface; if the wrapped backend also advertises that surface
+for the same model, the frontend may route requests directly to the backend and
+bypass ThunderAgent lifecycle handling such as `x-dynamo-session-final`.
 
 The control-loop knobs (`--pause-threshold`, `--pause-target`,
 `--resume-hysteresis`, `--scheduler-interval-seconds`, …) and their defaults are


### PR DESCRIPTION
## Overview:

This PR addresses the `session-final` GPU-forwarding issue described in #12016 for ThunderAgent Kubernetes deployments.

ThunderAgent already short-circuits final-session requests when they reach `dynamo.thunderagent_router`, but the K8s demo can bypass ThunderAgent when the wrapped backend advertises the same public chat/completions model surface. This PR adds an explicit topology-only endpoint mode so wrapped backends can stay discoverable for routing/readiness without being selected directly by the frontend.

## Details:

- Add `--endpoint-types none` support, parsed as `ModelType.Empty`, for topology-only backend registration.
- Reject mixed endpoint declarations such as `chat,none` or `none,completions`.
- Update shared runtime CLI help to document `none` for workers fronted by another Dynamo service.
- Document using `--endpoint-types none` for ThunderAgent-wrapped workers.
- Add parser coverage for `none`, invalid mixes, invalid endpoint names, and empty input.

Validation performed:

- `python3 -m py_compile components/src/dynamo/common/utils/endpoint_types.py components/src/dynamo/common/configuration/groups/runtime_args.py components/src/dynamo/common/utils/tests/test_endpoint_types.py`
- `git diff --check`
- `uv run --no-project --with ruff ruff check components/src/dynamo/common/utils/endpoint_types.py components/src/dynamo/common/utils/tests/test_endpoint_types.py`
- Parser smoke test with a stubbed `ModelType` for `chat`, `completions`, `chat,completions`, `none`, invalid `none` combinations, and empty inputs.
- Validated on AKS with Dynamo Platform v1.3.0 (`dynamo-platform-1.3.0`, app version `1.3.0`) using the existing `aks-dynamo-thunderagent` deployment and `Qwen/Qwen3-0.6B` on `Standard_NC4as_T4_v3`.
  - Baseline v1.3.0 behavior: 1 of 6 `x-dynamo-session-final: true` requests generated tokens; vLLM logs showed the final request hit `component=backend`, `endpoint=generate`.
  - Patched release deployment with an in-memory equivalent of this change plus `--endpoint-types none`: backend `DynamoWorkerMetadata` advertised `model_type: ""`, while ThunderAgent advertised `model_type: Chat | Completions`.
  - After patch: DGD Ready, `/v1/models` returned `Qwen/Qwen3-0.6B`, a normal chat request returned 200 with generated tokens, and 8 of 8 `x-dynamo-session-final: true` requests returned the empty ThunderAgent short-circuit response without backend generation.

## Where should the reviewer start?

Start with `components/src/dynamo/common/utils/endpoint_types.py` for the new parser behavior, then `components/src/dynamo/common/utils/tests/test_endpoint_types.py` for coverage. The ThunderAgent deployment guidance is in `components/src/dynamo/thunderagent_router/README.md`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #12016

This specifically addresses the `session-final` GPU-forwarding/bypass item in #12016. It does not close the full tracking issue, which also includes observability and DGDR items.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12175" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `none` endpoint type for topology-only workers.
  * Prevented `none` from being combined with chat or completions endpoints.

* **Documentation**
  * Updated command-line help and ThunderAgent setup guidance.
  * Clarified routing behavior when backend services also expose public endpoints.

* **Tests**
  * Added coverage for valid topology-only configuration, invalid combinations, empty input, and unsupported endpoint types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->