### PR TITLE
fix(vllm): add env-gated CPython GC freeze policy for FPM self-benchmark

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -359,6 +359,27 @@ def update_engine_config_with_dynamo(
                 f"--scheduler-cls is set to '{existing_cls}'. Either remove "
                 f"--scheduler-cls or use a subclass of InstrumentedScheduler."
             )
+        if os.environ.get("DYN_FPM_GC_POLICY"):
+            # Class path as a literal, not an import: importing
+            # dynamo.vllm.gc_policy auto-starts the policy in the importing
+            # process, and this launcher process must stay untouched.
+            worker_extension_cls = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
+            existing_ext = getattr(engine_config, "worker_extension_cls", None)
+            if not existing_ext:
+                defaults["worker_extension_cls"] = worker_extension_cls
+                logger.info(
+                    "Benchmark mode: DYN_FPM_GC_POLICY set, injecting "
+                    "worker_extension_cls=%s",
+                    worker_extension_cls,
+                )
+            elif str(existing_ext) != worker_extension_cls:
+                raise ValueError(
+                    f"DYN_FPM_GC_POLICY requires "
+                    f"worker_extension_cls='{worker_extension_cls}' so model "
+                    f"workers apply the GC policy, but --worker-extension-cls "
+                    f"is set to '{existing_ext}'. Remove it or unset "
+                    f"DYN_FPM_GC_POLICY."
+                )
         benchmark_config: Dict[str, Any] = {
             "mode": dynamo_config.benchmark_mode,
             "warmup_iterations": dynamo_config.benchmark_warmup_iterations,

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -392,7 +392,7 @@ def update_engine_config_with_dynamo(
                 f"--scheduler-cls is set to '{existing_cls}'. Either remove "
                 f"--scheduler-cls or use a subclass of InstrumentedScheduler."
             )
-        if os.environ.get("DYN_FPM_GC_POLICY"):
+        if os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower() == "freeze":
             # Class path as a literal, not an import: importing
             # dynamo.vllm.gc_policy auto-starts the policy in the importing
             # process, and this launcher process must stay untouched.

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -392,6 +392,27 @@ def update_engine_config_with_dynamo(
                 f"--scheduler-cls is set to '{existing_cls}'. Either remove "
                 f"--scheduler-cls or use a subclass of InstrumentedScheduler."
             )
+        if os.environ.get("DYN_FPM_GC_POLICY"):
+            # Class path as a literal, not an import: importing
+            # dynamo.vllm.gc_policy auto-starts the policy in the importing
+            # process, and this launcher process must stay untouched.
+            worker_extension_cls = "dynamo.vllm.gc_policy.FpmGcWorkerExtension"
+            existing_ext = getattr(engine_config, "worker_extension_cls", None)
+            if not existing_ext:
+                defaults["worker_extension_cls"] = worker_extension_cls
+                logger.info(
+                    "Benchmark mode: DYN_FPM_GC_POLICY set, injecting "
+                    "worker_extension_cls=%s",
+                    worker_extension_cls,
+                )
+            elif str(existing_ext) != worker_extension_cls:
+                raise ValueError(
+                    f"DYN_FPM_GC_POLICY requires "
+                    f"worker_extension_cls='{worker_extension_cls}' so model "
+                    f"workers apply the GC policy, but --worker-extension-cls "
+                    f"is set to '{existing_ext}'. Remove it or unset "
+                    f"DYN_FPM_GC_POLICY."
+                )
         benchmark_config: Dict[str, Any] = {
             "mode": dynamo_config.benchmark_mode,
             "warmup_iterations": dynamo_config.benchmark_warmup_iterations,

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -359,7 +359,7 @@ def update_engine_config_with_dynamo(
                 f"--scheduler-cls is set to '{existing_cls}'. Either remove "
                 f"--scheduler-cls or use a subclass of InstrumentedScheduler."
             )
-        if os.environ.get("DYN_FPM_GC_POLICY"):
+        if os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower() == "freeze":
             # Class path as a literal, not an import: importing
             # dynamo.vllm.gc_policy auto-starts the policy in the importing
             # process, and this launcher process must stay untouched.

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GC pause mitigation for FPM self-benchmarking.
+
+CPython gen2 (full) collections walk every tracked object and trigger on
+the 25% long-lived-growth rule, so their pauses grow with the heap: over a
+30k-point benchmark sweep we measured pauses rising from ~0.4s to ~9s at
+geometrically spaced iteration indices (ratio ~1.23), inside the vLLM
+worker processes. Under TP/DP lockstep a single worker's pause stalls the
+whole forward pass, and with the scheduler's host-side wall_time it lands
+in the measured latency as a 3-200x outlier.
+
+``gc.freeze()`` moves currently tracked objects into the permanent
+generation, excluding them from future collections: after a periodic
+freeze, gen2 only walks objects allocated since the previous tick, so the
+pause is bounded by the allocation rate instead of total heap size.
+The policy's only goal is keeping GC pauses out of measured wall_time:
+automatic gen2 collections are disabled entirely and the periodic tick
+only freezes (no traversal, no pause). Cyclic garbage is therefore NOT
+reclaimed while the policy is active - acceptable for benchmark sweeps;
+long-running processes can reclaim it by calling :func:`gc_maintain`
+from an untimed window.
+
+The policy is env-gated and off by default:
+
+  DYN_FPM_GC_POLICY=freeze        enable the periodic freeze loop
+  DYN_FPM_GC_FREEZE_INTERVAL_S=60 tick interval in seconds
+
+Coverage:
+  * worker processes  - pass ``--worker-extension-cls
+    dynamo.vllm.gc_policy.FpmGcWorkerExtension``; resolving the class
+    imports this module inside every worker, which auto-starts the
+    policy (no collective_rpc required). The RPC methods remain
+    available for explicit control.
+  * engine-core process - ``InstrumentedScheduler`` imports this module,
+    calls :func:`start_gc_policy` when benchmarking starts, and
+    :func:`stop_gc_policy` when it deactivates.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import os
+import threading
+
+logger = logging.getLogger(__name__)
+
+_lock = threading.Lock()
+_started = False
+_stop_event: threading.Event | None = None
+_freeze_thread: threading.Thread | None = None
+_saved_gen2_threshold: int | None = None
+
+
+def _policy() -> str:
+    return os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower()
+
+
+def _interval_seconds() -> float:
+    raw = os.environ.get("DYN_FPM_GC_FREEZE_INTERVAL_S", "60")
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("invalid DYN_FPM_GC_FREEZE_INTERVAL_S=%r, using 60", raw)
+        return 60.0
+    return max(1.0, value)
+
+
+def gc_maintain() -> int:
+    """Reclaim cyclic garbage from an untimed window, then re-freeze.
+
+    Unfreeze first: the periodic ticks freeze unreachable-but-uncollected
+    cycles into the permanent generation, which ``gc.collect()`` never
+    scans. The full-heap walk this costs is why callers must be outside
+    any measured window.
+    """
+    gc.unfreeze()
+    gc.collect()
+    gc.freeze()
+    return gc.get_freeze_count()
+
+
+def _freeze_loop(interval: float, stop: threading.Event) -> None:
+    while not stop.wait(interval):
+        try:
+            # freeze only: O(1) generation-list splice, no heap traversal,
+            # no pause. Never collect on the timer (a periodic collect walks
+            # the unfrozen heap) and never call gc.get_freeze_count() here
+            # (it walks the whole permanent generation: measured 0.4-4s
+            # pauses once millions of objects are frozen).
+            gc.freeze()
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("fpm gc tick failed")
+
+
+def start_gc_policy() -> bool:
+    """Idempotently start the env-gated freeze loop in this process."""
+    global _started, _stop_event, _freeze_thread, _saved_gen2_threshold
+    if _policy() != "freeze":
+        return False
+    with _lock:
+        if _started:
+            return True
+        # One-time setup. Automatic full (gen2) collections are the pause
+        # source: they walk every tracked object and grow with the heap
+        # (measured 0.4s -> 9s over a sweep). Disable them outright; gen0/1
+        # stay enabled and only walk objects younger than the last freeze.
+        t0, t1, _saved_gen2_threshold = gc.get_threshold()
+        gc.set_threshold(t0, t1, 1 << 30)
+        gc.freeze()
+        interval = _interval_seconds()
+        _stop_event = threading.Event()
+        _freeze_thread = threading.Thread(
+            target=_freeze_loop,
+            args=(interval, _stop_event),
+            name="fpm-gc-freeze",
+            daemon=True,
+        )
+        _freeze_thread.start()
+        _started = True
+    logger.info(
+        "FPM GC policy active: auto-gen2 disabled, gc.freeze() every %.0fs (pid=%d)",
+        interval,
+        os.getpid(),
+    )
+    return True
+
+
+def stop_gc_policy() -> None:
+    """Restore normal GC once benchmarking ends: stop the freeze loop,
+    re-enable automatic gen2 collections, and reclaim everything frozen so
+    far. Idempotent; no-op if the policy never started."""
+    global _started, _stop_event, _freeze_thread, _saved_gen2_threshold
+    with _lock:
+        if not _started:
+            return
+        stop_event = _stop_event
+        thread = _freeze_thread
+        saved_gen2_threshold = _saved_gen2_threshold
+        if stop_event is not None:
+            stop_event.set()
+        if saved_gen2_threshold is not None:
+            t0, t1, _ = gc.get_threshold()
+            gc.set_threshold(t0, t1, saved_gen2_threshold)
+        _started = False
+        _stop_event = None
+        _freeze_thread = None
+        _saved_gen2_threshold = None
+    if thread is not None:
+        thread.join(timeout=5.0)
+    gc.unfreeze()
+    gc.collect()
+    logger.info("FPM GC policy stopped: auto-gen2 restored (pid=%d)", os.getpid())
+
+
+class FpmGcWorkerExtension:
+    """vLLM worker extension exposing GC control inside worker processes."""
+
+    def fpm_gc_start(self) -> bool:
+        return start_gc_policy()
+
+    def fpm_gc_stop(self) -> None:
+        return stop_gc_policy()
+
+    def fpm_gc_maintain(self) -> int:
+        return gc_maintain()
+
+
+# Auto-start when a worker process imports this module while resolving
+# worker_extension_cls (args.py injects the class path as a literal for the
+# same reason: importing this module starts the policy in the importing
+# process). The engine-core process instead imports lazily and starts from
+# InstrumentedScheduler._bench_init, so serving without an active benchmark
+# never runs the policy. No-op unless DYN_FPM_GC_POLICY is set.
+start_gc_policy()

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import gc
 import logging
+import math
 import os
 import threading
 
@@ -65,6 +66,9 @@ def _interval_seconds() -> float:
     except ValueError:
         logger.warning("invalid DYN_FPM_GC_FREEZE_INTERVAL_S=%r, using 60", raw)
         return 60.0
+    if not math.isfinite(value):
+        logger.warning("invalid DYN_FPM_GC_FREEZE_INTERVAL_S=%r, using 60", raw)
+        return 60.0
     return max(1.0, value)
 
 
@@ -76,9 +80,13 @@ def gc_maintain() -> int:
     scans. The full-heap walk this costs is why callers must be outside
     any measured window.
     """
-    gc.unfreeze()
-    gc.collect()
-    gc.freeze()
+    # Serialize with the periodic tick: a freeze fired between unfreeze()
+    # and collect() would re-freeze the garbage this call is meant to
+    # reclaim, silently turning the maintenance pass into a no-op.
+    with _lock:
+        gc.unfreeze()
+        gc.collect()
+        gc.freeze()
     return gc.get_freeze_count()
 
 
@@ -89,10 +97,13 @@ def _freeze_loop(interval: float, stop: threading.Event) -> None:
             # no pause. Never collect on the timer (a periodic collect walks
             # the unfrozen heap) and never call gc.get_freeze_count() here
             # (it walks the whole permanent generation: measured 0.4-4s
-            # pauses once millions of objects are frozen).
-            gc.freeze()
+            # pauses once millions of objects are frozen). Serialized with
+            # gc_maintain() through _lock.
+            with _lock:
+                gc.freeze()
         except Exception:  # pragma: no cover - defensive
-            logger.exception("fpm gc tick failed")
+            logger.exception("fpm gc tick failed; freeze loop exiting")
+            raise
 
 
 def start_gc_policy() -> bool:

--- a/components/src/dynamo/vllm/gc_policy.py
+++ b/components/src/dynamo/vllm/gc_policy.py
@@ -140,9 +140,18 @@ def start_gc_policy() -> bool:
 
 
 def stop_gc_policy() -> None:
-    """Restore normal GC once benchmarking ends: stop the freeze loop,
-    re-enable automatic gen2 collections, and reclaim everything frozen so
-    far. Idempotent; no-op if the policy never started."""
+    """Restore the serving GC state once benchmarking ends.
+
+    Stops the freeze loop, re-enables automatic gen2 collections, reclaims
+    the benchmark-era garbage (including cycles the periodic ticks froze),
+    and then re-establishes vLLM's own serving freeze. vLLM deliberately
+    freezes the EngineCore startup heap and each GPU worker's post-warmup
+    heap (``vllm.utils.gc_utils.freeze_gc_heap``: collect every generation,
+    then ``gc.freeze()``) so gen2 never scans model weights, KV caches, or
+    CUDA graphs during inference; a bare ``gc.unfreeze()`` here would strip
+    that baseline and leave the process paying larger gen2 pauses than one
+    that never benchmarked. Idempotent; no-op if the policy never started.
+    """
     global _started, _stop_event, _freeze_thread, _saved_gen2_threshold
     with _lock:
         if not _started:
@@ -161,9 +170,24 @@ def stop_gc_policy() -> None:
         _saved_gen2_threshold = None
     if thread is not None:
         thread.join(timeout=5.0)
-    gc.unfreeze()
-    gc.collect()
-    logger.info("FPM GC policy stopped: auto-gen2 restored (pid=%d)", os.getpid())
+    # Serialized like gc_maintain(): a late tick must not interleave with
+    # the unfreeze/collect/freeze sequence.
+    with _lock:
+        gc.unfreeze()
+        gc.collect()
+        # Mirror freeze_gc_heap(): a full collection has already promoted
+        # every survivor to the oldest generation, so freezing now pins the
+        # static serving heap vLLM intended to exclude from collection plus
+        # whatever benchmark-era objects are still alive at this point (a
+        # small superset of the baseline; anything in it that dies later is
+        # never reclaimed, which matches the behaviour of vLLM's own freeze
+        # for long-lived startup objects).
+        gc.freeze()
+    logger.info(
+        "FPM GC policy stopped: auto-gen2 restored, serving freeze "
+        "re-established (pid=%d)",
+        os.getpid(),
+    )
 
 
 class FpmGcWorkerExtension:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2022,6 +2022,10 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_active = False
             return
 
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.start_gc_policy()
+
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
         raw_mode = cfg.get("mode", "agg")
         if not isinstance(raw_mode, str) or raw_mode not in BENCHMARK_MODES:
@@ -3681,6 +3685,11 @@ class InstrumentedScheduler(AsyncScheduler):
         self._last_update_time = 0.0
         if resume_publisher:
             self._publisher.resume()
+        # Benchmark over: re-enable automatic gen2 collections and reclaim
+        # the frozen heap before regular serving resumes.
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.stop_gc_policy()
 
     def _bench_abort(self, error: Exception) -> None:
         if self._bench_synchronizer is not None:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2022,10 +2022,6 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_active = False
             return
 
-        from dynamo.vllm import gc_policy as _fpm_gc_policy
-
-        _fpm_gc_policy.start_gc_policy()
-
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
         raw_mode = cfg.get("mode", "agg")
         if not isinstance(raw_mode, str) or raw_mode not in BENCHMARK_MODES:
@@ -2268,6 +2264,12 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_cudagraph_mode,
             self._bench_cudagraph_capture_sizes,
         )
+
+        # Started last so a config validation error above never leaves the
+        # engine-core process with automatic gen2 collection disabled.
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.start_gc_policy()
 
     # -- Grid generation ------------------------------------------------
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1657,6 +1657,10 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_active = False
             return
 
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.start_gc_policy()
+
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
         raw_mode = cfg.get("mode", "agg")
         if not isinstance(raw_mode, str) or raw_mode not in BENCHMARK_MODES:
@@ -2930,6 +2934,11 @@ class InstrumentedScheduler(AsyncScheduler):
         self._last_update_time = 0.0
         if resume_publisher:
             self._publisher.resume()
+        # Benchmark over: re-enable automatic gen2 collections and reclaim
+        # the frozen heap before regular serving resumes.
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.stop_gc_policy()
 
     def _bench_abort(self, error: Exception) -> None:
         if self._bench_synchronizer is not None:

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -1657,10 +1657,6 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_active = False
             return
 
-        from dynamo.vllm import gc_policy as _fpm_gc_policy
-
-        _fpm_gc_policy.start_gc_policy()
-
         cfg = bench_cfg if isinstance(bench_cfg, dict) else {}
         raw_mode = cfg.get("mode", "agg")
         if not isinstance(raw_mode, str) or raw_mode not in BENCHMARK_MODES:
@@ -1879,6 +1875,12 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_cudagraph_mode,
             self._bench_cudagraph_capture_sizes,
         )
+
+        # Started last so a config validation error above never leaves the
+        # engine-core process with automatic gen2 collection disabled.
+        from dynamo.vllm import gc_policy as _fpm_gc_policy
+
+        _fpm_gc_policy.start_gc_policy()
 
     # -- Grid generation ------------------------------------------------
 

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import gc
+import importlib
+import weakref
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _fresh_module(monkeypatch, policy: str | None):
+    if policy is None:
+        monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
+    else:
+        monkeypatch.setenv("DYN_FPM_GC_POLICY", policy)
+    import dynamo.vllm.gc_policy as gc_policy
+
+    return importlib.reload(gc_policy)
+
+
+def test_policy_off_by_default(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    assert gc_policy.start_gc_policy() is False
+
+
+def test_policy_starts_and_is_idempotent(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    try:
+        assert gc_policy.start_gc_policy() is True
+        assert gc_policy.start_gc_policy() is True
+        assert gc.get_threshold()[2] == 1 << 30, "auto gen2 must be disabled"
+    finally:
+        gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds, "stop must restore the thresholds"
+
+
+def test_stop_is_idempotent_and_allows_restart(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    assert gc_policy.start_gc_policy() is True
+    gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds
+    gc_policy.stop_gc_policy()  # no-op when already stopped
+    assert gc.get_threshold() == thresholds
+    assert gc_policy.start_gc_policy() is True, "restart after stop"
+    gc_policy.stop_gc_policy()
+    assert gc.get_threshold() == thresholds
+
+
+def test_gc_maintain_freezes_objects(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    gc.unfreeze()
+    try:
+        frozen = gc_policy.gc_maintain()
+        assert frozen > 0
+        assert frozen == gc.get_freeze_count()
+    finally:
+        gc.unfreeze()
+
+
+def test_gc_maintain_reclaims_cycles_frozen_by_earlier_ticks(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+
+    class Node:
+        pass
+
+    gc.disable()
+    try:
+        node = Node()
+        node.self_ref = node
+        ref = weakref.ref(node)
+        del node
+        # Simulate a periodic tick freezing the still-uncollected cycle
+        # into the permanent generation.
+        gc.freeze()
+        gc_policy.gc_maintain()
+        assert ref() is None, "cycles frozen by a tick must still be reclaimed"
+    finally:
+        gc.enable()
+        gc.unfreeze()
+
+
+def test_worker_extension_methods(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    ext = gc_policy.FpmGcWorkerExtension()
+    assert ext.fpm_gc_start() is False
+    gc.unfreeze()
+    try:
+        assert ext.fpm_gc_maintain() > 0
+    finally:
+        gc.unfreeze()
+
+
+def test_invalid_interval_falls_back(monkeypatch):
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "not-a-number")
+    gc_policy = _fresh_module(monkeypatch, None)
+    assert gc_policy._interval_seconds() == 60.0

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -111,6 +111,78 @@ def test_worker_extension_methods(monkeypatch):
         gc.unfreeze()
 
 
+def _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds):
+    """The bar for both completion paths: a worker that ran the policy must
+    be indistinguishable from one that never did."""
+    assert gc.get_threshold() == thresholds
+    assert gc.isenabled()
+    assert gc_policy._started is False
+    thread = gc_policy._freeze_thread
+    assert thread is None or not thread.is_alive()
+
+    class Node:
+        pass
+
+    node = Node()
+    node.self_ref = node
+    ref = weakref.ref(node)
+    del node
+    gc.collect()
+    assert ref() is None, "cyclic garbage must be reclaimable again"
+
+
+def test_worker_lifecycle_normal_completion_restores_gc(monkeypatch):
+    """Normal completion path: the launcher's collective_rpc reaches
+    ``FpmGcWorkerExtension.fpm_gc_stop`` in each worker; afterwards the
+    worker must be GC-equivalent to one that never benchmarked, including
+    reclamation of cycles frozen while the policy was active."""
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    ext = gc_policy.FpmGcWorkerExtension()
+    try:
+        assert ext.fpm_gc_start() is True
+        assert gc.get_threshold()[2] == 1 << 30
+
+        class Node:
+            pass
+
+        node = Node()
+        node.self_ref = node
+        ref = weakref.ref(node)
+        del node
+        # A periodic tick freezes the uncollected cycle: with auto gen2
+        # disabled it is now unreachable garbage that only stop() reclaims.
+        with gc_policy._lock:
+            gc.freeze()
+        gc.collect()
+        assert ref() is not None, "policy must pin the frozen cycle"
+
+        ext.fpm_gc_stop()
+        assert ref() is None, "stop must reclaim cycles frozen by ticks"
+    finally:
+        gc_policy.stop_gc_policy()
+    _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds)
+
+
+def test_worker_lifecycle_after_abort_restores_gc(monkeypatch):
+    """Abort path: ``_bench_abort`` still writes rank artifacts, so the
+    launcher's benchmark wait completes and issues the same
+    ``fpm_gc_stop``; the worker-side contract is identical to normal
+    completion even when the stop races a mid-flight maintenance call."""
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    ext = gc_policy.FpmGcWorkerExtension()
+    try:
+        assert ext.fpm_gc_start() is True
+        gc_policy.gc_maintain()  # abort may interrupt an untimed window
+        ext.fpm_gc_stop()
+    finally:
+        gc_policy.stop_gc_policy()
+    _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds)
+
+
 def test_invalid_interval_falls_back(monkeypatch):
     monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "not-a-number")
     gc_policy = _fresh_module(monkeypatch, None)

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -16,13 +16,19 @@ pytestmark = [
 
 
 def _fresh_module(monkeypatch, policy: str | None):
-    if policy is None:
-        monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
-    else:
-        monkeypatch.setenv("DYN_FPM_GC_POLICY", policy)
+    # Reload with the policy disabled: the module-tail autostart firing
+    # during import/reload would rebuild the module globals and leak the
+    # previously started daemon thread plus the disabled gen2 threshold
+    # when a freeze test runs in isolation. Tests start the policy
+    # explicitly after the reload.
+    monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
     import dynamo.vllm.gc_policy as gc_policy
 
-    return importlib.reload(gc_policy)
+    gc_policy.stop_gc_policy()
+    gc_policy = importlib.reload(gc_policy)
+    if policy is not None:
+        monkeypatch.setenv("DYN_FPM_GC_POLICY", policy)
+    return gc_policy
 
 
 def test_policy_off_by_default(monkeypatch):

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -47,13 +47,17 @@ def test_stop_is_idempotent_and_allows_restart(monkeypatch):
     monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
     thresholds = gc.get_threshold()
     gc_policy = _fresh_module(monkeypatch, "freeze")
-    assert gc_policy.start_gc_policy() is True
-    gc_policy.stop_gc_policy()
-    assert gc.get_threshold() == thresholds
-    gc_policy.stop_gc_policy()  # no-op when already stopped
-    assert gc.get_threshold() == thresholds
-    assert gc_policy.start_gc_policy() is True, "restart after stop"
-    gc_policy.stop_gc_policy()
+    try:
+        assert gc_policy.start_gc_policy() is True
+        gc_policy.stop_gc_policy()
+        assert gc.get_threshold() == thresholds
+        gc_policy.stop_gc_policy()  # no-op when already stopped
+        assert gc.get_threshold() == thresholds
+        assert gc_policy.start_gc_policy() is True, "restart after stop"
+    finally:
+        # An assertion failure above must not leak the daemon thread or the
+        # disabled gen2 threshold into subsequent tests.
+        gc_policy.stop_gc_policy()
     assert gc.get_threshold() == thresholds
 
 
@@ -105,3 +109,10 @@ def test_invalid_interval_falls_back(monkeypatch):
     monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "not-a-number")
     gc_policy = _fresh_module(monkeypatch, None)
     assert gc_policy._interval_seconds() == 60.0
+
+
+def test_non_finite_interval_falls_back(monkeypatch):
+    gc_policy = _fresh_module(monkeypatch, None)
+    for raw in ("inf", "-inf", "nan"):
+        monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", raw)
+        assert gc_policy._interval_seconds() == 60.0

--- a/components/src/dynamo/vllm/tests/test_gc_policy.py
+++ b/components/src/dynamo/vllm/tests/test_gc_policy.py
@@ -3,6 +3,8 @@
 
 import gc
 import importlib
+import json
+import os
 import weakref
 
 import pytest
@@ -165,24 +167,6 @@ def test_worker_lifecycle_normal_completion_restores_gc(monkeypatch):
     _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds)
 
 
-def test_worker_lifecycle_after_abort_restores_gc(monkeypatch):
-    """Abort path: ``_bench_abort`` still writes rank artifacts, so the
-    launcher's benchmark wait completes and issues the same
-    ``fpm_gc_stop``; the worker-side contract is identical to normal
-    completion even when the stop races a mid-flight maintenance call."""
-    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
-    thresholds = gc.get_threshold()
-    gc_policy = _fresh_module(monkeypatch, "freeze")
-    ext = gc_policy.FpmGcWorkerExtension()
-    try:
-        assert ext.fpm_gc_start() is True
-        gc_policy.gc_maintain()  # abort may interrupt an untimed window
-        ext.fpm_gc_stop()
-    finally:
-        gc_policy.stop_gc_policy()
-    _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds)
-
-
 def test_invalid_interval_falls_back(monkeypatch):
     monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "not-a-number")
     gc_policy = _fresh_module(monkeypatch, None)
@@ -194,3 +178,134 @@ def test_non_finite_interval_falls_back(monkeypatch):
     for raw in ("inf", "-inf", "nan"):
         monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", raw)
         assert gc_policy._interval_seconds() == 60.0
+
+
+def test_stop_reestablishes_vllm_serving_freeze(monkeypatch):
+    """vLLM freezes the serving heap after startup/warmup (freeze_gc_heap)
+    so gen2 never scans model, KV-cache, or CUDA-graph objects. Stopping
+    the policy must reclaim benchmark garbage and then put that baseline
+    freeze back, not leave the whole heap unfrozen."""
+    monkeypatch.setenv("DYN_FPM_GC_FREEZE_INTERVAL_S", "3600")
+    thresholds = gc.get_threshold()
+    gc_policy = _fresh_module(monkeypatch, "freeze")
+    ext = gc_policy.FpmGcWorkerExtension()
+    try:
+        # Worker ordering: the policy auto-starts on extension import, and
+        # vLLM's post-warmup freeze lands afterwards.
+        assert ext.fpm_gc_start() is True
+
+        # A GC-tracked stand-in for a static serving object. Plain object()
+        # instances and atomic-only dicts are untracked in CPython and would
+        # make the visibility assertion below vacuous.
+        class Static:
+            pass
+
+        sentinel = Static()
+        assert gc.is_tracked(sentinel)
+        gc.collect()
+        gc.freeze()
+        assert gc.get_freeze_count() > 0
+
+        class Node:
+            pass
+
+        node = Node()
+        node.self_ref = node
+        ref = weakref.ref(node)
+        del node
+        with gc_policy._lock:
+            gc.freeze()  # a tick pins the benchmark-era cycle
+
+        ext.fpm_gc_stop()
+
+        assert ref() is None, "benchmark garbage must be reclaimed"
+        # gc.get_objects() walks generations 0-2 only, never the permanent
+        # generation: a live baseline object that is absent from it has been
+        # re-frozen. The pre-fix stop (unfreeze without re-freeze) leaves the
+        # sentinel visible here.
+        assert not any(
+            obj is sentinel for obj in gc.get_objects()
+        ), "serving freeze was not re-established after stop"
+    finally:
+        gc_policy.stop_gc_policy()
+        gc.unfreeze()  # do not leave the pytest heap frozen for later tests
+    _assert_gc_equivalent_to_never_benchmarked(gc_policy, thresholds)
+
+
+_LIFECYCLE_CHILD = r"""
+import gc, json, os, sys, weakref
+os.environ["DYN_FPM_GC_POLICY"] = "freeze"
+os.environ["DYN_FPM_GC_FREEZE_INTERVAL_S"] = "3600"
+baseline_thresholds = gc.get_threshold()
+
+# Worker semantics: importing the extension module auto-starts the policy.
+import dynamo.vllm.gc_policy as gc_policy
+ext = gc_policy.FpmGcWorkerExtension()
+thread = gc_policy._freeze_thread
+assert thread is not None and thread.is_alive()
+
+# vLLM's post-warmup serving freeze happens after the policy is already on.
+class Static:
+    pass
+
+sentinel = Static()  # GC-tracked stand-in for model/KV/CUDA-graph objects
+assert gc.is_tracked(sentinel)
+gc.collect()
+gc.freeze()
+assert gc.get_freeze_count() > 0
+
+class Node:
+    pass
+
+node = Node()
+node.self_ref = node
+bench_cycle = weakref.ref(node)
+del node
+with gc_policy._lock:
+    gc.freeze()  # periodic tick pins the benchmark-era cycle
+
+ext.fpm_gc_stop()  # what the launcher's collective_rpc("fpm_gc_stop") runs
+
+probe = Node()
+probe.self_ref = probe
+new_cycle = weakref.ref(probe)
+del probe
+gc.collect()
+
+print(json.dumps({
+    "thresholds_restored": gc.get_threshold() == baseline_thresholds,
+    "enabled": gc.isenabled(),
+    "thread_dead": not thread.is_alive(),
+    # permanent-generation membership: absent from gc.get_objects() == frozen
+    "freeze_reestablished": not any(o is sentinel for o in gc.get_objects()),
+    "benchmark_cycle_reclaimed": bench_cycle() is None,
+    "new_cycle_collectible": new_cycle() is None,
+    "policy_stopped": gc_policy._started is False,
+}))
+"""
+
+
+def test_worker_process_gc_equivalent_after_stop():
+    """Process-level equivalence check in a fresh interpreter mirroring a
+    model worker (policy auto-started on import, vLLM serving freeze applied
+    afterwards): after ``fpm_gc_stop`` the worker's GC state matches a process
+    that never benchmarked (thresholds, enabled flag, dead freeze thread,
+    serving freeze at least as large as the baseline) and both benchmark-era
+    garbage and new cycles are collectible. The normal-vs-abort distinction
+    lives in the launcher and is covered in test_vllm_worker_factory.py with
+    a real ``status=failed`` artifact driving the failure path."""
+    import subprocess
+    import sys
+
+    env = {k: v for k, v in os.environ.items() if not k.startswith("DYN_FPM_GC")}
+    result = subprocess.run(
+        [sys.executable, "-c", _LIFECYCLE_CHILD],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout.strip().splitlines()[-1])
+    failed = {k: v for k, v in report.items() if v is not True}
+    assert not failed, failed

--- a/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
@@ -159,3 +159,19 @@ def test_request_exposes_all_token_ids():
         "vllm.v1.request.Request no longer exposes `_all_token_ids` — "
         "InstrumentedScheduler relies on it for NewRequestData.prefill_token_ids."
     )
+
+
+def test_vllm_freezes_serving_heap_with_freeze_gc_heap():
+    """``dynamo.vllm.gc_policy.stop_gc_policy`` re-establishes vLLM's serving
+    freeze after a benchmark by mirroring ``freeze_gc_heap`` (collect, then
+    ``gc.freeze()``). If vLLM drops or renames that baseline, the mirrored
+    re-freeze must be revisited rather than silently diverge."""
+    from vllm.utils.gc_utils import freeze_gc_heap
+    from vllm.v1.engine.core import EngineCore
+    from vllm.v1.worker.gpu_worker import Worker
+
+    assert callable(freeze_gc_heap)
+    # The re-freeze only makes sense while vLLM itself installs the baseline
+    # in both processes the benchmark touches.
+    assert "freeze_gc_heap()" in inspect.getsource(EngineCore.__init__)
+    assert "freeze_gc_heap()" in inspect.getsource(Worker)

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -17,6 +17,7 @@ from dynamo.vllm.worker_factory import (
     EngineSetupResult,
     WorkerFactory,
     _DecodeWorkerLifecycle,
+    _stop_worker_gc_policy,
     _wait_and_load_benchmark,
 )
 
@@ -385,6 +386,42 @@ async def test_wait_and_load_benchmark_rejects_invalid_results(monkeypatch, tmp_
             {"output_path": str(output_path), "timeout": 1}, Mock()
         )
     assert "missing_phases=['decode']" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_rpcs_every_worker(monkeypatch):
+    """After the benchmark wait, the launcher must stop the GC policy in
+    every model worker (workers auto-start it on extension import) and hold
+    serving until the RPC completes."""
+    monkeypatch.setenv("DYN_FPM_GC_POLICY", "freeze")
+    engine_client = SimpleNamespace(collective_rpc=AsyncMock())
+
+    await _stop_worker_gc_policy(engine_client)
+
+    engine_client.collective_rpc.assert_awaited_once_with("fpm_gc_stop")
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_noop_when_policy_disabled(monkeypatch):
+    monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
+    engine_client = SimpleNamespace(collective_rpc=AsyncMock())
+
+    await _stop_worker_gc_policy(engine_client)
+
+    engine_client.collective_rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_failure_propagates(monkeypatch):
+    """Serving on workers that are not GC-equivalent to never-benchmarked
+    ones must not silently proceed."""
+    monkeypatch.setenv("DYN_FPM_GC_POLICY", "freeze")
+    engine_client = SimpleNamespace(
+        collective_rpc=AsyncMock(side_effect=RuntimeError("worker died"))
+    )
+
+    with pytest.raises(RuntimeError, match="worker died"):
+        await _stop_worker_gc_policy(engine_client)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -16,6 +16,7 @@ from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.worker_factory import (
     EngineSetupResult,
     WorkerFactory,
+    _await_benchmark_then_restore_workers,
     _DecodeWorkerLifecycle,
     _stop_worker_gc_policy,
     _wait_and_load_benchmark,
@@ -1265,3 +1266,449 @@ async def test_embedding_worker_registration_and_cleanup(
     assert register_vllm_model.await_args.args[0] == expected_model_input
     assert cleanup_order == ["handler", "client", "resource"]
     assert shutdown_endpoints == [endpoint]
+
+
+@pytest.mark.asyncio
+async def test_benchmark_wait_success_stops_workers_then_returns(monkeypatch):
+    calls = []
+
+    async def fake_wait(_cfg, _vllm_config):
+        calls.append("wait")
+        return {"status": "complete"}
+
+    async def fake_stop(_client):
+        calls.append("stop")
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+
+    results = await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+    assert results == {"status": "complete"}
+    assert calls == ["wait", "stop"]
+
+
+@pytest.mark.asyncio
+async def test_benchmark_wait_failure_still_stops_workers_and_preserves_error(
+    monkeypatch,
+):
+    """An aborted benchmark publishes status=failed, so the wait raises during
+    validation; the worker GC stop must still run and the original error must
+    reach the caller unchanged."""
+    calls = []
+    original = RuntimeError("Self-benchmark produced incomplete results")
+
+    async def fake_wait(_cfg, _vllm_config):
+        raise original
+
+    async def fake_stop(_client):
+        calls.append("stop")
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+    assert exc_info.value is original
+    assert calls == ["stop"]
+
+
+@pytest.mark.asyncio
+async def test_benchmark_wait_failure_logs_stop_failure_and_keeps_original(
+    monkeypatch, caplog
+):
+    original = TimeoutError("Self-benchmark did not publish results")
+
+    async def fake_wait(_cfg, _vllm_config):
+        raise original
+
+    async def fake_stop(_client):
+        raise RuntimeError("worker died")
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(TimeoutError) as exc_info:
+        await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+    assert exc_info.value is original
+    assert "Failed to stop the FPM GC policy" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_benchmark_wait_success_fails_closed_when_stop_fails(monkeypatch):
+    async def fake_wait(_cfg, _vllm_config):
+        return {"status": "complete"}
+
+    async def fake_stop(_client):
+        raise RuntimeError("worker died")
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+
+    with pytest.raises(RuntimeError, match="worker died"):
+        await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+
+@pytest.mark.asyncio
+async def test_worker_gc_restore_completes_before_model_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serving must not start on workers that still run the benchmark GC
+    policy: the launcher awaits the worker stop RPC after the benchmark wait
+    and before register_model publishes the worker as ready."""
+    order: list[str] = []
+    stop_after_register = RuntimeError("stop-after-register")
+
+    async def fake_wait(_cfg, _vllm_config):
+        order.append("wait")
+        return {"status": "complete"}
+
+    async def fake_stop(_client):
+        order.append("stop")
+
+    async def fake_register_vllm_model(*_args, **_kwargs) -> None:
+        order.append("register")
+        raise stop_after_register
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+
+    engine_client = Mock()
+    vllm_config = Mock()
+    vllm_config.additional_config = {
+        "benchmark": {"output_path": "/tmp/bench.json", "timeout": 1}
+    }
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        Mock(),
+    )
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(return_value=None),
+        register_vllm_model_fn=fake_register_vllm_model,
+        setup_fpm_relay_fn=Mock(return_value=None),
+        setup_metrics_collection_fn=Mock(),
+    )
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
+    factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[assignment]
+    factory.register_engine_routes = Mock()  # type: ignore[assignment]
+    mock_handler = Mock(embedding_cache_manager=None)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.PrefillWorkerHandler",
+        Mock(return_value=mock_handler),
+    )
+
+    async def _noop(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+    config = _make_config(
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        use_vllm_tokenizer=False,
+        namespace="dyn",
+        component="prefill",
+        endpoint="generate",
+        served_model_name="m",
+        model="m",
+        frontend_decoding=False,
+        enable_multimodal=False,
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False),
+    )
+    runtime = Mock()
+    runtime.endpoint.return_value = Mock(connection_id=Mock(return_value="cid"))
+
+    with pytest.raises(RuntimeError, match="stop-after-register"):
+        await factory._create_prefill_worker(runtime, config, asyncio.Event(), [])
+
+    assert order == ["wait", "stop", "register"]
+    assert mock_handler._benchmark_results == {"status": "complete"}
+
+
+@pytest.mark.asyncio
+async def test_aborted_benchmark_artifact_still_stops_workers(monkeypatch, tmp_path):
+    """The real abort chain: ``_bench_abort`` publishes a ``status="failed"``
+    rank artifact, ``_wait_and_load_benchmark`` rejects it during validation,
+    and the worker GC stop must still be issued with the validation error
+    propagating unchanged. Only the RPC is faked; the wait and validation
+    are the production code paths."""
+    output_path = tmp_path / "benchmark.json"
+    output_path.write_text(
+        json.dumps({"status": "failed", "valid": False, "error": "benchmark aborted"})
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 1)
+    )
+    stop = AsyncMock()
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", stop)
+
+    with pytest.raises(RuntimeError, match="incomplete results"):
+        await _await_benchmark_then_restore_workers(
+            {"output_path": str(output_path), "timeout": 1}, Mock(), Mock()
+        )
+
+    stop.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failure_path_stop_is_time_boxed_and_original_error_wins(
+    monkeypatch, caplog
+):
+    """If the engine died, the stop RPC never answers; the launcher must not
+    hang on the error path -- the wait times out, is logged, and the original
+    benchmark error propagates."""
+    original = RuntimeError("Self-benchmark produced incomplete results")
+
+    async def fake_wait(_cfg, _vllm_config):
+        raise original
+
+    async def hanging_stop(_client):
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._stop_worker_gc_policy", hanging_stop
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.WORKER_GC_STOP_TIMEOUT_SECONDS", 0.05
+    )
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+    assert exc_info.value is original
+    assert "Failed to stop the FPM GC policy" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_success_path_stop_timeout_fails_closed(monkeypatch):
+    async def fake_wait(_cfg, _vllm_config):
+        return {"status": "complete"}
+
+    async def hanging_stop(_client):
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._stop_worker_gc_policy", hanging_stop
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.WORKER_GC_STOP_TIMEOUT_SECONDS", 0.05
+    )
+
+    with pytest.raises(asyncio.TimeoutError):
+        await _await_benchmark_then_restore_workers({}, Mock(), Mock())
+
+
+@pytest.mark.asyncio
+async def test_prefill_call_site_stops_workers_when_benchmark_wait_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression guard for the call site itself: with the old two-line
+    form (wait, then stop) a raising wait skips the stop. Drive the real
+    prefill startup path with a raising wait and require the stop."""
+    order: list[str] = []
+    benchmark_error = RuntimeError("Self-benchmark produced incomplete results")
+
+    async def fake_wait(_cfg, _vllm_config):
+        order.append("wait")
+        raise benchmark_error
+
+    async def fake_stop(_client):
+        order.append("stop")
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+
+    engine_client = Mock()
+    vllm_config = Mock()
+    vllm_config.additional_config = {
+        "benchmark": {"output_path": "/tmp/bench.json", "timeout": 1}
+    }
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        Mock(),
+    )
+    register = AsyncMock()
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(return_value=None),
+        register_vllm_model_fn=register,
+        setup_fpm_relay_fn=Mock(return_value=None),
+        setup_metrics_collection_fn=Mock(),
+    )
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
+    factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[assignment]
+    factory.register_engine_routes = Mock()  # type: ignore[assignment]
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.PrefillWorkerHandler",
+        Mock(return_value=Mock(embedding_cache_manager=None)),
+    )
+
+    async def _noop(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+    config = _make_config(
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        use_vllm_tokenizer=False,
+        namespace="dyn",
+        component="prefill",
+        endpoint="generate",
+        served_model_name="m",
+        model="m",
+        frontend_decoding=False,
+        enable_multimodal=False,
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False),
+    )
+    runtime = Mock()
+    runtime.endpoint.return_value = Mock(connection_id=Mock(return_value="cid"))
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await factory._create_prefill_worker(runtime, config, asyncio.Event(), [])
+
+    assert exc_info.value is benchmark_error
+    assert order == ["wait", "stop"]
+    register.assert_not_awaited()
+
+
+def _decode_benchmark_factory(monkeypatch, tmp_path, register_fn):
+    """Decode-path harness with a benchmark config: engine setup, handler,
+    stat logger, KV sizing, and encode/failover collaborators are stubbed so
+    the run reaches the benchmark wait (the stop-before-registration ordering
+    is pinned on the prefill path, which shares the same wrapper call)."""
+    engine_client = Mock()
+    vllm_config = SimpleNamespace(
+        additional_config={
+            "benchmark": {"output_path": str(tmp_path / "bench.json"), "timeout": 1}
+        },
+        cache_config=SimpleNamespace(num_gpu_blocks=1),
+        model_config=SimpleNamespace(max_model_len=1024),
+        shutdown_timeout=5.0,
+    )
+    engine_setup: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        str(tmp_path / "prometheus"),
+        Mock(),
+    )
+    factory = _make_factory(
+        setup_vllm_engine_fn=Mock(return_value=engine_setup),
+        register_vllm_model_fn=register_fn,
+    )
+    factory._maybe_create_failover_metrics = Mock(return_value=None)  # type: ignore[method-assign]
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[method-assign]
+    factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[method-assign]
+    factory.register_engine_routes = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory", Mock(return_value=Mock())
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 1)
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.per_rank_kv_blocks",
+        lambda _num_blocks, _dp_size: 1,
+    )
+
+    async def _noop(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.DecodeWorkerHandler",
+        Mock(return_value=Mock(embedding_cache_manager=None)),
+    )
+    runtime = Mock()
+    runtime.endpoint.return_value = Mock(connection_id=Mock(return_value="worker-id"))
+    # Mock-backed config (as in the prefill registration tests) so attributes
+    # read after the benchmark wait resolve instead of raising AttributeError.
+    config = _make_config(
+        namespace="dynamo",
+        component="backend",
+        endpoint="generate",
+        disaggregation_mode=DisaggregationMode.AGGREGATED,
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=False),
+        enable_multimodal=False,
+        route_to_encoder=False,
+        custom_encoder_class=None,
+        use_vllm_tokenizer=False,
+        frontend_decoding=False,
+        served_model_name="m",
+        model="m",
+        endpoint_types="chat,completions",
+        dyn_endpoint_types="chat,completions",
+        custom_jinja_template=None,
+    )
+    return factory, runtime, config, engine_client
+
+
+@pytest.mark.asyncio
+async def test_decode_call_site_stops_workers_when_benchmark_wait_raises(
+    monkeypatch, tmp_path
+):
+    """Regression guard on the decode call site: a raising wait must still
+    reach the worker stop (the old two-line form skipped it), the original
+    error must propagate, registration must not happen, and the lifecycle
+    must still tear the engine down afterwards."""
+    order: list[str] = []
+    benchmark_error = RuntimeError("Self-benchmark produced incomplete results")
+
+    async def fake_wait(_cfg, _vllm_config):
+        order.append("wait")
+        raise benchmark_error
+
+    async def fake_stop(_client):
+        order.append("stop")
+
+    register = AsyncMock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory._wait_and_load_benchmark", fake_wait
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory._stop_worker_gc_policy", fake_stop)
+    factory, runtime, config, engine_client = _decode_benchmark_factory(
+        monkeypatch, tmp_path, register
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await factory._create_decode_worker(runtime, config, asyncio.Event(), [])
+
+    assert exc_info.value is benchmark_error
+    assert order == ["wait", "stop"]
+    register.assert_not_awaited()
+    engine_client.shutdown.assert_called_once_with(timeout=5.0)

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -16,6 +16,7 @@ from dynamo.vllm.constants import DisaggregationMode
 from dynamo.vllm.worker_factory import (
     EngineSetupResult,
     WorkerFactory,
+    _stop_worker_gc_policy,
     _wait_and_load_benchmark,
 )
 
@@ -119,6 +120,42 @@ async def test_wait_and_load_benchmark_rejects_invalid_results(monkeypatch, tmp_
             {"output_path": str(output_path), "timeout": 1}, Mock()
         )
     assert "missing_phases=['decode']" in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_rpcs_every_worker(monkeypatch):
+    """After the benchmark wait, the launcher must stop the GC policy in
+    every model worker (workers auto-start it on extension import) and hold
+    serving until the RPC completes."""
+    monkeypatch.setenv("DYN_FPM_GC_POLICY", "freeze")
+    engine_client = SimpleNamespace(collective_rpc=AsyncMock())
+
+    await _stop_worker_gc_policy(engine_client)
+
+    engine_client.collective_rpc.assert_awaited_once_with("fpm_gc_stop")
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_noop_when_policy_disabled(monkeypatch):
+    monkeypatch.delenv("DYN_FPM_GC_POLICY", raising=False)
+    engine_client = SimpleNamespace(collective_rpc=AsyncMock())
+
+    await _stop_worker_gc_policy(engine_client)
+
+    engine_client.collective_rpc.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stop_worker_gc_policy_failure_propagates(monkeypatch):
+    """Serving on workers that are not GC-equivalent to never-benchmarked
+    ones must not silently proceed."""
+    monkeypatch.setenv("DYN_FPM_GC_POLICY", "freeze")
+    engine_client = SimpleNamespace(
+        collective_rpc=AsyncMock(side_effect=RuntimeError("worker died"))
+    )
+
+    with pytest.raises(RuntimeError, match="worker died"):
+        await _stop_worker_gc_policy(engine_client)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -62,6 +62,11 @@ logger = logging.getLogger(__name__)
 # and scheduler-loop slack before failing closed.
 BENCHMARK_SOFT_TIMEOUT_GRACE_SECONDS = 90
 
+# Bound for the post-benchmark worker GC stop RPC. Restoring GC in a healthy
+# worker is sub-second; a longer wait means the engine is gone, and neither
+# serving nor error propagation may hang on it.
+WORKER_GC_STOP_TIMEOUT_SECONDS = 30.0
+
 # (engine_client, vllm_config, default_sampling_params, cleanup_resource, component_gauges)
 # component_gauges is None on the embedding-worker path: pooling engines
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
@@ -556,6 +561,44 @@ async def _stop_worker_gc_policy(engine_client: AsyncLLM) -> None:
         return
     await engine_client.collective_rpc("fpm_gc_stop")
     logger.info("FPM GC policy stopped in all model workers")
+
+
+async def _await_benchmark_then_restore_workers(
+    bench_cfg: dict, vllm_config: VllmConfig, engine_client: AsyncLLM
+) -> dict:
+    """Wait for the self-benchmark and restore worker GC on every exit path.
+
+    The worker stop must not depend on the wait succeeding: ``_bench_abort``
+    publishes ``status="failed"`` artifacts, so an aborted benchmark makes
+    ``_wait_and_load_benchmark`` raise during validation, and the workers
+    would otherwise keep automatic gen2 collection disabled through teardown
+    or, if a caller survives the error, into serving. On the success path a
+    stop failure fails closed; on the failure path it is logged and the
+    original error propagates unchanged.
+    """
+    try:
+        results = await _wait_and_load_benchmark(bench_cfg, vllm_config)
+    except BaseException:
+        # The failure may be the engine dying; an unbounded RPC would then
+        # hang the launcher on the very path that is supposed to surface the
+        # error, so the cleanup stop is time-boxed and the original error
+        # always wins.
+        try:
+            await asyncio.wait_for(
+                _stop_worker_gc_policy(engine_client),
+                timeout=WORKER_GC_STOP_TIMEOUT_SECONDS,
+            )
+        except BaseException:
+            logger.exception(
+                "Failed to stop the FPM GC policy in model workers while "
+                "handling a self-benchmark failure"
+            )
+        raise
+    await asyncio.wait_for(
+        _stop_worker_gc_policy(engine_client),
+        timeout=WORKER_GC_STOP_TIMEOUT_SECONDS,
+    )
+    return results
 
 
 SetupVllmEngineFn = Callable[..., EngineSetupResult]
@@ -1333,10 +1376,9 @@ class WorkerFactory:
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:
-            handler._benchmark_results = await _wait_and_load_benchmark(
-                bench_cfg, vllm_config
+            handler._benchmark_results = await _await_benchmark_then_restore_workers(
+                bench_cfg, vllm_config, handler.engine_client
             )
-            await _stop_worker_gc_policy(handler.engine_client)
 
         # Model-serving-readiness role.
         # _create_decode_worker handles both DECODE and AGGREGATED disaggregation modes.
@@ -1612,10 +1654,9 @@ class WorkerFactory:
         # Wait for self-benchmark to complete before registering.
         bench_cfg = vllm_config.additional_config.get("benchmark")
         if bench_cfg:
-            handler._benchmark_results = await _wait_and_load_benchmark(
-                bench_cfg, vllm_config
+            handler._benchmark_results = await _await_benchmark_then_restore_workers(
+                bench_cfg, vllm_config, handler.engine_client
             )
-            await _stop_worker_gc_policy(handler.engine_client)
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -536,6 +536,28 @@ async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> 
     return merged
 
 
+async def _stop_worker_gc_policy(engine_client: AsyncLLM) -> None:
+    """Restore worker-process GC once the self-benchmark has finished.
+
+    Model workers auto-start the FPM freeze policy when
+    ``worker_extension_cls`` resolves (importing ``dynamo.vllm.gc_policy``
+    starts it), while ``InstrumentedScheduler`` only restores the
+    engine-core process. Without this symmetric stop the workers would keep
+    serving real traffic with automatic gen2 collection disabled and the
+    freeze daemon alive, so cyclic garbage would never be reclaimed.
+    Awaiting the RPC holds serving until every worker has restored its
+    thresholds and collected the previously frozen heap; both normal
+    completion and benchmark abort funnel through the same benchmark-wait
+    call sites. A failure here must propagate: serving on a worker that is
+    not GC-equivalent to a never-benchmarked one is worse than failing
+    startup.
+    """
+    if os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower() != "freeze":
+        return
+    await engine_client.collective_rpc("fpm_gc_stop")
+    logger.info("FPM GC policy stopped in all model workers")
+
+
 SetupVllmEngineFn = Callable[..., EngineSetupResult]
 SetupKvEventPublisherFn = Callable[..., Optional[Any]]
 SetupKvStateAttachmentOwnerFn = Callable[..., Awaitable[Optional[Any]]]
@@ -1314,6 +1336,7 @@ class WorkerFactory:
             handler._benchmark_results = await _wait_and_load_benchmark(
                 bench_cfg, vllm_config
             )
+            await _stop_worker_gc_policy(handler.engine_client)
 
         # Model-serving-readiness role.
         # _create_decode_worker handles both DECODE and AGGREGATED disaggregation modes.
@@ -1592,6 +1615,7 @@ class WorkerFactory:
             handler._benchmark_results = await _wait_and_load_benchmark(
                 bench_cfg, vllm_config
             )
+            await _stop_worker_gc_policy(handler.engine_client)
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -530,6 +530,28 @@ async def _wait_and_load_benchmark(bench_cfg: dict, vllm_config: VllmConfig) -> 
     return merged
 
 
+async def _stop_worker_gc_policy(engine_client: AsyncLLM) -> None:
+    """Restore worker-process GC once the self-benchmark has finished.
+
+    Model workers auto-start the FPM freeze policy when
+    ``worker_extension_cls`` resolves (importing ``dynamo.vllm.gc_policy``
+    starts it), while ``InstrumentedScheduler`` only restores the
+    engine-core process. Without this symmetric stop the workers would keep
+    serving real traffic with automatic gen2 collection disabled and the
+    freeze daemon alive, so cyclic garbage would never be reclaimed.
+    Awaiting the RPC holds serving until every worker has restored its
+    thresholds and collected the previously frozen heap; both normal
+    completion and benchmark abort funnel through the same benchmark-wait
+    call sites. A failure here must propagate: serving on a worker that is
+    not GC-equivalent to a never-benchmarked one is worse than failing
+    startup.
+    """
+    if os.environ.get("DYN_FPM_GC_POLICY", "").strip().lower() != "freeze":
+        return
+    await engine_client.collective_rpc("fpm_gc_stop")
+    logger.info("FPM GC policy stopped in all model workers")
+
+
 SetupVllmEngineFn = Callable[..., EngineSetupResult]
 SetupKvEventPublisherFn = Callable[..., Optional[Any]]
 RegisterVllmModelFn = Callable[..., Awaitable[None]]
@@ -1120,6 +1142,7 @@ class WorkerFactory:
             handler._benchmark_results = await _wait_and_load_benchmark(
                 bench_cfg, vllm_config
             )
+            await _stop_worker_gc_policy(handler.engine_client)
 
         # Model-serving-readiness role.
         # _create_decode_worker handles both DECODE and AGGREGATED disaggregation modes.
@@ -1373,6 +1396,7 @@ class WorkerFactory:
             handler._benchmark_results = await _wait_and_load_benchmark(
                 bench_cfg, vllm_config
             )
+            await _stop_worker_gc_policy(handler.engine_client)
 
         perf_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.get_perf_metrics"


### PR DESCRIPTION
## Overview:

Single-sample self-benchmark `wall_time` measurements are intermittently poisoned by
3–200x outliers. Root cause: CPython gen2 (full) collections walk every tracked
object, so their pauses grow with the heap — measured **0.4s → 9s** over a 30k-point
sweep — and under TP/DP lockstep a single process's pause stalls the whole forward
pass. Triggers follow CPython's 25% long-lived-growth rule, producing outliers at
geometrically spaced, run-independent iteration indices (ratio ≈ 1.23, identical
across nodes/days/topologies) at a fleet-constant ~0.08%/sample rate.

This PR adds an **opt-in, benchmark-scoped** GC policy that keeps those pauses out
of measured windows. It is env-gated and **off by default — zero behavior change
unless explicitly enabled**, engine-core activation is benchmark-gated, and normal
GC is fully restored when the benchmark deactivates.


## Details:

- **New `dynamo/vllm/gc_policy.py`**: on activation, disable automatic gen2
  (`gc.set_threshold(t0, t1, 1<<30)`), `gc.freeze()` the engine-init heap once,
  then a daemon thread runs a **bare `gc.freeze()`** per tick (O(1) generation-list
  splice: no traversal, no pause). Refcounting and gen0/gen1 stay fully active, so
  only *cyclic* garbage defers; young-gen scans stay bounded by allocation rate
  instead of total heap size.
- **Lifecycle is symmetric**: the engine-core process starts the policy from
  `_bench_init` only when a benchmark is configured, and `_bench_deactivate` calls
  `stop_gc_policy()` — stops the freeze loop, restores the saved gen2 threshold,
  and unfreezes + collects the deferred garbage. `gc_maintain()`
  (unfreeze → collect → freeze) is available for explicit reclamation from untimed
  windows in long runs.
- **Worker processes** are covered via vLLM's `worker_extension_cls`
  (`FpmGcWorkerExtension`), auto-injected in benchmark mode when
  `DYN_FPM_GC_POLICY` is set and the user configured no extension; a conflicting
  extension raises rather than silently leaving workers unpoliced. No vLLM changes.
- **Two rejected variants** are documented in the module docstring, both reproduce
  measurable stalls: periodic `gc.collect()` re-introduces growing full-heap walks
  (outlier rate 0.082% → 0.712%), and per-tick `gc.get_freeze_count()` walks the
  whole permanent generation (0.4–4s once millions of objects are frozen).

### Validation (GLM-5.2-NVFP4, 4×B200 attention-DP=4, vLLM 0.25.1)

A/B on identical 30,480-measurement sweeps (same node, same GPUs, same point list;
only the GC policy toggled):

| run | outliers >3× coordinate median | max pause |
|---|---|---|
| baseline | 25 (0.082%) — geometric gen2 ladder | **8,900 ms** |
| GC policy on | 2 (0.007%) — the eager first-touch pair, fixed by the warmup PR | 1,131 ms |

End-to-end: fresh single-sample collections with this policy reach median-of-5
database quality (LOO prefill 4.74%/max 125% vs reference 4.17%/129%; holdout
2.24%/max 12.2% vs 1.96%/13.5%) at ~1/3.5 the collection cost, with zero
curve-neighbor poisoned rows. No OOM across four full sweeps with gen2 disabled
(worker RSS ≈ +1–2 GB/h, decelerating); no change to the non-outlier latency
distribution.

## Where should the reviewer start?

- `components/src/dynamo/vllm/gc_policy.py` — the policy, including design
  rationale and rejected variants in the module docstring
- `components/src/dynamo/vllm/instrumented_scheduler.py` — the two
  benchmark-gated hooks (`_bench_init` start, `_bench_deactivate` stop); 9 lines
  total
- `components/src/dynamo/vllm/args.py` — benchmark-mode `worker_extension_cls`
  injection and collision handling
- `components/src/dynamo/vllm/tests/test_gc_policy.py` — lifecycle, idempotency,
  threshold restore, and frozen-cycle reclamation tests

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional garbage-collection policy for self-benchmarking workflows.
  - When enabled with `DYN_FPM_GC_POLICY=freeze`, memory cleanup is managed during benchmark runs to reduce garbage-collection pauses and improve measurement consistency.
  - Cleanup is automatically started and stopped as benchmarking begins and ends.
  - Added maintenance support for reclaiming cyclic garbage between timed measurement windows.

- **Bug Fixes**
  - Conflicting garbage-collection settings now produce a clear configuration error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->