### PR TITLE
fix(thunderagent): add router observability

### DIFF
--- a/components/src/dynamo/thunderagent_router/__main__.py
+++ b/components/src/dynamo/thunderagent_router/__main__.py
@@ -15,6 +15,7 @@ are routed via plain KvRouter with no lifecycle.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any, Optional
 
@@ -59,6 +60,22 @@ def _is_session_final(request: dict[str, Any]) -> bool:
     return isinstance(ctx, dict) and bool(ctx.get("session_final"))
 
 
+def _nvext_extra_field_requested(request: dict[str, Any], field: str) -> bool:
+    """Return whether the raw or preprocessed request opted into an nvext field."""
+    sources: list[Any] = [request.get("nvext")]
+    extra_args = request.get("extra_args")
+    if isinstance(extra_args, dict):
+        sources.append(extra_args.get("nvext"))
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        extra_fields = source.get("extra_fields")
+        if isinstance(extra_fields, list) and field in extra_fields:
+            return True
+    return False
+
+
 def _wrap_preprocessed_request(request: dict[str, Any]) -> dict[str, Any]:
     # Duplicated from dynamo.router/__main__.py since neither package exports
     # it. TODO(idhanani): file follow-up to lift this into dynamo.router as a
@@ -87,6 +104,23 @@ def _wrap_preprocessed_request(request: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _inject_thunderagent_route_proof(
+    chunk: Any,
+    proof: dict[str, Any],
+) -> None:
+    if not isinstance(chunk, dict):
+        return
+
+    engine_data = chunk.get("engine_data")
+    if engine_data is None:
+        engine_data = {}
+    elif not isinstance(engine_data, dict):
+        engine_data = {"backend_engine_data": engine_data}
+
+    engine_data["thunderagent"] = dict(proof)
+    chunk["engine_data"] = engine_data
+
+
 class ThunderAgentRouterHandler:
     def __init__(
         self,
@@ -99,6 +133,10 @@ class ThunderAgentRouterHandler:
         self._capacity: Optional[WorkerCapacityProvider] = None
         self._scheduler: Optional[ThunderAgentScheduler] = None
         self._worker_id_extract_warned = False
+        self._stat_requests_total = 0
+        self._stat_program_requests = 0
+        self._stat_passthrough_requests = 0
+        self._stat_session_final_requests = 0
 
     async def initialize(self) -> None:
         # Endpoint shape was validated by ThunderAgentRouterConfig.validate()
@@ -120,12 +158,18 @@ class ThunderAgentRouterHandler:
             config=self._config.to_thunderagent_config(),
         )
         self._scheduler.start()
+        logger.info(
+            "ThunderAgent Router initialized (worker_endpoint=%s, block_size=%s)",
+            self._config.endpoint,
+            self._config.router_block_size,
+        )
 
     async def shutdown(self) -> None:
         if self._scheduler is not None:
             await self._scheduler.stop()
         if self._capacity is not None:
             self._capacity.stop()
+        logger.info("ThunderAgent Router shutdown complete")
 
     async def generate(self, request: dict[str, Any]):
         if self._scheduler is None or self._kv_router is None:
@@ -133,23 +177,54 @@ class ThunderAgentRouterHandler:
                 "ThunderAgentRouterHandler used before initialize() was called"
             )
         program_id = _extract_program_id(request)
+        want_route_proof = _nvext_extra_field_requested(request, "engine_data")
+        self._stat_requests_total += 1
 
         # A request marked session_final just releases the program from the
         # table and is NOT forwarded to the engine (short-circuit).
         if program_id is not None and _is_session_final(request):
-            await self._scheduler.end_program(program_id)
+            self._stat_session_final_requests += 1
+            released = await self._scheduler.end_program(program_id)
+            logger.info(
+                "thunderagent.route path=session_final program=%s released=%s",
+                program_id,
+                released,
+            )
             return
 
         # Path A: no program_id -> behave like the standalone router.
         if program_id is None:
+            self._stat_passthrough_requests += 1
+            logger.debug(
+                "thunderagent.route path=passthrough model=%s", request.get("model")
+            )
             preprocessed = _wrap_preprocessed_request(request)
+            proof: Optional[dict[str, Any]] = (
+                {
+                    "handled_by": "thunderagent_router",
+                    "path": "passthrough",
+                    "program_id": None,
+                    "session_final": False,
+                }
+                if want_route_proof
+                else None
+            )
+            first_chunk = True
             async for chunk in await self._kv_router.generate_from_request(
                 preprocessed  # type: ignore[arg-type]
             ):
+                if proof is not None:
+                    if first_chunk:
+                        first_chunk = False
+                        selected_worker = self._extract_worker_id(chunk)
+                        if selected_worker is not None:
+                            proof["selected_worker_id"] = selected_worker
+                    _inject_thunderagent_route_proof(chunk, proof)
                 yield chunk
             return
 
         # Path B: program lifecycle.
+        self._stat_program_requests += 1
         token_ids = request["token_ids"]
         estimated_prompt_tokens = len(token_ids) if isinstance(token_ids, list) else 0
 
@@ -158,6 +233,18 @@ class ThunderAgentRouterHandler:
             estimated_prompt_tokens=estimated_prompt_tokens,
         )
         worker_pin = decision.assigned_worker_hint
+        logger.debug(
+            "thunderagent.route path=program program=%s prompt_tokens=%d "
+            "worker_hint=%s waited_seconds=%.4f was_paused=%s "
+            "soft_demoted=%s priority_jump=%.3f",
+            program_id,
+            estimated_prompt_tokens,
+            worker_pin,
+            decision.waited_seconds,
+            decision.was_paused,
+            decision.was_soft_demoted,
+            decision.priority_jump,
+        )
 
         preprocessed = _wrap_preprocessed_request(request)
         if decision.priority_jump != 0.0:
@@ -175,6 +262,22 @@ class ThunderAgentRouterHandler:
         completion_tokens_seen = 0
         usage_completion_seen = False
         first_chunk = True
