### PR TITLE
fix(operator): preserve runtime versions across updates

### DIFF
--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -358,6 +358,10 @@ class DynamoGraphDeploymentRequestStatus(BaseModel):
         default=None,
         description="ObservedGeneration is the most recent generation observed by the controller.",
     )
+    observedSpecFingerprint: Optional[str] = Field(
+        default=None,
+        description="ObservedSpecFingerprint identifies the spec associated with ObservedGeneration. The controller uses it to verify runtimeVersionOverride-only repairs.",
+    )
 
 
 class DynamoGraphDeploymentRequest(BaseModel):

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -69,11 +69,12 @@ Admission now requires every component's main-container image. In `v1beta1`, set
 required by Dynamo admission, but were effectively required: Kubernetes rejects the rendered Pod
 specification when its main container has no image.
 
-After upgrading the CRDs and operator, admission denies a new DGD, or an update to a pre-existing
-DGD, when a component's main-image tag is not a semantic version and `runtimeVersionOverride` is
-unset. This includes custom and SHA-tagged images. Set `runtimeVersionOverride` to the Dynamo
-runtime compatibility version for that image before creating or updating the DGD. Existing resources
-are not changed or revalidated solely by the upgrade.
+After upgrading the CRDs and operator, admission denies a new DGD, DCD, or DGDR when a component's
+main-image tag is not a semantic version and `runtimeVersionOverride` is unset. This includes custom
+and SHA-tagged images. On updates, this requirement is ratcheted: a pre-existing resource with an
+unchanged non-semantic-version image remains admissible without backfilling the override. Changing
+the image to a non-semantic-version tag requires setting `runtimeVersionOverride` to that image's
+Dynamo runtime compatibility version in the same update.
 
 ### Bundled NATS is now disabled by default
 

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -69,11 +69,12 @@ Admission now requires every component's main-container image. In `v1beta1`, set
 required by Dynamo admission, but were effectively required: Kubernetes rejects the rendered Pod
 specification when its main container has no image.
 
-After upgrading the CRDs and operator, admission denies a new DGD, or an update to a pre-existing
-DGD, when a component's main-image tag is not a semantic version and `runtimeVersionOverride` is
-unset. This includes custom and SHA-tagged images. Set `runtimeVersionOverride` to the Dynamo
-runtime compatibility version for that image before creating or updating the DGD. Existing resources
-are not changed or revalidated solely by the upgrade.
+After upgrading the CRDs and operator, admission denies a new DGD, DCD, or DGDR when a component's
+main-image tag is not a semantic version and `runtimeVersionOverride` is unset. This includes custom
+and SHA-tagged images. On updates, this requirement is ratcheted: a pre-existing resource with an
+unchanged non-semantic-version image remains admissible without backfilling the override. Changing
+the image to a non-semantic-version tag requires setting `runtimeVersionOverride` to that image's
+Dynamo runtime compatibility version in the same update.
 
 ### Bundled NATS is now disabled by default
 

--- a/deploy/operator/AGENTS.md
+++ b/deploy/operator/AGENTS.md
@@ -9,6 +9,14 @@ SPDX-License-Identifier: Apache-2.0
 - Keep chart-only grants in the manual section of the platform chart's
   `../helm/charts/platform/components/operator/templates/manager-rbac.yaml`.
 
+## Go Code Style
+
+- Put a one-line story comment above every multi-line block of logically
+  connected code.
+- Separate multi-line semantic blocks from surrounding code with one blank
+  line. Do not add trailing blank lines before a closing delimiter or between
+  a block-leading comment and its code.
+
 ## Go Test Style
 
 - Use `t.Log` to tell the test's story, with one heading before each block that

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -1013,6 +1013,7 @@ func saveDGDRHubOnlyStatus(src *v1beta1.DynamoGraphDeploymentRequestStatus, dst 
 	if src == nil || save == nil {
 		return
 	}
+	save.ObservedSpecFingerprint = src.ObservedSpecFingerprint
 	if src.Phase == v1beta1.DGDRPhaseDeployed && dgdrStateToPhase(string(dst.State), dst.Deployment) != src.Phase {
 		save.Phase = src.Phase
 		save.DGDName = src.DGDName
@@ -1035,6 +1036,7 @@ func restoreDGDRHubOnlyStatus(restored *v1beta1.DynamoGraphDeploymentRequestStat
 	if restored == nil || dst == nil {
 		return
 	}
+	dst.ObservedSpecFingerprint = restored.ObservedSpecFingerprint
 	if restored.Phase == v1beta1.DGDRPhaseDeployed &&
 		dst.Phase == v1beta1.DGDRPhaseReady &&
 		src != nil &&

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_test.go
@@ -137,11 +137,12 @@ func newV1beta1DGDR() *v1beta1.DynamoGraphDeploymentRequest {
 			},
 		},
 		Status: v1beta1.DynamoGraphDeploymentRequestStatus{
-			Phase:              v1beta1.DGDRPhaseProfiling,
-			ObservedGeneration: 2,
-			DGDName:            "hub-dgd",
-			ProfilingPhase:     v1beta1.ProfilingPhaseSweepingDecode,
-			ProfilingJobName:   "profiling-job-1",
+			Phase:                   v1beta1.DGDRPhaseProfiling,
+			ObservedGeneration:      2,
+			ObservedSpecFingerprint: "test-spec-fingerprint",
+			DGDName:                 "hub-dgd",
+			ProfilingPhase:          v1beta1.ProfilingPhaseSweepingDecode,
+			ProfilingJobName:        "profiling-job-1",
 			ProfilingResults: &v1beta1.ProfilingResultsStatus{
 				SelectedConfig: &runtime.RawExtension{Raw: rawDGD},
 			},

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -584,6 +584,11 @@ type DynamoGraphDeploymentRequestStatus struct {
 	// ObservedGeneration is the most recent generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
+	// ObservedSpecFingerprint identifies the spec associated with ObservedGeneration.
+	// The controller uses it to verify runtimeVersionOverride-only repairs.
+	// +optional
+	ObservedSpecFingerprint string `json:"observedSpecFingerprint,omitempty"`
 }
 
 // DynamoGraphDeploymentRequest is the Schema for the dynamographdeploymentrequests API.

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -9392,6 +9392,11 @@ spec:
                   description: ObservedGeneration is the most recent generation observed by the controller.
                   format: int64
                   type: integer
+                observedSpecFingerprint:
+                  description: |-
+                    ObservedSpecFingerprint identifies the spec associated with ObservedGeneration.
+                    The controller uses it to verify runtimeVersionOverride-only repairs.
+                  type: string
                 phase:
                   description: Phase is the high-level lifecycle phase of the deployment request.
                   enum:

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -462,22 +462,20 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, nil
 	}
 
-	// Check for spec changes (immutability enforcement)
+	// Observe spec changes admitted by the validation webhook before resuming the phase machine.
 	if dgdr.Status.ObservedGeneration > 0 && dgdr.Status.ObservedGeneration != dgdr.Generation {
-		// Spec changed after initial processing
 		if dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseProfiling || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeploying ||
 			dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseReady || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeployed {
-			logger.Info("Spec change detected in immutable phase",
+			logger.Info("Observing admitted spec repair in immutable phase",
 				"phase", dgdr.Status.Phase,
 				"observedGeneration", dgdr.Status.ObservedGeneration,
 				"currentGeneration", dgdr.Generation)
 
-			r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonSpecChangeRejected,
-				fmt.Sprintf(MessageSpecChangeRejected, dgdr.Status.Phase))
-
-			// Keep the old observedGeneration to continue rejecting changes
-			// No phase transition - stay in current phase with old spec
-			return ctrl.Result{}, nil
+			dgdr.Status.ObservedGeneration = dgdr.Generation
+			if err := r.Status().Update(ctx, dgdr); err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to observe admitted DGDR spec repair: %w", err)
+			}
+			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 	// Phase machine: handle different phases

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -955,6 +955,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to unmarshal generated deployment from annotation: %w", err)
 	}
+	applyDGDRRuntimeVersionOverride(dgdr, generatedDGD)
 
 	// Determine DGD name and namespace from generated deployment
 	dgdName := generatedDGD.Name
@@ -2052,6 +2053,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to extract DGD from %s: %w", outputFile, err)
 	}
+	applyDGDRRuntimeVersionOverride(dgdr, dgd)
 
 	// Override the profiler-generated name with a DGDR-scoped unique name.
 	// The profiler emits a static topology-derived name (e.g. "vllm-agg") which
@@ -2103,6 +2105,19 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	}
 	dgdr.ResourceVersion = apply.GetResourceVersion()
 	return profilingResults, dgd.Name, nil
+}
+
+// applyDGDRRuntimeVersionOverride makes the DGDR authoritative across profiler versions.
+func applyDGDRRuntimeVersionOverride(
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
+) {
+	if dgdr.Spec.RuntimeVersionOverride == "" {
+		return
+	}
+	for i := range dgd.Spec.Components {
+		dgd.Spec.Components[i].RuntimeVersionOverride = dgdr.Spec.RuntimeVersionOverride
+	}
 }
 
 // encodeBetaDGDManifest returns JSON/YAML manifest bytes for a beta DGD.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -54,6 +54,7 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdrutil"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
@@ -462,20 +463,51 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 		return ctrl.Result{}, nil
 	}
 
-	// Observe spec changes admitted by the validation webhook before resuming the phase machine.
+	currentSpecFingerprint, err := dgdrutil.SpecFingerprint(&dgdr.Spec)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Record the fingerprint for the spec associated with the observed generation.
+	if dgdr.Status.ObservedGeneration > 0 &&
+		dgdr.Status.ObservedGeneration == dgdr.Generation &&
+		dgdr.Status.ObservedSpecFingerprint != currentSpecFingerprint {
+		dgdr.Status.ObservedSpecFingerprint = currentSpecFingerprint
+		if err := r.Status().Update(ctx, dgdr); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to record observed DGDR spec fingerprint: %w", err)
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	// Verify immutable-phase repairs against the last observed spec before resuming the phase machine.
 	if dgdr.Status.ObservedGeneration > 0 && dgdr.Status.ObservedGeneration != dgdr.Generation {
 		if dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseProfiling || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeploying ||
 			dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseReady || dgdr.Status.Phase == nvidiacomv1beta1.DGDRPhaseDeployed {
-			logger.Info("Observing admitted spec repair in immutable phase",
+			repair, err := dgdrutil.IsRuntimeVersionOverrideRepair(&dgdr.Spec, dgdr.Status.ObservedSpecFingerprint)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+			if repair {
+				logger.Info("Observing verified runtime version override repair in immutable phase",
+					"phase", dgdr.Status.Phase,
+					"observedGeneration", dgdr.Status.ObservedGeneration,
+					"currentGeneration", dgdr.Generation)
+
+				dgdr.Status.ObservedGeneration = dgdr.Generation
+				dgdr.Status.ObservedSpecFingerprint = currentSpecFingerprint
+				if err := r.Status().Update(ctx, dgdr); err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to observe DGDR runtime version override repair: %w", err)
+				}
+				return ctrl.Result{Requeue: true}, nil
+			}
+
+			logger.Info("Spec change detected in immutable phase",
 				"phase", dgdr.Status.Phase,
 				"observedGeneration", dgdr.Status.ObservedGeneration,
 				"currentGeneration", dgdr.Generation)
-
-			dgdr.Status.ObservedGeneration = dgdr.Generation
-			if err := r.Status().Update(ctx, dgdr); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to observe admitted DGDR spec repair: %w", err)
-			}
-			return ctrl.Result{Requeue: true}, nil
+			r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonSpecChangeRejected,
+				fmt.Sprintf(MessageSpecChangeRejected, dgdr.Status.Phase))
+			return ctrl.Result{}, nil
 		}
 	}
 	// Phase machine: handle different phases

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -551,9 +551,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 			return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeValidation, metav1.ConditionFalse, nvidiacomv1beta1.EventReasonValidationFailed, err.Error())
 		}
 
