### PR TITLE
fix(sglang): normalize tokenizer manager responses

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -10,6 +10,7 @@ import logging
 import random
 import threading
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from contextlib import asynccontextmanager
 from typing import (
     Any,
@@ -147,7 +148,7 @@ class RLMixin:
                 }
         if dataclasses.is_dataclass(result) and not isinstance(result, type):
             return self._normalize_json_value(result)
-        if isinstance(result, dict):
+        if isinstance(result, Mapping):
             return self._normalize_json_value(result)
         return {"result": self._normalize_json_value(result)}
 
@@ -163,7 +164,7 @@ class RLMixin:
 
         is_dataclass = dataclasses.is_dataclass(value) and not isinstance(value, type)
         if not is_dataclass and not isinstance(
-            value, (dict, list, tuple, set, frozenset)
+            value, (Mapping, list, tuple, set, frozenset)
         ):
             return str(value)
 
@@ -180,7 +181,7 @@ class RLMixin:
                     )
                     for field in dataclasses.fields(value)
                 }
-            if isinstance(value, dict):
+            if isinstance(value, Mapping):
                 return {
                     str(key): self._normalize_json_value(item, active_ids)
                     for key, item in value.items()

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -151,17 +151,37 @@ class RLMixin:
             return self._normalize_json_value(result)
         return {"result": self._normalize_json_value(result)}
 
-    def _normalize_json_value(self, value: Any) -> Any:
+    def _normalize_json_value(
+        self, value: Any, active_ids: set[int] | None = None
+    ) -> Any:
         """Recursively convert tokenizer_manager values to transport-safe data."""
-        if dataclasses.is_dataclass(value) and not isinstance(value, type):
-            return self._normalize_json_value(dataclasses.asdict(value))
-        if isinstance(value, dict):
-            return {
-                str(key): self._normalize_json_value(item)
-                for key, item in value.items()
-            }
-        if isinstance(value, (list, tuple, set)):
-            return [self._normalize_json_value(item) for item in value]
+        if active_ids is None:
+            active_ids = set()
+
+        is_dataclass = dataclasses.is_dataclass(value) and not isinstance(value, type)
+        is_collection = isinstance(value, (dict, list, tuple, set, frozenset))
+        if is_dataclass or is_collection:
+            value_id = id(value)
+            if value_id in active_ids:
+                return "<recursive reference>"
+
+            active_ids.add(value_id)
+            try:
+                if is_dataclass:
+                    return {
+                        field.name: self._normalize_json_value(
+                            getattr(value, field.name), active_ids
+                        )
+                        for field in dataclasses.fields(value)
+                    }
+                if isinstance(value, dict):
+                    return {
+                        str(key): self._normalize_json_value(item, active_ids)
+                        for key, item in value.items()
+                    }
+                return [self._normalize_json_value(item, active_ids) for item in value]
+            finally:
+                active_ids.remove(value_id)
         if value is None or isinstance(value, (str, int, float, bool)):
             return value
         return str(value)

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -155,36 +155,39 @@ class RLMixin:
         self, value: Any, active_ids: set[int] | None = None
     ) -> Any:
         """Recursively convert tokenizer_manager values to transport-safe data."""
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+
         if active_ids is None:
             active_ids = set()
 
         is_dataclass = dataclasses.is_dataclass(value) and not isinstance(value, type)
-        is_collection = isinstance(value, (dict, list, tuple, set, frozenset))
-        if is_dataclass or is_collection:
-            value_id = id(value)
-            if value_id in active_ids:
-                return "<recursive reference>"
+        if not is_dataclass and not isinstance(
+            value, (dict, list, tuple, set, frozenset)
+        ):
+            return str(value)
 
