### PR TITLE
docs: cherry-pick add Kimi-K3 recipe page (#12210)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 - [Propose a feature](https://github.com/ai-dynamo/dynamo/issues/new?template=feature_request.yml)
 - [Design Proposals](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf)
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io)
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [Office Hours](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
 - [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings

--- a/docs/README.md
+++ b/docs/README.md
@@ -356,7 +356,7 @@ workflows. Authors never need to run it manually.
 ## Running Locally
 
 You can preview the documentation site on your machine using the
-[Fern CLI](https://buildwithfern.com/learn/cli-api/overview). This is useful
+[Fern CLI](https://buildwithfern.com/learn/docs/getting-started/overview/). This is useful
 for verifying layout, navigation, and content before opening a PR.
 
 ### Prerequisites

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -12,7 +12,7 @@ With 200+ external contributors, 220+ merged community PRs, and new contributors
 
 Join the community:
 
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf) -- join CNCF Slack and find us in `#ai-dynamo`
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io) -- join CNCF Slack and find us in `#ai-dynamo`
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - [Design Proposals](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22) -- RFCs for major features, tracked as `dep:*` labeled GitHub issues
@@ -65,7 +65,7 @@ Ready to write code? See the [Contribution Workflow](#contribution-workflow) sec
 
 Not all contributions are code. You can also:
 
-- Answer questions on [Discord](https://discord.gg/D92uqZRjCZ) or in the `#ai-dynamo` channel on [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)
+- Answer questions on [Discord](https://discord.gg/D92uqZRjCZ) or in the `#ai-dynamo` channel on [CNCF Slack](https://slack.cncf.io)
 - Review pull requests
 - Share how you're using Dynamo -- blog posts, talks, or social media
 - Star the [repository](https://github.com/ai-dynamo/dynamo)
@@ -422,7 +422,7 @@ If you discover a security vulnerability, please follow the instructions in our 
 
 ## Getting Help
 
-- **CNCF Slack**: [Join CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) and find us in `#ai-dynamo`
+- **CNCF Slack**: [Join CNCF Slack](https://slack.cncf.io) and find us in `#ai-dynamo`
 - **Discord**: [Join our community](https://discord.gg/D92uqZRjCZ)
 - **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - **Design Proposals**: [RFCs for major features, tracked as `dep:*` labeled GitHub issues](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -99,7 +99,7 @@ Frontend (round-robin) → MM Router Worker → Backend Workers
                               └─ KvRouter selects best worker
 ```
 
-For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend workers. See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for setup instructions.
+For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend workers. See the [TRT-LLM MM Router README](../../../examples/backends/trtllm/mm_router_worker/README.md) for setup instructions.
 
 ### SGLang
 
@@ -199,7 +199,7 @@ cd $DYNAMO_HOME/examples/backends/trtllm/mm_router_worker
 ./launch.sh
 ```
 
-See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for full setup instructions and configuration options.
+See the [TRT-LLM MM Router README](../../../examples/backends/trtllm/mm_router_worker/README.md) for full setup instructions and configuration options.
 
 ### SGLang
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -641,6 +641,9 @@ navigation:
       - page: Browse All Recipes
         path: recipes/README.mdx
         slug: browse
+      - page: Kimi-K3
+        path: recipes/kimi-k3.mdx
+        slug: kimi-k3
       - page: GLM-5.2
         path: recipes/glm-5-2.mdx
         slug: glm-5-2

--- a/docs/recipes/README.mdx
+++ b/docs/recipes/README.mdx
@@ -30,17 +30,18 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
 <input className="dynamo-filter-input" type="radio" id="hardware-h100" name="hardware" />
 <input className="dynamo-filter-input" type="radio" id="hardware-h200" name="hardware" />
 <input className="dynamo-filter-input" type="radio" id="hardware-gb200" name="hardware" />
+<input className="dynamo-filter-input" type="radio" id="hardware-gb300" name="hardware" />
 <input className="dynamo-filter-input" type="radio" id="hardware-b200" name="hardware" />
 
 <div className="dynamo-recipe-browser" aria-label="Dynamo model recipe browser">
   <div className="dynamo-recipe-browser-header">
     <div>
       <p className="dynamo-recipe-eyebrow">Recipe catalog</p>
-      <h3>14 model families</h3>
+      <h3>15 model families</h3>
       <p>Filter by provider, runtime, and hardware. Each card notes its serving technique and workload shape.</p>
     </div>
     <div className="dynamo-catalog-facts">
-      <strong>38</strong>
+      <strong>42</strong>
       <span>Deployable configurations</span>
       <button className="dynamo-filter-reset" type="reset">Reset filters</button>
     </div>
@@ -63,10 +64,20 @@ Start with the model, runtime, and hardware you need to run. Model cards are sor
 <label className="dynamo-recipe-chip" htmlFor="hardware-h100">H100</label>
 <label className="dynamo-recipe-chip" htmlFor="hardware-h200">H200</label>
 <label className="dynamo-recipe-chip" htmlFor="hardware-gb200">GB200</label>
+<label className="dynamo-recipe-chip" htmlFor="hardware-gb300">GB300</label>
 <label className="dynamo-recipe-chip" htmlFor="hardware-b200">B200</label></div></div>
 </div>
 
 <div className="dynamo-model-grid" data-recipe-card-grid>
+  <div className="dynamo-model-card" data-recipe-card data-provider="moonshot" data-runtime="vllm" data-hardware="gb200 gb300" data-technique="aggregated disaggregated kv-routing" data-workload="agentic-coding">
+    <div className="dynamo-model-card-top">
+      <img className="dynamo-model-logo" src="../assets/img/recipes/providers/moonshotai.webp" alt="" />
+      <div><h3>Kimi-K3</h3><p>Moonshot / NVIDIA</p></div>
+    </div>
+    <p className="dynamo-model-summary">Day-0 vLLM recipes for Moonshot's Kimi-K3 on GB200 and GB300, aggregated or with prefill/decode disaggregation and KV-aware routing.</p>
+    <div className="dynamo-model-tags"><span>vLLM</span><span>GB200 · GB300</span><span>Day-0</span></div>
+  <a className="dynamo-card-link" href="./kimi-k3.mdx" aria-label="Open the Kimi-K3 recipe">Open recipe</a>
+  </div>
   <div className="dynamo-model-card" data-recipe-card data-provider="zai" data-runtime="sglang" data-hardware="b200 h200" data-technique="aggregated disaggregated kv-routing spec-decoding" data-workload="agentic-coding long-context-reuse">
     <div className="dynamo-model-card-top">
       <img className="dynamo-model-logo" src="../assets/img/recipes/providers/zai-org.svg" alt="" />

--- a/docs/recipes/_catalog/index.yaml
+++ b/docs/recipes/_catalog/index.yaml
@@ -10,6 +10,7 @@
 # active ones in recipes/<id>.yaml.
 schema_version: 1
 recipes:
+- kimi-k3
 - glm-5-2
 - inkling
 - kimi-k2-6

--- a/docs/recipes/_catalog/recipes/kimi-k3.yaml
+++ b/docs/recipes/_catalog/recipes/kimi-k3.yaml
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+id: kimi-k3
+title: Kimi-K3
+page: recipes/kimi-k3.mdx
+provider: moonshot
+model:
+  name: Kimi-K3
+  hf_id: moonshotai/Kimi-K3
+  precision: MXFP4 experts + BF16 dense, FP8 KV cache
+status: experimental  # Day-0
+targets:
+- id: vllm-agg-gb200
+  recommended: false
+  hardware:
+    gpu: GB200
+    count: 16
+  runtime:
+    framework: vllm
+  topology: aggregated
+  techniques:
+  - kv-aware-routing
+  - mxfp4
+  - fp8-kv-cache
+  workload:
+    type: agentic
+    traffic: ~57.6K-token shared system prompt, 6.4K ISL / 200 OSL, 90% KV cache hit
+  deploy:
+    asset: recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml
+  expected_performance:
+    available: false
+- id: vllm-disagg-gb200
+  recommended: false
+  hardware:
+    gpu: GB200
+    count: 32
+  runtime:
+    framework: vllm
+  topology: disaggregated
+  techniques:
+  - disaggregated-prefill-decode
+  - kv-aware-routing
+  - mxfp4
+  - fp8-kv-cache
+  workload:
+    type: agentic
+    traffic: ~57.6K-token shared system prompt, 6.4K ISL / 200 OSL, 90% KV cache hit
+  deploy:
+    asset: recipes/kimi-k3/vllm/disagg-gb200-agentic/deploy.yaml
+  expected_performance:
+    available: false
+- id: vllm-agg-gb300
+  recommended: false
+  hardware:
+    gpu: GB300
+    count: 16
+  runtime:
+    framework: vllm
+  topology: aggregated
+  techniques:
+  - kv-aware-routing
+  - mxfp4
+  - fp8-kv-cache
+  workload:
+    type: agentic
+    traffic: ~57.6K-token shared system prompt, 6.4K ISL / 200 OSL, 90% KV cache hit
+  deploy:
+    asset: recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml
+  expected_performance:
+    available: false
+- id: vllm-disagg-gb300
+  recommended: false
+  hardware:
+    gpu: GB300
+    count: 24
+  runtime:
+    framework: vllm
+  topology: disaggregated
+  techniques:
+  - disaggregated-prefill-decode
+  - kv-aware-routing
+  - mxfp4
+  - fp8-kv-cache
+  workload:
+    type: agentic
+    traffic: ~57.6K-token shared system prompt, 6.4K ISL / 200 OSL, 90% KV cache hit
+  deploy:
+    asset: recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml
+  expected_performance:
+    available: false
+related_benchmarks: []
+maintainer: null
+gaps:
+- Recipe source tree ships on the release/1.4.0-kimi-k3-dev.1 branch; catalog asset paths resolve on main once that branch merges
+- GB200 manifests mount weights via node-local hostPath (GKE pattern); all four targets pin the public NGC image (1.4.0-kimi-k3-dev.1)
+- No perf assets in the recipe tree; no validated expected-performance numbers (Day-0)

--- a/docs/recipes/kimi-k3.mdx
+++ b/docs/recipes/kimi-k3.mdx
@@ -1,0 +1,238 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: "Kimi-K3"
+subtitle: "Serve Kimi-K3 with Dynamo and vLLM on GB200 or GB300, aggregated or disaggregated over NVLink."
+---
+
+import { RecipeStyles } from "@/components/RecipeStyles";
+
+<RecipeStyles />
+
+Each target below is a Dynamo + vLLM deployment of Moonshot AI's Kimi-K3 — a multimodal MoE model serving up to 1M-token context — with KV-aware routing, MXFP4-packed routed experts, and FP8 KV cache, running aggregated or with prefill/decode disaggregation on GB200 and GB300 NVL72 racks. KV transfer and tensor parallelism run over NVLink (MNNVL) using Kubernetes ComputeDomains. Pick your GPU architecture and serving topology; every command on this page updates to match.
+
+<div className="dynamo-target-picker">
+<p className="dynamo-target-picker-title">Choose your deployment target</p>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">GPU</span>
+<input type="radio" id="recipe-sku-gb200" name="recipe-sku" value="gb200" defaultChecked />
+<label htmlFor="recipe-sku-gb200">GB200</label>
+<input type="radio" id="recipe-sku-gb300" name="recipe-sku" value="gb300" />
+<label htmlFor="recipe-sku-gb300">GB300</label>
+</div>
+<div className="dynamo-target-picker-row">
+<span className="dynamo-target-picker-dim">Topology</span>
+<input type="radio" id="recipe-variant-agg" name="recipe-variant" value="agg" defaultChecked />
+<label htmlFor="recipe-variant-agg">Aggregated</label>
+<input type="radio" id="recipe-variant-disagg" name="recipe-variant" value="disagg" />
+<label htmlFor="recipe-variant-disagg">Disaggregated</label>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="agg">
+<span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
+<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
+<span><b>GPUs</b> 16x GB200 (4 nodes), one worker</span>
+<span><b>Parallelism</b> TP16 over MNNVL</span>
+<span><b>Routing</b> KV-aware</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb200" data-variant="disagg">
+<span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
+<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
+<span><b>GPUs</b> 16x GB200 prefill + 16x GB200 decode (1P1D)</span>
+<span><b>Parallelism</b> TP16 / TP16 over MNNVL</span>
+<span><b>Routing</b> KV-aware, NIXL KV transfer over RDMA</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="agg">
+<span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
+<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
+<span><b>GPUs</b> 16x GB300 — two 8-GPU replicas</span>
+<span><b>Parallelism</b> TP8 per replica, KV-routed</span>
+<span><b>Routing</b> KV-aware across replicas</span>
+</div>
+<div className="dynamo-target-picker-summary" data-sku="gb300" data-variant="disagg">
+<span><b>Checkpoint</b> moonshotai/Kimi-K3</span>
+<span><b>Precision</b> MXFP4 experts + BF16 dense, FP8 KV</span>
+<span><b>GPUs</b> 8x GB300 prefill + 16x GB300 decode (1P2D)</span>
+<span><b>Parallelism</b> TP8 per replica over MNNVL</span>
+<span><b>Routing</b> KV-aware, NIXL/MNNVL KV transfer</span>
+</div>
+</div>
+
+## Prerequisites
+
+<div data-sku="gb200">
+
+- A Kubernetes cluster with the Dynamo platform installed and GB200 GPUs available — 16x (4 nodes) for aggregated, 32x (8 nodes, 4 prefill + 4 decode) for disaggregated. See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
+- A Hugging Face token with access to `moonshotai/Kimi-K3`.
+
+</div>
+
+<div data-sku="gb300">
+
+- A Kubernetes cluster with the Dynamo platform installed and GB300 GPUs available — 16x (4 nodes) for aggregated, 24x (6 nodes) for disaggregated. See the [Kubernetes Deployment Guide](../kubernetes/quickstart.mdx).
+- The NVIDIA DRA driver with ComputeDomain support installed (required for multi-node NVLink).
+- A Hugging Face token with access to `moonshotai/Kimi-K3`.
+
+</div>
+
+Create the namespace and token secret:
+
+```bash
+export NAMESPACE=your-namespace
+kubectl create namespace ${NAMESPACE}
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" \
+  -n ${NAMESPACE}
+```
+
+<Warning>
+If you use the `model-cache` PVC (required on GB300, optional on GB200), edit `storageClassName` in `model-cache/model-cache.yaml` to a ReadWriteMany storage class on your cluster (`kubectl get storageclass`) before applying it. Review namespace, image tags, node selectors, and resource claims in the manifests as well.
+</Warning>
+
+## Deploy
+
+The two SKUs source the checkpoint differently, so follow the block for your target.
+
+<div data-sku="gb300">
+
+The GB300 manifests read the checkpoint from a `model-cache` PVC (`HF_HOME=/model-cache`, `--model moonshotai/Kimi-K3`). Create the cache and download the weights:
+
+```bash
+# Edit storageClassName in model-cache/model-cache.yaml first.
+kubectl apply -f recipes/kimi-k3/model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f recipes/kimi-k3/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
+```
+
+</div>
+
+<div data-sku="gb200">
+
+The GB200 manifests read the checkpoint from node-local storage, not the `model-cache` PVC: they mount the host path `/mnt/stateful_partition/kube-ephemeral-ssd/models` (a GKE layout) at `/models` and serve `--model /models/model_weight` with `HF_HUB_OFFLINE=1`. Pick one of:
+
+- **Pre-stage the weights on every GB200 node** in the deployment at `<host-path>/model_weight`, then edit the `models` `hostPath` in the deploy manifest to match your cluster's path.
+- **Switch the manifest to the PVC flow** used by the GB300 recipes: create the cache and run the download job below, then in the deploy manifest replace the `models` `hostPath` volume with a `persistentVolumeClaim` (`claimName: model-cache`) mounted at `/model-cache`, add `HF_HOME=/model-cache`, and set `MODEL_PATH` to `moonshotai/Kimi-K3`.
+
+```bash
+# PVC flow only. Edit storageClassName in model-cache/model-cache.yaml first.
+kubectl apply -f recipes/kimi-k3/model-cache/model-cache.yaml -n ${NAMESPACE}
+kubectl apply -f recipes/kimi-k3/model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=14400s
+```
+
+</div>
+
+Then deploy the target DGD:
+
+<div data-sku="gb200" data-variant="agg">
+
+```bash
+kubectl apply -f recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb200" data-variant="disagg">
+
+```bash
+kubectl apply -f recipes/kimi-k3/vllm/disagg-gb200-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="agg">
+
+```bash
+kubectl apply -f recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="disagg">
+
+```bash
+kubectl apply -f recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+</div>
+
+First worker launch loads weights and captures CUDA graphs and can take tens of minutes.
+
+## Smoke Test
+
+Send a test request to verify the deployment serves traffic. First forward the frontend port for your target:
+
+
+<div data-sku="gb200" data-variant="agg">
+
+```bash
+kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb200" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="agg">
+
+```bash
+kubectl port-forward svc/kimi-k3-agg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+<div data-sku="gb300" data-variant="disagg">
+
+```bash
+kubectl port-forward svc/kimi-k3-disagg-frontend 8000:8000 -n ${NAMESPACE}
+```
+
+</div>
+
+All targets serve under the same model name, `moonshotai/Kimi-K3`:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"moonshotai/Kimi-K3","messages":[{"role":"user","content":"Write a one-sentence readiness check."}],"max_tokens":64}'
+```
+
+Kimi-K3 reasons before answering, and tool calling is supported — the deployment uses the `kimi_k3` reasoning and tool-call parsers at the frontend.
+
+## Compare All Targets
+
+All four targets serve Kimi-K3 on vLLM with FP8 KV cache, KV-aware routing, prefix caching, and the FlashInfer TRT-LLM MoE backend, with tensor parallelism over NVLink (MNNVL):
+
+| | GB200 aggregated | GB200 disaggregated | GB300 aggregated | GB300 disaggregated |
+|---|---|---|---|---|
+| **GPUs** | 16x GB200 (4 nodes) | 16x prefill + 16x decode | 16x GB300 (2 replicas) | 8x prefill + 16x decode |
+| **Workers** | 1 | 1P + 1D | 2 (KV-routed) | 1P + 2D |
+| **Parallelism** | TP16 | TP16 / TP16 | TP8 per replica | TP8 per replica |
+| **KV transfer** | — | NIXL over RDMA (IB) | — | NIXL over MNNVL |
+| **Attention** | FlashInfer MLA | FlashInfer MLA | FlashInfer MLA | FlashInfer MLA |
+| **Precision** | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV | MXFP4 + BF16, FP8 KV |
+| **Max context** | 1,048,576 | 1,048,576 | 1,048,576 | 1,048,576 |
+
+## Notes
+
+- All targets use KV-aware routing at the Dynamo frontend with prefix caching and KV events enabled.
+- Kimi-K3 is multimodal — the deployments enable the multimodal encoder (`--enable-multimodal`) with data-parallel encoder sharding.
+- Multi-node tensor parallelism runs over NVLink (MNNVL) via Kubernetes ComputeDomains (DRA). Disaggregated KV transfer uses NIXL — over NVLink on GB300, over RDMA InfiniBand on GB200 (`UCX_TLS=^cuda_ipc`, GKE `rdma-*` network resources).
+- Kimi-K3 support requires the updated Dynamo frontend (tokenizer, `kimi_k3` reasoning and tool-call parsers) that ships with this release.
+
+## Source
+
+The recipe assets ship on the `release/1.4.0-kimi-k3-dev.1` branch:
+
+- Source README: [recipes/kimi-k3/README.md](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/README.md)
+- Aggregated GB200: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/vllm/agg-gb200-agentic/deploy.yaml)
+- Disaggregated GB200: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/vllm/disagg-gb200-agentic/deploy.yaml)
+- Aggregated GB300: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/vllm/agg-gb300-agentic/deploy.yaml)
+- Disaggregated GB300: [deploy.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/vllm/disagg-gb300-agentic/deploy.yaml)
+- Setup assets: [model-cache.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/model-cache/model-cache.yaml) and [model-download.yaml](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0-kimi-k3-dev.1/recipes/kimi-k3/model-cache/model-download.yaml)

--- a/fern/components/RecipeStyles.tsx
+++ b/fern/components/RecipeStyles.tsx
@@ -201,6 +201,7 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
 #hardware-h100:checked ~ .dynamo-recipe-browser label[for="hardware-h100"],
 #hardware-h200:checked ~ .dynamo-recipe-browser label[for="hardware-h200"],
 #hardware-gb200:checked ~ .dynamo-recipe-browser label[for="hardware-gb200"],
+#hardware-gb300:checked ~ .dynamo-recipe-browser label[for="hardware-gb300"],
 #hardware-b200:checked ~ .dynamo-recipe-browser label[for="hardware-b200"],
 #technique-all:checked ~ .dynamo-recipe-browser label[for="technique-all"],
 #technique-aggregated:checked ~ .dynamo-recipe-browser label[for="technique-aggregated"],
@@ -671,6 +672,7 @@ main.fern-main:not(:has(> .fern-layout-content-wrapper ~ aside)) .fern-layout-gu
 #hardware-h100:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-hardware~="h100"]),
 #hardware-h200:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-hardware~="h200"]),
 #hardware-gb200:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-hardware~="gb200"]),
+#hardware-gb300:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-hardware~="gb300"]),
 #hardware-b200:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-hardware~="b200"]),
 #technique-aggregated:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-technique~="aggregated"]),
 #technique-disaggregated:checked ~ .dynamo-model-grid [data-recipe-card]:not([data-technique~="disaggregated"]),
@@ -2159,6 +2161,7 @@ body:has(input[name="recipe-sku"][value="b200"]:checked) [data-sku]:not([data-sk
 body:has(input[name="recipe-sku"][value="h200"]:checked) [data-sku]:not([data-sku~="h200"]),
 body:has(input[name="recipe-sku"][value="h100"]:checked) [data-sku]:not([data-sku~="h100"]),
 body:has(input[name="recipe-sku"][value="gb200"]:checked) [data-sku]:not([data-sku~="gb200"]),
+body:has(input[name="recipe-sku"][value="gb300"]:checked) [data-sku]:not([data-sku~="gb300"]),
 body:has(input[name="recipe-usecase"][value="chat"]:checked) [data-usecase]:not([data-usecase~="chat"]),
 body:has(input[name="recipe-usecase"][value="agentic"]:checked) [data-usecase]:not([data-usecase~="agentic"]) {
     display: none;

--- a/fern/translations/zh-CN/pages-dev/contribution-guide.md
+++ b/fern/translations/zh-CN/pages-dev/contribution-guide.md
@@ -12,7 +12,7 @@ Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并�
 
 加入社区：
 
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf) -- 加入 CNCF Slack，并在 `#ai-dynamo` 中找到我们
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io) -- 加入 CNCF Slack，并在 `#ai-dynamo` 中找到我们
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - [设计提案](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22) -- 重大功能的 RFC，以带 `dep:*` 标签的 GitHub issue 形式跟踪
@@ -65,7 +65,7 @@ Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并�
 
 并非所有贡献都是代码。你还可以：
 
-- 在 [Discord](https://discord.gg/D92uqZRjCZ) 或 [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) 的 `#ai-dynamo` 频道中回答问题
+- 在 [Discord](https://discord.gg/D92uqZRjCZ) 或 [CNCF Slack](https://slack.cncf.io) 的 `#ai-dynamo` 频道中回答问题
 - 审阅 pull request
 - 分享你如何使用 Dynamo -- 博客文章、演讲或社交媒体都可以
 - 为[仓库](https://github.com/ai-dynamo/dynamo)点 star
@@ -422,7 +422,7 @@ git commit -s -m "fix: your descriptive message"
 
 ## 获取帮助
 
-- **CNCF Slack**: [加入 CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)，并在 `#ai-dynamo` 中找到我们
+- **CNCF Slack**: [加入 CNCF Slack](https://slack.cncf.io)，并在 `#ai-dynamo` 中找到我们
 - **Discord**: [加入我们的社区](https://discord.gg/D92uqZRjCZ)
 - **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - **设计提案**: [重大功能的 RFC，以带 `dep:*` 标签的 GitHub issue 形式跟踪](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)


### PR DESCRIPTION
## Summary

Cherry-picks merged #12210 commit (`329aba5d0c91c4520c5ce8a1707310fa68fccc69`) onto `release/1.4.0-kimi-k3-dev.1`.

- Adds the Kimi-K3 Fern recipe page, catalog entry, landing card, GB300 picker axis, and Recipes-tab nav wiring
- Adapts main `docs/fern/*` paths to this branch layout (`docs/recipes/*`, `fern/components/*`, `docs/index.yml`)
- Keeps release-branch Planner Guide URLs (main-only docs URL rewrite from #12210 not applicable here)
- Uses a signed-off cherry-pick commit

## Verification

- [x] Path-mapped recipe page, catalog YAML, and RecipeStyles are byte-identical to `main`
- [x] `git diff --check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->