-		// Set observedGeneration to track the spec we're processing
-		dgdr.Status.ObservedGeneration = dgdr.Generation
-
 		dgdr.AddStatusCondition(metav1.Condition{
 			Type:               nvidiacomv1beta1.ConditionTypeValidation,
 			Status:             metav1.ConditionTrue,
@@ -2433,8 +2430,10 @@ func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, 
 func (r *DynamoGraphDeploymentRequestReconciler) updatePhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase, message string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Updating DGDR phase", "name", dgdr.Name, "phase", phase, "message", message)
+	if err := observeCurrentDGDRSpec(dgdr); err != nil {
+		return ctrl.Result{}, err
+	}
 	dgdr.Status.Phase = phase
-	dgdr.Status.ObservedGeneration = dgdr.Generation
 	setSucceededCondition(dgdr, phase)
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
@@ -2452,8 +2451,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	reason string,
 	message string,
 ) (ctrl.Result, error) {
+	if err := observeCurrentDGDRSpec(dgdr); err != nil {
+		return ctrl.Result{}, err
+	}
 	dgdr.Status.Phase = phase
-	dgdr.Status.ObservedGeneration = dgdr.Generation
 
 	// Set the specific condition first so setSucceededCondition can surface it.
 	dgdr.AddStatusCondition(metav1.Condition{
@@ -2471,6 +2472,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func observeCurrentDGDRSpec(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
+	specFingerprint, err := dgdrutil.SpecFingerprint(&dgdr.Spec)
+	if err != nil {
+		return err
+	}
+	dgdr.Status.ObservedGeneration = dgdr.Generation
+	dgdr.Status.ObservedSpecFingerprint = specFingerprint
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -493,6 +493,11 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 					"observedGeneration", dgdr.Status.ObservedGeneration,
 					"currentGeneration", dgdr.Generation)
 
+				// Repair generated manifests before acknowledging the new generation.
+				if err := r.repairGeneratedDGDArtifacts(ctx, dgdr); err != nil {
+					return ctrl.Result{}, err
+				}
+
 				dgdr.Status.ObservedGeneration = dgdr.Generation
 				dgdr.Status.ObservedSpecFingerprint = currentSpecFingerprint
 				if err := r.Status().Update(ctx, dgdr); err != nil {
@@ -2148,6 +2153,66 @@ func applyDGDRRuntimeVersionOverride(
 	for i := range dgd.Spec.Components {
 		dgd.Spec.Components[i].RuntimeVersionOverride = dgdr.Spec.RuntimeVersionOverride
 	}
+}
+
+// repairGeneratedDGDArtifacts applies a repaired override to every persisted generated manifest.
+func (r *DynamoGraphDeploymentRequestReconciler) repairGeneratedDGDArtifacts(
+	ctx context.Context,
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+) error {
+	// Repair the manifest exposed for manual application.
+	if dgdr.Status.ProfilingResults != nil &&
+		dgdr.Status.ProfilingResults.SelectedConfig != nil &&
+		len(dgdr.Status.ProfilingResults.SelectedConfig.Raw) > 0 {
+		dgd, err := r.extractDGDFromYAML(dgdr.Status.ProfilingResults.SelectedConfig.Raw)
+		if err != nil {
+			return fmt.Errorf("failed to decode selected DGD config for runtime version repair: %w", err)
+		}
+		applyDGDRRuntimeVersionOverride(dgdr, dgd)
+		dgdJSON, _, err := r.encodeBetaDGDManifest(dgd)
+		if err != nil {
+			return fmt.Errorf("failed to encode selected DGD config after runtime version repair: %w", err)
+		}
+		dgdr.Status.ProfilingResults.SelectedConfig.Raw = dgdJSON
+	}
+
+	// Repair the manifest retained for automatic DGD creation.
+	generatedDGDYAML := dgdr.Annotations[AnnotationGeneratedDGDSpec]
+	if generatedDGDYAML == "" {
+		return nil
+	}
+
+	dgd, err := r.extractDGDFromYAML([]byte(generatedDGDYAML))
+	if err != nil {
+		return fmt.Errorf("failed to decode generated DGD annotation for runtime version repair: %w", err)
+	}
+	applyDGDRRuntimeVersionOverride(dgdr, dgd)
+	_, dgdYAML, err := r.encodeBetaDGDManifest(dgd)
+	if err != nil {
+		return fmt.Errorf("failed to encode generated DGD annotation after runtime version repair: %w", err)
+	}
+
+	// Persist the repaired annotation without taking ownership of unrelated metadata.
+	annotations := map[string]any{AnnotationGeneratedDGDSpec: string(dgdYAML)}
+	if additionalResources := dgdr.Annotations[AnnotationAdditionalResources]; additionalResources != "" {
+		annotations[AnnotationAdditionalResources] = additionalResources
+	}
+	apply := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": nvidiacomv1beta1.GroupVersion.String(),
+		"kind":       "DynamoGraphDeploymentRequest",
+		"metadata": map[string]any{
+			"name":            dgdr.Name,
+			"namespace":       dgdr.Namespace,
+			"resourceVersion": dgdr.ResourceVersion,
+			"annotations":     annotations,
+		},
+	}}
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(apply), client.FieldOwner("dynamo-operator-dgdr"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to persist repaired generated DGD annotation: %w", err)
+	}
+	dgdr.Annotations[AnnotationGeneratedDGDSpec] = string(dgdYAML)
+	dgdr.ResourceVersion = apply.GetResourceVersion()
+	return nil
 }
 
 // encodeBetaDGDManifest returns JSON/YAML manifest bytes for a beta DGD.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1409,7 +1409,7 @@ spec:
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).Should(BeTrue())
+			Expect(result.IsZero()).Should(BeFalse())
 
 			t.Log("Read the initialized generation and fingerprint")
 			var current nvidiacomv1beta1.DynamoGraphDeploymentRequest
@@ -1456,7 +1456,7 @@ spec:
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).Should(BeTrue())
+			Expect(result.IsZero()).Should(BeFalse())
 
 			t.Log("Verify that reconciliation advances the observed generation")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
@@ -1488,7 +1488,7 @@ spec:
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Requeue).Should(BeFalse())
+			Expect(result.IsZero()).Should(BeTrue())
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
 			Expect(current.Status.ObservedGeneration).Should(Equal(repairedGeneration))
 			Expect(current.Generation).Should(BeNumerically(">", repairedGeneration))

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -963,7 +963,6 @@ spec:
   services:
     Frontend:
       replicas: 1
-      runtimeVersionOverride: 1.1.0
       extraPodSpec:
         mainContainer:
           image: registry.example/runtime:custom`
@@ -995,6 +994,8 @@ spec:
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeploying))
+			Expect(updated.Annotations[AnnotationGeneratedDGDSpec]).Should(ContainSubstring("runtimeVersionOverride: 1.1.0"))
+			Expect(string(updated.Status.ProfilingResults.SelectedConfig.Raw)).Should(ContainSubstring(`"runtimeVersionOverride":"1.1.0"`))
 
 			// Reconcile again to create DGD
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
@@ -1016,6 +1017,44 @@ spec:
 			// Clean up DGD
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
 			_ = k8sClient.Delete(ctx, dgd)
+		})
+
+		It("Should apply the DGDR runtime version to a persisted legacy profiler result", func() {
+			ctx := context.Background()
+			dgdName := "legacy-profiler-result-dgd"
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "legacy-profiler-result",
+					Namespace: envtestNamespace,
+					Annotations: map[string]string{
+						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: legacy-profiler-result-dgd
+spec:
+  services:
+    worker:
+      extraPodSpec:
+        mainContainer:
+          image: registry.example/runtime:custom`,
+					},
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					RuntimeVersionOverride: "1.2.3",
+				},
+				Status: nvidiacomv1beta1.DynamoGraphDeploymentRequestStatus{
+					DGDName: dgdName,
+				},
+			}
+
+			_, err := reconciler.createDGD(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+
+			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: envtestNamespace}, dgd)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
+			Expect(dgd.Spec.Components).Should(HaveLen(1))
+			Expect(dgd.Spec.Components[0].RuntimeVersionOverride).Should(Equal("1.2.3"))
 		})
 
 		It("Should create additional ConfigMaps without DGDR ownership and adopt them after DGD creation", func() {

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1367,11 +1367,11 @@ spec:
 		})
 	})
 
