### PR TITLE
fix(responses): stream reasoning summaries

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -927,6 +927,15 @@ pub struct ResponseParams {
     pub safety_identifier: Option<String>,
 }
 
+impl ResponseParams {
+    fn reasoning_summary_requested(&self) -> bool {
+        self.reasoning
+            .as_ref()
+            .and_then(|reasoning| reasoning.summary)
+            .is_some()
+    }
+}
+
 /// Normalize tools so that `FunctionTool.strict` is always set.
 /// The upstream type uses `skip_serializing_if = "Option::is_none"` on `strict`,
 /// so `None` causes the field to be omitted during JSON serialization.
@@ -1007,6 +1016,7 @@ pub fn chat_completion_to_response(
         // Map reasoning_content to a Reasoning output item
         if let Some(reasoning_text) = choice.message.reasoning_content
             && !reasoning_text.is_empty()
+            && params.reasoning_summary_requested()
         {
             output.push(OutputItem::Reasoning(ReasoningItem {
                 id: Some(format!("rs_{}", Uuid::new_v4().simple())),
@@ -2895,6 +2905,57 @@ thinking
             },
             nvext: None,
         }
+    }
+
+    fn make_chat_resp_with_reasoning(reasoning: &str) -> NvCreateChatCompletionResponse {
+        let mut response = make_chat_resp_with_text("answer");
+        response.inner.choices[0].message.reasoning_content = Some(reasoning.into());
+        response
+    }
+
+    #[test]
+    fn test_reasoning_summary_requires_explicit_request() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let unrequested = chat_completion_to_response(
+            make_chat_resp_with_reasoning("private reasoning"),
+            &ResponseParams::default(),
+            None,
+        )
+        .unwrap();
+        assert!(
+            unrequested
+                .inner
+                .output
+                .iter()
+                .all(|item| !matches!(item, OutputItem::Reasoning(_)))
+        );
+
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..Default::default()
+        };
+        let requested =
+            chat_completion_to_response(make_chat_resp_with_reasoning("summary"), &params, None)
+                .unwrap();
+        let reasoning = requested
+            .inner
+            .output
+            .iter()
+            .find_map(|item| match item {
+                OutputItem::Reasoning(reasoning) => Some(reasoning),
+                _ => None,
+            })
+            .expect("requested reasoning summary output");
+        assert_eq!(
+            reasoning.summary,
+            vec![SummaryPart::SummaryText(SummaryTextContent {
+                text: "summary".into(),
+            })]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -255,7 +255,8 @@ impl ResponseStreamConverter {
 
             if let Some(reasoning) = delta.reasoning_content.as_deref()
                 && !reasoning.is_empty()
-                && self.reasoning_summary_requested()
+                && !self.reasoning_done
+                && self.params.reasoning_summary_requested()
             {
                 self.accumulated_reasoning.push_str(reasoning);
                 if !self.reasoning_started {
@@ -504,14 +505,6 @@ impl ResponseStreamConverter {
         if should_finish_function_calls {
             self.append_pending_function_call_done_events(events);
         }
-    }
-
-    fn reasoning_summary_requested(&self) -> bool {
-        self.params
-            .reasoning
-            .as_ref()
-            .and_then(|reasoning| reasoning.summary)
-            .is_some()
     }
 
     fn append_reasoning_done_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
@@ -1357,6 +1350,36 @@ mod tests {
 
         assert!(events.is_empty());
         assert!(conv.completed_output().is_empty());
+    }
+
+    #[test]
+    fn test_reasoning_summary_ignores_updates_after_completion() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..default_params()
+        };
+        let mut conv = ResponseStreamConverter::new("test-model".into(), params);
+
+        let _ = conv.process_chunk(&reasoning_chunk("summary"));
+        let _ = conv.process_chunk(&text_chunk("answer"));
+        let late_events = conv.process_chunk(&reasoning_chunk(" must not be appended"));
+
+        assert!(late_events.is_empty());
+        let output = conv.completed_output();
+        let OutputItem::Reasoning(reasoning) = &output[0] else {
+            panic!("expected reasoning output");
+        };
+        assert_eq!(
+            reasoning.summary,
+            vec![SummaryPart::SummaryText(SummaryTextContent {
+                text: "summary".to_string(),
+            })]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -508,10 +508,13 @@ impl ResponseStreamConverter {
     }
 
     fn append_reasoning_done_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
-        if !self.reasoning_started || self.reasoning_done {
+        if self.reasoning_done {
             return;
         }
         self.reasoning_done = true;
+        if !self.reasoning_started {
+            return;
+        }
 
         let text_done = ResponseStreamEvent::ResponseReasoningSummaryTextDone(
             ResponseReasoningSummaryTextDoneEvent {
@@ -1379,6 +1382,60 @@ mod tests {
             vec![SummaryPart::SummaryText(SummaryTextContent {
                 text: "summary".to_string(),
             })]
+        );
+    }
+
+    #[test]
+    fn test_reasoning_summary_finishes_before_tool_call() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..default_params()
+        };
+        let mut conv = ResponseStreamConverter::new("test-model".into(), params);
+
+        let _ = conv.process_chunk(&reasoning_chunk("summary"));
+        let tool_events =
+            conv.process_chunk(&tool_call_chunk(0, Some("call-1"), Some("get_time"), None));
+        assert_eq!(
+            event_types(&tool_events),
+            vec![
+                "response.reasoning_summary_text.done".to_string(),
+                "response.reasoning_summary_part.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.output_item.added".to_string(),
+            ]
+        );
+
+        let late_events = conv.process_chunk(&reasoning_chunk(" must not be appended"));
+        assert!(late_events.is_empty());
+    }
+
+    #[test]
+    fn test_reasoning_summary_does_not_start_after_visible_output() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..default_params()
+        };
+        let mut conv = ResponseStreamConverter::new("test-model".into(), params);
+
+        let _ = conv.process_chunk(&text_chunk("answer"));
+        let late_events = conv.process_chunk(&reasoning_chunk("out of order"));
+
+        assert!(late_events.is_empty());
+        assert!(
+            conv.completed_output()
+                .iter()
+                .all(|item| !matches!(item, OutputItem::Reasoning(_)))
         );
     }
 

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -16,11 +16,14 @@ use axum::response::sse::Event;
 use dynamo_protocols::types::responses::{
     AssistantRole, FunctionToolCall, InputTokenDetails, Instructions, OutputContent, OutputItem,
     OutputMessage, OutputMessageContent, OutputStatus, OutputTextContent, OutputTokenDetails,
-    Response, ResponseCompletedEvent, ResponseContentPartAddedEvent, ResponseContentPartDoneEvent,
-    ResponseCreatedEvent, ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
-    ResponseFunctionCallArgumentsDoneEvent, ResponseInProgressEvent, ResponseOutputItemAddedEvent,
-    ResponseOutputItemDoneEvent, ResponseStreamEvent, ResponseTextDeltaEvent,
-    ResponseTextDoneEvent, ResponseTextParam, ResponseUsage, ServiceTier, Status,
+    ReasoningItem, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
+    ResponseInProgressEvent, ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
+    ResponseReasoningSummaryPartAddedEvent, ResponseReasoningSummaryPartDoneEvent,
+    ResponseReasoningSummaryTextDeltaEvent, ResponseReasoningSummaryTextDoneEvent,
+    ResponseStreamEvent, ResponseTextDeltaEvent, ResponseTextDoneEvent, ResponseTextParam,
+    ResponseUsage, ServiceTier, Status, SummaryPart, SummaryTextContent,
     TextResponseFormatConfiguration, ToolChoiceOptions, ToolChoiceParam, Truncation,
 };
 use serde::{
@@ -49,6 +52,12 @@ pub struct ResponseStreamConverter {
     message_started: bool,
     message_output_index: u32,
     accumulated_text: String,
+    // Reasoning summary tracking
+    reasoning_item_id: String,
+    reasoning_started: bool,
+    reasoning_done: bool,
+    reasoning_output_index: u32,
+    accumulated_reasoning: String,
     // Function call tracking
     function_call_items: Vec<FunctionCallState>,
     // Output index counter
@@ -92,6 +101,11 @@ impl ResponseStreamConverter {
             message_started: false,
             message_output_index: 0,
             accumulated_text: String::new(),
+            reasoning_item_id: format!("rs_{}", Uuid::new_v4().simple()),
+            reasoning_started: false,
+            reasoning_done: false,
+            reasoning_output_index: 0,
+            accumulated_reasoning: String::new(),
             function_call_items: Vec::new(),
             next_output_index: 0,
             usage: None,
@@ -239,6 +253,58 @@ impl ResponseStreamConverter {
         for choice in &chunk.inner.choices {
             let delta = &choice.delta;
 
+            if let Some(reasoning) = delta.reasoning_content.as_deref()
+                && !reasoning.is_empty()
+                && self.reasoning_summary_requested()
+            {
+                self.accumulated_reasoning.push_str(reasoning);
+                if !self.reasoning_started {
+                    self.reasoning_started = true;
+                    self.reasoning_output_index = self.next_output_index;
+                    let output_index = self.reasoning_output_index;
+                    self.next_output_index += 1;
+
+                    let item_added = ResponseStreamEvent::ResponseOutputItemAdded(
+                        ResponseOutputItemAddedEvent {
+                            sequence_number: self.next_seq(),
+                            output_index,
+                            item: OutputItem::Reasoning(ReasoningItem {
+                                id: Some(self.reasoning_item_id.clone()),
+                                summary: vec![],
+                                content: None,
+                                encrypted_content: None,
+                                status: Some(OutputStatus::InProgress),
+                            }),
+                        },
+                    );
+                    events.push(self.make_sse_event(&item_added));
+
+                    let part_added = ResponseStreamEvent::ResponseReasoningSummaryPartAdded(
+                        ResponseReasoningSummaryPartAddedEvent {
+                            sequence_number: self.next_seq(),
+                            item_id: self.reasoning_item_id.clone(),
+                            output_index,
+                            summary_index: 0,
+                            part: SummaryPart::SummaryText(SummaryTextContent {
+                                text: String::new(),
+                            }),
+                        },
+                    );
+                    events.push(self.make_sse_event(&part_added));
+                }
+
+                let reasoning_delta = ResponseStreamEvent::ResponseReasoningSummaryTextDelta(
+                    ResponseReasoningSummaryTextDeltaEvent {
+                        sequence_number: self.next_seq(),
+                        item_id: self.reasoning_item_id.clone(),
+                        output_index: self.reasoning_output_index,
+                        summary_index: 0,
+                        delta: reasoning.to_string(),
+                    },
+                );
+                events.push(self.make_sse_event(&reasoning_delta));
+            }
+
             // Handle text content deltas — extract text from the enum
             let content_text = match &delta.content {
                 Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
@@ -251,6 +317,8 @@ impl ResponseStreamConverter {
             if let Some(content) = content_text
                 && !content.is_empty()
             {
+                self.append_reasoning_done_events(events);
+
                 // Emit output_item.added + content_part.added on first text
                 if !self.message_started {
                     self.message_started = true;
@@ -305,6 +373,9 @@ impl ResponseStreamConverter {
 
             // Handle tool call deltas
             if let Some(tool_calls) = &delta.tool_calls {
+                if !tool_calls.is_empty() {
+                    self.append_reasoning_done_events(events);
+                }
                 for tc in tool_calls {
                     let tc_index = tc.index as usize;
 
@@ -435,6 +506,59 @@ impl ResponseStreamConverter {
         }
     }
 
+    fn reasoning_summary_requested(&self) -> bool {
+        self.params
+            .reasoning
+            .as_ref()
+            .and_then(|reasoning| reasoning.summary)
+            .is_some()
+    }
+
+    fn append_reasoning_done_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
+        if !self.reasoning_started || self.reasoning_done {
+            return;
+        }
+        self.reasoning_done = true;
+
+        let text_done = ResponseStreamEvent::ResponseReasoningSummaryTextDone(
+            ResponseReasoningSummaryTextDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: self.reasoning_item_id.clone(),
+                output_index: self.reasoning_output_index,
+                summary_index: 0,
+                text: self.accumulated_reasoning.clone(),
+            },
+        );
+        events.push(self.make_sse_event(&text_done));
+
+        let summary = SummaryPart::SummaryText(SummaryTextContent {
+            text: self.accumulated_reasoning.clone(),
+        });
+        let part_done = ResponseStreamEvent::ResponseReasoningSummaryPartDone(
+            ResponseReasoningSummaryPartDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: self.reasoning_item_id.clone(),
+                output_index: self.reasoning_output_index,
+                summary_index: 0,
+                part: summary.clone(),
+            },
+        );
+        events.push(self.make_sse_event(&part_done));
+
+        let item_done = ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
+            sequence_number: self.next_seq(),
+            output_index: self.reasoning_output_index,
+            item: OutputItem::Reasoning(ReasoningItem {
+                id: Some(self.reasoning_item_id.clone()),
+                summary: vec![summary],
+                content: None,
+                encrypted_content: None,
+                status: Some(OutputStatus::Completed),
+            }),
+        });
+        events.push(self.make_sse_event(&item_done));
+    }
+
     fn append_pending_function_call_done_events(
         &mut self,
         events: &mut Vec<Result<Event, anyhow::Error>>,
@@ -490,6 +614,20 @@ impl ResponseStreamConverter {
 
     fn completed_output(&self) -> Vec<OutputItem> {
         let mut output = Vec::new();
+        if self.reasoning_started {
+            output.push((
+                self.reasoning_output_index,
+                OutputItem::Reasoning(ReasoningItem {
+                    id: Some(self.reasoning_item_id.clone()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: self.accumulated_reasoning.clone(),
+                    })],
+                    content: None,
+                    encrypted_content: None,
+                    status: Some(OutputStatus::Completed),
+                }),
+            ));
+        }
         if self.message_started {
             output.push((
                 self.message_output_index,
@@ -534,6 +672,8 @@ impl ResponseStreamConverter {
 
     /// Append remaining output completion events and `response.completed` at stream end.
     pub fn append_end_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
+        self.append_reasoning_done_events(events);
+
         // Close text message if it was started
         if self.message_started {
             let text_done = ResponseStreamEvent::ResponseOutputTextDone(ResponseTextDoneEvent {
@@ -1023,6 +1163,36 @@ mod tests {
         }
     }
 
+    fn reasoning_chunk(text: &str) -> NvCreateChatCompletionStreamResponse {
+        #[allow(deprecated)]
+        NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "chat-1".into(),
+                choices: vec![ChatChoiceStream {
+                    index: 0,
+                    delta: ChatCompletionStreamResponseDelta {
+                        content: None,
+                        function_call: None,
+                        tool_calls: None,
+                        role: None,
+                        refusal: None,
+                        reasoning_content: Some(text.into()),
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "test".into(),
+                service_tier: None,
+                system_fingerprint: None,
+                object: "chat.completion.chunk".into(),
+                usage: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        }
+    }
+
     /// Extract the SSE event type from a Result<Event, _>.
     fn event_type(event: &Result<Event, anyhow::Error>) -> String {
         let debug = format!("{:?}", event.as_ref().unwrap());
@@ -1127,6 +1297,66 @@ mod tests {
                 "response.output_item.done".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn test_requested_reasoning_summary_streams_complete_event_sequence() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..default_params()
+        };
+        let mut conv = ResponseStreamConverter::new("test-model".into(), params);
+
+        let reasoning_events = conv.process_chunk(&reasoning_chunk("thinking"));
+        assert_eq!(
+            event_types(&reasoning_events),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.reasoning_summary_part.added".to_string(),
+                "response.reasoning_summary_text.delta".to_string(),
+            ]
+        );
+
+        let text_events = conv.process_chunk(&text_chunk("answer"));
+        assert_eq!(
+            event_types(&text_events),
+            vec![
+                "response.reasoning_summary_text.done".to_string(),
+                "response.reasoning_summary_part.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.output_text.delta".to_string(),
+            ]
+        );
+
+        let response = conv.make_response(Status::Completed, conv.completed_output());
+        assert_eq!(response.output.len(), 2);
+        let OutputItem::Reasoning(reasoning) = &response.output[0] else {
+            panic!("expected reasoning output before message");
+        };
+        assert_eq!(
+            reasoning.summary,
+            vec![SummaryPart::SummaryText(SummaryTextContent {
+                text: "thinking".to_string(),
+            })]
+        );
+        assert!(matches!(response.output[1], OutputItem::Message(_)));
+    }
+
+    #[test]
+    fn test_reasoning_without_requested_summary_emits_no_events() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+
+        let events = conv.process_chunk(&reasoning_chunk("private reasoning"));
+
+        assert!(events.is_empty());
+        assert!(conv.completed_output().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Emit requested reasoning summary items with the complete ordered streaming lifecycle.
- Retain accumulated reasoning summaries in the completed response before later message or tool output.
- Cover both requested and unrequested summary behavior.

## Root cause

`ResponseStreamConverter` handled visible text and function calls but ignored backend `reasoning_content` deltas.

## Impact

Responses clients can consume requested reasoning summaries consistently in streaming and unary modes.

## Validation

- `cargo test -p dynamo-llm protocols::openai::responses` (72 passed)
- `cargo fmt --all --check`
- `cargo clippy -p dynamo-llm --tests -- -D warnings`

Linear: [DIS-2512](https://linear.app/nvidia/issue/DIS-2512/responses-api-stream-reasoning-summary-events)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added streaming support for requested reasoning summaries.
  * Reasoning summaries now appear as dedicated response items with incremental updates and completion events.
  * Completed responses include the finalized reasoning output.

* **Bug Fixes**
  * Ensured reasoning streams finalize correctly when text or tool-call content follows—or when the stream ends without either.
  * Reasoning content remains excluded when summaries are not requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Codex CLI behavior

With `model_reasoning_summary = "detailed"` and the same prompt:

Before:

```jsonl
{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"17 × 19 = 323."}}
```

After:

```jsonl
{"type":"item.completed","item":{"id":"item_1","type":"reasoning","text":"Compute 17 × (20 − 1) = 340 − 17."}}
{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"17 × 19 = 323."}}
```

The observable change is the new completed `reasoning` item before the normal `agent_message`. Unrelated lifecycle and skill-budget events are omitted.