-            active_ids.add(value_id)
-            try:
-                if is_dataclass:
-                    return {
-                        field.name: self._normalize_json_value(
-                            getattr(value, field.name), active_ids
-                        )
-                        for field in dataclasses.fields(value)
-                    }
-                if isinstance(value, dict):
-                    return {
-                        str(key): self._normalize_json_value(item, active_ids)
-                        for key, item in value.items()
-                    }
-                return [self._normalize_json_value(item, active_ids) for item in value]
-            finally:
-                active_ids.remove(value_id)
-        if value is None or isinstance(value, (str, int, float, bool)):
-            return value
-        return str(value)
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive reference>"
+
+        active_ids.add(value_id)
+        try:
+            if is_dataclass:
+                return {
+                    field.name: self._normalize_json_value(
+                        getattr(value, field.name), active_ids
+                    )
+                    for field in dataclasses.fields(value)
+                }
+            if isinstance(value, dict):
+                return {
+                    str(key): self._normalize_json_value(item, active_ids)
+                    for key, item in value.items()
+                }
+            return [self._normalize_json_value(item, active_ids) for item in value]
+        finally:
+            active_ids.remove(value_id)
 
     async def call_tokenizer_manager(self, body: dict) -> dict:
         """Generic passthrough to any tokenizer_manager method.

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -135,31 +135,36 @@ class RLMixin:
             return {"status": "ok"}
         if isinstance(result, tuple):
             if len(result) == 2:
-                return {"success": result[0], "message": result[1]}
+                return {
+                    "success": self._normalize_json_value(result[0]),
+                    "message": self._normalize_json_value(result[1]),
+                }
             if len(result) == 3:
                 return {
-                    "success": result[0],
-                    "message": result[1],
-                    "num_paused_requests": result[2],
+                    "success": self._normalize_json_value(result[0]),
+                    "message": self._normalize_json_value(result[1]),
+                    "num_paused_requests": self._normalize_json_value(result[2]),
                 }
-        if isinstance(result, list):
-            return {
-                "result": [
-                    (
-                        dataclasses.asdict(item)
-                        if dataclasses.is_dataclass(item) and not isinstance(item, type)
-                        else item
-                    )
-                    for item in result
-                ]
-            }
         if dataclasses.is_dataclass(result) and not isinstance(result, type):
-            return dataclasses.asdict(result)
+            return self._normalize_json_value(result)
         if isinstance(result, dict):
-            return result
-        if isinstance(result, (str, int, float, bool)):
-            return {"result": result}
-        return {"result": str(result)}
+            return self._normalize_json_value(result)
+        return {"result": self._normalize_json_value(result)}
+
+    def _normalize_json_value(self, value: Any) -> Any:
+        """Recursively convert tokenizer_manager values to transport-safe data."""
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            return self._normalize_json_value(dataclasses.asdict(value))
+        if isinstance(value, dict):
+            return {
+                str(key): self._normalize_json_value(item)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple, set)):
+            return [self._normalize_json_value(item) for item in value]
+        if value is None or isinstance(value, (str, int, float, bool)):
+            return value
+        return str(value)
 
     async def call_tokenizer_manager(self, body: dict) -> dict:
         """Generic passthrough to any tokenizer_manager method.

--- a/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
@@ -4,6 +4,7 @@
 """Unit tests for RLMixin generic tokenizer_manager passthrough."""
 
 import dataclasses
+import json
 import sys
 import types
 from types import SimpleNamespace
@@ -144,9 +145,9 @@ class TestNormalizeResult:
             "num_paused_requests": 5,
         }
 
-    def test_dict_passthrough(self):
+    def test_dict_normalized(self):
         d = {"foo": "bar", "count": 3}
-        assert self.handler._normalize_result(d) is d
+        assert self.handler._normalize_result(d) == d
 
     def test_dataclass(self):
         @dataclasses.dataclass
@@ -188,6 +189,41 @@ class TestNormalizeResult:
         assert self.handler._normalize_result(items) == {
             "result": [{"val": 1}, "plain", 42]
         }
+
+    def test_get_internal_state_normalizes_nested_cuda_graph_config(self):
+        @dataclasses.dataclass
+        class CudaGraphConfig:
+            tp_size: int
+            pp_size: int
+            dp_size: int
+            max_bs: int
+
+        internal_state = [
+            {
+                "dp_rank": 0,
+                "cuda_graph_config": CudaGraphConfig(
+                    tp_size=4,
+                    pp_size=2,
+                    dp_size=8,
+                    max_bs=32,
+                ),
+                "tp_rank_ids": (0, 1, 2, 3),
+                "active_batch_ids": {7, 9},
+            }
+        ]
+
+        result = self.handler._normalize_result(internal_state)
+
+        state = result["result"][0]
+        assert state["cuda_graph_config"] == {
+            "tp_size": 4,
+            "pp_size": 2,
+            "dp_size": 8,
+            "max_bs": 32,
+        }
+        assert state["tp_rank_ids"] == [0, 1, 2, 3]
+        assert set(state["active_batch_ids"]) == {7, 9}
+        json.dumps(result)
 
     def test_other_value(self):
         assert self.handler._normalize_result(42) == {"result": 42}