-	Context("When enforcing spec immutability", func() {
-		It("Should reject spec changes after profiling starts", func() {
+	Context("When observing admitted spec repairs", func() {
+		It("Should continue reconciliation after a runtime version override repair", func() {
 			t := GinkgoT()
 			ctx := context.Background()
-			dgdrName := "test-dgdr-immutable"
+			dgdrName := "test-dgdr-runtime-version-repair"
 			namespace := envtestNamespace
 
 			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
@@ -1382,7 +1382,7 @@ spec:
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "test-model",
 					Backend: "vllm",
-					Image:   "test-profiler:1.1.0",
+					Image:   "test-profiler:custom",
 					Hardware: &nvidiacomv1beta1.HardwareSpec{
 						NumGPUsPerNode: ptr.To[int32](8),
 						GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
@@ -1396,8 +1396,8 @@ spec:
 				},
 			}
 
-			t.Log("Create and reconcile the initial request")
-			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			t.Log("Seed and reconcile the legacy request")
+			Expect(admissionBypassClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
@@ -1408,38 +1408,28 @@ spec:
 			var current nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
 			initialGeneration := current.Generation
-			observedGeneration := current.Status.ObservedGeneration
 
 			t.Log("Move the request into the profiling phase")
 			current.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
 			Expect(k8sClient.Status().Update(ctx, &current)).Should(Succeed())
 
-			t.Log("Seed a spec change that validating admission normally rejects")
+			t.Log("Repair the missing runtime version override")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
-			current.Spec.Model = "modified-model"
-			Expect(admissionBypassClient.Update(ctx, &current)).Should(Succeed())
+			current.Spec.RuntimeVersionOverride = "1.1.0"
+			Expect(k8sClient.Update(ctx, &current)).Should(Succeed())
 
-			t.Log("Reconcile the legacy invalid state")
-			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+			t.Log("Observe the admitted repair")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).Should(BeTrue())
 
-			t.Log("Verify that reconciliation preserves the previously observed state")
+			t.Log("Verify that reconciliation advances the observed generation")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
 			Expect(current.Generation).Should(BeNumerically(">", initialGeneration))
-			Expect(current.Status.ObservedGeneration).Should(Equal(observedGeneration))
+			Expect(current.Status.ObservedGeneration).Should(Equal(current.Generation))
 			Expect(current.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
-
-			t.Log("Verify that reconciliation reports the rejected change")
-			Eventually(func() bool {
-				select {
-				case event := <-recorder.Events:
-					return strings.Contains(event, "DynamoGraphDeploymentRequest is immutable once profiling starts")
-				default:
-					return false
-				}
-			}, timeout, interval).Should(BeTrue())
 		})
 	})
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1404,7 +1404,7 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			t.Log("Backfill the observed spec fingerprint")
+			t.Log("Continue reconciliation after initialization")
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1417,8 +1417,33 @@ spec:
 			initialGeneration := current.Generation
 			Expect(current.Status.ObservedSpecFingerprint).ShouldNot(BeEmpty())
 
-			t.Log("Move the request into the profiling phase")
-			current.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
+			t.Log("Store legacy generated manifests and move the request into the ready phase")
+			generatedDGD := &nvidiacomv1beta1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      dgdrName + "-generated",
+					Namespace: namespace,
+				},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentSpec{
+					BackendFramework: "vllm",
+					Components: []nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{{
+						ComponentName: "worker",
+						ComponentType: nvidiacomv1beta1.ComponentTypeWorker,
+						Replicas:      ptr.To[int32](1),
+						PodTemplate: &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: consts.MainContainerName, Image: "registry.example/runtime:custom"}},
+						}},
+					}},
+				},
+			}
+			dgdJSON, dgdYAML, err := reconciler.encodeBetaDGDManifest(generatedDGD)
+			Expect(err).NotTo(HaveOccurred())
+			current.Annotations = map[string]string{AnnotationGeneratedDGDSpec: string(dgdYAML)}
+			Expect(k8sClient.Update(ctx, &current)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
+			current.Status.Phase = nvidiacomv1beta1.DGDRPhaseReady
+			current.Status.ProfilingResults = &nvidiacomv1beta1.ProfilingResultsStatus{
+				SelectedConfig: &runtime.RawExtension{Raw: dgdJSON},
+			}
 			Expect(k8sClient.Status().Update(ctx, &current)).Should(Succeed())
 
 			t.Log("Repair the missing runtime version override")
@@ -1437,7 +1462,21 @@ spec:
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
 			Expect(current.Generation).Should(BeNumerically(">", initialGeneration))
 			Expect(current.Status.ObservedGeneration).Should(Equal(current.Generation))
-			Expect(current.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+			Expect(current.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseReady))
+
+			t.Log("Verify that both persisted generated manifests contain the repaired override")
+			selectedDGD, err := reconciler.extractDGDFromYAML(current.Status.ProfilingResults.SelectedConfig.Raw)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(selectedDGD.Spec.Components).Should(HaveLen(1))
+			Expect(selectedDGD.Spec.Components[0].RuntimeVersionOverride).Should(Equal("1.1.0"))
+			annotatedDGD, err := reconciler.extractDGDFromYAML([]byte(current.Annotations[AnnotationGeneratedDGDSpec]))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(annotatedDGD.Spec.Components).Should(HaveLen(1))
+			Expect(annotatedDGD.Spec.Components[0].RuntimeVersionOverride).Should(Equal("1.1.0"))
+
+			t.Log("Apply the repaired selected config through admission")
+			Expect(k8sClient.Create(ctx, selectedDGD)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, selectedDGD) }()
 
 			t.Log("Bypass admission with an unrelated spec change")
 			repairedGeneration := current.Status.ObservedGeneration

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1404,10 +1404,18 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			t.Log("Read the initialized generation")
+			t.Log("Backfill the observed spec fingerprint")
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).Should(BeTrue())
+
+			t.Log("Read the initialized generation and fingerprint")
 			var current nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
 			initialGeneration := current.Generation
+			Expect(current.Status.ObservedSpecFingerprint).ShouldNot(BeEmpty())
 
 			t.Log("Move the request into the profiling phase")
 			current.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
@@ -1419,7 +1427,7 @@ spec:
 			Expect(k8sClient.Update(ctx, &current)).Should(Succeed())
 
 			t.Log("Observe the admitted repair")
-			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -1430,6 +1438,21 @@ spec:
 			Expect(current.Generation).Should(BeNumerically(">", initialGeneration))
 			Expect(current.Status.ObservedGeneration).Should(Equal(current.Generation))
 			Expect(current.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+
+			t.Log("Bypass admission with an unrelated spec change")
+			repairedGeneration := current.Status.ObservedGeneration
+			current.Spec.Model = "modified-model"
+			Expect(admissionBypassClient.Update(ctx, &current)).Should(Succeed())
+
+			t.Log("Verify that the fingerprint prevents observing the unrelated change")
+			result, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).Should(BeFalse())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &current)).Should(Succeed())
+			Expect(current.Status.ObservedGeneration).Should(Equal(repairedGeneration))
+			Expect(current.Generation).Should(BeNumerically(">", repairedGeneration))
 		})
 	})
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_envtest_test.go
@@ -1409,7 +1409,7 @@ spec:
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.IsZero()).Should(BeFalse())
+			Expect(result.IsZero()).Should(BeTrue())
 
 			t.Log("Read the initialized generation and fingerprint")
 			var current nvidiacomv1beta1.DynamoGraphDeploymentRequest
@@ -2848,7 +2848,7 @@ spec:
 
 			// Transition to Profiling
 			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
-			dgdr.Status.ObservedGeneration = dgdr.Generation
+			Expect(observeCurrentDGDRSpec(dgdr)).Should(Succeed())
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
 			// Create completed job

--- a/deploy/operator/internal/dgdrutil/spec_fingerprint.go
+++ b/deploy/operator/internal/dgdrutil/spec_fingerprint.go
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgdrutil
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+// SpecFingerprint returns a stable SHA-256 fingerprint of a DGDR spec.
+func SpecFingerprint(spec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec) (string, error) {
+	data, err := json.Marshal(spec)
+	if err != nil {
+		return "", fmt.Errorf("marshal DGDR spec: %w", err)
+	}
+	return fmt.Sprintf("%x", sha256.Sum256(data)), nil
+}
+
+// IsRuntimeVersionOverrideRepair reports whether current only adds an override to the observed spec.
+func IsRuntimeVersionOverrideRepair(
+	current *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
+	observedFingerprint string,
+) (bool, error) {
+	if observedFingerprint == "" || current.RuntimeVersionOverride == "" {
+		return false, nil
+	}
+
+	observedCandidate := current.DeepCopy()
+	observedCandidate.RuntimeVersionOverride = ""
+	fingerprint, err := SpecFingerprint(observedCandidate)
+	if err != nil {
+		return false, err
+	}
+	return fingerprint == observedFingerprint, nil
+}

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -70,16 +70,8 @@ func (v *DynamoComponentDeploymentValidator) validate(
 
 // ValidateUpdate performs complete validation of an updated v1beta1 DCD and
 // compares its state with the previous object.
-// ctx, oldDCD, and newDCD must not be nil.
+// ctx, oldDCD, and newDCD must not be nil. runtimeVersionSource identifies the request's source API.
 func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
-	ctx context.Context,
-	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
-	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
-) (admission.Warnings, error) {
-	return v.validateUpdate(ctx, oldDCD, newDCD, runtimeVersionSourceV1Beta1)
-}
-
-func (v *DynamoComponentDeploymentValidator) validateUpdate(
 	ctx context.Context,
 	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
 	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
@@ -96,20 +88,20 @@ func (v *DynamoComponentDeploymentValidator) validateUpdate(
 	}
 	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentV1alpha1(newAlpha)...)
 
+	// Re-enable source-version runtime validation for the old/new ratchet.
 	validation.runtimeVersionSource = runtimeVersionSource
 	if validation.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
 		oldAlpha, err := alphaDynamoComponentDeploymentForValidation(oldDCD)
 		if err != nil {
 			return nil, fmt.Errorf("cannot validate old preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
 		}
-		if err := runtimeVersionOverrideUpdateErrorV1Alpha1(
+		allErrs = append(allErrs, validation.validateRuntimeVersionOverrideUpdateV1Alpha1(
 			&newAlpha.Spec.DynamoComponentDeploymentSharedSpec,
 			&oldAlpha.Spec.DynamoComponentDeploymentSharedSpec,
 			field.NewPath("spec"),
-		); err != nil {
-			allErrs = append(allErrs, err)
-		}
+		)...)
 	}
+
 	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentUpdate(newDCD, oldDCD)...)
 	return validation.warnings, invalidDynamoComponentDeploymentError(newDCD, allErrs)
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -86,15 +86,30 @@ func (v *DynamoComponentDeploymentValidator) validateUpdate(
 	runtimeVersionSource runtimeVersionValidationSource,
 ) (admission.Warnings, error) {
 	validation := &dynamoComponentDeploymentValidation{
-		sharedValidation: sharedValidation{ctx: ctx, runtimeVersionSource: runtimeVersionSource},
+		sharedValidation: sharedValidation{ctx: ctx, runtimeVersionSource: runtimeVersionSourceDisabled},
 	}
 
 	allErrs := validation.validateDynamoComponentDeployment(newDCD)
-	alpha, err := alphaDynamoComponentDeploymentForValidation(newDCD)
+	newAlpha, err := alphaDynamoComponentDeploymentForValidation(newDCD)
 	if err != nil {
 		return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
 	}
-	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentV1alpha1(alpha)...)
+	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentV1alpha1(newAlpha)...)
+
+	validation.runtimeVersionSource = runtimeVersionSource
+	if validation.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
+		oldAlpha, err := alphaDynamoComponentDeploymentForValidation(oldDCD)
+		if err != nil {
+			return nil, fmt.Errorf("cannot validate old preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
+		}
+		if err := runtimeVersionOverrideUpdateErrorV1Alpha1(
+			&newAlpha.Spec.DynamoComponentDeploymentSharedSpec,
+			&oldAlpha.Spec.DynamoComponentDeploymentSharedSpec,
+			field.NewPath("spec"),
+		); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
 	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentUpdate(newDCD, oldDCD)...)
 	return validation.warnings, invalidDynamoComponentDeploymentError(newDCD, allErrs)
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -95,7 +95,7 @@ func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
 		if err != nil {
 			return nil, fmt.Errorf("cannot validate old preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
 		}
-		allErrs = append(allErrs, validation.validateRuntimeVersionOverrideUpdateV1Alpha1(
+		allErrs = append(allErrs, validation.validateDynamoComponentDeploymentSharedSpecUpdateV1alpha1(
 			&newAlpha.Spec.DynamoComponentDeploymentSharedSpec,
 			&oldAlpha.Spec.DynamoComponentDeploymentSharedSpec,
 			field.NewPath("spec"),

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
@@ -118,7 +118,7 @@ func (h *DynamoComponentDeploymentHandler) validateUpdate(
 	}
 
 	validator := NewDynamoComponentDeploymentValidator()
-	return validator.validateUpdate(ctx, oldDeployment, newDeployment, runtimeVersionValidationSourceForRequest(ctx, expectedGVK))
+	return validator.ValidateUpdate(ctx, oldDeployment, newDeployment, runtimeVersionValidationSourceForRequest(ctx, expectedGVK))
 }
 
 // ValidateDelete validates a DynamoComponentDeployment delete request.

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -97,6 +97,56 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{"spec.runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
 		},
 		{
+			name:               "unchanged legacy v1beta1 runtime version is ratcheted on update",
+			seedWithoutWebhook: true,
+			oldDeployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+			}),
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				dcd.Labels = map[string]string{"updated": "true"}
+			}),
+		},
+		{
+			name:               "unchanged legacy v1alpha1 runtime version is ratcheted on update",
+			seedWithoutWebhook: true,
+			oldDeployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+			}),
+			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dcd.Labels = map[string]string{"updated": "true"}
+			}),
+		},
+		{
+			name: "v1beta1 image change to custom requires runtime version override",
+			oldDeployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+			}),
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+			}),
+			wantWebhookErrs: []string{"spec.runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
+		},
+		{
+			name:               "changing a legacy v1alpha1 custom image requires runtime version override",
+			seedWithoutWebhook: true,
+			oldDeployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+			}),
+			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
+				dcd.Spec.RuntimeVersionOverride = ""
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:other-custom"
+			}),
+			wantWebhookErrs: []string{"spec.runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
+		},
+		{
 			name: "v1alpha1 compatibility validation does not duplicate runtime version errors",
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_validation_envtest_test.go
@@ -91,7 +91,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
 				dcd.Spec.ExtraPodSpec = &nvidiacomv1alpha1.ExtraPodSpec{
-					MainContainer: &corev1.Container{Image: "registry.example/runtime:custom"},
+					MainContainer: &corev1.Container{Image: customRuntimeImage},
 				}
 			}),
 			wantWebhookErrs: []string{"spec.runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
@@ -101,11 +101,11 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			seedWithoutWebhook: true,
 			oldDeployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 			}),
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 				dcd.Labels = map[string]string{"updated": "true"}
 			}),
 		},
