### PR TITLE
docs: point picker-axis authoring docs at RecipeStyles.tsx, not main.css

### DIFF
--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -192,10 +192,12 @@ Each page is a triple — page + catalog entry + nav:
 3. **Wire navigation** in `docs/index.yml`: a `- page:` under `- tab: recipes` for recipes, or under
    the **Feature Benchmarks** section (`- tab: docs`) for benchmarks. Per-benchmark pages are usually
    `hidden: true` (surfaced from the landing page).
-4. **Patch `fern/main.css` only if** the page introduces a picker axis value not already supported
-   (`recipe-sku`: `b200`/`h200`/`h100`/`gb200`/`hopper`/`blackwell`; `recipe-usecase`:
-   `chat`/`agentic`; `recipe-variant`: `agg`/`disagg`/…). A value missing from CSS renders but
-   filters nothing.
+4. **Patch `fern/components/RecipeStyles.tsx` only if** the page introduces a picker axis value not
+   already supported (`recipe-sku`: `b200`/`h200`/`h100`/`gb200`/`hopper`/`blackwell`;
+   `recipe-usecase`: `chat`/`agentic`; `recipe-variant`: `agg`/`disagg`/…). A value missing from CSS
+   renders but filters nothing. A new value needs up to three rule groups there: the picker hide
+   rule (the "Variant visibility" `body:has(...)` block) and, if it is also a landing-page filter,
+   the chip label rule and the card filter rule — details in the authoritative guide above.
 5. **Add the landing card** in `docs/recipes/README.mdx` and update the model/target counts.
 6. **Validate**: `python3 docs/recipes/_catalog/validate.py` (covers both catalogs), then `fern
    check` and `fern docs broken-links`.
@@ -388,7 +390,7 @@ CI**, so run it by hand for any `_catalog/` change. Optional local preview: `fer
 ## Commit
 
 ```bash
-git add docs/ fern/docs.yml          # also recipes/ examples/ fern/main.css when touched
+git add docs/ fern/docs.yml          # also recipes/ examples/ fern/components/ when touched
 git commit -s -m "docs: <add|update|move|remove> <page-title>"
 ```
 
@@ -404,7 +406,7 @@ git commit -s -m "docs: <add|update|move|remove> <page-title>"
 | 404 after a move/rename | Add a **dev-scoped** `fern/docs.yml` redirect (`/dynamo/dev/<old>` → `/dynamo/dev/<new>`); don't redirect `latest`/unversioned (those serve the frozen newest release) |
 | MDX parse error | Replace `<https://...>` with `[text](https://...)`; escape stray `<`/`>`; blank line after `<div ...>` and before `</div>`, code fences at column 0 |
 | Page missing from site | Ensure the nav entry exists in `index.yml`; allow a few minutes for sync |
-| Target picker renders but filters nothing | Use `className` (not `class`) and the exact `dynamo-target-picker` classes; and ensure the axis `value=` is in `fern/main.css` (add its hide rule) |
+| Target picker renders but filters nothing | Use `className` (not `class`) and the exact `dynamo-target-picker` classes; and ensure the axis `value=` is in `fern/components/RecipeStyles.tsx` (add its hide rule in the "Variant visibility" block) |
 | `validate.py` fails (orphan/dangling/id) | `_catalog/<id>.yaml` filename, internal `id:`, and the `index.yaml` entry must all match; every deploy/perf asset path must resolve |
 | Recipe page absent from the Recipes tab | Add the `- page:` under `- tab: recipes` **and** the `<id>` to `_catalog/index.yaml` |
 
@@ -419,7 +421,7 @@ git commit -s -m "docs: <add|update|move|remove> <page-title>"
 | `docs/` | Content directory (`.md`, plus `.mdx` for recipe/benchmark pages) |
 | `docs/assets/` | Images, SVGs, fonts |
 | `fern/docs.yml` | Fern site configuration + `redirects:` |
-| `fern/main.css` | Pure-CSS target-picker axis values (recipe/benchmark pages) |
+| `fern/components/RecipeStyles.tsx` | Pure-CSS picker axis values + landing-page filter rules (imported as `<RecipeStyles />` on recipe/benchmark pages) |
 | `fern/convert_callouts.py` | Callout conversion (GitHub -> Fern) |
 | `recipes/README.md` | Available Recipes tables (code recipes) |
 | `recipes/CONTRIBUTING.md` | How to contribute a code recipe |

--- a/docs/recipes/_catalog/README.md
+++ b/docs/recipes/_catalog/README.md
@@ -12,9 +12,10 @@ CSS-coupled vocabulary. For the machine-readable catalog contract, see the
 
 > [!IMPORTANT]
 > The picker is **pure CSS** (no JavaScript). Every allowed dimension value is
