### PR TITLE
refactor(trtllm): single-source NIXL version from NIXL_REF

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -141,7 +141,7 @@ trtllm:
     runtime_image_tag: 1.3.0rc22
     # Per-arch baseline stem (re-captured against tensorrt-llm/release, both arches).
     baseline_sbom: release@36d6146d
-  nixl_ref: v1.0.1
+  nixl_ref: v1.3.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"

--- a/container/deps/requirements.trtllm.txt
+++ b/container/deps/requirements.trtllm.txt
@@ -18,11 +18,6 @@ imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file
 # does not ship them; vllm/vllm-openai does (which is why DYN-2204's vllm path
 # does not need this).
 msgspec>=0.19.0
-# KVBM uses `import nixl` to load libnixl.so via DT_RPATH (matching its
-# nixl-sys ABI). Upstream's NIXL at /opt/nvidia/nvda_nixl coexists
-# unused because Dynamo's --connector kvbm bypasses TRT-LLM's native NIXL
-# transceiver. The nixl-cu13 wheel is harmless if KVBM is disabled.
-nixl==1.0.1
-nixl-cu13==1.0.1
+# NIXL is unpinned here; trtllm_runtime.Dockerfile installs it from NIXL_REF.
 # Required by ai_dynamo_runtime (companion to msgspec above).
 uvloop>=0.21.0

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -40,20 +40,17 @@ FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS pre_runtime
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
 ARG TARGETARCH
+ARG NIXL_REF
 
-# DYNAMO_HOME points at /workspace so bundled TRT-LLM scripts that reference
-# $DYNAMO_HOME/examples/... resolve. LD_PRELOAD/NIXL_PLUGIN_DIR are a workaround
-# for ai-dynamo/nixl#1668: nixl-cu13's bundled UCX 1.20.0 hangs in
-# `uct_md_query_tl_resources` (md_resources realloc loop, >1 GiB) when two NIXL
-# agents init on the same host. Force-load TRT-LLM's bundled libnixl 0.9.0
-# (uses system UCX, no bug). LD_PRELOAD is the only lever: nixl-cu13's
-# _bindings.so has DT_RPATH which beats LD_LIBRARY_PATH. Drop the two NIXL
-# vars when the upstream issue is fixed.
+# LD_PRELOAD pins TRT-LLM's bundled libnixl to dodge ai-dynamo/nixl#1668
+# (nixl-cu13's UCX 1.20.0 hangs with two agents/host); drop it when fixed.
+# NIXL_VERSION= clears the base image's stale value (see nixl-versions.txt).
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
     PATH=/usr/local/bin/etcd:${PATH} \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
-    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
+    NIXL_VERSION=
 
 WORKDIR /workspace
 
@@ -126,9 +123,17 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
     uv pip install --no-deps /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl && \
     uv pip install --no-deps /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
     \