@@ -114,11 +114,11 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			seedWithoutWebhook: true,
 			oldDeployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 			}),
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 				dcd.Labels = map[string]string{"updated": "true"}
 			}),
 		},
@@ -129,7 +129,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				dcd.Spec.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 			}),
 			wantWebhookErrs: []string{"spec.runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
 		},
@@ -138,7 +138,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			seedWithoutWebhook: true,
 			oldDeployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 			}),
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
@@ -150,7 +150,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			name: "v1alpha1 compatibility validation does not duplicate runtime version errors",
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.RuntimeVersionOverride = ""
-				dcd.Spec.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dcd.Spec.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 				dcd.Spec.Ingress = &nvidiacomv1alpha1.IngressSpec{Enabled: true}
 			}),
 			wantWebhookErrs: []string{

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -99,19 +99,9 @@ func (v *DynamoGraphDeploymentValidator) validate(
 }
 
 // ValidateUpdate performs stateful validation comparing old and new v1beta1 DGD objects.
-// ctx, oldDGD, and newDGD must not be nil.
+// ctx, oldDGD, and newDGD must not be nil. runtimeVersionSource identifies the request's source API.
 // If userInfo is nil, replica changes for DGDSA-enabled components fail closed.
 func (v *DynamoGraphDeploymentValidator) ValidateUpdate(
-	ctx context.Context,
-	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
-	newDGD *nvidiacomv1beta1.DynamoGraphDeployment,
-	userInfo *authenticationv1.UserInfo,
-	operatorPrincipal string,
-) (admission.Warnings, error) {
-	return v.validateUpdate(ctx, oldDGD, newDGD, userInfo, operatorPrincipal, runtimeVersionSourceV1Beta1)
-}
-
-func (v *DynamoGraphDeploymentValidator) validateUpdate(
 	ctx context.Context,
 	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
 	newDGD *nvidiacomv1beta1.DynamoGraphDeployment,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -108,13 +108,39 @@ func (v *DynamoGraphDeploymentValidator) ValidateUpdate(
 	userInfo *authenticationv1.UserInfo,
 	operatorPrincipal string,
 ) (admission.Warnings, error) {
+	return v.validateUpdate(ctx, oldDGD, newDGD, userInfo, operatorPrincipal, runtimeVersionSourceV1Beta1)
+}
+
+func (v *DynamoGraphDeploymentValidator) validateUpdate(
+	ctx context.Context,
+	oldDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	newDGD *nvidiacomv1beta1.DynamoGraphDeployment,
+	userInfo *authenticationv1.UserInfo,
+	operatorPrincipal string,
+	runtimeVersionSource runtimeVersionValidationSource,
+) (admission.Warnings, error) {
 	validation := &dynamoGraphDeploymentValidation{
-		sharedValidation:  sharedValidation{ctx: ctx, mgr: v.mgr, runtimeVersionSource: runtimeVersionSourceV1Beta1},
+		sharedValidation:  sharedValidation{ctx: ctx, mgr: v.mgr, runtimeVersionSource: runtimeVersionSource},
 		userInfo:          userInfo,
 		operatorPrincipal: operatorPrincipal,
 	}
 
 	allErrs := validation.validateDynamoGraphDeploymentUpdate(newDGD, oldDGD)
+	if validation.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
+		newAlpha, err := alphaDynamoGraphDeploymentForValidation(newDGD)
+		if err != nil {
+			return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoGraphDeployment fields: %w", err)
+		}
+		oldAlpha, err := alphaDynamoGraphDeploymentForValidation(oldDGD)
+		if err != nil {
+			return nil, fmt.Errorf("cannot validate old preserved v1alpha1 DynamoGraphDeployment fields: %w", err)
+		}
+		allErrs = append(allErrs, validation.validateDynamoGraphDeploymentSpecUpdateV1alpha1(
+			&newAlpha.Spec,
+			&oldAlpha.Spec,
+			field.NewPath("spec"),
+		)...)
+	}
 	return validation.warnings, invalidDynamoGraphDeploymentError(newDGD, allErrs)
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -132,7 +132,8 @@ func (h *DynamoGraphDeploymentHandler) validateUpdate(
 
 	// Create validator with manager for API group detection and perform validation.
 	validator := NewDynamoGraphDeploymentValidator(h.mgr)
-	warnings, err := validator.validate(ctx, newDeployment, runtimeVersionValidationSourceForRequest(ctx, expectedGVK))
+	runtimeVersionSource := runtimeVersionValidationSourceForRequest(ctx, expectedGVK)
+	warnings, err := validator.validate(ctx, newDeployment, runtimeVersionSourceDisabled)
 	if err != nil {
 		return warnings, err
 	}
@@ -148,7 +149,14 @@ func (h *DynamoGraphDeploymentHandler) validateUpdate(
 	}
 
 	// Validate stateful rules (immutability + replicas protection)
-	updateWarnings, err := validator.ValidateUpdate(ctx, oldDeployment, newDeployment, userInfo, h.operatorPrincipal)
+	updateWarnings, err := validator.validateUpdate(
+		ctx,
+		oldDeployment,
+		newDeployment,
+		userInfo,
+		h.operatorPrincipal,
+		runtimeVersionSource,
+	)
 	if err != nil {
 		username := "<unknown>"
 		if userInfo != nil {

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_handler.go
@@ -149,7 +149,7 @@ func (h *DynamoGraphDeploymentHandler) validateUpdate(
 	}
 
 	// Validate stateful rules (immutability + replicas protection)
-	updateWarnings, err := validator.validateUpdate(
+	updateWarnings, err := validator.ValidateUpdate(
 		ctx,
 		oldDeployment,
 		newDeployment,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
@@ -80,13 +80,11 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdat
 		if !exists {
 			continue
 		}
-		if err := runtimeVersionOverrideUpdateErrorV1Alpha1(
+		allErrs = append(allErrs, v.validateRuntimeVersionOverrideUpdateV1Alpha1(
 			newService,
 			oldService,
 			servicesPath.Key(serviceName),
-		); err != nil {
-			allErrs = append(allErrs, err)
-		}
+		)...)
 	}
 	return allErrs
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
@@ -65,6 +65,32 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecV1alp
 	return allErrs
 }
 
+// validateDynamoGraphDeploymentSpecUpdateV1alpha1 validates source-version runtime fields on update.
+// newSpec, oldSpec, and fldPath must not be nil.
+func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdateV1alpha1(
+	newSpec *nvidiacomv1alpha1.DynamoGraphDeploymentSpec,
+	oldSpec *nvidiacomv1alpha1.DynamoGraphDeploymentSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+	servicesPath := fldPath.Child("services")
+	for _, serviceName := range sortedV1Alpha1ServiceNames(newSpec.Services) {
+		newService := newSpec.Services[serviceName]
+		oldService, exists := oldSpec.Services[serviceName]
+		if !exists {
+			continue
+		}
+		if err := runtimeVersionOverrideUpdateErrorV1Alpha1(
+			newService,
+			oldService,
+			servicesPath.Key(serviceName),
+		); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+	return allErrs
+}
+
 // validatePVCV1alpha1 validates pvc. pvc and fldPath must not be nil.
 func (v *dynamoGraphDeploymentValidation) validatePVCV1alpha1(
 	pvc *nvidiacomv1alpha1.PVC,

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_v1alpha1.go
@@ -80,7 +80,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdat
 		if !exists {
 			continue
 		}
-		allErrs = append(allErrs, v.validateRuntimeVersionOverrideUpdateV1Alpha1(
+		allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpecUpdateV1alpha1(
 			newService,
 			oldService,
 			servicesPath.Key(serviceName),

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -47,14 +47,15 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 	tooLongComponentName := boundaryComponentName + "x"
 
 	tests := []struct {
-		name            string
-		deployment      runtime.Object
-		oldDeployment   runtime.Object
-		mutateRequest   func(*testing.T, map[string]any) // mutates the source-version request map
-		withoutTopology bool                             // omits the default cluster topology fixture
-		groveDisabled   bool                             // disables the configured Grove pathway
-		checkpointOff   bool                             // disables checkpoint creation and restore
-		username        string                           // supplies the admission request identity
+		name               string
+		deployment         runtime.Object
+		oldDeployment      runtime.Object
+		mutateRequest      func(*testing.T, map[string]any) // mutates the source-version request map
+		withoutTopology    bool                             // omits the default cluster topology fixture
+		groveDisabled      bool                             // disables the configured Grove pathway
+		checkpointOff      bool                             // disables checkpoint creation and restore
+		seedWithoutWebhook bool                             // seeds oldDeployment without validating it
+		username           string                           // supplies the admission request identity
 
 		wantSchemaErr     string
 		wantCELErr        string
@@ -85,6 +86,64 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker := dgd.Spec.Services["worker"]
 				worker.RuntimeVersionOverride = ""
 				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+			}),
+			wantWebhookErrs: []string{"spec.services[worker].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
+		},
+		{
+			name:               "unchanged legacy beta component runtime version is ratcheted on update",
+			seedWithoutWebhook: true,
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.RuntimeVersionOverride = ""
+				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.RuntimeVersionOverride = ""
+				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				dgd.Labels = map[string]string{"updated": "true"}
+			}),
+		},
+		{
+			name:               "unchanged legacy alpha service runtime version is ratcheted on update",
+			seedWithoutWebhook: true,
+			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.RuntimeVersionOverride = ""
+				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+			}),
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.RuntimeVersionOverride = ""
+				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				dgd.Labels = map[string]string{"updated": "true"}
+			}),
+		},
+		{
+			name: "beta component image change to custom requires runtime version override",
+			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.RuntimeVersionOverride = ""
+			}),
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				worker := betaWorkerComponent(dgd)
+				worker.RuntimeVersionOverride = ""
+				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+			}),
+			wantWebhookErrs: []string{"spec.components[1].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
+		},
+		{
+			name:               "changing a legacy alpha custom image requires runtime version override",
+			seedWithoutWebhook: true,
+			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.RuntimeVersionOverride = ""
+				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+			}),
+			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
+				worker := dgd.Spec.Services["worker"]
+				worker.RuntimeVersionOverride = ""
+				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:other-custom"
 			}),
 			wantWebhookErrs: []string{"spec.services[worker].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
 		},
