### PR TITLE
fix(snapshot): exit vLLM source without engine teardown

### DIFF
--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -3,6 +3,7 @@
 
 import gc
 import logging
+import os
 from collections.abc import Callable
 
 from dynamo.common.snapshot.lifecycle import (
@@ -46,6 +47,7 @@ async def prepare_snapshot_engine(
         pause_args=(None,),
     )
     if not await snapshot_controller.wait_for_restore():
-        raise SystemExit(0)
+        logger.info("vLLM snapshot captured successfully")
+        os._exit(0)
 
     return snapshot_controller


### PR DESCRIPTION
## Summary

- terminate the source vLLM process directly after a successful initial
  Snapshot capture;
- avoid unwinding and destroying the checkpointed CUDA engine during source
  shutdown; and
- leave the restored path unchanged.

## Motivation

This is a generic Dynamo Snapshot/vLLM lifecycle fix, independent of GMS V1.

The initial source path raises `SystemExit` after successful capture. That
unwinds vLLM and may enter CUDA and EngineCore teardown after the process image
has already been checkpointed. In the observed failure, teardown produced a
source-process SIGSEGV even though capture itself had succeeded.

The successful initial-capture boundary does not need Python cleanup: the
source container is deliberately being replaced by a restore-standby
container. This change therefore exits directly with `os._exit(0)`, matching
the existing TensorRT-LLM Snapshot lifecycle. The restored path still returns
normally.

This fix is split from #12011 because it applies to Dynamo Snapshot with or
without GMS.

## Validation

### Focused test

The focused unit test covers both lifecycle branches:

- successful initial capture exits directly with status 0; and
- restored execution returns without exiting.

### nscale Snapshot E2E

The fix passed in the final graph-enabled Qwen3-0.6B TP1/DP1 Snapshot + GMS V1
proof on `nscale-dev`, node `s2877`.

The source engine logged:

```text
Initial vLLM snapshot captured successfully; exiting without destroying the engine
```

Its terminal state was:

```text
exitCode=0
reason=Completed
```

The replacement entered restore standby, Snapshot reported
`nvidia.com/snapshot-restore-status.engine=completed`, restore completed in
2.674 seconds, and the restored engine served five coherent requests with
`cached_tokens=0`.

The previous destructor-path SIGSEGV did not recur. No CUDA fault, illegal
memory access, late free, engine crash, or restore retry was observed.

Qualification build:
<https://github.com/ai-dynamo/dynamo/actions/runs/30227329178>.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the snapshot capture completion flow to exit cleanly after a successful restore.
  * Added a confirmation message when the vLLM snapshot is captured successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->