+        selected_worker_id = None
+        proof = (
+            {
+                "handled_by": "thunderagent_router",
+                "path": "program",
+                "program_id": program_id,
+                "session_final": False,
+                "was_paused": decision.was_paused,
+                "was_soft_demoted": decision.was_soft_demoted,
+                "waited_seconds": decision.waited_seconds,
+                "priority_jump": decision.priority_jump,
+                "assigned_worker_hint": worker_pin,
+            }
+            if want_route_proof
+            else None
+        )
         try:
             async for chunk in await self._kv_router.generate_from_request(
                 preprocessed  # type: ignore[arg-type]
@@ -184,6 +287,15 @@ class ThunderAgentRouterHandler:
                     selected_worker = self._extract_worker_id(chunk)
                     if selected_worker is not None:
                         await self._scheduler.assign_worker(program_id, selected_worker)
+                        selected_worker_id = selected_worker
+                        if proof is not None:
+                            proof["selected_worker_id"] = selected_worker
+                        logger.debug(
+                            "thunderagent.route_selected program=%s worker=%s "
+                            "source=first_chunk",
+                            program_id,
+                            selected_worker,
+                        )
 
                 usage = (
                     chunk.get("completion_usage") if isinstance(chunk, dict) else None
@@ -205,6 +317,8 @@ class ThunderAgentRouterHandler:
                         completion_tokens_seen += len(token_ids_out)
                     self._scheduler.record_output_tokens(program_id, len(token_ids_out))
 
+                if proof is not None:
+                    _inject_thunderagent_route_proof(chunk, proof)
                 yield chunk
         finally:
             # Fall back to len(token_ids) if the engine didn't report usage --
@@ -216,6 +330,56 @@ class ThunderAgentRouterHandler:
                 prompt_tokens_seen,
                 completion_tokens_seen,
             )
+            logger.debug(
+                "thunderagent.request_complete program=%s prompt_tokens=%d "
+                "completion_tokens=%d worker_hint=%s selected_worker=%s",
+                program_id,
+                prompt_tokens_seen,
+                completion_tokens_seen,
+                worker_pin,
+                selected_worker_id,
+            )
+
+    async def status(self, request: Optional[dict[str, Any]] = None):
+        scheduler_status = (
+            await self._scheduler.status_snapshot()
+            if self._scheduler is not None
+            else None
+        )
+        yield {
+            "status": "ready" if self._scheduler is not None else "starting",
+            "component": "thunderagent_router",
+            "namespace": self._config.namespace,
+            "worker_endpoint": self._config.endpoint,
+            "scheduler": scheduler_status,
+            "requests": {
+                "total": self._stat_requests_total,
+                "program": self._stat_program_requests,
+                "passthrough": self._stat_passthrough_requests,
+                "session_final": self._stat_session_final_requests,
+            },
+        }
+
+    async def metrics(self, request: Optional[dict[str, Any]] = None):
+        scheduler_metrics = (
+            await self._scheduler.metrics_snapshot()
+            if self._scheduler is not None
+            else {"counters": {}, "gauges": {}, "workers": {}}
+        )
+        counters = {
+            **scheduler_metrics["counters"],
+            "requests_total": self._stat_requests_total,
+            "program_requests_total": self._stat_program_requests,
+            "passthrough_requests_total": self._stat_passthrough_requests,
+            "session_final_requests_total": self._stat_session_final_requests,
+        }
+        yield {
+            "component": "thunderagent_router",
+            "namespace": self._config.namespace,
+            "counters": counters,
+            "gauges": scheduler_metrics["gauges"],
+            "workers": scheduler_metrics["workers"],
+        }
 
     def _extract_worker_id(self, chunk: Any) -> Optional[int]:
         # Expects the shape set by ``inject_worker_id_from_tracker`` in the Python
@@ -234,8 +398,8 @@ class ThunderAgentRouterHandler:
             # ``WorkerIdInfo`` carries prefill/decode IDs (and DP ranks); there is no
             # nested ``worker_id`` key. The sticky pin is applied as
             # ``backend_instance_id``, which the frontend resolves to the decode/backend
-            # worker, so prefer ``decode_worker_id`` and fall back to ``prefill_worker_id``
-            # (identical in aggregated mode).
+            # worker, so prefer ``decode_worker_id`` and fall back to
+            # ``prefill_worker_id`` (identical in aggregated mode).
             worker_id = info.get("decode_worker_id")
             if not isinstance(worker_id, int):
                 worker_id = info.get("prefill_worker_id")
@@ -298,11 +462,35 @@ async def worker(runtime: DistributedRuntime) -> None:
             worker_type=WorkerType.Aggregated,
         )
 
+    status_endpoint = runtime.endpoint(f"{config.namespace}.thunderagent_router.status")
+    metrics_endpoint = runtime.endpoint(
+        f"{config.namespace}.thunderagent_router.metrics"
+    )
+
+    logger.info(
+        "ThunderAgent Router serving endpoints: generate=%s status=%s metrics=%s",
+        f"{config.namespace}.thunderagent_router.generate",
+        f"{config.namespace}.thunderagent_router.status",
+        f"{config.namespace}.thunderagent_router.metrics",
+    )
+
     try:
-        await generate_endpoint.serve_endpoint(
-            handler.generate,
-            graceful_shutdown=True,
-            metrics_labels=[("service", "thunderagent_router")],
+        await asyncio.gather(
+            generate_endpoint.serve_endpoint(
+                handler.generate,
+                graceful_shutdown=True,
+                metrics_labels=[("service", "thunderagent_router")],
+            ),
+            status_endpoint.serve_endpoint(
+                handler.status,
+                graceful_shutdown=True,
+                metrics_labels=[("service", "thunderagent_router")],
+            ),
+            metrics_endpoint.serve_endpoint(
+                handler.metrics,
+                graceful_shutdown=True,
+                metrics_labels=[("service", "thunderagent_router")],
+            ),
         )
     finally:
         await handler.shutdown()

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -14,7 +14,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from dynamo.thunderagent_router.capacity import WorkerCapacityProvider
 from dynamo.thunderagent_router.program_state import (
@@ -64,6 +64,14 @@ class ThunderAgentScheduler:
         self._lock = asyncio.Lock()
         self._scheduler_task: Optional[asyncio.Task] = None
         self._stat_forced_resumes = 0
+        self._stat_programs_created = 0
+        self._stat_programs_ended = 0
+        self._stat_requests_admitted = 0
+        self._stat_requests_paused = 0
+        self._stat_pauses = 0
+        self._stat_resumes = 0
+        self._stat_marked_for_pause = 0
+        self._stat_worker_assignments = 0
 
     def start(self) -> None:
         if self._scheduler_task is not None:
@@ -127,6 +135,10 @@ class ThunderAgentScheduler:
             if program is None:
                 return PauseDecision(program_id=program_id, waited_seconds=waited)
 
+            self._stat_requests_admitted += 1
+            if was_paused:
+                self._stat_requests_paused += 1
+
             priority_jump = self._cfg.resume_priority_boost if was_paused else 0.0
             soft_demoted = program.soft_demoted_until > time.monotonic()
             if soft_demoted:
@@ -149,6 +161,15 @@ class ThunderAgentScheduler:
         # Caller holds self._lock.
         was_new = program_id not in self._table.programs
         program = self._table.begin_request(program_id, estimated_prompt_tokens)
+        if was_new:
+            self._stat_programs_created += 1
+            logger.info(
+                "thunderagent.program created program=%s "
+                "estimated_prompt_tokens=%d active=%d",
+                program_id,
+                estimated_prompt_tokens,
+                len(self._table.programs),
+            )
         if program.lifecycle == ProgramLifecycle.PAUSED:
             program.waiting = program.waiting or asyncio.Event()
             return program.waiting, True
@@ -168,16 +189,20 @@ class ThunderAgentScheduler:
         )
         if worker_id is not None:
             program.assigned_worker_id = worker_id
+            self._stat_worker_assignments += 1
             return None, False
 
         # All workers full: queue until the scheduler tick resumes us.
         program.waiting = program.waiting or asyncio.Event()
         program.lifecycle = ProgramLifecycle.PAUSED
         self._table.paused[program_id] = None
-        logger.debug(
-            "Queued new program %s (tokens=%d)",
+        self._stat_pauses += 1
+        logger.info(
+            "thunderagent.program paused program=%s reason=admission_full "
+            "tokens=%d paused=%d",
             program_id,
             program.token_total,
+            len(self._table.paused),
         )
         return program.waiting, True
 
@@ -214,6 +239,7 @@ class ThunderAgentScheduler:
             program = self._table.programs.get(program_id)
             if program is not None:
                 program.assigned_worker_id = worker_id
+                self._stat_worker_assignments += 1
 
     async def _scheduler_loop(self) -> None:
         consecutive_failures = 0
@@ -346,6 +372,7 @@ class ThunderAgentScheduler:
                             and reasoning.status == ProgramStatus.REASONING
                         ):
                             reasoning.marked_for_pause = True
+                            self._stat_marked_for_pause += 1
                             marked_this_tick += 1
                         continue
                     break
@@ -380,12 +407,11 @@ class ThunderAgentScheduler:
                     or program.token_total < smallest_acting.token_total
                 ):
                     smallest_acting = program
