### PR TITLE
feat(vllm): discover sidecar metadata through control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2983,6 +2983,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.13.1",
+ "tonic-health",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -3007,6 +3008,7 @@ dependencies = [
  "tokio-util",
  "tonic 0.13.1",
  "tonic-build 0.13.1",
+ "tonic-health",
  "tracing",
 ]
 

--- a/lib/mocker/servers/vllm/Cargo.toml
+++ b/lib/mocker/servers/vllm/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Mocker-backed implementation of vLLM's native Generate gRPC API"
+description = "Mocker-backed implementation of vLLM's native gRPC API"
 readme = "README.md"
 
 [[bin]]
@@ -28,6 +28,7 @@ futures = { workspace = true }
 prost-types = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/lib/mocker/servers/vllm/README.md
+++ b/lib/mocker/servers/vllm/README.md
@@ -5,14 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Mocker-backed vLLM gRPC server
 
-`dynamo-vllm-mocker-server` implements vLLM's native `Generate` and
-`GenerateStream` RPCs on CPU, using the Dynamo Mocker scheduler for batching,
-KV-capacity, prefix-cache, and timing behavior. Its primary purpose is fast,
-repeatable testing of `dynamo-vllm-sidecar` without a model or GPU.
+`dynamo-vllm-mocker-server` implements vLLM's native Inference and Control services plus standard gRPC health on CPU. It uses the Dynamo Mocker scheduler for batching, KV capacity, prefix cache, and timing behavior.
 
-The mock server temporarily imports the generated types exposed by
-`dynamo-vllm-sidecar`, whose proto is vendored unchanged from vLLM v0.25.1.
-Both consumers will move to vLLM's upstream package once it is published.
+The mock server imports the generated types exposed by `dynamo-vllm-sidecar`. The proto files are vendored unchanged from vLLM.
 
 ## Aggregated serving
 
@@ -29,8 +24,7 @@ Point the existing Dynamo sidecar at it:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path mocker-model
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 `--extra-engine-args` accepts inline JSON or a JSON file path. The values use
@@ -62,13 +56,15 @@ Then start one sidecar for each endpoint:
 
 ```bash
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 --model-path mocker-model \
+  --vllm-endpoint 127.0.0.1:50051 \
   --disaggregation-mode prefill
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50052 --model-path mocker-model \
+  --vllm-endpoint 127.0.0.1:50052 \
   --disaggregation-mode decode
 ```
+
+The sidecar discovers model identity through Control. Keep `--disaggregation-mode` for prefill and decode because the current discovery API does not report engine role.
 
 The prefill endpoint returns an opaque vLLM-shaped `kv_transfer_params`
 payload, and the decode endpoint validates that the sidecar forwarded it

--- a/lib/mocker/servers/vllm/src/main.rs
+++ b/lib/mocker/servers/vllm/src/main.rs
@@ -7,20 +7,21 @@ use anyhow::Context;
 use clap::Parser;
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
+use tonic_health::ServingStatus;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "dynamo-vllm-mocker-server",
-    about = "Run a CPU-only, Mocker-backed implementation of vLLM's native Generate gRPC API"
+    about = "Run a CPU-only, Mocker-backed implementation of vLLM's native gRPC API"
 )]
 struct Args {
     /// Address on which to expose the vLLM-compatible gRPC service.
     #[arg(long, default_value = "127.0.0.1:50051")]
     listen: SocketAddr,
 
-    /// Model name accepted in Generate requests. The empty model used by the
-    /// Dynamo vLLM sidecar is always accepted.
+    /// Model name reported by Control and accepted in Inference requests.
     #[arg(long, default_value = "mocker-model")]
     model: String,
 
@@ -81,8 +82,17 @@ async fn main() -> anyhow::Result<()> {
         mode = %service.config().mode,
         "starting Mocker-backed vLLM gRPC server"
     );
+    let (health, health_service) = tonic_health::server::health_reporter();
+    health
+        .set_service_status("vllm.Control", ServingStatus::Serving)
+        .await;
+    health
+        .set_service_status("vllm.Inference", ServingStatus::Serving)
+        .await;
     tonic::transport::Server::builder()
-        .add_service(GenerateServer::new(service))
+        .add_service(InferenceServer::new(service.clone()))
+        .add_service(ControlServer::new(service))
+        .add_service(health_service)
         .serve_with_shutdown(args.listen, async {
             let _ = tokio::signal::ctrl_c().await;
         })

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -14,7 +14,7 @@ use futures::Stream;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tonic::{Request, Response, Status};
 
-use request::{PreparedRequest, SequenceOutputExt};
+use request::{PreparedRequest, SequenceOutputExt, stable_uuid};
 
 #[path = "server_request.rs"]
 mod request;
@@ -60,10 +60,12 @@ impl Default for MockerServerConfig {
     }
 }
 
-/// vLLM-compatible Generate service driven by one shared Mocker scheduler.
+/// vLLM-compatible Inference and Control services driven by one Mocker scheduler.
 #[derive(Clone)]
 pub struct VllmMockerService {
     config: Arc<MockerServerConfig>,
+    model_info: Arc<pb::ModelInfo>,
+    server_info: Arc<pb::ServerInfo>,
     engine: LiveEngine,
     request_permits: Arc<Semaphore>,
 }
@@ -84,8 +86,56 @@ impl VllmMockerService {
             "Mocker worker_type must be aggregated; use the server mode for the emulated wire role"
         );
         let max_concurrent_requests = config.max_concurrent_requests;
