### PR TITLE
fix(protocols): preserve media in tool results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1554,7 +1554,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2703,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "5.1.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19147fbb880a3f07b83abad406c34cfb3397aa287c5d5dfc922b55354c3a1df4"
+checksum = "d1b48bce38cc72a6151e73a181123bd254c097588e329d67db6c403cfca34f8e"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2726,24 +2726,26 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a8fca0f27b610454cd33858b5eb01c78c24d3ace7af2728d0723713775a939"
+checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
 dependencies = [
  "anyhow",
- "dynamo-parsers",
+ "num-traits",
  "openai-harmony",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "dynamo-protocols"
-version = "4.0.0"
-source = "git+https://github.com/michaelfeil/frontend-crates.git?rev=811870b3fe9896eeb31e6561273b6896ba9f668e#811870b3fe9896eeb31e6561273b6896ba9f668e"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80937007fc20dc38ee49c202b94bb6f5d1228e10cdf0bcd4bd2bbfe62f49fa83"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2758,9 +2760,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb98f4d3624bc51dcd445422f19a3b974f8fb604e924875990a72d2d16b5538"
+checksum = "8530c084fb18a1cf435200b8e7e39b023db5878cc3f6d462ebb4157e6e208fd4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2900,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843cd9cd50002ae23f3df525e1c551775b7bc7c9041742539faf63bc35ea225"
+checksum = "5513d4b084bbc3dfe874fb945188454d9f61dcbefc7f7dbda3b84aafd2620839"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -4143,7 +4145,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -6948,8 +6950,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6968,8 +6970,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6990,7 +6992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7003,7 +7005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7193,7 +7195,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7230,7 +7232,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10539,7 +10541,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,8 +2743,7 @@ dependencies = [
 [[package]]
 name = "dynamo-protocols"
 version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b32c5f7709c5797d30c3949ac1e79b02d833e4467af92af7c4a3eef321155"
+source = "git+https://github.com/michaelfeil/frontend-crates.git?rev=811870b3fe9896eeb31e6561273b6896ba9f668e#811870b3fe9896eeb31e6561273b6896ba9f668e"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.4.0" }
 dynamo-llm = { path = "lib/llm", version = "1.4.0" }
 dynamo-rl = { path = "lib/rl", version = "1.4.0" }
-dynamo-tokenizers = { version = "=1.5.3" }
-dynamo-renderer = { version = "=3.0.0" }
+dynamo-tokenizers = { version = "=1.5.4" }
+dynamo-renderer = { version = "=4.0.0" }
 dynamo-tokens = { path = "lib/tokens", version = "1.4.0" }
 dynamo-truthy = { path = "lib/truthy", version = "1.4.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.4.0" }
@@ -58,12 +58,12 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.4.0" }
 dynamo-memory = { path = "lib/memory", version = "1.4.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.4.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.4.0" }
-dynamo-protocols = { version = "=4.0.0" }
-dynamo-parsers = { version = "5.1.3" }
+dynamo-protocols = { version = "=5.0.0" }
+dynamo-parsers = { version = "6.0.2" }
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions
 #   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.1.19" }
+dynamo-parsers-v2 = { version = "0.1.23" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.4.0" }
 dynamo-sidecar-common = { path = "lib/sidecar/common", version = "1.4.0" }
 fastokens = { version = "0.2.0" }
@@ -183,9 +183,6 @@ rcgen = { version = "0.13" }
 tokio-rustls = { version = "0.26" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2" }
-
-[patch.crates-io]
-dynamo-protocols = { git = "https://github.com/michaelfeil/frontend-crates.git", rev = "811870b3fe9896eeb31e6561273b6896ba9f668e" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,6 +184,9 @@ tokio-rustls = { version = "0.26" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2" }
 
+[patch.crates-io]
+dynamo-protocols = { git = "https://github.com/michaelfeil/frontend-crates.git", rev = "811870b3fe9896eeb31e6561273b6896ba9f668e" }
+
 [profile.dev.package]
 insta.opt-level = 3
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1750,9 +1750,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "5.1.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19147fbb880a3f07b83abad406c34cfb3397aa287c5d5dfc922b55354c3a1df4"
+checksum = "d1b48bce38cc72a6151e73a181123bd254c097588e329d67db6c403cfca34f8e"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1773,25 +1773,26 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a8fca0f27b610454cd33858b5eb01c78c24d3ace7af2728d0723713775a939"
+checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
 dependencies = [
  "anyhow",
- "dynamo-parsers",
+ "num-traits",
  "openai-harmony",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "dynamo-protocols"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b32c5f7709c5797d30c3949ac1e79b02d833e4467af92af7c4a3eef321155"
+checksum = "80937007fc20dc38ee49c202b94bb6f5d1228e10cdf0bcd4bd2bbfe62f49fa83"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -1806,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb98f4d3624bc51dcd445422f19a3b974f8fb604e924875990a72d2d16b5538"
+checksum = "8530c084fb18a1cf435200b8e7e39b023db5878cc3f6d462ebb4157e6e208fd4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1905,9 +1906,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843cd9cd50002ae23f3df525e1c551775b7bc7c9041742539faf63bc35ea225"
+checksum = "5513d4b084bbc3dfe874fb945188454d9f61dcbefc7f7dbda3b84aafd2620839"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2363,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "5.1.3"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19147fbb880a3f07b83abad406c34cfb3397aa287c5d5dfc922b55354c3a1df4"
+checksum = "d1b48bce38cc72a6151e73a181123bd254c097588e329d67db6c403cfca34f8e"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2386,25 +2386,26 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a8fca0f27b610454cd33858b5eb01c78c24d3ace7af2728d0723713775a939"
+checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
 dependencies = [
  "anyhow",
- "dynamo-parsers",
+ "num-traits",
  "openai-harmony",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "dynamo-protocols"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4b32c5f7709c5797d30c3949ac1e79b02d833e4467af92af7c4a3eef321155"
+checksum = "80937007fc20dc38ee49c202b94bb6f5d1228e10cdf0bcd4bd2bbfe62f49fa83"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -2459,9 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb98f4d3624bc51dcd445422f19a3b974f8fb604e924875990a72d2d16b5538"
+checksum = "8530c084fb18a1cf435200b8e7e39b023db5878cc3f6d462ebb4157e6e208fd4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2581,9 +2582,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843cd9cd50002ae23f3df525e1c551775b7bc7c9041742539faf63bc35ea225"
+checksum = "5513d4b084bbc3dfe874fb945188454d9f61dcbefc7f7dbda3b84aafd2620839"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -51,7 +51,7 @@ mm-routing = ["dynamo-llm/mm-routing"]
 aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "5.1.3" }
+dynamo-parsers = { version = "6.0.2" }
 dynamo-backend-common = { path = "../../backend-common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -24,14 +24,17 @@ use anyhow::{Result, bail};
 
 use dynamo_protocols::types::{
     ChatCompletionMessageContent, ChatCompletionRequestMessage,
+    ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
     ChatCompletionToolChoiceOption, EncodingFormat,
 };
 use dynamo_renderer::OAIPromptFormatter;
 use dynamo_runtime::config::is_truthy;
 use dynamo_runtime::error::{DynamoError, ErrorType};
+use either::Either;
 use futures::Stream;
 use futures::stream::{self, StreamExt};
+use std::borrow::Cow;
 use std::time::Instant;
 
 use dynamo_runtime::dynamo_nvtx_range;
@@ -104,6 +107,55 @@ fn invalid_argument_error(message: impl Into<String>) -> anyhow::Error {
         .message(message.into())
         .build()
         .into()
+}
+
+fn tool_content_part_as_user(
+    part: &ChatCompletionRequestToolMessageContentPart,
+) -> Cow<'_, ChatCompletionRequestUserMessageContentPart> {
+    Cow::Owned(match part {
+        ChatCompletionRequestToolMessageContentPart::Text(part) => {
+            ChatCompletionRequestUserMessageContentPart::Text(part.clone())
+        }
+        ChatCompletionRequestToolMessageContentPart::ImageUrl(part) => {
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(part.clone())
+        }
+        ChatCompletionRequestToolMessageContentPart::VideoUrl(part) => {
+            ChatCompletionRequestUserMessageContentPart::VideoUrl(part.clone())
+        }
+        ChatCompletionRequestToolMessageContentPart::AudioUrl(part) => {
+            ChatCompletionRequestUserMessageContentPart::AudioUrl(part.clone())
+        }
+    })
+}
+
+fn multimodal_content_parts(
+    message: &ChatCompletionRequestMessage,
+) -> Option<impl Iterator<Item = Cow<'_, ChatCompletionRequestUserMessageContentPart>>> {
+    match message {
+        ChatCompletionRequestMessage::User(user) => match &user.content {
+            ChatCompletionRequestUserMessageContent::Array(parts) => {
+                Some(Either::Left(parts.iter().map(Cow::Borrowed)))
+            }
+            ChatCompletionRequestUserMessageContent::Text(_) => None,
+        },
+        ChatCompletionRequestMessage::Tool(tool) => match &tool.content {
+            ChatCompletionRequestToolMessageContent::Array(parts) => {
+                Some(Either::Right(parts.iter().map(tool_content_part_as_user)))
+            }
+            ChatCompletionRequestToolMessageContent::Text(_) => None,
+        },
+        _ => None,
+    }
+}
+
+#[cfg(feature = "mm-routing")]
+fn image_content_part_url(
+    content_part: &ChatCompletionRequestUserMessageContentPart,
+) -> Option<&str> {
+    let ChatCompletionRequestUserMessageContentPart::ImageUrl(part) = content_part else {
+        return None;
+    };
+    part.image_url.as_ref().map(|image| image.url.as_str())
 }
 
 /// Encode a slice of `f32` values as a base64 string per the OpenAI
@@ -198,9 +250,7 @@ pub struct MmImageEntry {
 struct MediaFetchTask<'a> {
     modality: &'static str,
     slot_idx: usize,
-    #[cfg(feature = "mm-routing")]
-    source_url: &'a str,
-    content_part: &'a ChatCompletionRequestUserMessageContentPart,
+    content_part: Cow<'a, ChatCompletionRequestUserMessageContentPart>,
 }
 
 /// Per-request media content-part counts, carried to the metrics annotation.
@@ -1399,7 +1449,7 @@ impl OpenAIPreprocessor {
         // URLs here and resolve dims via header-only HTTP after the loop so we
         // can issue all fetches in parallel.
         #[cfg(feature = "mm-routing")]
-        let mut url_passthrough_images: Vec<(u64, &str)> = Vec::new();
+        let mut url_passthrough_images: Vec<(u64, String)> = Vec::new();
 
         let Some(messages) = request.typed_messages() else {
             return Ok((Vec::new(), None));
@@ -1407,19 +1457,15 @@ impl OpenAIPreprocessor {
         let has_media_loader = self.media_loader.is_some();
 
         for message in messages.iter() {
-            let content_parts = match message {
-                ChatCompletionRequestMessage::User(u) => match &u.content {
-                    ChatCompletionRequestUserMessageContent::Array(parts) => parts,
-                    _ => continue,
-                },
-                _ => continue,
+            let Some(content_parts) = multimodal_content_parts(message) else {
+                continue;
             };
-            for content_part in content_parts.iter() {
-                let (type_str, url, uuid): (&'static str, Option<&url::Url>, Option<String>) =
-                    match content_part {
+            for content_part in content_parts {
+                let (type_str, url, uuid): (&'static str, Option<url::Url>, Option<String>) =
+                    match content_part.as_ref() {
                         ChatCompletionRequestUserMessageContentPart::ImageUrl(part) => (
                             "image_url",
-                            part.image_url.as_ref().map(|media| &media.url),
+                            part.image_url.as_ref().map(|media| media.url.clone()),
                             part.uuid.clone(),
                         ),
                         ChatCompletionRequestUserMessageContentPart::VideoUrl(part) => {
@@ -1430,7 +1476,7 @@ impl OpenAIPreprocessor {
                             }
                             (
                                 "video_url",
-                                part.video_url.as_ref().map(|media| &media.url),
+                                part.video_url.as_ref().map(|media| media.url.clone()),
                                 None,
                             )
                         }
@@ -1442,7 +1488,7 @@ impl OpenAIPreprocessor {
                             }
                             (
                                 "audio_url",
-                                part.audio_url.as_ref().map(|media| &media.url),
+                                part.audio_url.as_ref().map(|media| media.url.clone()),
                                 None,
                             )
                         }
@@ -1476,18 +1522,16 @@ impl OpenAIPreprocessor {
                             fetch_tasks.push(MediaFetchTask {
                                 modality: type_str,
                                 slot_idx,
-                                #[cfg(feature = "mm-routing")]
-                                source_url: url.as_str(),
                                 content_part,
                             });
                         } else {
                             #[cfg(feature = "mm-routing")]
                             if type_str == "image_url" {
                                 let mm_hash = Self::hash_image_url(url.as_str());
-                                url_passthrough_images.push((mm_hash, url.as_str()));
+                                url_passthrough_images.push((mm_hash, url.as_str().to_string()));
                             }
                         }
-                        slots.push(MultimodalData::Url(url.clone()));
+                        slots.push(MultimodalData::Url(url));
                     }
                     (None, Some(uuid)) => {
                         slots.push(MultimodalData::UuidOnly(uuid));
@@ -1506,7 +1550,7 @@ impl OpenAIPreprocessor {
             let loader = self.media_loader.as_ref().unwrap();
             let media_io_kwargs = request.media_io_kwargs();
             let results = futures::future::join_all(fetch_tasks.iter().map(|task| {
-                loader.fetch_and_decode_media_part(task.content_part, media_io_kwargs)
+                loader.fetch_and_decode_media_part(task.content_part.as_ref(), media_io_kwargs)
             }))
             .await;
 
@@ -1531,7 +1575,15 @@ impl OpenAIPreprocessor {
                         // shouldn't happen on the frontend.
                         let (mm_hash, hash_source) = match rdma_descriptor.content_hash() {
                             Some(h) => (h, "decoded_bytes"),
-                            None => (Self::hash_image_url(task.source_url), "url_fallback"),
+                            None => {
+                                let source_url = image_content_part_url(task.content_part.as_ref())
+                                    .ok_or_else(|| {
+                                        invalid_argument_error(
+                                            "image_url task must contain an image URL",
+                                        )
+                                    })?;
+                                (Self::hash_image_url(source_url), "url_fallback")
+                            }
                         };
                         if let Some(counter) = self.image_token_counter.as_ref() {
                             let n = counter.count_tokens(w, h);
@@ -3979,6 +4031,49 @@ mod tests {
         assert_eq!(counts.image, 0);
         assert_eq!(counts.video, 0);
         assert_eq!(counts.audio, 0);
+    }
+
+    #[test]
+    fn tool_message_exposes_multimodal_content_parts() {
+        let message: ChatCompletionRequestMessage = serde_json::from_value(serde_json::json!({
+            "role": "tool",
+            "tool_call_id": "call_media",
+            "content": [
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,aGVsbG8="
+                    }
+                },
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "https://example.com/clip.mp4"
+                    }
+                },
+                {
+                    "type": "audio_url",
+                    "audio_url": {
+                        "url": "https://example.com/audio.wav"
+                    }
+                }
+            ]
+        }))
+        .unwrap();
+
+        let parts: Vec<_> = multimodal_content_parts(&message).unwrap().collect();
+        assert!(matches!(
+            parts[0].as_ref(),
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(_)
+        ));
+        assert!(matches!(
+            parts[1].as_ref(),
+            ChatCompletionRequestUserMessageContentPart::VideoUrl(_)
+        ));
+        assert!(matches!(
+            parts[2].as_ref(),
+            ChatCompletionRequestUserMessageContentPart::AudioUrl(_)
+        ));
     }
 
     #[cfg(feature = "mm-routing")]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -128,19 +128,74 @@ fn tool_content_part_as_user(
     })
 }
 
+enum MultimodalContentPart<'a> {
+    User(&'a ChatCompletionRequestUserMessageContentPart),
+    Tool(&'a ChatCompletionRequestToolMessageContentPart),
+}
+
+impl<'a> MultimodalContentPart<'a> {
+    fn as_user(&self) -> Cow<'a, ChatCompletionRequestUserMessageContentPart> {
+        match self {
+            Self::User(part) => Cow::Borrowed(part),
+            Self::Tool(part) => tool_content_part_as_user(part),
+        }
+    }
+
+    fn media_info(&self) -> Option<(&'static str, Option<url::Url>, Option<String>)> {
+        match self {
+            Self::User(part) => match *part {
+                ChatCompletionRequestUserMessageContentPart::ImageUrl(part) => Some((
+                    "image_url",
+                    part.image_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                ChatCompletionRequestUserMessageContentPart::VideoUrl(part) => Some((
+                    "video_url",
+                    part.video_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                ChatCompletionRequestUserMessageContentPart::AudioUrl(part) => Some((
+                    "audio_url",
+                    part.audio_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                _ => None,
+            },
+            Self::Tool(part) => match *part {
+                ChatCompletionRequestToolMessageContentPart::ImageUrl(part) => Some((
+                    "image_url",
+                    part.image_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                ChatCompletionRequestToolMessageContentPart::VideoUrl(part) => Some((
+                    "video_url",
+                    part.video_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                ChatCompletionRequestToolMessageContentPart::AudioUrl(part) => Some((
+                    "audio_url",
+                    part.audio_url.as_ref().map(|media| media.url.clone()),
+                    part.uuid.clone(),
+                )),
+                _ => None,
+            },
+        }
+    }
+}
+
 fn multimodal_content_parts(
     message: &ChatCompletionRequestMessage,
-) -> Option<impl Iterator<Item = Cow<'_, ChatCompletionRequestUserMessageContentPart>>> {
+) -> Option<impl Iterator<Item = MultimodalContentPart<'_>>> {
     match message {
         ChatCompletionRequestMessage::User(user) => match &user.content {
             ChatCompletionRequestUserMessageContent::Array(parts) => {
-                Some(Either::Left(parts.iter().map(Cow::Borrowed)))
+                Some(Either::Left(parts.iter().map(MultimodalContentPart::User)))
             }
             ChatCompletionRequestUserMessageContent::Text(_) => None,
         },
         ChatCompletionRequestMessage::Tool(tool) => match &tool.content {
             ChatCompletionRequestToolMessageContent::Array(parts) => {
-                Some(Either::Right(parts.iter().map(tool_content_part_as_user)))
+                Some(Either::Right(parts.iter().map(MultimodalContentPart::Tool)))
             }
             ChatCompletionRequestToolMessageContent::Text(_) => None,
         },
@@ -1461,39 +1516,15 @@ impl OpenAIPreprocessor {
                 continue;
             };
             for content_part in content_parts {
-                let (type_str, url, uuid): (&'static str, Option<url::Url>, Option<String>) =
-                    match content_part.as_ref() {
-                        ChatCompletionRequestUserMessageContentPart::ImageUrl(part) => (
-                            "image_url",
-                            part.image_url.as_ref().map(|media| media.url.clone()),
-                            part.uuid.clone(),
-                        ),
-                        ChatCompletionRequestUserMessageContentPart::VideoUrl(part) => {
-                            if part.uuid.is_some() {
-                                return Err(invalid_argument_error(
-                                    "multimodal cache UUIDs are supported only for image_url parts with vLLM",
-                                ));
-                            }
-                            (
-                                "video_url",
-                                part.video_url.as_ref().map(|media| media.url.clone()),
-                                None,
-                            )
-                        }
-                        ChatCompletionRequestUserMessageContentPart::AudioUrl(part) => {
-                            if part.uuid.is_some() {
-                                return Err(invalid_argument_error(
-                                    "multimodal cache UUIDs are supported only for image_url parts with vLLM",
-                                ));
-                            }
-                            (
-                                "audio_url",
-                                part.audio_url.as_ref().map(|media| media.url.clone()),
-                                None,
-                            )
-                        }
-                        _ => continue,
-                    };
+                let Some((type_str, url, uuid)) = content_part.media_info() else {
+                    continue;
+                };
+
+                if type_str != "image_url" && uuid.is_some() {
+                    return Err(invalid_argument_error(
+                        "multimodal cache UUIDs are supported only for image_url parts with vLLM",
+                    ));
+                }
 
                 #[cfg(feature = "mm-routing")]
                 if type_str == "image_url" {
@@ -1522,7 +1553,7 @@ impl OpenAIPreprocessor {
                             fetch_tasks.push(MediaFetchTask {
                                 modality: type_str,
                                 slot_idx,
-                                content_part,
+                                content_part: content_part.as_user(),
                             });
                         } else {
                             #[cfg(feature = "mm-routing")]
@@ -4063,15 +4094,15 @@ mod tests {
 
         let parts: Vec<_> = multimodal_content_parts(&message).unwrap().collect();
         assert!(matches!(
-            parts[0].as_ref(),
+            parts[0].as_user().as_ref(),
             ChatCompletionRequestUserMessageContentPart::ImageUrl(_)
         ));
         assert!(matches!(
-            parts[1].as_ref(),
+            parts[1].as_user().as_ref(),
             ChatCompletionRequestUserMessageContentPart::VideoUrl(_)
         ));
         assert!(matches!(
-            parts[2].as_ref(),
+            parts[2].as_user().as_ref(),
             ChatCompletionRequestUserMessageContentPart::AudioUrl(_)
         ));
     }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -260,6 +260,15 @@ fn convert_tool_result_content(
         ToolResultContent::Blocks(blocks) => blocks,
     };
 
+    if blocks
+        .iter()
+        .any(|block| matches!(block, ToolResultContentBlock::Other(_)))
+    {
+        anyhow::bail!(
+            "unsupported Anthropic tool_result content block; only text and image are supported"
+        );
+    }
+
     if !blocks
         .iter()
         .any(|block| matches!(block, ToolResultContentBlock::Image { .. }))
@@ -282,7 +291,7 @@ fn convert_tool_result_content(
                     convert_image(source)?,
                 ));
             }
-            ToolResultContentBlock::Other(_) => {}
+            ToolResultContentBlock::Other(_) => unreachable!("validated above"),
         }
     }
     Ok(ChatCompletionRequestToolMessageContent::Array(parts))
@@ -1448,6 +1457,20 @@ mod tests {
         assert_eq!(
             image.image_url.as_ref().unwrap().url.as_str(),
             "data:image/png;base64,aGVsbG8="
+        );
+    }
+
+    #[test]
+    fn test_tool_result_other_block_is_rejected() {
+        let content = ToolResultContent::Blocks(vec![ToolResultContentBlock::Other(
+            serde_json::json!({"type": "document"}),
+        )]);
+
+        let error = convert_tool_result_content(&content).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("only text and image are supported")
         );
     }
 

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -17,10 +17,11 @@ use dynamo_protocols::types::{
     ChatCompletionRequestMessage, ChatCompletionRequestMessageContentPartImageArgs,
     ChatCompletionRequestMessageContentPartText, ChatCompletionRequestSystemMessage,
     ChatCompletionRequestSystemMessageContent, ChatCompletionRequestToolMessage,
-    ChatCompletionRequestToolMessageContent, ChatCompletionRequestUserMessage,
-    ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-    ChatCompletionTool, ChatCompletionToolChoiceOption, ChatCompletionToolType, CompletionUsage,
-    FunctionName, FunctionObject, FunctionType, ImageUrl, ReasoningContent,
+    ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
+    ChatCompletionRequestUserMessage, ChatCompletionRequestUserMessageContent,
+    ChatCompletionRequestUserMessageContentPart, ChatCompletionTool,
+    ChatCompletionToolChoiceOption, ChatCompletionToolType, CompletionUsage, FunctionName,
+    FunctionObject, FunctionType, ImageUrl, ReasoningContent,
 };
 use uuid::Uuid;
 
@@ -186,21 +187,10 @@ fn convert_user_blocks(
                 ));
             }
             AnthropicContentBlock::Image { source } => {
-                if source.source_type != "base64" {
-                    anyhow::bail!(
-                        "unsupported image source type {:?}; only base64 is supported",
-                        source.source_type
-                    );
-                }
                 has_image = true;
-                let data_uri = format!("data:{};base64,{}", source.media_type, source.data);
-                let url = url::Url::parse(&data_uri)
-                    .map_err(|e| anyhow::anyhow!("invalid image data URI: {e}"))?;
-                let image_url = ImageUrl::from(url.to_string());
-                let image_part = ChatCompletionRequestMessageContentPartImageArgs::default()
-                    .image_url(image_url)
-                    .build()?;
-                content_parts.push(image_part.into());
+                content_parts.push(ChatCompletionRequestUserMessageContentPart::ImageUrl(
+                    convert_image(source)?,
+                ));
             }
             AnthropicContentBlock::ToolResult {
                 tool_use_id,
@@ -211,10 +201,14 @@ fn convert_user_blocks(
                 flush_user_content_parts(&mut content_parts, has_image, messages);
                 has_image = false;
 
-                let text = content.clone().map(|c| c.into_text()).unwrap_or_default();
+                let content = content
+                    .as_ref()
+                    .map(convert_tool_result_content)
+                    .transpose()?
+                    .unwrap_or_default();
                 messages.push(ChatCompletionRequestMessage::Tool(
                     ChatCompletionRequestToolMessage {
-                        content: ChatCompletionRequestToolMessageContent::Text(text),
+                        content,
                         tool_call_id: tool_use_id.clone(),
                     },
                 ));
@@ -234,6 +228,64 @@ fn convert_user_blocks(
     flush_user_content_parts(&mut content_parts, has_image, messages);
 
     Ok(())
+}
+
+fn convert_image(
+    source: &AnthropicImageSource,
+) -> Result<dynamo_protocols::types::ChatCompletionRequestMessageContentPartImage, anyhow::Error> {
+    if source.source_type != "base64" {
+        anyhow::bail!(
+            "unsupported image source type {:?}; only base64 is supported",
+            source.source_type
+        );
+    }
+
+    let data_uri = format!("data:{};base64,{}", source.media_type, source.data);
+    let url =
+        url::Url::parse(&data_uri).map_err(|e| anyhow::anyhow!("invalid image data URI: {e}"))?;
+    let image_url = ImageUrl::from(url.to_string());
+    let image = ChatCompletionRequestMessageContentPartImageArgs::default()
+        .image_url(image_url)
+        .build()?;
+    Ok(image)
+}
+
+fn convert_tool_result_content(
+    content: &ToolResultContent,
+) -> Result<ChatCompletionRequestToolMessageContent, anyhow::Error> {
+    let blocks = match content {
+        ToolResultContent::Text(text) => {
+            return Ok(ChatCompletionRequestToolMessageContent::Text(text.clone()));
+        }
+        ToolResultContent::Blocks(blocks) => blocks,
+    };
+
+    if !blocks
+        .iter()
+        .any(|block| matches!(block, ToolResultContentBlock::Image { .. }))
+    {
+        return Ok(ChatCompletionRequestToolMessageContent::Text(
+            content.clone().into_text(),
+        ));
+    }
+
+    let mut parts = Vec::with_capacity(blocks.len());
+    for block in blocks {
+        match block {
+            ToolResultContentBlock::Text { text } => {
+                parts.push(ChatCompletionRequestToolMessageContentPart::Text(
+                    ChatCompletionRequestMessageContentPartText { text: text.clone() },
+                ));
+            }
+            ToolResultContentBlock::Image { source } => {
+                parts.push(ChatCompletionRequestToolMessageContentPart::ImageUrl(
+                    convert_image(source)?,
+                ));
+            }
+            ToolResultContentBlock::Other(_) => {}
+        }
+    }
+    Ok(ChatCompletionRequestToolMessageContent::Array(parts))
 }
 
 /// Flush accumulated user content parts into a user message.
@@ -1343,6 +1395,60 @@ mod tests {
             },
             _ => panic!("expected blocks"),
         }
+
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let ChatCompletionRequestMessage::Tool(tool) = &chat_req.inner.messages[0] else {
+            panic!("expected tool message");
+        };
+        assert_eq!(
+            tool.content,
+            ChatCompletionRequestToolMessageContent::Text("line 1line 2".into())
+        );
+    }
+
+    #[test]
+    fn test_tool_result_image_preserved() {
+        let json = r#"{
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [{
+                "role": "user",
+                "content": [{
+                    "type": "tool_result",
+                    "tool_use_id": "t1",
+                    "content": [
+                        {"type": "text", "text": "Screenshot captured"},
+                        {"type": "image", "source": {
+                            "type": "base64",
+                            "media_type": "image/png",
+                            "data": "aGVsbG8="
+                        }}
+                    ]
+                }]
+            }]
+        }"#;
+
+        let req: AnthropicCreateMessageRequest = serde_json::from_str(json).unwrap();
+        let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        let ChatCompletionRequestMessage::Tool(tool) = &chat_req.inner.messages[0] else {
+            panic!("expected tool message");
+        };
+        let ChatCompletionRequestToolMessageContent::Array(parts) = &tool.content else {
+            panic!("expected array content");
+        };
+        assert_eq!(parts.len(), 2);
+        assert!(matches!(
+            &parts[0],
+            ChatCompletionRequestToolMessageContentPart::Text(text)
+                if text.text == "Screenshot captured"
+        ));
+        let ChatCompletionRequestToolMessageContentPart::ImageUrl(image) = &parts[1] else {
+            panic!("expected image_url part");
+        };
+        assert_eq!(
+            image.image_url.as_ref().unwrap().url.as_str(),
+            "data:image/png;base64,aGVsbG8="
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Preserve Anthropic tool-result images and accept image, video, and audio URL parts in OpenAI-compatible tool messages.

Tool media now follows the existing user-media preprocessing path; text-only results are unchanged. Depends on ai-dynamo/frontend-crates#143. Closes ai-dynamo/dynamo#12179.

## Validation

* `cargo test -p dynamo-llm protocols::anthropic::types::tests --lib`
* `cargo test -p dynamo-llm tool_message_exposes_multimodal_content_parts --lib`
* `cargo clippy -p dynamo-llm --lib -- -D warnings`
* `cargo check -p dynamo-llm --features mm-routing`
* `cargo fmt --all --check`

## Summary by CodeRabbit

* **New Features**
  * Improved multimodal message handling for tool responses, preserving images alongside text.
  * Added support for processing image, video, and audio content from tool messages.
  * Enhanced multimodal routing for image URLs, including reliable media identification and retrieval.
* **Bug Fixes**
  * Fixed Anthropic tool results so embedded images are no longer reduced to text-only content.
  * Improved handling of image-based tool content when media metadata is unavailable.