### PR TITLE
fix(snapshot): skip ordinal discovery for one DRA GPU

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -152,6 +152,9 @@ func discoverGPUUUIDs(
 				"DRA GPU allocation has no resolvable UUIDs",
 			)
 		}
+		if len(gpuUUIDs) == 1 {
+			return append([]string(nil), gpuUUIDs...), nil
+		}
 		visibleGPUUUIDs, err := discoverVisibleGPUs(ctx, hostProcPath, pid)
 		if err != nil {
 			return nil, fmt.Errorf(

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -305,6 +305,84 @@ func TestDiscoverGPUUUIDsFallsBackToPodResourcesAfterDRAAPILookupError(t *testin
 	}
 }
 
+func TestDiscoverGPUUUIDsSkipsOrdinalDiscoveryForSingleDRAGPU(t *testing.T) {
+	nodeName := "node-1"
+	poolName := "pool-node-1"
+	namespace := "default"
+	podName := "test-pod"
+	claimName := "gpu-claim"
+	uuid := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+					},
+				},
+			},
+			ResourceClaims: []corev1.PodResourceClaim{
+				{
+					Name:              "gpu",
+					ResourceClaimName: &claimName,
+				},
+			},
+		},
+	}
+	claim := &resourcev1.ResourceClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: namespace},
+		Status: resourcev1.ResourceClaimStatus{
+			Allocation: &resourcev1.AllocationResult{
+				Devices: resourcev1.DeviceAllocationResult{
+					Results: []resourcev1.DeviceRequestAllocationResult{
+						{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-0", Request: "gpu"},
+					},
+				},
+			},
+		},
+	}
+	slice := &resourcev1.ResourceSlice{
+		ObjectMeta: metav1.ObjectMeta{Name: poolName + "-gpu.nvidia.com-xxx"},
+		Spec: resourcev1.ResourceSliceSpec{
+			Driver:   nvidiaGPUDRADriver,
+			NodeName: &nodeName,
+			Pool:     resourcev1.ResourcePool{Name: poolName},
+			Devices: []resourcev1.Device{
+				{
+					Name: "gpu-0",
+					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+						resourcev1.QualifiedName("uuid"): {StringValue: &uuid},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := discoverGPUUUIDs(
+		context.Background(),
+		fake.NewSimpleClientset(pod, claim, slice),
+		podName,
+		namespace,
+		"main",
+		"/proc",
+		123,
+		func(context.Context, string, int) ([]string, error) {
+			return nil, errors.New("visible GPU discovery must not be called")
+		},
+		logr.Discard(),
+	)
+	if err != nil {
+		t.Fatalf("discoverGPUUUIDs: %v", err)
+	}
+	if len(got) != 1 || got[0] != uuid {
+		t.Fatalf("got %v, want [%s]", got, uuid)
+	}
+}
+
 func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 	previousSocketPath := podResourcesSocketPath
 	podResourcesSocketPath = filepath.Join(t.TempDir(), "missing-kubelet.sock")


### PR DESCRIPTION
## Summary

For a one-GPU DRA allocation, return a copy of the sole UUID reported by the
DRA API without running visible-GPU ordinal discovery.

Ordinal reconciliation is only needed for multi-GPU allocations. With one UUID
there is only one possible order, so entering the source process namespaces and
running `nvidia-smi` adds no information. Avoiding that probe also allows the
Snapshot Agent to checkpoint a quiesced or sleeping single-GPU source.

The Qwen3-0.6B Snapshot + GMS V1 E2E exposed this pre-existing generic Snapshot
issue, so the fix is split from #12011:

```text
failed to discover source GPU UUIDs: discover DRA GPUs in container
ordinal order: nvidia-smi via nsenter (...) failed: signal:
trace/breakpoint trap
```

Multi-GPU DRA allocations retain the existing namespace-visible ordinal
discovery path.

## Validation

### Focused Go tests

```text
cd deploy/snapshot
go test ./internal/cuda
ok github.com/ai-dynamo/dynamo/deploy/snapshot/internal/cuda
```

Repeated focused tests, race testing, vet, and the full Snapshot Agent test
suite also passed during review.

### nscale Snapshot E2E

The fix passed in the final graph-enabled Qwen3-0.6B TP1/DP1 Snapshot + GMS V1
proof on `nscale-dev`, node `s2877`, using the sole assigned DRA UUID:

```text
GPU-02ff0cc1-647f-dee7-8365-921738e945a6
```

The Snapshot Agent resolved the one-element DRA allocation directly and did
not invoke the failing source-namespace `nsenter` / `nvidia-smi` probe.

```text
capture: 16.422993 s
restore: 2.674033 s
post-restore inference: 5/5 HTTP 200, cached_tokens=0
```

No trace/breakpoint trap, CUDA fault, Xid, source crash, or restore retry
occurred.

Qualification build:
<https://github.com/ai-dynamo/dynamo/actions/runs/30227329178>.
