### PR TITLE
fix(replay): forecast offered request load

### DIFF
--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -133,18 +133,18 @@ def _merge_traffic(
 
     Exact for every field the planner's scaling consumes:
       - ``duration_s``/``num_req``: summed.
-      - ``avg_isl``/``avg_osl``: num_req-weighted — their denominator *is*
-        ``num_req``, so a num_req-weighted mean of per-window means re-sums to
-        the exact overall mean.
+      - ``avg_isl``/``avg_osl``: weighted by ``shape_count`` (completed,
+        non-rejected requests). ``num_req`` is offered load and intentionally
+        has different timing under queueing.
+      - ``avg_ttft_ms``/``avg_itl_ms``: weighted by their native sample counts.
       - ``avg_kv_hit_rate``: weighted by ``hit_rate_count`` (its true
         denominator: router admissions with ``isl_blocks > 0``), so the merge
         reconstructs the exact sample mean rather than approximating it.
       - ``avg_accept_length``: weighted by ``accept_length_forward_count``
         (decode request-forwards, its true denominator), exact across windows.
 
-    ``avg_ttft_ms``/``avg_itl_ms`` are num_req-weighted approximations (their
-    per-sample counts are not carried across windows); they feed diagnostics
-    only, never the scaling trajectory."""
+    Older bridge payloads without native counts fall back to ``num_req`` for
+    compatibility."""
     if acc is None:
         return dict(window)
     na = float(acc.get("num_req", 0.0))
@@ -161,6 +161,12 @@ def _merge_traffic(
     hit_w = float(window.get("hit_rate_count", 0.0))
     fwd_a = float(acc.get("accept_length_forward_count", 0.0))
     fwd_w = float(window.get("accept_length_forward_count", 0.0))
+    shape_a = float(acc.get("shape_count", na))
+    shape_w = float(window.get("shape_count", nw))
+    ttft_a = float(acc.get("ttft_count", na))
+    ttft_w = float(window.get("ttft_count", nw))
+    itl_a = float(acc.get("itl_count", na))
+    itl_w = float(window.get("itl_count", nw))
 
     merged: dict[str, Any] = {
         "duration_s": acc.get("duration_s", 0.0) + window.get("duration_s", 0.0),
@@ -168,11 +174,13 @@ def _merge_traffic(
         # Carry the native denominators so chained multi-window merges stay exact.
         "hit_rate_count": hit_a + hit_w,
         "accept_length_forward_count": fwd_a + fwd_w,
-        # num_req-weighted: exact for isl/osl, diagnostics-only for ttft/itl.
-        "avg_isl": _weighted("avg_isl", na, nw),
-        "avg_osl": _weighted("avg_osl", na, nw),
-        "avg_ttft_ms": _weighted("avg_ttft_ms", na, nw),
-        "avg_itl_ms": _weighted("avg_itl_ms", na, nw),
+        "shape_count": shape_a + shape_w,
+        "ttft_count": ttft_a + ttft_w,
+        "itl_count": itl_a + itl_w,
+        "avg_isl": _weighted("avg_isl", shape_a, shape_w),
+        "avg_osl": _weighted("avg_osl", shape_a, shape_w),
+        "avg_ttft_ms": _weighted("avg_ttft_ms", ttft_a, ttft_w),
+        "avg_itl_ms": _weighted("avg_itl_ms", itl_a, itl_w),
         # Count-weighted by the true denominator -> exact across windows.
         "avg_kv_hit_rate": _weighted("avg_kv_hit_rate", hit_a, hit_w),
     }
@@ -613,12 +621,11 @@ class ReplayPlannerAdapter:
                     accept_length=t.get("avg_accept_length"),
                 )
                 # Stash observed TTFT/ITL for the diagnostics recorder.
-                # When num_req == 0, the Rust accumulator returns 0 as a
-                # placeholder; only record latency values when we actually
-                # observed requests in this window.
+                ttft_count = float(t.get("ttft_count", num_req))
+                itl_count = float(t.get("itl_count", num_req))
                 self._last_traffic = Metrics(
-                    ttft=t.get("avg_ttft_ms") if num_req > 0 else None,
-                    itl=t.get("avg_itl_ms") if num_req > 0 else None,
+                    ttft=t.get("avg_ttft_ms") if ttft_count > 0 else None,
+                    itl=t.get("avg_itl_ms") if itl_count > 0 else None,
                     num_req=traffic.num_req,
                     isl=traffic.isl,
                     osl=traffic.osl,

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -290,3 +290,37 @@ def test_merge_traffic_weights_ratio_fields_by_native_counts():
     assert merged["hit_rate_count"] == 100
     assert merged["accept_length_forward_count"] == 100
     assert merged["avg_isl"] == pytest.approx(100.0)
+
+
+def test_merge_traffic_keeps_offered_count_separate_from_completion_samples():
+    a = {
+        "num_req": 100,
+        "duration_s": 1.0,
+        "avg_isl": 10.0,
+        "avg_osl": 20.0,
+        "shape_count": 1,
+        "avg_ttft_ms": 1_000.0,
+        "ttft_count": 1,
+        "avg_itl_ms": 10.0,
+        "itl_count": 1,
+    }
+    b = {
+        "num_req": 1,
+        "duration_s": 1.0,
+        "avg_isl": 100.0,
+        "avg_osl": 200.0,
+        "shape_count": 9,
+        "avg_ttft_ms": 2_000.0,
+        "ttft_count": 9,
+        "avg_itl_ms": 20.0,
+        "itl_count": 9,
+    }
+
+    merged = _merge_traffic(a, b)
+
+    assert merged["num_req"] == 101
+    assert merged["shape_count"] == 10
+    assert merged["avg_isl"] == pytest.approx(91.0)
+    assert merged["avg_osl"] == pytest.approx(182.0)
+    assert merged["avg_ttft_ms"] == pytest.approx(1_900.0)
+    assert merged["avg_itl_ms"] == pytest.approx(19.0)

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -2798,6 +2798,11 @@ impl PlannerHook for PyPlannerHook {
                     "avg_osl": traffic.avg_osl,
                     "avg_ttft_ms": traffic.avg_ttft_ms,
                     "avg_itl_ms": traffic.avg_itl_ms,
+                    // Native denominators keep completion-derived shape and
+                    // latency averages exact even though num_req is offered load.
+                    "shape_count": traffic.shape_count,
+                    "ttft_count": traffic.ttft_count,
+                    "itl_count": traffic.itl_count,
                     "avg_accept_length": traffic.avg_accept_length,
                     "avg_kv_hit_rate": traffic.avg_kv_hit_rate,
                     // Denominators behind the two ratio averages, so the Python

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -404,6 +404,7 @@ where
 
         self.collector
             .on_arrival(uuid, arrival_time_ms, input_length, output_length);
+        self.traffic.on_arrival();
 
         let effects = self
             .placement
@@ -534,8 +535,9 @@ where
             let removed_state = self.requests.remove(&signal.uuid).ok_or_else(|| {
                 anyhow::anyhow!("offline replay missing request state for {}", signal.uuid)
             })?;
-            // Rejected requests never ran: keep them out of the planner-facing
-            // traffic deltas (they still free their slot and advance below).
+            // Rejected requests never ran: keep them out of completed-request
+            // shape and latency samples. Their offered demand was already
+            // recorded at arrival, matching requests_started_total.
             if !signal.rejected {
                 let latencies = self.collector.request_latencies(signal.uuid);
                 let actual_output_tokens = self
@@ -548,7 +550,7 @@ where
                         )
                     })?;
                 debug_assert!(actual_output_tokens <= removed_state.output_tokens);
-                self.traffic.on_request(
+                self.traffic.on_completion(
                     removed_state.input_tokens,
                     actual_output_tokens,
                     latencies,

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -144,11 +144,19 @@ impl<Events: EngineEventBatch> EngineEffects<Events> {
 #[derive(Debug, Clone)]
 pub struct TrafficStats {
     pub duration_s: f64,
+    /// Requests offered to the replay runtime during the window. This matches
+    /// the live planner's `requests_started_total` demand signal.
     pub num_req: usize,
     pub avg_isl: f64,
     pub avg_osl: f64,
     pub avg_ttft_ms: f64,
     pub avg_itl_ms: f64,
+    /// Completed, non-rejected requests behind `avg_isl` and `avg_osl`.
+    pub shape_count: usize,
+    /// Completed requests behind `avg_ttft_ms`.
+    pub ttft_count: usize,
+    /// Completed requests behind `avg_itl_ms`.
+    pub itl_count: usize,
     /// Mean visible tokens produced per decode request-forward, including the
     /// base token. ``None`` means the window had no decode forwards.
     pub avg_accept_length: Option<f64>,
@@ -176,12 +184,13 @@ pub struct TrafficStats {
 /// `TrafficObservation` (num_req, avg ISL, avg OSL, avg latencies, avg
 /// KV hit rate over a window).
 ///
-/// Latency samples are tracked independently of request counts: a request
-/// only contributes to ``total_ttft_ms`` / ``ttft_count`` if a positive TTFT
-/// was recorded, and similarly for ITL.  This means ``avg_ttft_ms`` and
-/// ``avg_itl_ms`` reflect only requests that actually produced the sample,
-/// rather than silently underestimating when some requests lack latency
-/// data (e.g. requests that fail before emitting a token).
+/// Offered request counts are recorded at arrival, matching the live
+/// planner's `requests_started_total` signal. Shape and latency samples are
+/// recorded independently at completion: a completed, non-rejected request
+/// contributes to ISL/OSL, and only contributes to ``total_ttft_ms`` /
+/// ``ttft_count`` if a positive TTFT was recorded (similarly for ITL). This
+/// keeps demand independent of deployment capacity while preserving actual
+/// output lengths and completed-request latency semantics.
 ///
 /// KV hit-rate observations come from the router at admission time (not
 /// completion) and are recorded as per-request ratios, matching the real
@@ -191,9 +200,10 @@ pub struct TrafficStats {
 #[derive(Debug)]
 pub(in crate::replay::offline) struct TrafficAccumulator {
     window_start_ms: f64,
-    num_req: usize,
+    offered_count: usize,
     total_isl: usize,
     total_osl: usize,
+    shape_count: usize,
     total_ttft_ms: f64,
     total_itl_ms: f64,
     ttft_count: usize,
@@ -213,9 +223,10 @@ impl TrafficAccumulator {
     pub(in crate::replay::offline) fn new() -> Self {
         Self {
             window_start_ms: 0.0,
-            num_req: 0,
+            offered_count: 0,
             total_isl: 0,
             total_osl: 0,
+            shape_count: 0,
             total_ttft_ms: 0.0,
             total_itl_ms: 0.0,
             ttft_count: 0,
@@ -227,16 +238,21 @@ impl TrafficAccumulator {
         }
     }
 
-    /// Record one completed request with optional latency data.
-    pub(in crate::replay::offline) fn on_request(
+    /// Record one request offered to the replay runtime.
+    pub(in crate::replay::offline) fn on_arrival(&mut self) {
+        self.offered_count += 1;
+    }
+
+    /// Record one completed, non-rejected request with optional latency data.
+    pub(in crate::replay::offline) fn on_completion(
         &mut self,
         input_tokens: usize,
         output_tokens: usize,
         latencies: Option<(f64, f64)>,
     ) {
-        self.num_req += 1;
         self.total_isl += input_tokens;
         self.total_osl += output_tokens;
+        self.shape_count += 1;
         if let Some((ttft_ms, mean_itl_ms)) = latencies {
             if ttft_ms > 0.0 {
                 self.total_ttft_ms += ttft_ms;
@@ -288,14 +304,14 @@ impl TrafficAccumulator {
     /// Drain the accumulator at the given simulated time, resetting counters.
     pub(in crate::replay::offline) fn drain(&mut self, now_ms: f64) -> TrafficStats {
         let duration_s = (now_ms - self.window_start_ms) / 1000.0;
-        let num_req = self.num_req;
-        let avg_isl = if num_req > 0 {
-            self.total_isl as f64 / num_req as f64
+        let num_req = self.offered_count;
+        let avg_isl = if self.shape_count > 0 {
+            self.total_isl as f64 / self.shape_count as f64
         } else {
             0.0
         };
-        let avg_osl = if num_req > 0 {
-            self.total_osl as f64 / num_req as f64
+        let avg_osl = if self.shape_count > 0 {
+            self.total_osl as f64 / self.shape_count as f64
         } else {
             0.0
         };
@@ -321,12 +337,16 @@ impl TrafficAccumulator {
         };
         // Capture the sample counts before the reset so a consumer that merges
         // several drained windows can reconstruct exact count-weighted means.
+        let shape_count = self.shape_count;
+        let ttft_count = self.ttft_count;
+        let itl_count = self.itl_count;
         let hit_rate_count = self.hit_rate_count;
         let accept_length_forward_count = self.accept_length_forward_count;
         self.window_start_ms = now_ms;
-        self.num_req = 0;
+        self.offered_count = 0;
         self.total_isl = 0;
         self.total_osl = 0;
+        self.shape_count = 0;
         self.total_ttft_ms = 0.0;
         self.total_itl_ms = 0.0;
         self.ttft_count = 0;
@@ -342,6 +362,9 @@ impl TrafficAccumulator {
             avg_osl,
             avg_ttft_ms,
             avg_itl_ms,
+            shape_count,
+            ttft_count,
+            itl_count,
             avg_accept_length,
             avg_kv_hit_rate,
             hit_rate_count,
@@ -367,9 +390,11 @@ mod tests {
     #[test]
     fn traffic_accumulator_drain_with_no_admissions_reports_zero_hit_rate() {
         let mut acc = TrafficAccumulator::new();
-        acc.on_request(100, 50, None);
+        acc.on_arrival();
+        acc.on_completion(100, 50, None);
         let stats = acc.drain(1_000.0);
         assert_eq!(stats.num_req, 1);
+        assert_eq!(stats.shape_count, 1);
         assert!((stats.avg_isl - 100.0).abs() < 1e-9);
         assert!((stats.avg_osl - 50.0).abs() < 1e-9);
         assert_eq!(stats.avg_kv_hit_rate, 0.0);
@@ -382,8 +407,10 @@ mod tests {
         // Small request: mostly hit. Big request: no hit.
         acc.on_admission(3, 4); // per-request ratio: 0.75
         acc.on_admission(0, 12); // per-request ratio: 0.0
-        acc.on_request(256, 32, None);
-        acc.on_request(768, 32, None);
+        acc.on_arrival();
+        acc.on_arrival();
+        acc.on_completion(256, 32, None);
+        acc.on_completion(768, 32, None);
         let stats = acc.drain(1_000.0);
         assert_eq!(stats.num_req, 2);
         // Per-request mean matches the real router's Prometheus histogram:
@@ -424,7 +451,8 @@ mod tests {
     fn traffic_accumulator_resets_counters_on_drain() {
         let mut acc = TrafficAccumulator::new();
         acc.on_admission(5, 10);
-        acc.on_request(100, 50, None);
+        acc.on_arrival();
+        acc.on_completion(100, 50, None);
         let _ = acc.drain(1_000.0);
         // Second drain on the same accumulator should see no state carried over.
         let stats = acc.drain(2_000.0);
@@ -439,9 +467,32 @@ mod tests {
     #[test]
     fn traffic_accumulator_retains_zero_millisecond_itl_samples() {
         let mut acc = TrafficAccumulator::new();
-        acc.on_request(10, 3, Some((1.0, 0.0)));
-        acc.on_request(10, 3, Some((1.0, 10.0)));
+        acc.on_arrival();
+        acc.on_arrival();
+        acc.on_completion(10, 3, Some((1.0, 0.0)));
+        acc.on_completion(10, 3, Some((1.0, 10.0)));
         let stats = acc.drain(1_000.0);
         assert_eq!(stats.avg_itl_ms, 5.0);
+    }
+
+    #[test]
+    fn traffic_accumulator_reports_offered_demand_before_completion() {
+        let mut acc = TrafficAccumulator::new();
+        acc.on_arrival();
+
+        let offered = acc.drain(1_000.0);
+        assert_eq!(offered.num_req, 1);
+        assert_eq!(offered.shape_count, 0);
+        assert_eq!(offered.avg_isl, 0.0);
+        assert_eq!(offered.avg_osl, 0.0);
+
+        acc.on_completion(100, 50, Some((2_000.0, 20.0)));
+        let completed = acc.drain(2_000.0);
+        assert_eq!(completed.num_req, 0);
+        assert_eq!(completed.shape_count, 1);
+        assert_eq!(completed.avg_isl, 100.0);
+        assert_eq!(completed.avg_osl, 50.0);
+        assert_eq!(completed.ttft_count, 1);
+        assert_eq!(completed.itl_count, 1);
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -799,7 +799,7 @@ impl DisaggFlowState {
                 })?;
             debug_assert!(actual_output_tokens <= requested_output_tokens);
             let latencies = collector.request_latencies(signal.uuid);
-            traffic.on_request(input_tokens, actual_output_tokens, latencies);
+            traffic.on_completion(input_tokens, actual_output_tokens, latencies);
         }
         let terminal_status = if signal.rejected {
             ReplayTerminalStatus::Rejected
@@ -1636,13 +1636,15 @@ where
         replay_hashes: Option<ReplayRequestHashes>,
         session_id: Option<String>,
     ) -> Result<Uuid> {
-        self.flow.on_external_arrival(
+        let uuid = self.flow.on_external_arrival(
             request,
             arrival_time_ms,
             replay_hashes,
             session_id,
             &mut self.collector,
-        )
+        )?;
+        self.traffic.on_arrival();
+        Ok(uuid)
     }
 
     /// Return true once both stages, both routers, and all admissions are fully


### PR DESCRIPTION
## Summary

- count offline replay traffic at request arrival, matching the live Planner's `requests_started_total` offered-load signal
- keep completed-request ISL/OSL and latency samples separate from offered request counts
- carry native sample denominators through the Rust/Python bridge so merged Planner windows remain exact
- cover offered-before-completion behavior and native-denominator traffic merges

## Root cause

Offline replay incremented `num_req` only when requests completed. An underscaled deployment therefore produced fewer completions, which the throughput predictor interpreted as lower demand, creating a positive feedback loop that sustained underscaling. Live Planner intentionally forecasts started requests instead.

## Dependency

Stacked on #12211 (`fix(replay): support Dynamo traces and planner warmup`). Retarget to `main` after #12211 merges.

## Validation

- `cargo test -p dynamo-mocker replay::offline --lib` — 173 passed
- `PYTHONPATH=/home/hongkuanz/Projects/dynamo/components/src .venv/bin/pytest -q components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py` — 10 passed
- `cargo clippy -p dynamo-mocker --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- targeted pre-commit format/lint hooks passed; the repository-wide pytest marker report was blocked by missing local KVBM/SGLang test dependencies