@@ -1666,18 +1725,19 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gates := features.Gates{Checkpoint: !tt.checkpointOff, Grove: !tt.groveDisabled}
 			test := admissionTestCase{
-				object:            tt.deployment,
-				oldObject:         tt.oldDeployment,
-				mutateObject:      tt.mutateRequest,
-				gates:             gates,
-				withoutTopology:   tt.withoutTopology,
-				username:          tt.username,
-				wantSchemaError:   tt.wantSchemaErr,
-				wantCELError:      tt.wantCELErr,
-				wantAdmissionErrs: tt.wantAdmissionErrs,
-				wantWebhookErrors: tt.wantWebhookErrs,
-				wantWarnings:      tt.wantWarnings,
-				notWantError:      tt.notWantErr,
+				object:             tt.deployment,
+				oldObject:          tt.oldDeployment,
+				mutateObject:       tt.mutateRequest,
+				gates:              gates,
+				withoutTopology:    tt.withoutTopology,
+				seedWithoutWebhook: tt.seedWithoutWebhook,
+				username:           tt.username,
+				wantSchemaError:    tt.wantSchemaErr,
+				wantCELError:       tt.wantCELErr,
+				wantAdmissionErrs:  tt.wantAdmissionErrs,
+				wantWebhookErrors:  tt.wantWebhookErrs,
+				wantWarnings:       tt.wantWarnings,
+				notWantError:       tt.notWantErr,
 			}
 			if tt.oldDeployment != nil {
 				test.oldBeforeUpdate = dgdBeforeRestart(t, tt.oldDeployment)

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -75,7 +75,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker := betaWorkerComponent(dgd)
 				worker.RuntimeVersionOverride = ""
 				worker.PodTemplate = &corev1.PodTemplateSpec{Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: consts.MainContainerName, Image: "registry.example/runtime:custom"}},
+					Containers: []corev1.Container{{Name: consts.MainContainerName, Image: customRuntimeImage}},
 				}}
 			}),
 			wantWebhookErrs: []string{"spec.components[1].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
@@ -85,7 +85,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				worker := dgd.Spec.Services["worker"]
 				worker.RuntimeVersionOverride = ""
-				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				worker.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 			}),
 			wantWebhookErrs: []string{"spec.services[worker].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
 		},
@@ -95,12 +95,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				worker := betaWorkerComponent(dgd)
 				worker.RuntimeVersionOverride = ""
-				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				worker.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 			}),
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				worker := betaWorkerComponent(dgd)
 				worker.RuntimeVersionOverride = ""
-				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				worker.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 				dgd.Labels = map[string]string{"updated": "true"}
 			}),
 		},
@@ -110,12 +110,12 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				worker := dgd.Spec.Services["worker"]
 				worker.RuntimeVersionOverride = ""
-				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				worker.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 			}),
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				worker := dgd.Spec.Services["worker"]
 				worker.RuntimeVersionOverride = ""
-				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				worker.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 				dgd.Labels = map[string]string{"updated": "true"}
 			}),
 		},
@@ -128,7 +128,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				worker := betaWorkerComponent(dgd)
 				worker.RuntimeVersionOverride = ""
-				worker.PodTemplate.Spec.Containers[0].Image = "registry.example/runtime:custom"
+				worker.PodTemplate.Spec.Containers[0].Image = customRuntimeImage
 			}),
 			wantWebhookErrs: []string{"spec.components[1].runtimeVersionOverride: Required value: is required when the specified main container image has no parseable semantic-version tag"},
 		},
@@ -138,7 +138,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			oldDeployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				worker := dgd.Spec.Services["worker"]
 				worker.RuntimeVersionOverride = ""
-				worker.ExtraPodSpec.MainContainer.Image = "registry.example/runtime:custom"
+				worker.ExtraPodSpec.MainContainer.Image = customRuntimeImage
 			}),
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				worker := dgd.Spec.Services["worker"]

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -177,6 +177,7 @@ func dgdrRuntimeVersionOverrideRequired(spec *nvidiacomv1beta1.DynamoGraphDeploy
 	return err != nil
 }
 
+// isDGDRRuntimeVersionOverrideRepair reports whether an update only repairs a missing required override.
 func isDGDRRuntimeVersionOverrideRepair(
 	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdrutil"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -115,18 +114,16 @@ func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRe
 		&oldRequest.Spec,
 		field.NewPath("spec"),
 		oldRequest.Status.Phase,
-		oldRequest.Status.ObservedSpecFingerprint,
 	)
 }
 
 // validateDynamoGraphDeploymentRequestSpecUpdate validates a spec update.
-// newSpec, oldSpec, and fldPath must not be nil; status values come from the owning old resource.
+// newSpec, oldSpec, and fldPath must not be nil; oldPhase comes from the owning old resource.
 func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRequestSpecUpdate(
 	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	fldPath *field.Path,
 	oldPhase nvidiacomv1beta1.DGDRPhase,
-	observedSpecFingerprint string,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -162,7 +159,7 @@ func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRe
 
 	if isImmutableDGDRPhase(oldPhase) &&
 		!apiequality.Semantic.DeepEqual(newSpec, oldSpec) &&
-		!isDGDRRuntimeVersionOverrideRepair(newSpec, oldSpec, observedSpecFingerprint) {
+		!isDGDRRuntimeVersionOverrideRepair(newSpec, oldSpec) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,
 			fmt.Sprintf("updates are forbidden while the resource is in phase %q; delete and recreate the resource to change its spec", oldPhase),
@@ -184,7 +181,6 @@ func dgdrRuntimeVersionOverrideRequired(spec *nvidiacomv1beta1.DynamoGraphDeploy
 func isDGDRRuntimeVersionOverrideRepair(
 	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
-	observedSpecFingerprint string,
 ) bool {
 	if !dgdrRuntimeVersionOverrideRequired(oldSpec) ||
 		newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride ||
@@ -194,10 +190,5 @@ func isDGDRRuntimeVersionOverrideRepair(
 
 	newWithoutRepair := newSpec.DeepCopy()
 	newWithoutRepair.RuntimeVersionOverride = oldSpec.RuntimeVersionOverride
-	if !apiequality.Semantic.DeepEqual(newWithoutRepair, oldSpec) {
-		return false
-	}
-
-	fingerprint, err := dgdrutil.SpecFingerprint(oldSpec)
-	return err == nil && fingerprint == observedSpecFingerprint
+	return apiequality.Semantic.DeepEqual(newWithoutRepair, oldSpec)
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -149,14 +149,17 @@ func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRe
 		))
 	}
 
-	if dgdrRuntimeVersionOverrideRequired(newSpec) {
+	if dgdrRuntimeVersionOverrideRequired(newSpec) &&
+		(newSpec.Image != oldSpec.Image || newSpec.RuntimeVersionOverride != oldSpec.RuntimeVersionOverride) {
 		allErrs = append(allErrs, field.Required(
 			fldPath.Child("runtimeVersionOverride"),
 			"is required when spec.image has no parseable semantic-version tag",
 		))
 	}
 
-	if isImmutableDGDRPhase(oldPhase) && !apiequality.Semantic.DeepEqual(newSpec, oldSpec) {
+	if isImmutableDGDRPhase(oldPhase) &&
+		!apiequality.Semantic.DeepEqual(newSpec, oldSpec) &&
+		!isDGDRRuntimeVersionOverrideRepair(newSpec, oldSpec) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,
 			fmt.Sprintf("updates are forbidden while the resource is in phase %q; delete and recreate the resource to change its spec", oldPhase),
@@ -172,4 +175,19 @@ func dgdrRuntimeVersionOverrideRequired(spec *nvidiacomv1beta1.DynamoGraphDeploy
 	}
 	_, err := runtimeversion.ParseImageVersion(spec.Image)
 	return err != nil
+}
+
+func isDGDRRuntimeVersionOverrideRepair(
+	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
+	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
+) bool {
+	if !dgdrRuntimeVersionOverrideRequired(oldSpec) ||
+		newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride ||
+		dgdrRuntimeVersionOverrideRequired(newSpec) {
+		return false
+	}
+
+	newWithoutRepair := newSpec.DeepCopy()
+	newWithoutRepair.RuntimeVersionOverride = oldSpec.RuntimeVersionOverride
+	return apiequality.Semantic.DeepEqual(newWithoutRepair, oldSpec)
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdrutil"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -114,16 +115,18 @@ func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRe
 		&oldRequest.Spec,
 		field.NewPath("spec"),
 		oldRequest.Status.Phase,
+		oldRequest.Status.ObservedSpecFingerprint,
 	)
 }
 
 // validateDynamoGraphDeploymentRequestSpecUpdate validates a spec update.
-// newSpec, oldSpec, and fldPath must not be nil; oldPhase comes from the owning old resource status.
+// newSpec, oldSpec, and fldPath must not be nil; status values come from the owning old resource.
 func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRequestSpecUpdate(
 	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	fldPath *field.Path,
 	oldPhase nvidiacomv1beta1.DGDRPhase,
+	observedSpecFingerprint string,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -159,7 +162,7 @@ func (v *dynamoGraphDeploymentRequestValidation) validateDynamoGraphDeploymentRe
 
 	if isImmutableDGDRPhase(oldPhase) &&
 		!apiequality.Semantic.DeepEqual(newSpec, oldSpec) &&
-		!isDGDRRuntimeVersionOverrideRepair(newSpec, oldSpec) {
+		!isDGDRRuntimeVersionOverrideRepair(newSpec, oldSpec, observedSpecFingerprint) {
 		allErrs = append(allErrs, field.Forbidden(
 			fldPath,
 			fmt.Sprintf("updates are forbidden while the resource is in phase %q; delete and recreate the resource to change its spec", oldPhase),
@@ -181,6 +184,7 @@ func dgdrRuntimeVersionOverrideRequired(spec *nvidiacomv1beta1.DynamoGraphDeploy
 func isDGDRRuntimeVersionOverrideRepair(
 	newSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
 	oldSpec *nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec,
+	observedSpecFingerprint string,
 ) bool {
 	if !dgdrRuntimeVersionOverrideRequired(oldSpec) ||
 		newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride ||
@@ -190,5 +194,10 @@ func isDGDRRuntimeVersionOverrideRepair(
 
 	newWithoutRepair := newSpec.DeepCopy()
 	newWithoutRepair.RuntimeVersionOverride = oldSpec.RuntimeVersionOverride
-	return apiequality.Semantic.DeepEqual(newWithoutRepair, oldSpec)
+	if !apiequality.Semantic.DeepEqual(newWithoutRepair, oldSpec) {
+		return false
+	}
+
+	fingerprint, err := dgdrutil.SpecFingerprint(oldSpec)
+	return err == nil && fingerprint == observedSpecFingerprint
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_helpers.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_helpers.go
@@ -32,6 +32,7 @@ func isImmutableDGDRPhase(phase nvidiacomv1beta1.DGDRPhase) bool {
 	switch phase {
 	case nvidiacomv1beta1.DGDRPhaseProfiling,
 		nvidiacomv1beta1.DGDRPhaseDeploying,
+		nvidiacomv1beta1.DGDRPhaseReady,
 		nvidiacomv1beta1.DGDRPhaseDeployed:
 		return true
 	default:

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
@@ -253,7 +253,7 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 			gpuDiscovery: true,
 		},
 		{
-			name:               "runtime version override repair without observed fingerprint is rejected",
+			name:               "runtime version override repair does not require observed fingerprint",
 			seedWithoutWebhook: true,
 			oldRequest: betaDGDRForAdmissionWithoutFingerprint(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
 				request.Spec.RuntimeVersionOverride = ""
@@ -263,9 +263,6 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 			}),
 			gpuDiscovery: true,
-			wantWebhook: []string{
-				`spec: Forbidden: updates are forbidden while the resource is in phase "Deployed"; delete and recreate the resource to change its spec`,
-			},
 		},
 		{
 			name: "newly introduced custom image without override is rejected on update",

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
@@ -225,27 +225,28 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 			gpuDiscovery: true,
 		},
 		{
-			name:               "legacy custom image without override must be repaired on update",
+			name:               "unchanged legacy custom image without override is ratcheted on update",
 			seedWithoutWebhook: true,
 			oldRequest: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
 				request.Spec.RuntimeVersionOverride = ""
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 			}),
 			request: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
 				request.Spec.RuntimeVersionOverride = ""
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 				request.Labels = map[string]string{"updated": "true"}
 			}),
 			gpuDiscovery: true,
-			wantWebhook: []string{
-				"spec.runtimeVersionOverride: Required value: is required when spec.image has no parseable semantic-version tag",
-			},
 		},
 		{
-			name:               "adding runtime version override repairs legacy custom image",
+			name:               "adding runtime version override repairs legacy custom image in immutable phase",
 			seedWithoutWebhook: true,
 			oldRequest: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
 				request.Spec.RuntimeVersionOverride = ""
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 			}),
 			request: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 				request.Labels = map[string]string{"updated": "true"}
 			}),
 			gpuDiscovery: true,
@@ -257,6 +258,21 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 				request.Spec.RuntimeVersionOverride = ""
 			}),
 			request: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Spec.RuntimeVersionOverride = ""
+			}),
+			gpuDiscovery: true,
+			wantWebhook: []string{
+				"spec.runtimeVersionOverride: Required value: is required when spec.image has no parseable semantic-version tag",
+			},
+		},
+		{
+			name:               "changing a legacy custom image without override is rejected on update",
+			seedWithoutWebhook: true,
+			oldRequest: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Spec.RuntimeVersionOverride = ""
+			}),
+			request: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Spec.Image = "test-profiler:other-custom"
 				request.Spec.RuntimeVersionOverride = ""
 			}),
 			gpuDiscovery: true,

