### PR TITLE
feat(vllm): support multimodal sidecar requests

### DIFF
--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -35,9 +35,9 @@ pub use engine::{
     AsyncEngineContext, BootstrapInfo, CompletionUsage, ComponentSnapshot, EngineConfig,
     FinishReason, GenerateContext, GuidedDecodingOptions, HEALTH_CHECK_KEY, KvEventPublisher,
     KvEventSource, LLMEngine, LLMEngineOutput, LLMEngineOutputExt, LlmRegistration, LogProbs,
-    Metrics, MetricsBindings, MetricsCtx, OnPublisherReady, OnSnapshotPublisherReady,
-    OutputOptions, PrefillResult, PreprocessedRequest, RawEngine, SamplingOptions, StopConditions,
-    StopReason, TopLogprob, TopLogprobs, chunk, usage,
+    Metrics, MetricsBindings, MetricsCtx, MultimodalData, OnPublisherReady,
+    OnSnapshotPublisherReady, OutputOptions, PrefillResult, PreprocessedRequest, RawEngine,
+    SamplingOptions, StopConditions, StopReason, TopLogprob, TopLogprobs, chunk, usage,
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -26,8 +26,13 @@ It is a standalone Rust executable.
 - Sampling, stop conditions, structured output, logprobs, cache options, and priority
 - Opaque `kv_transfer_params` handoff
 - Data-parallel rank routing and KV-event source discovery
+- Image URL and data-URI inputs, including media UUIDs
 
-The protocol does not support multimodal input, LoRA, encode workers, beam search, or `n > 1`.
+The protocol does not support LoRA, encode workers, beam search, `n > 1`,
+preprocessed multimodal features, audio/video media, or Dynamo tool-call and
+reasoning parsers. Parser defaults returned by Control are intentionally not
+advertised to the Dynamo frontend because the current inference protocol does
+not preserve all parser-related request semantics.
 
 ## Run
 
@@ -51,7 +56,7 @@ dynamo-vllm-sidecar \
 Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
 provided through the environment.
 
-The sidecar discovers `model_id`, the served name, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates. Parser defaults are not advertised because the current inference protocol cannot preserve all parser-related request semantics.
+The sidecar discovers `model_id`, the served name, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates.
 
 The sidecar currently supports one vLLM frontend hosting the complete data-parallel group starting at rank 0. Control reports the global size; Dynamo forwards the selected rank as `x-data-parallel-rank` gRPC metadata on each generation request. Partial and hybrid rank ownership are unsupported because the protocol does not report the locally hosted rank count, and a nonzero starting rank is rejected. When KV routing is enabled, Control must return one unique ZMQ event source for every rank in the group.
 

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -26,12 +26,18 @@ It is a standalone Rust executable.
 - Sampling, stop conditions, structured output, logprobs, cache options, and priority
 - Opaque `kv_transfer_params` handoff
 - Data-parallel rank routing and KV-event source discovery
+- Image URL and data-URI inputs, including media UUIDs
 
-The protocol does not support multimodal input, LoRA, encode workers, beam search, or `n > 1`.
+The protocol does not support LoRA, encode workers, beam search, `n > 1`,
+preprocessed multimodal features, audio/video media, or Dynamo tool-call and
+reasoning parsers. Parser defaults returned by Control are intentionally not
+advertised to the Dynamo frontend because the current inference protocol does
+not preserve all parser-related request semantics.
 
 ## Run
 
-Start a vLLM build with the split Inference and Control services and explicit data-parallel-rank capability used by the vendored protocol:
+Start a vLLM build with the split Inference and Control services and explicit
+data-parallel-rank capability used by the vendored protocol:
 
 ```bash
 vllm-rs serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051
@@ -51,7 +57,7 @@ dynamo-vllm-sidecar \
 Use `VLLM_GRPC_ENDPOINT` instead of `--vllm-endpoint` when the endpoint is
 provided through the environment.
 
-The sidecar discovers `model_id`, the served name, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates. Parser defaults are not advertised because the current inference protocol cannot preserve all parser-related request semantics.
+The sidecar discovers `model_id`, the served name, context length, KV capacity, scheduler limits, data-parallel topology, and KV-event sources through `vllm.Control`. `model_id` must be readable locally or fetchable by Dynamo for tokenization and chat templates.
 
 The sidecar currently supports one vLLM frontend hosting the complete data-parallel group starting at rank 0. Control reports the global size and whether explicit rank routing is supported; Dynamo forwards the selected rank on each generation request. Partial and hybrid rank ownership are unsupported because the protocol does not report the locally hosted rank count, and a nonzero starting rank is rejected. When KV routing is enabled, Control must return one unique ZMQ event source for every rank in the group.
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_backend_common::{
-    DisaggregationMode, DynamoError, GuidedDecodingOptions, LLMEngineOutput, PrefillResult,
-    PreprocessedRequest, StopReason, TopLogprob, usage,
+    DisaggregationMode, DynamoError, GuidedDecodingOptions, LLMEngineOutput, MultimodalData,
+    PrefillResult, PreprocessedRequest, StopReason, TopLogprob, usage,
 };
 
 use crate::client;
@@ -11,6 +11,9 @@ use crate::json::{json_to_struct, struct_to_json};
 use crate::proto as pb;
 
 const VLLM_LOGPROB_FLOOR: f64 = -9999.0;
+const MULTIMODAL_PROMPT_TOKEN_IDS_KEY: &str = "_dynamo_sidecar_multimodal_prompt_token_ids";
+const MM_HASHES_KEY: &str = "mm_hashes";
+// Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
 const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 
 pub(crate) fn build_generate_request(
@@ -20,6 +23,26 @@ pub(crate) fn build_generate_request(
 ) -> Result<pb::GenerateRequest, DynamoError> {
     validate_request(&request, mode)?;
 
+    let has_media = request
+        .multi_modal_data
+        .as_ref()
+        .is_some_and(|media| media.values().any(|items| !items.is_empty()));
+    // Decode reuses the prefill-expanded tokens without reprocessing media.
+    let forwarded_mm_uuids = if has_media && !mode.is_decode() {
+        forwarded_mm_uuids(&request)?
+    } else {
+        None
+    };
+    let media = if mode.is_decode() {
+        Vec::new()
+    } else {
+        build_media(&request, forwarded_mm_uuids.as_deref())?
+    };
+    let mut prefill_result = request.prefill_result;
+    let mut token_ids = request.token_ids;
+    if mode.is_decode() && has_media {
+        token_ids = take_multimodal_prompt_token_ids(&mut prefill_result)?;
+    }
     let prompt_logprobs = request.output_options.prompt_logprobs;
     let output_logprobs = request.output_options.logprobs;
     let max_new_tokens = if mode.is_prefill() {
@@ -45,13 +68,19 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let mut extra_args = request.extra_args;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
-    let kv = build_kv_parameters(extra_args, request.prefill_result, cache_salt, mode)?;
+    if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
+        // These fields are already represented by token_ids and media.
+        extra.remove("messages");
+        extra.remove("formatted_prompt");
+        extra.remove(MM_HASHES_KEY);
+    }
+    let kv = build_kv_parameters(extra_args, prefill_result, cache_salt, mode)?;
 
     Ok(pb::GenerateRequest {
         request_id,
         model: String::new(),
         prompt: Some(pb::generate_request::Prompt::TokenIds(pb::TokenIds {
-            ids: request.token_ids,
+            ids: token_ids,
         })),
         temperature: sampling.temperature,
         sampling: Some(pb::RandomSampling {
@@ -81,7 +110,7 @@ pub(crate) fn build_generate_request(
             ignore_eos: stop_conditions.ignore_eos.unwrap_or(false),
         }),
         response: Some(pb::ResponseOptions {
-            prompt_token_ids: prompt_logprobs.is_some(),
+            prompt_token_ids: prompt_logprobs.is_some() || (has_media && mode.is_prefill()),
             prompt_logprobs: prompt_logprobs.is_some(),
             prompt_candidates: prompt_logprobs.map(top_n_candidates).transpose()?,
             output_text: Some(true),
@@ -93,7 +122,7 @@ pub(crate) fn build_generate_request(
         truncate_prompt_tokens: 0,
         priority,
         session_id: None,
-        media: Vec::new(),
+        media,
     })
 }
 
@@ -157,6 +186,176 @@ fn consume_redundant_nvext(
         extra.remove("nvext");
     }
     Ok(())
+}
+
+fn take_multimodal_prompt_token_ids(
+    prefill_result: &mut Option<PrefillResult>,
+) -> Result<Vec<u32>, DynamoError> {
+    let params = &mut prefill_result
+        .as_mut()
+        .ok_or_else(|| {
+            client::invalid_argument("multimodal decode request is missing the prefill result")
+        })?
+        .disaggregated_params;
+    let value = params
+        .as_object_mut()
+        .and_then(|params| params.remove(MULTIMODAL_PROMPT_TOKEN_IDS_KEY))
+        .ok_or_else(|| {
+            client::invalid_argument(
+                "multimodal decode request is missing expanded prefill token IDs",
+            )
+        })?;
+    let token_ids: Vec<u32> = serde_json::from_value(value).map_err(|error| {
+        client::invalid_argument(format!("multimodal prefill token IDs are invalid: {error}"))
+    })?;
+    if token_ids.is_empty() {
+        return Err(client::invalid_argument(
+            "multimodal prefill token IDs must not be empty",
+        ));
+    }
+    Ok(token_ids)
+}
+
+fn media_source(source: &str) -> Result<pb::media_item::Source, DynamoError> {
+    if source.starts_with("data:") {
+        Ok(pb::media_item::Source::DataUri(source.to_string()))
+    } else if source.starts_with("http://") || source.starts_with("https://") {
+        Ok(pb::media_item::Source::Url(source.to_string()))
+    } else {
+        Err(client::invalid_argument(
+            "vLLM gRPC image input must use an http://, https://, or data: URI",
+        ))
+    }
+}
+
+fn forwarded_mm_uuids(request: &PreprocessedRequest) -> Result<Option<Vec<String>>, DynamoError> {
+    let has_user_uuid = request
+        .multi_modal_uuids
+        .as_ref()
+        .is_some_and(|by_modality| {
+            by_modality
+                .values()
+                .flatten()
+                .any(|uuid| uuid.as_ref().is_some_and(|uuid| !uuid.is_empty()))
+        });
+    if has_user_uuid {
+        return Ok(None);
+    }
+
+    let hashes = match request.extra_args.as_ref() {
+        Some(serde_json::Value::Object(extra)) => extra.get(MM_HASHES_KEY),
+        _ => None,
+    };
+    let Some(hashes) = hashes else {
+        return Ok(None);
+    };
+    let hashes = hashes.as_array().ok_or_else(|| {
+        client::invalid_argument("extra_args.mm_hashes must be an array of strings")
+    })?;
+    if hashes.is_empty() {
+        return Ok(None);
+    }
+    hashes
+        .iter()
+        .enumerate()
+        .map(|(index, hash)| {
+            let hash = hash
+                .as_str()
+                .filter(|hash| !hash.is_empty())
+                .ok_or_else(|| {
+                    client::invalid_argument(format!(
+                        "extra_args.mm_hashes[{index}] must be a non-empty string"
+                    ))
+                })?;
+            let mut uuid = hash.to_string();
+            if uuid.len() < 64 {
+                uuid.extend(std::iter::repeat_n('0', 64 - uuid.len()));
+            }
+            Ok(uuid)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+fn build_media(
+    request: &PreprocessedRequest,
+    forwarded_uuids: Option<&[String]>,
+) -> Result<Vec<pb::MediaItem>, DynamoError> {
+    let Some(media_by_modality) = request.multi_modal_data.as_ref() else {
+        if request
+            .multi_modal_uuids
+            .as_ref()
+            .is_some_and(|uuids| !uuids.is_empty())
+        {
+            return Err(client::invalid_argument(
+                "multi_modal_uuids were provided without multi_modal_data",
+            ));
+        }
+        return Ok(Vec::new());
+    };
+
+    let mut media = Vec::new();
+    for (key, items) in media_by_modality {
+        if items.is_empty() {
+            continue;
+        }
+        if key != "image_url" {
+            return Err(client::invalid_argument(format!(
+                "vLLM gRPC currently supports image_url media only; got `{key}`"
+            )));
+        }
+        let uuids = request
+            .multi_modal_uuids
+            .as_ref()
+            .and_then(|by_modality| by_modality.get(key));
+        if let Some(uuids) = uuids
+            && uuids.len() != items.len()
+        {
+            return Err(client::invalid_argument(format!(
+                "multi_modal_uuids.{key} has {} entries for {} media items",
+                uuids.len(),
+                items.len()
+            )));
+        }
+        if let Some(uuids) = forwarded_uuids
+            && uuids.len() != items.len()
+        {
+            return Err(client::invalid_argument(format!(
+                "extra_args.mm_hashes has {} entries for {} media items",
+                uuids.len(),
+                items.len()
+            )));
+        }
+
+        for (index, item) in items.iter().enumerate() {
+            let source = match item {
+                MultimodalData::Url(url) => media_source(url.as_str())?,
+                MultimodalData::RawUrl(source) => media_source(source)?,
+                MultimodalData::Decoded(_) => {
+                    return Err(client::invalid_argument(
+                        "vLLM sidecar cannot dereference pre-decoded RDMA media; configure URL passthrough",
+                    ));
+                }
+                MultimodalData::UuidOnly(_) => {
+                    return Err(client::invalid_argument(
+                        "vLLM gRPC requires a media source and cannot resolve UUID-only media",
+                    ));
+                }
+            };
+            let uuid = uuids
+                .and_then(|uuids| uuids.get(index))
+                .and_then(Clone::clone)
+                .or_else(|| forwarded_uuids.and_then(|uuids| uuids.get(index)).cloned())
+                .unwrap_or_default();
+            media.push(pb::MediaItem {
+                modality: pb::Modality::Image as i32,
+                source: Some(source),
+                mime_type: String::new(),
+                uuid,
+            });
+        }
+    }
+    Ok(media)
 }
 
 fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
@@ -366,13 +565,9 @@ fn validate_request(
             "prompt embeddings are not supported by vLLM gRPC v0.25.1",
         ));
     }
-    if request.multi_modal_data.is_some()
-        || request.mm_routing_info.is_some()
-        || request.mm_processor_kwargs.is_some()
-        || request.encoder_result.is_some()
-    {
+    if request.mm_processor_kwargs.is_some() || request.encoder_result.is_some() {
         return Err(client::invalid_argument(
-            "multimodal requests are not supported by vLLM gRPC v0.25.1",
+            "preprocessed multimodal features are not supported by vLLM gRPC",
         ));
     }
     if mode.is_encode() {
@@ -437,6 +632,8 @@ fn validate_request(
 
 pub(crate) struct ResponseState {
     prompt_tokens: u32,
+    has_media: bool,
+    multimodal_prompt_token_ids: Option<Vec<u32>>,
     completion_tokens: u32,
     is_prefill: bool,
     output_logprobs: Option<u32>,
@@ -448,6 +645,11 @@ impl ResponseState {
     pub(crate) fn new(request: &PreprocessedRequest, mode: DisaggregationMode) -> Self {
         Self {
             prompt_tokens: request.token_ids.len() as u32,
+            has_media: request
+                .multi_modal_data
+                .as_ref()
+                .is_some_and(|media| media.values().any(|items| !items.is_empty())),
+            multimodal_prompt_token_ids: None,
             completion_tokens: 0,
             is_prefill: mode.is_prefill(),
             output_logprobs: request.output_options.logprobs,
@@ -570,6 +772,28 @@ impl ResponseState {
                 "prefill terminal is missing kv_transfer_params",
             ));
         }
+        if self.is_prefill && self.has_media {
+            let token_ids = self.multimodal_prompt_token_ids.take().ok_or_else(|| {
+                client::protocol_error(
+                    "multimodal prefill did not return expanded prompt token IDs",
+                )
+            })?;
+            let params = mapped
+                .disaggregated_params
+                .as_mut()
+                .and_then(serde_json::Value::as_object_mut)
+                .ok_or_else(|| {
+                    client::protocol_error("prefill kv_transfer_params is not a JSON object")
+                })?;
+            params.insert(
+                MULTIMODAL_PROMPT_TOKEN_IDS_KEY.to_string(),
+                serde_json::to_value(token_ids).map_err(|error| {
+                    client::protocol_error(format!(
+                        "failed to encode multimodal prefill token IDs: {error}"
+                    ))
+                })?,
+            );
+        }
         self.attach_prompt_data(&mut mapped);
         Ok(Some(mapped))
     }
@@ -582,10 +806,24 @@ impl ResponseState {
 
     fn consume_prompt_info(&mut self, prompt: pb::PromptInfo) -> Result<(), DynamoError> {
         if prompt.num_prompt_tokens != self.prompt_tokens {
-            return Err(client::protocol_error(format!(
-                "prompt token count {} does not match request count {}",
-                prompt.num_prompt_tokens, self.prompt_tokens
-            )));
+            if !self.has_media {
+                return Err(client::protocol_error(format!(
+                    "prompt token count {} does not match request count {}",
+                    prompt.num_prompt_tokens, self.prompt_tokens
+                )));
+            }
+            // vLLM's count includes expanded media tokens.
+            self.prompt_tokens = prompt.num_prompt_tokens;
+        }
+        if self.is_prefill && self.has_media {
+            if prompt.token_ids.len() != prompt.num_prompt_tokens as usize {
+                return Err(client::protocol_error(format!(
+                    "multimodal prefill returned {} prompt token IDs for {} prompt tokens",
+                    prompt.token_ids.len(),
+                    prompt.num_prompt_tokens
+                )));
+            }
+            self.multimodal_prompt_token_ids = Some(prompt.token_ids.clone());
         }
         if !self.expect_prompt_logprobs {
             return Ok(());

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_backend_common::{
-    DisaggregationMode, DynamoError, GuidedDecodingOptions, LLMEngineOutput, PrefillResult,
-    PreprocessedRequest, StopReason, TopLogprob, usage,
+    DisaggregationMode, DynamoError, GuidedDecodingOptions, LLMEngineOutput, MultimodalData,
+    PrefillResult, PreprocessedRequest, StopReason, TopLogprob, usage,
 };
 
 use crate::client;
@@ -11,6 +11,9 @@ use crate::json::{json_to_struct, struct_to_json};
 use crate::proto as pb;
 
 const VLLM_LOGPROB_FLOOR: f64 = -9999.0;
+const MULTIMODAL_PROMPT_TOKEN_IDS_KEY: &str = "_dynamo_sidecar_multimodal_prompt_token_ids";
+const MM_HASHES_KEY: &str = "mm_hashes";
+// Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
 const DYNAMO_CACHE_SALT_PREFIX: &str = "dynamo-cache-salt:";
 
 pub(crate) fn build_generate_request(
@@ -20,6 +23,26 @@ pub(crate) fn build_generate_request(
 ) -> Result<pb::GenerateRequest, DynamoError> {
     validate_request(&request, mode)?;
 
+    let has_media = request
+        .multi_modal_data
+        .as_ref()
+        .is_some_and(|media| media.values().any(|items| !items.is_empty()));
+    // Decode reuses the prefill-expanded tokens without reprocessing media.
+    let forwarded_mm_uuids = if has_media && !mode.is_decode() {
+        forwarded_mm_uuids(&request)?
+    } else {
+        None
+    };
+    let media = if mode.is_decode() {
+        Vec::new()
+    } else {
+        build_media(&request, forwarded_mm_uuids.as_deref())?
+    };
+    let mut prefill_result = request.prefill_result;
+    let mut token_ids = request.token_ids;
+    if mode.is_decode() && has_media {
+        token_ids = take_multimodal_prompt_token_ids(&mut prefill_result)?;
+    }
     let data_parallel_rank = request.routing.as_ref().and_then(|routing| {
         if mode.is_prefill() {
             routing.prefill_dp_rank.or(routing.dp_rank)
@@ -53,13 +76,19 @@ pub(crate) fn build_generate_request(
     let stop_conditions = request.stop_conditions;
     let mut extra_args = request.extra_args;
     consume_redundant_nvext(&mut extra_args, cache_salt.as_deref())?;
-    let kv = build_kv_parameters(extra_args, request.prefill_result, cache_salt, mode)?;
+    if has_media && let Some(serde_json::Value::Object(extra)) = extra_args.as_mut() {
+        // These fields are already represented by token_ids and media.
+        extra.remove("messages");
+        extra.remove("formatted_prompt");
+        extra.remove(MM_HASHES_KEY);
+    }
+    let kv = build_kv_parameters(extra_args, prefill_result, cache_salt, mode)?;
 
     Ok(pb::GenerateRequest {
         request_id,
         model: String::new(),
         prompt: Some(pb::generate_request::Prompt::TokenIds(pb::TokenIds {
-            ids: request.token_ids,
+            ids: token_ids,
         })),
         temperature: sampling.temperature,
         sampling: Some(pb::RandomSampling {
@@ -89,7 +118,7 @@ pub(crate) fn build_generate_request(
             ignore_eos: stop_conditions.ignore_eos.unwrap_or(false),
         }),
         response: Some(pb::ResponseOptions {
-            prompt_token_ids: prompt_logprobs.is_some(),
+            prompt_token_ids: prompt_logprobs.is_some() || (has_media && mode.is_prefill()),
             prompt_logprobs: prompt_logprobs.is_some(),
             prompt_candidates: prompt_logprobs.map(top_n_candidates).transpose()?,
             output_text: Some(true),
@@ -101,7 +130,7 @@ pub(crate) fn build_generate_request(
         truncate_prompt_tokens: 0,
         priority,
         session_id: None,
-        media: Vec::new(),
+        media,
         data_parallel_rank,
     })
 }
@@ -153,6 +182,176 @@ fn consume_redundant_nvext(
         extra.remove("nvext");
     }
     Ok(())
+}
+
+fn take_multimodal_prompt_token_ids(
+    prefill_result: &mut Option<PrefillResult>,
+) -> Result<Vec<u32>, DynamoError> {
+    let params = &mut prefill_result
+        .as_mut()
+        .ok_or_else(|| {
+            client::invalid_argument("multimodal decode request is missing the prefill result")
+        })?
+        .disaggregated_params;
+    let value = params
+        .as_object_mut()
+        .and_then(|params| params.remove(MULTIMODAL_PROMPT_TOKEN_IDS_KEY))
+        .ok_or_else(|| {
+            client::invalid_argument(
+                "multimodal decode request is missing expanded prefill token IDs",
+            )
+        })?;
+    let token_ids: Vec<u32> = serde_json::from_value(value).map_err(|error| {
+        client::invalid_argument(format!("multimodal prefill token IDs are invalid: {error}"))
+    })?;
+    if token_ids.is_empty() {
+        return Err(client::invalid_argument(
+            "multimodal prefill token IDs must not be empty",
+        ));
+    }
+    Ok(token_ids)
+}
+
+fn media_source(source: &str) -> Result<pb::media_item::Source, DynamoError> {
+    if source.starts_with("data:") {
+        Ok(pb::media_item::Source::DataUri(source.to_string()))
+    } else if source.starts_with("http://") || source.starts_with("https://") {
+        Ok(pb::media_item::Source::Url(source.to_string()))
+    } else {
+        Err(client::invalid_argument(
+            "vLLM gRPC image input must use an http://, https://, or data: URI",
+        ))
+    }
+}
+
+fn forwarded_mm_uuids(request: &PreprocessedRequest) -> Result<Option<Vec<String>>, DynamoError> {
+    let has_user_uuid = request
+        .multi_modal_uuids
+        .as_ref()
+        .is_some_and(|by_modality| {
+            by_modality
+                .values()
+                .flatten()
+                .any(|uuid| uuid.as_ref().is_some_and(|uuid| !uuid.is_empty()))
+        });
+    if has_user_uuid {
+        return Ok(None);
+    }
+
+    let hashes = match request.extra_args.as_ref() {
+        Some(serde_json::Value::Object(extra)) => extra.get(MM_HASHES_KEY),
+        _ => None,
+    };
+    let Some(hashes) = hashes else {
+        return Ok(None);
+    };
+    let hashes = hashes.as_array().ok_or_else(|| {
+        client::invalid_argument("extra_args.mm_hashes must be an array of strings")
+    })?;
+    if hashes.is_empty() {
+        return Ok(None);
+    }
+    hashes
+        .iter()
+        .enumerate()
+        .map(|(index, hash)| {
+            let hash = hash
+                .as_str()
+                .filter(|hash| !hash.is_empty())
+                .ok_or_else(|| {
+                    client::invalid_argument(format!(
+                        "extra_args.mm_hashes[{index}] must be a non-empty string"
+                    ))
+                })?;
+            let mut uuid = hash.to_string();
+            if uuid.len() < 64 {
+                uuid.extend(std::iter::repeat_n('0', 64 - uuid.len()));
+            }
+            Ok(uuid)
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Some)
+}
+
+fn build_media(
+    request: &PreprocessedRequest,
+    forwarded_uuids: Option<&[String]>,
+) -> Result<Vec<pb::MediaItem>, DynamoError> {
+    let Some(media_by_modality) = request.multi_modal_data.as_ref() else {
+        if request
+            .multi_modal_uuids
+            .as_ref()
+            .is_some_and(|uuids| !uuids.is_empty())
+        {
+            return Err(client::invalid_argument(
+                "multi_modal_uuids were provided without multi_modal_data",
+            ));
+        }
+        return Ok(Vec::new());
+    };
+
+    let mut media = Vec::new();
+    for (key, items) in media_by_modality {
+        if items.is_empty() {
+            continue;
+        }
+        if key != "image_url" {
+            return Err(client::invalid_argument(format!(
+                "vLLM gRPC currently supports image_url media only; got `{key}`"
+            )));
+        }
+        let uuids = request
+            .multi_modal_uuids
+            .as_ref()
+            .and_then(|by_modality| by_modality.get(key));
+        if let Some(uuids) = uuids
+            && uuids.len() != items.len()
+        {
+            return Err(client::invalid_argument(format!(
+                "multi_modal_uuids.{key} has {} entries for {} media items",
+                uuids.len(),
+                items.len()
+            )));
+        }
+        if let Some(uuids) = forwarded_uuids
+            && uuids.len() != items.len()
+        {
+            return Err(client::invalid_argument(format!(
+                "extra_args.mm_hashes has {} entries for {} media items",
+                uuids.len(),
+                items.len()
+            )));
+        }
+
+        for (index, item) in items.iter().enumerate() {
+            let source = match item {
+                MultimodalData::Url(url) => media_source(url.as_str())?,
+                MultimodalData::RawUrl(source) => media_source(source)?,
+                MultimodalData::Decoded(_) => {
+                    return Err(client::invalid_argument(
+                        "vLLM sidecar cannot dereference pre-decoded RDMA media; configure URL passthrough",
+                    ));
+                }
+                MultimodalData::UuidOnly(_) => {
+                    return Err(client::invalid_argument(
+                        "vLLM gRPC requires a media source and cannot resolve UUID-only media",
+                    ));
+                }
+            };
+            let uuid = uuids
+                .and_then(|uuids| uuids.get(index))
+                .and_then(Clone::clone)
+                .or_else(|| forwarded_uuids.and_then(|uuids| uuids.get(index)).cloned())
+                .unwrap_or_default();
+            media.push(pb::MediaItem {
+                modality: pb::Modality::Image as i32,
+                source: Some(source),
+                mime_type: String::new(),
+                uuid,
+            });
+        }
+    }
+    Ok(media)
 }
 
 fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
@@ -362,13 +561,9 @@ fn validate_request(
             "prompt embeddings are not supported by vLLM gRPC v0.25.1",
         ));
     }
-    if request.multi_modal_data.is_some()
-        || request.mm_routing_info.is_some()
-        || request.mm_processor_kwargs.is_some()
-        || request.encoder_result.is_some()
-    {
+    if request.mm_processor_kwargs.is_some() || request.encoder_result.is_some() {
         return Err(client::invalid_argument(
-            "multimodal requests are not supported by vLLM gRPC v0.25.1",
+            "preprocessed multimodal features are not supported by vLLM gRPC",
         ));
     }
     if mode.is_encode() {
@@ -433,6 +628,8 @@ fn validate_request(
 
 pub(crate) struct ResponseState {
     prompt_tokens: u32,
+    has_media: bool,
+    multimodal_prompt_token_ids: Option<Vec<u32>>,
     completion_tokens: u32,
     is_prefill: bool,
     output_logprobs: Option<u32>,
@@ -444,6 +641,11 @@ impl ResponseState {
     pub(crate) fn new(request: &PreprocessedRequest, mode: DisaggregationMode) -> Self {
         Self {
             prompt_tokens: request.token_ids.len() as u32,
+            has_media: request
+                .multi_modal_data
+                .as_ref()
+                .is_some_and(|media| media.values().any(|items| !items.is_empty())),
+            multimodal_prompt_token_ids: None,
             completion_tokens: 0,
             is_prefill: mode.is_prefill(),
             output_logprobs: request.output_options.logprobs,
@@ -566,6 +768,28 @@ impl ResponseState {
                 "prefill terminal is missing kv_transfer_params",
             ));
         }
+        if self.is_prefill && self.has_media {
+            let token_ids = self.multimodal_prompt_token_ids.take().ok_or_else(|| {
+                client::protocol_error(
+                    "multimodal prefill did not return expanded prompt token IDs",
+                )
+            })?;
+            let params = mapped
+                .disaggregated_params
+                .as_mut()
+                .and_then(serde_json::Value::as_object_mut)
+                .ok_or_else(|| {
+                    client::protocol_error("prefill kv_transfer_params is not a JSON object")
+                })?;
+            params.insert(
+                MULTIMODAL_PROMPT_TOKEN_IDS_KEY.to_string(),
+                serde_json::to_value(token_ids).map_err(|error| {
+                    client::protocol_error(format!(
+                        "failed to encode multimodal prefill token IDs: {error}"
+                    ))
+                })?,
+            );
+        }
         self.attach_prompt_data(&mut mapped);
         Ok(Some(mapped))
     }
@@ -578,10 +802,24 @@ impl ResponseState {
 
     fn consume_prompt_info(&mut self, prompt: pb::PromptInfo) -> Result<(), DynamoError> {
         if prompt.num_prompt_tokens != self.prompt_tokens {
-            return Err(client::protocol_error(format!(
-                "prompt token count {} does not match request count {}",
-                prompt.num_prompt_tokens, self.prompt_tokens
-            )));
+            if !self.has_media {
+                return Err(client::protocol_error(format!(
+                    "prompt token count {} does not match request count {}",
+                    prompt.num_prompt_tokens, self.prompt_tokens
+                )));
+            }
+            // vLLM's count includes expanded media tokens.
+            self.prompt_tokens = prompt.num_prompt_tokens;
+        }
+        if self.is_prefill && self.has_media {
+            if prompt.token_ids.len() != prompt.num_prompt_tokens as usize {
+                return Err(client::protocol_error(format!(
+                    "multimodal prefill returned {} prompt token IDs for {} prompt tokens",
+                    prompt.token_ids.len(),
+                    prompt.num_prompt_tokens
+                )));
+            }
+            self.multimodal_prompt_token_ids = Some(prompt.token_ids.clone());
         }
         if !self.expect_prompt_logprobs {
             return Ok(());

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -186,6 +186,17 @@ impl LLMEngine for VllmSidecarEngine {
         request: dynamo_backend_common::PreprocessedRequest,
         ctx: GenerateContext,
     ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        if request
+            .multi_modal_data
+            .as_ref()
+            .is_some_and(|media| media.values().any(|items| !items.is_empty()))
+            && !self.model.supports_multimodal
+        {
+            return Err(client::invalid_argument(format!(
+                "model `{}` does not advertise multimodal support",
+                self.model.served_name
+            )));
+        }
         let client = self
             .client
             .get()

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -21,6 +21,7 @@ struct ModelIdentity {
 pub(crate) struct DiscoveredModel {
     pub source: String,
     pub served_name: String,
+    pub supports_multimodal: bool,
     identity: ModelIdentity,
     server: pb::ServerInfo,
 }
@@ -68,6 +69,7 @@ impl DiscoveredModel {
         Ok(Self {
             source,
             served_name,
+            supports_multimodal: model.supports_multimodal,
             identity,
             server,
         })

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -21,6 +21,7 @@ struct ModelIdentity {
 pub(crate) struct DiscoveredModel {
     pub source: String,
     pub served_name: String,
+    pub supports_multimodal: bool,
     identity: ModelIdentity,
     server: pb::ServerInfo,
 }
@@ -78,6 +79,7 @@ impl DiscoveredModel {
         Ok(Self {
             source,
             served_name,
+            supports_multimodal: model.supports_multimodal,
             identity,
             server,
         })

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dynamo_backend_common::engine::RoutingHints;
 use dynamo_backend_common::{
-    DisaggregationMode, FinishReason, GenerateContext, LLMEngine, OutputOptions, PrefillResult,
-    PreprocessedRequest, SamplingOptions, StopConditions,
+    DisaggregationMode, FinishReason, GenerateContext, LLMEngine, MultimodalData, OutputOptions,
+    PrefillResult, PreprocessedRequest, SamplingOptions, StopConditions,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -102,10 +102,19 @@ impl pb::inference_server::Inference for FakeVllm {
             }
             None => return Err(Status::invalid_argument("prompt required")),
         };
+        let prompt_tokens = if request.media.is_empty() {
+            prompt_tokens
+        } else {
+            601
+        };
         let wants_logprobs = request
             .response
             .as_ref()
             .is_some_and(|response| response.output_logprobs);
+        let wants_prompt_token_ids = request
+            .response
+            .as_ref()
+            .is_some_and(|response| response.prompt_token_ids);
         let wants_prompt_logprobs = request
             .response
             .as_ref()
@@ -144,23 +153,28 @@ impl pb::inference_server::Inference for FakeVllm {
 
         let stream = async_stream::try_stream! {
             let _drop_signal = DropSignal(dropped);
-            let prompt_info = if wants_prompt_logprobs {
-                pb::PromptInfo {
-                    num_prompt_tokens: prompt_tokens,
-                    token_ids: vec![11, 22, 33],
-                    logprobs: vec![0.0, -0.2, -0.3],
-                    ranks: vec![0, 1, 2],
-                    candidate_tokens: vec![
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                    ],
-                }
-            } else {
-                pb::PromptInfo {
-                    num_prompt_tokens: prompt_tokens,
-                    ..Default::default()
-                }
+            let prompt_info = pb::PromptInfo {
+                num_prompt_tokens: prompt_tokens,
+                token_ids: if wants_prompt_token_ids {
+                    (0..prompt_tokens).collect()
+                } else {
+                    Vec::new()
+                },
+                logprobs: if wants_prompt_logprobs {
+                    vec![-0.2; prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
+                ranks: if wants_prompt_logprobs {
+                    vec![1; prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
+                candidate_tokens: if wants_prompt_logprobs {
+                    vec![pb::CandidateTokenInfo::default(); prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
             };
             yield pb::GenerateResponse {
                 prompt_info: Some(prompt_info),
@@ -544,14 +558,19 @@ fn decode_request() -> PreprocessedRequest {
     request
 }
 
-fn engine(endpoint: &str, mode: DisaggregationMode, connections: usize) -> VllmSidecarEngine {
+fn engine(
+    endpoint: &str,
+    mode: DisaggregationMode,
+    connections: usize,
+    model: pb::ModelInfo,
+) -> VllmSidecarEngine {
     let transport = GrpcTransportConfig {
         connections: NonZeroUsize::new(connections).expect("non-zero connection count"),
         ..Default::default()
     };
     VllmSidecarEngine::new(
         GrpcEndpoint::parse(endpoint, "--vllm-endpoint").expect("valid test endpoint"),
-        DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery"),
+        DiscoveredModel::from_proto(model, server_info()).expect("valid discovery"),
         mode,
         transport,
     )
@@ -735,11 +754,143 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 }
 
 #[tokio::test]
+async fn multimodal_image_is_forwarded_with_uuid() {
+    let service = FakeVllm::default();
+    let mut discovered = model_info();
+    discovered.supports_multimodal = true;
+    *service.model_info_override.lock().await = Some(discovered.clone());
+    let server = FakeServer::start(service).await;
+    let (aggregate, _) = engine_from_args(&server.endpoint).await;
+    aggregate.start(0).await.expect("start");
+
+    let mut image_request = request();
+    image_request.multi_modal_data = Some(std::collections::HashMap::from([(
+        "image_url".to_string(),
+        vec![MultimodalData::RawUrl(
+            "data:image/png;base64,iVBORw0KGgo=".to_string(),
+        )],
+    )]));
+    image_request.output_options.prompt_logprobs = None;
+    image_request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .extend([
+            (
+                "messages".to_string(),
+                json!([{"role": "user", "content": [{"type": "image_url"}]}]),
+            ),
+            ("formatted_prompt".to_string(), json!("<image>\nDescribe.")),
+            ("mm_hashes".to_string(), json!(["0123456789abcdef"])),
+        ]);
+
+    let outputs = collect(&aggregate, image_request.clone()).await;
+    assert_eq!(outputs[0].finish_reason, Some(FinishReason::Stop));
+    assert_eq!(
+        outputs[0]
+            .completion_usage
+            .as_ref()
+            .expect("usage")
+            .prompt_tokens,
+        601
+    );
+
+    let requests = server.service.requests.lock().await;
+    let media = &requests.last().expect("recorded request").media;
+    assert_eq!(media.len(), 1);
+    assert_eq!(media[0].modality(), pb::Modality::Image);
+    assert_eq!(
+        media[0].uuid,
+        "0123456789abcdef000000000000000000000000000000000000000000000000"
+    );
+    assert!(matches!(
+        media[0].source.as_ref(),
+        Some(pb::media_item::Source::DataUri(_))
+    ));
+    drop(requests);
+
+    let prefill = engine(
+        &server.endpoint,
+        DisaggregationMode::Prefill,
+        1,
+        discovered.clone(),
+    );
+    let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1, discovered);
+    prefill.start(1).await.expect("start prefill");
+    decode.start(2).await.expect("start decode");
+
+    let prefill_outputs = collect(&prefill, image_request.clone()).await;
+    let handoff = prefill_outputs[0]
+        .disaggregated_params
+        .clone()
+        .expect("multimodal handoff");
+    assert_eq!(
+        handoff["_dynamo_sidecar_multimodal_prompt_token_ids"]
+            .as_array()
+            .expect("expanded prompt token IDs")
+            .len(),
+        601
+    );
+
+    let mut decode_request = image_request;
+    decode_request.prefill_result = Some(PrefillResult {
+        disaggregated_params: handoff,
+        prompt_tokens_details: None,
+    });
+    let decode_outputs = collect(&decode, decode_request).await;
+    assert_eq!(
+        decode_outputs[0]
+            .completion_usage
+            .as_ref()
+            .expect("decode usage")
+            .prompt_tokens,
+        601
+    );
+
+    let requests = server.service.requests.lock().await;
+    let prefill_wire = &requests[requests.len() - 2];
+    let decode_wire = &requests[requests.len() - 1];
+    assert_eq!(prefill_wire.media.len(), 1);
+    assert!(
+        prefill_wire
+            .response
+            .as_ref()
+            .expect("prefill response options")
+            .prompt_token_ids
+    );
+    assert!(decode_wire.media.is_empty());
+    assert_eq!(
+        decode_wire.prompt.as_ref(),
+        Some(&pb::generate_request::Prompt::TokenIds(pb::TokenIds {
+            ids: (0..601).collect(),
+        }))
+    );
+    let decode_kv = struct_to_json(
+        decode_wire
+            .kv
+            .as_ref()
+            .and_then(|kv| kv.kv_transfer_params.clone())
+            .expect("decode KV handoff"),
+    )
+    .expect("decode KV JSON");
+    assert!(
+        decode_kv["_dynamo_sidecar_multimodal_prompt_token_ids"].is_null(),
+        "sidecar metadata must not reach vLLM"
+    );
+}
+
+#[tokio::test]
 async fn grpc_request_errors_are_propagated() {
     let service = FakeVllm::default();
     service.reject.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -753,8 +904,18 @@ async fn grpc_request_errors_are_propagated() {
 #[tokio::test]
 async fn prefill_decode_handoff_is_opaque_and_repeatable() {
     let server = FakeServer::start(FakeVllm::default()).await;
-    let prefill = engine(&server.endpoint, DisaggregationMode::Prefill, 1);
-    let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let prefill = engine(
+        &server.endpoint,
+        DisaggregationMode::Prefill,
+        1,
+        model_info(),
+    );
+    let decode = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     prefill.start(0).await.expect("start prefill");
     decode.start(1).await.expect("start decode");
 
@@ -868,7 +1029,12 @@ async fn cancellation_drops_the_remote_stream() {
     let service = FakeVllm::default();
     service.hang.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -897,7 +1063,12 @@ async fn cancellation_interrupts_pending_response_headers() {
     let service = FakeVllm::default();
     service.hang_before_headers.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -931,7 +1102,12 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
         .hold_before_first_token
         .store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -1005,7 +1181,12 @@ async fn decode_cancellation_maps_premature_eof_to_cancelled() {
         .close_before_first_token
         .store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -1028,7 +1209,12 @@ async fn decode_cancellation_maps_premature_eof_to_cancelled() {
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
     let server = FakeServer::start(FakeVllm::default()).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let mut requests = Vec::new();

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -10,8 +10,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use dynamo_backend_common::engine::RoutingHints;
 use dynamo_backend_common::{
-    DisaggregationMode, FinishReason, GenerateContext, LLMEngine, OutputOptions, PrefillResult,
-    PreprocessedRequest, SamplingOptions, StopConditions,
+    DisaggregationMode, FinishReason, GenerateContext, LLMEngine, MultimodalData, OutputOptions,
+    PrefillResult, PreprocessedRequest, SamplingOptions, StopConditions,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
@@ -91,10 +91,19 @@ impl pb::inference_server::Inference for FakeVllm {
             }
             None => return Err(Status::invalid_argument("prompt required")),
         };
+        let prompt_tokens = if request.media.is_empty() {
+            prompt_tokens
+        } else {
+            601
+        };
         let wants_logprobs = request
             .response
             .as_ref()
             .is_some_and(|response| response.output_logprobs);
+        let wants_prompt_token_ids = request
+            .response
+            .as_ref()
+            .is_some_and(|response| response.prompt_token_ids);
         let wants_prompt_logprobs = request
             .response
             .as_ref()
@@ -133,23 +142,28 @@ impl pb::inference_server::Inference for FakeVllm {
 
         let stream = async_stream::try_stream! {
             let _drop_signal = DropSignal(dropped);
-            let prompt_info = if wants_prompt_logprobs {
-                pb::PromptInfo {
-                    num_prompt_tokens: prompt_tokens,
-                    token_ids: vec![11, 22, 33],
-                    logprobs: vec![0.0, -0.2, -0.3],
-                    ranks: vec![0, 1, 2],
-                    candidate_tokens: vec![
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                        pb::CandidateTokenInfo { tokens: vec![] },
-                    ],
-                }
-            } else {
-                pb::PromptInfo {
-                    num_prompt_tokens: prompt_tokens,
-                    ..Default::default()
-                }
+            let prompt_info = pb::PromptInfo {
+                num_prompt_tokens: prompt_tokens,
+                token_ids: if wants_prompt_token_ids {
+                    (0..prompt_tokens).collect()
+                } else {
+                    Vec::new()
+                },
+                logprobs: if wants_prompt_logprobs {
+                    vec![-0.2; prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
+                ranks: if wants_prompt_logprobs {
+                    vec![1; prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
+                candidate_tokens: if wants_prompt_logprobs {
+                    vec![pb::CandidateTokenInfo::default(); prompt_tokens as usize]
+                } else {
+                    Vec::new()
+                },
             };
             yield pb::GenerateResponse {
                 prompt_info: Some(prompt_info),
@@ -534,14 +548,19 @@ fn decode_request() -> PreprocessedRequest {
     request
 }
 
-fn engine(endpoint: &str, mode: DisaggregationMode, connections: usize) -> VllmSidecarEngine {
+fn engine(
+    endpoint: &str,
+    mode: DisaggregationMode,
+    connections: usize,
+    model: pb::ModelInfo,
+) -> VllmSidecarEngine {
     let transport = GrpcTransportConfig {
         connections: NonZeroUsize::new(connections).expect("non-zero connection count"),
         ..Default::default()
     };
     VllmSidecarEngine::new(
         GrpcEndpoint::parse(endpoint, "--vllm-endpoint").expect("valid test endpoint"),
-        DiscoveredModel::from_proto(model_info(), server_info()).expect("valid discovery"),
+        DiscoveredModel::from_proto(model, server_info()).expect("valid discovery"),
         mode,
         transport,
     )
@@ -722,11 +741,143 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 }
 
 #[tokio::test]
+async fn multimodal_image_is_forwarded_with_uuid() {
+    let service = FakeVllm::default();
+    let mut discovered = model_info();
+    discovered.supports_multimodal = true;
+    *service.model_info_override.lock().await = Some(discovered.clone());
+    let server = FakeServer::start(service).await;
+    let (aggregate, _) = engine_from_args(&server.endpoint).await;
+    aggregate.start(0).await.expect("start");
+
+    let mut image_request = request();
+    image_request.multi_modal_data = Some(std::collections::HashMap::from([(
+        "image_url".to_string(),
+        vec![MultimodalData::RawUrl(
+            "data:image/png;base64,iVBORw0KGgo=".to_string(),
+        )],
+    )]));
+    image_request.output_options.prompt_logprobs = None;
+    image_request
+        .extra_args
+        .as_mut()
+        .and_then(serde_json::Value::as_object_mut)
+        .expect("object extra_args")
+        .extend([
+            (
+                "messages".to_string(),
+                json!([{"role": "user", "content": [{"type": "image_url"}]}]),
+            ),
+            ("formatted_prompt".to_string(), json!("<image>\nDescribe.")),
+            ("mm_hashes".to_string(), json!(["0123456789abcdef"])),
+        ]);
+
+    let outputs = collect(&aggregate, image_request.clone()).await;
+    assert_eq!(outputs[0].finish_reason, Some(FinishReason::Stop));
+    assert_eq!(
+        outputs[0]
+            .completion_usage
+            .as_ref()
+            .expect("usage")
+            .prompt_tokens,
+        601
+    );
+
+    let requests = server.service.requests.lock().await;
+    let media = &requests.last().expect("recorded request").media;
+    assert_eq!(media.len(), 1);
+    assert_eq!(media[0].modality(), pb::Modality::Image);
+    assert_eq!(
+        media[0].uuid,
+        "0123456789abcdef000000000000000000000000000000000000000000000000"
+    );
+    assert!(matches!(
+        media[0].source.as_ref(),
+        Some(pb::media_item::Source::DataUri(_))
+    ));
+    drop(requests);
+
+    let prefill = engine(
+        &server.endpoint,
+        DisaggregationMode::Prefill,
+        1,
+        discovered.clone(),
+    );
+    let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1, discovered);
+    prefill.start(1).await.expect("start prefill");
+    decode.start(2).await.expect("start decode");
+
+    let prefill_outputs = collect(&prefill, image_request.clone()).await;
+    let handoff = prefill_outputs[0]
+        .disaggregated_params
+        .clone()
+        .expect("multimodal handoff");
+    assert_eq!(
+        handoff["_dynamo_sidecar_multimodal_prompt_token_ids"]
+            .as_array()
+            .expect("expanded prompt token IDs")
+            .len(),
+        601
+    );
+
+    let mut decode_request = image_request;
+    decode_request.prefill_result = Some(PrefillResult {
+        disaggregated_params: handoff,
+        prompt_tokens_details: None,
+    });
+    let decode_outputs = collect(&decode, decode_request).await;
+    assert_eq!(
+        decode_outputs[0]
+            .completion_usage
+            .as_ref()
+            .expect("decode usage")
+            .prompt_tokens,
+        601
+    );
+
+    let requests = server.service.requests.lock().await;
+    let prefill_wire = &requests[requests.len() - 2];
+    let decode_wire = &requests[requests.len() - 1];
+    assert_eq!(prefill_wire.media.len(), 1);
+    assert!(
+        prefill_wire
+            .response
+            .as_ref()
+            .expect("prefill response options")
+            .prompt_token_ids
+    );
+    assert!(decode_wire.media.is_empty());
+    assert_eq!(
+        decode_wire.prompt.as_ref(),
+        Some(&pb::generate_request::Prompt::TokenIds(pb::TokenIds {
+            ids: (0..601).collect(),
+        }))
+    );
+    let decode_kv = struct_to_json(
+        decode_wire
+            .kv
+            .as_ref()
+            .and_then(|kv| kv.kv_transfer_params.clone())
+            .expect("decode KV handoff"),
+    )
+    .expect("decode KV JSON");
+    assert!(
+        decode_kv["_dynamo_sidecar_multimodal_prompt_token_ids"].is_null(),
+        "sidecar metadata must not reach vLLM"
+    );
+}
+
+#[tokio::test]
 async fn grpc_request_errors_are_propagated() {
     let service = FakeVllm::default();
     service.reject.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -740,8 +891,18 @@ async fn grpc_request_errors_are_propagated() {
 #[tokio::test]
 async fn prefill_decode_handoff_is_opaque_and_repeatable() {
     let server = FakeServer::start(FakeVllm::default()).await;
-    let prefill = engine(&server.endpoint, DisaggregationMode::Prefill, 1);
-    let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let prefill = engine(
+        &server.endpoint,
+        DisaggregationMode::Prefill,
+        1,
+        model_info(),
+    );
+    let decode = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     prefill.start(0).await.expect("start prefill");
     decode.start(1).await.expect("start decode");
 
@@ -843,7 +1004,12 @@ async fn cancellation_drops_the_remote_stream() {
     let service = FakeVllm::default();
     service.hang.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -872,7 +1038,12 @@ async fn cancellation_interrupts_pending_response_headers() {
     let service = FakeVllm::default();
     service.hang_before_headers.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -906,7 +1077,12 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
         .hold_before_first_token
         .store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -980,7 +1156,12 @@ async fn decode_cancellation_maps_premature_eof_to_cancelled() {
         .close_before_first_token
         .store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Decode,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let context = dynamo_backend_common::testing::mock_context();
@@ -1003,7 +1184,12 @@ async fn decode_cancellation_maps_premature_eof_to_cancelled() {
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
     let server = FakeServer::start(FakeVllm::default()).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    let engine = engine(
+        &server.endpoint,
+        DisaggregationMode::Aggregated,
+        1,
+        model_info(),
+    );
     engine.start(0).await.expect("start");
 
     let mut requests = Vec::new();


### PR DESCRIPTION
## Summary

Part 4 of a 4-PR stack.

- Convert Dynamo multimodal inputs into vLLM `MediaItem` messages.
- Map canonical `mm_hashes` to `MediaItem.uuid` so repeated images use the same keys as vLLM KV events.
- Carry multimodal prompt token IDs through the private preprocessor-to-sidecar handoff.
- Support aggregate and disaggregated multimodal generation without duplicating media processing.
- Keep this layer free of mocker changes.

## Stack

1. [#12734 — split gRPC services and Control discovery](https://github.com/ai-dynamo/dynamo/pull/12734)
2. [#12736 — preserve decode handoff on cancellation](https://github.com/ai-dynamo/dynamo/pull/12736)
3. [#12735 — deterministic DP and KV routing](https://github.com/ai-dynamo/dynamo/pull/12735)
4. [#12214 — multimodal sidecar requests](https://github.com/ai-dynamo/dynamo/pull/12214)

**Base:** [#12735](https://github.com/ai-dynamo/dynamo/pull/12735)

## Validation

- `cargo test -p dynamo-sidecar-common -p dynamo-vllm-sidecar -p dynamo-vllm-mocker` — 38 tests passed
- `cargo clippy -p dynamo-sidecar-common -p dynamo-vllm-sidecar -p dynamo-vllm-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- The cumulative implementation was previously exercised across the planned 2×H100 aggregate, cancellation, DP2/KV-routing, disaggregated, KVBM, multimodal, and recovery matrix. This stack split preserves that implementation; the rebase added only an unrelated upstream documentation commit.