-> hardcoded in `fern/main.css`. A page that uses a value not listed below will
-> render the picker but **filter nothing** — adding a new value requires a
-> `fern/main.css` edit (see [Adding a new axis value](#adding-a-new-axis-value)).
+> hardcoded in `fern/components/RecipeStyles.tsx`. A page that uses a value not
+> listed below will render the picker but **filter nothing** — adding a new value
+> requires a `RecipeStyles.tsx` edit (see
+> [Adding a new axis value](#adding-a-new-axis-value)).
 
 ## Steps to add a page
 
@@ -29,8 +30,8 @@ CSS-coupled vocabulary. For the machine-readable catalog contract, see the
    run `python3 docs/recipes/_catalog/validate.py`.
 3. **Wire navigation** in `docs/index.yml` (add the `- page:` under the Recipes
    tab or the Feature Benchmarks section).
-4. **Patch `fern/main.css` only if** the page introduces a picker axis value not
-   already supported (see below).
+4. **Patch `fern/components/RecipeStyles.tsx` only if** the page introduces a
+   picker axis value not already supported (see below).
 5. Add the landing-page card (`docs/recipes/README.mdx`) and update the model /
    target counts.
 6. Run `fern check` and `fern docs broken-links`; preview with `fern docs dev`.
@@ -157,8 +158,8 @@ matching `data-*` attributes. Space-separated values mean "applies to several"
 
 ## CSS-coupled vocabulary
 
-The hide/highlight rules in `fern/main.css` enumerate every allowed value.
-A new value renders but filters nothing until CSS is added.
+The hide/highlight rules in `fern/components/RecipeStyles.tsx` enumerate every
+allowed value. A new value renders but filters nothing until CSS is added.
 
 | Dimension (`name=`) | Supported `value=` |
 | --- | --- |
@@ -168,23 +169,35 @@ A new value renders but filters nothing until CSS is added.
 
 Landing-page filter chips (`docs/recipes/README.mdx`) are a separate
 vocabulary — `provider`, `runtime`, `hardware`, `technique`, `workload` — also
-hardcoded in CSS; a chip that matches no card is a dead end, so only add a chip
-when a card carries the matching `data-*` token.
+hardcoded in `RecipeStyles.tsx`; a chip that matches no card is a dead end, so
+only add a chip when a card carries the matching `data-*` token.
 
 ## Adding a new axis value
 
-To support, e.g., an `mi300` SKU or a `disagg-3node` topology:
+To support, e.g., an `mi300` SKU or a `disagg-3node` topology, edit
+`fern/components/RecipeStyles.tsx`. A fully wired value touches up to three
+rule groups there:
 
-1. In `fern/main.css`, find the picker `body:has(...)` block and add the
-   hide rule:
+1. **Picker hide rule** — in the "Variant visibility" `body:has(...)` block,
+   add:
    ```css
    body:has(input[name="recipe-sku"][value="mi300"]:checked) [data-sku]:not([data-sku~="mi300"]) { display: none; }
    ```
-2. If the value participates in Expected-Performance row highlighting, add it to
-   the matching `tr[data-...]` rule group too.
-3. Then use the value in the page's picker inputs and `data-*` blocks.
+   If the value participates in Expected-Performance row highlighting, add it
+   to the matching `tr[data-...]` rule group too.
+2. **Landing chip label rule** — if the value also becomes a landing-page
+   filter chip (e.g. a new GPU under `hardware`), add its
+   `#<dim>-<value>:checked ~ .dynamo-recipe-browser label[for="<dim>-<value>"]`
+   selector to the selected-chip highlight group.
+3. **Landing card filter rule** — add the matching
+   `#<dim>-<value>:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-<dim>~="<value>"])`
+   selector to the card-hiding group.
 
-Skipping step 1 produces a picker that renders but silently filters nothing.
+Then use the value in the page's picker inputs and `data-*` blocks (and, for
+landing chips, tag the card in `docs/recipes/README.mdx`).
+
+Skipping step 1 produces a picker that renders but silently filters nothing;
+skipping 2–3 produces a chip that highlights or filters nothing.
 
 ## Why it's pure CSS
 
@@ -194,7 +207,8 @@ safely on older browsers (all variants show stacked rather than breaking).
 Hidden variants use `display: none` (clean a11y tree); comparison tables dim
 non-selected rows with `opacity` so every row stays readable.
 
-This component styling lives entirely under the `dynamo-*` namespace and only
-renders when `fern/main.css` is applied — see the preview-vs-production note in
-`.github/workflows/fern-docs.yml` (PR previews skip the global theme so project
-CSS renders).
+This component styling lives entirely under the `dynamo-*` namespace and ships
+with the page itself: each recipe/benchmark page imports `<RecipeStyles />`
+from `fern/components/RecipeStyles.tsx`, which injects the rules as a component
+`<style>` block (so they compose with the NVIDIA global theme — see the
+preview-vs-production note in `.github/workflows/fern-docs.yml`).


### PR DESCRIPTION
## Summary

`docs/recipes/_catalog/README.md` and `.agents/skills/dynamo-docs/SKILL.md` still instruct authors to add new target-picker axis values (`recipe-sku` etc.) to `fern/main.css`. That file is now a deprecation stub (site chrome moved to `SiteStyles.tsx`) and contains zero picker rules on `main`; the rules actually live in `fern/components/RecipeStyles.tsx`, delivered as a page-level `<style>` block via the `<RecipeStyles />` import.

This updates both docs to point at `fern/components/RecipeStyles.tsx` and describes the three rule groups a fully wired axis value needs:

1. **Picker hide rule** in the "Variant visibility" `body:has(...)` block (plus the `tr[data-...]` row-highlight group where applicable)
2. **Landing chip label rule** (selected-chip highlight group), when the value is also a landing-page filter
3. **Landing card filter rule** (card-hiding group)

Also fixes the stale claim that the component styling "only renders when `fern/main.css` is applied" — it ships with the page via the component import.

Docs-only; no code or CSS changes.

## Validation

- `grep -n main.css` over both files returns no hits
- `python3 scripts/validate_skills.py` → `validated 14 skills: OK`
- `pre-commit` hooks relevant to markdown (codespell, whitespace, skills validator) pass on both files
- Claims verified against `origin/main`: `fern/main.css` has no `recipe-sku`/`dynamo-target-picker` rules; the "Variant visibility" block, chip label group, and card filter group are all in `fern/components/RecipeStyles.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12178" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contributor guidance for maintaining Recipes and Feature Benchmarks.
  - Clarified where target-picker styling and filtering rules are managed.
  - Added instructions for introducing new picker axis values, including hide, highlight, and card-filter behavior.
  - Documented expected behavior when styling rules are incomplete or omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->