### PR TITLE
fix(vllm): warm up eager shapes before FPM self-benchmark measurement

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -198,6 +198,9 @@ class _BenchPhase(enum.Enum):
     DONE = "done"
 
 
+EAGER_WARMUP_REASON = "eager_warmup"
+
+
 @dataclass
 class BenchmarkPoint:
     point_type: str  # "prefill" or "decode"
@@ -2364,6 +2367,38 @@ class InstrumentedScheduler(AsyncScheduler):
             return capacity.usable_blocks_with_watermark
         return capacity.usable_blocks_without_watermark
 
+    def _bench_eager_warmup_points(self) -> list[BenchmarkPoint]:
+        """One discarded replica per eager shape, executed before the sweep.
+
+        Captured shapes are executed during cudagraph capture at startup, so
+        their one-time per-shape costs (first kernel launch and selection,
+        allocator pool growth) are paid before any measurement. Eager shapes
+        (no capture available) get no such implicit warmup: their first
+        execution pays a ~1s one-off (measured 1126ms vs 147ms warm on
+        decode batch 513) and a single-sample sweep books that cost as the
+        point's latency. Prepending one replica per eager shape - deduped by
+        the shape driver: token count for prefill, batch size for decode -
+        puts eager and captured points on the same footing. Replicas run
+        through the normal injection/lockstep/validation path on every rank
+        (grids stay identical by construction) and are dropped at save time.
+        """
+        seen: set[tuple[str, int]] = set()
+        replicas: list[BenchmarkPoint] = []
+        for point in self._bench_grid:
+            if point.expected_capture_size is not None:
+                continue
+            key = (
+                point.point_type,
+                point.total_prefill_tokens
+                if point.point_type == "prefill"
+                else point.batch_size,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            replicas.append(replace(point, sample_reasons=[EAGER_WARMUP_REASON]))
+        return replicas
+
     def _bench_build_grid(self) -> None:
         """Generate the sweep grid once scheduler limits are known."""
         if self._bench_grid_built:
@@ -2410,9 +2445,50 @@ class InstrumentedScheduler(AsyncScheduler):
                 if len(self._bench_grid) == points_before:
                     self._bench_missing_phases.append("decode")
                     logger.warning("Benchmark decode phase generated no points")
-        self._bench_expected_points = len(self._bench_grid)
-        for benchmark_id, point in enumerate(self._bench_grid, start=1):
-            point.benchmark_id = benchmark_id
+        warmup_points = self._bench_eager_warmup_points()
+        if warmup_points:
+            # _bench_pop_next() treats a type mismatch at the queue front as
+            # "phase complete", so each warmup block must stay contiguous
+            # with its phase's real block; mixed-type warmups prepended as a
+            # single run would end PREFILL_SWEEP at the first decode warmup
+            # and DECODE_SWEEP at the first real prefill point.
+            warmup = {
+                point_type: [
+                    point for point in warmup_points if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            real = {
+                point_type: [
+                    point
+                    for point in self._bench_grid
+                    if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            self._bench_grid = deque(
+                warmup["prefill"] + real["prefill"] + warmup["decode"] + real["decode"]
+            )
+            logger.info(
+                "Benchmark grid: prepending %d eager-shape warmup point(s); "
+                "their results are discarded",
+                len(warmup_points),
+            )
+        self._bench_expected_points = len(self._bench_grid) - len(warmup_points)
+        # Published results must carry contiguous benchmark IDs starting at 1
+        # (the native-artifact contract), so real points are numbered first;
+        # discarded warmup replicas take IDs after the real range. counter_id
+        # stamping uses point.benchmark_id directly, so execution order and
+        # ID order are independent.
+        real_id = 0
+        warmup_id = self._bench_expected_points
+        for point in self._bench_grid:
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                warmup_id += 1
+                point.benchmark_id = warmup_id
+            else:
+                real_id += 1
+                point.benchmark_id = real_id
         grid_payload = json.dumps(
             [asdict(point) for point in self._bench_grid],
             sort_keys=True,
@@ -4142,6 +4218,15 @@ class InstrumentedScheduler(AsyncScheduler):
                     reason,
                 )
                 self._bench_skip_point(point, reason)
+                self._bench_current_point = None
+                self._bench_current_fpms = []
+                self._bench_point_deadline = 0.0
+                if group_result.stop_requested:
+                    self._bench_request_timeout_stop(point)
+                return
+
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                logger.debug("Discarding eager-shape warmup result: %s", point)
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -4298,6 +4298,19 @@ class InstrumentedScheduler(AsyncScheduler):
                 f"benchmark_id={point.benchmark_id}: "
                 f"explicit benchmark point failed: {reason}"
             )
+        if EAGER_WARMUP_REASON in point.sample_reasons:
+            # Warmup replicas are best-effort scaffolding on EVERY failure
+            # path, not just shape validation: fake-prefix allocation,
+            # injection shortfall, and validation failures all land here,
+            # and a single skipped-point entry flips the published artifact
+            # to unusable/invalid (both gates require skipped_points == 0).
+            logger.warning(
+                "Discarding failed eager-shape warmup replica instead of "
+                "recording a skipped point: reason=%s point=%s",
+                reason,
+                point,
+            )
+            return
         self._bench_skipped_points.append(
             SkippedBenchmarkPoint(point=point, reason=reason)
         )

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -4208,6 +4208,29 @@ class InstrumentedScheduler(AsyncScheduler):
                 if reason is not None and validation_failure is None:
                     validation_failure = (dp_rank, reason)
 
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                # Warmup replicas are best-effort scaffolding and must be
+                # discarded BEFORE the shape-validation skip: recording one
+                # as a skipped point would flip the published artifact to
+                # unusable/invalid (both gates require skipped_points == 0)
+                # even though every real measurement succeeded.
+                if validation_failure is not None:
+                    logger.warning(
+                        "Discarding eager-shape warmup result with mismatched "
+                        "shape on ADP rank %d: point=%s reason=%s",
+                        validation_failure[0],
+                        point,
+                        validation_failure[1],
+                    )
+                else:
+                    logger.debug("Discarding eager-shape warmup result: %s", point)
+                self._bench_current_point = None
+                self._bench_current_fpms = []
+                self._bench_point_deadline = 0.0
+                if group_result.stop_requested:
+                    self._bench_request_timeout_stop(point)
+                return
+
             if validation_failure is not None:
                 dp_rank, reason = validation_failure
                 logger.warning(
@@ -4218,15 +4241,6 @@ class InstrumentedScheduler(AsyncScheduler):
                     reason,
                 )
                 self._bench_skip_point(point, reason)
-                self._bench_current_point = None
-                self._bench_current_fpms = []
-                self._bench_point_deadline = 0.0
-                if group_result.stop_requested:
-                    self._bench_request_timeout_stop(point)
-                return
-
-            if EAGER_WARMUP_REASON in point.sample_reasons:
-                logger.debug("Discarding eager-shape warmup result: %s", point)
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3534,6 +3534,29 @@ class InstrumentedScheduler(AsyncScheduler):
                 if reason is not None and validation_failure is None:
                     validation_failure = (dp_rank, reason)
 
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                # Warmup replicas are best-effort scaffolding and must be
+                # discarded BEFORE the shape-validation skip: recording one
+                # as a skipped point would flip the published artifact to
+                # unusable/invalid (both gates require skipped_points == 0)
+                # even though every real measurement succeeded.
+                if validation_failure is not None:
+                    logger.warning(
+                        "Discarding eager-shape warmup result with mismatched "
+                        "shape on ADP rank %d: point=%s reason=%s",
+                        validation_failure[0],
+                        point,
+                        validation_failure[1],
+                    )
+                else:
+                    logger.debug("Discarding eager-shape warmup result: %s", point)
+                self._bench_current_point = None
+                self._bench_current_fpms = []
+                self._bench_point_deadline = 0.0
+                if group_result.stop_requested:
+                    self._bench_request_timeout_stop(point)
+                return
+
             if validation_failure is not None:
                 dp_rank, reason = validation_failure
                 logger.warning(
@@ -3544,15 +3567,6 @@ class InstrumentedScheduler(AsyncScheduler):
                     reason,
                 )
                 self._bench_skip_point(point, reason)
-                self._bench_current_point = None
-                self._bench_current_fpms = []
-                self._bench_point_deadline = 0.0
-                if group_result.stop_requested:
-                    self._bench_request_timeout_stop(point)
-                return
-
-            if EAGER_WARMUP_REASON in point.sample_reasons:
-                logger.debug("Discarding eager-shape warmup result: %s", point)
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -3624,6 +3624,19 @@ class InstrumentedScheduler(AsyncScheduler):
                 f"benchmark_id={point.benchmark_id}: "
                 f"explicit benchmark point failed: {reason}"
             )
+        if EAGER_WARMUP_REASON in point.sample_reasons:
+            # Warmup replicas are best-effort scaffolding on EVERY failure
+            # path, not just shape validation: fake-prefix allocation,
+            # injection shortfall, and validation failures all land here,
+            # and a single skipped-point entry flips the published artifact
+            # to unusable/invalid (both gates require skipped_points == 0).
+            logger.warning(
+                "Discarding failed eager-shape warmup replica instead of "
+                "recording a skipped point: reason=%s point=%s",
+                reason,
+                point,
+            )
+            return
         self._bench_skipped_points.append(
             SkippedBenchmarkPoint(point=point, reason=reason)
         )

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -165,6 +165,9 @@ class _BenchPhase(enum.Enum):
     DONE = "done"
 
 
+EAGER_WARMUP_REASON = "eager_warmup"
+
+
 @dataclass
 class BenchmarkPoint:
     point_type: str  # "prefill" or "decode"
@@ -1878,6 +1881,38 @@ class InstrumentedScheduler(AsyncScheduler):
 
     # -- Grid generation ------------------------------------------------
 
+    def _bench_eager_warmup_points(self) -> list[BenchmarkPoint]:
+        """One discarded replica per eager shape, executed before the sweep.
+
+        Captured shapes are executed during cudagraph capture at startup, so
+        their one-time per-shape costs (first kernel launch and selection,
+        allocator pool growth) are paid before any measurement. Eager shapes
+        (no capture available) get no such implicit warmup: their first
+        execution pays a ~1s one-off (measured 1126ms vs 147ms warm on
+        decode batch 513) and a single-sample sweep books that cost as the
+        point's latency. Prepending one replica per eager shape - deduped by
+        the shape driver: token count for prefill, batch size for decode -
+        puts eager and captured points on the same footing. Replicas run
+        through the normal injection/lockstep/validation path on every rank
+        (grids stay identical by construction) and are dropped at save time.
+        """
+        seen: set[tuple[str, int]] = set()
+        replicas: list[BenchmarkPoint] = []
+        for point in self._bench_grid:
+            if point.expected_capture_size is not None:
+                continue
+            key = (
+                point.point_type,
+                point.total_prefill_tokens
+                if point.point_type == "prefill"
+                else point.batch_size,
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            replicas.append(replace(point, sample_reasons=[EAGER_WARMUP_REASON]))
+        return replicas
+
     def _bench_build_grid(self) -> None:
         """Generate the sweep grid once scheduler limits are known."""
         if self._bench_grid_built:
@@ -1900,9 +1935,50 @@ class InstrumentedScheduler(AsyncScheduler):
                 if len(self._bench_grid) == points_before:
                     self._bench_missing_phases.append("decode")
                     logger.warning("Benchmark decode phase generated no points")
-        self._bench_expected_points = len(self._bench_grid)
-        for benchmark_id, point in enumerate(self._bench_grid, start=1):
-            point.benchmark_id = benchmark_id
+        warmup_points = self._bench_eager_warmup_points()
+        if warmup_points:
+            # _bench_pop_next() treats a type mismatch at the queue front as
+            # "phase complete", so each warmup block must stay contiguous
+            # with its phase's real block; mixed-type warmups prepended as a
+            # single run would end PREFILL_SWEEP at the first decode warmup
+            # and DECODE_SWEEP at the first real prefill point.
+            warmup = {
+                point_type: [
+                    point for point in warmup_points if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            real = {
+                point_type: [
+                    point
+                    for point in self._bench_grid
+                    if point.point_type == point_type
+                ]
+                for point_type in ("prefill", "decode")
+            }
+            self._bench_grid = deque(
+                warmup["prefill"] + real["prefill"] + warmup["decode"] + real["decode"]
+            )
+            logger.info(
+                "Benchmark grid: prepending %d eager-shape warmup point(s); "
+                "their results are discarded",
+                len(warmup_points),
+            )
+        self._bench_expected_points = len(self._bench_grid) - len(warmup_points)
+        # Published results must carry contiguous benchmark IDs starting at 1
+        # (the native-artifact contract), so real points are numbered first;
+        # discarded warmup replicas take IDs after the real range. counter_id
+        # stamping uses point.benchmark_id directly, so execution order and
+        # ID order are independent.
+        real_id = 0
+        warmup_id = self._bench_expected_points
+        for point in self._bench_grid:
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                warmup_id += 1
+                point.benchmark_id = warmup_id
+            else:
+                real_id += 1
+                point.benchmark_id = real_id
         grid_payload = json.dumps(
             [asdict(point) for point in self._bench_grid],
             sort_keys=True,
@@ -3468,6 +3544,15 @@ class InstrumentedScheduler(AsyncScheduler):
                     reason,
                 )
                 self._bench_skip_point(point, reason)
+                self._bench_current_point = None
+                self._bench_current_fpms = []
+                self._bench_point_deadline = 0.0
+                if group_result.stop_requested:
+                    self._bench_request_timeout_stop(point)
+                return
+
+            if EAGER_WARMUP_REASON in point.sample_reasons:
+                logger.debug("Discarding eager-shape warmup result: %s", point)
                 self._bench_current_point = None
                 self._bench_current_fpms = []
                 self._bench_point_deadline = 0.0

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3790,3 +3790,68 @@ def test_warmup_replica_with_failed_validation_is_discarded_not_skipped():
     assert stub._bench_results == []
     assert stub._bench_skipped_points == []
     assert stub._bench_current_point is None
+
+
+def test_warmup_replica_injection_failure_is_discarded_not_skipped():
+    """A warmup replica that dies BEFORE producing an FPM (decode injection
+    shortfall) must also stay out of skipped-point accounting: every
+    ``_bench_skip_point`` caller shares the central warmup exemption."""
+    point = BenchmarkPoint(
+        point_type="decode",
+        benchmark_id=9,
+        total_kv_read_tokens=48,
+        batch_size=3,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_if_pending = MagicMock(return_value=False)
+    stub._bench_active_req_ids = set()
+    stub._bench_grid = deque([point])
+    stub._bench_current_point = None
+    stub._bench_current_fpms = []
+    stub._bench_skipped_points = []
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_inject_fake_decode = MagicMock(
+        return_value=SimpleNamespace(total_num_scheduled_tokens=0)
+    )
+
+    output = InstrumentedScheduler._bench_step_decode(stub)
+
+    assert output is None
+    assert stub._bench_current_point is None
+    assert stub._bench_skipped_points == []
+    stub._bench_cleanup_requests.assert_called_once_with()
+
+
+def test_skip_point_exempts_warmup_replicas_on_every_path():
+    """The exemption lives in ``_bench_skip_point`` itself, so fake-prefix,
+    injection, and validation failures are all covered; real points still
+    book a skipped entry."""
+    warmup = BenchmarkPoint(
+        point_type="prefill",
+        benchmark_id=1,
+        total_prefill_tokens=64,
+        batch_size=1,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    real = BenchmarkPoint(
+        point_type="prefill",
+        benchmark_id=2,
+        total_prefill_tokens=64,
+        batch_size=1,
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_skipped_points = []
+
+    for reason in (
+        "fake_prefix_cache_allocation_failed",
+        "prefill_injection_failed",
+        "measured_batch_size_mismatch",
+    ):
+        InstrumentedScheduler._bench_skip_point(stub, warmup, reason)
+    assert stub._bench_skipped_points == []
+
+    InstrumentedScheduler._bench_skip_point(stub, real, "prefill_injection_failed")
+    assert stub._bench_skipped_points == [
+        SkippedBenchmarkPoint(point=real, reason="prefill_injection_failed")
+    ]

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3708,14 +3708,7 @@ def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
 
 
 def test_eager_warmup_points_dedupe_and_flag():
-    from types import SimpleNamespace
-
-    from dynamo.vllm.instrumented_scheduler import (
-        EAGER_WARMUP_REASON,
-        BenchmarkPoint,
-        InstrumentedScheduler,
-    )
-
+    EAGER_WARMUP_REASON = instrumented_scheduler_module.EAGER_WARMUP_REASON
     grid = [
         BenchmarkPoint(
             point_type="decode",
@@ -3767,3 +3760,33 @@ def test_eager_warmup_points_dedupe_and_flag():
     assert all(p.sample_reasons == [EAGER_WARMUP_REASON] for p in replicas)
     # originals untouched
     assert all(EAGER_WARMUP_REASON not in p.sample_reasons for p in grid)
+
+
+def test_warmup_replica_with_failed_validation_is_discarded_not_skipped():
+    """A warmup replica whose FPM fails shape validation must be discarded:
+    recording it in skipped_points would mark the whole artifact unusable
+    even though every real measurement succeeded."""
+    point = BenchmarkPoint(
+        point_type="decode",
+        benchmark_id=9,
+        total_kv_read_tokens=48,
+        batch_size=3,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    stub = _benchmark_save_stub(
+        point,
+        [
+            {
+                "scheduled_requests": {
+                    "num_decode_requests": 3,
+                    "sum_decode_kv_tokens": 47,  # mismatch -> validation failure
+                }
+            }
+        ],
+    )
+
+    InstrumentedScheduler._bench_save_current_point(stub)
+
+    assert stub._bench_results == []
+    assert stub._bench_skipped_points == []
+    assert stub._bench_current_point is None

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -37,6 +37,7 @@ from dynamo.vllm.benchmark_points import (  # noqa: E402
     PrefillPointCandidate,
 )
 from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
+    EAGER_WARMUP_REASON,
     BenchmarkConfig,
     BenchmarkPoint,
     InstrumentedScheduler,
@@ -1647,8 +1648,13 @@ def test_benchmark_grid_has_no_point_cap():
     InstrumentedScheduler._bench_build_grid(stub)
 
     assert stub._bench_expected_points == 4097
-    assert len(stub._bench_grid) == 4097
-    assert [point.benchmark_id for point in stub._bench_grid] == list(range(1, 4098))
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    assert len(real_points) == 4097
+    assert [point.benchmark_id for point in real_points] == list(range(1, 4098))
     assert stub._bench_grid_error is None
 
 
@@ -1674,7 +1680,21 @@ def test_benchmark_grid_assigns_stable_contiguous_ids_and_digest():
 
     InstrumentedScheduler._bench_build_grid(stub)
 
-    assert [point.benchmark_id for point in stub._bench_grid] == [1, 2]
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    warmup_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON in point.sample_reasons
+    ]
+    # Real points own the contiguous 1..N range (native-artifact contract);
+    # discarded eager-warmup replicas take IDs after the real range even
+    # though they execute first.
+    assert [point.benchmark_id for point in real_points] == [1, 2]
+    assert [point.benchmark_id for point in warmup_points] == [3, 4]
     assert len(stub._bench_grid_digest) == 64
 
 
@@ -2286,6 +2306,44 @@ def test_agg_grid_contains_piecewise_prefill_then_full_decode_points():
         for point in points
         if point.point_type == "decode"
     } == {"FULL"}
+
+
+def test_agg_eager_warmups_stay_contiguous_with_their_phase():
+    """``_bench_pop_next()`` treats a type mismatch at the queue front as
+    "phase complete", so eager warmups of both types prepended as a single
+    run would end PREFILL_SWEEP at the first decode warmup and DECODE_SWEEP
+    at the first real prefill point, silently dropping every real point."""
+    stub = _prefill_grid_stub()
+    stub._bench_grid = deque()
+    stub._bench_grid_built = False
+    stub._bench_missing_phases = []
+    stub._bench_grid_error = None
+    stub._bench_feasible_max_decode_batch_size = 0
+    stub._bench_config.mode = "agg"
+    stub._bench_explicit_points = None
+    # Captures end below the feasible max batch so decode also has eager
+    # shapes; prefill already has them (max tokens 40 > largest capture 16).
+    stub._bench_decode_capture_sizes = [1, 2, 4]
+    stub._bench_decode_cudagraph_mode = "FULL"
+
+    InstrumentedScheduler._bench_build_grid(stub)
+
+    points = list(stub._bench_grid)
+    warmup_types = {
+        point.point_type
+        for point in points
+        if instrumented_scheduler_module.EAGER_WARMUP_REASON in point.sample_reasons
+    }
+    assert warmup_types == {"prefill", "decode"}, "need warmups on both phases"
+
+    # Drain the grid exactly as the phase machine does: prefill until the
+    # front stops matching, then decode.
+    drained = 0
+    for phase in ("prefill", "decode"):
+        while InstrumentedScheduler._bench_pop_next(stub, phase) is not None:
+            drained += 1
+    assert not stub._bench_grid, "phase transitions must consume every point"
+    assert drained == len(points)
 
 
 def test_prefill_kv_read_ladder_is_total_block_aligned():
@@ -3647,3 +3705,65 @@ def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
     stub._bench_current_point = BenchmarkPoint(point_type="decode")
     stub._last_update_time = 0.0  # previous update was an empty step
     assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+
+
+def test_eager_warmup_points_dedupe_and_flag():
+    from types import SimpleNamespace
+
+    from dynamo.vllm.instrumented_scheduler import (
+        EAGER_WARMUP_REASON,
+        BenchmarkPoint,
+        InstrumentedScheduler,
+    )
+
+    grid = [
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=513,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=2048,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=512,
+            total_kv_read_tokens=512,
+            expected_capture_size=512,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=0,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=2,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=4096,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=256,
+            total_kv_read_tokens=0,
+            expected_capture_size=256,
+        ),
+    ]
+    stub = SimpleNamespace(_bench_grid=grid)
+    replicas = InstrumentedScheduler._bench_eager_warmup_points(stub)
+
+    assert [(p.point_type, p.batch_size, p.total_prefill_tokens) for p in replicas] == [
+        ("decode", 513, 0),
+        ("prefill", 1, 1024),
+    ]
+    assert all(p.sample_reasons == [EAGER_WARMUP_REASON] for p in replicas)
+    # originals untouched
+    assert all(EAGER_WARMUP_REASON not in p.sample_reasons for p in grid)

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3398,3 +3398,68 @@ def test_warmup_replica_with_failed_validation_is_discarded_not_skipped():
     assert stub._bench_results == []
     assert stub._bench_skipped_points == []
     assert stub._bench_current_point is None
+
+
+def test_warmup_replica_injection_failure_is_discarded_not_skipped():
+    """A warmup replica that dies BEFORE producing an FPM (decode injection
+    shortfall) must also stay out of skipped-point accounting: every
+    ``_bench_skip_point`` caller shares the central warmup exemption."""
+    point = BenchmarkPoint(
+        point_type="decode",
+        benchmark_id=9,
+        total_kv_read_tokens=48,
+        batch_size=3,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_if_pending = MagicMock(return_value=False)
+    stub._bench_active_req_ids = set()
+    stub._bench_grid = deque([point])
+    stub._bench_current_point = None
+    stub._bench_current_fpms = []
+    stub._bench_skipped_points = []
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_inject_fake_decode = MagicMock(
+        return_value=SimpleNamespace(total_num_scheduled_tokens=0)
+    )
+
+    output = InstrumentedScheduler._bench_step_decode(stub)
+
+    assert output is None
+    assert stub._bench_current_point is None
+    assert stub._bench_skipped_points == []
+    stub._bench_cleanup_requests.assert_called_once_with()
+
+
+def test_skip_point_exempts_warmup_replicas_on_every_path():
+    """The exemption lives in ``_bench_skip_point`` itself, so fake-prefix,
+    injection, and validation failures are all covered; real points still
+    book a skipped entry."""
+    warmup = BenchmarkPoint(
+        point_type="prefill",
+        benchmark_id=1,
+        total_prefill_tokens=64,
+        batch_size=1,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    real = BenchmarkPoint(
+        point_type="prefill",
+        benchmark_id=2,
+        total_prefill_tokens=64,
+        batch_size=1,
+    )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_skipped_points = []
+
+    for reason in (
+        "fake_prefix_cache_allocation_failed",
+        "prefill_injection_failed",
+        "measured_batch_size_mismatch",
+    ):
+        InstrumentedScheduler._bench_skip_point(stub, warmup, reason)
+    assert stub._bench_skipped_points == []
+
+    InstrumentedScheduler._bench_skip_point(stub, real, "prefill_injection_failed")
+    assert stub._bench_skipped_points == [
+        SkippedBenchmarkPoint(point=real, reason="prefill_injection_failed")
+    ]

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -34,6 +34,7 @@ from vllm.v1.request import RequestStatus  # noqa: E402
 import dynamo.vllm.instrumented_scheduler as instrumented_scheduler_module  # noqa: E402
 from dynamo.vllm.benchmark_points import BenchmarkPoints  # noqa: E402
 from dynamo.vllm.instrumented_scheduler import (  # noqa: E402
+    EAGER_WARMUP_REASON,
     BenchmarkConfig,
     BenchmarkPoint,
     InstrumentedScheduler,
@@ -1359,8 +1360,13 @@ def test_benchmark_grid_has_no_point_cap():
     InstrumentedScheduler._bench_build_grid(stub)
 
     assert stub._bench_expected_points == 4097
-    assert len(stub._bench_grid) == 4097
-    assert [point.benchmark_id for point in stub._bench_grid] == list(range(1, 4098))
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    assert len(real_points) == 4097
+    assert [point.benchmark_id for point in real_points] == list(range(1, 4098))
     assert stub._bench_grid_error is None
 
 
@@ -1385,7 +1391,21 @@ def test_benchmark_grid_assigns_stable_contiguous_ids_and_digest():
 
     InstrumentedScheduler._bench_build_grid(stub)
 
-    assert [point.benchmark_id for point in stub._bench_grid] == [1, 2]
+    real_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON not in point.sample_reasons
+    ]
+    warmup_points = [
+        point
+        for point in stub._bench_grid
+        if EAGER_WARMUP_REASON in point.sample_reasons
+    ]
+    # Real points own the contiguous 1..N range (native-artifact contract);
+    # discarded eager-warmup replicas take IDs after the real range even
+    # though they execute first.
+    assert [point.benchmark_id for point in real_points] == [1, 2]
+    assert [point.benchmark_id for point in warmup_points] == [3, 4]
     assert len(stub._bench_grid_digest) == 64
 
 
@@ -1918,6 +1938,44 @@ def test_agg_grid_contains_piecewise_prefill_then_full_decode_points():
         for point in points
         if point.point_type == "decode"
     } == {"FULL"}
+
+
+def test_agg_eager_warmups_stay_contiguous_with_their_phase():
+    """``_bench_pop_next()`` treats a type mismatch at the queue front as
+    "phase complete", so eager warmups of both types prepended as a single
+    run would end PREFILL_SWEEP at the first decode warmup and DECODE_SWEEP
+    at the first real prefill point, silently dropping every real point."""
+    stub = _prefill_grid_stub()
+    stub._bench_grid = deque()
+    stub._bench_grid_built = False
+    stub._bench_missing_phases = []
+    stub._bench_grid_error = None
+    stub._bench_feasible_max_decode_batch_size = 0
+    stub._bench_config.mode = "agg"
+    stub._bench_explicit_points = None
+    # Captures end below the feasible max batch so decode also has eager
+    # shapes; prefill already has them (max tokens 40 > largest capture 16).
+    stub._bench_decode_capture_sizes = [1, 2, 4]
+    stub._bench_decode_cudagraph_mode = "FULL"
+
+    InstrumentedScheduler._bench_build_grid(stub)
+
+    points = list(stub._bench_grid)
+    warmup_types = {
+        point.point_type
+        for point in points
+        if instrumented_scheduler_module.EAGER_WARMUP_REASON in point.sample_reasons
+    }
+    assert warmup_types == {"prefill", "decode"}, "need warmups on both phases"
+
+    # Drain the grid exactly as the phase machine does: prefill until the
+    # front stops matching, then decode.
+    drained = 0
+    for phase in ("prefill", "decode"):
+        while InstrumentedScheduler._bench_pop_next(stub, phase) is not None:
+            drained += 1
+    assert not stub._bench_grid, "phase transitions must consume every point"
+    assert drained == len(points)
 
 
 def test_prefill_kv_read_ladder_is_total_block_aligned():
@@ -3255,3 +3313,65 @@ def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
     stub._bench_current_point = BenchmarkPoint(point_type="decode")
     stub._last_update_time = 0.0  # previous update was an empty step
     assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+
+
+def test_eager_warmup_points_dedupe_and_flag():
+    from types import SimpleNamespace
+
+    from dynamo.vllm.instrumented_scheduler import (
+        EAGER_WARMUP_REASON,
+        BenchmarkPoint,
+        InstrumentedScheduler,
+    )
+
+    grid = [
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=513,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=513,
+            total_kv_read_tokens=2048,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="decode",
+            batch_size=512,
+            total_kv_read_tokens=512,
+            expected_capture_size=512,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=0,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=2,
+            total_prefill_tokens=1024,
+            total_kv_read_tokens=4096,
+            expected_capture_size=None,
+        ),
+        BenchmarkPoint(
+            point_type="prefill",
+            batch_size=1,
+            total_prefill_tokens=256,
+            total_kv_read_tokens=0,
+            expected_capture_size=256,
+        ),
+    ]
+    stub = SimpleNamespace(_bench_grid=grid)
+    replicas = InstrumentedScheduler._bench_eager_warmup_points(stub)
+
+    assert [(p.point_type, p.batch_size, p.total_prefill_tokens) for p in replicas] == [
+        ("decode", 513, 0),
+        ("prefill", 1, 1024),
+    ]
+    assert all(p.sample_reasons == [EAGER_WARMUP_REASON] for p in replicas)
+    # originals untouched
+    assert all(EAGER_WARMUP_REASON not in p.sample_reasons for p in grid)

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3316,14 +3316,7 @@ def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
 
 
 def test_eager_warmup_points_dedupe_and_flag():
-    from types import SimpleNamespace
-
-    from dynamo.vllm.instrumented_scheduler import (
-        EAGER_WARMUP_REASON,
-        BenchmarkPoint,
-        InstrumentedScheduler,
-    )
-
+    EAGER_WARMUP_REASON = instrumented_scheduler_module.EAGER_WARMUP_REASON
     grid = [
         BenchmarkPoint(
             point_type="decode",
@@ -3375,3 +3368,33 @@ def test_eager_warmup_points_dedupe_and_flag():
     assert all(p.sample_reasons == [EAGER_WARMUP_REASON] for p in replicas)
     # originals untouched
     assert all(EAGER_WARMUP_REASON not in p.sample_reasons for p in grid)
+
+
+def test_warmup_replica_with_failed_validation_is_discarded_not_skipped():
+    """A warmup replica whose FPM fails shape validation must be discarded:
+    recording it in skipped_points would mark the whole artifact unusable
+    even though every real measurement succeeded."""
+    point = BenchmarkPoint(
+        point_type="decode",
+        benchmark_id=9,
+        total_kv_read_tokens=48,
+        batch_size=3,
+        sample_reasons=[instrumented_scheduler_module.EAGER_WARMUP_REASON],
+    )
+    stub = _benchmark_save_stub(
+        point,
+        [
+            {
+                "scheduled_requests": {
+                    "num_decode_requests": 3,
+                    "sum_decode_kv_tokens": 47,  # mismatch -> validation failure
+                }
+            }
+        ],
+    )
+
+    InstrumentedScheduler._bench_save_current_point(stub)
+
+    assert stub._bench_results == []
+    assert stub._bench_skipped_points == []
+    assert stub._bench_current_point is None


### PR DESCRIPTION
## Overview:

Self-benchmark points whose shapes fall outside the cudagraph capture range pay a ~1s
first-execution one-off — five consecutive repeats of decode batch 513 read
`[1126, 147, 147, 144, 144]` ms. Captured shapes are immune because capture itself
executes them at startup; eager shapes get no such implicit warmup, and a
single-sample sweep books the one-off as the point's latency, permanently poisoning
that database row (up to 8x on the affected points).

This PR pre-warms every eager shape with a discarded warmup replica, putting eager
and captured points on the same footing.


## Details:

- **`_bench_build_grid` prepends one discarded warmup replica per eager shape**,
  deduped by the shape driver (token count for prefill, batch size for decode) —
  typically a handful of replicas ≈ +10s bring-up. Replicas run the normal
  injection/lockstep/validation path on every rank, so attention-DP grids stay
  identical by construction, and results are dropped at save time.
- **Each warmup block stays contiguous with its phase's real block**
  (`[prefill warmups, prefill points, decode warmups, decode points]`):
  `_bench_pop_next()` treats a type mismatch at the queue front as "phase
  complete", so mixed-type warmups prepended as a single run would end
  PREFILL_SWEEP at the first decode warmup and silently drop every real point in
  agg mode. Covered by `test_agg_eager_warmups_stay_contiguous_with_their_phase`,
  which drains the grid exactly as the phase machine does.
- **Real points are numbered 1..N first** so published benchmark IDs stay
  contiguous (native-artifact contract); warmup replicas take IDs after the real
  range. `counter_id` stamping uses `point.benchmark_id` directly, so execution
  order and ID order are independent.

### Validation (GLM-5.2-NVFP4, 4×B200 attention-DP=4, vLLM 0.25.1)

- The two eager decode points (B=513 / B=1024, min-KV) read **190 / 185 ms (warm)**
  vs 1216 / 1184 ms first-touch before; an independent re-collection reproduced
  **189 / 185 ms** on a coordinate-identical grid.
- Whole-DB curve-neighbor outlier scan (>3× neighborhood median): **0 rows**.
- No sweep-duration regression; warmup replicas verified discarded from published
  artifacts with contiguous real IDs.

## Where should the reviewer start?

- `components/src/dynamo/vllm/instrumented_scheduler.py` —
  `_bench_eager_warmup_points` (docstring carries the rationale), the grid
  regrouping + ID numbering in `_bench_build_grid`, and the save-time discard
- `components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py` —
  `test_agg_eager_warmups_stay_contiguous_with_their_phase`,
  `test_eager_warmup_points_dedupe_and_flag`, and the warmup-ID grid-test
  adaptations

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark startup by warming up replicas for eager-shaped workloads.
  * Prevented warmup-only measurements from being included in benchmark results.
  * Preserved correct phase ordering and timeout handling during benchmark execution.
  * Improved benchmark ID tracking so measurable results remain sequential and accurate.
* **Tests**
  * Added coverage for warmup grouping, deduplication, filtering, and result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->