-            elif program.status == ProgramStatus.REASONING:
-                if (
-                    smallest_reasoning is None
-                    or program.token_total < smallest_reasoning.token_total
-                ):
-                    smallest_reasoning = program
+            elif program.status == ProgramStatus.REASONING and (
+                smallest_reasoning is None
+                or program.token_total < smallest_reasoning.token_total
+            ):
+                smallest_reasoning = program
         return smallest_acting, smallest_reasoning
 
     async def _pause_acting(self, program_id: str) -> bool:
@@ -408,7 +434,14 @@ class ThunderAgentScheduler:
         else:
             program.waiting.clear()
         self._table.paused[program_id] = None
-        logger.debug("Paused program %s (tokens=%d)", program_id, program.token_total)
+        self._stat_pauses += 1
+        logger.info(
+            "thunderagent.program paused program=%s reason=pressure "
+            "tokens=%d paused=%d",
+            program_id,
+            program.token_total,
+            len(self._table.paused),
+        )
         return True
 
     async def end_program(self, program_id: str) -> bool:
@@ -427,8 +460,9 @@ class ThunderAgentScheduler:
                 program.waiting.set()  # unblock any coroutine paused on this program
                 program.waiting = None
             self._table.release(program_id)
+            self._stat_programs_ended += 1
             logger.info(
-                "Released program %s (%d remaining)",
+                "thunderagent.program terminated program=%s remaining=%d",
                 program_id,
                 len(self._table.programs),
             )
@@ -523,14 +557,112 @@ class ThunderAgentScheduler:
             return
         program.lifecycle = ProgramLifecycle.ACTIVE
         program.assigned_worker_id = target_worker_id
+        if target_worker_id is not None:
+            self._stat_worker_assignments += 1
         notify = program.waiting
         program.waiting = None
         self._table.paused.pop(program.program_id, None)
         if notify is not None:
             notify.set()