--- a/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
@@ -191,92 +191,26 @@ class TestNormalizeResult:
             "result": [{"val": 1}, "plain", 42]
         }
 
-    def test_get_internal_state_normalizes_nested_cuda_graph_config(self):
-        @dataclasses.dataclass
-        class PhaseConfig:
-            backend: str
-            max_bs: int | None
-            bs: list[int] | None
-            tc_compiler: str
-            full_prefill_max_req: int | None = None
-
-        @dataclasses.dataclass
-        class CudaGraphConfig:
-            decode: PhaseConfig
-            prefill: PhaseConfig
-
-        internal_state = [
-            {
-                "dp_rank": 0,
-                "tp_size": 4,
-                "pp_size": 2,
-                "dp_size": 8,
-                "cuda_graph_config": CudaGraphConfig(
-                    decode=PhaseConfig("full", 32, [1, 2, 4, 8], "eager"),
-                    prefill=PhaseConfig(
-                        "breakable", None, [1], "eager", full_prefill_max_req=4
-                    ),
-                ),
-                "tp_rank_ids": (0, 1, 2, 3),
-                "active_batch_ids": {7, 9},
-            }
-        ]
-
-        result = self.handler._normalize_result(internal_state)
-
-        state = result["result"][0]
-        assert state["tp_size"] == 4
-        assert state["pp_size"] == 2
-        assert state["dp_size"] == 8
-        assert state["cuda_graph_config"] == {
-            "decode": {
-                "backend": "full",
-                "max_bs": 32,
-                "bs": [1, 2, 4, 8],
-                "tc_compiler": "eager",
-                "full_prefill_max_req": None,
-            },
-            "prefill": {
-                "backend": "breakable",
-                "max_bs": None,
-                "bs": [1],
-                "tc_compiler": "eager",
-                "full_prefill_max_req": 4,
-            },
-        }
-        assert state["tp_rank_ids"] == [0, 1, 2, 3]
-        assert set(state["active_batch_ids"]) == {7, 9}
-        json.dumps(result)
-
-    def test_cyclic_nested_containers_use_placeholder(self):
-        internal_state: dict[str, Any] = {"dp_rank": 0}
-        internal_state["self"] = internal_state
-
-        result = self.handler._normalize_result(internal_state)
-
-        assert result == {"dp_rank": 0, "self": "<recursive reference>"}
-        json.dumps(result)
-
-    def test_cyclic_dataclass_uses_placeholder(self):
+    def test_cyclic_dataclass_and_container_use_placeholder(self):
         @dataclasses.dataclass
         class RecursiveConfig:
             nested: Any = None
 
         config = RecursiveConfig()
-        config.nested = config
+        config.nested = {"config": config}
 
-        assert self.handler._normalize_result(config) == {
-            "nested": "<recursive reference>"
-        }
+        result = self.handler._normalize_result(config)
+
+        assert result == {"nested": {"config": "<recursive reference>"}}
+        json.dumps(result)
 
     def test_other_value(self):
         assert self.handler._normalize_result(42) == {"result": 42}
         assert self.handler._normalize_result("text") == {"result": "text"}
 
-    def test_non_serializable_falls_back_to_str(self):
+    def test_nested_non_serializable_falls_back_to_str(self):
         obj = object()
-        result = self.handler._normalize_result(obj)
-        assert result == {"result": str(obj)}
+        assert self.handler._normalize_result({"value": obj}) == {"value": str(obj)}
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
@@ -8,6 +8,7 @@ import json
 import sys
 import types
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -192,20 +193,29 @@ class TestNormalizeResult:
 
     def test_get_internal_state_normalizes_nested_cuda_graph_config(self):
         @dataclasses.dataclass
+        class PhaseConfig:
+            backend: str
+            max_bs: int | None
+            bs: list[int] | None
+            tc_compiler: str
+            full_prefill_max_req: int | None = None
+
+        @dataclasses.dataclass
         class CudaGraphConfig:
-            tp_size: int
-            pp_size: int
-            dp_size: int
-            max_bs: int
+            decode: PhaseConfig
+            prefill: PhaseConfig
 
         internal_state = [
             {
                 "dp_rank": 0,
+                "tp_size": 4,
+                "pp_size": 2,
+                "dp_size": 8,
                 "cuda_graph_config": CudaGraphConfig(
-                    tp_size=4,
-                    pp_size=2,
-                    dp_size=8,
-                    max_bs=32,
+                    decode=PhaseConfig("full", 32, [1, 2, 4, 8], "eager"),
+                    prefill=PhaseConfig(
+                        "breakable", None, [1], "eager", full_prefill_max_req=4
+                    ),
                 ),
                 "tp_rank_ids": (0, 1, 2, 3),
                 "active_batch_ids": {7, 9},
@@ -215,15 +225,49 @@ class TestNormalizeResult:
         result = self.handler._normalize_result(internal_state)
 
         state = result["result"][0]
+        assert state["tp_size"] == 4
+        assert state["pp_size"] == 2
+        assert state["dp_size"] == 8
         assert state["cuda_graph_config"] == {
-            "tp_size": 4,
-            "pp_size": 2,
-            "dp_size": 8,
-            "max_bs": 32,
+            "decode": {
+                "backend": "full",
+                "max_bs": 32,
+                "bs": [1, 2, 4, 8],
+                "tc_compiler": "eager",
+                "full_prefill_max_req": None,
+            },
+            "prefill": {
+                "backend": "breakable",
+                "max_bs": None,
+                "bs": [1],
+                "tc_compiler": "eager",
+                "full_prefill_max_req": 4,
+            },
         }
         assert state["tp_rank_ids"] == [0, 1, 2, 3]
         assert set(state["active_batch_ids"]) == {7, 9}
         json.dumps(result)
+
+    def test_cyclic_nested_containers_use_placeholder(self):
+        internal_state: dict[str, Any] = {"dp_rank": 0}
+        internal_state["self"] = internal_state
+
+        result = self.handler._normalize_result(internal_state)
+
+        assert result == {"dp_rank": 0, "self": "<recursive reference>"}
+        json.dumps(result)
+
+    def test_cyclic_dataclass_uses_placeholder(self):
+        @dataclasses.dataclass
+        class RecursiveConfig:
+            nested: Any = None
+
+        config = RecursiveConfig()
+        config.nested = config
+
+        assert self.handler._normalize_result(config) == {
+            "nested": "<recursive reference>"
+        }
 
     def test_other_value(self):
         assert self.handler._normalize_result(42) == {"result": 42}

--- a/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py
@@ -7,7 +7,7 @@ import dataclasses
 import json
 import sys
 import types
-from types import SimpleNamespace
+from types import MappingProxyType, SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -149,6 +149,10 @@ class TestNormalizeResult:
     def test_dict_normalized(self):
         d = {"foo": "bar", "count": 3}
         assert self.handler._normalize_result(d) == d
+
+    def test_mapping_normalized(self):
+        value = MappingProxyType({"nested": {"count": 3}})
+        assert self.handler._normalize_result(value) == {"nested": {"count": 3}}
 
     def test_dataclass(self):
         @dataclasses.dataclass

--- a/tests/runtime/test_engine_controls_e2e.py
+++ b/tests/runtime/test_engine_controls_e2e.py
@@ -88,21 +88,30 @@ async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclas
     )
 
     @dataclasses.dataclass
+    class PhaseConfig:
+        backend: str
+        max_bs: int | None
+        bs: list[int] | None
+        tc_compiler: str
+        full_prefill_max_req: int | None = None
+
+    @dataclasses.dataclass
     class CudaGraphConfig:
-        tp_size: int
-        pp_size: int
-        dp_size: int
-        max_bs: int
+        decode: PhaseConfig
+        prefill: PhaseConfig
 
     async def get_internal_state() -> list[dict[str, Any]]:
         return [
             {
                 "dp_rank": 0,
+                "tp_size": 4,
+                "pp_size": 2,
+                "dp_size": 8,
                 "cuda_graph_config": CudaGraphConfig(
-                    tp_size=4,
-                    pp_size=2,
-                    dp_size=8,
-                    max_bs=32,
+                    decode=PhaseConfig("full", 32, [1, 2, 4, 8], "eager"),
+                    prefill=PhaseConfig(
+                        "breakable", None, [1], "eager", full_prefill_max_req=4
+                    ),
                 ),
                 "tp_rank_ids": (0, 1, 2, 3),
                 "active_batch_ids": {7, 9},
@@ -139,11 +148,24 @@ async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclas
 
         assert response.status_code == 200
         state = response.json()["result"][0]
+        assert state["tp_size"] == 4
+        assert state["pp_size"] == 2
+        assert state["dp_size"] == 8
         assert state["cuda_graph_config"] == {
-            "tp_size": 4,
-            "pp_size": 2,
-            "dp_size": 8,
-            "max_bs": 32,
+            "decode": {
+                "backend": "full",
+                "max_bs": 32,
+                "bs": [1, 2, 4, 8],
+                "tc_compiler": "eager",
+                "full_prefill_max_req": None,
+            },
+            "prefill": {
+                "backend": "breakable",
+                "max_bs": None,
+                "bs": [1],
+                "tc_compiler": "eager",
+                "full_prefill_max_req": 4,
+            },
         }
         assert state["tp_rank_ids"] == [0, 1, 2, 3]
         assert set(state["active_batch_ids"]) == {7, 9}

--- a/tests/runtime/test_engine_controls_e2e.py
+++ b/tests/runtime/test_engine_controls_e2e.py
@@ -78,6 +78,7 @@ async def test_engine_control_route_invokes_registered_callback(
 
 @pytest.mark.asyncio
 @pytest.mark.sglang
+@pytest.mark.timeout(30)
 async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclass(
     monkeypatch: pytest.MonkeyPatch, dynamo_dynamic_ports
 ):

--- a/tests/runtime/test_engine_controls_e2e.py
+++ b/tests/runtime/test_engine_controls_e2e.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import dataclasses
+from collections.abc import Awaitable, Callable
 from types import SimpleNamespace
 from typing import Any
 
@@ -35,45 +36,51 @@ async def _post_with_retry(
     raise AssertionError(f"system server did not accept connections: {last_error}")
 
 
+async def _post_engine_route(
+    monkeypatch: pytest.MonkeyPatch,
+    dynamo_dynamic_ports,
+    route: str,
+    handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]],
+    body: dict[str, Any],
+) -> httpx.Response:
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
+    # Keep this local-only test independent of ambient CI NATS_SERVER settings.
+    runtime = DistributedRuntime(
+        asyncio.get_running_loop(), "mem", "tcp", event_plane="zmq"
+    )
+    runtime.register_engine_route(route, handler)
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            return await _post_with_retry(
+                client, f"http://127.0.0.1:{system_port}/engine/{route}", body
+            )
+    finally:
+        runtime.shutdown()
+
+
 @pytest.mark.asyncio
 async def test_engine_control_route_invokes_registered_callback(
     monkeypatch: pytest.MonkeyPatch, dynamo_dynamic_ports
 ):
-    system_port = dynamo_dynamic_ports.system_ports[0]
-    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
-
-    # Keep this local-only test independent of ambient CI NATS_SERVER settings.
-    runtime = DistributedRuntime(
-        asyncio.get_running_loop(),
-        "mem",
-        "tcp",
-        event_plane="zmq",
-    )
     calls: list[dict[str, Any]] = []
 
     async def sleep_control(body: dict[str, Any]) -> dict[str, Any]:
         calls.append(body)
         return {"status": "ok", "control": "sleep", "body": body}
 
-    runtime.register_engine_route("control/sleep", sleep_control)
+    response = await _post_engine_route(
+        monkeypatch, dynamo_dynamic_ports, "control/sleep", sleep_control, {"level": 1}
+    )
 
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await _post_with_retry(
-                client,
-                f"http://127.0.0.1:{system_port}/engine/control/sleep",
-                {"level": 1},
-            )
-
-        assert response.status_code == 200
-        assert response.json() == {
-            "status": "ok",
-            "control": "sleep",
-            "body": {"level": 1},
-        }
-        assert calls == [{"level": 1}]
-    finally:
-        runtime.shutdown()
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "control": "sleep",
+        "body": {"level": 1},
+    }
+    assert calls == [{"level": 1}]
 
 
 @pytest.mark.asyncio
@@ -126,48 +133,33 @@ async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclas
         )
     )
 
-    system_port = dynamo_dynamic_ports.system_ports[0]
-    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
-    runtime = DistributedRuntime(
-        asyncio.get_running_loop(),
-        "mem",
-        "tcp",
-        event_plane="zmq",
+    response = await _post_engine_route(
+        monkeypatch,
+        dynamo_dynamic_ports,
+        "call_tokenizer_manager",
+        handler.call_tokenizer_manager,
+        {"method": "get_internal_state"},
     )
-    runtime.register_engine_route(
-        "call_tokenizer_manager", handler.call_tokenizer_manager
-    )
-
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await _post_with_retry(
-                client,
-                f"http://127.0.0.1:{system_port}/engine/call_tokenizer_manager",
-                {"method": "get_internal_state"},
-            )
-
-        assert response.status_code == 200
-        state = response.json()["result"][0]
-        assert state["tp_size"] == 4
-        assert state["pp_size"] == 2
-        assert state["dp_size"] == 8
-        assert state["cuda_graph_config"] == {
-            "decode": {
-                "backend": "full",
-                "max_bs": 32,
-                "bs": [1, 2, 4, 8],
-                "tc_compiler": "eager",
-                "full_prefill_max_req": None,
-            },
-            "prefill": {
-                "backend": "breakable",
-                "max_bs": None,
-                "bs": [1],
-                "tc_compiler": "eager",
-                "full_prefill_max_req": 4,
-            },
-        }
-        assert state["tp_rank_ids"] == [0, 1, 2, 3]
-        assert set(state["active_batch_ids"]) == {7, 9}
-    finally:
-        runtime.shutdown()
+    assert response.status_code == 200
+    state = response.json()["result"][0]
+    assert state["tp_size"] == 4
+    assert state["pp_size"] == 2
+    assert state["dp_size"] == 8
+    assert state["cuda_graph_config"] == {
+        "decode": {
+            "backend": "full",
+            "max_bs": 32,
+            "bs": [1, 2, 4, 8],
+            "tc_compiler": "eager",
+            "full_prefill_max_req": None,
+        },
+        "prefill": {
+            "backend": "breakable",
+            "max_bs": None,
+            "bs": [1],
+            "tc_compiler": "eager",
+            "full_prefill_max_req": 4,
+        },
+    }
+    assert state["tp_rank_ids"] == [0, 1, 2, 3]
+    assert set(state["active_batch_ids"]) == {7, 9}

--- a/tests/runtime/test_engine_controls_e2e.py
+++ b/tests/runtime/test_engine_controls_e2e.py
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import dataclasses
-from collections.abc import Awaitable, Callable
-from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -36,43 +33,34 @@ async def _post_with_retry(
     raise AssertionError(f"system server did not accept connections: {last_error}")
 
 
-async def _post_engine_route(
-    monkeypatch: pytest.MonkeyPatch,
-    dynamo_dynamic_ports,
-    route: str,
-    handler: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]],
-    body: dict[str, Any],
-) -> httpx.Response:
-    system_port = dynamo_dynamic_ports.system_ports[0]
-    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
-    # Keep this local-only test independent of ambient CI NATS_SERVER settings.
-    runtime = DistributedRuntime(
-        asyncio.get_running_loop(), "mem", "tcp", event_plane="zmq"
-    )
-    runtime.register_engine_route(route, handler)
-
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            return await _post_with_retry(
-                client, f"http://127.0.0.1:{system_port}/engine/{route}", body
-            )
-    finally:
-        runtime.shutdown()
-
-
+# The Python bindings share one Tokio runtime for the process. shutdown() is
+# terminal, so tests in this module must leave it alive for later tests and
+# retry attempts.
 @pytest.mark.asyncio
 async def test_engine_control_route_invokes_registered_callback(
     monkeypatch: pytest.MonkeyPatch, dynamo_dynamic_ports
 ):
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
+
+    # Keep this local-only test independent of ambient CI NATS_SERVER settings.
+    runtime = DistributedRuntime(
+        asyncio.get_running_loop(), "mem", "tcp", event_plane="zmq"
+    )
     calls: list[dict[str, Any]] = []
 
     async def sleep_control(body: dict[str, Any]) -> dict[str, Any]:
         calls.append(body)
         return {"status": "ok", "control": "sleep", "body": body}
 