--- a/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeploymentrequest_validation_envtest_test.go
@@ -23,6 +23,7 @@ import (
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dgdrutil"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -252,6 +253,21 @@ func TestDynamoGraphDeploymentRequestValidator_Validate(t *testing.T) {
 			gpuDiscovery: true,
 		},
 		{
+			name:               "runtime version override repair without observed fingerprint is rejected",
+			seedWithoutWebhook: true,
+			oldRequest: betaDGDRForAdmissionWithoutFingerprint(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Spec.RuntimeVersionOverride = ""
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
+			}),
+			request: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
+				request.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
+			}),
+			gpuDiscovery: true,
+			wantWebhook: []string{
+				`spec: Forbidden: updates are forbidden while the resource is in phase "Deployed"; delete and recreate the resource to change its spec`,
+			},
+		},
+		{
 			name: "newly introduced custom image without override is rejected on update",
 			oldRequest: betaDGDRForAdmission(func(request *nvidiacomv1beta1.DynamoGraphDeploymentRequest) {
 				request.Spec.Image = "test-profiler:1.1.0"
@@ -364,6 +380,15 @@ func betaDGDRForAdmission(
 	if mutate != nil {
 		mutate(request)
 	}
+	request.Status.ObservedSpecFingerprint, _ = dgdrutil.SpecFingerprint(&request.Spec)
+	return request
+}
+
+func betaDGDRForAdmissionWithoutFingerprint(
+	mutate func(*nvidiacomv1beta1.DynamoGraphDeploymentRequest),
+) *nvidiacomv1beta1.DynamoGraphDeploymentRequest {
+	request := betaDGDRForAdmission(mutate)
+	request.Status.ObservedSpecFingerprint = ""
 	return request
 }
 

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -47,6 +47,7 @@ type runtimeVersionValidationSource uint8
 const (
 	runtimeVersionSourceV1Beta1 runtimeVersionValidationSource = iota
 	runtimeVersionSourceV1Alpha1
+	runtimeVersionSourceDisabled
 )
 
 // runtimeVersionValidationSourceForRequest uses RequestKind because it preserves

--- a/deploy/operator/internal/webhook/validation/shared_helpers.go
+++ b/deploy/operator/internal/webhook/validation/shared_helpers.go
@@ -27,8 +27,10 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -38,6 +40,8 @@ const (
 
 	vllmDistributedExecutorBackendMP  = "mp"
 	vllmDistributedExecutorBackendRay = "ray"
+
+	runtimeVersionOverrideRequiredMessage = "is required when the specified main container image has no parseable semantic-version tag"
 )
 
 // runtimeVersionValidationSource identifies the API representation whose field
@@ -75,6 +79,46 @@ func runtimeVersionValidationSourceForGVK(gvk schema.GroupVersionKind) runtimeVe
 
 func (v *sharedValidation) validatesRuntimeVersionFor(source runtimeVersionValidationSource) bool {
 	return v.runtimeVersionSource == source
+}
+
+// runtimeVersionImageAndPath returns the main image and its v1beta1 field path.
+// spec and fldPath must not be nil.
+func runtimeVersionImageAndPath(
+	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) (string, *field.Path) {
+	imagePath := fldPath.Child("podTemplate", "spec", "containers")
+
+	// Resolve the exact container path when the named main container exists.
+	if spec.PodTemplate != nil {
+		if index := containerIndexByName(spec.PodTemplate.Spec.Containers, consts.MainContainerName); index >= 0 {
+			imagePath = imagePath.Index(index).Child("image")
+			return spec.PodTemplate.Spec.Containers[index].Image, imagePath
+		}
+	}
+	return "", imagePath
+}
+
+// runtimeVersionImageAndPathV1Alpha1 returns the main image and its v1alpha1 field path.
+// spec and fldPath must not be nil.
+func runtimeVersionImageAndPathV1Alpha1(
+	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) (string, *field.Path) {
+	imagePath := fldPath.Child("extraPodSpec", "mainContainer", "image")
+	if spec.ExtraPodSpec != nil && spec.ExtraPodSpec.MainContainer != nil {
+		return spec.ExtraPodSpec.MainContainer.Image, imagePath
+	}
+	return "", imagePath
+}
+
+// runtimeVersionOverrideRequired reports whether image cannot provide a version and override is absent.
+func runtimeVersionOverrideRequired(image, override string) bool {
+	if override != "" {
+		return false
+	}
+	_, err := runtimeversion.ParseImageVersion(image)
+	return err != nil
 }
 
 func hasContainerNamed(containers []corev1.Container, name string) bool {

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -77,9 +77,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 		allErrs = append(allErrs, v.validateFailoverSpecV1alpha1(spec.Failover, fldPath.Child("failover"))...)
 	}
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
-		if err := runtimeVersionOverrideErrorV1Alpha1(spec, fldPath); err != nil {
-			allErrs = append(allErrs, err)
-		}
+		allErrs = append(allErrs, v.validateRuntimeVersionOverrideV1Alpha1(spec, fldPath)...)
 	}
 
 	return allErrs
@@ -140,33 +138,38 @@ func (v *sharedValidation) validateFailoverSpecV1alpha1(
 	)}
 }
 
-func runtimeVersionOverrideErrorV1Alpha1(
+// validateRuntimeVersionOverrideV1Alpha1 validates runtime compatibility fields on create.
+// spec and fldPath must not be nil.
+func (v *sharedValidation) validateRuntimeVersionOverrideV1Alpha1(
 	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
-) *field.Error {
-	image, imagePath := runtimeVersionImageAndPathV1Alpha1(spec, fldPath)
-	return runtimeVersionError(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+) field.ErrorList {
+	image, imagePath := v.runtimeVersionImageAndPathV1Alpha1(spec, fldPath)
+	return v.validateRuntimeVersion(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
 }
 
-func runtimeVersionOverrideUpdateErrorV1Alpha1(
+// validateRuntimeVersionOverrideUpdateV1Alpha1 ratchets runtime compatibility fields on update.
+// newSpec, oldSpec, and fldPath must not be nil.
+func (v *sharedValidation) validateRuntimeVersionOverrideUpdateV1Alpha1(
 	newSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
 	oldSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
-) *field.Error {
-	newImage, imagePath := runtimeVersionImageAndPathV1Alpha1(newSpec, fldPath)
-	err := runtimeVersionError(newImage, newSpec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
-	if err == nil || newImage == "" {
-		return err
-	}
-
-	oldImage, _ := runtimeVersionImageAndPathV1Alpha1(oldSpec, fldPath)
-	if newImage == oldImage && newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride {
-		return nil
-	}
-	return err
+) field.ErrorList {
+	newImage, imagePath := v.runtimeVersionImageAndPathV1Alpha1(newSpec, fldPath)
+	oldImage, _ := v.runtimeVersionImageAndPathV1Alpha1(oldSpec, fldPath)
+	return v.validateRuntimeVersionUpdate(
+		newImage,
+		newSpec.RuntimeVersionOverride,
+		oldImage,
+		oldSpec.RuntimeVersionOverride,
+		imagePath,
+		fldPath.Child("runtimeVersionOverride"),
+	)
 }
 
-func runtimeVersionImageAndPathV1Alpha1(
+// runtimeVersionImageAndPathV1Alpha1 returns the main image and its source-version field path.
+// spec and fldPath must not be nil.
+func (v *sharedValidation) runtimeVersionImageAndPathV1Alpha1(
 	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 ) (string, *field.Path) {

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -76,8 +76,45 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 	if spec.Failover != nil {
 		allErrs = append(allErrs, v.validateFailoverSpecV1alpha1(spec.Failover, fldPath.Child("failover"))...)
 	}
+
+	// Validate runtime compatibility against the source-version fields.
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
-		allErrs = append(allErrs, v.validateRuntimeVersionOverrideV1Alpha1(spec, fldPath)...)
+		image, imagePath := runtimeVersionImageAndPathV1Alpha1(spec, fldPath)
+		if image == "" {
+			allErrs = append(allErrs, field.Required(imagePath, "is required"))
+		} else if runtimeVersionOverrideRequired(image, spec.RuntimeVersionOverride) {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child("runtimeVersionOverride"),
+				runtimeVersionOverrideRequiredMessage,
+			))
+		}
+	}
+
+	return allErrs
+}
+
+// validateDynamoComponentDeploymentSharedSpecUpdateV1alpha1 validates a preserved v1alpha1 shared spec update.
+// newSpec, oldSpec, and fldPath must not be nil.
+func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdateV1alpha1(
+	newSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	oldSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	// Ratchet an unchanged legacy tuple but reject a missing image or newly invalid tuple.
+	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Alpha1) {
+		newImage, imagePath := runtimeVersionImageAndPathV1Alpha1(newSpec, fldPath)
+		oldImage, _ := runtimeVersionImageAndPathV1Alpha1(oldSpec, fldPath)
+		if newImage == "" {
+			allErrs = append(allErrs, field.Required(imagePath, "is required"))
+		} else if runtimeVersionOverrideRequired(newImage, newSpec.RuntimeVersionOverride) &&
+			(newImage != oldImage || newSpec.RuntimeVersionOverride != oldSpec.RuntimeVersionOverride) {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child("runtimeVersionOverride"),
+				runtimeVersionOverrideRequiredMessage,
+			))
+		}
 	}
 
 	return allErrs
@@ -136,46 +173,4 @@ func (v *sharedValidation) validateFailoverSpecV1alpha1(
 		failover.NumShadows,
 		fmt.Sprintf("is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=%q to configure numShadows", nvidiacomv1alpha1.GMSModeIntraPod, nvidiacomv1alpha1.GMSModeInterPod),
 	)}
