### PR TITLE
build(container): bump dev image nsight-systems pin to 2025.6.1

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -144,7 +144,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nsight-systems-2025.5.1 gh && \
+    apt-get install -y --no-install-recommends nsight-systems-2025.6.1 gh && \
     rm -rf /var/lib/apt/lists/*
 
 # ======================================================================


### PR DESCRIPTION
## Summary

The dev image's pinned `nsight-systems-2025.5.1` is no longer fetchable from NVIDIA's devtools apt repo, so every `*-dev` multi-arch build (vLLM / SGLang / TensorRT-LLM) fails at `apt-get install`:

```
E: Failed to fetch .../nsight-systems-2025.5.1_2025.5.1.121-1_amd64.deb  404 Not Found
```

NVIDIA's index still advertises revision `-1`, but the published artifact moved to a new build-id revision, so the pinned fetch 404s. This bumps the pin to `nsight-systems-2025.6.1`, which the repo currently serves for both `amd64` and `arm64`.

- Dev-image only (`container/templates/dev.Dockerfile`); `nsight-systems` is not installed by any runtime/release Dockerfile.
- Runtime/release images pull `nsight-systems-cli` from the CUDA base image, so `container/compliance/license_overrides.yaml` is unaffected (no override churn).

## Test plan

- [ ] `vllm-dev` / `sglang-dev` / `trtllm-dev` "Build multi-arch" jobs go green (apt resolves `nsight-systems-2025.6.1`).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the NVIDIA Nsight Systems development tool to version 2025.6.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->