### PR TITLE
fix(container): workaround for devtools repo error (404) on nsight-systems

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -134,6 +134,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Add external repos (NVIDIA devtools, GitHub CLI) and install in one pass.
 # Cache apt downloads; sharing=locked avoids apt/dpkg races with concurrent builds.
+#
+# ==================== TEMPORARY WORKAROUND ====================
+# The devtools repo index lists "Filename: ./nsight-systems-...deb", so apt
+# requests the "/./" literally and that bucket 404s on it (the CUDA repo
+# normalizes fine). Fetch the normalized URL directly instead of by name.
+# Revert to a plain apt-get install once NVIDIA fixes the bucket.
+# ==============================================================
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget -qO - "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nvidia.pub" \
         | gpg --dearmor -o /etc/apt/keyrings/nvidia-devtools.gpg && \
@@ -144,7 +151,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    apt-get install -y --no-install-recommends nsight-systems-2025.5.1 gh && \
+    curl --retry 3 --retry-delay 5 -fsSL -o /tmp/nsys.deb \
+        "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nsight-systems-2025.5.1_2025.5.1.121-1_${TARGETARCH}.deb" && \
+    apt-get install -y --no-install-recommends /tmp/nsys.deb gh && \
+    rm -f /tmp/nsys.deb && \
     rm -rf /var/lib/apt/lists/*
 
 # ======================================================================


### PR DESCRIPTION
## Overview

Unbreaks the dev image build. Not related to any in-flight PR — this is ambient breakage on `main`, so every `*-dev` build is currently red. Re-running jobs won't help.

## Details

The NVIDIA devtools repo is a flat repo whose `Packages` index lists:

```
Filename: ./nsight-systems-2025.5.1_2025.5.1.121-1_amd64.deb
```

apt resolves that against the base URI and puts the dot segment on the wire literally. The bucket behind `developer.download.nvidia.com` does not normalize `/./` and returns 404 (S3 `NoSuchKey`), so the build fails with:

```
E: Failed to fetch https://developer.download.nvidia.com/devtools/repos/ubuntu2404/amd64/./nsight-systems-2025.5.1_2025.5.1.121-1_amd64.deb  404  Not Found
```

Verified, deterministic, and affects both arches:

| | literal `/./` (what apt sends) | normalized |
|---|---|---|
| amd64 | 404 | 200 |
| arm64 | 404 | 200 |

The CUDA repo normalizes `/./` correctly, which is why only this repo broke. Browsers collapse `/./` per RFC 3986 before sending, which is why the same URL appears to work when clicked.

This fetches the normalized URL directly instead of installing by name. Verified end-to-end in `ubuntu:24.04`: dependencies resolve, `update-alternatives` wires `/usr/local/bin/nsys`, and `nsys --version` reports `2025.5.1.121-255136380782v0`.

## Temporary

Tagged with a `WORKAROUND` banner. Revert to the plain `apt-get install` once the bucket is fixed — check with:

```
curl -sIo /dev/null -w '%{http_code}\n' --path-as-is "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/amd64/./nsight-systems-2025.5.1_2025.5.1.121-1_amd64.deb"
```

`200` means it's fixed and this can come out.

## Where should the reviewer start?

`container/templates/dev.Dockerfile` — single hunk, +11/-1.

## Related Issues

Root cause is NVIDIA-side; the devtools bucket should normalize dot segments the way the CUDA one does, or the index generator should drop the `./` prefix.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment setup by applying a workaround for NVIDIA Nsight Systems package installation issues.
  * Ensured the specified Nsight Systems version installs reliably alongside GitHub CLI tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->