-}
-
-// validateRuntimeVersionOverrideV1Alpha1 validates runtime compatibility fields on create.
-// spec and fldPath must not be nil.
-func (v *sharedValidation) validateRuntimeVersionOverrideV1Alpha1(
-	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) field.ErrorList {
-	image, imagePath := v.runtimeVersionImageAndPathV1Alpha1(spec, fldPath)
-	return v.validateRuntimeVersion(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
-}
-
-// validateRuntimeVersionOverrideUpdateV1Alpha1 ratchets runtime compatibility fields on update.
-// newSpec, oldSpec, and fldPath must not be nil.
-func (v *sharedValidation) validateRuntimeVersionOverrideUpdateV1Alpha1(
-	newSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-	oldSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) field.ErrorList {
-	newImage, imagePath := v.runtimeVersionImageAndPathV1Alpha1(newSpec, fldPath)
-	oldImage, _ := v.runtimeVersionImageAndPathV1Alpha1(oldSpec, fldPath)
-	return v.validateRuntimeVersionUpdate(
-		newImage,
-		newSpec.RuntimeVersionOverride,
-		oldImage,
-		oldSpec.RuntimeVersionOverride,
-		imagePath,
-		fldPath.Child("runtimeVersionOverride"),
-	)
-}
-
-// runtimeVersionImageAndPathV1Alpha1 returns the main image and its source-version field path.
-// spec and fldPath must not be nil.
-func (v *sharedValidation) runtimeVersionImageAndPathV1Alpha1(
-	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) (string, *field.Path) {
-	imagePath := fldPath.Child("extraPodSpec", "mainContainer", "image")
-	if spec.ExtraPodSpec != nil && spec.ExtraPodSpec.MainContainer != nil {
-		return spec.ExtraPodSpec.MainContainer.Image, imagePath
-	}
-	return "", imagePath
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -22,7 +22,6 @@ import (
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -145,19 +144,35 @@ func runtimeVersionOverrideErrorV1Alpha1(
 	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 ) *field.Error {
-	overridePath := fldPath.Child("runtimeVersionOverride")
-	image := ""
-	if spec.ExtraPodSpec != nil && spec.ExtraPodSpec.MainContainer != nil {
-		image = spec.ExtraPodSpec.MainContainer.Image
+	image, imagePath := runtimeVersionImageAndPathV1Alpha1(spec, fldPath)
+	return runtimeVersionError(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+}
+
+func runtimeVersionOverrideUpdateErrorV1Alpha1(
+	newSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	oldSpec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) *field.Error {
+	newImage, imagePath := runtimeVersionImageAndPathV1Alpha1(newSpec, fldPath)
+	err := runtimeVersionError(newImage, newSpec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+	if err == nil || newImage == "" {
+		return err
 	}
-	if image == "" {
-		return field.Required(fldPath.Child("extraPodSpec", "mainContainer", "image"), "is required")
-	}
-	if spec.RuntimeVersionOverride != "" {
+
+	oldImage, _ := runtimeVersionImageAndPathV1Alpha1(oldSpec, fldPath)
+	if newImage == oldImage && newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride {
 		return nil
 	}
-	if _, err := runtimeversion.ParseImageVersion(image); err != nil {
-		return field.Required(overridePath, "is required when the specified main container image has no parseable semantic-version tag")
+	return err
+}
+
+func runtimeVersionImageAndPathV1Alpha1(
+	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) (string, *field.Path) {
+	imagePath := fldPath.Child("extraPodSpec", "mainContainer", "image")
+	if spec.ExtraPodSpec != nil && spec.ExtraPodSpec.MainContainer != nil {
+		return spec.ExtraPodSpec.MainContainer.Image, imagePath
 	}
-	return nil
+	return "", imagePath
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -26,7 +26,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/runtimeversion"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -127,8 +126,17 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpec(
 		)...)
 	}
 
+	// Validate runtime compatibility against the source-version fields.
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Beta1) {
-		allErrs = append(allErrs, v.validateRuntimeVersionOverride(spec, fldPath)...)
+		image, imagePath := runtimeVersionImageAndPath(spec, fldPath)
+		if image == "" {
+			allErrs = append(allErrs, field.Required(imagePath, "is required"))
+		} else if runtimeVersionOverrideRequired(image, spec.RuntimeVersionOverride) {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child("runtimeVersionOverride"),
+				runtimeVersionOverrideRequiredMessage,
+			))
+		}
 	}
 
 	return allErrs
@@ -396,8 +404,20 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			))
 		}
 	}
+
+	// Ratchet an unchanged legacy tuple but reject a missing image or newly invalid tuple.
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Beta1) {
-		allErrs = append(allErrs, v.validateRuntimeVersionOverrideUpdate(newComponent, oldComponent, fldPath)...)
+		newImage, imagePath := runtimeVersionImageAndPath(newComponent, fldPath)
+		oldImage, _ := runtimeVersionImageAndPath(oldComponent, fldPath)
+		if newImage == "" {
+			allErrs = append(allErrs, field.Required(imagePath, "is required"))
+		} else if runtimeVersionOverrideRequired(newImage, newComponent.RuntimeVersionOverride) &&
+			(newImage != oldImage || newComponent.RuntimeVersionOverride != oldComponent.RuntimeVersionOverride) {
+			allErrs = append(allErrs, field.Required(
+				fldPath.Child("runtimeVersionOverride"),
+				runtimeVersionOverrideRequiredMessage,
+			))
+		}
 	}
 	return allErrs
 }
@@ -457,89 +477,4 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		))
 	}
 	return allErrs
-}
-
-// validateRuntimeVersionOverride validates runtime compatibility fields on create.
-// spec and fldPath must not be nil.
-func (v *sharedValidation) validateRuntimeVersionOverride(
-	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) field.ErrorList {
-	image, imagePath := v.runtimeVersionImageAndPath(spec, fldPath)
-	return v.validateRuntimeVersion(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
-}
-
-// validateRuntimeVersionOverrideUpdate ratchets runtime compatibility fields on update.
-// newSpec, oldSpec, and fldPath must not be nil.
-func (v *sharedValidation) validateRuntimeVersionOverrideUpdate(
-	newSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	oldSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) field.ErrorList {
-	newImage, imagePath := v.runtimeVersionImageAndPath(newSpec, fldPath)
-	oldImage, _ := v.runtimeVersionImageAndPath(oldSpec, fldPath)
-	return v.validateRuntimeVersionUpdate(
-		newImage,
-		newSpec.RuntimeVersionOverride,
-		oldImage,
-		oldSpec.RuntimeVersionOverride,
-		imagePath,
-		fldPath.Child("runtimeVersionOverride"),
-	)
-}
-
-// runtimeVersionImageAndPath returns the main image and its v1beta1 field path.
-// spec and fldPath must not be nil.
-func (v *sharedValidation) runtimeVersionImageAndPath(
-	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
-	fldPath *field.Path,
-) (string, *field.Path) {
-	imagePath := fldPath.Child("podTemplate", "spec", "containers")
-	if spec.PodTemplate != nil {
-		if index := containerIndexByName(spec.PodTemplate.Spec.Containers, consts.MainContainerName); index >= 0 {
-			imagePath = imagePath.Index(index).Child("image")
-			return spec.PodTemplate.Spec.Containers[index].Image, imagePath
-		}
-	}
-	return "", imagePath
-}
-
-// validateRuntimeVersionUpdate validates the new runtime fields unless an invalid old value is unchanged.
-// imagePath and overridePath must not be nil.
-func (v *sharedValidation) validateRuntimeVersionUpdate(
-	newImage string,
-	newOverride string,
-	oldImage string,
-	oldOverride string,
-	imagePath *field.Path,
-	overridePath *field.Path,
-) field.ErrorList {
-	allErrs := v.validateRuntimeVersion(newImage, newOverride, imagePath, overridePath)
-	if len(allErrs) == 0 || newImage == "" {
-		return allErrs
-	}
-	if newImage == oldImage && newOverride == oldOverride {
-		return nil
-	}
-	return allErrs
-}
-
-// validateRuntimeVersion validates a resolved image and override pair.
-// imagePath and overridePath must not be nil.
-func (v *sharedValidation) validateRuntimeVersion(
-	image string,
-	override string,
-	imagePath *field.Path,
-	overridePath *field.Path,
-) field.ErrorList {
-	if image == "" {
-		return field.ErrorList{field.Required(imagePath, "is required")}
-	}
-	if override != "" {
-		return nil
-	}
-	if _, err := runtimeversion.ParseImageVersion(image); err != nil {
-		return field.ErrorList{field.Required(overridePath, "is required when the specified main container image has no parseable semantic-version tag")}
-	}
-	return nil
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -128,9 +128,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpec(
 	}
 
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Beta1) {
-		if err := runtimeVersionOverrideError(spec, fldPath); err != nil {
-			allErrs = append(allErrs, err)
-		}
+		allErrs = append(allErrs, v.validateRuntimeVersionOverride(spec, fldPath)...)
 	}
 
 	return allErrs
@@ -399,9 +397,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 		}
 	}
 	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Beta1) {
-		if err := runtimeVersionOverrideUpdateError(newComponent, oldComponent, fldPath); err != nil {
-			allErrs = append(allErrs, err)
-		}
+		allErrs = append(allErrs, v.validateRuntimeVersionOverrideUpdate(newComponent, oldComponent, fldPath)...)
 	}
 	return allErrs
 }
@@ -463,33 +459,38 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 	return allErrs
 }
 