+        let model_info = pb::ModelInfo {
+            model_id: config.model.clone(),
+            served_model_name: config.model.clone(),
+            served_model_aliases: Vec::new(),
+            supports_text_input: true,
+            supports_token_ids_input: true,
+            supports_multimodal: false,
+            reasoning_parser: String::new(),
+            tool_call_parser: String::new(),
+        };
+        let server_info = pb::ServerInfo {
+            engine_version: env!("CARGO_PKG_VERSION").to_string(),
+            api_version: "vllm".to_string(),
+            instance_id: format!("dynamo-vllm-mocker-{}", config.mode),
+            parallelism: Some(pb::ParallelismInfo {
+                tensor_parallel_size: 1,
+                pipeline_parallel_size: 1,
+                data_parallel_size: engine_args.dp_size,
+                data_parallel_rank: DP_RANK,
+                decode_context_parallel_size: 1,
+            }),
+            max_model_len: engine_args
+                .max_model_len
+                .map(u32::try_from)
+                .transpose()
+                .map_err(|_| anyhow::anyhow!("max_model_len exceeds the Control API range"))?
+                .unwrap_or_default(),
+            kv_block_size: u32::try_from(engine_args.block_size)
+                .map_err(|_| anyhow::anyhow!("block_size exceeds the Control API range"))?,
+            total_kv_blocks: u64::try_from(engine_args.num_gpu_blocks)
+                .map_err(|_| anyhow::anyhow!("num_gpu_blocks exceeds the Control API range"))?,
+            max_running_requests: engine_args
+                .max_num_seqs
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| anyhow::anyhow!("max_num_seqs exceeds the Control API range"))?
+                .unwrap_or_default(),
+            max_batched_tokens: engine_args
+                .max_num_batched_tokens
+                .map(u64::try_from)
+                .transpose()
+                .map_err(|_| {
+                    anyhow::anyhow!("max_num_batched_tokens exceeds the Control API range")
+                })?
+                .unwrap_or_default(),
+        };
         Ok(Self {
             config: Arc::new(config),
+            model_info: Arc::new(model_info),
+            server_info: Arc::new(server_info),
             engine: LiveEngine::start(engine_args, DP_RANK)?,
             request_permits: Arc::new(Semaphore::new(max_concurrent_requests)),
         })
@@ -125,7 +175,7 @@ impl VllmMockerService {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for VllmMockerService {
+impl pb::inference_server::Inference for VllmMockerService {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send + 'static>>;
 
@@ -206,6 +256,36 @@ impl pb::generate_server::Generate for VllmMockerService {
             ))?;
         };
         Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for VllmMockerService {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        Ok(Response::new((*self.server_info).clone()))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        Ok(Response::new((*self.model_info).clone()))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        for request_id in request.into_inner().request_ids {
+            self.engine
+                .cancel(stable_uuid(self.config.seed, &request_id))
+                .await
+                .map_err(|error| Status::internal(format!("Mocker abort failed: {error}")))?;
+        }
+        Ok(Response::new(pb::AbortResponse {}))
     }
 }
 

--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -290,6 +290,7 @@ impl PreparedRequest {
                 finish_reason: pb::finish_info::FinishReason::Length as i32,
                 stop_reason: None,
                 kv_transfer_params: (self.mode == ServerMode::Prefill).then(|| self.handoff()),
+                ec_transfer_params: None,
             }),
         }
     }
@@ -382,7 +383,7 @@ impl KvTransferRole {
     }
 }
 
-fn stable_uuid(seed: u64, request_id: &str) -> Uuid {
+pub(super) fn stable_uuid(seed: u64, request_id: &str) -> Uuid {
     let mut hasher = blake3::Hasher::new();
     hasher.update(&seed.to_le_bytes());
     hasher.update(request_id.as_bytes());

--- a/lib/mocker/servers/vllm/src/server_tests.rs
+++ b/lib/mocker/servers/vllm/src/server_tests.rs
@@ -219,7 +219,7 @@ async fn unary_generate_maps_capacity_rejection_to_resource_exhausted() {
         ids: vec![1, 2, 3, 4, 5],
     }));
 
-    let error = pb::generate_server::Generate::generate(&service, Request::new(oversized))
+    let error = pb::inference_server::Inference::generate(&service, Request::new(oversized))
         .await
         .unwrap_err();
     assert_eq!(error.code(), tonic::Code::ResourceExhausted);
@@ -245,18 +245,18 @@ async fn concurrent_request_limit_rejects_a_stalled_stream() {
     let mut first_request = request("stalled");
     first_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let first =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(first_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(first_request))
             .await
             .unwrap();
 
     let mut queued_request = request("queued");
     queued_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let queued =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(queued_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(queued_request))
             .await
             .unwrap();
 
-    let error = match pb::generate_server::Generate::generate_stream(
+    let error = match pb::inference_server::Inference::generate_stream(
         &service,
         Request::new(request("rejected")),
     )
@@ -312,7 +312,7 @@ async fn unary_generate_accumulates_output_and_terminal_metadata() {
     let service = VllmMockerService::new(MockerServerConfig::default(), admitting_args()).unwrap();
 
     let response =
-        pb::generate_server::Generate::generate(&service, Request::new(request("unary")))
+        pb::inference_server::Inference::generate(&service, Request::new(request("unary")))
             .await
             .unwrap()
             .into_inner();
@@ -355,7 +355,7 @@ async fn streaming_generate_maps_capacity_rejection_to_resource_exhausted() {
     }));
 
     let mut stream =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(oversized))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(oversized))
             .await
             .expect("streaming RPC opens before the scheduler rejects")
             .into_inner();
