### PR TITLE
fix(snapshot): enter PID namespace for GPU probe

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -79,15 +79,17 @@ func GetPodGPUUUIDs(ctx context.Context, podName, podNamespace, containerName st
 }
 
 // GetGPUUUIDsViaNvidiaSmi discovers GPU UUIDs by running nvidia-smi inside the
-// container's mount namespace. This is the fallback path when the kubelet
+// container's mount and PID namespaces. This is the fallback path when the kubelet
 // PodResources API does not report GPU devices (e.g. when GPUs are allocated
 // via DRA instead of the NVIDIA device plugin).
 func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) ([]string, error) {
 	mountPath := fmt.Sprintf("%s/%d/ns/mnt", strings.TrimRight(hostProcPath, "/"), pid)
+	pidPath := fmt.Sprintf("%s/%d/ns/pid", strings.TrimRight(hostProcPath, "/"), pid)
 	cmd := exec.CommandContext(
 		ctx,
 		"nsenter",
 		fmt.Sprintf("--mount=%s", mountPath),
+		fmt.Sprintf("--pid=%s", pidPath),
 		"--",
 		"nvidia-smi", "--query-gpu=gpu_uuid", "--format=csv,noheader",
 	)


### PR DESCRIPTION
## Summary

- enter the workload PID namespace together with its mount namespace before running the DRA `nvidia-smi` ordinal probe
- keep `/proc` coherent for NVIDIA driver initialization while preserving the existing ordered UUID discovery and cross-GPU migration behavior

The snapshot agent previously entered only the workload mount namespace. That exposed the workload's PID-namespaced `/proc` to a process still running in the agent's host PID namespace. `/proc/self/maps` was therefore missing, `libcuda` failed `cuosInit`, and deliberately trapped with `SIGTRAP`.

## Validation

- `cd deploy/snapshot && go test ./...` — passed
- `cd deploy/snapshot && go vet ./...` — passed
- `gofmt -l deploy/snapshot/internal/cuda/cuda.go` — clean
- `git diff --check origin/main...HEAD` — passed
- reproduced on `dynamo-nscale-dev-cluster` with a four-GPU DRA allocation:
  - mount-only `nsenter`: `/proc/self/maps` returned `ENOENT`; `libcuda.so.595.58.03` asserted in `cuosInit` and raised `SIGTRAP`
  - mount + PID namespace: the same `nvidia-smi` binary and driver libraries succeeded and returned exactly the four allocated GPU UUIDs
  - `strace` and `dmesg` confirmed the failing `int3` path

TP=4 Qwen3-0.6B checkpoint/restore E2E with the branch image is pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback GPU detection in containerized environments.
  * GPU UUID discovery now works more reliably when device information is unavailable through standard Kubernetes reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->