-        logger.debug(
-            "Resumed program %s -> worker=%s (tokens=%d)",
+        self._stat_resumes += 1
+        logger.info(
+            "thunderagent.program resumed program=%s worker=%s tokens=%d paused=%d",
             program.program_id,
             target_worker_id,
             program.token_total,
+            len(self._table.paused),
         )
+
+    def _worker_snapshot_locked(
+        self, capacities: dict[int, int]
+    ) -> dict[str, dict[str, Any]]:
+        """Build worker metrics while the scheduler lock is held."""
+        used = dict.fromkeys(capacities, 0)
+        used_decayed = dict.fromkeys(capacities, 0)
+        active_programs = dict.fromkeys(capacities, 0)
+
+        for program in self._table.programs.values():
+            worker_id = program.assigned_worker_id
+            if (
+                program.lifecycle != ProgramLifecycle.ACTIVE
+                or worker_id is None
+                or worker_id not in capacities
+            ):
+                continue
+            active_programs[worker_id] += 1
+            used[worker_id] += self._program_tokens(program)
+            used_decayed[worker_id] += self._program_tokens(program, decayed=True)
+
+        workers = {}
+        for worker_id, capacity in capacities.items():
+            buffer_tokens = active_programs[worker_id] * self._cfg.buffer_per_program
+            worker_used = used[worker_id] + buffer_tokens
+            worker_used_decayed = used_decayed[worker_id] + buffer_tokens
+            workers[str(worker_id)] = {
+                "capacity": capacity,
+                "used": worker_used,
+                "used_decayed": worker_used_decayed,
+                "utilization": worker_used / capacity if capacity else None,
+                "utilization_decayed": worker_used_decayed / capacity
+                if capacity
+                else None,
+                "active_programs": active_programs[worker_id],
+            }
+        return workers
+
+    async def status_snapshot(self) -> dict:
+        async with self._lock:
+            capacities = self._capacity.snapshot()
+            lifecycle_counts = {lifecycle.value: 0 for lifecycle in ProgramLifecycle}
+            status_counts = {status.value: 0 for status in ProgramStatus}
+            programs = []
+
+            for program in self._table.programs.values():
+                lifecycle_counts[program.lifecycle.value] += 1
+                status_counts[program.status.value] += 1
+                programs.append(
+                    {
+                        "program_id": program.program_id,
+                        "lifecycle": program.lifecycle.value,
+                        "status": program.status.value,
+                        "assigned_worker_id": program.assigned_worker_id,
+                        "token_total": program.token_total,
+                        "step_count": program.step_count,
+                        "marked_for_pause": program.marked_for_pause,
+                        "soft_demoted": program.soft_demoted_until > time.monotonic(),
+                    }
+                )
+
+            workers = self._worker_snapshot_locked(capacities)
+
+            return {
+                "programs_total": len(self._table.programs),
+                "paused_total": len(self._table.paused),
+                "lifecycle_counts": lifecycle_counts,
+                "status_counts": status_counts,
+                "workers": workers,
+                "programs": programs,
+            }
+
+    async def metrics_snapshot(self) -> dict:
+        async with self._lock:
+            workers = self._worker_snapshot_locked(self._capacity.snapshot())
+            return {
+                "counters": {
+                    "programs_created_total": self._stat_programs_created,
+                    "programs_ended_total": self._stat_programs_ended,
+                    "requests_admitted_total": self._stat_requests_admitted,
+                    "requests_paused_total": self._stat_requests_paused,
+                    "program_pauses_total": self._stat_pauses,
+                    "program_resumes_total": self._stat_resumes,
+                    "programs_marked_for_pause_total": self._stat_marked_for_pause,
+                    "forced_resumes_total": self._stat_forced_resumes,
+                    "worker_assignments_total": self._stat_worker_assignments,
+                },
+                "gauges": {
+                    "programs_total": len(self._table.programs),
+                    "paused_total": len(self._table.paused),
+                    "workers_total": len(workers),
+                },
+                "workers": workers,
+            }

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -61,6 +61,58 @@ async def test_after_request_records_real_tokens():
 
 
 @pytest.mark.asyncio
+async def test_status_snapshot_reports_programs_and_worker_utilization():
+    workers = {
+        1: 1000,
+        2: 500,
+    }
+    router, _ = make_router(capacity_workers=workers)
+
+    await router.before_request("p1", estimated_prompt_tokens=100)
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=25)
+    await router.before_request("p2", estimated_prompt_tokens=50)
+
+    snapshot = await router.status_snapshot()
+
+    assert snapshot["programs_total"] == 2
+    assert snapshot["paused_total"] == 0
+    assert snapshot["lifecycle_counts"]["active"] == 2
+    assert snapshot["status_counts"]["acting"] == 1
+    assert snapshot["status_counts"]["reasoning"] == 1
+    assert snapshot["workers"]["1"]["capacity"] == 1000
+    assert snapshot["workers"]["1"]["used"] == 225
+    assert snapshot["workers"]["1"]["active_programs"] == 1
+    assert {
+        (program["program_id"], program["assigned_worker_id"])
+        for program in snapshot["programs"]
+    } == {("p1", 1), ("p2", 2)}
+
+
+@pytest.mark.asyncio
+async def test_metrics_snapshot_reports_lifecycle_counters_and_gauges():
+    router, _ = make_router(capacity_workers={1: 1000})
+
+    await router.before_request("p1", estimated_prompt_tokens=100)
+    await router.after_request("p1", prompt_tokens=100, completion_tokens=20)
+    assert await router.end_program("p1") is True
+
+    async def fail_status_snapshot() -> dict:
+        raise AssertionError("metrics_snapshot must not build detailed status rows")
+
+    router.status_snapshot = fail_status_snapshot  # type: ignore[method-assign]
+
+    metrics = await router.metrics_snapshot()
+
+    assert metrics["counters"]["programs_created_total"] == 1
+    assert metrics["counters"]["programs_ended_total"] == 1
+    assert metrics["counters"]["requests_admitted_total"] == 1
+    assert metrics["counters"]["worker_assignments_total"] == 1
+    assert metrics["gauges"]["programs_total"] == 0
+    assert metrics["gauges"]["paused_total"] == 0
+    assert metrics["gauges"]["workers_total"] == 1
+
+
+@pytest.mark.asyncio
 async def test_before_request_records_exact_prompt_estimate_before_admission():
     router, _ = make_router()
     await router.before_request("p1", estimated_prompt_tokens=1234)