-    # Third-party deps Dynamo wheels declare but upstream lacks, plus the
-    # huggingface-hub pin and KVBM-matching nixl-cu13. See the file for context.
-    # The requirements.trtllm.txt file itself carries a `--no-binary imageio-ffmpeg`
+    # nixl/nixl-cu13 for KVBM's `import nixl` ABI; version from NIXL_REF, matching
+    # the nixl-sys wheel_builder links. LD_PRELOAD swaps the runtime .so (nixl#1668).
+    echo "${NIXL_REF}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$' || { echo "NIXL_REF must be a vX.Y.Z release tag; got '${NIXL_REF}'" >&2; exit 1; } && \
+    _nixl_ver="${NIXL_REF#v}" && \
+    uv pip install --no-deps "nixl==${_nixl_ver}" "nixl-cu13==${_nixl_ver}" && \
+    \
+    # Record effective NIXL versions (pip vs loaded .so) for diagnosis.
+    { uv pip show nixl nixl-cu13 | grep -E '^(Name|Version)'; echo "loaded_libnixl: ${LD_PRELOAD##*:}"; } | tee /opt/dynamo/nixl-versions.txt && \
+    \
+    # Third-party deps Dynamo wheels declare but upstream lacks. The
+    # requirements.trtllm.txt file itself carries a `--no-binary imageio-ffmpeg`
     # directive that keeps the GPL-encumbered prebuilt ffmpeg off disk; IMAGEIO_FFMPEG_EXE
     # below points imageio at the in-tree LGPL CLI.
     uv pip install --no-deps --requirement /tmp/requirements.trtllm.txt && \
@@ -203,7 +208,8 @@ ENV DYNAMO_HOME=/workspace \
     PATH=/usr/local/bin/etcd:${PATH} \
     IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
-    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
+    NIXL_VERSION=
 {% else %}
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
@@ -211,7 +217,8 @@ ENV DYNAMO_HOME=/workspace \
     PATH=/opt/dynamo/venv/bin:/usr/local/bin/etcd:${PATH} \
     IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
-    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins
+    NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
+    NIXL_VERSION=
 {% endif %}
 
 WORKDIR /workspace


### PR DESCRIPTION
## Summary

The TRT-LLM image pinned the NIXL version in two places. `requirements.trtllm.txt` hardcoded `nixl==1.0.1`. `context.yaml` set `nixl_ref`, which the source build uses. A person had to keep the two in sync. When they drifted, the image reported a NIXL version that did not match the pin.

This PR removes the duplicate pin. The pip version now comes from `NIXL_REF`. The pip wheel and the source SDK stay on one version.

It also hardens the setup:

- **Single source.** The pip `nixl`/`nixl-cu13` version comes from `NIXL_REF`. The hardcoded pins are removed.
- **Validated.** A bad `NIXL_REF` (branch, SHA, or typo) fails the build early with a clear message. Before, it failed late with a cryptic `pip` error.
- **No stale label.** The base image's inherited `NIXL_VERSION=1.0.0` is blanked. Nothing reads it, and it disagreed with the installed version.
- **Diagnostic.** The image writes `/opt/dynamo/nixl-versions.txt`. It lists the pip versions and the loaded `.so` path.
- **Clearer build log.** The install shell var is renamed to `_nixl_ver`. It no longer clashes with that env var. That removes a misleading `nixl==1.0.0` from the build log.

One thing is unchanged. Runtime still `LD_PRELOAD`s TRT-LLM's bundled libnixl (ai-dynamo/nixl#1668). So the pip wheel provides the Python ABI only. Dropping that workaround is out of scope.

## Before / After

### Before — two version pins that drift

The version lived in two places. Someone kept them in sync by hand. Miss one, and the image shipped mismatched NIXL: the Python ABI at one version, `nixl-sys` built at another. That is the mismatch that showed up at runtime.

```mermaid
flowchart LR
    R["context.yaml<br/>nixl_ref = v1.0.1"]
    P["requirements.trtllm.txt<br/>nixl==1.0.1 (hardcoded)"]
    R --> WB["wheel_builder<br/>builds nixl-sys from source"]
    P --> PIP["pip install<br/>Python ABI"]
    R -. "kept in sync by hand → drifts" .-> P
    WB --> IMG["TRT-LLM image"]
    PIP --> IMG
    IMG --> Q["runtime reports a NIXL version<br/>that disagrees with the pin ⚠️"]
```

Three smaller issues rode along. The base image's `NIXL_VERSION=1.0.0` leaked through unchanged. A bad ref failed late with a cryptic pip error. Nothing recorded which `libnixl.so` loads.

### After — one source, validated and observable

`nixl_ref` is the one source. The pip install derives from it. A guard rejects a malformed ref up front. The image records what it installed and what it loads.

```mermaid
flowchart LR
    R["context.yaml<br/>nixl_ref = v1.0.1<br/>(single source of truth)"]
    R --> WB["wheel_builder<br/>git checkout → nixl-sys"]
    R --> G{"guard:<br/>ref looks like vX.Y.Z?"}
    G -->|yes| PIP["pip install<br/>nixl==1.0.1 · nixl-cu13==1.0.1"]
    G -->|no| F["build fails fast<br/>with a clear message"]
    WB --> IMG["TRT-LLM image"]
    PIP --> IMG
    IMG --> REP["/opt/dynamo/nixl-versions.txt<br/>pip versions + loaded .so path"]
```

| | Before | After |
|---|---|---|
| **Version pin** | Two places: `requirements.trtllm.txt` and `context.yaml`. Synced by hand. | One place: derived from `nixl_ref` at build time. |
| **Bad `nixl_ref`** | Cryptic `nixl==<sha>` pip error, late in the build. | Fails fast up front. Guard: `^v[0-9]+\.[0-9]+\.[0-9]+$`. |
| **`NIXL_VERSION` env** | Stale `1.0.0` from the base image. Disagrees with the installed `1.0.1`. | Blanked. No misleading value. |
| **"Which NIXL is here?"** | Unclear. Pin, source SDK, and loaded `.so` can differ. | `/opt/dynamo/nixl-versions.txt` lists pip versions and the loaded `.so`. |

## Validation

Built `dynamo:latest-trtllm-runtime` locally.

- `nixl` and `nixl-cu13` install at **1.0.1**. This matches `nixl_ref: v1.0.1`. `NIXL_VERSION` is empty. `/opt/dynamo/nixl-versions.txt` is present.
- Ran `examples/backends/trtllm/launch/disagg_same_gpu.sh` (Qwen3-0.6B, prefill + decode on one GPU). `/v1/chat/completions` returned `status=success`. The `prefill_worker_id` and `decode_worker_id` differ. That confirms the NIXL prefill->decode KV handoff over UCX.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NIXL version consistency between the runtime image and installed Python packages.
  * Added validation to prevent unsupported or improperly formatted NIXL versions.
  * Added runtime diagnostics for the installed NIXL versions and preloaded library path.

* **Chores**
  * Centralized NIXL version selection through the runtime build configuration.
  * Ensured development and production environments use consistent NIXL settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