-func runtimeVersionOverrideError(
+// validateRuntimeVersionOverride validates runtime compatibility fields on create.
+// spec and fldPath must not be nil.
+func (v *sharedValidation) validateRuntimeVersionOverride(
 	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
-) *field.Error {
-	image, imagePath := runtimeVersionImageAndPath(spec, fldPath)
-	return runtimeVersionError(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+) field.ErrorList {
+	image, imagePath := v.runtimeVersionImageAndPath(spec, fldPath)
+	return v.validateRuntimeVersion(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
 }
 
-func runtimeVersionOverrideUpdateError(
+// validateRuntimeVersionOverrideUpdate ratchets runtime compatibility fields on update.
+// newSpec, oldSpec, and fldPath must not be nil.
+func (v *sharedValidation) validateRuntimeVersionOverrideUpdate(
 	newSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	oldSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
-) *field.Error {
-	newImage, imagePath := runtimeVersionImageAndPath(newSpec, fldPath)
-	err := runtimeVersionError(newImage, newSpec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
-	if err == nil || newImage == "" {
-		return err
-	}
-
-	oldImage, _ := runtimeVersionImageAndPath(oldSpec, fldPath)
-	if newImage == oldImage && newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride {
-		return nil
-	}
-	return err
+) field.ErrorList {
+	newImage, imagePath := v.runtimeVersionImageAndPath(newSpec, fldPath)
+	oldImage, _ := v.runtimeVersionImageAndPath(oldSpec, fldPath)
+	return v.validateRuntimeVersionUpdate(
+		newImage,
+		newSpec.RuntimeVersionOverride,
+		oldImage,
+		oldSpec.RuntimeVersionOverride,
+		imagePath,
+		fldPath.Child("runtimeVersionOverride"),
+	)
 }
 
-func runtimeVersionImageAndPath(
+// runtimeVersionImageAndPath returns the main image and its v1beta1 field path.
+// spec and fldPath must not be nil.
+func (v *sharedValidation) runtimeVersionImageAndPath(
 	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 ) (string, *field.Path) {
@@ -503,20 +504,42 @@ func runtimeVersionImageAndPath(
 	return "", imagePath
 }
 
-func runtimeVersionError(
+// validateRuntimeVersionUpdate validates the new runtime fields unless an invalid old value is unchanged.
+// imagePath and overridePath must not be nil.
+func (v *sharedValidation) validateRuntimeVersionUpdate(
+	newImage string,
+	newOverride string,
+	oldImage string,
+	oldOverride string,
+	imagePath *field.Path,
+	overridePath *field.Path,
+) field.ErrorList {
+	allErrs := v.validateRuntimeVersion(newImage, newOverride, imagePath, overridePath)
+	if len(allErrs) == 0 || newImage == "" {
+		return allErrs
+	}
+	if newImage == oldImage && newOverride == oldOverride {
+		return nil
+	}
+	return allErrs
+}
+
+// validateRuntimeVersion validates a resolved image and override pair.
+// imagePath and overridePath must not be nil.
+func (v *sharedValidation) validateRuntimeVersion(
 	image string,
 	override string,
 	imagePath *field.Path,
 	overridePath *field.Path,
-) *field.Error {
+) field.ErrorList {
 	if image == "" {
-		return field.Required(imagePath, "is required")
+		return field.ErrorList{field.Required(imagePath, "is required")}
 	}
 	if override != "" {
 		return nil
 	}
 	if _, err := runtimeversion.ParseImageVersion(image); err != nil {
-		return field.Required(overridePath, "is required when the specified main container image has no parseable semantic-version tag")
+		return field.ErrorList{field.Required(overridePath, "is required when the specified main container image has no parseable semantic-version tag")}
 	}
 	return nil
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -398,6 +398,11 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			))
 		}
 	}
+	if v.validatesRuntimeVersionFor(runtimeVersionSourceV1Beta1) {
+		if err := runtimeVersionOverrideUpdateError(newComponent, oldComponent, fldPath); err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
 	return allErrs
 }
 
@@ -462,19 +467,52 @@ func runtimeVersionOverrideError(
 	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 ) *field.Error {
-	overridePath := fldPath.Child("runtimeVersionOverride")
-	image := ""
+	image, imagePath := runtimeVersionImageAndPath(spec, fldPath)
+	return runtimeVersionError(image, spec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+}
+
+func runtimeVersionOverrideUpdateError(
+	newSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	oldSpec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) *field.Error {
+	newImage, imagePath := runtimeVersionImageAndPath(newSpec, fldPath)
+	err := runtimeVersionError(newImage, newSpec.RuntimeVersionOverride, imagePath, fldPath.Child("runtimeVersionOverride"))
+	if err == nil || newImage == "" {
+		return err
+	}
+
+	oldImage, _ := runtimeVersionImageAndPath(oldSpec, fldPath)
+	if newImage == oldImage && newSpec.RuntimeVersionOverride == oldSpec.RuntimeVersionOverride {
+		return nil
+	}
+	return err
+}
+
+func runtimeVersionImageAndPath(
+	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
+	fldPath *field.Path,
+) (string, *field.Path) {
 	imagePath := fldPath.Child("podTemplate", "spec", "containers")
 	if spec.PodTemplate != nil {
 		if index := containerIndexByName(spec.PodTemplate.Spec.Containers, consts.MainContainerName); index >= 0 {
-			image = spec.PodTemplate.Spec.Containers[index].Image
 			imagePath = imagePath.Index(index).Child("image")
+			return spec.PodTemplate.Spec.Containers[index].Image, imagePath
 		}
 	}
+	return "", imagePath
+}
+
+func runtimeVersionError(
+	image string,
+	override string,
+	imagePath *field.Path,
+	overridePath *field.Path,
+) *field.Error {
 	if image == "" {
 		return field.Required(imagePath, "is required")
 	}
-	if spec.RuntimeVersionOverride != "" {
+	if override != "" {
 		return nil
 	}
 	if _, err := runtimeversion.ParseImageVersion(image); err != nil {

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"

--- a/deploy/operator/internal/webhook/validation/suite_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/suite_envtest_test.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	admissionOperatorPrincipal = "system:serviceaccount:dynamo-system:dynamo-operator"
+	customRuntimeImage         = "registry.example/runtime:custom"
 	legacySeedUsername         = "operatorenv-legacy-seeder"
 )
 

--- a/docs/fern/components/profiler/profiler-guide.md
+++ b/docs/fern/components/profiler/profiler-guide.md
@@ -215,6 +215,9 @@ spec:
 > 1.3.0 or earlier discards the field while parsing the DGDR. Set the override
 > when the effective generated runtime images do not use tags that identify
 > their Dynamo runtime versions.
+> The profiler also applies the field when its output is consumed directly,
+> outside the operator-managed DGDR workflow. The operator remains authoritative
+> for DGDR-managed deployments and reapplies the value after all DGD overrides.
 >
 > [Profiler Image Version Compatibility](../../kubernetes/dgdr-reference.mdx#profiler-image-version-compatibility)
 > for details.

--- a/docs/fern/components/profiler/profiler-guide.md
+++ b/docs/fern/components/profiler/profiler-guide.md
@@ -208,12 +208,13 @@ spec:
   image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"  # dynamo-frontend for Dynamo < 1.1.0
 ```
 
-> [!WARNING]
-> With Dynamo Operator 1.4.0 or later, an explicitly selected profiler based on
-> Dynamo 1.3.0 or earlier must use a `spec.image` tag that accurately identifies
-> its runtime with semantic versioning, such as `:1.3.0`. Older profilers
-> silently discard the DGDR-level `spec.runtimeVersionOverride` field and
-> therefore cannot propagate it into the generated DGD.
+> [!NOTE]
+> The DGDR-level `spec.runtimeVersionOverride` is authoritative for every
+> component in the generated DGD. The operator applies it after processing
+> profiler output and DGD overrides, including when a profiler based on Dynamo
+> 1.3.0 or earlier discards the field while parsing the DGDR. Set the override
+> when the effective generated runtime images do not use tags that identify
+> their Dynamo runtime versions.
 >
 > [Profiler Image Version Compatibility](../../kubernetes/dgdr-reference.mdx#profiler-image-version-compatibility)
 > for details.

--- a/docs/fern/kubernetes/api-reference.md
+++ b/docs/fern/kubernetes/api-reference.md
@@ -2313,6 +2313,7 @@ _Appears in:_
 | `profilingResults` _[ProfilingResultsStatus](#profilingresultsstatus)_ | ProfilingResults contains the selected deployment configuration produced by profiling.<br />Deprecated compatibility fields may remain on objects created by older releases. |  | Optional: \{\} <br /> |
 | `deploymentInfo` _[DeploymentInfoStatus](#deploymentinfostatus)_ | DeploymentInfo tracks the state of the deployed DynamoGraphDeployment.<br />Populated when a DGD has been created (either via autoApply or manually). |  | Optional: \{\} <br /> |
 | `observedGeneration` _integer_ | ObservedGeneration is the most recent generation observed by the controller. |  | Optional: \{\} <br /> |
+| `observedSpecFingerprint` _string_ | ObservedSpecFingerprint identifies the spec associated with ObservedGeneration.<br />The controller uses it to verify runtimeVersionOverride-only repairs. |  | Optional: \{\} <br /> |
 
 
 #### DynamoGraphDeploymentScalingAdapter

--- a/docs/fern/kubernetes/dgdr-reference.mdx
+++ b/docs/fern/kubernetes/dgdr-reference.mdx
@@ -50,36 +50,30 @@ When `spec.image` is omitted, the operator defaults it on creation to
 requires `operatorVersion` to be valid semantic versioning, so the default
 image has a parseable version tag.
 
-<Warning>
-  When using Dynamo Operator 1.4.0 or later, explicitly setting `spec.image` to
-  a profiler based on Dynamo 1.3.0 or earlier requires a semantic-version tag
-  that accurately identifies the generated runtime version, such as
-  `dynamo-planner:1.3.0`.
+The DGDR-level `spec.runtimeVersionOverride` is authoritative for every
+component in the generated DGD. After the profiler materializes the DGD and
+applies `spec.overrides.dgd`, the operator copies the DGDR value to every
+generated component before DGD admission. This behavior applies across profiler
+versions. Profilers through Dynamo 1.3.0 may discard the field while parsing the
+DGDR, but the operator reapplies it from the stored DGDR.
 
-  Profilers through 1.3.0 do not recognize the DGDR-level
-  `spec.runtimeVersionOverride` field and silently discard it while parsing the
-  DGDR configuration. These profilers derive generated DGD component images
-  from `spec.image` but cannot propagate the DGDR-level override into those
-  components. The DGD admission webhook must therefore infer compatibility from
-  the generated component image tags. Do not use tags such as `:latest`,
-  `:custom`, or `:sha-abc123` for this version combination.
-</Warning>
+Set `spec.runtimeVersionOverride` when an effective generated component image
+uses a non-semantic-version tag or digest, or when its tag does not identify the
+intended Dynamo runtime version. The DGDR value also covers images replaced
+through `spec.overrides.dgd` and takes precedence over component-level values in
+that override.
 
-Images supplied through `spec.overrides.dgd` follow the DGD component rules
-independently. An overridden worker image with no parseable semantic-version tag
-requires `runtimeVersionOverride` in the effective DGD component.
+When the DGDR-level field is unset, each effective generated DGD component
+follows the DGD component rules independently. An overridden image without a
+parseable semantic-version tag requires `runtimeVersionOverride` on that
+component.
 
-Profilers from Dynamo 1.4.0 or later propagate the DGDR-level override to every
-generated component, so `spec.runtimeVersionOverride` also covers a worker image
-replaced through `overrides.dgd`.
-
-With a profiler based on Dynamo 1.3.0 or earlier, the DGDR-level field is
-ignored. Those profilers also discard the embedded override's `apiVersion` and
-`kind`, then directly merge the remaining dictionary into a generated
+Profilers through Dynamo 1.3.0 discard the embedded DGD override's `apiVersion`
+and `kind`, then directly merge the remaining dictionary into a generated
 `v1alpha1` DGD. Raw storage preserves the override fields but does not convert
-between DGD schemas. Use a `v1alpha1`-shaped override under `spec.services` and
-set `runtimeVersionOverride` on the affected service. A `v1beta1`
-`spec.components` override is not translated into the generated service.
+between DGD schemas. Use a `v1alpha1`-shaped override under `spec.services`; a
+`v1beta1` `spec.components` override is not translated into the generated
+service.
 
 <ParamField path="workload" type="WorkloadSpec">
   Expected workload characteristics for SLA-based profiling.


### PR DESCRIPTION
## Summary

- ratchet `runtimeVersionOverride` admission across DGDR, DGD, and DCD updates so unchanged legacy images remain updateable
- require an override when an update introduces or changes a non-semver runtime image
- allow an override-only DGDR repair while the remaining spec stays immutable
- make the DGDR controller apply the request-level override to profiler output before persistence and again before DGD creation
- cover v1alpha1 and v1beta1 source paths, current profiler output, and persisted legacy profiler output

This is a stacked fix for #10494 and targets `tmonty12/dyn-940-runtime-version`.

Linear: [DYN-940](https://linear.app/nvidia/issue/DYN-940/autoscaling-with-planner-grove)

## Root cause

The new create-time runtime-version requirement was applied inconsistently on updates: full revalidation trapped unchanged legacy resources, while the selected profiler image remained responsible for propagating a field that older profiler versions do not understand.

## User impact

Existing resources with unchanged custom image tags remain editable, but changing to a non-semver image still requires an explicit runtime version. DGDRs using older profiler images no longer produce DGD manifests that fail admission after the request itself was accepted.

## Validation

- `gofmt` on all changed Go files
- repository pre-commit hooks passed for both commits
- `git diff --check`
- GPG signatures verified for both commits
- tests not run, per review constraint