### PR TITLE
refactor(mocker): introduce KV cache groups in the native vLLM backend

### DIFF
--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -3,7 +3,7 @@
 
 //! Physical-capacity model for vLLM's GPU block pool.
 //!
-//! A cached hash may have several physical copies. Copy identity is internal;
+//! A cached key may have several physical copies. Copy identity is internal;
 //! the pool models occupancy, reference/pin state, and LRU eviction without
 //! reproducing vLLM's numeric block IDs or null block.
 
@@ -18,11 +18,35 @@ new_key_type! {
     pub(crate) struct BlockCopyId;
 }
 
+/// Index of a KV cache group within one worker's cache configuration.
+///
+/// A hybrid model splits its layers across groups (full attention, Mamba/SSM,
+/// sliding window) that share this physical pool but keep independent cache
+/// visibility.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(crate) struct KvCacheGroupId(pub(crate) u8);
+
+/// vLLM's `BlockHashWithGroupId`: cache visibility is per KV cache group.
+///
+/// Groups derive their block hashes from the same tokens, so the group index
+/// is what keeps one group's cached blocks from satisfying another's lookups.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct GroupedHash {
+    pub(crate) group: KvCacheGroupId,
+    pub(crate) hash: SequenceHash,
+}
+
+impl GroupedHash {
+    pub(crate) fn new(group: KvCacheGroupId, hash: SequenceHash) -> Self {
+        Self { group, hash }
+    }
+}
+
 #[derive(Debug)]
 enum CopyState {
     Private,
     Cached {
-        hash: SequenceHash,
+        key: GroupedHash,
         refs: usize,
         pins: usize,
         inactive_at: Option<u64>,
@@ -42,7 +66,7 @@ pub(crate) struct PrefixHit {
 /// Capacity and cached-prefix pins held before a manager commits ownership.
 pub(crate) struct BlockReservation {
     /// Cached prefix copies in request order, from root/head to suffix/leaf.
-    prefix: Vec<(SequenceHash, BlockCopyId)>,
+    prefix: Vec<(GroupedHash, BlockCopyId)>,
     fresh: usize,
 }
 
@@ -58,14 +82,14 @@ impl BlockReservation {
 
 pub(crate) struct ReserveOutcome {
     pub(crate) reservation: BlockReservation,
-    /// Hashes whose final cache-visible physical copy was evicted.
-    pub(crate) removed: Vec<SequenceHash>,
+    /// Keys whose final cache-visible physical copy was evicted.
+    pub(crate) removed: Vec<GroupedHash>,
 }
 
 pub(crate) struct VllmBlockPool {
     capacity: usize,
     copies: SlotMap<BlockCopyId, BlockCopy>,
-    by_hash: FxHashMap<SequenceHash, SmallVec<[BlockCopyId; 1]>>,
+    by_key: FxHashMap<GroupedHash, SmallVec<[BlockCopyId; 1]>>,
     /// Ordinary LRU: lower timestamp is evicted first.
     inactive: BTreeMap<u64, BlockCopyId>,
     next_lru: u64,
@@ -78,18 +102,18 @@ impl VllmBlockPool {
         Self {
             capacity,
             copies: SlotMap::with_key(),
-            by_hash: FxHashMap::default(),
+            by_key: FxHashMap::default(),
             inactive: BTreeMap::new(),
             next_lru: 0,
             reserved: 0,
         }
     }
 
-    pub(crate) fn prefix_hit(&self, hash: SequenceHash) -> Option<PrefixHit> {
-        let id = self.first_copy(hash)?;
+    pub(crate) fn prefix_hit(&self, key: GroupedHash) -> Option<PrefixHit> {
+        let id = self.first_copy(key)?;
         let copy = &self.copies[id];
         let CopyState::Cached { refs, pins, .. } = &copy.state else {
-            unreachable!("hash index points to a private copy")
+            unreachable!("key index points to a private copy")
         };
         Some(PrefixHit {
             is_active: *refs > 0 || *pins > 0,
@@ -99,11 +123,11 @@ impl VllmBlockPool {
     /// Atomically pins `prefix` and reserves `fresh` additional copies.
     ///
     /// The caller obtains `prefix` from a preceding synchronous lookup. A
-    /// missing hash is therefore an invariant violation rather than capacity
+    /// missing key is therefore an invariant violation rather than capacity
     /// exhaustion.
     pub(crate) fn reserve(
         &mut self,
-        prefix: &[SequenceHash],
+        prefix: &[GroupedHash],
         fresh: usize,
     ) -> Option<ReserveOutcome> {
         if prefix.is_empty() {
@@ -112,11 +136,11 @@ impl VllmBlockPool {
 
         let hits = prefix
             .iter()
-            .map(|hash| {
-                let Some(id) = self.first_copy(*hash) else {
-                    panic!("authorized prefix hash {hash} is no longer resident")
+            .map(|key| {
+                let Some(id) = self.first_copy(*key) else {
+                    panic!("authorized prefix key {key:?} is no longer resident")
                 };
-                (*hash, id)
+                (*key, id)
             })
             .collect::<Vec<_>>();
 
@@ -140,8 +164,8 @@ impl VllmBlockPool {
 
         let mut removed = Vec::with_capacity(needed_evictions);
         for _ in 0..needed_evictions {
-            if let Some(hash) = self.evict_one() {
-                removed.push(hash);
+            if let Some(key) = self.evict_one() {
+                removed.push(key);
             }
         }
         self.reserved += fresh;
@@ -164,8 +188,8 @@ impl VllmBlockPool {
 
         let mut removed = Vec::with_capacity(needed_evictions);
         for _ in 0..needed_evictions {
-            if let Some(hash) = self.evict_one() {
-                removed.push(hash);
+            if let Some(key) = self.evict_one() {
+                removed.push(key);
             }
         }
         self.reserved += fresh;
@@ -186,8 +210,8 @@ impl VllmBlockPool {
     ) -> Vec<BlockCopyId> {
         let prefix = std::mem::take(&mut reservation.prefix);
         let mut ids = Vec::with_capacity(prefix.len());
-        for (hash, id) in prefix {
-            self.activate_pin(id, hash);
+        for (key, id) in prefix {
+            self.activate_pin(id, key);
             ids.push(id);
         }
         ids
@@ -205,21 +229,21 @@ impl VllmBlockPool {
     }
 
     /// Allocate a transferred/computed full block directly into the cache.
-    /// Returns whether the hash became router-visible (`0 -> 1`).
+    /// Returns whether the key became router-visible (`0 -> 1`).
     pub(crate) fn allocate_cached(
         &mut self,
         reservation: &mut BlockReservation,
-        hash: SequenceHash,
+        key: GroupedHash,
     ) -> (BlockCopyId, bool) {
         let id = self.allocate_private(reservation);
-        let became_visible = self.cache_private(id, hash);
+        let became_visible = self.cache_private(id, key);
         (id, became_visible)
     }
 
     /// Make a request-private computed full block available for prefix reuse.
-    /// Returns whether this is the first resident physical copy of `hash`.
-    pub(crate) fn cache_private(&mut self, id: BlockCopyId, hash: SequenceHash) -> bool {
-        let became_visible = !self.by_hash.contains_key(&hash);
+    /// Returns whether this is the first resident physical copy of `key`.
+    pub(crate) fn cache_private(&mut self, id: BlockCopyId, key: GroupedHash) -> bool {
+        let became_visible = !self.by_key.contains_key(&key);
         let Some(copy) = self.copies.get_mut(id) else {
             panic!("attempted to cache an unknown block copy")
         };
@@ -228,12 +252,12 @@ impl VllmBlockPool {
             "only a private copy can enter the prefix cache"
         );
         copy.state = CopyState::Cached {
-            hash,
+            key,
             refs: 1,
             pins: 0,
             inactive_at: None,
         };
-        self.by_hash.entry(hash).or_default().push(id);
+        self.by_key.entry(key).or_default().push(id);
         became_visible
     }
 
@@ -267,8 +291,8 @@ impl VllmBlockPool {
     /// callers to release them in eviction-priority order. Unpinning in reverse
     /// makes suffix/leaf blocks older LRU candidates than their parents.
     pub(crate) fn cancel(&mut self, reservation: BlockReservation) {
-        for (hash, id) in reservation.prefix.into_iter().rev() {
-            self.unpin(id, hash);
+        for (key, id) in reservation.prefix.into_iter().rev() {
+            self.unpin(id, key);
         }
         assert!(
             self.reserved >= reservation.fresh,
@@ -305,9 +329,9 @@ impl VllmBlockPool {
             .unwrap_or_else(|| panic!("block-pool occupancy exceeds capacity"))
     }
 
-    fn first_copy(&self, hash: SequenceHash) -> Option<BlockCopyId> {
-        self.by_hash
-            .get(&hash)
+    fn first_copy(&self, key: GroupedHash) -> Option<BlockCopyId> {
+        self.by_key
+            .get(&key)
             .and_then(|copies| copies.first())
             .copied()
     }
@@ -328,7 +352,7 @@ impl VllmBlockPool {
                 pins, inactive_at, ..
             } = &mut self.copies[id].state
             else {
-                panic!("prefix hash points to a private copy")
+                panic!("prefix key points to a private copy")
             };
             *pins = pins
                 .checked_add(1)
@@ -340,14 +364,14 @@ impl VllmBlockPool {
         }
     }
 
-    fn activate_pin(&mut self, id: BlockCopyId, expected_hash: SequenceHash) {
+    fn activate_pin(&mut self, id: BlockCopyId, expected_key: GroupedHash) {
         let CopyState::Cached {
-            hash, refs, pins, ..
+            key, refs, pins, ..
         } = &mut self.copies[id].state
         else {
             panic!("prefix reservation points to a private copy")
         };
-        assert_eq!(*hash, expected_hash, "reserved prefix hash changed");
+        assert_eq!(*key, expected_key, "reserved prefix key changed");
         assert!(*pins > 0, "prefix pin underflow");
         *pins -= 1;
         *refs = refs
@@ -355,15 +379,15 @@ impl VllmBlockPool {
             .unwrap_or_else(|| panic!("reference count overflow"));
     }
 
-    fn unpin(&mut self, id: BlockCopyId, expected_hash: SequenceHash) {
+    fn unpin(&mut self, id: BlockCopyId, expected_key: GroupedHash) {
         let should_deactivate = {
             let CopyState::Cached {
-                hash, refs, pins, ..
+                key, refs, pins, ..
             } = &mut self.copies[id].state
             else {
                 panic!("prefix reservation points to a private copy")
             };
-            assert_eq!(*hash, expected_hash, "reserved prefix hash changed");
+            assert_eq!(*key, expected_key, "reserved prefix key changed");
             assert!(*pins > 0, "prefix pin underflow");
             *pins -= 1;
             *pins == 0 && *refs == 0
@@ -386,8 +410,8 @@ impl VllmBlockPool {
         assert!(self.inactive.insert(timestamp, id).is_none());
     }
 
-    /// Evict one physical copy. A hash is returned only on its final copy.
-    fn evict_one(&mut self) -> Option<SequenceHash> {
+    /// Evict one physical copy. A key is returned only on its final copy.
+    fn evict_one(&mut self) -> Option<GroupedHash> {
         let Some((timestamp, id)) = self.inactive.pop_first() else {
             panic!("prechecked inactive capacity disappeared")
         };
@@ -395,7 +419,7 @@ impl VllmBlockPool {
             panic!("inactive LRU points to a missing copy")
         };
         let CopyState::Cached {
-            hash,
+            key,
             refs,
             pins,
             inactive_at,
@@ -407,19 +431,19 @@ impl VllmBlockPool {
         assert_eq!(pins, 0);
         assert_eq!(inactive_at, Some(timestamp));
 
-        let remove_hash = {
-            let Some(copies) = self.by_hash.get_mut(&hash) else {
-                panic!("evicted cached hash is missing from its index")
+        let remove_key = {
+            let Some(copies) = self.by_key.get_mut(&key) else {
+                panic!("evicted cached key is missing from its index")
             };
             let Some(position) = copies.iter().position(|candidate| *candidate == id) else {
-                panic!("evicted copy is missing from its hash index")
+                panic!("evicted copy is missing from its key index")
             };
             copies.remove(position);
             copies.is_empty()
         };
-        if remove_hash {
-            self.by_hash.remove(&hash);
-            Some(hash)
+        if remove_key {
+            self.by_key.remove(&key);
+            Some(key)
         } else {
             None
         }
@@ -430,7 +454,15 @@ impl VllmBlockPool {
 mod tests {
     use super::*;
 
-    fn reserve(pool: &mut VllmBlockPool, prefix: &[u64], fresh: usize) -> ReserveOutcome {
+    const ATTENTION: KvCacheGroupId = KvCacheGroupId(0);
+    const SECOND: KvCacheGroupId = KvCacheGroupId(1);
+
+    /// Attention-group key, the implicit group of every single-group test.
+    fn key(hash: SequenceHash) -> GroupedHash {
+        GroupedHash::new(ATTENTION, hash)
+    }
+
+    fn reserve(pool: &mut VllmBlockPool, prefix: &[GroupedHash], fresh: usize) -> ReserveOutcome {
         pool.reserve(prefix, fresh)
             .unwrap_or_else(|| panic!("unexpected capacity exhaustion"))
     }
@@ -440,11 +472,11 @@ mod tests {
         let mut pool = VllmBlockPool::new(2);
         let mut first = reserve(&mut pool, &[], 1).reservation;
         let first_id = pool.allocate_private(&mut first);
-        assert!(pool.cache_private(first_id, 7));
+        assert!(pool.cache_private(first_id, key(7)));
 
         let mut second = reserve(&mut pool, &[], 1).reservation;
         let second_id = pool.allocate_private(&mut second);
-        assert!(!pool.cache_private(second_id, 7));
+        assert!(!pool.cache_private(second_id, key(7)));
         assert_eq!(pool.num_active(), 2);
 
         pool.release(first_id);
@@ -457,10 +489,10 @@ mod tests {
         let mut pool = VllmBlockPool::new(1);
         let mut seed = reserve(&mut pool, &[], 1).reservation;
         let id = pool.allocate_private(&mut seed);
-        assert!(pool.cache_private(id, 9));
+        assert!(pool.cache_private(id, key(9)));
         pool.release(id);
 
-        assert!(pool.reserve(&[9], 1).is_none());
+        assert!(pool.reserve(&[key(9)], 1).is_none());
         assert_eq!(pool.num_active(), 0);
         assert_eq!(pool.num_inactive(), 1);
     }
@@ -470,10 +502,10 @@ mod tests {
         let mut pool = VllmBlockPool::new(2);
         let mut first = reserve(&mut pool, &[], 1).reservation;
         let first_id = pool.allocate_private(&mut first);
-        assert!(pool.cache_private(first_id, 3));
+        assert!(pool.cache_private(first_id, key(3)));
         let mut second = reserve(&mut pool, &[], 1).reservation;
         let second_id = pool.allocate_private(&mut second);
-        assert!(!pool.cache_private(second_id, 3));
+        assert!(!pool.cache_private(second_id, key(3)));
         pool.release(first_id);
         pool.release(second_id);
 
@@ -482,7 +514,7 @@ mod tests {
         pool.cancel(first_eviction.reservation);
 
         let second_eviction = reserve(&mut pool, &[], 2);
-        assert_eq!(second_eviction.removed, vec![3]);
+        assert_eq!(second_eviction.removed, vec![key(3)]);
         pool.cancel(second_eviction.reservation);
     }
 
@@ -492,22 +524,71 @@ mod tests {
         let mut seed = reserve(&mut pool, &[], 2).reservation;
         let parent = pool.allocate_private(&mut seed);
         let leaf = pool.allocate_private(&mut seed);
-        assert!(pool.cache_private(parent, 7));
-        assert!(pool.cache_private(leaf, 8));
+        assert!(pool.cache_private(parent, key(7)));
+        assert!(pool.cache_private(leaf, key(8)));
 
         // Match the normal request-release contract: the leaf enters the LRU
         // before its parent.
         pool.release(leaf);
         pool.release(parent);
 
-        let canceled = reserve(&mut pool, &[7, 8], 0);
+        let canceled = reserve(&mut pool, &[key(7), key(8)], 0);
         assert!(canceled.removed.is_empty());
         pool.cancel(canceled.reservation);
 
         let pressure = reserve(&mut pool, &[], 1);
-        assert_eq!(pressure.removed, vec![8]);
-        assert!(pool.prefix_hit(7).is_some());
-        assert!(pool.prefix_hit(8).is_none());
+        assert_eq!(pressure.removed, vec![key(8)]);
+        assert!(pool.prefix_hit(key(7)).is_some());
+        assert!(pool.prefix_hit(key(8)).is_none());
         pool.cancel(pressure.reservation);
+    }
+
+    /// Groups derive block hashes from the same tokens, so one group's cached
+    /// block must never satisfy another group's lookup.
+    #[test]
+    fn groups_do_not_share_cache_visibility_for_the_same_hash() {
+        let mut pool = VllmBlockPool::new(2);
+        let mut reservation = reserve(&mut pool, &[], 2).reservation;
+        let attention = pool.allocate_private(&mut reservation);
+        let second = pool.allocate_private(&mut reservation);
+
+        assert!(pool.cache_private(attention, GroupedHash::new(ATTENTION, 7)));
+        assert!(
+            pool.cache_private(second, GroupedHash::new(SECOND, 7)),
+            "the second group's copy of hash 7 is its own first resident copy"
+        );
+        assert_eq!(pool.num_active(), 2, "each group consumes its own block");
+
+        pool.release(second);
+        let pressure = reserve(&mut pool, &[], 1);
+        assert_eq!(pressure.removed, vec![GroupedHash::new(SECOND, 7)]);
+        assert!(
+            pool.prefix_hit(GroupedHash::new(ATTENTION, 7)).is_some(),
+            "evicting the second group's block must not remove the attention block"
+        );
+        assert!(pool.prefix_hit(GroupedHash::new(SECOND, 7)).is_none());
+        pool.cancel(pressure.reservation);
+    }
+
+    /// vLLM's `free_blocks` sends hashed blocks to the free-queue tail, where
+    /// they stay matchable until LRU evicts them, and unhashed blocks to the
+    /// head for immediate recycling. Groups that recycle blocks mid-request
+    /// rely on both.
+    #[test]
+    fn released_cached_copy_stays_matchable_while_private_copy_is_recycled() {
+        let mut pool = VllmBlockPool::new(2);
+        let mut reservation = reserve(&mut pool, &[], 2).reservation;
+        let cached = pool.allocate_private(&mut reservation);
+        let private = pool.allocate_private(&mut reservation);
+        assert!(pool.cache_private(cached, key(5)));
+
+        pool.release(cached);
+        pool.release(private);
+
+        assert_eq!(pool.num_inactive(), 1, "only the cached copy is retained");
+        assert!(
+            pool.prefix_hit(key(5)).is_some_and(|hit| !hit.is_active),
+            "a released cached copy remains an inactive prefix hit"
+        );
     }
 }

--- a/lib/mocker/src/kv_manager/mod.rs
+++ b/lib/mocker/src/kv_manager/mod.rs
@@ -60,6 +60,7 @@ pub mod sglang_backend;
 mod vllm_backend;
 #[cfg(test)]
 mod vllm_firewall_tests;
+mod vllm_groups;
 
 pub(crate) use g1_manager::DestinationReservation;
 pub use g1_manager::G1Manager;

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -224,9 +224,23 @@ impl VllmKvManager {
         self.process_use(&alloc, None)
     }
 
+    /// Release a request's blocks from every group.
+    ///
+    /// A release always covers the request's whole footprint: each `Deref` signal
+    /// derives its block list from the sequence's allocated tokens. Groups whose
+    /// table is not parallel to the attention table lean on that, dropping all of
+    /// a request's state rather than trimming it. Trimming a live request is a
+    /// real vLLM operation — `remove_skipped_blocks` — that this mocker does not
+    /// model yet, so a partial release stops here rather than guessing.
     pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        let (pool, attention) = self.attention_mut();
-        attention.deref(pool, request_id, blocks);
+        let Self { pool, groups, .. } = self;
+        for group in groups.iter_mut() {
+            group.release(pool, request_id, blocks);
+        }
+        assert!(
+            !self.attention().holds_request(request_id),
+            "releasing part of a request's table is not modeled yet"
+        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -781,6 +795,20 @@ mod tests {
             .pool
             .prefix_hit(GroupedHash::new(manager.attention_id(), hash))
             .is_some()
+    }
+
+    /// Groups other than attention drop a request's whole state on release, so a
+    /// release that leaves the request holding blocks has to stop rather than
+    /// half-apply. Trimming a live request is vLLM's `remove_skipped_blocks`,
+    /// which the mocker does not model.
+    #[test]
+    #[should_panic(expected = "not modeled")]
+    fn releasing_part_of_a_request_table_is_rejected() {
+        let mut manager = attention_manager(4);
+        let owner = Uuid::from_u128(1);
+        ready(use_full(&mut manager, owner, &[7, 8], 0));
+
+        manager.deref_for_request(owner, &[UniqueBlock::FullBlock(8)]);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -3,8 +3,11 @@
 
 //! vLLM G1 manager over a minimal physical block-pool model.
 //!
-//! The manager owns request block tables and KV-event metadata. The pool owns
-//! physical occupancy, duplicate copies, prefix pins, and LRU eviction.
+//! [`VllmKvManager`] is the coordinator. It owns one manager per KV cache group,
+//! sizes every allocation as a single reservation against the shared pool, and
+//! reconciles per-group prefix hits the way vLLM's `HybridKVCacheCoordinator`
+//! does. Per-group request block tables live in the group managers; the pool
+//! owns physical occupancy, duplicate copies, prefix pins, and LRU eviction.
 
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
@@ -12,38 +15,17 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
-use rustc_hash::{FxHashMap, FxHashSet};
 use uuid::Uuid;
 
-use crate::cache::vllm_block_pool::{BlockCopyId, BlockReservation, ReserveOutcome, VllmBlockPool};
+use crate::cache::vllm_block_pool::{BlockReservation, GroupedHash, ReserveOutcome, VllmBlockPool};
 use crate::common::kv_cache_trace;
 use crate::common::protocols::{KvEventPublishers, PrefillCost};
 use crate::common::sequence::ActiveSequence;
 
-struct PendingStore {
-    parent_hash: Option<SequenceHash>,
-    local_hash: Option<BlockHash>,
-    token_ids: Option<Vec<u32>>,
-}
-
-struct FullBlock {
-    copy: BlockCopyId,
-    hash: SequenceHash,
-    /// Whether a freshly allocated full block still needs to become cache-visible.
-    pending_cache: bool,
-    /// Event metadata retained until `pending_cache` is finalized.
-    pending_store: Option<PendingStore>,
-}
-
-enum OwnedBlock {
-    Partial { copy: BlockCopyId, uuid: Uuid },
-    Full(FullBlock),
-}
-
-struct StoredBlock {
-    hash: SequenceHash,
-    metadata: PendingStore,
-}
+use super::vllm_groups::{
+    ATTENTION_GROUP, CacheHit, FullAttentionGroup, GroupAllocation, GroupManager, PendingStore,
+    StoredBlock,
+};
 
 struct StoreGroup {
     parent_hash: Option<SequenceHash>,
@@ -82,7 +64,6 @@ impl StoreGroup {
         }
     }
 }
-
 pub(crate) struct NativeDecodeBlockReservation {
     pool: BlockReservation,
 }
@@ -97,11 +78,16 @@ pub(crate) struct NativeDestinationReservation {
     request_id: Uuid,
     pool: BlockReservation,
     layout: Option<VllmBlockLayout>,
+    /// Attention blocks the reservation covers, excluding other groups' share.
+    attention_fresh: usize,
+    /// Leading attention prefix pins, which precede other groups' pins in the
+    /// reservation.
+    attention_prefix: usize,
 }
 
 impl NativeDestinationReservation {
     pub(crate) fn transferable_prompt_tokens(&self, block_size: usize) -> usize {
-        self.pool.fresh_len().saturating_mul(block_size)
+        self.attention_fresh.saturating_mul(block_size)
     }
 
     #[cfg(test)]
@@ -140,8 +126,9 @@ impl VllmBlockLayout {
 
 pub(crate) struct VllmKvManager {
     pool: VllmBlockPool,
-    request_blocks: FxHashMap<Uuid, Vec<OwnedBlock>>,
-    partial_uuids: FxHashSet<Uuid>,
+    /// Group 0 is always the main attention group; a hybrid model's
+    /// non-attention state groups follow it.
+    groups: Vec<GroupManager>,
     block_size: usize,
     enable_prefix_caching: bool,
     kv_event_publishers: KvEventPublishers,
@@ -163,14 +150,22 @@ impl VllmKvManager {
         }
         Self {
             pool: VllmBlockPool::new(max_capacity),
-            request_blocks: FxHashMap::default(),
-            partial_uuids: FxHashSet::default(),
+            groups: vec![GroupManager::FullAttention(FullAttentionGroup::new(
+                ATTENTION_GROUP,
+                block_size,
+                enable_prefix_caching,
+            ))],
             block_size,
             enable_prefix_caching,
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
         }
+    }
+
+    fn attention(&self) -> &FullAttentionGroup {
+        let GroupManager::FullAttention(group) = &self.groups[0];
+        group
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -183,19 +178,22 @@ impl VllmKvManager {
         parent: Option<&UniqueBlock>,
         reusable_prefix_blocks: usize,
     ) -> VllmAcquire<usize> {
-        self.process_use(
+        let alloc = GroupAllocation {
             request_id,
             blocks,
             local_hashes,
             token_ids,
             parent,
             reusable_prefix_blocks,
-            None,
-        )
+            cache_fresh: false,
+        };
+        self.process_use(&alloc, None)
     }
 
     pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        self.process_deref(request_id, blocks);
+        let Self { pool, groups, .. } = self;
+        let GroupManager::FullAttention(attention) = &mut groups[0];
+        attention.deref(pool, request_id, blocks);
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -208,7 +206,24 @@ impl VllmKvManager {
         local_hash: Option<BlockHash>,
         token_ids: Option<Vec<u32>>,
     ) {
-        self.process_promote(request_id, uuid, hash, parent_hash, local_hash, token_ids);
+        let materialize_store_events = self.materialize_store_events();
+        let Self { pool, groups, .. } = self;
+        let GroupManager::FullAttention(attention) = &mut groups[0];
+        let stored = attention.promote(
+            pool,
+            request_id,
+            uuid,
+            hash,
+            PendingStore {
+                parent_hash,
+                local_hash,
+                token_ids,
+            },
+            materialize_store_events,
+        );
+        if let Some(stored) = stored {
+            self.publish_store_sequence(vec![Some(stored)]);
+        }
     }
 
     /// Publish full blocks completed by this scheduling decision.
@@ -238,43 +253,17 @@ impl VllmKvManager {
         }
 
         let materialize_store_events = self.materialize_store_events();
-        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
-            panic!("request {request_id} owns no block table")
+        let stores = {
+            let Self { pool, groups, .. } = self;
+            let GroupManager::FullAttention(attention) = &mut groups[0];
+            attention.finalize_computed_prefix(
+                pool,
+                request_id,
+                first_new_block,
+                completed_blocks,
+                materialize_store_events,
+            )
         };
-        let completed_blocks = completed_blocks.min(blocks.len());
-        if first_new_block >= completed_blocks {
-            return;
-        }
-        let mut stores = materialize_store_events
-            .then(|| Vec::with_capacity(completed_blocks - first_new_block));
-        for block in &mut blocks[first_new_block..completed_blocks] {
-            match block {
-                OwnedBlock::Full(full) => {
-                    if !full.pending_cache {
-                        if let Some(stores) = &mut stores {
-                            stores.push(None);
-                        }
-                        continue;
-                    }
-                    full.pending_cache = false;
-                    let metadata = full.pending_store.take();
-                    let became_visible = self.pool.cache_private(full.copy, full.hash);
-                    if let Some(stores) = &mut stores {
-                        stores.push(became_visible.then(|| {
-                            StoredBlock {
-                                hash: full.hash,
-                                metadata: metadata.expect(
-                                    "materialized pending store must retain event metadata",
-                                ),
-                            }
-                        }));
-                    } else {
-                        debug_assert!(metadata.is_none());
-                    }
-                }
-                OwnedBlock::Partial { .. } => break,
-            }
-        }
         if let Some(stores) = stores {
             self.publish_store_sequence(stores);
         }
@@ -307,15 +296,16 @@ impl VllmKvManager {
         parent: Option<&UniqueBlock>,
         reservation: &mut NativeDecodeBlockReservation,
     ) {
-        let outcome = self.process_use(
+        let alloc = GroupAllocation {
             request_id,
             blocks,
             local_hashes,
             token_ids,
             parent,
-            0,
-            Some(&mut reservation.pool),
-        );
+            reusable_prefix_blocks: 0,
+            cache_fresh: false,
+        };
+        let outcome = self.process_use(&alloc, Some(&mut reservation.pool));
         assert!(
             matches!(outcome, VllmAcquire::Ready(allocated) if allocated == blocks.len()),
             "reserved decode allocation must be infallible"
@@ -329,28 +319,26 @@ impl VllmKvManager {
         _eviction_now_ms: Option<f64>,
     ) -> VllmAcquire<NativeDestinationReservation> {
         assert!(
-            !self.request_blocks.contains_key(&request_id),
+            !self.attention().holds_request(request_id),
             "destination request already owns a block table"
         );
-        let (prefix, fresh) = match layout.as_ref() {
-            Some(VllmBlockLayout {
-                blocks,
-                local_hashes,
-                token_ids,
-                parent,
-            }) => {
-                Self::validate_use_metadata(
-                    blocks,
-                    local_hashes,
-                    token_ids.as_deref(),
-                    parent.as_ref(),
-                );
-                self.validate_fresh_partials(blocks);
-                let prefix = self.resident_prefix(blocks);
-                let fresh = blocks.len() - prefix.len();
-                (prefix, fresh)
+        let (prefix, fresh, attention_fresh, attention_prefix) = match layout.as_ref() {
+            Some(layout) => {
+                let alloc = Self::destination_alloc(request_id, layout, 0);
+                FullAttentionGroup::validate_use_metadata(&alloc);
+                self.attention().validate_fresh_partials(alloc.blocks);
+                let prefix = self.attention().resident_prefix(&self.pool, &layout.blocks);
+                let attention_prefix = prefix.len();
+                let alloc = Self::destination_alloc(request_id, layout, attention_prefix);
+                let attention_fresh = self.attention().fresh_blocks(&alloc);
+                let (mut keys, mut fresh) = (prefix, attention_fresh);
+                for group in &self.groups[1..] {
+                    keys.extend(group.prefix_keys(&alloc));
+                    fresh += group.fresh_blocks(&alloc);
+                }
+                (keys, fresh, attention_fresh, attention_prefix)
             }
-            None => (Vec::new(), 0),
+            None => (Vec::new(), 0, 0, 0),
         };
         let Some(outcome) = self.pool.reserve(&prefix, fresh) else {
             return VllmAcquire::CapacityExhausted;
@@ -360,7 +348,27 @@ impl VllmKvManager {
             request_id,
             pool: outcome.reservation,
             layout,
+            attention_fresh,
+            attention_prefix,
         })
+    }
+
+    /// Destination transfers arrive as one already-computed prefix, so their
+    /// allocation covers the whole layout at once.
+    fn destination_alloc(
+        request_id: Uuid,
+        layout: &VllmBlockLayout,
+        reusable_prefix_blocks: usize,
+    ) -> GroupAllocation<'_> {
+        GroupAllocation {
+            request_id,
+            blocks: &layout.blocks,
+            local_hashes: &layout.local_hashes,
+            token_ids: layout.token_ids.as_deref(),
+            parent: layout.parent.as_ref(),
+            reusable_prefix_blocks,
+            cache_fresh: true,
+        }
     }
 
     pub(crate) fn activate_destination(&mut self, reservation: NativeDestinationReservation) {
@@ -368,37 +376,22 @@ impl VllmKvManager {
             request_id,
             mut pool,
             layout,
+            attention_prefix,
+            ..
         } = reservation;
         assert!(
-            !self.request_blocks.contains_key(&request_id),
+            !self.attention().holds_request(request_id),
             "destination request already owns a block table"
         );
-        let Some(VllmBlockLayout {
-            blocks,
-            local_hashes,
-            token_ids,
-            parent,
-        }) = layout
-        else {
+        let Some(layout) = layout else {
             self.pool.cancel(pool);
             return;
         };
-        Self::validate_use_metadata(
-            &blocks,
-            &local_hashes,
-            token_ids.as_deref(),
-            parent.as_ref(),
-        );
-        self.validate_fresh_partials(&blocks);
-        self.commit_layout(
-            request_id,
-            &blocks,
-            &local_hashes,
-            token_ids.as_deref(),
-            parent.as_ref(),
-            &mut pool,
-            self.enable_prefix_caching,
-        );
+        let mut alloc = Self::destination_alloc(request_id, &layout, attention_prefix);
+        alloc.cache_fresh = self.enable_prefix_caching;
+        FullAttentionGroup::validate_use_metadata(&alloc);
+        self.attention().validate_fresh_partials(alloc.blocks);
+        self.commit_groups(&alloc, &mut pool);
         assert_eq!(pool.len(), 0, "destination reservation was not consumed");
         self.pool.cancel(pool);
     }
@@ -407,44 +400,27 @@ impl VllmKvManager {
         self.pool.cancel(reservation.pool);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn process_use(
         &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-        reusable_prefix_blocks: usize,
+        alloc: &GroupAllocation,
         reservation: Option<&mut BlockReservation>,
     ) -> VllmAcquire<usize> {
-        Self::validate_use_metadata(blocks, local_hashes, token_ids, parent);
-        self.validate_fresh_partials(blocks);
-        assert!(reusable_prefix_blocks <= blocks.len());
-        assert!(self.enable_prefix_caching || reusable_prefix_blocks == 0);
+        FullAttentionGroup::validate_use_metadata(alloc);
+        self.attention().validate_fresh_partials(alloc.blocks);
+        assert!(alloc.reusable_prefix_blocks <= alloc.blocks.len());
+        assert!(self.enable_prefix_caching || alloc.reusable_prefix_blocks == 0);
         assert!(
-            reusable_prefix_blocks == 0
-                || self
-                    .request_blocks
-                    .get(&request_id)
-                    .is_none_or(Vec::is_empty),
+            alloc.reusable_prefix_blocks == 0
+                || self.attention().block_count(alloc.request_id) == 0,
             "only a request's first allocation may reuse a prefix"
         );
 
-        let prefix = if reusable_prefix_blocks == 0 {
-            Vec::new()
-        } else {
-            blocks[..reusable_prefix_blocks]
-                .iter()
-                .map(|block| match block {
-                    UniqueBlock::FullBlock(hash) => *hash,
-                    UniqueBlock::PartialBlock(_) => {
-                        panic!("a reusable prefix can contain only full blocks")
-                    }
-                })
-                .collect::<Vec<_>>()
-        };
-        let fresh = blocks.len() - reusable_prefix_blocks;
+        let mut prefix = self.attention().prefix_keys(alloc);
+        let mut fresh = self.attention().fresh_blocks(alloc);
+        for group in &self.groups[1..] {
+            prefix.extend(group.prefix_keys(alloc));
+            fresh += group.fresh_blocks(alloc);
+        }
 
         match reservation {
             Some(reservation) => {
@@ -452,15 +428,7 @@ impl VllmKvManager {
                 if reservation.fresh_len() < fresh {
                     return VllmAcquire::CapacityExhausted;
                 }
-                self.commit_layout(
-                    request_id,
-                    blocks,
-                    local_hashes,
-                    token_ids,
-                    parent,
-                    reservation,
-                    false,
-                );
+                self.commit_groups(alloc, reservation);
             }
             None => {
                 let Some(ReserveOutcome {
@@ -471,270 +439,41 @@ impl VllmKvManager {
                     return VllmAcquire::CapacityExhausted;
                 };
                 self.publish_removed(removed);
-                self.commit_layout(
-                    request_id,
-                    blocks,
-                    local_hashes,
-                    token_ids,
-                    parent,
-                    &mut reservation,
-                    false,
-                );
+                self.commit_groups(alloc, &mut reservation);
                 assert_eq!(reservation.len(), 0, "Use reservation was not consumed");
                 self.pool.cancel(reservation);
             }
         }
-        VllmAcquire::Ready(blocks.len())
+        VllmAcquire::Ready(alloc.blocks.len())
     }
 
-    #[allow(clippy::too_many_arguments)]
-    fn commit_layout(
-        &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-        reservation: &mut BlockReservation,
-        cache_fresh: bool,
-    ) {
-        let prefix_len = reservation.len() - reservation.fresh_len();
-        let prefix_copies = self.pool.activate_prefix(reservation);
-        assert_eq!(prefix_copies.len(), prefix_len);
-        let mut prefix_copies = prefix_copies.into_iter();
-        let mut cursor = match parent {
-            None => None,
-            Some(UniqueBlock::FullBlock(hash)) => Some(*hash),
-            Some(UniqueBlock::PartialBlock(_)) => unreachable!("validated above"),
-        };
-        let mut full_idx = 0;
+    /// Commit every group against the shared reservation, publishing only the
+    /// main attention group's store events.
+    fn commit_groups(&mut self, alloc: &GroupAllocation, reservation: &mut BlockReservation) {
         let materialize_store_events = self.materialize_store_events();
-        let owned = self.request_blocks.entry(request_id).or_default();
-        owned.reserve(blocks.len());
-        let mut stores =
-            (cache_fresh && materialize_store_events).then(|| Vec::with_capacity(blocks.len()));
-
-        for (block_idx, block) in blocks.iter().enumerate() {
-            match block {
-                UniqueBlock::FullBlock(hash) => {
-                    let local_hash = local_hashes.get(full_idx).copied();
-                    full_idx += 1;
-
-                    if block_idx < prefix_len {
-                        let Some(copy) = prefix_copies.next() else {
-                            panic!("prefix reservation returned too few copies")
-                        };
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache: false,
-                            pending_store: None,
-                        }));
-                        cursor = Some(*hash);
-                        continue;
-                    }
-
-                    if cache_fresh {
-                        let (copy, became_visible) = self.pool.allocate_cached(reservation, *hash);
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache: false,
-                            pending_store: None,
-                        }));
-                        if let Some(stores) = &mut stores {
-                            let metadata = PendingStore {
-                                parent_hash: cursor,
-                                local_hash,
-                                token_ids: token_ids.and_then(|ids| ids.get(full_idx - 1).cloned()),
-                            };
-                            stores.push(became_visible.then_some(StoredBlock {
-                                hash: *hash,
-                                metadata,
-                            }));
-                        }
-                    } else {
-                        let copy = self.pool.allocate_private(reservation);
-                        let pending_cache = self.enable_prefix_caching;
-                        let pending_store =
-                            (pending_cache && materialize_store_events).then(|| PendingStore {
-                                parent_hash: cursor,
-                                local_hash,
-                                token_ids: token_ids.and_then(|ids| ids.get(full_idx - 1).cloned()),
-                            });
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache,
-                            pending_store,
-                        }));
-                    }
-                    cursor = Some(*hash);
-                }
-                UniqueBlock::PartialBlock(uuid) => {
-                    let copy = self.pool.allocate_private(reservation);
-                    assert!(
-                        self.partial_uuids.insert(*uuid),
-                        "partial block {uuid} is already allocated"
-                    );
-                    owned.push(OwnedBlock::Partial { copy, uuid: *uuid });
-                    if let Some(stores) = &mut stores {
-                        stores.push(None);
+        let stores = {
+            let Self { pool, groups, .. } = self;
+            // Prefix pins were reserved in group order, matching the order the
+            // groups are visited here.
+            let prefix_copies = pool.activate_prefix(reservation);
+            let mut stores = None;
+            for group in groups.iter_mut() {
+                match group {
+                    GroupManager::FullAttention(attention) => {
+                        stores = attention.commit(
+                            pool,
+                            reservation,
+                            alloc,
+                            &prefix_copies,
+                            materialize_store_events,
+                        );
                     }
                 }
             }
-        }
-        assert!(prefix_copies.next().is_none());
+            stores
+        };
         if let Some(stores) = stores {
             self.publish_store_sequence(stores);
-        }
-    }
-
-    fn validate_use_metadata(
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-    ) {
-        let full_blocks = blocks
-            .iter()
-            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
-            .count();
-        assert!(
-            local_hashes.is_empty() || local_hashes.len() == full_blocks,
-            "local hashes must be empty or align with full blocks"
-        );
-        assert!(
-            token_ids.is_none_or(|ids| ids.len() == full_blocks),
-            "token IDs must align with full blocks"
-        );
-        assert!(!matches!(parent, Some(UniqueBlock::PartialBlock(_))));
-    }
-
-    fn validate_fresh_partials(&self, blocks: &[UniqueBlock]) {
-        let mut first_partial = None;
-        for (index, uuid) in blocks
-            .iter()
-            .enumerate()
-            .filter_map(|(index, block)| match block {
-                UniqueBlock::PartialBlock(uuid) => Some((index, uuid)),
-                UniqueBlock::FullBlock(_) => None,
-            })
-        {
-            let repeated_in_layout = first_partial.is_some_and(|first| {
-                first == *uuid
-                    || blocks[..index].iter().any(
-                        |block| matches!(block, UniqueBlock::PartialBlock(seen) if seen == uuid),
-                    )
-            });
-            assert!(
-                !self.partial_uuids.contains(uuid) && !repeated_in_layout,
-                "partial block {uuid} is already allocated"
-            );
-            first_partial.get_or_insert(*uuid);
-        }
-    }
-
-    fn resident_prefix(&self, blocks: &[UniqueBlock]) -> Vec<SequenceHash> {
-        if !self.enable_prefix_caching {
-            return Vec::new();
-        }
-        blocks
-            .iter()
-            .map_while(|block| match block {
-                UniqueBlock::FullBlock(hash) if self.pool.prefix_hit(*hash).is_some() => {
-                    Some(*hash)
-                }
-                _ => None,
-            })
-            .collect()
-    }
-
-    /// Release request blocks in caller-provided eviction-priority order.
-    ///
-    /// Like vLLM's `BlockPool::free_blocks`, the physical pool is lineage-agnostic:
-    /// reversing the request-owned table here makes suffix/leaf blocks older LRU
-    /// candidates than their parents, so capacity pressure evicts the leaf first.
-    fn process_deref(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        let released = {
-            let Some(owned) = self.request_blocks.get_mut(&request_id) else {
-                panic!("request {request_id} owns no block table")
-            };
-            assert!(
-                blocks.len() <= owned.len(),
-                "request releases too many blocks"
-            );
-            let start = owned.len() - blocks.len();
-            for (expected, actual) in blocks.iter().zip(owned[start..].iter().rev()) {
-                match (expected, actual) {
-                    (UniqueBlock::FullBlock(expected), OwnedBlock::Full(full)) => {
-                        assert_eq!(*expected, full.hash, "full-block Deref mismatch");
-                    }
-                    (UniqueBlock::PartialBlock(expected), OwnedBlock::Partial { uuid, .. }) => {
-                        assert_eq!(expected, uuid, "partial Deref mismatch")
-                    }
-                    _ => panic!("Deref block kind disagrees with request table"),
-                }
-            }
-            owned.split_off(start)
-        };
-        if self.request_blocks[&request_id].is_empty() {
-            self.request_blocks.remove(&request_id);
-        }
-
-        for block in released.into_iter().rev() {
-            match block {
-                OwnedBlock::Partial { copy, uuid } => {
-                    assert!(self.partial_uuids.remove(&uuid));
-                    self.pool.release(copy);
-                }
-                OwnedBlock::Full(full) => self.pool.release(full.copy),
-            }
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn process_promote(
-        &mut self,
-        request_id: Uuid,
-        uuid: Uuid,
-        hash: SequenceHash,
-        parent_hash: Option<SequenceHash>,
-        local_hash: Option<BlockHash>,
-        token_ids: Option<Vec<u32>>,
-    ) {
-        let materialize_store_events = self.materialize_store_events();
-        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
-            panic!("request {request_id} owns no block table")
-        };
-        let Some(last) = blocks.last_mut() else {
-            panic!("Promote requires a request-owned partial tail")
-        };
-        let copy = match last {
-            OwnedBlock::Partial { copy, uuid: actual } => {
-                assert_eq!(*actual, uuid, "Promote partial UUID mismatch");
-                *copy
-            }
-            OwnedBlock::Full(_) => panic!("Promote requires a partial tail"),
-        };
-        assert!(self.partial_uuids.remove(&uuid));
-
-        let became_visible = self.enable_prefix_caching && self.pool.cache_private(copy, hash);
-        *last = OwnedBlock::Full(FullBlock {
-            copy,
-            hash,
-            pending_cache: false,
-            pending_store: None,
-        });
-        if became_visible && materialize_store_events {
-            self.publish_store_sequence(vec![Some(StoredBlock {
-                hash,
-                metadata: PendingStore {
-                    parent_hash,
-                    local_hash,
-                    token_ids,
-                },
-            })]);
         }
     }
 
@@ -776,7 +515,17 @@ impl VllmKvManager {
         );
     }
 
-    fn publish_removed(&mut self, hashes: Vec<SequenceHash>) {
+    /// Publish evictions for the main attention group only.
+    ///
+    /// `KvCacheEvent` has no group field and the router indexes a single block
+    /// namespace, so a non-attention group's eviction must not be reported as
+    /// an attention block disappearing.
+    fn publish_removed(&mut self, keys: Vec<GroupedHash>) {
+        let hashes = keys
+            .into_iter()
+            .filter(|key| key.group == ATTENTION_GROUP)
+            .map(|key| key.hash)
+            .collect::<Vec<_>>();
         if !hashes.is_empty() {
             self.publish_kv_event(hashes, &[], None, false, None);
         }
@@ -884,33 +633,33 @@ impl VllmKvManager {
 
     #[cfg(test)]
     pub(crate) fn request_block_count(&self, request_id: Uuid) -> usize {
-        self.request_blocks.get(&request_id).map_or(0, Vec::len)
+        self.attention().block_count(request_id)
     }
 
     pub(crate) fn get_prefill_cost(&self, sequence: &ActiveSequence) -> PrefillCost {
-        let (overlap_blocks, active_overlap_blocks) =
-            if self.enable_prefix_caching && sequence.enable_prefix_caching() {
-                let mut overlap = 0;
-                let mut active = 0;
-                for block in sequence.unique_blocks() {
-                    let UniqueBlock::FullBlock(hash) = block else {
-                        break;
-                    };
-                    let Some(hit) = self.pool.prefix_hit(*hash) else {
-                        break;
-                    };
-                    overlap += 1;
-                    active += usize::from(hit.is_active);
-                }
-                (overlap, active)
-            } else {
-                (0, 0)
+        let blocks = sequence.unique_blocks();
+        let attention = if self.enable_prefix_caching && sequence.enable_prefix_caching() {
+            self.attention().longest_cache_hit(&self.pool, blocks)
+        } else {
+            CacheHit::default()
+        };
+
+        // vLLM's hybrid coordinator reduces the candidate hit until every group
+        // agrees on one boundary. Groups share a block size here, so a single
+        // pass converges (its `is_simple_hybrid` shortcut).
+        let mut reconciled = attention.tokens;
+        for group in &self.groups[1..] {
+            let Some(hit) = group.longest_cache_hit(&self.pool, blocks) else {
+                continue;
             };
-        let new_blocks = sequence.unique_blocks().len() - overlap_blocks;
-        let cached_tokens = (overlap_blocks * self.block_size).min(sequence.len());
-        let active_cached_tokens = (active_overlap_blocks * self.block_size).min(sequence.len());
+            reconciled = reconciled.min(hit.tokens);
+        }
+
+        let overlap_blocks = reconciled / self.block_size;
+        let cached_tokens = reconciled.min(sequence.len());
+        let active_cached_tokens = attention.active_tokens.min(cached_tokens);
         PrefillCost {
-            new_blocks,
+            new_blocks: blocks.len() - overlap_blocks,
             new_tokens: sequence.len() - cached_tokens,
             cached_tokens,
             active_cached_tokens,
@@ -943,6 +692,18 @@ mod tests {
         }
     }
 
+    const BLOCK_SIZE: usize = 4;
+
+    fn attention_manager(capacity: usize) -> VllmKvManager {
+        VllmKvManager::new_with_event_sink(
+            capacity,
+            BLOCK_SIZE,
+            true,
+            KvEventPublishers::default(),
+            0,
+        )
+    }
+
     fn use_full(
         manager: &mut VllmKvManager,
         owner: Uuid,
@@ -972,10 +733,16 @@ mod tests {
         }
     }
 
+    fn attention_hit(manager: &VllmKvManager, hash: SequenceHash) -> bool {
+        manager
+            .pool
+            .prefix_hit(GroupedHash::new(ATTENTION_GROUP, hash))
+            .is_some()
+    }
+
     #[test]
     fn duplicate_full_hashes_consume_physical_capacity() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         for owner in [Uuid::from_u128(1), Uuid::from_u128(2)] {
             ready(use_full(&mut manager, owner, &[7], 0));
             manager.finalize_computed_prefix(owner, 0, 4);
@@ -989,8 +756,7 @@ mod tests {
 
     #[test]
     fn authorized_prefix_reuses_one_physical_copy() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         let first = Uuid::from_u128(1);
         ready(use_full(&mut manager, first, &[7], 0));
         manager.finalize_computed_prefix(first, 0, 4);
@@ -1003,47 +769,43 @@ mod tests {
 
     #[test]
     fn full_block_is_hidden_until_computed() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         let owner = Uuid::from_u128(1);
         ready(use_full(&mut manager, owner, &[7], 0));
-        assert!(manager.pool.prefix_hit(7).is_none());
+        assert!(!attention_hit(&manager, 7));
         manager.finalize_computed_prefix(owner, 0, 4);
-        assert!(manager.pool.prefix_hit(7).is_some());
+        assert!(attention_hit(&manager, 7));
     }
 
     #[test]
     fn finalization_only_visits_blocks_completed_by_this_decision() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         let owner = Uuid::from_u128(1);
         ready(use_full(&mut manager, owner, &[7, 8], 0));
 
         manager.finalize_computed_prefix(owner, 0, 4);
-        assert!(manager.pool.prefix_hit(7).is_some());
-        assert!(manager.pool.prefix_hit(8).is_none());
+        assert!(attention_hit(&manager, 7));
+        assert!(!attention_hit(&manager, 8));
 
         manager.finalize_computed_prefix(owner, 4, 8);
-        assert!(manager.pool.prefix_hit(8).is_some());
+        assert!(attention_hit(&manager, 8));
     }
 
     #[test]
     fn finalization_handles_unaligned_decision_boundaries() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(3, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(3);
         let owner = Uuid::from_u128(1);
         ready(use_full(&mut manager, owner, &[7, 8, 9], 0));
 
         manager.finalize_computed_prefix(owner, 3, 9);
-        assert!(manager.pool.prefix_hit(7).is_some());
-        assert!(manager.pool.prefix_hit(8).is_some());
-        assert!(manager.pool.prefix_hit(9).is_none());
+        assert!(attention_hit(&manager, 7));
+        assert!(attention_hit(&manager, 8));
+        assert!(!attention_hit(&manager, 9));
     }
 
     #[test]
     fn cached_prefix_watermark_finalizes_only_the_fresh_suffix() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         let seed = Uuid::from_u128(1);
         ready(use_full(&mut manager, seed, &[7], 0));
         manager.finalize_computed_prefix(seed, 0, 4);
@@ -1052,14 +814,13 @@ mod tests {
         let owner = Uuid::from_u128(2);
         ready(use_full(&mut manager, owner, &[7, 8], 1));
         manager.finalize_computed_prefix(owner, 4, 8);
-        assert!(manager.pool.prefix_hit(7).is_some());
-        assert!(manager.pool.prefix_hit(8).is_some());
+        assert!(attention_hit(&manager, 7));
+        assert!(attention_hit(&manager, 8));
     }
 
     #[test]
     fn request_release_evicts_leaf_before_parent() {
-        let mut manager =
-            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut manager = attention_manager(2);
         let owner = Uuid::from_u128(1);
         ready(use_full(&mut manager, owner, &[7, 8], 0));
         manager.finalize_computed_prefix(owner, 0, 8);
@@ -1071,21 +832,15 @@ mod tests {
         );
         ready(use_full(&mut manager, Uuid::from_u128(2), &[9], 0));
 
-        assert!(
-            manager.pool.prefix_hit(7).is_some(),
-            "parent should remain resident"
-        );
-        assert!(
-            manager.pool.prefix_hit(8).is_none(),
-            "leaf should be evicted first"
-        );
+        assert!(attention_hit(&manager, 7), "parent should remain resident");
+        assert!(!attention_hit(&manager, 8), "leaf should be evicted first");
     }
 
     #[test]
     fn event_enabled_finalization_preserves_store_payload() {
         let sink = Arc::new(CapturingRawSink::default());
         let publishers = KvEventPublishers::new(None, Some(sink.clone()));
-        let mut manager = VllmKvManager::new_with_event_sink(2, 4, true, publishers, 3);
+        let mut manager = VllmKvManager::new_with_event_sink(2, BLOCK_SIZE, true, publishers, 3);
         let owner = Uuid::from_u128(1);
         let token_ids = vec![vec![1, 2, 3, 4]];
         let parent = UniqueBlock::FullBlock(6);
@@ -1113,5 +868,33 @@ mod tests {
         assert_eq!(stored.blocks.len(), 1);
         assert_eq!(stored.blocks[0].block_hash, ExternalSequenceBlockHash(7));
         assert_eq!(stored.blocks[0].tokens_hash, LocalBlockHash(107));
+    }
+
+    /// Removals are published per group, so an attention eviction must still
+    /// reach the router.
+    #[test]
+    fn attention_eviction_is_published_as_a_removal() {
+        let sink = Arc::new(CapturingRawSink::default());
+        let publishers = KvEventPublishers::new(None, Some(sink.clone()));
+        let mut manager = VllmKvManager::new_with_event_sink(1, BLOCK_SIZE, true, publishers, 0);
+
+        let owner = Uuid::from_u128(1);
+        ready(use_full(&mut manager, owner, &[7], 0));
+        manager.finalize_computed_prefix(owner, 0, 4);
+        manager.deref_for_request(owner, &[UniqueBlock::FullBlock(7)]);
+        sink.take();
+
+        // The next request needs the pool's only block back.
+        ready(use_full(&mut manager, Uuid::from_u128(2), &[8], 0));
+        let removed = sink
+            .take()
+            .into_iter()
+            .filter_map(|event| match event.event.data {
+                KvCacheEventData::Removed(removed) => Some(removed.block_hashes),
+                _ => None,
+            })
+            .flatten()
+            .collect::<Vec<_>>();
+        assert_eq!(removed, vec![ExternalSequenceBlockHash(7)]);
     }
 }

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -231,16 +231,21 @@ impl VllmKvManager {
     /// table is not parallel to the attention table lean on that, dropping all of
     /// a request's state rather than trimming it. Trimming a live request is a
     /// real vLLM operation — `remove_skipped_blocks` — that this mocker does not
-    /// model yet, so a partial release stops here rather than guessing.
+    /// model yet, so a partial release is rejected before any group mutates,
+    /// because releases run group by group and cannot be rolled back.
     pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
+        // A request the attention group does not hold falls through to it, which
+        // reports that more precisely than a totality check can.
+        let held = self.attention().block_count(request_id);
+        assert!(
+            held == 0 || blocks.len() == held,
+            "releasing {} of a request's {held} blocks is not modeled yet",
+            blocks.len()
+        );
         let Self { pool, groups, .. } = self;
         for group in groups.iter_mut() {
             group.release(pool, request_id, blocks);
         }
-        assert!(
-            !self.attention().holds_request(request_id),
-            "releasing part of a request's table is not modeled yet"
-        );
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -810,17 +815,24 @@ mod tests {
     }
 
     /// Groups other than attention drop a request's whole state on release, so a
-    /// release that leaves the request holding blocks has to stop rather than
-    /// half-apply. Trimming a live request is vLLM's `remove_skipped_blocks`,
-    /// which the mocker does not model.
+    /// release that would leave the request holding blocks has to be rejected
+    /// before any group runs: the groups release one at a time, so a half-applied
+    /// release cannot be undone. Trimming a live request is vLLM's
+    /// `remove_skipped_blocks`, which the mocker does not model.
     #[test]
-    #[should_panic(expected = "not modeled")]
-    fn releasing_part_of_a_request_table_is_rejected() {
+    fn deref_rejects_a_partial_release_before_mutating() {
         let mut manager = attention_manager(4);
         let owner = Uuid::from_u128(1);
         ready(use_full(&mut manager, owner, &[7, 8], 0));
+        let active_before = manager.num_active_blocks();
 
-        manager.deref_for_request(owner, &[UniqueBlock::FullBlock(8)]);
+        let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            manager.deref_for_request(owner, &[UniqueBlock::FullBlock(8)])
+        }));
+
+        assert!(outcome.is_err(), "partial release must be rejected");
+        assert_eq!(manager.request_block_count(owner), 2);
+        assert_eq!(manager.num_active_blocks(), active_before);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -443,7 +443,12 @@ impl VllmKvManager {
             self.pool.cancel(pool);
             return;
         };
-        let alloc = Self::destination_alloc(request_id, &layout, attention_prefix, self.enable_prefix_caching);
+        let alloc = Self::destination_alloc(
+            request_id,
+            &layout,
+            attention_prefix,
+            self.enable_prefix_caching,
+        );
         alloc.validate();
         self.attention().validate_fresh_partials(alloc.blocks);
         self.commit_groups(&alloc, &mut pool);

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -79,15 +79,15 @@ pub(crate) struct NativeDestinationReservation {
     request_id: Uuid,
     pool: BlockReservation,
     layout: Option<VllmBlockLayout>,
-    /// Attention blocks the reservation covers, excluding other groups' share.
+    /// Used to count missing prompt tokens for transfer timing (`attention_fresh * block_size`).
     attention_fresh: usize,
-    /// Leading attention prefix pins, which precede other groups' pins in the
-    /// reservation.
+    /// Attention reusable prefix length fixed at reserve time and replayed at activate.
     attention_prefix: usize,
 }
 
 impl NativeDestinationReservation {
     pub(crate) fn transferable_prompt_tokens(&self, block_size: usize) -> usize {
+        // only looking at attention layers so we don't double count
         self.attention_fresh.saturating_mul(block_size)
     }
 
@@ -127,10 +127,6 @@ impl VllmBlockLayout {
 
 pub(crate) struct VllmKvManager {
     pool: VllmBlockPool,
-    /// The model's KV cache groups, in the order this coordinator visits them:
-    /// prefix pins are reserved and later activated in that order. Group ids are
-    /// assigned when the groups are built, and every lookup goes by group kind,
-    /// so nothing below `new` depends on the order.
     groups: Vec<GroupManager>,
     block_size: usize,
     enable_prefix_caching: bool,
@@ -193,9 +189,6 @@ impl VllmKvManager {
         self.attention().id()
     }
 
-    /// Groups that only constrain the attention group's decisions, never seed
-    /// them: they can reduce a cache hit and consume capacity, but they own no
-    /// dense table and no router-visible block.
     fn other_groups(&self) -> impl Iterator<Item = &GroupManager> {
         self.groups
             .iter()
@@ -225,17 +218,11 @@ impl VllmKvManager {
     }
 
     /// Release a request's blocks from every group.
-    ///
-    /// A release always covers the request's whole footprint: each `Deref` signal
-    /// derives its block list from the sequence's allocated tokens. Groups whose
-    /// table is not parallel to the attention table lean on that, dropping all of
-    /// a request's state rather than trimming it. Trimming a live request is a
-    /// real vLLM operation — `remove_skipped_blocks` — that this mocker does not
-    /// model yet, so a partial release is rejected before any group mutates,
-    /// because releases run group by group and cannot be rolled back.
     pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        // A request the attention group does not hold falls through to it, which
-        // reports that more precisely than a totality check can.
+        // TODO: trimming a live request is a real vLLM operation — `remove_skipped_blocks` — 
+        // that this mocker does not model yet, so a partial release is rejected before any group mutates.
+        // Unknown requests (`held == 0`) skip the partial-release check and let
+        // attention's `release` panic with "owns no block table" instead.
         let held = self.attention().block_count(request_id);
         assert!(
             held == 0 || blocks.len() == held,
@@ -594,8 +581,7 @@ impl VllmKvManager {
     /// Publish evictions for the main attention group only.
     ///
     /// `KvCacheEvent` has no group field and the router indexes a single block
-    /// namespace, so a non-attention group's eviction must not be reported as
-    /// an attention block disappearing.
+    /// namespace, so non-attention groups' evictions are not reported
     fn publish_removed(&mut self, keys: Vec<GroupedHash>) {
         let attention = self.attention_id();
         let hashes = keys
@@ -715,16 +701,15 @@ impl VllmKvManager {
 
     pub(crate) fn get_prefill_cost(&self, sequence: &ActiveSequence) -> PrefillCost {
         let blocks = sequence.unique_blocks();
+
+        // vLLM's hybrid coordinator seeds the candidate with the dense
+        // full-attention hit and reduces it until every group agrees on one boundary.
         let attention = if self.enable_prefix_caching && sequence.enable_prefix_caching() {
             self.attention().longest_cache_hit(&self.pool, blocks)
         } else {
             CacheHit::default()
         };
 
-        // vLLM's hybrid coordinator seeds the candidate with the dense
-        // full-attention hit and reduces it until every group agrees on one
-        // boundary. Groups share a block size here, so a single pass converges
-        // (its `is_simple_hybrid` shortcut).
         let mut reconciled = attention.tokens;
         for group in self.other_groups() {
             let Some(hit) = group.longest_cache_hit(&self.pool, blocks) else {

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -292,22 +292,27 @@ impl VllmKvManager {
             computed_before <= computed_after,
             "computed token count cannot move backwards during one scheduling decision"
         );
-        let first_new_block = computed_before / self.block_size;
-        let completed_blocks = computed_after / self.block_size;
-        if first_new_block == completed_blocks {
-            return;
-        }
 
         let materialize_store_events = self.materialize_store_events();
         let stores = {
-            let (pool, attention) = self.attention_mut();
-            attention.finalize_computed_prefix(
-                pool,
-                request_id,
-                first_new_block,
-                completed_blocks,
-                materialize_store_events,
-            )
+            let Self { pool, groups, .. } = self;
+            let mut stores = None;
+            for group in groups.iter_mut() {
+                let group_stores = group.finalize_computed_prefix(
+                    pool,
+                    request_id,
+                    computed_before,
+                    computed_after,
+                    materialize_store_events,
+                );
+                if let Some(group_stores) = group_stores {
+                    assert!(
+                        stores.replace(group_stores).is_none(),
+                        "only one group's blocks can be reported"
+                    );
+                }
+            }
+            stores
         };
         if let Some(stores) = stores {
             self.publish_store_sequence(stores);
@@ -370,7 +375,7 @@ impl VllmKvManager {
         let (prefix, fresh, attention_fresh, attention_prefix) = match layout.as_ref() {
             Some(layout) => {
                 let alloc = Self::destination_alloc(request_id, layout, 0);
-                FullAttentionGroup::validate_use_metadata(&alloc);
+                alloc.validate();
                 self.attention().validate_fresh_partials(alloc.blocks);
                 // No prior lookup authorized this transfer's reusable prefix, so
                 // the attention group discovers it here; every group then sizes
@@ -435,7 +440,7 @@ impl VllmKvManager {
         };
         let mut alloc = Self::destination_alloc(request_id, &layout, attention_prefix);
         alloc.cache_fresh = self.enable_prefix_caching;
-        FullAttentionGroup::validate_use_metadata(&alloc);
+        alloc.validate();
         self.attention().validate_fresh_partials(alloc.blocks);
         self.commit_groups(&alloc, &mut pool);
         assert_eq!(pool.len(), 0, "destination reservation was not consumed");
@@ -451,7 +456,7 @@ impl VllmKvManager {
         alloc: &GroupAllocation,
         reservation: Option<&mut BlockReservation>,
     ) -> VllmAcquire<usize> {
-        FullAttentionGroup::validate_use_metadata(alloc);
+        alloc.validate();
         self.attention().validate_fresh_partials(alloc.blocks);
         assert!(alloc.reusable_prefix_blocks <= alloc.blocks.len());
         assert!(self.enable_prefix_caching || alloc.reusable_prefix_blocks == 0);
@@ -509,22 +514,29 @@ impl VllmKvManager {
         let stores = {
             let Self { pool, groups, .. } = self;
             // Pins come back in the order [`Self::group_demand`] reserved them,
-            // which is the order the groups are visited here.
-            let prefix_copies = pool.activate_prefix(reservation);
+            // which is the order the groups drain them here.
+            let activated = pool.activate_prefix(reservation);
+            let mut prefix_copies = activated.iter().copied();
             let mut stores = None;
             for group in groups.iter_mut() {
-                match group {
-                    GroupManager::FullAttention(attention) => {
-                        stores = attention.commit(
-                            pool,
-                            reservation,
-                            alloc,
-                            &prefix_copies,
-                            materialize_store_events,
-                        );
-                    }
+                let group_stores = group.commit(
+                    pool,
+                    reservation,
+                    alloc,
+                    &mut prefix_copies,
+                    materialize_store_events,
+                );
+                if let Some(group_stores) = group_stores {
+                    assert!(
+                        stores.replace(group_stores).is_none(),
+                        "only one group's blocks can be reported"
+                    );
                 }
             }
+            assert!(
+                prefix_copies.next().is_none(),
+                "prefix reservation was not consumed"
+            );
             stores
         };
         if let Some(stores) = stores {

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -379,7 +379,7 @@ impl VllmKvManager {
         );
         let (prefix, fresh, attention_fresh, attention_prefix) = match layout.as_ref() {
             Some(layout) => {
-                let alloc = Self::destination_alloc(request_id, layout, 0);
+                let alloc = Self::destination_alloc(request_id, layout, 0, false);
                 alloc.validate();
                 self.attention().validate_fresh_partials(alloc.blocks);
                 // No prior lookup authorized this transfer's reusable prefix, so
@@ -387,9 +387,8 @@ impl VllmKvManager {
                 // itself against the prefix the request will keep.
                 let attention_prefix = self
                     .attention()
-                    .resident_prefix(&self.pool, &layout.blocks)
-                    .len();
-                let alloc = Self::destination_alloc(request_id, layout, attention_prefix);
+                    .resident_prefix_len(&self.pool, &layout.blocks);
+                let alloc = Self::destination_alloc(request_id, layout, attention_prefix, false);
                 let (prefix, fresh) = self.group_demand(&alloc);
                 let attention_fresh = self.attention().fresh_blocks(&alloc);
                 (prefix, fresh, attention_fresh, attention_prefix)
@@ -415,6 +414,7 @@ impl VllmKvManager {
         request_id: Uuid,
         layout: &VllmBlockLayout,
         reusable_prefix_blocks: usize,
+        cache_fresh: bool,
     ) -> GroupAllocation<'_> {
         GroupAllocation {
             request_id,
@@ -423,7 +423,7 @@ impl VllmKvManager {
             token_ids: layout.token_ids.as_deref(),
             parent: layout.parent.as_ref(),
             reusable_prefix_blocks,
-            cache_fresh: true,
+            cache_fresh,
         }
     }
 
@@ -443,8 +443,7 @@ impl VllmKvManager {
             self.pool.cancel(pool);
             return;
         };
-        let mut alloc = Self::destination_alloc(request_id, &layout, attention_prefix);
-        alloc.cache_fresh = self.enable_prefix_caching;
+        let alloc = Self::destination_alloc(request_id, &layout, attention_prefix, self.enable_prefix_caching);
         alloc.validate();
         self.attention().validate_fresh_partials(alloc.blocks);
         self.commit_groups(&alloc, &mut pool);

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -17,14 +17,15 @@ use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
 use uuid::Uuid;
 
-use crate::cache::vllm_block_pool::{BlockReservation, GroupedHash, ReserveOutcome, VllmBlockPool};
+use crate::cache::vllm_block_pool::{
+    BlockReservation, GroupedHash, KvCacheGroupId, ReserveOutcome, VllmBlockPool,
+};
 use crate::common::kv_cache_trace;
 use crate::common::protocols::{KvEventPublishers, PrefillCost};
 use crate::common::sequence::ActiveSequence;
 
 use super::vllm_groups::{
-    ATTENTION_GROUP, CacheHit, FullAttentionGroup, GroupAllocation, GroupManager, PendingStore,
-    StoredBlock,
+    CacheHit, FullAttentionGroup, GroupAllocation, GroupManager, PendingStore, StoredBlock,
 };
 
 struct StoreGroup {
@@ -126,8 +127,10 @@ impl VllmBlockLayout {
 
 pub(crate) struct VllmKvManager {
     pool: VllmBlockPool,
-    /// Group 0 is always the main attention group; a hybrid model's
-    /// non-attention state groups follow it.
+    /// The model's KV cache groups, in the order this coordinator visits them:
+    /// prefix pins are reserved and later activated in that order. Group ids are
+    /// assigned when the groups are built, and every lookup goes by group kind,
+    /// so nothing below `new` depends on the order.
     groups: Vec<GroupManager>,
     block_size: usize,
     enable_prefix_caching: bool,
@@ -151,7 +154,7 @@ impl VllmKvManager {
         Self {
             pool: VllmBlockPool::new(max_capacity),
             groups: vec![GroupManager::FullAttention(FullAttentionGroup::new(
-                ATTENTION_GROUP,
+                KvCacheGroupId(0),
                 block_size,
                 enable_prefix_caching,
             ))],
@@ -163,9 +166,40 @@ impl VllmKvManager {
         }
     }
 
+    /// The main attention group, which every request has a dense block table in.
+    ///
+    /// vLLM's hybrid coordinator singles this group out the same way: it is the
+    /// dense reference for cross-group cache-hit reconciliation, and the only
+    /// group whose blocks the router's single namespace can describe.
     fn attention(&self) -> &FullAttentionGroup {
-        let GroupManager::FullAttention(group) = &self.groups[0];
-        group
+        self.groups
+            .iter()
+            .find_map(|group| group.as_full_attention())
+            .expect("a model has a main attention group")
+    }
+
+    /// Disjoint borrows of the pool and the attention group, which the group
+    /// needs together to move blocks in or out of the pool.
+    fn attention_mut(&mut self) -> (&mut VllmBlockPool, &mut FullAttentionGroup) {
+        let Self { pool, groups, .. } = self;
+        let attention = groups
+            .iter_mut()
+            .find_map(|group| group.as_full_attention_mut())
+            .expect("a model has a main attention group");
+        (pool, attention)
+    }
+
+    fn attention_id(&self) -> KvCacheGroupId {
+        self.attention().id()
+    }
+
+    /// Groups that only constrain the attention group's decisions, never seed
+    /// them: they can reduce a cache hit and consume capacity, but they own no
+    /// dense table and no router-visible block.
+    fn other_groups(&self) -> impl Iterator<Item = &GroupManager> {
+        self.groups
+            .iter()
+            .filter(|group| !group.is_full_attention())
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -191,8 +225,7 @@ impl VllmKvManager {
     }
 
     pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        let Self { pool, groups, .. } = self;
-        let GroupManager::FullAttention(attention) = &mut groups[0];
+        let (pool, attention) = self.attention_mut();
         attention.deref(pool, request_id, blocks);
     }
 
@@ -207,8 +240,7 @@ impl VllmKvManager {
         token_ids: Option<Vec<u32>>,
     ) {
         let materialize_store_events = self.materialize_store_events();
-        let Self { pool, groups, .. } = self;
-        let GroupManager::FullAttention(attention) = &mut groups[0];
+        let (pool, attention) = self.attention_mut();
         let stored = attention.promote(
             pool,
             request_id,
@@ -254,8 +286,7 @@ impl VllmKvManager {
 
         let materialize_store_events = self.materialize_store_events();
         let stores = {
-            let Self { pool, groups, .. } = self;
-            let GroupManager::FullAttention(attention) = &mut groups[0];
+            let (pool, attention) = self.attention_mut();
             attention.finalize_computed_prefix(
                 pool,
                 request_id,
@@ -327,16 +358,17 @@ impl VllmKvManager {
                 let alloc = Self::destination_alloc(request_id, layout, 0);
                 FullAttentionGroup::validate_use_metadata(&alloc);
                 self.attention().validate_fresh_partials(alloc.blocks);
-                let prefix = self.attention().resident_prefix(&self.pool, &layout.blocks);
-                let attention_prefix = prefix.len();
+                // No prior lookup authorized this transfer's reusable prefix, so
+                // the attention group discovers it here; every group then sizes
+                // itself against the prefix the request will keep.
+                let attention_prefix = self
+                    .attention()
+                    .resident_prefix(&self.pool, &layout.blocks)
+                    .len();
                 let alloc = Self::destination_alloc(request_id, layout, attention_prefix);
+                let (prefix, fresh) = self.group_demand(&alloc);
                 let attention_fresh = self.attention().fresh_blocks(&alloc);
-                let (mut keys, mut fresh) = (prefix, attention_fresh);
-                for group in &self.groups[1..] {
-                    keys.extend(group.prefix_keys(&alloc));
-                    fresh += group.fresh_blocks(&alloc);
-                }
-                (keys, fresh, attention_fresh, attention_prefix)
+                (prefix, fresh, attention_fresh, attention_prefix)
             }
             None => (Vec::new(), 0, 0, 0),
         };
@@ -415,12 +447,7 @@ impl VllmKvManager {
             "only a request's first allocation may reuse a prefix"
         );
 
-        let mut prefix = self.attention().prefix_keys(alloc);
-        let mut fresh = self.attention().fresh_blocks(alloc);
-        for group in &self.groups[1..] {
-            prefix.extend(group.prefix_keys(alloc));
-            fresh += group.fresh_blocks(alloc);
-        }
+        let (prefix, fresh) = self.group_demand(alloc);
 
         match reservation {
             Some(reservation) => {
@@ -447,14 +474,28 @@ impl VllmKvManager {
         VllmAcquire::Ready(alloc.blocks.len())
     }
 
+    /// Prefix pins and fresh pool blocks every group needs for `alloc`.
+    ///
+    /// Groups are visited in coordinator order, which fixes the order the pins
+    /// are reserved in and so the order [`Self::commit_groups`] activates them.
+    fn group_demand(&self, alloc: &GroupAllocation) -> (Vec<GroupedHash>, usize) {
+        let mut prefix = Vec::new();
+        let mut fresh = 0;
+        for group in &self.groups {
+            prefix.extend(group.prefix_keys(alloc));
+            fresh += group.fresh_blocks(alloc);
+        }
+        (prefix, fresh)
+    }
+
     /// Commit every group against the shared reservation, publishing only the
     /// main attention group's store events.
     fn commit_groups(&mut self, alloc: &GroupAllocation, reservation: &mut BlockReservation) {
         let materialize_store_events = self.materialize_store_events();
         let stores = {
             let Self { pool, groups, .. } = self;
-            // Prefix pins were reserved in group order, matching the order the
-            // groups are visited here.
+            // Pins come back in the order [`Self::group_demand`] reserved them,
+            // which is the order the groups are visited here.
             let prefix_copies = pool.activate_prefix(reservation);
             let mut stores = None;
             for group in groups.iter_mut() {
@@ -521,9 +562,10 @@ impl VllmKvManager {
     /// namespace, so a non-attention group's eviction must not be reported as
     /// an attention block disappearing.
     fn publish_removed(&mut self, keys: Vec<GroupedHash>) {
+        let attention = self.attention_id();
         let hashes = keys
             .into_iter()
-            .filter(|key| key.group == ATTENTION_GROUP)
+            .filter(|key| key.group == attention)
             .map(|key| key.hash)
             .collect::<Vec<_>>();
         if !hashes.is_empty() {
@@ -644,11 +686,12 @@ impl VllmKvManager {
             CacheHit::default()
         };
 
-        // vLLM's hybrid coordinator reduces the candidate hit until every group
-        // agrees on one boundary. Groups share a block size here, so a single
-        // pass converges (its `is_simple_hybrid` shortcut).
+        // vLLM's hybrid coordinator seeds the candidate with the dense
+        // full-attention hit and reduces it until every group agrees on one
+        // boundary. Groups share a block size here, so a single pass converges
+        // (its `is_simple_hybrid` shortcut).
         let mut reconciled = attention.tokens;
-        for group in &self.groups[1..] {
+        for group in self.other_groups() {
             let Some(hit) = group.longest_cache_hit(&self.pool, blocks) else {
                 continue;
             };
@@ -736,7 +779,7 @@ mod tests {
     fn attention_hit(manager: &VllmKvManager, hash: SequenceHash) -> bool {
         manager
             .pool
-            .prefix_hit(GroupedHash::new(ATTENTION_GROUP, hash))
+            .prefix_hit(GroupedHash::new(manager.attention_id(), hash))
             .is_some()
     }
 

--- a/lib/mocker/src/kv_manager/vllm_firewall_tests.rs
+++ b/lib/mocker/src/kv_manager/vllm_firewall_tests.rs
@@ -6,7 +6,7 @@ const VLLM_BACKEND: &str = include_str!("vllm_backend.rs");
 
 /// Every KV cache group implementation, by the label a failure should name.
 const VLLM_GROUPS: [(&str, &str); 2] = [
-    ("vllm_groups/mod.rs", include_str!("vllm_groups/mod.rs")),
+    ("vllm_groups.rs", include_str!("vllm_groups.rs")),
     (
         "vllm_groups/full_attention.rs",
         include_str!("vllm_groups/full_attention.rs"),

--- a/lib/mocker/src/kv_manager/vllm_firewall_tests.rs
+++ b/lib/mocker/src/kv_manager/vllm_firewall_tests.rs
@@ -4,6 +4,15 @@
 const BLOCK_POOL: &str = include_str!("../cache/vllm_block_pool.rs");
 const VLLM_BACKEND: &str = include_str!("vllm_backend.rs");
 
+/// Every KV cache group implementation, by the label a failure should name.
+const VLLM_GROUPS: [(&str, &str); 2] = [
+    ("vllm_groups/mod.rs", include_str!("vllm_groups/mod.rs")),
+    (
+        "vllm_groups/full_attention.rs",
+        include_str!("vllm_groups/full_attention.rs"),
+    ),
+];
+
 fn assert_absent(label: &str, source: &str, forbidden: &[&str]) {
     let source = source.to_ascii_lowercase();
     let found = forbidden
@@ -40,20 +49,39 @@ fn vllm_block_pool_is_a_leaf_core() {
 
 #[test]
 fn vllm_backend_has_no_kvbm_or_legacy_g1_dependencies() {
-    assert_absent(
-        "vllm_backend.rs",
-        VLLM_BACKEND,
-        &[
-            "kvbm",
-            "moveblock",
-            "positionallineagehash",
-            "plh",
-            "g1acquire",
-            "g1backend",
-            "offload",
-            "swapin",
-            "swap_in",
-            "immutableblock",
-        ],
-    );
+    for (label, source) in [("vllm_backend.rs", VLLM_BACKEND)]
+        .into_iter()
+        .chain(VLLM_GROUPS)
+    {
+        assert_absent(
+            label,
+            source,
+            &[
+                "kvbm",
+                "moveblock",
+                "positionallineagehash",
+                "plh",
+                "g1acquire",
+                "g1backend",
+                "offload",
+                "swapin",
+                "swap_in",
+                "immutableblock",
+            ],
+        );
+    }
+}
+
+/// A group implementation must never reach the typed event sink: `KvCacheEvent`
+/// has no group field, so the router would read another group's hash as an
+/// attention block. Only the coordinator publishes.
+#[test]
+fn groups_never_publish_kv_events() {
+    for (label, source) in VLLM_GROUPS {
+        assert_absent(
+            label,
+            source,
+            &["kveventpublishers", "kvcacheevent", "rawkvevent", "publish"],
+        );
+    }
 }

--- a/lib/mocker/src/kv_manager/vllm_groups.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups.rs
@@ -129,7 +129,7 @@ impl GroupManager {
         blocks: &[UniqueBlock],
     ) {
         match self {
-            Self::FullAttention(group) => group.deref(pool, request_id, blocks),
+            Self::FullAttention(group) => group.release(pool, request_id, blocks),
         }
     }
 

--- a/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
@@ -141,12 +141,10 @@ impl FullAttentionGroup {
         pool: &mut VllmBlockPool,
         reservation: &mut BlockReservation,
         alloc: &GroupAllocation,
-        prefix_copies: &[BlockCopyId],
+        prefix_copies: &mut impl Iterator<Item = BlockCopyId>,
         materialize_store_events: bool,
     ) -> Option<Vec<Option<StoredBlock>>> {
         let prefix_len = alloc.reusable_prefix_blocks;
-        assert_eq!(prefix_copies.len(), prefix_len);
-        let mut prefix_copies = prefix_copies.iter().copied();
         let mut cursor = match alloc.parent {
             None => None,
             Some(UniqueBlock::FullBlock(hash)) => Some(*hash),
@@ -233,19 +231,26 @@ impl FullAttentionGroup {
                 }
             }
         }
-        assert!(prefix_copies.next().is_none());
         stores
     }
 
     /// Make blocks completed by this scheduling decision cache-visible.
+    ///
+    /// The watermarks are token counts, which this group quantizes with its own
+    /// block size the way each of vLLM's managers does.
     pub(crate) fn finalize_computed_prefix(
         &mut self,
         pool: &mut VllmBlockPool,
         request_id: Uuid,
-        first_new_block: usize,
-        completed_blocks: usize,
+        computed_before: usize,
+        computed_after: usize,
         materialize_store_events: bool,
     ) -> Option<Vec<Option<StoredBlock>>> {
+        let first_new_block = computed_before / self.block_size;
+        let completed_blocks = computed_after / self.block_size;
+        if first_new_block == completed_blocks {
+            return None;
+        }
         let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
             panic!("request {request_id} owns no block table")
         };
@@ -368,23 +373,6 @@ impl FullAttentionGroup {
             pending_store: None,
         });
         (became_visible && materialize_store_events).then_some(StoredBlock { hash, metadata })
-    }
-
-    pub(crate) fn validate_use_metadata(alloc: &GroupAllocation) {
-        let full_blocks = alloc
-            .blocks
-            .iter()
-            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
-            .count();
-        assert!(
-            alloc.local_hashes.is_empty() || alloc.local_hashes.len() == full_blocks,
-            "local hashes must be empty or align with full blocks"
-        );
-        assert!(
-            alloc.token_ids.is_none_or(|ids| ids.len() == full_blocks),
-            "token IDs must align with full blocks"
-        );
-        assert!(!matches!(alloc.parent, Some(UniqueBlock::PartialBlock(_))));
     }
 
     pub(crate) fn validate_fresh_partials(&self, blocks: &[UniqueBlock]) {

--- a/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
@@ -1,0 +1,409 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! The main attention KV cache group.
+
+use dynamo_tokens::SequenceHash;
+use dynamo_tokens::blocks::UniqueBlock;
+use rustc_hash::{FxHashMap, FxHashSet};
+use uuid::Uuid;
+
+use crate::cache::vllm_block_pool::{
+    BlockCopyId, BlockReservation, GroupedHash, KvCacheGroupId, VllmBlockPool,
+};
+
+use super::{CacheHit, GroupAllocation, PendingStore, StoredBlock};
+
+struct FullBlock {
+    copy: BlockCopyId,
+    hash: SequenceHash,
+    /// Whether a freshly allocated full block still needs to become cache-visible.
+    pending_cache: bool,
+    /// Event metadata retained until `pending_cache` is finalized.
+    pending_store: Option<PendingStore>,
+}
+
+enum OwnedBlock {
+    Partial { copy: BlockCopyId, uuid: Uuid },
+    Full(FullBlock),
+}
+
+/// Per-request block table for the main attention group.
+///
+/// This is vLLM's `FullAttentionManager`: a dense block table whose cache hits
+/// are a contiguous prefix scanned left to right.
+pub(crate) struct FullAttentionGroup {
+    group: KvCacheGroupId,
+    request_blocks: FxHashMap<Uuid, Vec<OwnedBlock>>,
+    partial_uuids: FxHashSet<Uuid>,
+    block_size: usize,
+    enable_prefix_caching: bool,
+}
+
+impl FullAttentionGroup {
+    pub(crate) fn new(
+        group: KvCacheGroupId,
+        block_size: usize,
+        enable_prefix_caching: bool,
+    ) -> Self {
+        Self {
+            group,
+            request_blocks: FxHashMap::default(),
+            partial_uuids: FxHashSet::default(),
+            block_size,
+            enable_prefix_caching,
+        }
+    }
+
+    fn key(&self, hash: SequenceHash) -> GroupedHash {
+        GroupedHash::new(self.group, hash)
+    }
+
+    pub(crate) fn holds_request(&self, request_id: Uuid) -> bool {
+        self.request_blocks.contains_key(&request_id)
+    }
+
+    pub(crate) fn block_count(&self, request_id: Uuid) -> usize {
+        self.request_blocks.get(&request_id).map_or(0, Vec::len)
+    }
+
+    /// Cached-prefix keys this step may pin, taken from the caller-authorized
+    /// reusable prefix.
+    pub(crate) fn prefix_keys(&self, alloc: &GroupAllocation) -> Vec<GroupedHash> {
+        alloc.blocks[..alloc.reusable_prefix_blocks]
+            .iter()
+            .map(|block| match block {
+                UniqueBlock::FullBlock(hash) => self.key(*hash),
+                UniqueBlock::PartialBlock(_) => {
+                    panic!("a reusable prefix can contain only full blocks")
+                }
+            })
+            .collect()
+    }
+
+    pub(crate) fn fresh_blocks(&self, alloc: &GroupAllocation) -> usize {
+        alloc.blocks.len() - alloc.reusable_prefix_blocks
+    }
+
+    /// Longest resident prefix of `blocks`, for a destination reservation whose
+    /// reusable prefix has not been authorized by a prior lookup.
+    pub(crate) fn resident_prefix(
+        &self,
+        pool: &VllmBlockPool,
+        blocks: &[UniqueBlock],
+    ) -> Vec<GroupedHash> {
+        if !self.enable_prefix_caching {
+            return Vec::new();
+        }
+        blocks
+            .iter()
+            .map_while(|block| match block {
+                UniqueBlock::FullBlock(hash) if pool.prefix_hit(self.key(*hash)).is_some() => {
+                    Some(self.key(*hash))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub(crate) fn longest_cache_hit(
+        &self,
+        pool: &VllmBlockPool,
+        blocks: &[UniqueBlock],
+    ) -> CacheHit {
+        if !self.enable_prefix_caching {
+            return CacheHit::default();
+        }
+        let mut overlap = 0;
+        let mut active = 0;
+        for block in blocks {
+            let UniqueBlock::FullBlock(hash) = block else {
+                break;
+            };
+            let Some(hit) = pool.prefix_hit(self.key(*hash)) else {
+                break;
+            };
+            overlap += 1;
+            active += usize::from(hit.is_active);
+        }
+        CacheHit {
+            tokens: overlap * self.block_size,
+            active_tokens: active * self.block_size,
+        }
+    }
+
+    pub(crate) fn commit(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        reservation: &mut BlockReservation,
+        alloc: &GroupAllocation,
+        prefix_copies: &[BlockCopyId],
+        materialize_store_events: bool,
+    ) -> Option<Vec<Option<StoredBlock>>> {
+        let prefix_len = alloc.reusable_prefix_blocks;
+        assert_eq!(prefix_copies.len(), prefix_len);
+        let mut prefix_copies = prefix_copies.iter().copied();
+        let mut cursor = match alloc.parent {
+            None => None,
+            Some(UniqueBlock::FullBlock(hash)) => Some(*hash),
+            Some(UniqueBlock::PartialBlock(_)) => unreachable!("validated above"),
+        };
+        let mut full_idx = 0;
+        let owned = self.request_blocks.entry(alloc.request_id).or_default();
+        owned.reserve(alloc.blocks.len());
+        let mut stores = (alloc.cache_fresh && materialize_store_events)
+            .then(|| Vec::with_capacity(alloc.blocks.len()));
+
+        for (block_idx, block) in alloc.blocks.iter().enumerate() {
+            match block {
+                UniqueBlock::FullBlock(hash) => {
+                    let local_hash = alloc.local_hashes.get(full_idx).copied();
+                    full_idx += 1;
+
+                    if block_idx < prefix_len {
+                        let Some(copy) = prefix_copies.next() else {
+                            panic!("prefix reservation returned too few copies")
+                        };
+                        owned.push(OwnedBlock::Full(FullBlock {
+                            copy,
+                            hash: *hash,
+                            pending_cache: false,
+                            pending_store: None,
+                        }));
+                        cursor = Some(*hash);
+                        continue;
+                    }
+
+                    if alloc.cache_fresh {
+                        let (copy, became_visible) =
+                            pool.allocate_cached(reservation, GroupedHash::new(self.group, *hash));
+                        owned.push(OwnedBlock::Full(FullBlock {
+                            copy,
+                            hash: *hash,
+                            pending_cache: false,
+                            pending_store: None,
+                        }));
+                        if let Some(stores) = &mut stores {
+                            let metadata = PendingStore {
+                                parent_hash: cursor,
+                                local_hash,
+                                token_ids: alloc
+                                    .token_ids
+                                    .and_then(|ids| ids.get(full_idx - 1).cloned()),
+                            };
+                            stores.push(became_visible.then_some(StoredBlock {
+                                hash: *hash,
+                                metadata,
+                            }));
+                        }
+                    } else {
+                        let copy = pool.allocate_private(reservation);
+                        let pending_cache = self.enable_prefix_caching;
+                        let pending_store =
+                            (pending_cache && materialize_store_events).then(|| PendingStore {
+                                parent_hash: cursor,
+                                local_hash,
+                                token_ids: alloc
+                                    .token_ids
+                                    .and_then(|ids| ids.get(full_idx - 1).cloned()),
+                            });
+                        owned.push(OwnedBlock::Full(FullBlock {
+                            copy,
+                            hash: *hash,
+                            pending_cache,
+                            pending_store,
+                        }));
+                    }
+                    cursor = Some(*hash);
+                }
+                UniqueBlock::PartialBlock(uuid) => {
+                    let copy = pool.allocate_private(reservation);
+                    assert!(
+                        self.partial_uuids.insert(*uuid),
+                        "partial block {uuid} is already allocated"
+                    );
+                    owned.push(OwnedBlock::Partial { copy, uuid: *uuid });
+                    if let Some(stores) = &mut stores {
+                        stores.push(None);
+                    }
+                }
+            }
+        }
+        assert!(prefix_copies.next().is_none());
+        stores
+    }
+
+    /// Make blocks completed by this scheduling decision cache-visible.
+    pub(crate) fn finalize_computed_prefix(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        request_id: Uuid,
+        first_new_block: usize,
+        completed_blocks: usize,
+        materialize_store_events: bool,
+    ) -> Option<Vec<Option<StoredBlock>>> {
+        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
+            panic!("request {request_id} owns no block table")
+        };
+        let completed_blocks = completed_blocks.min(blocks.len());
+        if first_new_block >= completed_blocks {
+            return None;
+        }
+        let mut stores = materialize_store_events
+            .then(|| Vec::with_capacity(completed_blocks - first_new_block));
+        for block in &mut blocks[first_new_block..completed_blocks] {
+            match block {
+                OwnedBlock::Full(full) => {
+                    if !full.pending_cache {
+                        if let Some(stores) = &mut stores {
+                            stores.push(None);
+                        }
+                        continue;
+                    }
+                    full.pending_cache = false;
+                    let metadata = full.pending_store.take();
+                    let became_visible =
+                        pool.cache_private(full.copy, GroupedHash::new(self.group, full.hash));
+                    if let Some(stores) = &mut stores {
+                        stores.push(became_visible.then(|| {
+                            StoredBlock {
+                                hash: full.hash,
+                                metadata: metadata.expect(
+                                    "materialized pending store must retain event metadata",
+                                ),
+                            }
+                        }));
+                    } else {
+                        debug_assert!(metadata.is_none());
+                    }
+                }
+                OwnedBlock::Partial { .. } => break,
+            }
+        }
+        stores
+    }
+
+    /// Release request blocks in caller-provided eviction-priority order.
+    ///
+    /// Like vLLM's `BlockPool::free_blocks`, the physical pool is lineage-agnostic:
+    /// reversing the request-owned table here makes suffix/leaf blocks older LRU
+    /// candidates than their parents, so capacity pressure evicts the leaf first.
+    pub(crate) fn deref(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        request_id: Uuid,
+        blocks: &[UniqueBlock],
+    ) {
+        let released = {
+            let Some(owned) = self.request_blocks.get_mut(&request_id) else {
+                panic!("request {request_id} owns no block table")
+            };
+            assert!(
+                blocks.len() <= owned.len(),
+                "request releases too many blocks"
+            );
+            let start = owned.len() - blocks.len();
+            for (expected, actual) in blocks.iter().zip(owned[start..].iter().rev()) {
+                match (expected, actual) {
+                    (UniqueBlock::FullBlock(expected), OwnedBlock::Full(full)) => {
+                        assert_eq!(*expected, full.hash, "full-block Deref mismatch");
+                    }
+                    (UniqueBlock::PartialBlock(expected), OwnedBlock::Partial { uuid, .. }) => {
+                        assert_eq!(expected, uuid, "partial Deref mismatch")
+                    }
+                    _ => panic!("Deref block kind disagrees with request table"),
+                }
+            }
+            owned.split_off(start)
+        };
+        if self.request_blocks[&request_id].is_empty() {
+            self.request_blocks.remove(&request_id);
+        }
+
+        for block in released.into_iter().rev() {
+            match block {
+                OwnedBlock::Partial { copy, uuid } => {
+                    assert!(self.partial_uuids.remove(&uuid));
+                    pool.release(copy);
+                }
+                OwnedBlock::Full(full) => pool.release(full.copy),
+            }
+        }
+    }
+
+    pub(crate) fn promote(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        request_id: Uuid,
+        uuid: Uuid,
+        hash: SequenceHash,
+        metadata: PendingStore,
+        materialize_store_events: bool,
+    ) -> Option<StoredBlock> {
+        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
+            panic!("request {request_id} owns no block table")
+        };
+        let Some(last) = blocks.last_mut() else {
+            panic!("Promote requires a request-owned partial tail")
+        };
+        let copy = match last {
+            OwnedBlock::Partial { copy, uuid: actual } => {
+                assert_eq!(*actual, uuid, "Promote partial UUID mismatch");
+                *copy
+            }
+            OwnedBlock::Full(_) => panic!("Promote requires a partial tail"),
+        };
+        assert!(self.partial_uuids.remove(&uuid));
+
+        let became_visible = self.enable_prefix_caching
+            && pool.cache_private(copy, GroupedHash::new(self.group, hash));
+        *last = OwnedBlock::Full(FullBlock {
+            copy,
+            hash,
+            pending_cache: false,
+            pending_store: None,
+        });
+        (became_visible && materialize_store_events).then_some(StoredBlock { hash, metadata })
+    }
+
+    pub(crate) fn validate_use_metadata(alloc: &GroupAllocation) {
+        let full_blocks = alloc
+            .blocks
+            .iter()
+            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
+            .count();
+        assert!(
+            alloc.local_hashes.is_empty() || alloc.local_hashes.len() == full_blocks,
+            "local hashes must be empty or align with full blocks"
+        );
+        assert!(
+            alloc.token_ids.is_none_or(|ids| ids.len() == full_blocks),
+            "token IDs must align with full blocks"
+        );
+        assert!(!matches!(alloc.parent, Some(UniqueBlock::PartialBlock(_))));
+    }
+
+    pub(crate) fn validate_fresh_partials(&self, blocks: &[UniqueBlock]) {
+        let mut first_partial = None;
+        for (index, uuid) in blocks
+            .iter()
+            .enumerate()
+            .filter_map(|(index, block)| match block {
+                UniqueBlock::PartialBlock(uuid) => Some((index, uuid)),
+                UniqueBlock::FullBlock(_) => None,
+            })
+        {
+            let repeated_in_layout = first_partial.is_some_and(|first| {
+                first == *uuid
+                    || blocks[..index].iter().any(
+                        |block| matches!(block, UniqueBlock::PartialBlock(seen) if seen == uuid),
+                    )
+            });
+            assert!(
+                !self.partial_uuids.contains(uuid) && !repeated_in_layout,
+                "partial block {uuid} is already allocated"
+            );
+            first_partial.get_or_insert(*uuid);
+        }
+    }
+}

--- a/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
@@ -59,6 +59,10 @@ impl FullAttentionGroup {
         GroupedHash::new(self.group, hash)
     }
 
+    pub(crate) fn id(&self) -> KvCacheGroupId {
+        self.group
+    }
+
     pub(crate) fn holds_request(&self, request_id: Uuid) -> bool {
         self.request_blocks.contains_key(&request_id)
     }

--- a/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
@@ -290,7 +290,15 @@ impl FullAttentionGroup {
         stores
     }
 
-    /// Release request blocks in caller-provided eviction-priority order.
+    /// Release the request's whole table, in caller-provided eviction-priority
+    /// order.
+    ///
+    /// Totality is the caller's precondition, checked once against
+    /// [`Self::block_count`] before any group mutates: a group whose table is not
+    /// parallel to this one drops a request's state wholesale, so a release that
+    /// covered only part of the table could not be honored here anyway. What this
+    /// checks instead is agreement — that `blocks` names the table it claims to,
+    /// block for block.
     ///
     /// Like vLLM's `BlockPool::free_blocks`, the physical pool is lineage-agnostic:
     /// reversing the request-owned table here makes suffix/leaf blocks older LRU
@@ -301,31 +309,31 @@ impl FullAttentionGroup {
         request_id: Uuid,
         blocks: &[UniqueBlock],
     ) {
-        let released = {
-            let Some(owned) = self.request_blocks.get_mut(&request_id) else {
-                panic!("request {request_id} owns no block table")
-            };
-            assert!(
-                blocks.len() <= owned.len(),
-                "request releases too many blocks"
-            );
-            let start = owned.len() - blocks.len();
-            for (expected, actual) in blocks.iter().zip(owned[start..].iter().rev()) {
-                match (expected, actual) {
-                    (UniqueBlock::FullBlock(expected), OwnedBlock::Full(full)) => {
-                        assert_eq!(*expected, full.hash, "full-block Deref mismatch");
-                    }
-                    (UniqueBlock::PartialBlock(expected), OwnedBlock::Partial { uuid, .. }) => {
-                        assert_eq!(expected, uuid, "partial Deref mismatch")
-                    }
-                    _ => panic!("Deref block kind disagrees with request table"),
-                }
-            }
-            owned.split_off(start)
+        let Some(table) = self.request_blocks.get_mut(&request_id) else {
+            panic!("request {request_id} owns no block table")
         };
-        if self.request_blocks[&request_id].is_empty() {
-            self.request_blocks.remove(&request_id);
+        // `zip` below would quietly stop at the shorter side, so keep the
+        // precondition falsifiable in tests rather than duplicating the
+        // coordinator's check at run time.
+        debug_assert_eq!(
+            blocks.len(),
+            table.len(),
+            "release must cover the request's whole table"
+        );
+        for (expected, actual) in blocks.iter().zip(table.iter().rev()) {
+            match (expected, actual) {
+                (UniqueBlock::FullBlock(expected), OwnedBlock::Full(full)) => {
+                    assert_eq!(*expected, full.hash, "full-block Deref mismatch");
+                }
+                (UniqueBlock::PartialBlock(expected), OwnedBlock::Partial { uuid, .. }) => {
+                    assert_eq!(expected, uuid, "partial Deref mismatch")
+                }
+                _ => panic!("Deref block kind disagrees with request table"),
+            }
         }
+
+        let released = std::mem::take(table);
+        self.request_blocks.remove(&request_id);
 
         for block in released.into_iter().rev() {
             match block {

--- a/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/full_attention.rs
@@ -89,25 +89,23 @@ impl FullAttentionGroup {
         alloc.blocks.len() - alloc.reusable_prefix_blocks
     }
 
-    /// Longest resident prefix of `blocks`, for a destination reservation whose
-    /// reusable prefix has not been authorized by a prior lookup.
-    pub(crate) fn resident_prefix(
+    /// Length of the longest resident prefix of `blocks`, for a destination
+    /// reservation whose reusable prefix has not been authorized by a prior lookup.
+    pub(crate) fn resident_prefix_len(
         &self,
         pool: &VllmBlockPool,
         blocks: &[UniqueBlock],
-    ) -> Vec<GroupedHash> {
+    ) -> usize {
         if !self.enable_prefix_caching {
-            return Vec::new();
+            return 0;
         }
         blocks
             .iter()
-            .map_while(|block| match block {
-                UniqueBlock::FullBlock(hash) if pool.prefix_hit(self.key(*hash)).is_some() => {
-                    Some(self.key(*hash))
-                }
-                _ => None,
+            .take_while(|block| match block {
+                UniqueBlock::FullBlock(hash) => pool.prefix_hit(self.key(*hash)).is_some(),
+                _ => false,
             })
-            .collect()
+            .count()
     }
 
     pub(crate) fn longest_cache_hit(
@@ -297,7 +295,7 @@ impl FullAttentionGroup {
     /// Like vLLM's `BlockPool::free_blocks`, the physical pool is lineage-agnostic:
     /// reversing the request-owned table here makes suffix/leaf blocks older LRU
     /// candidates than their parents, so capacity pressure evicts the leaf first.
-    pub(crate) fn deref(
+    pub(crate) fn release(
         &mut self,
         pool: &mut VllmBlockPool,
         request_id: Uuid,

--- a/lib/mocker/src/kv_manager/vllm_groups/mod.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/mod.rs
@@ -21,13 +21,9 @@ use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
 use uuid::Uuid;
 
-use crate::cache::vllm_block_pool::{GroupedHash, KvCacheGroupId, VllmBlockPool};
+use crate::cache::vllm_block_pool::{GroupedHash, VllmBlockPool};
 
 pub(crate) use full_attention::FullAttentionGroup;
-
-/// Group 0 is the main attention group. vLLM sorts full attention first, and it
-/// is the only group whose blocks Dynamo's router indexes.
-pub(crate) const ATTENTION_GROUP: KvCacheGroupId = KvCacheGroupId(0);
 
 /// Event metadata a group retains until its block becomes cache-visible.
 pub(crate) struct PendingStore {
@@ -78,6 +74,27 @@ pub(crate) enum GroupManager {
 }
 
 impl GroupManager {
+    /// This group if it is the main attention group.
+    ///
+    /// The coordinator resolves the attention group by kind, the way vLLM's
+    /// coordinator resolves `full_attention_group_id`, so no caller depends on
+    /// where the group sits among the others.
+    pub(crate) fn as_full_attention(&self) -> Option<&FullAttentionGroup> {
+        match self {
+            Self::FullAttention(group) => Some(group),
+        }
+    }
+
+    pub(crate) fn as_full_attention_mut(&mut self) -> Option<&mut FullAttentionGroup> {
+        match self {
+            Self::FullAttention(group) => Some(group),
+        }
+    }
+
+    pub(crate) fn is_full_attention(&self) -> bool {
+        self.as_full_attention().is_some()
+    }
+
     /// Cached-prefix keys this group may pin for `alloc`.
     pub(crate) fn prefix_keys(&self, alloc: &GroupAllocation) -> Vec<GroupedHash> {
         match self {

--- a/lib/mocker/src/kv_manager/vllm_groups/mod.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/mod.rs
@@ -21,7 +21,7 @@ use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
 use uuid::Uuid;
 
-use crate::cache::vllm_block_pool::{GroupedHash, VllmBlockPool};
+use crate::cache::vllm_block_pool::{BlockCopyId, BlockReservation, GroupedHash, VllmBlockPool};
 
 pub(crate) use full_attention::FullAttentionGroup;
 
@@ -62,6 +62,26 @@ pub(crate) struct GroupAllocation<'a> {
     /// enter the prefix cache immediately instead of waiting for a compute
     /// watermark.
     pub(crate) cache_fresh: bool,
+}
+
+impl GroupAllocation<'_> {
+    /// Check that the step's metadata describes its own blocks.
+    pub(crate) fn validate(&self) {
+        let full_blocks = self
+            .blocks
+            .iter()
+            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
+            .count();
+        assert!(
+            self.local_hashes.is_empty() || self.local_hashes.len() == full_blocks,
+            "local hashes must be empty or align with full blocks"
+        );
+        assert!(
+            self.token_ids.is_none_or(|ids| ids.len() == full_blocks),
+            "token IDs must align with full blocks"
+        );
+        assert!(!matches!(self.parent, Some(UniqueBlock::PartialBlock(_))));
+    }
 }
 
 /// A KV cache group sharing the coordinator's physical pool.
@@ -110,6 +130,55 @@ impl GroupManager {
     ) {
         match self {
             Self::FullAttention(group) => group.deref(pool, request_id, blocks),
+        }
+    }
+
+    /// Take this group's share of `alloc` out of the shared reservation.
+    ///
+    /// `prefix_copies` yields the activated pins in the order the groups asked
+    /// for them, so each group drains exactly the ones it requested through
+    /// [`Self::prefix_keys`] and leaves the rest for the groups behind it.
+    ///
+    /// Returns the blocks that became cache-visible, for the coordinator to
+    /// report. Only the main attention group returns them: the router indexes a
+    /// single block namespace with no group identity.
+    pub(crate) fn commit(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        reservation: &mut BlockReservation,
+        alloc: &GroupAllocation,
+        prefix_copies: &mut impl Iterator<Item = BlockCopyId>,
+        materialize_store_events: bool,
+    ) -> Option<Vec<Option<StoredBlock>>> {
+        match self {
+            Self::FullAttention(group) => group.commit(
+                pool,
+                reservation,
+                alloc,
+                prefix_copies,
+                materialize_store_events,
+            ),
+        }
+    }
+
+    /// Make everything this group completed between the two token watermarks
+    /// cache-visible, returning the blocks the coordinator may report.
+    pub(crate) fn finalize_computed_prefix(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        request_id: Uuid,
+        computed_before: usize,
+        computed_after: usize,
+        materialize_store_events: bool,
+    ) -> Option<Vec<Option<StoredBlock>>> {
+        match self {
+            Self::FullAttention(group) => group.finalize_computed_prefix(
+                pool,
+                request_id,
+                computed_before,
+                computed_after,
+                materialize_store_events,
+            ),
         }
     }
 

--- a/lib/mocker/src/kv_manager/vllm_groups/mod.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/mod.rs
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! KV cache groups over one shared physical block pool.
+//!
+//! vLLM splits a model's layers into KV cache groups — one per attention type —
+//! each keeping its own per-request block table while drawing blocks from a
+//! single pool with a uniform page size. Cache visibility is namespaced per
+//! group (`BlockHashWithGroupId`), which is what keeps two groups that hash the
+//! same tokens from satisfying each other's lookups.
+//!
+//! This module holds the group implementations and the vocabulary they exchange
+//! with the coordinator in [`super::vllm_backend`]. A group hands its newly
+//! cache-visible blocks back to the coordinator and never touches the
+//! router-facing event path: router events carry no group identity, so only the
+//! coordinator can decide which group's blocks may be reported.
+
+mod full_attention;
+
+use dynamo_tokens::blocks::UniqueBlock;
+use dynamo_tokens::{BlockHash, SequenceHash};
+use uuid::Uuid;
+
+use crate::cache::vllm_block_pool::{GroupedHash, KvCacheGroupId, VllmBlockPool};
+
+pub(crate) use full_attention::FullAttentionGroup;
+
+/// Group 0 is the main attention group. vLLM sorts full attention first, and it
+/// is the only group whose blocks Dynamo's router indexes.
+pub(crate) const ATTENTION_GROUP: KvCacheGroupId = KvCacheGroupId(0);
+
+/// Event metadata a group retains until its block becomes cache-visible.
+pub(crate) struct PendingStore {
+    pub(crate) parent_hash: Option<SequenceHash>,
+    pub(crate) local_hash: Option<BlockHash>,
+    pub(crate) token_ids: Option<Vec<u32>>,
+}
+
+/// A block that just became cache-visible, for the coordinator to report.
+pub(crate) struct StoredBlock {
+    pub(crate) hash: SequenceHash,
+    pub(crate) metadata: PendingStore,
+}
+
+/// One group's prefix-cache lookup result, in tokens.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct CacheHit {
+    /// Longest cached token prefix this group can serve.
+    pub(crate) tokens: usize,
+    /// Portion of `tokens` whose copies are already active, and so are not
+    /// re-consumed from physical capacity when the request claims them.
+    pub(crate) active_tokens: usize,
+}
+
+/// Everything a group needs to size and commit one allocation step.
+pub(crate) struct GroupAllocation<'a> {
+    pub(crate) request_id: Uuid,
+    /// Attention blocks added by this step, in request order.
+    pub(crate) blocks: &'a [UniqueBlock],
+    pub(crate) local_hashes: &'a [BlockHash],
+    pub(crate) token_ids: Option<&'a [Vec<u32>]>,
+    pub(crate) parent: Option<&'a UniqueBlock>,
+    /// Leading entries of `blocks` that are already resident and reusable.
+    pub(crate) reusable_prefix_blocks: usize,
+    /// Destination transfers arrive already computed, so their fresh blocks
+    /// enter the prefix cache immediately instead of waiting for a compute
+    /// watermark.
+    pub(crate) cache_fresh: bool,
+}
+
+/// A KV cache group sharing the coordinator's physical pool.
+///
+/// vLLM's `SingleTypeKVCacheManager` hierarchy, narrowed to the group kinds the
+/// mocker models. Dispatch is static so the single-group hot path keeps its
+/// shape.
+pub(crate) enum GroupManager {
+    FullAttention(FullAttentionGroup),
+}
+
+impl GroupManager {
+    /// Cached-prefix keys this group may pin for `alloc`.
+    pub(crate) fn prefix_keys(&self, alloc: &GroupAllocation) -> Vec<GroupedHash> {
+        match self {
+            Self::FullAttention(group) => group.prefix_keys(alloc),
+        }
+    }
+
+    /// Pool blocks `alloc` needs beyond the prefix this group can reuse.
+    pub(crate) fn fresh_blocks(&self, alloc: &GroupAllocation) -> usize {
+        match self {
+            Self::FullAttention(group) => group.fresh_blocks(alloc),
+        }
+    }
+
+    /// This group's prefix hit, or `None` when the group takes no part in
+    /// prefix caching and so constrains no boundary.
+    pub(crate) fn longest_cache_hit(
+        &self,
+        pool: &VllmBlockPool,
+        blocks: &[UniqueBlock],
+    ) -> Option<CacheHit> {
+        match self {
+            Self::FullAttention(group) => Some(group.longest_cache_hit(pool, blocks)),
+        }
+    }
+}

--- a/lib/mocker/src/kv_manager/vllm_groups/mod.rs
+++ b/lib/mocker/src/kv_manager/vllm_groups/mod.rs
@@ -95,6 +95,24 @@ impl GroupManager {
         self.as_full_attention().is_some()
     }
 
+    /// Release everything this group holds for `request_id`.
+    ///
+    /// `blocks` is the attention table's release order, leaf first, so that the
+    /// pool ages a leaf ahead of the parent it descends from. A group whose own
+    /// table is not parallel to the attention table ignores the list and drops
+    /// the request's whole state, which the coordinator's `deref_for_request`
+    /// guarantees is what a release means.
+    pub(crate) fn release(
+        &mut self,
+        pool: &mut VllmBlockPool,
+        request_id: Uuid,
+        blocks: &[UniqueBlock],
+    ) {
+        match self {
+            Self::FullAttention(group) => group.deref(pool, request_id, blocks),
+        }
+    }
+
     /// Cached-prefix keys this group may pin for `alloc`.
     pub(crate) fn prefix_keys(&self, alloc: &GroupAllocation) -> Vec<GroupedHash> {
         match self {


### PR DESCRIPTION
## Summary

The mocker's native vLLM KV manager assumes one homogeneous block pool. vLLM assumes the opposite: a model's layers are split into **KV cache groups** — one per attention type — each keeping its own per-request block table while drawing from a single physical pool with a uniform page size, with cache visibility namespaced per group (`BlockHashWithGroupId`). This PR builds that seam and stops there: `VllmKvManager` becomes a coordinator over N groups.

Exactly one group — the main attention group — is registered when this lands, so **there is no behavioral change**: no config knob, no scheduler decision change, no new event, no capacity-accounting change. `VllmKvManager`'s `pub(crate)` / `pub(super)` surface is unchanged from `main`, and the diff is confined to `lib/mocker/src/cache/vllm_block_pool.rs` and `lib/mocker/src/kv_manager/`.

Three invariants make that claim checkable in review:

1. Every non-test `GroupedHash` takes its group from the group that owns the block — `self.group` inside a group, `attention_id()` in the coordinator — so no call site can name a group it isn't.
2. `VllmKvManager::new` pushes exactly one `GroupManager`, so every per-group loop runs exactly once, `other_groups()` is empty, and each summed per-group quantity is the attention group's own.
3. Pool capacity, reservations, and the LRU stay global. That *is* vLLM's shared pool, and it is what makes one group indistinguishable from today.

Group implementations move into a new `kv_manager/vllm_groups/` module — `FullAttentionGroup` in its own file, the `GroupManager` contract in `mod.rs` — so most of the diff reads as a file move plus a namespacing change, and the follow-up adds a sibling file instead of reopening the coordinator's file. The coordinator resolves the attention group by kind rather than by index, the way vLLM resolves `full_attention_group_id`, so nothing depends on where that group sits among the others.

One rule has to land here, because this is where the event path gets its filter: only the main attention group's blocks may be reported to the router. `KvCacheEvent` carries no group identity, so a second group's `Removed(H)` would tell the router an attention block is gone while it is still cached. A firewall test keeps group implementations away from the publishers entirely.

Stacked follow-up: `nealv/mocker-mamba-hybrid-kv-cache` adds the Mamba group (`none` / `align` cache modes) that makes this coordination non-trivial. That is where behavior changes.

## Validation

- `cargo test -p dynamo-mocker` — 637 pass (`main`'s suite plus the four added here). No existing test's expected values changed; edits to existing tests are call-site updates for the group-keyed pool.
- Added: pool key namespacing (the same `SequenceHash` in two groups is two distinct copies, and evicting one reports the group-scoped key while leaving the other matchable); the pool release semantics the group layer depends on (a released *cached* copy stays matchable, a released *private* copy is recycled); an attention eviction reaching the event sink as a removal, which the new group filter made worth pinning; and rejection of a partial release before any group mutates.
- `cargo clippy -p dynamo-mocker --all-targets` and `cargo fmt -p dynamo-mocker -- --check` clean.
- `cargo check --workspace` is not usable as a gate here: it fails on macOS inside `dynamo-llm` for pre-existing Linux-only reasons (`dynamo_memory::numa`, `nix::fcntl::fallocate`, `OFlag::O_DIRECT`).

<details>
<summary>Design plan for this branch — rationale, module layout, and what is deliberately deferred to PR 2 (file links are repo-relative paths)</summary>

# PR 1 — KV cache groups in the mocker's native vLLM backend

Stacked PR 1 of 2, split out of [mocker_hybrid_kv_cache_a3cb85d6.plan.md](mocker_hybrid_kv_cache_a3cb85d6.plan.md).

| | |
|---|---|
| Branch | `nealv/mocker-kv-cache-groups` |
| Worktree | `/Users/nealv/Documents/dynamo/dynamo-mocker-kv-groups` |
| Base | `origin/main` @ `a9a7db43a3` |
| Followed by | PR 2 — `nealv/mocker-mamba-hybrid-kv-cache` ([plan](pr2_mocker_mamba_hybrid_cache.md)) |
| Title | `refactor(mocker): introduce KV cache groups in the native vLLM backend` |

## The contract this PR must hold

Generalize the mocker's native vLLM KV manager from *one homogeneous block pool* into a *coordinator over N groups sharing one physical pool*, and stop there. Exactly one group — the main attention group — exists when this PR lands, so **there is no behavioral change**: no new config knob, no scheduler decision change, no new event, no capacity-accounting change.

Three invariants make that claim checkable in review:

1. Every `GroupedHash` built in non-test code takes its group from the group that owns the block — `self.group` inside a group, `attention_id()` in the coordinator — so no call site can name a group it isn't. `rg "GroupedHash::new\(" lib/mocker/src` should show nothing else outside `#[cfg(test)]`.
2. `VllmKvManager::new` pushes exactly one `GroupManager`, so every per-group loop runs exactly once, `other_groups()` is empty, and every summed per-group quantity is the attention group's own.
3. The diff touches only [lib/mocker/src/cache/vllm_block_pool.rs](lib/mocker/src/cache/vllm_block_pool.rs) and [lib/mocker/src/kv_manager/](lib/mocker/src/kv_manager/). No scheduler, `protocols.rs`, bindings, or KV-event-protocol file changes — those all belong to PR 2.

Every existing `#[cfg(test)]` assertion keeps its expected values. Test edits are limited to call sites (the pool's helpers now take a key) plus the two new pool tests below.

## Why groups at all

vLLM splits a hybrid model's layers into **KV cache groups** — one per attention/SSM type — each with its own per-request block table, all drawing from **one shared physical pool** with a uniform page size. Cache keys are namespaced per group (`BlockHashWithGroupId`), and `HybridKVCacheCoordinator` reconciles per-group prefix hits down to a single agreed token boundary. PR 2 adds the Mamba group that makes this non-trivial; this PR builds the seam.

One piece of PR 2's rationale has to land here, because this PR is where the event path gets its group filter: **only the attention group may publish KV events.** Real vLLM tags `BlockStored` / `BlockRemoved` with `group_idx` and `kv_cache_spec_kind`, and Dynamo's `ZmqEventNormalizer` drops the non-main-attention ones ([lib/kv-router/src/zmq_wire/filter.rs](lib/kv-router/src/zmq_wire/filter.rs)) — but that filter exists only on the ZMQ wire path. The mocker's primary path is the typed `KvCacheEventSink`, and `KvCacheEvent` ([lib/kv-router/src/protocols.rs](lib/kv-router/src/protocols.rs)) carries no group identity, so a second group's `Removed(H)` would tell the router that attention block `H` is gone while it is still cached. The coordinator therefore filters removals to the attention group's own id and a firewall test keeps group implementations away from the publishers entirely.

## Module layout

The first pass at this work kept everything in `vllm_backend.rs` and produced a 1,500-line in-place rewrite. Splitting the group implementations into their own module makes this PR read as *a file move plus a namespacing change*, and lets PR 2 add a sibling file instead of reopening the coordinator's file.

| File | Contents |
|---|---|
| `kv_manager/vllm_groups/mod.rs` | The group contract: the `GroupManager` enum, its dispatch, and its by-kind accessors, plus the vocabulary crossing the coordinator↔group boundary — `CacheHit`, `GroupAllocation`, `PendingStore`, `StoredBlock` |
| `kv_manager/vllm_groups/full_attention.rs` | `FullAttentionGroup` plus its private block-table types `OwnedBlock` and `FullBlock` |
| `kv_manager/vllm_backend.rs` | `VllmKvManager` (the coordinator), the reservation types `NativeDecodeBlockReservation` / `NativeDestinationReservation` / `VllmBlockLayout`, event shaping (`StoreGroup`, `publish_store_sequence`, `publish_removed`, `publish_kv_event`), and `get_prefill_cost` |
| `cache/vllm_block_pool.rs` | `KvCacheGroupId`, `GroupedHash`, and the group-keyed pool |

`GroupManager` is an enum, not a `dyn` trait: static dispatch keeps the hot path free of vtables, and the set of group kinds is closed and small.

```mermaid
flowchart TB
    SEQ[ActiveSequence blocks] --> COORD

    subgraph COORD [VllmKvManager coordinator]
      REC[collect prefix keys, sum fresh needs, one pool reserve, commit per group]
      G0[GroupManager::FullAttention  group 0]
      G1[group 1 — PR 2]
    end

    REC --> G0
    REC -.-> G1
    G0 -->|"GroupedHash(0, seq_hash)"| POOL[VllmBlockPool shared capacity + LRU]
    G1 -.->|"GroupedHash(1, seq_hash)"| POOL
    G0 -->|store/remove events| EV[KvEventPublishers]
```

## Implementation

### 1. Group-scope the pool keys

[vllm_block_pool.rs](lib/mocker/src/cache/vllm_block_pool.rs) keys visibility on a bare `SequenceHash`, so two groups caching the same token prefix would collide. Introduce the pool's own leaf-level key type (the file must stay free of `crate::` per [vllm_firewall_tests.rs](lib/mocker/src/kv_manager/vllm_firewall_tests.rs)):

```rust
#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
pub(crate) struct KvCacheGroupId(pub(crate) u8);

/// vLLM's `BlockHashWithGroupId`: cache visibility is per KV cache group.
#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
pub(crate) struct GroupedHash {
    pub(crate) group: KvCacheGroupId,
    pub(crate) hash: SequenceHash,
}
```

`reserve(&[GroupedHash], fresh)`, `ReserveOutcome::removed`, `cache_private`, `allocate_cached`, `prefix_hit`, `activate_pin`, and `cancel` all move to `GroupedHash`, and the internals follow the same vocabulary: the cache index becomes `by_key` and `CopyState::Cached` stores a `key`. Capacity, `reserved`, and the LRU stay **global** — that is exactly vLLM's shared pool, and keeping them global is what makes "one group" indistinguishable from today.

### 2. Move the attention block table into `vllm_groups/full_attention.rs`

`FullAttentionGroup` is today's per-request block-table logic, unchanged except that it carries a `KvCacheGroupId` and routes every pool call through `fn key(&self, hash) -> GroupedHash`. Its surface, all `pub(crate)` inside the private `vllm_groups` module, or private:

`new`, `id`, `key`, `holds_request`, `block_count`, `prefix_keys`, `fresh_blocks`, `resident_prefix`, `longest_cache_hit`, `commit`, `finalize_computed_prefix`, `deref`, `promote`, and `validate_fresh_partials`.

It owns its `request_blocks: FxHashMap<Uuid, Vec<OwnedBlock>>` and `partial_uuids` set. It does **not** publish: `commit` and `promote` return `StoredBlock`s and the coordinator decides what reaches the event sink.

The coordinator↔group vocabulary in `mod.rs`:

```rust
/// One group's prefix-cache lookup result, in tokens.
#[derive(Clone, Copy, Debug, Default)]
pub(crate) struct CacheHit {
    pub(crate) tokens: usize,
    /// Portion of `tokens` whose copies are already active, and so are not
    /// re-consumed from physical capacity when the request claims them.
    pub(crate) active_tokens: usize,
}

/// Everything a group needs to size and commit one allocation step.
pub(crate) struct GroupAllocation<'a> {
    pub(crate) request_id: Uuid,
    pub(crate) blocks: &'a [UniqueBlock],
    pub(crate) local_hashes: &'a [BlockHash],
    pub(crate) token_ids: Option<&'a [Vec<u32>]>,
    pub(crate) parent: Option<&'a UniqueBlock>,
    /// Leading entries of `blocks` that are already resident and reusable.
    pub(crate) reusable_prefix_blocks: usize,
    /// Destination transfers arrive already computed, so their fresh blocks
    /// enter the prefix cache immediately instead of waiting for a compute
    /// watermark.
    pub(crate) cache_fresh: bool,
}
```

`GroupAllocation` replaces the long argument lists the entrypoints pass down, and owns the check that a step's metadata describes its own blocks (`validate`) — that check is about the struct's internal consistency, not about any group's state. Add no field without a live consumer in this PR — PR 2 adds `target_tokens` when the Mamba group needs the watermark.

### 3. Turn `VllmKvManager` into a coordinator

`VllmKvManager` stays the scheduler-facing type — its `pub(crate)` / `pub(super)` API must be byte-identical to `main` so [g1_manager.rs](lib/mocker/src/kv_manager/g1_manager.rs) and the scheduler are untouched. Internally it gains `groups: Vec<GroupManager>` and every mutating entrypoint follows one shape:

1. Ask every group for its cached-prefix keys (`prefix_keys`) and fresh-block need (`fresh_blocks`).
2. Issue **one** `pool.reserve(&all_prefix_keys, sum_fresh)`.
3. Commit each group against that shared reservation (`commit_groups`).
4. Publish only the attention group's stores, and filter removals: `publish_removed` keeps `key.group == self.attention_id()`.

The entrypoints that run this sequence are `use_for_request`, `use_decode_reservation_for_request`, `reserve_destination_at` / `destination_alloc` / `activate_destination`, `deref_for_request`, `promote_for_request`, `finalize_computed_prefix`, and `reserve_decode_blocks`.

What the coordinator may ask a group to do is the whole reviewable seam, so keep it on `GroupManager` rather than in a match arm in the coordinator: `prefix_keys` and `fresh_blocks` (sizing), `commit` and `finalize_computed_prefix` (making blocks cache-visible), `release`, and `longest_cache_hit`. Two consequences shape the signatures: `commit` drains a shared iterator of activated prefix pins, so a group takes exactly the pins it asked for and leaves the rest to the groups behind it; and `finalize_computed_prefix` takes *token* watermarks rather than block indices, so a group quantizes with its own block size instead of the coordinator's.

Three mechanics worth knowing before starting:

- **Borrow discipline.** Any method that hands the pool to a group while iterating groups must destructure first — `let Self { pool, groups, .. } = self;` — otherwise `&mut self.pool` and `&mut self.groups` collide. This applies to `deref_for_request`, `promote_for_request`, `finalize_computed_prefix`, and `commit_groups`.
- **Attention-group access by kind, never by index.** vLLM sorts groups and resolves `full_attention_group_id` by kind; do the same with `GroupManager::as_full_attention{,_mut}` behind `attention()` / `attention_mut()` / `attention_id()`, and reach the rest through `other_groups()`. Nothing then depends on where the attention group sits among the others, and PR 2 adds a group without revisiting these call sites.
- **A release is total.** Every `Deref` signal derives its block list from the sequence's whole allocated footprint, and a group whose table isn't parallel to the attention table drops a request's state wholesale, so `deref_for_request` checks the release covers the attention table *before* any group mutates — releases run group by group and cannot be rolled back. Trimming a live request is a real vLLM operation (`remove_skipped_blocks`) that the mocker does not model yet, so the check is an assertion rather than a branch.

There is no separate `UnitaryKVCacheCoordinator`-style fast path: with one group, every per-group loop runs once and `other_groups()` contributes no keys, no fresh blocks, and no commits.

### 4. Cross-group reconciliation in `get_prefill_cost`

The reconciliation structure lands here; the group that makes it bite lands in PR 2. Attention reports a contiguous hit; every other group may only shorten it:

```rust
let mut reconciled = attention.tokens;
for group in self.other_groups() {
    let Some(hit) = group.longest_cache_hit(&self.pool, blocks) else {
        continue;
    };
    reconciled = reconciled.min(hit.tokens);
}
```

Groups share a block size, so a single pass converges (vLLM's `is_simple_hybrid` shortcut) — worth a comment, since vLLM's general coordinator loops. `active_cached_tokens` is the attention active-prefix capped by the reconciled length. `PrefillCost` itself is **unchanged** in this PR: no new fields, so [protocols.rs](lib/mocker/src/common/protocols.rs) and [policy.rs](lib/mocker/src/scheduler/vllm/policy.rs) stay out of the diff.

`longest_cache_hit` returns `Option<CacheHit>` so a group can say "I constrain no boundary" without inventing a token count.

### 5. Firewall tests

[vllm_firewall_tests.rs](lib/mocker/src/kv_manager/vllm_firewall_tests.rs) `include_str!`s each source file it guards, so add `vllm_groups/mod.rs` and `vllm_groups/full_attention.rs` to the no-KVBM/no-legacy-G1 list, and generalize the event check to the whole group layer:

```rust
/// A group implementation must never reach the typed event sink: `KvCacheEvent`
/// has no group field, so the router would read another group's hash as an
/// attention block. Only the coordinator publishes.
#[test]
fn groups_never_publish_kv_events() { /* over every vllm_groups/* source */ }
```

This is the enforcement point PR 2 inherits for free when it adds `mamba.rs`.

## Tests

New, and specific to what this PR adds:

- **Pool group-namespacing**: the same `SequenceHash` in group 0 and group 1 occupies two distinct copies; evicting the group-1 copy reports the group-scoped key and leaves the group-0 block matchable by `prefix_hit`.
- **Release semantics the group layer depends on**: a released *cached* copy stays matchable as an inactive `prefix_hit` while a released *private* copy is recycled outright — vLLM's `free_blocks` sending hashed blocks to the free-queue tail and unhashed blocks to the head.

Everything else is a regression check: `cargo test -p dynamo-mocker` with no expected-value edits, `cargo clippy -p dynamo-mocker --all-targets`, `cargo fmt -p dynamo-mocker -- --check`. (`cargo check --workspace` fails on macOS inside `dynamo-llm` for pre-existing Linux-only reasons — `dynamo_memory::numa`, `nix::fcntl::fallocate`, `OFlag::O_DIRECT`.)

## Deliberately deferred to PR 2

Each of these is either a Mamba fact or a field with no live consumer here; a reviewer should not have to accept always-zero values or a no-op hook:

| Deferred | Why it can't justify itself in PR 1 |
|---|---|
| `vllm_groups/mamba.rs`, `MAMBA_GROUP` | the whole point of PR 2 |
| `CacheHit::deferred` | only a state cached in the current pass can defer a request |
| `GroupAllocation::target_tokens`, `VllmKvManager::target_tokens` | nothing consumes the watermark until a group pages state by tokens |
| `GroupManager::{overhead_blocks, decode_blocks_per_new_block, new_scheduling_pass}`, `VllmKvManager::begin_scheduling_pass` (+ its `G1Manager` / [core.rs](lib/mocker/src/scheduler/vllm/core.rs) plumbing) | constant 0 / 1 / no-op with one group |
| `PrefillCost::{group_overhead_blocks, deferred_by_group}`, its `Default` derive, and the `decide_waiting_admission` changes | admission has nothing extra to charge or defer yet |
| `cache_group_boundary_states`, `is_hybrid`, `FullAttentionGroup::full_block_hash` | boundary-state caching exists only for a state-holding group |
| `MambaCacheMode`, `has_mamba_layers`, `mamba_block_size` and their validation/accessors | configuration for a group that doesn't exist yet |
| `mamba_block_aligned_split` and its `schedule_request` call | the only scheduler-visible behavior change in the stack |
| `VllmKvManager::new_with_event_sink` → `new` rename | the rename exists to add the `mamba` argument |

## As implemented — divergences from the sketch above

All of these are consequences of PR 1 having exactly one group; each is listed in PR 2's contract extensions.

| Divergence | Why |
|---|---|
| `vllm_groups` items are `pub(crate)`, not `pub(super)` | `vllm_backend` is a sibling of `vllm_groups`, not a descendant, so `pub(super)` inside `full_attention.rs` would hide `FullAttentionGroup` from the coordinator (and block the `pub use` re-export). `vllm_groups` is a private module, so reachability is still the `kv_manager` subtree — the same idiom `cache/vllm_block_pool.rs` uses |
| `GroupManager::as_full_attention` can't fail, and `attention()` still `expect`s | `GroupManager` has one variant here, so the accessor's `match` is irrefutable and the `expect` is unreachable — but it states the invariant the coordinator actually relies on ("a model has a main attention group"), which survives PR 2 adding a variant that returns `None` |
| `GroupManager::prefix_keys(alloc)` takes no `&VllmBlockPool`, and `longest_cache_hit(pool, blocks)` no `max_tokens` | the attention group needs neither, and an unused parameter would be dead weight a reviewer has to accept. PR 2 widens both when the Mamba group needs the pool and the running boundary |
| `FullAttentionGroup::deref` returns `()`, matching `main`'s `process_deref` | nothing acts on "the request's table just emptied" until another group has per-request state to free |
| `commit_groups`'s shared prefix-pin iterator is drained entirely by the attention group | the drain and the assert that nothing is left over are the contract PR 2 needs, but with one group there is no second consumer to leave pins for |
| `NativeDestinationReservation` gains `attention_fresh` / `attention_prefix` | both have live consumers here — `transferable_prompt_tokens` must report attention blocks rather than the whole reservation, and `activate_destination` must rebuild the alloc with the same reusable prefix the reservation pinned |
| Two tests beyond the two pool tests: `attention_eviction_is_published_as_a_removal` and `deref_rejects_a_partial_release_before_mutating` | `publish_removed` gained a group filter and no existing test asserts a removal reaches the sink; and the release-is-total precondition is new, so it needs a test that the rejection leaves the block table and the pool untouched. PR 2 extends the first with the shared-hash Mamba case |
| The pool's second-group test constant is `SECOND`, not `MAMBA` | no Mamba concept exists in this PR |

Result: 637 tests pass (`main`'s suite plus the four added here), clippy clean, `cargo fmt --check` clean, and `VllmKvManager`'s `pub(crate)` / `pub(super)` signature list is byte-identical to `main`.

## PR mechanics

- Conventional-commit title, `Summary` and `Validation` sections in the description, `git commit -s` (DCO), per [AGENTS.md](AGENTS.md).
- Say explicitly in `Summary` that this is refactor-only, list the three invariants above, and point at PR 2 as the behavioral follow-up.
- Full CI runs only after a maintainer comments `/ok to test <sha>`.

</details>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved KV-cache management across different cache groups.
  * Prevented identical cached sequences from being incorrectly shared between separate groups.
  * Improved prefix-cache reuse and block allocation for requests using multiple cache groups.
  * Enhanced cache lifecycle handling, including promotion, release, eviction, and restoration of cached data.
  * Improved cache event reporting and handling of partial request data for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->