@@ -384,10 +384,11 @@ async fn streaming_survives_a_producer_that_outruns_a_stalled_consumer() {
     let mut bursty = request("bursty");
     bursty.stopping.as_mut().unwrap().max_new_tokens = 50;
 
-    let mut stream = pb::generate_server::Generate::generate_stream(&service, Request::new(bursty))
-        .await
-        .unwrap()
-        .into_inner();
+    let mut stream =
+        pb::inference_server::Inference::generate_stream(&service, Request::new(bursty))
+            .await
+            .unwrap()
+            .into_inner();
 
     // Stall the consumer so the instant producer fills and overflows the fixed
     // per-request buffer before we read anything.

--- a/lib/mocker/servers/vllm/tests/sidecar.rs
+++ b/lib/mocker/servers/vllm/tests/sidecar.rs
@@ -10,11 +10,13 @@ use dynamo_backend_common::{
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
 use dynamo_vllm_sidecar::VllmSidecarEngine;
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
 use futures::StreamExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 use tokio_stream::wrappers::TcpListenerStream;
+use tonic_health::ServingStatus;
 
 struct RunningServer {
     endpoint: String,
@@ -35,10 +37,20 @@ impl RunningServer {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         let (shutdown, shutdown_rx) = oneshot::channel();
-        let server_service = service.clone();
+        let inference_service = service.clone();
+        let control_service = service.clone();
+        let (health, health_service) = tonic_health::server::health_reporter();
+        health
+            .set_service_status("vllm.Control", ServingStatus::Serving)
+            .await;
+        health
+            .set_service_status("vllm.Inference", ServingStatus::Serving)
+            .await;
         tokio::spawn(async move {
             tonic::transport::Server::builder()
-                .add_service(GenerateServer::new(server_service))
+                .add_service(InferenceServer::new(inference_service))
+                .add_service(ControlServer::new(control_service))
+                .add_service(health_service)
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -73,13 +85,11 @@ fn fast_engine_args() -> MockEngineArgs {
         .unwrap()
 }
 
-fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
+async fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
     let mut argv = vec![
         "dynamo-vllm-sidecar".to_string(),
         "--vllm-endpoint".to_string(),
         endpoint.to_string(),
-        "--model-path".to_string(),
-        "mocker-model".to_string(),
         "--grpc-connections".to_string(),
         "1".to_string(),
         "--grpc-startup-deadline-secs".to_string(),
@@ -90,7 +100,11 @@ fn sidecar(endpoint: &str, mode: DisaggregationMode) -> VllmSidecarEngine {
     if mode != DisaggregationMode::Aggregated {
         argv.extend(["--disaggregation-mode".to_string(), mode.to_string()]);
     }
-    VllmSidecarEngine::from_args(Some(argv)).unwrap().0
+    tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
+        .await
+        .unwrap()
+        .unwrap()
+        .0
 }
 
 fn request(max_tokens: u32) -> PreprocessedRequest {
@@ -132,7 +146,7 @@ async fn collect(
 #[tokio::test]
 async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
     let server = RunningServer::start(ServerMode::Aggregated, fast_engine_args()).await;
-    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated);
+    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
     engine.start(0).await.unwrap();
 
     let outputs = collect(&engine, request(3)).await;
@@ -160,8 +174,8 @@ async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
 async fn prefill_handoff_round_trips_through_a_decode_server() {
     let prefill_server = RunningServer::start(ServerMode::Prefill, fast_engine_args()).await;
     let decode_server = RunningServer::start(ServerMode::Decode, fast_engine_args()).await;
-    let prefill = sidecar(&prefill_server.endpoint, DisaggregationMode::Prefill);
-    let decode = sidecar(&decode_server.endpoint, DisaggregationMode::Decode);
+    let prefill = sidecar(&prefill_server.endpoint, DisaggregationMode::Prefill).await;
+    let decode = sidecar(&decode_server.endpoint, DisaggregationMode::Decode).await;
     prefill.start(0).await.unwrap();
     decode.start(1).await.unwrap();
 
@@ -199,7 +213,7 @@ async fn dropping_sidecar_stream_cancels_mocker_work() {
     let mut args = fast_engine_args();
     args.speedup_ratio = 0.1;
     let server = RunningServer::start(ServerMode::Aggregated, args).await;
-    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated);
+    let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated).await;
     engine.start(0).await.unwrap();
 
     let context = dynamo_backend_common::testing::mock_context();

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }
+tonic-health = { workspace = true }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -5,8 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # vLLM sidecar
 
-`dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC
-`Generate` service. It is a standalone Rust executable.
+`dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC services:
+
+- `vllm.Inference` for generation
+- `vllm.Control` for model and server discovery
+- Standard gRPC health for startup readiness
 
 ## Supported
 
@@ -35,12 +38,15 @@ Start the Dynamo worker explicitly:
 
 ```bash
 dynamo-vllm-sidecar \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path Qwen/Qwen3-0.6B
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
 provided through the environment.
+
+The sidecar discovers `model_id`, the served name, parser defaults, context length, KV capacity, scheduler limits, and data-parallel layout through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates.
+
+Aggregated serving is the default. Set the existing `--disaggregation-mode` to `prefill` or `decode` only for non-aggregated deployments; the current Control API does not report engine role.
 
 The sidecar opens eight gRPC connections by default. This avoided
 connection-level throttling in high-concurrency sidecar tests. Override the
@@ -57,8 +63,7 @@ deferred to a follow-up change.
 
 ## Test without vLLM or a GPU
 
-Use the CPU-only `dynamo-vllm-mocker-server` to exercise this sidecar against
-the same `Generate` gRPC contract:
+Use the CPU-only `dynamo-vllm-mocker-server` to exercise the same Inference, Control, and health contracts:
 
 ```bash
 cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
@@ -67,8 +72,7 @@ cargo run -p dynamo-vllm-mocker --bin dynamo-vllm-mocker-server -- \
   --extra-engine-args '{"speedup_ratio":1000}'
 
 cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
-  --vllm-endpoint 127.0.0.1:50051 \
-  --model-path mocker-model
+  --vllm-endpoint 127.0.0.1:50051
 ```
 
 See [`../../mocker/servers/vllm/README.md`](../../mocker/servers/vllm/README.md)

--- a/lib/sidecar/vllm/build.rs
+++ b/lib/sidecar/vllm/build.rs
@@ -4,7 +4,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/vllm_grpc.proto"], &["proto"])?;
-    println!("cargo:rerun-if-changed=proto/vllm_grpc.proto");
+        .compile_protos(
+            &["proto/inference.proto", "proto/control.proto"],
+            &["proto"],
+        )?;
+    println!("cargo:rerun-if-changed=proto/inference.proto");
+    println!("cargo:rerun-if-changed=proto/control.proto");
     Ok(())
 }

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,12 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Source: `rust/proto/vllm_grpc.proto`
-- Release: `v0.25.1`
-- Commit: `752a3a504485790a2e8491cacbb35c137339ad34`
-- SHA-256: `7cccd0e1b2e54f189550e1090cc80321fc2bbd188c98a4e22701b28fdeb177b6`
+- Source: `rust/proto/inference.proto` and `rust/proto/control.proto`
+- Commit: `e3c2fc3b3ca3f41466126cd2aa0b228eb8465844`
+- `inference.proto` SHA-256: `4e6c90467ea308bbed9c175c60943241064c7cf7f8007e837fd235d9d61e69e2`
+- `control.proto` SHA-256: `922d4fefa69cc51264d05df612acc58d16e52291e3e7e6cbb99070109c3ab869`
 
-The file is copied without modification. Update the revision and checksum when
-updating the protocol. `dynamo-vllm-sidecar` generates and temporarily exports
-these types for `dynamo-vllm-mocker-server`; both consumers will move to the
-upstream package once vLLM publishes it.
+The files are copied without modification. Update the revision and checksums together. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+service Control {
+  rpc GetServerInfo (GetServerInfoRequest) returns (ServerInfo) {}
+  rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
+  rpc Abort (AbortRequest) returns (AbortResponse) {}
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string engine_version = 1;
+  string api_version = 2;
+  string instance_id = 3;
+  ParallelismInfo parallelism = 4;
+  uint32 max_model_len = 5;
+  uint32 kv_block_size = 6;
+  uint64 total_kv_blocks = 7;
+  uint64 max_running_requests = 8;
+  uint64 max_batched_tokens = 9;
+}
+
+message ParallelismInfo {
+  uint32 tensor_parallel_size = 1;
+  uint32 pipeline_parallel_size = 2;
+  uint32 data_parallel_size = 3;
+  uint32 data_parallel_rank = 4;
+  uint32 decode_context_parallel_size = 5;
+}
+
+message GetModelInfoRequest {}
+
+message ModelInfo {
+  string model_id = 1;
+  string served_model_name = 2;
+  repeated string served_model_aliases = 3;
+
+  bool supports_text_input = 20;
+  bool supports_token_ids_input = 21;
+  bool supports_multimodal = 23;
+  string reasoning_parser = 24;
+  string tool_call_parser = 25;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {}

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -1,10 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
 syntax = "proto3";
 package vllm;
 
 import "google/protobuf/struct.proto";
 
 
-service Generate {
+service Inference {
   // Generates text given a prompt
   rpc Generate (GenerateRequest) returns (GenerateResponse) {}
   // Generates text given a prompt, streaming the outputs
@@ -107,6 +110,9 @@ message KVCacheParameters {
 
   // KV Connector transfer parameters
   google.protobuf.Struct kv_transfer_params = 3;
+
+  // Encoder cache connector transfer parameters
+  google.protobuf.Struct ec_transfer_params = 4;
 }
 
 // Controls which extra candidate tokens at each position should be returned
@@ -173,6 +179,7 @@ message FinishInfo {
 
   google.protobuf.Struct kv_transfer_params = 6;
   //uint64 seed = 7;
+  google.protobuf.Struct ec_transfer_params = 8;
 }
 
 // Info for candidate tokens other than the input/sampled
@@ -193,4 +200,3 @@ message CandidateTokenInfo {
 message TokenIds {
   repeated uint32 ids = 1;
 }
-

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -15,12 +15,4 @@ pub(crate) struct Args {
     /// vLLM gRPC endpoint as host:port or an http:// URL.
     #[arg(long, env = "VLLM_GRPC_ENDPOINT")]
     pub vllm_endpoint: String,
-
-    /// Hugging Face model ID or local path used by Dynamo for model-card
-    /// registration, tokenization, and chat templates. The released vLLM gRPC
-    /// API does not expose this metadata, so it cannot be inferred from the
-    /// endpoint. This flag is temporary and can be removed once vLLM exposes
-    /// model and tokenizer metadata over gRPC.
-    #[arg(long)]
-    pub model_path: String,
 }

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -1,14 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 use dynamo_backend_common::DynamoError;
 use dynamo_sidecar_common::{
     DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
 };
+use tokio::time::{Instant, sleep_until, timeout_at};
+use tonic_health::pb::health_check_response::ServingStatus;
+use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
 
 pub(crate) use dynamo_sidecar_common::{engine_shutdown, invalid_argument, status_to_dynamo};
 
 use crate::proto as pb;
+
+pub(crate) const CONTROL_SERVICE: &str = "vllm.Control";
+pub(crate) const INFERENCE_SERVICE: &str = "vllm.Inference";
 
 pub(crate) struct VllmClient {
     pool: GrpcChannelPool,
@@ -27,11 +35,98 @@ impl VllmClient {
         self.pool.len()
     }
 
+    pub(crate) async fn wait_for_services(
+        &self,
+        services: &[&str],
+        startup_deadline: Duration,
+        retry_interval: Duration,
+    ) -> Result<(), DynamoError> {
+        let deadline = checked_deadline(startup_deadline)?;
+        for service in services {
+            self.wait_for_service(service, deadline, startup_deadline, retry_interval)
+                .await?;
+        }
+        Ok(())
+    }
+
+    async fn wait_for_service(
+        &self,
+        service: &str,
+        deadline: Instant,
+        startup_deadline: Duration,
+        retry_interval: Duration,
+    ) -> Result<(), DynamoError> {
+        loop {
+            let mut client = HealthClient::new(self.pool.next_channel());
+            let last_status = match timeout_at(
+                deadline,
+                client.check(HealthCheckRequest {
+                    service: service.to_string(),
+                }),
+            )
+            .await
+            {
+                Ok(Ok(response)) => {
+                    let status = ServingStatus::try_from(response.into_inner().status)
+                        .unwrap_or(ServingStatus::Unknown);
+                    if status == ServingStatus::Serving {
+                        return Ok(());
+                    }
+                    format!("reported {}", status.as_str_name())
+                }
+                Ok(Err(status)) => format!("health check failed: {status}"),
+                Err(_) => "health check exceeded the startup deadline".to_string(),
+            };
+
+            let now = Instant::now();
+            if now >= deadline {
+                return Err(dynamo_sidecar_common::cannot_connect(format!(
+                    "{service} did not become SERVING within {startup_deadline:?}: {last_status}"
+                )));
+            }
+            let retry_at = now.checked_add(retry_interval).unwrap_or(deadline);
+            sleep_until(retry_at.min(deadline)).await;
+        }
+    }
+
+    pub(crate) async fn discover(
+        &self,
+        startup_deadline: Duration,
+    ) -> Result<(pb::ModelInfo, pb::ServerInfo), DynamoError> {
+        let deadline = checked_deadline(startup_deadline)?;
+        let channel = self.pool.next_channel();
+        let mut client = pb::control_client::ControlClient::new(channel)
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        let model = timeout_at(deadline, client.get_model_info(pb::GetModelInfoRequest {}))
+            .await
+            .map_err(|_| {
+                dynamo_sidecar_common::connection_timeout(format!(
+                    "GetModelInfo exceeded the vLLM startup deadline of {startup_deadline:?}"
+                ))
+            })?
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("GetModelInfo", status))?;
+        let server = timeout_at(
+            deadline,
+            client.get_server_info(pb::GetServerInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            dynamo_sidecar_common::connection_timeout(format!(
+                "GetServerInfo exceeded the vLLM startup deadline of {startup_deadline:?}"
+            ))
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetServerInfo", status))?;
+        Ok((model, server))
+    }
+
     pub(crate) async fn generate_stream(
         &self,
         request: pb::GenerateRequest,
     ) -> Result<tonic::Streaming<pb::GenerateResponse>, DynamoError> {
-        let mut client = pb::generate_client::GenerateClient::new(self.pool.next_channel())
+        let mut client = pb::inference_client::InferenceClient::new(self.pool.next_channel())
             .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
             .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
         client
@@ -40,6 +135,14 @@ impl VllmClient {
             .map(tonic::Response::into_inner)
             .map_err(|status| status_to_dynamo("GenerateStream", status))
     }
+}
+
+fn checked_deadline(duration: Duration) -> Result<Instant, DynamoError> {
+    Instant::now().checked_add(duration).ok_or_else(|| {
+        invalid_argument(format!(
+            "gRPC startup deadline {duration:?} exceeds the supported monotonic clock range"
+        ))
+    })
 }
 
 pub(crate) fn protocol_error(message: impl Into<String>) -> DynamoError {

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -237,6 +237,7 @@ fn build_kv_parameters(
         bypass_prefix_cache,
         cache_salt: cache_salt.unwrap_or_default(),
         kv_transfer_params: kv_transfer_params.map(json_to_struct).transpose()?,
+        ec_transfer_params: None,
     })
 }
 

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -12,13 +12,13 @@ use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
 
 use crate::args::Args;
-use crate::client::{self, VllmClient};
+use crate::client::{self, CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
-use crate::model::ConfiguredModel;
+use crate::model::DiscoveredModel;
 
 pub struct VllmSidecarEngine {
     endpoint: GrpcEndpoint,
-    model: ConfiguredModel,
+    model: DiscoveredModel,
     mode: DisaggregationMode,
     transport: GrpcTransportConfig,
     client: OnceCell<VllmClient>,
@@ -35,7 +35,7 @@ fn cancelled(state: &ResponseState) -> LLMEngineOutput {
 impl VllmSidecarEngine {
     pub(crate) fn new(
         endpoint: GrpcEndpoint,
-        model: ConfiguredModel,
+        model: DiscoveredModel,
         mode: DisaggregationMode,
         transport: GrpcTransportConfig,
     ) -> Self {
@@ -73,9 +73,6 @@ impl VllmSidecarEngine {
     }
 
     fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {
-        if args.model_path.trim().is_empty() {
-            return Err(client::invalid_argument("model-path must not be empty"));
-        }
         if args.sidecar.common.disaggregation_mode.is_encode() {
             return Err(client::invalid_argument(
                 "encode mode is not supported by the vLLM sidecar",
@@ -89,19 +86,19 @@ impl VllmSidecarEngine {
 
         let endpoint = GrpcEndpoint::parse(&args.vllm_endpoint, "--vllm-endpoint")?;
         let transport = args.sidecar.grpc.config();
-        let model = ConfiguredModel {
-            source: args.model_path,
-        };
+        let model = bootstrap_discover(&endpoint, transport)?;
         let mode = args.sidecar.common.disaggregation_mode;
         let engine = Self::new(endpoint, model.clone(), mode, transport);
-        let (tool_call_parser, reasoning_parser) = if mode.is_prefill() {
-            (None, None)
-        } else {
-            (
-                args.sidecar.common.dyn_tool_call_parser,
-                args.sidecar.common.dyn_reasoning_parser,
-            )
-        };
+        let tool_call_parser = args
+            .sidecar
+            .common
+            .dyn_tool_call_parser
+            .or_else(|| model.tool_call_parser.clone());
+        let reasoning_parser = args
+            .sidecar
+            .common
+            .dyn_reasoning_parser
+            .or_else(|| model.reasoning_parser.clone());
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
             component: args.sidecar.common.component,
@@ -109,7 +106,7 @@ impl VllmSidecarEngine {
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,
             model_name: model.source.clone(),
-            served_model_name: None,
+            served_model_name: Some(model.served_name.clone()),
             tool_call_parser,
             reasoning_parser,
             exclude_tools_when_tool_choice_none: args
@@ -141,6 +138,16 @@ impl LLMEngine for VllmSidecarEngine {
             "connecting to vLLM gRPC"
         );
         let client = VllmClient::connect(&self.endpoint, self.transport).await?;
+        client
+            .wait_for_services(
+                &[CONTROL_SERVICE, INFERENCE_SERVICE],
+                self.transport.startup_deadline,
+                self.transport.retry_interval,
+            )
+            .await?;
+        let (model, server) = client.discover(self.transport.startup_deadline).await?;
+        let observed = DiscoveredModel::from_proto(model, server)?;
+        self.model.ensure_same_identity(&observed)?;
         let connection_count = client.connection_count();
         self.client
             .set(client)
@@ -148,11 +155,12 @@ impl LLMEngine for VllmSidecarEngine {
         tracing::info!(
             endpoint = %self.endpoint,
             connections = connection_count,
-            configured_model_source = %self.model.source,
+            model = %observed.source,
+            served_model_name = %observed.served_name,
             mode = %self.mode,
-            "vLLM gRPC transport connected"
+            "vLLM gRPC services are ready"
         );
-        Ok(self.model.engine_config())
+        Ok(observed.engine_config())
     }
 
     async fn generate(
@@ -166,7 +174,8 @@ impl LLMEngine for VllmSidecarEngine {
             .ok_or_else(|| client::engine_shutdown("vLLM sidecar is not started"))?;
         let request_id = ctx.id().to_string();
         let mut state = ResponseState::new(&request, self.mode);
-        let proto_request = build_generate_request(request, request_id, self.mode)?;
+        let mut proto_request = build_generate_request(request, request_id, self.mode)?;
+        proto_request.model.clone_from(&self.model.served_name);
         let stopped_ctx = ctx.inner_arc();
         let shutdown = self.cancel.clone();
         let mut cancellation = Box::pin(async move {
@@ -230,4 +239,30 @@ impl LLMEngine for VllmSidecarEngine {
         self.cancel.cancel();
         Ok(())
     }
+}
+
+fn bootstrap_discover(
+    endpoint: &GrpcEndpoint,
+    transport: GrpcTransportConfig,
+) -> Result<DiscoveredModel, DynamoError> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| client::engine_shutdown(format!("bootstrap runtime: {error}")))?;
+    runtime.block_on(async {
+        let bootstrap_transport = GrpcTransportConfig {
+            connections: std::num::NonZeroUsize::MIN,
+            ..transport
+        };
+        let client = VllmClient::connect(endpoint, bootstrap_transport).await?;
+        client
+            .wait_for_services(
+                &[CONTROL_SERVICE],
+                transport.startup_deadline,
+                transport.retry_interval,
+            )
+            .await?;
+        let (model, server) = client.discover(transport.startup_deadline).await?;
+        DiscoveredModel::from_proto(model, server)
+    })
 }

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,20 +1,122 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{EngineConfig, LlmRegistration};
+use dynamo_backend_common::{DynamoError, EngineConfig, LlmRegistration};
 
-#[derive(Clone, Debug)]
-pub(crate) struct ConfiguredModel {
-    pub source: String,
+use crate::client;
+use crate::proto as pb;
+
+const SUPPORTED_API_VERSION: &str = "vllm";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ModelIdentity {
+    source: String,
+    served_name: String,
+    aliases: Vec<String>,
+    reasoning_parser: Option<String>,
+    tool_call_parser: Option<String>,
 }
 
-impl ConfiguredModel {
+#[derive(Clone, Debug)]
+pub(crate) struct DiscoveredModel {
+    pub source: String,
+    pub served_name: String,
+    pub reasoning_parser: Option<String>,
+    pub tool_call_parser: Option<String>,
+    identity: ModelIdentity,
+    server: pb::ServerInfo,
+}
+
+impl DiscoveredModel {
+    pub(crate) fn from_proto(
+        model: pb::ModelInfo,
+        server: pb::ServerInfo,
+    ) -> Result<Self, DynamoError> {
+        if server.api_version != SUPPORTED_API_VERSION {
+            return Err(client::protocol_error(format!(
+                "unsupported Control API version `{}`; expected `{SUPPORTED_API_VERSION}`",
+                server.api_version
+            )));
+        }
+        let source = required("model_id", model.model_id)?;
+        let served_name = required("served_model_name", model.served_model_name)?;
+        if !model.supports_token_ids_input {
+            return Err(client::protocol_error(
+                "the discovered model does not support token-ID input",
+            ));
+        }
+        let reasoning_parser = nonempty(model.reasoning_parser);
+        let tool_call_parser = nonempty(model.tool_call_parser);
+        let identity = ModelIdentity {
+            source: source.clone(),
+            served_name: served_name.clone(),
+            aliases: model.served_model_aliases,
+            reasoning_parser: reasoning_parser.clone(),
+            tool_call_parser: tool_call_parser.clone(),
+        };
+        Ok(Self {
+            source,
+            served_name,
+            reasoning_parser,
+            tool_call_parser,
+            identity,
+            server,
+        })
+    }
+
+    pub(crate) fn ensure_same_identity(&self, observed: &Self) -> Result<(), DynamoError> {
+        if self.identity != observed.identity {
+            return Err(client::protocol_error(format!(
+                "model identity changed between bootstrap and startup: expected `{}` served as `{}`, observed `{}` served as `{}`",
+                self.source, self.served_name, observed.source, observed.served_name
+            )));
+        }
+        Ok(())
+    }
+
     pub(crate) fn engine_config(&self) -> EngineConfig {
+        let parallelism = self.server.parallelism.as_ref();
+        let data_parallel_size =
+            nonzero(parallelism.map_or(0, |parallelism| parallelism.data_parallel_size));
+        let data_parallel_start_rank = data_parallel_size.map(|_| {
+            parallelism
+                .expect("parallelism was present")
+                .data_parallel_rank
+        });
         EngineConfig {
             model: self.source.clone(),
-            served_model_name: None,
+            served_model_name: Some(self.served_name.clone()),
             runtime_data: Default::default(),
-            llm: Some(LlmRegistration::default()),
+            llm: Some(LlmRegistration {
+                context_length: nonzero(self.server.max_model_len),
+                kv_cache_block_size: nonzero(self.server.kv_block_size),
+                total_kv_blocks: nonzero(self.server.total_kv_blocks),
+                max_num_seqs: nonzero(self.server.max_running_requests),
+                max_num_batched_tokens: nonzero(self.server.max_batched_tokens),
+                data_parallel_size,
+                data_parallel_start_rank,
+                ..Default::default()
+            }),
         }
     }
+}
+
+fn required(field: &str, value: String) -> Result<String, DynamoError> {
+    if value.trim().is_empty() {
+        return Err(client::protocol_error(format!(
+            "Control returned an empty {field}"
+        )));
+    }
+    Ok(value)
+}
+
+fn nonempty(value: String) -> Option<String> {
+    (!value.trim().is_empty()).then_some(value)
+}
+
+fn nonzero<T>(value: T) -> Option<T>
+where
+    T: Default + PartialEq,
+{
+    (value != T::default()).then_some(value)
 }

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -19,16 +19,18 @@ use tokio::net::TcpListener;
 use tokio::sync::{Mutex, Notify, oneshot};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
+use tonic_health::ServingStatus as HealthServingStatus;
+use tonic_health::server::HealthReporter;
 
-use crate::client::VllmClient;
+use crate::client::{CONTROL_SERVICE, INFERENCE_SERVICE, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
 use crate::engine::VllmSidecarEngine;
 use crate::json::{json_to_struct, struct_to_json};
-use crate::model::ConfiguredModel;
+use crate::model::DiscoveredModel;
 use crate::proto as pb;
 
 #[derive(Clone, Default)]
-struct FakeGenerate {
+struct FakeVllm {
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
     peers: Arc<Mutex<Vec<SocketAddr>>>,
     reject: Arc<AtomicBool>,
@@ -48,7 +50,7 @@ impl Drop for DropSignal {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for FakeGenerate {
+impl pb::inference_server::Inference for FakeVllm {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
 
@@ -161,6 +163,63 @@ impl pb::generate_server::Generate for FakeGenerate {
     }
 }
 
+#[tonic::async_trait]
+impl pb::control_server::Control for FakeVllm {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        Ok(Response::new(server_info()))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        Ok(Response::new(model_info()))
+    }
+
+    async fn abort(
+        &self,
+        _request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        Ok(Response::new(pb::AbortResponse {}))
+    }
+}
+
+fn model_info() -> pb::ModelInfo {
+    pb::ModelInfo {
+        model_id: "model-source".to_string(),
+        served_model_name: "served-model".to_string(),
+        served_model_aliases: vec!["model-alias".to_string()],
+        supports_text_input: true,
+        supports_token_ids_input: true,
+        supports_multimodal: false,
+        reasoning_parser: "deepseek_r1".to_string(),
+        tool_call_parser: "hermes".to_string(),
+    }
+}
+
+fn server_info() -> pb::ServerInfo {
+    pb::ServerInfo {
+        engine_version: "test-vllm".to_string(),
+        api_version: "vllm".to_string(),
+        instance_id: "test-instance".to_string(),
+        parallelism: Some(pb::ParallelismInfo {
+            tensor_parallel_size: 2,
+            pipeline_parallel_size: 1,
+            data_parallel_size: 4,
+            data_parallel_rank: 2,
+            decode_context_parallel_size: 1,
+        }),
+        max_model_len: 8192,
+        kv_block_size: 16,
+        total_kv_blocks: 4096,
+        max_running_requests: 128,
+        max_batched_tokens: 2048,
+    }
+}
+
 fn sequence_response(
     terminal: bool,
     logprobs: bool,
@@ -189,6 +248,7 @@ fn sequence_response(
                 finish_reason: pb::finish_info::FinishReason::Stop as i32,
                 stop_reason: Some(pb::finish_info::StopReason::StopTokenId(2)),
                 kv_transfer_params,
+                ec_transfer_params: None,
             }),
         }),
     }
@@ -313,23 +373,34 @@ fn oversized_logprob_counts_are_rejected() {
 
 struct FakeServer {
     endpoint: String,
-    service: FakeGenerate,
+    service: FakeVllm,
+    health: HealthReporter,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
 impl FakeServer {
-    async fn start(service: FakeGenerate) -> Self {
+    async fn start(service: FakeVllm) -> Self {
+        Self::start_with_health(service, HealthServingStatus::Serving).await
+    }
+
+    async fn start_with_health(service: FakeVllm, status: HealthServingStatus) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("address");
         let (shutdown, shutdown_rx) = oneshot::channel();
-        let server_service = service.clone();
+        let inference_service = service.clone();
+        let control_service = service.clone();
+        let (health, health_service) = tonic_health::server::health_reporter();
+        health.set_service_status(CONTROL_SERVICE, status).await;
+        health.set_service_status(INFERENCE_SERVICE, status).await;
         tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(
-                    pb::generate_server::GenerateServer::new(server_service)
+                    pb::inference_server::InferenceServer::new(inference_service)
                         .max_encoding_message_size(64 * 1024 * 1024)
                         .max_decoding_message_size(64 * 1024 * 1024),
                 )
+                .add_service(pb::control_server::ControlServer::new(control_service))
+                .add_service(health_service)
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -339,6 +410,7 @@ impl FakeServer {
         Self {
             endpoint: format!("http://{address}"),
             service,
+            health,
             shutdown: Some(shutdown),
         }
     }
@@ -399,15 +471,33 @@ fn request() -> PreprocessedRequest {
 fn engine(endpoint: &str, mode: DisaggregationMode, connections: usize) -> VllmSidecarEngine {
     VllmSidecarEngine::new(
         GrpcEndpoint::parse(endpoint, "--vllm-endpoint").expect("valid test endpoint"),
-        ConfiguredModel {
-            source: "model-source".to_string(),
-        },
+        DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery"),
         mode,
         GrpcTransportConfig {
             connections: NonZeroUsize::new(connections).expect("non-zero connection count"),
             ..Default::default()
         },
     )
+}
+
+async fn engine_from_args(
+    endpoint: &str,
+) -> (VllmSidecarEngine, dynamo_backend_common::WorkerConfig) {
+    let argv = vec![
+        "dynamo-vllm-sidecar".to_string(),
+        "--vllm-endpoint".to_string(),
+        endpoint.to_string(),
+        "--grpc-connections".to_string(),
+        "2".to_string(),
+        "--grpc-startup-deadline-secs".to_string(),
+        "5".to_string(),
+        "--grpc-connect-attempt-timeout-secs".to_string(),
+        "1".to_string(),
+    ];
+    tokio::task::spawn_blocking(move || VllmSidecarEngine::from_args(Some(argv)))
+        .await
+        .expect("bootstrap task")
+        .expect("bootstrap discovery")
 }
 
 async fn collect(
@@ -426,11 +516,23 @@ async fn collect(
 
 #[tokio::test]
 async fn aggregated_generation_converts_request_stream_and_usage() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 2);
+    let server = FakeServer::start(FakeVllm::default()).await;
+    let (engine, worker) = engine_from_args(&server.endpoint).await;
+    assert_eq!(worker.model_name, "model-source");
+    assert_eq!(worker.served_model_name.as_deref(), Some("served-model"));
+    assert_eq!(worker.reasoning_parser.as_deref(), Some("deepseek_r1"));
+    assert_eq!(worker.tool_call_parser.as_deref(), Some("hermes"));
     let config = engine.start(0).await.expect("start");
     assert_eq!(config.model, "model-source");
-    assert_eq!(config.served_model_name, None);
+    assert_eq!(config.served_model_name.as_deref(), Some("served-model"));
+    let registration = config.llm.expect("LLM registration");
+    assert_eq!(registration.context_length, Some(8192));
+    assert_eq!(registration.kv_cache_block_size, Some(16));
+    assert_eq!(registration.total_kv_blocks, Some(4096));
+    assert_eq!(registration.max_num_seqs, Some(128));
+    assert_eq!(registration.max_num_batched_tokens, Some(2048));
+    assert_eq!(registration.data_parallel_size, Some(4));
+    assert_eq!(registration.data_parallel_start_rank, Some(2));
 
     let outputs = collect(&engine, request()).await;
     assert_eq!(outputs.len(), 1);
@@ -446,7 +548,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 
     let requests = server.service.requests.lock().await;
     let sent = requests.first().expect("recorded request");
-    assert!(sent.model.is_empty());
+    assert_eq!(sent.model, "served-model");
     assert_eq!(sent.priority, 0);
     let sampling = sent.sampling.as_ref().unwrap();
     assert_eq!(
@@ -482,8 +584,34 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 }
 
 #[tokio::test]
+async fn startup_waits_for_control_and_inference_health() {
+    let server =
+        FakeServer::start_with_health(FakeVllm::default(), HealthServingStatus::NotServing).await;
+    let endpoint = server.endpoint.clone();
+    let bootstrap = tokio::spawn(async move { engine_from_args(&endpoint).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    assert!(!bootstrap.is_finished(), "bootstrap ignored Control health");
+
+    server
+        .health
+        .set_service_status(CONTROL_SERVICE, HealthServingStatus::Serving)
+        .await;
+    server
+        .health
+        .set_service_status(INFERENCE_SERVICE, HealthServingStatus::Serving)
+        .await;
+
+    let (engine, _) = tokio::time::timeout(std::time::Duration::from_secs(2), bootstrap)
+        .await
+        .expect("bootstrap did not observe SERVING")
+        .expect("bootstrap task");
+    engine.start(0).await.expect("start");
+}
+
+#[tokio::test]
 async fn grpc_request_errors_are_propagated() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.reject.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -499,7 +627,7 @@ async fn grpc_request_errors_are_propagated() {
 
 #[tokio::test]
 async fn prefill_decode_handoff_is_opaque_and_repeatable() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let prefill = engine(&server.endpoint, DisaggregationMode::Prefill, 1);
     let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1);
     prefill.start(0).await.expect("start prefill");
@@ -531,7 +659,7 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
 
 #[tokio::test]
 async fn pool_uses_each_configured_connection() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let transport = GrpcTransportConfig {
         connections: NonZeroUsize::new(2).unwrap(),
         ..Default::default()
@@ -567,7 +695,7 @@ async fn pool_uses_each_configured_connection() {
 
 #[tokio::test]
 async fn cancellation_drops_the_remote_stream() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.hang.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -596,7 +724,7 @@ async fn cancellation_drops_the_remote_stream() {
 
 #[tokio::test]
 async fn cancellation_interrupts_pending_response_headers() {
-    let service = FakeGenerate::default();
+    let service = FakeVllm::default();
     service.hang_before_headers.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -627,7 +755,7 @@ async fn cancellation_interrupts_pending_response_headers() {
 
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeVllm::default()).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
     engine.start(0).await.expect("start");
 

--- a/lib/sidecar/vllm/tests/executable.rs
+++ b/lib/sidecar/vllm/tests/executable.rs
@@ -19,7 +19,6 @@ fn executable_exposes_native_grpc_configuration() {
     for flag in [
         "--vllm-endpoint",
         "--grpc-connections",
-        "--model-path",
         "--disaggregation-mode",
         "--grpc-connect-attempt-timeout-secs",
         "--grpc-retry-interval-secs",
@@ -27,6 +26,10 @@ fn executable_exposes_native_grpc_configuration() {
     ] {
         assert!(stdout.contains(flag), "missing {flag} in help output");
     }
+    assert!(
+        !stdout.contains("--model-path"),
+        "model identity must be discovered through vllm.Control"
+    );
 
     for env in [
         "DYN_SIDECAR_GRPC_CONNECTIONS",


### PR DESCRIPTION
## Overview:

Align the vLLM sidecar with the merged native gRPC discovery API from [vllm-project/vllm#49491](https://github.com/vllm-project/vllm/pull/49491). The sidecar now discovers model and server metadata instead of requiring `--model-path`.

## Details:

- Vendor the exact merged `inference.proto` and `control.proto` files.
- Use `vllm.Inference` for generation and `vllm.Control` for discovery.
- Wait for standard gRPC health on `vllm.Control` during bootstrap and both services during `start()`.
- Build `WorkerConfig` and registration metadata from `GetModelInfo` and `GetServerInfo`.
- Set every `GenerateRequest.model` to the discovered served model name.
- Reject unsupported API versions, missing identity fields, missing token-ID support, and identity changes between bootstrap and startup.
- Preserve request cancellation by dropping only the request stream; the sidecar does not call `Abort` or close pooled connections.
- Update the CPU Mocker to expose Inference, Control, and standard gRPC health, including an idempotent Control Abort implementation.
- Update focused sidecar and Mocker tests and remove `--model-path` from documentation and commands.

## Where should the reviewer start?

- `lib/sidecar/vllm/src/engine.rs`: bootstrap, readiness, identity revalidation, and request model selection.
- `lib/sidecar/vllm/src/model.rs`: discovery validation and metadata mapping.
- `lib/sidecar/vllm/src/client.rs`: Inference, Control, and health clients.
- `lib/mocker/servers/vllm/src/server.rs`: Mocker discovery and Abort behavior.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-vllm-sidecar -p dynamo-vllm-mocker --all-targets -- -D warnings`
- `cargo test -p dynamo-vllm-sidecar -p dynamo-vllm-mocker`
- Vendored proto files compared byte-for-byte with vLLM merge commit `e3c2fc3b3ca3f41466126cd2aa0b228eb8465844`.
- Aggregated GPU smoke: not run; the registry and compute-session services were unavailable while preparing this draft.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue