### PR TITLE
fix(vllm): checkpoint communicator state for snapshots

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -398,9 +398,12 @@ class VllmEnginePauseController:
                     "Failed to resume generation after native vLLM sleep failure"
                 )
             raise
-        self._is_paused = True
+        # Prepare before recording the pause: a failed prepare must not leave
+        # the controller claiming paused, or the next resume would issue a
+        # checkpoint_restore with no matching prepare.
         if self._prepare_for_process_checkpoint:
             await self._engine_client.checkpoint_prepare()
+        self._is_paused = True
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -358,8 +358,14 @@ async def _deferred_abort_guard(
 
 
 class VllmEnginePauseController:
-    def __init__(self, engine_client: Any):
+    def __init__(
+        self,
+        engine_client: Any,
+        *,
+        prepare_for_process_checkpoint: bool = False,
+    ):
         self._engine_client = engine_client
+        self._prepare_for_process_checkpoint = prepare_for_process_checkpoint
         self._is_paused = False
         self._generation_paused = False
 
@@ -393,6 +399,8 @@ class VllmEnginePauseController:
                 )
             raise
         self._is_paused = True
+        if self._prepare_for_process_checkpoint:
+            await self._engine_client.checkpoint_prepare()
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
@@ -400,6 +408,8 @@ class VllmEnginePauseController:
             return False
 
         if self._is_paused:
+            if self._prepare_for_process_checkpoint:
+                await self._engine_client.checkpoint_restore()
             if tags is None:
                 await self._engine_client.wake_up()
             else:

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -329,8 +329,14 @@ async def _deferred_abort_guard(
 
 
 class VllmEnginePauseController:
-    def __init__(self, engine_client: Any):
+    def __init__(
+        self,
+        engine_client: Any,
+        *,
+        prepare_for_process_checkpoint: bool = False,
+    ):
         self._engine_client = engine_client
+        self._prepare_for_process_checkpoint = prepare_for_process_checkpoint
         self._is_paused = False
         self._generation_paused = False
 
@@ -364,6 +370,8 @@ class VllmEnginePauseController:
                 )
             raise
         self._is_paused = True
+        if self._prepare_for_process_checkpoint:
+            await self._engine_client.checkpoint_prepare()
         return True
 
     async def resume(self, tags: list[str] | None = None) -> bool:
@@ -371,6 +379,8 @@ class VllmEnginePauseController:
             return False
 
         if self._is_paused:
+            if self._prepare_for_process_checkpoint:
+                await self._engine_client.checkpoint_restore()
             if tags is None:
                 await self._engine_client.wake_up()
             else:

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -42,7 +42,10 @@ async def prepare_snapshot_engine(
     gc.collect()
     snapshot_controller = EngineSnapshotController(
         engine=engine,
-        pause_controller=VllmEnginePauseController(engine[0]),
+        pause_controller=VllmEnginePauseController(
+            engine[0],
+            prepare_for_process_checkpoint=True,
+        ),
         snapshot_config=snapshot_config,
         pause_args=(None,),
     )

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -39,12 +39,25 @@ async def prepare_snapshot_engine(
     config.engine_args.enable_sleep_mode = True
 
     engine = setup_vllm_engine(config)
+    # Decide before the first pause: reaching this at pause time would raise
+    # after sleep() had already released the engine's memory.
+    checkpoint_hooks = all(
+        hasattr(engine[0], hook)
+        for hook in ("checkpoint_prepare", "checkpoint_restore")
+    )
+    if not checkpoint_hooks:
+        logger.warning(
+            "This vLLM build has no AsyncLLM.checkpoint_prepare/checkpoint_restore; "
+            "snapshotting without communicator checkpointing. "
+            "Requires vLLM 0.27.0 or newer."
+        )
+
     gc.collect()
     snapshot_controller = EngineSnapshotController(
         engine=engine,
         pause_controller=VllmEnginePauseController(
             engine[0],
-            prepare_for_process_checkpoint=True,
+            prepare_for_process_checkpoint=checkpoint_hooks,
         ),
         snapshot_config=snapshot_config,
         pause_args=(None,),

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -3,7 +3,7 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, call
 
 import pytest
 
@@ -96,6 +96,27 @@ async def test_pause_without_level_uses_vllm_default_sleep():
     assert changed is True
     engine_client.pause_generation.assert_awaited_once()
     engine_client.sleep.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
+async def test_snapshot_wraps_sleep_wake_with_communicator_checkpoint_calls():
+    engine_client = AsyncMock()
+    controller = VllmEnginePauseController(
+        engine_client,
+        prepare_for_process_checkpoint=True,
+    )
+
+    assert await controller.pause(None) is True
+    assert await controller.resume() is True
+
+    assert engine_client.mock_calls == [
+        call.pause_generation(),
+        call.sleep(),
+        call.checkpoint_prepare(),
+        call.checkpoint_restore(),
+        call.wake_up(),
+        call.resume_generation(),
+    ]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sleep_wake_handlers.py
@@ -120,6 +120,50 @@ async def test_snapshot_wraps_sleep_wake_with_communicator_checkpoint_calls():
 
 
 @pytest.mark.asyncio
+async def test_snapshot_restore_failure_is_fail_closed():
+    """A failed communicator restore must not be replayed.
+
+    The restored process keeps the engine paused and lets the exception
+    propagate, so it dies rather than resuming on half-rebuilt communicators.
+    """
+    engine_client = AsyncMock()
+    engine_client.checkpoint_restore.side_effect = RuntimeError("restore failed")
+    controller = VllmEnginePauseController(
+        engine_client,
+        prepare_for_process_checkpoint=True,
+    )
+    assert await controller.pause(None) is True
+
+    with pytest.raises(RuntimeError, match="restore failed"):
+        await controller.resume()
+
+    engine_client.checkpoint_restore.assert_awaited_once()
+    # Never reaches wake_up, so memory is not remapped and scheduling stays
+    # stopped; the controller is still paused because only mark_resumed()
+    # clears that, and the caller never gets there.
+    engine_client.wake_up.assert_not_awaited()
+    engine_client.resume_generation.assert_not_awaited()
+    assert controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_snapshot_prepare_failure_leaves_controller_unpaused():
+    """A failed prepare must not record a pause it did not complete, or the
+    next resume would issue a checkpoint_restore with no matching prepare."""
+    engine_client = AsyncMock()
+    engine_client.checkpoint_prepare.side_effect = RuntimeError("prepare failed")
+    controller = VllmEnginePauseController(
+        engine_client,
+        prepare_for_process_checkpoint=True,
+    )
+
+    with pytest.raises(RuntimeError, match="prepare failed"):
+        await controller.pause(None)
+
+    assert controller.is_paused is False
+
+
+@pytest.mark.asyncio
 async def test_wake_up_passes_explicit_tags_from_request():
     handler = _make_handler()
     await handler._pause_controller.pause(1)


### PR DESCRIPTION
## Summary

A process-level checkpoint captures a vLLM worker while its communicators
(FlashInfer, NCCL) hold live state that CRIU cannot restore meaningfully, so the
restored process comes back with communicators pointing at a world that no
longer exists.

This wraps the existing snapshot sleep/wake with vLLM's communicator
checkpoint hooks:

```text
sleep                  native vLLM: pauses and drains scheduling
checkpoint_prepare     communicators tear down
  << CRIU dump / restore >>
checkpoint_restore     communicators rebuild
wake_up                native vLLM: remaps memory, resumes scheduling
```

The ordering matters. `sleep()` already owns the scheduler pause, so preparation
runs on a quiesced engine, and `wake_up()` is not reached until communicators are
back. That is also why this does not need vllm-project/vllm#50036.

Only the snapshot pause controller passes `prepare_for_process_checkpoint=True`.
Ordinary admin sleep/wake and the GMS shadow-mode failover path construct their
own controller without it, so their behaviour is unchanged.

Failures fail closed: if `checkpoint_prepare()` or `checkpoint_restore()` raises,
the exception propagates and the process dies rather than continuing on
half-rebuilt communicators.

## Changes

- `vllm/handlers.py` — `VllmEnginePauseController` gains the opt-in flag and
  calls the two hooks around the existing sleep/wake
- `vllm/snapshot.py` — the snapshot controller opts in
- `vllm/tests/test_vllm_sleep_wake_handlers.py` — call ordering, plus both
  failure directions

## vLLM requirement

Needs `AsyncLLM.checkpoint_prepare()` and `checkpoint_restore()` from
vllm-project/vllm#46877 (merged upstream 2026-07-26 as `b5b61c62`).

**Minimum vLLM is 0.27.0**, and every runtime image in `container/context.yaml`
clears it: CUDA and CPU are on `v0.28.0`, XPU on `v0.27.1`. The hooks are absent
from 0.26.0, which is what an earlier revision of this branch pinned:

```python
# vllm/v1/engine/async_llm.py @ v0.28.0
async def checkpoint_prepare(self) -> None:
    await self.collective_rpc("checkpoint_prepare")

async def checkpoint_restore(self) -> None:
    await self.collective_rpc("checkpoint_restore")
```

An earlier revision of this PR was based on a tree pinning 0.26.0, where the
hooks were genuinely missing; it has been rebased onto `main`.

## Validation

- Rebased onto `main`; patch applies with no conflicts
- `black`, `isort`, `flake8` clean at the versions pinned in
  `.pre-commit-config.yaml`
- Hook presence and signatures verified against the upstream `v0.27.0` and
  `v0.28.0` tags
- Focused pytest collection is unavailable locally because the compiled
  `dynamo._core` extension is not installed; CI's backend image provides it