@@ -103,6 +155,8 @@ async def test_pause_acting_then_before_request_blocks_until_resume():
     assert decision.was_paused is True
     assert decision.priority_jump == cfg.resume_priority_boost
     assert decision.assigned_worker_hint == 1
+    metrics = await router.metrics_snapshot()
+    assert metrics["counters"]["worker_assignments_total"] == 2
 
 
 @pytest.mark.asyncio

--- a/docs/fern/pages/use-cases/agents/thunderagent-program-scheduler.md
+++ b/docs/fern/pages/use-cases/agents/thunderagent-program-scheduler.md
@@ -97,7 +97,36 @@ All `KvRouter` flags from `dynamo.router` (`--router-temperature`, `--use-kv-eve
 
 ## Observability
 
-The scheduler emits a per-tick INFO summary on each side of the control loop, so both pause and resume activity are visible at INFO without enabling DEBUG. Per-program detail stays at DEBUG.
+The router emits INFO logs for lifecycle transitions and DEBUG logs for per-request route decisions. These lines let you confirm that a request went through ThunderAgent, whether it was a one-off passthrough or a program-scoped turn, and which worker hint or selected worker was used.
+
+**Request routing** — logged at DEBUG once per request:
+
+```text
+thunderagent.route path=<program|passthrough|session_final> ...
+```
+
+For program-scoped traffic, the line includes `program`, `prompt_tokens`, `worker_hint`, `waited_seconds`, `was_paused`, `soft_demoted`, and `priority_jump`. When the first response chunk carries backend worker attribution, the router also logs at DEBUG:
+
+```text
+thunderagent.route_selected program=<program_id> worker=<id> source=first_chunk
+```
+
+**Lifecycle transitions** — logged when a program is created, paused, resumed, or terminated:
+
+```text
+thunderagent.program created program=<program_id> ...
+thunderagent.program paused program=<program_id> reason=<admission_full|pressure> ...
+thunderagent.program resumed program=<program_id> worker=<id> ...
+thunderagent.program terminated program=<program_id> ...
+```
+
+**Request completion** — logged at DEBUG after token accounting runs:
+
+```text
+thunderagent.request_complete program=<program_id> prompt_tokens=<n> completion_tokens=<n> ...
+```
+
+The scheduler also emits a per-tick INFO summary on each side of the control loop, so both pause and resume activity are visible at INFO without enabling DEBUG.
 
 **Pause side** — logged when a worker pauses or marks any program in a tick:
 
@@ -115,14 +144,18 @@ scheduler.tick resumed=<N> still_paused=<M>
 
 `resumed` is the number of programs resumed this tick and `still_paused` is the size of the paused table afterward. This line is symmetric to the pause-side summary; before it existed, pause was observable at INFO but resume was only visible at DEBUG, leaving a gap when reconstructing a control-loop cycle from INFO logs alone.
 
-**Per-program detail (DEBUG):**
+### Status and Metrics Endpoints
 
-```text
-Paused program <program_id> (tokens=<n>)
-Resumed program <program_id> -> worker=<id> (tokens=<n>)
-```
+ThunderAgent serves two Dynamo runtime endpoints alongside `generate`:
 
-Enable these by lowering the log level for `dynamo.thunderagent_router`. They give the exact program identities behind each INFO summary count.
+- `<namespace>.thunderagent_router.status` returns scheduler state, active/paused program counts, per-program lifecycle state, per-worker utilization, and request counters.
+- `<namespace>.thunderagent_router.metrics` returns counters and gauges shaped for quick operational checks, including created/ended programs, admitted/paused requests, pause/resume totals, forced resumes, and per-worker utilization.
+
+These are Dynamo runtime endpoints, not public OpenAI HTTP routes. Use them from another Dynamo component or a small runtime client connected to the same namespace.
+
+### Response Route Proof
+
+For response-level debugging, request `nvext.extra_fields=["engine_data"]`. Only when that field is requested, ThunderAgent adds a `thunderagent` object under `nvext.engine_data` on generated chunks, with fields such as `handled_by`, `path`, `program_id`, `was_paused`, `waited_seconds`, `priority_jump`, `assigned_worker_hint`, and `selected_worker_id` when worker attribution is available.
 
 For per-request tracing (token counts, cache hits, worker placement), the router also integrates with [Agent Tracing](agent-tracing.md#enable-output): set `DYN_REQUEST_TRACE=1` on the frontend to land a `request_end` record per LLM call. Harness tool-event spans are separate: they require `DYN_REQUEST_TRACE_TOOL_EVENTS_ZMQ_ENDPOINT` plus a configured publisher.
 


### PR DESCRIPTION
## Overview

Adds ThunderAgent router observability so operators can verify that traffic passed through ThunderAgent and inspect the scheduler's live program and worker state.

## Details

- Adds INFO logs for program creation, pause, resume, termination, scheduler activity, and session-final cleanup.
- Adds DEBUG logs for per-request route decisions, backend worker attribution, and request completion.
- Adds Dynamo runtime endpoints for `<namespace>.thunderagent_router.status` and `<namespace>.thunderagent_router.metrics`.
- Adds opt-in route proof under `nvext.engine_data.thunderagent` when callers request `nvext.extra_fields=["engine_data"]`.
- Adds scheduler snapshots and counters for active and paused programs, per-worker utilization, lifecycle activity, worker assignments, and request categories.
- Counts worker assignments made when paused or queued programs resume on a selected worker.
- Documents the logs, runtime endpoints, and response proof path.

## Where should the reviewer start?

Start with `components/src/dynamo/thunderagent_router/__main__.py` for request classification, route proof injection, and runtime endpoint registration. Then review `components/src/dynamo/thunderagent_router/router.py` for lifecycle counters, snapshots, and logs.

Focused handler coverage is in `components/src/dynamo/thunderagent_router/tests/test_main.py`; scheduler snapshot and counter coverage is in `components/src/dynamo/thunderagent_router/tests/test_router.py`.

## Related Issues

**This PR is linked to an issue:**

- Relates to #12016

## Validation

- ThunderAgent unit suite: `30 passed`.
- Repository pre-commit hooks passed for the modified Python files, including isort, Black, Flake8, Ruff, codespell, merge-conflict checks, and pytest marker validation.
- `python3 -m py_compile` passed for the router implementation and tests.
- `git diff --check` passed.
- Rebased cleanly onto the latest upstream `main`.

Validated the production request path on the existing AKS A100 cluster using a separate CPU-only ThunderAgent router pod connected to the running Qwen3-0.6B A100 backend:

- The `generate`, `status`, and `metrics` runtime endpoints registered and were discoverable.
- A program-scoped request generated normally on the A100 backend.
- Route proof appeared on generated chunks when `nvext.extra_fields=["engine_data"]` was requested and was absent without that opt-in.
- The status endpoint reported live programs, worker assignments, token totals, and worker utilization.
- The metrics endpoint reported request, program, assignment, and session-final counters and gauges.
- A session-final request returned an empty stream and removed the intended program; focused unit coverage confirms this path does not call the backend router.
- INFO logs showed program creation, termination, and session-final cleanup.
- The original DGD remained `Ready=True`, and all temporary validation resources were removed.

The resumed-worker assignment counter is additionally covered by a focused scheduler regression test that pauses a program, resumes it on another worker, and verifies both assignments are counted.
