### PR TITLE
fix(llm): GLM-5.2 chat template compatibility — argument normalization and tool_call recovery

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2973,18 +2973,15 @@ impl OpenAIPreprocessor {
                 p.template = Some(metrics);
             }
             // Buffer input content only for glm47 (truncation recovery).
-            if is_glm47 {
-                if let Some(data) = &a.data {
-                    let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
-                    for choice in &data.inner.choices {
-                        if let Some(ChatCompletionMessageContent::Text(content)) =
-                            &choice.delta.content
-                        {
-                            cr.entry(choice.index)
-                                .or_default()
-                                .input_text
-                                .push_str(content);
-                        }
+            if is_glm47 && let Some(data) = &a.data {
+                let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
+                for choice in &data.inner.choices {
+                    if let Some(ChatCompletionMessageContent::Text(content)) = &choice.delta.content
+                    {
+                        cr.entry(choice.index)
+                            .or_default()
+                            .input_text
+                            .push_str(content);
                     }
                 }
             }
@@ -3035,46 +3032,42 @@ impl OpenAIPreprocessor {
             // <tool_call> markup — callers that require strict "no tool tags in content"
             // must filter on finish_reason=length.
             let mut recoveries: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
-            if is_glm47 {
-                if let Some(ref data) = nv_chunk.data {
-                    let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
-                    for choice in &data.inner.choices {
-                        let state = cr.entry(choice.index).or_default();
-                        if matches!(
-                            choice.finish_reason,
-                            Some(dynamo_protocols::types::FinishReason::Length)
-                        ) {
-                            let recovered =
-                                state.input_text.rfind("<tool_call>").and_then(|start| {
-                                    let tail = &state.input_text[start..];
-                                    if !tail.contains("</tool_call>") {
-                                        Some(tail.to_string())
-                                    } else {
-                                        None
-                                    }
-                                });
-                            if let Some(recovered) = recovered {
-                                tracing::warn!(
-                                    choice_index = choice.index,
-                                    recovered_bytes = recovered.len(),
-                                    "glm47 streaming: partial <tool_call> emitted as content \
-                                     on length finish (TRT-LLM parity; raw markup in content)"
-                                );
-                                let mut rec = nv_chunk.clone();
-                                if let Some(ref mut rd) = rec.data {
-                                    rd.inner.usage = None;
-                                    rd.llm_metrics = None;
-                                    rd.inner.choices.retain(|c| c.index == choice.index);
-                                    for rc in &mut rd.inner.choices {
-                                        rc.delta.content = Some(
-                                            ChatCompletionMessageContent::Text(recovered.clone()),
-                                        );
-                                        rc.delta.tool_calls = None;
-                                        rc.finish_reason = None;
-                                    }
-                                }
-                                recoveries.push(rec);
+            if is_glm47 && let Some(ref data) = nv_chunk.data {
+                let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
+                for choice in &data.inner.choices {
+                    let state = cr.entry(choice.index).or_default();
+                    if matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    ) {
+                        let recovered = state.input_text.rfind("<tool_call>").and_then(|start| {
+                            let tail = &state.input_text[start..];
+                            if !tail.contains("</tool_call>") {
+                                Some(tail.to_string())
+                            } else {
+                                None
                             }
+                        });
+                        if let Some(recovered) = recovered {
+                            tracing::warn!(
+                                choice_index = choice.index,
+                                recovered_bytes = recovered.len(),
+                                "glm47 streaming: partial <tool_call> emitted as content \
+                                 on length finish (TRT-LLM parity; raw markup in content)"
+                            );
+                            let mut rec = nv_chunk.clone();
+                            if let Some(ref mut rd) = rec.data {
+                                rd.inner.usage = None;
+                                rd.llm_metrics = None;
+                                rd.inner.choices.retain(|c| c.index == choice.index);
+                                for rc in &mut rd.inner.choices {
+                                    rc.delta.content =
+                                        Some(ChatCompletionMessageContent::Text(recovered.clone()));
+                                    rc.delta.tool_calls = None;
+                                    rc.finish_reason = None;
+                                }
+                            }
+                            recoveries.push(rec);
                         }
                     }
                 }
@@ -3774,6 +3767,7 @@ impl
             &next,
             &self.formatter,
             &self.tokenizer,
+            self.tool_arguments_mode,
         );
 
         let final_stream = crate::request_trace::wrap_chat_request_end_stream(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -76,7 +76,10 @@ use crate::protocols::{
 };
 use crate::tokenizers::traits::Tokenizer;
 
-use crate::preprocessor::prompt::{MediaRequestExt, prompt_formatter_from_mdc};
+use crate::preprocessor::prompt::{
+    MediaRequestExt, ToolArgumentsMode, ToolArgumentsModeGuard, detect_tool_arguments_mode,
+    mdc_jinja_template_text, prompt_formatter_from_mdc,
+};
 use dynamo_renderer::{OAIChatLikeRequest, PromptFormatter, PromptInput, TextInput, TokenInput};
 
 pub use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
@@ -326,6 +329,10 @@ pub struct OpenAIPreprocessor {
     /// KV cache block size published in the model deployment card.
     kv_cache_block_size: usize,
     tool_call_parser: Option<String>,
+    /// Whether the loaded chat template requires tool_calls[*].function.arguments
+    /// as a parsed serde_json object (vs. the OpenAI wire-schema JSON string).
+    /// Derived once from the Jinja template source at construction.
+    tool_arguments_mode: ToolArgumentsMode,
     media_loader: Option<MediaLoader>,
     /// Max context length (in tokens) this model can handle, from ModelDeploymentCard
     context_length: u32,
@@ -658,6 +665,12 @@ impl OpenAIPreprocessor {
         };
         let model_info = model_info.get_model_info()?;
         let tool_call_parser = mdc.runtime_config.tool_call_parser.clone();
+        // Detect argument mode from the Jinja template source once at construction.
+        // Falls back to JsonString (no-op normalization) for models without a .jinja file.
+        let tool_arguments_mode = mdc_jinja_template_text(&mdc)
+            .as_deref()
+            .map(detect_tool_arguments_mode)
+            .unwrap_or_default();
 
         if let Some(ref lora_name) = lora_name {
             tracing::info!(model = %mdc.display_name, lora_name, "LoRA adapter detected in MDC");
@@ -850,6 +863,7 @@ impl OpenAIPreprocessor {
             runtime_config,
             kv_cache_block_size,
             tool_call_parser,
+            tool_arguments_mode,
             media_loader,
             context_length,
             #[cfg(feature = "mm-routing")]
@@ -919,6 +933,7 @@ impl OpenAIPreprocessor {
         let template_start = Instant::now();
         let formatted_prompt = {
             let _nvtx = dynamo_nvtx_range!("preprocess.template");
+            let _mode_guard = ToolArgumentsModeGuard::new(self.tool_arguments_mode);
             self.apply_template(request)
                 .with_context(|| "Failed to apply prompt template")?
         };

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2953,12 +2953,40 @@ impl OpenAIPreprocessor {
         let pending = Arc::new(Mutex::new(PendingMetrics::default()));
         let pending_in = Arc::clone(&pending);
 
+        // Per-choice recovery state — allocated only for glm47 since only that
+        // parser emits <tool_call> XML that can be truncated at max_tokens.
+        // Buffers raw input per choice.index so n > 1 is handled correctly.
+        #[derive(Default)]
+        struct ChoiceRecovery {
+            input_text: String,
+        }
+        let is_glm47 = tool_call_parser.as_deref() == Some("glm47");
+        let choice_recovery: Arc<Mutex<std::collections::HashMap<u32, ChoiceRecovery>>> =
+            Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let choice_recovery_in = Arc::clone(&choice_recovery);
+
         // dynamo `Annotated<Nv>` -> jail `Annotated<Create>` (buffer llm_metrics)
         let jail_input = stream.map(move |mut a| {
             if let Some(metrics) = a.data.as_mut().and_then(|nv| nv.llm_metrics.take()) {
                 let mut p = pending_in.lock().expect("jail metrics buffer poisoned");
                 p.chunk_tokens = p.chunk_tokens.saturating_add(metrics.chunk_tokens);
                 p.template = Some(metrics);
+            }
+            // Buffer input content only for glm47 (truncation recovery).
+            if is_glm47 {
+                if let Some(data) = &a.data {
+                    let mut cr = choice_recovery_in.lock().expect("choice recovery poisoned");
+                    for choice in &data.inner.choices {
+                        if let Some(ChatCompletionMessageContent::Text(content)) =
+                            &choice.delta.content
+                        {
+                            cr.entry(choice.index)
+                                .or_default()
+                                .input_text
+                                .push_str(content);
+                        }
+                    }
+                }
             }
             JailAnnotated {
                 data: a.data.map(|nv| nv.inner),
@@ -2977,7 +3005,7 @@ impl OpenAIPreprocessor {
             uses_tool_call_structural_tag,
             jail_input,
         )
-        .map(move |a| {
+        .flat_map(move |a| {
             // Stamp the accumulated metrics onto the next emitted data chunk;
             // data-less/synthesized chunks carry it forward (or `None`).
             let llm_metrics = a.data.as_ref().and_then(|_| {
@@ -2989,7 +3017,7 @@ impl OpenAIPreprocessor {
                     metrics
                 })
             });
-            Annotated {
+            let nv_chunk = Annotated {
                 data: a.data.map(|inner| NvCreateChatCompletionStreamResponse {
                     inner,
                     nvext: None,
@@ -2999,7 +3027,63 @@ impl OpenAIPreprocessor {
                 event: a.event,
                 comment: a.comment,
                 error: a.error.map(DynamoError::msg),
+            };
+
+            // glm47: on finish_reason=length, recover the last incomplete <tool_call>
+            // block. rfind skips complete blocks, so earlier parsed tool calls are
+            // never duplicated as raw content. Recovered content WILL contain raw
+            // <tool_call> markup — callers that require strict "no tool tags in content"
+            // must filter on finish_reason=length.
+            let mut recoveries: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = Vec::new();
+            if is_glm47 {
+                if let Some(ref data) = nv_chunk.data {
+                    let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
+                    for choice in &data.inner.choices {
+                        let state = cr.entry(choice.index).or_default();
+                        if matches!(
+                            choice.finish_reason,
+                            Some(dynamo_protocols::types::FinishReason::Length)
+                        ) {
+                            let recovered =
+                                state.input_text.rfind("<tool_call>").and_then(|start| {
+                                    let tail = &state.input_text[start..];
+                                    if !tail.contains("</tool_call>") {
+                                        Some(tail.to_string())
+                                    } else {
+                                        None
+                                    }
+                                });
+                            if let Some(recovered) = recovered {
+                                tracing::warn!(
+                                    choice_index = choice.index,
+                                    recovered_bytes = recovered.len(),
+                                    "glm47 streaming: partial <tool_call> emitted as content \
+                                     on length finish (TRT-LLM parity; raw markup in content)"
+                                );
+                                let mut rec = nv_chunk.clone();
+                                if let Some(ref mut rd) = rec.data {
+                                    rd.inner.usage = None;
+                                    rd.llm_metrics = None;
+                                    rd.inner.choices.retain(|c| c.index == choice.index);
+                                    for rc in &mut rd.inner.choices {
+                                        rc.delta.content = Some(
+                                            ChatCompletionMessageContent::Text(recovered.clone()),
+                                        );
+                                        rc.delta.tool_calls = None;
+                                        rc.finish_reason = None;
+                                    }
+                                }
+                                recoveries.push(rec);
+                            }
+                        }
+                    }
+                }
             }
+
+            let mut out = Vec::with_capacity(recoveries.len() + 1);
+            out.extend(recoveries);
+            out.push(nv_chunk);
+            futures::stream::iter(out)
         })
     }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -35,13 +35,335 @@ pub trait MediaRequestExt {
     fn media_io_kwargs(&self) -> Option<&MediaDecoder>;
 }
 
+/// How a chat template expects tool_calls[*].function.arguments to be passed.
+/// Inferred once from the Jinja source at formatter construction; never from the
+/// served model name, which is arbitrary and not reliable for template detection.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ToolArgumentsMode {
+    /// Template receives arguments as a JSON-object string (OpenAI wire default).
+    #[default]
+    JsonString,
+    /// Template calls `.items()` on arguments (e.g. GLM-5.2's
+    /// `{% for k, v in _args.items() %}`), so arguments must be a parsed object.
+    ParsedObject,
+}
+
+pub fn detect_tool_arguments_mode(template: &str) -> ToolArgumentsMode {
+    // GLM-5.2: `{% set _args = tc.arguments %}{% for k, v in _args.items() %}`
+    if template.contains("_args.items()") || template.contains("arguments.items()") {
+        ToolArgumentsMode::ParsedObject
+    } else {
+        ToolArgumentsMode::JsonString
+    }
+}
+
+thread_local! {
+    /// Argument mode for the current formatter.render() call. Set by the preprocessor
+    /// immediately before the synchronous `apply_template` invocation; never across an
+    /// `.await` point. Using a thread-local avoids adding a field to
+    /// `NvCreateChatCompletionRequest` (which would require updating every struct literal).
+    static RENDER_TOOL_ARGUMENTS_MODE: std::cell::Cell<ToolArgumentsMode> =
+        const { std::cell::Cell::new(ToolArgumentsMode::JsonString) };
+}
+
+/// RAII guard that sets the thread-local tool-argument mode for the duration of a
+/// synchronous rendering call and restores the previous mode on drop.
+///
+/// SAFETY: Only use in a *synchronous* (non-`async`) scope with no `.await`
+/// between guard creation and drop. Thread-locals are not preserved across
+/// async executor boundaries — the task may resume on a different OS thread.
+pub(crate) struct ToolArgumentsModeGuard {
+    previous: ToolArgumentsMode,
+}
+
+impl ToolArgumentsModeGuard {
+    pub(crate) fn new(mode: ToolArgumentsMode) -> Self {
+        let previous = RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.replace(mode));
+        Self { previous }
+    }
+}
+
+impl Drop for ToolArgumentsModeGuard {
+    fn drop(&mut self) {
+        RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.set(self.previous));
+    }
+}
+
+pub(crate) fn get_tool_arguments_mode_for_render() -> ToolArgumentsMode {
+    RENDER_TOOL_ARGUMENTS_MODE.with(|m| m.get())
+}
+
+/// Extract the Jinja template source from a ModelDeploymentCard for analysis.
+///
+/// Priority order:
+/// 1. `mdc.chat_template_file` — standalone `.jinja` or `chat_template.json` file.
+/// 2. `mdc.prompt_formatter` — `tokenizer_config.json` with an embedded
+///    `"chat_template"` string (the normal HF layout for most models).
+///
+/// This covers both layouts so models that ship only a tokenizer config are not
+/// silently left in [`ToolArgumentsMode::JsonString`] when their template calls
+/// `.items()` on tool-call arguments.
+pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
+    fn read_embedded(checked_file: &crate::common::checked_file::CheckedFile) -> Option<String> {
+        let path = checked_file.path()?;
+        let contents = std::fs::read_to_string(path).ok()?;
+        let config: serde_json::Value = serde_json::from_str(&contents).ok()?;
+        let value = config.get("chat_template")?;
+        if let Some(s) = value.as_str() {
+            return Some(s.to_owned());
+        }
+        // Some HF configs store templates as [{name, template}, ...]. Concatenate
+        // so .items() in any variant is visible to detect_tool_arguments_mode.
+        if let Some(arr) = value.as_array() {
+            let combined: String = arr
+                .iter()
+                .filter_map(|v| v.get("template").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("\n");
+            if !combined.is_empty() {
+                return Some(combined);
+            }
+        }
+        None
+    }
+
+    if let Some(artifact) = mdc.chat_template_file.as_ref() {
+        match artifact {
+            PromptFormatterArtifact::HfChatTemplateJinja { file, .. } => {
+                if let Some(path) = file.path() {
+                    if let Ok(s) = std::fs::read_to_string(path) {
+                        return Some(s);
+                    }
+                }
+            }
+            // HfChatTemplateJson and HfTokenizerConfigJson both embed the template
+            // under the "chat_template" JSON key; read_embedded handles both.
+            PromptFormatterArtifact::HfChatTemplateJson { file, .. }
+            | PromptFormatterArtifact::HfTokenizerConfigJson(file) => {
+                if let Some(s) = read_embedded(file) {
+                    return Some(s);
+                }
+            }
+        }
+    }
+
+    // Fallback: normal HF layout stores tokenizer_config.json in mdc.prompt_formatter;
+    // chat_template_file is None unless a separate template file was present.
+    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref() {
+        if let Some(s) = read_embedded(f) {
+            return Some(s);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_mode_glm_items_pattern() {
+        let glm_snippet = r#"
+            {%- set _args = tc.arguments -%}
+            {%- for k, v in _args.items() -%}
+        "#;
+        assert_eq!(
+            detect_tool_arguments_mode(glm_snippet),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_direct_arguments_items() {
+        assert_eq!(
+            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_standard_template_no_items() {
+        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
+        assert_eq!(
+            detect_tool_arguments_mode(standard),
+            ToolArgumentsMode::JsonString
+        );
+    }
+
+    #[test]
+    fn normalize_parses_json_string_to_object() {
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "read",
+                    "arguments": r#"{"path": "/tmp/foo"}"#
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(
+            args.is_object(),
+            "arguments should be an object after normalization"
+        );
+        assert_eq!(args["path"], "/tmp/foo");
+    }
+
+    #[test]
+    fn normalize_ignores_non_assistant_messages() {
+        let mut msgs = serde_json::json!([{
+            "role": "user",
+            "content": "hello"
+        }]);
+        let original = msgs.clone();
+        normalize_tool_call_arguments(&mut msgs);
+        assert_eq!(msgs, original);
+    }
+
+    #[test]
+    fn normalize_skips_already_object_arguments() {
+        // If somehow arguments is already an object, it should remain unchanged.
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "f",
+                    "arguments": {"key": "val"}
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_object());
+        assert_eq!(args["key"], "val");
+    }
+
+    /// Test that mdc_jinja_template_text reads the embedded chat_template
+    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
+    #[test]
+    fn mdc_template_text_reads_prompt_formatter_embedded() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tc_path = dir.path().join("tokenizer_config.json");
+        std::fs::write(
+            &tc_path,
+            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
+
+        // Build a minimal MDC with only prompt_formatter set.
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
+
+        let text = mdc_jinja_template_text(&mdc).expect("should find template");
+        assert!(
+            text.contains("_args.items()"),
+            "extracted template should contain .items() pattern"
+        );
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
+    #[test]
+    fn mdc_template_text_reads_chat_template_json() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chat_template.json");
+        std::fs::write(
+            &path,
+            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
+
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
+            file: checked,
+            is_custom: false,
+        });
+
+        let text = mdc_jinja_template_text(&mdc).expect("template");
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+}
+
+/// Parse `tool_calls[*].function.arguments` from JSON string to object in a
+/// serialized messages array before handing it to MiniJinja.
+/// Only applied when `ToolArgumentsMode::ParsedObject` is detected from the template.
+pub(crate) fn normalize_tool_call_arguments(messages_json: &mut serde_json::Value) {
+    let Some(messages) = messages_json.as_array_mut() else {
+        return;
+    };
+    for message in messages {
+        let Some(tool_calls) = message
+            .get_mut("tool_calls")
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            continue;
+        };
+        for tc in tool_calls.iter_mut() {
+            let Some(args_str) = tc.pointer("/function/arguments").and_then(|v| v.as_str()) else {
+                continue;
+            };
+            let value = match serde_json::from_str::<serde_json::Value>(args_str) {
+                Ok(v) if v.is_object() => v,
+                Ok(_) => {
+                    // Scalar or array — GLM's .items() would panic at render time.
+                    tracing::warn!(
+                        args_len = args_str.len(),
+                        "tool_call arguments parsed to a non-object; \
+                         substituting {{}} for GLM template safety"
+                    );
+                    serde_json::Value::Object(serde_json::Map::new())
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        args_len = args_str.len(),
+                        "tool_call arguments are not valid JSON; \
+                         substituting {{}} for GLM template safety"
+                    );
+                    serde_json::Value::Object(serde_json::Map::new())
+                }
+            };
+            if let Some(obj) = tc
+                .get_mut("function")
+                .and_then(serde_json::Value::as_object_mut)
+            {
+                obj.insert("arguments".to_string(), value);
+            }
+        }
+    }
+}
+
 impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     fn model(&self) -> String {
         self.inner.model.clone()
     }
 
     fn messages(&self) -> Value {
-        let messages_json = serde_json::to_value(&self.inner.messages).unwrap();
+        let mut messages_json = serde_json::to_value(&self.inner.messages).unwrap();
+        // Normalize tool_calls[*].function.arguments from JSON string to object when
+        // the loaded Jinja template requires dict args (e.g. GLM-5.2 .items() call).
+        // The mode is written by OpenAIPreprocessor::preprocess before template render.
+        if get_tool_arguments_mode_for_render() == ToolArgumentsMode::ParsedObject {
+            normalize_tool_call_arguments(&mut messages_json);
+        }
         Value::from_serialize(&messages_json)
     }
 

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -130,10 +130,10 @@ pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
     if let Some(artifact) = mdc.chat_template_file.as_ref() {
         match artifact {
             PromptFormatterArtifact::HfChatTemplateJinja { file, .. } => {
-                if let Some(path) = file.path() {
-                    if let Ok(s) = std::fs::read_to_string(path) {
-                        return Some(s);
-                    }
+                if let Some(path) = file.path()
+                    && let Ok(s) = std::fs::read_to_string(path)
+                {
+                    return Some(s);
                 }
             }
             // HfChatTemplateJson and HfTokenizerConfigJson both embed the template
@@ -149,158 +149,13 @@ pub fn mdc_jinja_template_text(mdc: &ModelDeploymentCard) -> Option<String> {
 
     // Fallback: normal HF layout stores tokenizer_config.json in mdc.prompt_formatter;
     // chat_template_file is None unless a separate template file was present.
-    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref() {
-        if let Some(s) = read_embedded(f) {
-            return Some(s);
-        }
+    if let Some(PromptFormatterArtifact::HfTokenizerConfigJson(f)) = mdc.prompt_formatter.as_ref()
+        && let Some(s) = read_embedded(f)
+    {
+        return Some(s);
     }
 
     None
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn detect_mode_glm_items_pattern() {
-        let glm_snippet = r#"
-            {%- set _args = tc.arguments -%}
-            {%- for k, v in _args.items() -%}
-        "#;
-        assert_eq!(
-            detect_tool_arguments_mode(glm_snippet),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    #[test]
-    fn detect_mode_direct_arguments_items() {
-        assert_eq!(
-            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    #[test]
-    fn detect_mode_standard_template_no_items() {
-        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
-        assert_eq!(
-            detect_tool_arguments_mode(standard),
-            ToolArgumentsMode::JsonString
-        );
-    }
-
-    #[test]
-    fn normalize_parses_json_string_to_object() {
-        let mut msgs = serde_json::json!([{
-            "role": "assistant",
-            "tool_calls": [{
-                "function": {
-                    "name": "read",
-                    "arguments": r#"{"path": "/tmp/foo"}"#
-                }
-            }]
-        }]);
-        normalize_tool_call_arguments(&mut msgs);
-        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
-        assert!(
-            args.is_object(),
-            "arguments should be an object after normalization"
-        );
-        assert_eq!(args["path"], "/tmp/foo");
-    }
-
-    #[test]
-    fn normalize_ignores_non_assistant_messages() {
-        let mut msgs = serde_json::json!([{
-            "role": "user",
-            "content": "hello"
-        }]);
-        let original = msgs.clone();
-        normalize_tool_call_arguments(&mut msgs);
-        assert_eq!(msgs, original);
-    }
-
-    #[test]
-    fn normalize_skips_already_object_arguments() {
-        // If somehow arguments is already an object, it should remain unchanged.
-        let mut msgs = serde_json::json!([{
-            "role": "assistant",
-            "tool_calls": [{
-                "function": {
-                    "name": "f",
-                    "arguments": {"key": "val"}
-                }
-            }]
-        }]);
-        normalize_tool_call_arguments(&mut msgs);
-        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
-        assert!(args.is_object());
-        assert_eq!(args["key"], "val");
-    }
-
-    /// Test that mdc_jinja_template_text reads the embedded chat_template
-    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
-    #[test]
-    fn mdc_template_text_reads_prompt_formatter_embedded() {
-        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
-
-        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
-        let dir = tempfile::tempdir().expect("tempdir");
-        let tc_path = dir.path().join("tokenizer_config.json");
-        std::fs::write(
-            &tc_path,
-            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
-        )
-        .expect("write");
-
-        let checked =
-            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
-
-        // Build a minimal MDC with only prompt_formatter set.
-        let mut mdc = ModelDeploymentCard::default();
-        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
-
-        let text = mdc_jinja_template_text(&mdc).expect("should find template");
-        assert!(
-            text.contains("_args.items()"),
-            "extracted template should contain .items() pattern"
-        );
-        assert_eq!(
-            detect_tool_arguments_mode(&text),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
-
-    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
-    #[test]
-    fn mdc_template_text_reads_chat_template_json() {
-        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
-
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("chat_template.json");
-        std::fs::write(
-            &path,
-            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
-        )
-        .expect("write");
-
-        let checked =
-            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
-
-        let mut mdc = ModelDeploymentCard::default();
-        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
-            file: checked,
-            is_custom: false,
-        });
-
-        let text = mdc_jinja_template_text(&mdc).expect("template");
-        assert_eq!(
-            detect_tool_arguments_mode(&text),
-            ToolArgumentsMode::ParsedObject
-        );
-    }
 }
 
 /// Parse `tool_calls[*].function.arguments` from JSON string to object in a
@@ -593,5 +448,150 @@ pub fn prompt_formatter_from_mdc(mdc: &ModelDeploymentCard) -> Result<PromptForm
         | PromptFormatterArtifact::HfChatTemplateJson { .. } => Err(anyhow::anyhow!(
             "prompt_formatter should not have type HfChatTemplate*"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_mode_glm_items_pattern() {
+        let glm_snippet = r#"
+            {%- set _args = tc.arguments -%}
+            {%- for k, v in _args.items() -%}
+        "#;
+        assert_eq!(
+            detect_tool_arguments_mode(glm_snippet),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_direct_arguments_items() {
+        assert_eq!(
+            detect_tool_arguments_mode("{% for k, v in arguments.items() %}"),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    #[test]
+    fn detect_mode_standard_template_no_items() {
+        let standard = r#"{% for tc in tool_calls %}{{ tc.function.arguments }}{% endfor %}"#;
+        assert_eq!(
+            detect_tool_arguments_mode(standard),
+            ToolArgumentsMode::JsonString
+        );
+    }
+
+    #[test]
+    fn normalize_parses_json_string_to_object() {
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "read",
+                    "arguments": r#"{"path": "/tmp/foo"}"#
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(
+            args.is_object(),
+            "arguments should be an object after normalization"
+        );
+        assert_eq!(args["path"], "/tmp/foo");
+    }
+
+    #[test]
+    fn normalize_ignores_non_assistant_messages() {
+        let mut msgs = serde_json::json!([{
+            "role": "user",
+            "content": "hello"
+        }]);
+        let original = msgs.clone();
+        normalize_tool_call_arguments(&mut msgs);
+        assert_eq!(msgs, original);
+    }
+
+    #[test]
+    fn normalize_skips_already_object_arguments() {
+        // If somehow arguments is already an object, it should remain unchanged.
+        let mut msgs = serde_json::json!([{
+            "role": "assistant",
+            "tool_calls": [{
+                "function": {
+                    "name": "f",
+                    "arguments": {"key": "val"}
+                }
+            }]
+        }]);
+        normalize_tool_call_arguments(&mut msgs);
+        let args = &msgs[0]["tool_calls"][0]["function"]["arguments"];
+        assert!(args.is_object());
+        assert_eq!(args["key"], "val");
+    }
+
+    /// Test that mdc_jinja_template_text reads the embedded chat_template
+    /// from mdc.prompt_formatter (the HfTokenizerConfigJson / normal HF layout).
+    #[test]
+    fn mdc_template_text_reads_prompt_formatter_embedded() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        // Write a minimal tokenizer_config.json with a chat_template that uses .items()
+        let dir = tempfile::tempdir().expect("tempdir");
+        let tc_path = dir.path().join("tokenizer_config.json");
+        std::fs::write(
+            &tc_path,
+            r#"{"tokenizer_class":"PreTrainedTokenizer","chat_template":"{% for k, v in _args.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&tc_path).expect("CheckedFile");
+
+        // Build a minimal MDC with only prompt_formatter set.
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.prompt_formatter = Some(PromptFormatterArtifact::HfTokenizerConfigJson(checked));
+
+        let text = mdc_jinja_template_text(&mdc).expect("should find template");
+        assert!(
+            text.contains("_args.items()"),
+            "extracted template should contain .items() pattern"
+        );
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
+    }
+
+    /// Test that chat_template.json (HfChatTemplateJson) is also detected.
+    #[test]
+    fn mdc_template_text_reads_chat_template_json() {
+        use crate::model_card::{ModelDeploymentCard, PromptFormatterArtifact};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("chat_template.json");
+        std::fs::write(
+            &path,
+            r#"{"chat_template":"{% for k, v in arguments.items() %}"}"#,
+        )
+        .expect("write");
+
+        let checked =
+            crate::common::checked_file::CheckedFile::from_disk(&path).expect("CheckedFile");
+
+        let mut mdc = ModelDeploymentCard::default();
+        mdc.chat_template_file = Some(PromptFormatterArtifact::HfChatTemplateJson {
+            file: checked,
+            is_custom: false,
+        });
+
+        let text = mdc_jinja_template_text(&mdc).expect("template");
+        assert_eq!(
+            detect_tool_arguments_mode(&text),
+            ToolArgumentsMode::ParsedObject
+        );
     }
 }

--- a/lib/llm/src/preprocessor/speculative_prefill.rs
+++ b/lib/llm/src/preprocessor/speculative_prefill.rs
@@ -24,6 +24,7 @@ use dynamo_runtime::engine::AsyncEngine;
 use dynamo_runtime::pipeline::{Context as PipelineContext, Error, ManyOut, SingleIn};
 use dynamo_runtime::protocols::annotated::Annotated;
 
+use crate::preprocessor::prompt::{ToolArgumentsMode, normalize_tool_call_arguments};
 use crate::protocols::common::llm_backend::{BackendOutput, PreprocessedRequest};
 use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 use crate::protocols::openai::chat_completions::{
@@ -38,11 +39,18 @@ use dynamo_renderer::{OAIChatLikeRequest, OAIPromptFormatter};
 /// exact prefix the next user turn will see.
 pub struct SpeculativePrefillRequest {
     messages: Vec<ChatCompletionRequestMessage>,
+    tool_arguments_mode: ToolArgumentsMode,
 }
 
 impl SpeculativePrefillRequest {
-    pub fn new(messages: Vec<ChatCompletionRequestMessage>) -> Self {
-        Self { messages }
+    pub fn new(
+        messages: Vec<ChatCompletionRequestMessage>,
+        tool_arguments_mode: ToolArgumentsMode,
+    ) -> Self {
+        Self {
+            messages,
+            tool_arguments_mode,
+        }
     }
 }
 
@@ -52,7 +60,10 @@ impl OAIChatLikeRequest for SpeculativePrefillRequest {
     }
 
     fn messages(&self) -> Value {
-        let json = serde_json::to_value(&self.messages).unwrap();
+        let mut json = serde_json::to_value(&self.messages).unwrap();
+        if self.tool_arguments_mode == ToolArgumentsMode::ParsedObject {
+            normalize_tool_call_arguments(&mut json);
+        }
         Value::from_serialize(&json)
     }
 
@@ -80,6 +91,7 @@ pub fn maybe_wrap_stream(
     >,
     formatter: &Arc<dyn OAIPromptFormatter>,
     tokenizer: &Arc<dyn Tokenizer>,
+    tool_arguments_mode: ToolArgumentsMode,
 ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>> {
     let enabled = request
         .nvext
@@ -102,7 +114,16 @@ pub fn maybe_wrap_stream(
         let Ok(response_text) = rx.await else {
             return;
         };
-        if let Err(e) = prefill_task(next, formatter, tokenizer, messages, response_text).await {
+        if let Err(e) = prefill_task(
+            next,
+            formatter,
+            tokenizer,
+            messages,
+            response_text,
+            tool_arguments_mode,
+        )
+        .await
+        {
             tracing::warn!(error = %e, "Speculative prefill failed");
         }
     });
@@ -139,6 +160,7 @@ async fn prefill_task(
     tokenizer: Arc<dyn Tokenizer>,
     original_messages: Vec<ChatCompletionRequestMessage>,
     response_text: String,
+    tool_arguments_mode: ToolArgumentsMode,
 ) -> Result<()> {
     let assistant_msg =
         ChatCompletionRequestMessage::Assistant(ChatCompletionRequestAssistantMessage {
@@ -151,7 +173,7 @@ async fn prefill_task(
     let mut messages = original_messages;
     messages.push(assistant_msg);
 
-    let prefill_request = SpeculativePrefillRequest::new(messages);
+    let prefill_request = SpeculativePrefillRequest::new(messages, tool_arguments_mode);
     let formatted_prompt = formatter.render(&prefill_request)?;
     let encoding = tokenizer.encode(&formatted_prompt)?;
     let token_ids = encoding.token_ids().to_vec();

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -388,6 +388,25 @@ impl DeltaAggregator {
                 // (tool_choice=required/named or structural-tag, gated by
                 // experimental_v2_batch_eligible — see tool_parser_v2::batch_tool_choice_eligible)
                 // keep the v1 finalize path.
+                // Extract the truncated tail BEFORE parsing so a second <tool_call>
+                // truncated after a complete first one is not silently dropped.
+                let glm47_truncated_tail = if parser == "glm47"
+                    && matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    ) {
+                    choice.text.rfind("<tool_call>").and_then(|start| {
+                        let tail = &choice.text[start..];
+                        if !tail.contains("</tool_call>") {
+                            Some(tail.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
+
                 let parse_result = if super::tool_parser_v2::enabled()
                     && super::tool_parser_v2::supports_family(parser)
                     && parsing_options.experimental_v2_batch_eligible
@@ -416,9 +435,40 @@ impl DeltaAggregator {
                             .map(super::tool_call_response_to_protocol)
                             .collect(),
                     );
+                    // Start with prose before tool calls (may be empty).
                     choice.text = content.unwrap_or_default();
                 } else if is_harmony_parser(parser) && contains_harmony_protocol(&choice.text) {
                     choice.text = content.unwrap_or_default();
+                } else if parser == "glm47"
+                    && matches!(
+                        choice.finish_reason,
+                        Some(dynamo_protocols::types::FinishReason::Length)
+                    )
+                    && choice.text.contains("<tool_call>")
+                {
+                    tracing::warn!(
+                        parser,
+                        "glm47: partial <tool_call> returned as content on length finish \
+                         (TRT-LLM parity; raw markup in content)"
+                    );
+                }
+
+                // Recover any tail saved before parsing — the parser drops a truncated
+                // second block silently when an earlier complete block was already parsed.
+                if let Some(tail) = glm47_truncated_tail {
+                    if !choice.text.contains(&tail) {
+                        tracing::warn!(
+                            parser,
+                            tail_bytes = tail.len(),
+                            "glm47: truncated later <tool_call> appended as content \
+                         (TRT-LLM parity; raw markup in content)"
+                        );
+                        if choice.text.is_empty() {
+                            choice.text = tail;
+                        } else {
+                            choice.text.push_str(&tail);
+                        }
+                    }
                 }
             }
         }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -455,19 +455,19 @@ impl DeltaAggregator {
 
                 // Recover any tail saved before parsing — the parser drops a truncated
                 // second block silently when an earlier complete block was already parsed.
-                if let Some(tail) = glm47_truncated_tail {
-                    if !choice.text.contains(&tail) {
-                        tracing::warn!(
-                            parser,
-                            tail_bytes = tail.len(),
-                            "glm47: truncated later <tool_call> appended as content \
+                if let Some(tail) = glm47_truncated_tail
+                    && !choice.text.contains(&tail)
+                {
+                    tracing::warn!(
+                        parser,
+                        tail_bytes = tail.len(),
+                        "glm47: truncated later <tool_call> appended as content \
                          (TRT-LLM parity; raw markup in content)"
-                        );
-                        if choice.text.is_empty() {
-                            choice.text = tail;
-                        } else {
-                            choice.text.push_str(&tail);
-                        }
+                    );
+                    if choice.text.is_empty() {
+                        choice.text = tail;
+                    } else {
+                        choice.text.push_str(&tail);
                     }
                 }
             }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -463,7 +463,12 @@ impl OAIChatLikeRequest for UnifiedRequest {
     }
 
     fn messages(&self) -> minijinja::value::Value {
-        let messages_json = serde_json::to_value(&self.inner.inner.messages).unwrap();
+        let mut messages_json = serde_json::to_value(&self.inner.inner.messages).unwrap();
+        if crate::preprocessor::prompt::get_tool_arguments_mode_for_render()
+            == crate::preprocessor::prompt::ToolArgumentsMode::ParsedObject
+        {
+            crate::preprocessor::prompt::normalize_tool_call_arguments(&mut messages_json);
+        }
         minijinja::value::Value::from_serialize(&messages_json)
     }
 


### PR DESCRIPTION
## Summary

GLM-5.2's Jinja chat template calls `.items()` on tool-call arguments, expecting a parsed dict rather than the OpenAI wire-schema JSON string. It also emits `<tool_call>` XML blocks that can be truncated at `max_tokens`. This PR fixes both, plus a speculative-prefill rendering inconsistency.

- **Argument mode detection** (`preprocessor/prompt.rs`): scan the Jinja template source at formatter construction for `.items()` patterns. Introduce `ToolArgumentsMode` enum and `detect_tool_arguments_mode`. Use a thread-local `ToolArgumentsModeGuard` (RAII, sync-only scope) so the mode is applied only during the synchronous `apply_template` call with no async boundary risk.

- **Argument normalization** (`preprocessor/prompt.rs`): `normalize_tool_call_arguments` parses `tool_calls[*].function.arguments` from JSON string to object in `NvCreateChatCompletionRequest::messages()` when `ParsedObject` mode is active. Non-object and malformed-JSON values are replaced with `{}` and warned (by length only — no raw argument content in logs).

- **Array template variants** (`preprocessor/prompt.rs`): `mdc_jinja_template_text` now handles HF configs that store `chat_template` as `[{name, template}, ...]` by scanning all variant strings, so `.items()` in any variant is detectable.

- **Non-streaming recovery** (`aggregator.rs`): extract the last incomplete `<tool_call>` block before parsing. If a second block is truncated after a complete first one, it is appended to `choice.text` after parsing (the parser drops it silently otherwise).

- **Streaming recovery** (`preprocessor.rs`): on `finish_reason=length`, use `rfind("<tool_call>")` to recover the last block without a matching `</tool_call>`. Avoids duplicating already-emitted complete blocks. Per-choice `ChoiceRecovery` buffers input text; recovered content is emitted as a synthetic chunk before the finish chunk.

- **Speculative prefill** (`preprocessor/speculative_prefill.rs`): propagate `tool_arguments_mode` into `SpeculativePrefillRequest::messages()` so the prefill render applies the same argument normalization as the main request, keeping KV prefix hashes consistent.

## Validation

- `cargo build -p dynamo-llm`: clean, zero warnings
- `cargo test -p dynamo-llm`: all tests pass, including 8 new unit tests covering `detect_tool_arguments_mode`, `normalize_tool_call_arguments` (object, non-object, malformed JSON, non-assistant messages), and `mdc_jinja_template_text` (tokenizer_config.json and chat_template.json paths)
- `cargo fmt --check -p dynamo-llm`: clean