-    response = await _post_engine_route(
-        monkeypatch, dynamo_dynamic_ports, "control/sleep", sleep_control, {"level": 1}
-    )
+    runtime.register_engine_route("control/sleep", sleep_control)
+
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        response = await _post_with_retry(
+            client,
+            f"http://127.0.0.1:{system_port}/engine/control/sleep",
+            {"level": 1},
+        )
 
     assert response.status_code == 200
     assert response.json() == {
@@ -81,85 +69,3 @@ async def test_engine_control_route_invokes_registered_callback(
         "body": {"level": 1},
     }
     assert calls == [{"level": 1}]
-
-
-@pytest.mark.asyncio
-@pytest.mark.sglang
-@pytest.mark.timeout(30)
-async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclass(
-    monkeypatch: pytest.MonkeyPatch, dynamo_dynamic_ports
-):
-    handler_base = pytest.importorskip(
-        "dynamo.sglang.request_handlers.handler_base",
-        reason="SGLang is required for the tokenizer manager route",
-    )
-
-    @dataclasses.dataclass
-    class PhaseConfig:
-        backend: str
-        max_bs: int | None
-        bs: list[int] | None
-        tc_compiler: str
-        full_prefill_max_req: int | None = None
-
-    @dataclasses.dataclass
-    class CudaGraphConfig:
-        decode: PhaseConfig
-        prefill: PhaseConfig
-
-    async def get_internal_state() -> list[dict[str, Any]]:
-        return [
-            {
-                "dp_rank": 0,
-                "tp_size": 4,
-                "pp_size": 2,
-                "dp_size": 8,
-                "cuda_graph_config": CudaGraphConfig(
-                    decode=PhaseConfig("full", 32, [1, 2, 4, 8], "eager"),
-                    prefill=PhaseConfig(
-                        "breakable", None, [1], "eager", full_prefill_max_req=4
-                    ),
-                ),
-                "tp_rank_ids": (0, 1, 2, 3),
-                "active_batch_ids": {7, 9},
-            }
-        ]
-
-    handler = handler_base.RLMixin()
-    handler.engine = SimpleNamespace(
-        tokenizer_manager=SimpleNamespace(
-            auto_create_handle_loop=lambda: None,
-            get_internal_state=get_internal_state,
-        )
-    )
-
-    response = await _post_engine_route(
-        monkeypatch,
-        dynamo_dynamic_ports,
-        "call_tokenizer_manager",
-        handler.call_tokenizer_manager,
-        {"method": "get_internal_state"},
-    )
-    assert response.status_code == 200
-    state = response.json()["result"][0]
-    assert state["tp_size"] == 4
-    assert state["pp_size"] == 2
-    assert state["dp_size"] == 8
-    assert state["cuda_graph_config"] == {
-        "decode": {
-            "backend": "full",
-            "max_bs": 32,
-            "bs": [1, 2, 4, 8],
-            "tc_compiler": "eager",
-            "full_prefill_max_req": None,
-        },
-        "prefill": {
-            "backend": "breakable",
-            "max_bs": None,
-            "bs": [1],
-            "tc_compiler": "eager",
-            "full_prefill_max_req": 4,
-        },
-    }
-    assert state["tp_rank_ids"] == [0, 1, 2, 3]
-    assert set(state["active_batch_ids"]) == {7, 9}

--- a/tests/runtime/test_engine_controls_e2e.py
+++ b/tests/runtime/test_engine_controls_e2e.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import dataclasses
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -70,5 +72,79 @@ async def test_engine_control_route_invokes_registered_callback(
             "body": {"level": 1},
         }
         assert calls == [{"level": 1}]
+    finally:
+        runtime.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.sglang
+async def test_tokenizer_manager_internal_state_route_serializes_nested_dataclass(
+    monkeypatch: pytest.MonkeyPatch, dynamo_dynamic_ports
+):
+    handler_base = pytest.importorskip(
+        "dynamo.sglang.request_handlers.handler_base",
+        reason="SGLang is required for the tokenizer manager route",
+    )
+
+    @dataclasses.dataclass
+    class CudaGraphConfig:
+        tp_size: int
+        pp_size: int
+        dp_size: int
+        max_bs: int
+
+    async def get_internal_state() -> list[dict[str, Any]]:
+        return [
+            {
+                "dp_rank": 0,
+                "cuda_graph_config": CudaGraphConfig(
+                    tp_size=4,
+                    pp_size=2,
+                    dp_size=8,
+                    max_bs=32,
+                ),
+                "tp_rank_ids": (0, 1, 2, 3),
+                "active_batch_ids": {7, 9},
+            }
+        ]
+
+    handler = handler_base.RLMixin()
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            auto_create_handle_loop=lambda: None,
+            get_internal_state=get_internal_state,
+        )
+    )
+
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    monkeypatch.setenv("DYN_SYSTEM_PORT", str(system_port))
+    runtime = DistributedRuntime(
+        asyncio.get_running_loop(),
+        "mem",
+        "tcp",
+        event_plane="zmq",
+    )
+    runtime.register_engine_route(
+        "call_tokenizer_manager", handler.call_tokenizer_manager
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await _post_with_retry(
+                client,
+                f"http://127.0.0.1:{system_port}/engine/call_tokenizer_manager",
+                {"method": "get_internal_state"},
+            )
+
+        assert response.status_code == 200
+        state = response.json()["result"][0]
+        assert state["cuda_graph_config"] == {
+            "tp_size": 4,
+            "pp_size": 2,
+            "dp_size": 8,
+            "max_bs": 32,
+        }
+        assert state["tp_rank_ids"] == [0, 1, 2, 3]
+        assert set(state["active_batch_ids"]) == {7, 9}
     finally:
         runtime.shutdown()

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import pytest
+import requests
 
 from tests.serve.common import (
     SERVE_TEST_DIR,
@@ -62,6 +63,21 @@ class SGLangConfig(EngineConfig):
     stragglers: list[str] = field(default_factory=lambda: ["SGLANG:EngineCore"])
 
 
+def _assert_internal_state_serializes(system_port: int) -> None:
+    response = requests.post(
+        f"http://127.0.0.1:{system_port}/engine/call_tokenizer_manager",
+        json={"method": "get_internal_state"},
+        timeout=10,
+    )
+    assert response.status_code == 200, response.text
+
+    state = response.json()["result"][0]
+    assert state["tp_size"] == 1
+    assert state["pp_size"] == 1
+    assert state["dp_size"] == 1
+    assert {"decode", "prefill"} <= state["cuda_graph_config"].keys()
+
+
 sglang_dir = os.environ.get("SGLANG_DIR") or os.path.join(
     WORKSPACE_DIR, "examples/backends/sglang"
 )
@@ -110,7 +126,7 @@ sglang_configs = {
             pytest.mark.pre_merge,
         ],
         model="Qwen/Qwen3-0.6B",
-        env={},
+        env={"DYN_SGL_ENABLE_RL": "true"},
         frontend_port=DefaultPort.FRONTEND.value,
         request_payloads=[
             chat_payload_default(),
@@ -873,7 +889,19 @@ def test_sglang_deployment(
     config = dataclasses.replace(
         sglang_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
     )
-    run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
+    if config.name == "aggregated":
+
+        def post_validation() -> None:
+            _assert_internal_state_serializes(dynamo_dynamic_ports.system_ports[0])
+
+    else:
+        post_validation = None
+    run_serve_deployment(
+        config,
+        request,
+        ports=dynamo_dynamic_ports,
+        post_validation=post_validation,
+    )
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
## Summary
- Recursively normalize tokenizer-manager RPC results, including nested dataclasses, mappings, sequences, and sets.
- Detect active-path cycles and preserve the existing `None` and two-/three-tuple response envelopes.
- Add focused unit coverage for cycles, non-serializable leaves, and immutable mappings.
- Validate the real SGLang `get_internal_state` route during the existing aggregated deployment test, preserving topology and nested CUDA-graph configuration in the JSON response.

## Validation
- `uvx pre-commit run --files components/src/dynamo/sglang/request_handlers/handler_base.py components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py tests/runtime/test_engine_controls_e2e.py tests/serve/test_sglang.py`
- `python3 -m compileall -q components/src/dynamo/sglang/request_handlers/handler_base.py components/src/dynamo/sglang/tests/test_sglang_rl_mixin.py tests/runtime/test_engine_controls_e2e.py tests/serve/test_sglang.py`

Focused pytest could not be collected locally because the system Python has neither pytest nor the Dynamo package; full SGLang CI is running on the PR.