### PR TITLE
perf(mocker): streamline native block pool hot paths

### DIFF
--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -16,7 +16,7 @@ new_key_type! {
     pub(crate) struct BlockCopyId;
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct InactiveLinks {
     previous: Option<BlockCopyId>,
     next: Option<BlockCopyId>,
@@ -29,7 +29,7 @@ enum CopyState {
         hash: SequenceHash,
         refs: usize,
         pins: usize,
-        inactive: Option<InactiveLinks>,
+        inactive: InactiveLinks,
     },
 }
 
@@ -136,9 +136,9 @@ impl VllmBlockPool {
         candidates: impl IntoIterator<Item = SequenceHash>,
         total: usize,
     ) -> Option<ReserveOutcome> {
-        let mut hits = Vec::new();
+        let mut hits = Vec::with_capacity(total);
         for hash in candidates {
-            assert!(hits.len() < total, "prefix candidates exceed layout");
+            debug_assert!(hits.len() < total, "prefix candidates exceed layout");
             let Some(id) = self.first_copy(hash) else {
                 break;
             };
@@ -232,16 +232,20 @@ impl VllmBlockPool {
     }
 
     pub(crate) fn allocate_private(&mut self, reservation: &mut BlockReservation) -> BlockCopyId {
+        let id = self.allocate_private_unchecked(reservation);
+        self.debug_assert_invariants();
+        id
+    }
+
+    fn allocate_private_unchecked(&mut self, reservation: &mut BlockReservation) -> BlockCopyId {
         assert!(reservation.fresh > 0, "reservation has no fresh capacity");
         assert!(self.reserved > 0, "pool reserved-capacity underflow");
         reservation.fresh -= 1;
         self.reserved -= 1;
 
-        let id = self.copies.insert(BlockCopy {
+        self.copies.insert(BlockCopy {
             state: CopyState::Private,
-        });
-        self.debug_assert_invariants();
-        id
+        })
     }
 
     /// Allocate a transferred/computed full block directly into the cache.
@@ -251,14 +255,21 @@ impl VllmBlockPool {
         reservation: &mut BlockReservation,
         hash: SequenceHash,
     ) -> (BlockCopyId, bool) {
-        let id = self.allocate_private(reservation);
-        let became_visible = self.cache_private(id, hash);
+        let id = self.allocate_private_unchecked(reservation);
+        let became_visible = self.cache_private_unchecked(id, hash);
+        self.debug_assert_invariants();
         (id, became_visible)
     }
 
     /// Make a request-private computed full block available for prefix reuse.
     /// Returns whether this is the first resident physical copy of `hash`.
     pub(crate) fn cache_private(&mut self, id: BlockCopyId, hash: SequenceHash) -> bool {
+        let became_visible = self.cache_private_unchecked(id, hash);
+        self.debug_assert_invariants();
+        became_visible
+    }
+
+    fn cache_private_unchecked(&mut self, id: BlockCopyId, hash: SequenceHash) -> bool {
         let became_visible = !self.by_hash.contains_key(&hash);
         let Some(copy) = self.copies.get_mut(id) else {
             panic!("attempted to cache an unknown block copy")
@@ -271,10 +282,9 @@ impl VllmBlockPool {
             hash,
             refs: 1,
             pins: 0,
-            inactive: None,
+            inactive: InactiveLinks::default(),
         };
         self.by_hash.entry(hash).or_default().push(id);
-        self.debug_assert_invariants();
         became_visible
     }
 
@@ -360,25 +370,31 @@ impl VllmBlockPool {
         matches!(
             &self.copies[id].state,
             CopyState::Cached {
-                inactive: Some(_),
+                refs: 0,
+                pins: 0,
                 ..
             }
         )
     }
 
     fn pin(&mut self, id: BlockCopyId) {
-        let was_inactive = {
-            let CopyState::Cached { pins, inactive, .. } = &mut self.copies[id].state else {
+        let (was_inactive, new_pins) = {
+            let CopyState::Cached { refs, pins, .. } = &self.copies[id].state else {
                 panic!("prefix hash points to a private copy")
             };
-            *pins = pins
-                .checked_add(1)
-                .unwrap_or_else(|| panic!("pin count overflow"));
-            inactive.is_some()
+            (
+                *refs == 0 && *pins == 0,
+                pins.checked_add(1)
+                    .unwrap_or_else(|| panic!("pin count overflow")),
+            )
         };
         if was_inactive {
             self.remove_inactive(id);
         }
+        let CopyState::Cached { pins, .. } = &mut self.copies[id].state else {
+            unreachable!()
+        };
+        *pins = new_pins;
     }
 
     fn activate_pin(&mut self, id: BlockCopyId, expected_hash: SequenceHash) {
@@ -416,92 +432,156 @@ impl VllmBlockPool {
 
     fn insert_inactive(&mut self, id: BlockCopyId) {
         let previous = self.inactive_tail;
-        if let Some(previous) = previous {
-            let CopyState::Cached {
-                inactive: Some(links),
-                ..
-            } = &mut self.copies[previous].state
-            else {
-                panic!("inactive tail is not linked")
-            };
-            assert!(links.next.replace(id).is_none());
-        } else {
-            assert!(self.inactive_head.replace(id).is_none());
-        }
-
-        let CopyState::Cached { inactive, .. } = &mut self.copies[id].state else {
-            panic!("private copy cannot enter inactive LRU")
-        };
-        assert!(
-            inactive
-                .replace(InactiveLinks {
-                    previous,
-                    next: None,
-                })
-                .is_none()
-        );
-        self.inactive_tail = Some(id);
-        self.inactive_len = self
+        let new_len = self
             .inactive_len
             .checked_add(1)
             .unwrap_or_else(|| panic!("inactive LRU length overflow"));
-    }
 
-    fn remove_inactive(&mut self, id: BlockCopyId) {
-        let links = match &self.copies[id].state {
-            CopyState::Cached {
-                inactive: Some(links),
-                ..
-            } => *links,
-            _ => panic!("copy is not in the inactive LRU"),
+        let Some(copy) = self.copies.get(id) else {
+            panic!("unknown copy cannot enter inactive LRU")
         };
+        let CopyState::Cached {
+            refs,
+            pins,
+            inactive,
+            ..
+        } = &copy.state
+        else {
+            panic!("private copy cannot enter inactive LRU")
+        };
+        assert_eq!(*refs, 0, "inactive copy retains request references");
+        assert_eq!(*pins, 0, "inactive copy retains reservation pins");
+        assert_eq!(*inactive, InactiveLinks::default());
+        assert_ne!(self.inactive_head, Some(id), "copy is already LRU head");
+        assert_ne!(self.inactive_tail, Some(id), "copy is already LRU tail");
 
-        if let Some(previous) = links.previous {
-            let CopyState::Cached {
-                inactive: Some(previous_links),
-                ..
-            } = &mut self.copies[previous].state
-            else {
-                panic!("inactive predecessor is not linked")
-            };
-            assert_eq!(
-                std::mem::replace(&mut previous_links.next, links.next),
-                Some(id)
+        if let Some(previous) = previous {
+            assert!(
+                self.inactive_head.is_some(),
+                "inactive LRU tail exists without a head"
             );
+            let Some(previous_copy) = self.copies.get(previous) else {
+                panic!("inactive LRU tail points to a missing copy")
+            };
+            let CopyState::Cached {
+                refs,
+                pins,
+                inactive,
+                ..
+            } = &previous_copy.state
+            else {
+                panic!("inactive tail is not linked")
+            };
+            assert_eq!(*refs, 0, "inactive tail retains request references");
+            assert_eq!(*pins, 0, "inactive tail retains reservation pins");
+            assert_eq!(inactive.next, None, "inactive tail has a successor");
         } else {
-            assert_eq!(
-                std::mem::replace(&mut self.inactive_head, links.next),
-                Some(id)
+            assert!(
+                self.inactive_head.is_none(),
+                "inactive LRU endpoints disagree"
             );
         }
 
-        if let Some(next) = links.next {
-            let CopyState::Cached {
-                inactive: Some(next_links),
-                ..
-            } = &mut self.copies[next].state
-            else {
-                panic!("inactive successor is not linked")
+        if let Some(previous) = previous {
+            let CopyState::Cached { inactive, .. } = &mut self.copies[previous].state else {
+                unreachable!()
             };
-            assert_eq!(
-                std::mem::replace(&mut next_links.previous, links.previous),
-                Some(id)
-            );
+            inactive.next = Some(id);
         } else {
-            assert_eq!(
-                std::mem::replace(&mut self.inactive_tail, links.previous),
-                Some(id)
-            );
+            self.inactive_head = Some(id);
         }
-
         let CopyState::Cached { inactive, .. } = &mut self.copies[id].state else {
             unreachable!()
         };
-        assert_eq!(inactive.take(), Some(links));
-        self.inactive_len = self
+        *inactive = InactiveLinks {
+            previous,
+            next: None,
+        };
+        self.inactive_tail = Some(id);
+        self.inactive_len = new_len;
+    }
+
+    fn remove_inactive(&mut self, id: BlockCopyId) {
+        let new_len = self
             .inactive_len
             .checked_sub(1)
             .unwrap_or_else(|| panic!("inactive LRU length underflow"));
+        let Some(copy) = self.copies.get(id) else {
+            panic!("inactive LRU points to a missing copy")
+        };
+        let links = match &copy.state {
+            CopyState::Cached {
+                refs: 0,
+                pins: 0,
+                inactive,
+                ..
+            } => *inactive,
+            _ => panic!("copy is not in the inactive LRU"),
+        };
+        assert_ne!(
+            links.previous,
+            Some(id),
+            "inactive copy is its own predecessor"
+        );
+        assert_ne!(links.next, Some(id), "inactive copy is its own successor");
+
+        if let Some(previous) = links.previous {
+            let Some(previous_copy) = self.copies.get(previous) else {
+                panic!("inactive predecessor points to a missing copy")
+            };
+            let CopyState::Cached {
+                refs: 0,
+                pins: 0,
+                inactive: previous_links,
+                ..
+            } = &previous_copy.state
+            else {
+                panic!("inactive predecessor is not linked")
+            };
+            assert_eq!(previous_links.next, Some(id));
+        } else {
+            assert_eq!(self.inactive_head, Some(id));
+        }
+
+        if let Some(next) = links.next {
+            let Some(next_copy) = self.copies.get(next) else {
+                panic!("inactive successor points to a missing copy")
+            };
+            let CopyState::Cached {
+                refs: 0,
+                pins: 0,
+                inactive: next_links,
+                ..
+            } = &next_copy.state
+            else {
+                panic!("inactive successor is not linked")
+            };
+            assert_eq!(next_links.previous, Some(id));
+        } else {
+            assert_eq!(self.inactive_tail, Some(id));
+        }
+
+        if let Some(previous) = links.previous {
+            let CopyState::Cached { inactive, .. } = &mut self.copies[previous].state else {
+                unreachable!()
+            };
+            inactive.next = links.next;
+        } else {
+            self.inactive_head = links.next;
+        }
+        if let Some(next) = links.next {
+            let CopyState::Cached { inactive, .. } = &mut self.copies[next].state else {
+                unreachable!()
+            };
+            inactive.previous = links.previous;
+        } else {
+            self.inactive_tail = links.previous;
+        }
+        let CopyState::Cached { inactive, .. } = &mut self.copies[id].state else {
+            unreachable!()
+        };
+        *inactive = InactiveLinks::default();
+        self.inactive_len = new_len;
     }
 
     /// Evict one physical copy. A hash is returned only on its final copy.
@@ -514,17 +594,13 @@ impl VllmBlockPool {
             panic!("inactive LRU points to a missing copy")
         };
         let CopyState::Cached {
-            hash,
-            refs,
-            pins,
-            inactive,
+            hash, refs, pins, ..
         } = copy.state
         else {
             panic!("inactive LRU points to a private copy")
         };
         assert_eq!(refs, 0);
         assert_eq!(pins, 0);
-        assert_eq!(inactive, None);
 
         let remove_hash = {
             let Some(copies) = self.by_hash.get_mut(&hash) else {
@@ -538,16 +614,32 @@ impl VllmBlockPool {
         };
         if remove_hash {
             self.by_hash.remove(&hash);
-            self.debug_assert_invariants();
-            Some(hash)
-        } else {
-            self.debug_assert_invariants();
-            None
         }
+        remove_hash.then_some(hash)
     }
 
-    #[cfg(debug_assertions)]
     fn debug_assert_invariants(&self) {
+        debug_assert!(
+            self.copies.len() + self.reserved <= self.capacity,
+            "block-pool occupancy exceeds capacity"
+        );
+        debug_assert_eq!(
+            self.inactive_head.is_none(),
+            self.inactive_tail.is_none(),
+            "inactive LRU endpoints disagree"
+        );
+        debug_assert_eq!(
+            self.inactive_len == 0,
+            self.inactive_head.is_none(),
+            "inactive LRU length disagrees with its endpoints"
+        );
+
+        #[cfg(test)]
+        self.assert_full_invariants();
+    }
+
+    #[cfg(test)]
+    fn assert_full_invariants(&self) {
         assert!(
             self.copies.len() + self.reserved <= self.capacity,
             "block-pool occupancy exceeds capacity"
@@ -556,6 +648,11 @@ impl VllmBlockPool {
             self.inactive_head.is_none(),
             self.inactive_tail.is_none(),
             "inactive LRU endpoints disagree"
+        );
+        assert_eq!(
+            self.inactive_len == 0,
+            self.inactive_head.is_none(),
+            "inactive LRU length disagrees with its endpoints"
         );
 
         let mut seen = FxHashSet::default();
@@ -569,11 +666,11 @@ impl VllmBlockPool {
             let CopyState::Cached {
                 refs,
                 pins,
-                inactive: Some(links),
+                inactive: links,
                 ..
             } = &copy.state
             else {
-                panic!("inactive LRU points to an active or private copy")
+                panic!("inactive LRU points to a private copy")
             };
             assert_eq!(*refs, 0, "inactive copy retains request references");
             assert_eq!(*pins, 0, "inactive copy retains reservation pins");
@@ -598,15 +695,14 @@ impl VllmBlockPool {
                         .get(hash)
                         .is_some_and(|copies| copies.contains(&id));
                     assert!(indexed, "cached copy is missing from its hash index");
-                    if inactive.is_some() {
+                    if *refs == 0 && *pins == 0 {
                         assert!(seen.contains(&id), "inactive copy is missing from the LRU");
-                        assert_eq!(*refs, 0);
-                        assert_eq!(*pins, 0);
                     } else {
                         assert!(
-                            *refs > 0 || *pins > 0,
-                            "unreferenced cached copy is missing from the inactive LRU"
+                            !seen.contains(&id),
+                            "active cached copy is present in the inactive LRU"
                         );
+                        assert_eq!(*inactive, InactiveLinks::default());
                     }
                 }
             }
@@ -635,10 +731,6 @@ impl VllmBlockPool {
             "hash index does not cover every cached copy"
         );
     }
-
-    #[cfg(not(debug_assertions))]
-    #[inline(always)]
-    fn debug_assert_invariants(&self) {}
 }
 
 #[cfg(test)]

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -7,8 +7,6 @@
 //! the pool models occupancy, reference/pin state, and LRU eviction without
 //! reproducing vLLM's numeric block IDs or null block.
 
-use std::collections::BTreeMap;
-
 use dynamo_tokens::SequenceHash;
 use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
@@ -18,6 +16,12 @@ new_key_type! {
     pub(crate) struct BlockCopyId;
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InactiveLinks {
+    previous: Option<BlockCopyId>,
+    next: Option<BlockCopyId>,
+}
+
 #[derive(Debug)]
 enum CopyState {
     Private,
@@ -25,7 +29,7 @@ enum CopyState {
         hash: SequenceHash,
         refs: usize,
         pins: usize,
-        inactive_at: Option<u64>,
+        inactive: Option<InactiveLinks>,
     },
 }
 
@@ -66,9 +70,10 @@ pub(crate) struct VllmBlockPool {
     capacity: usize,
     copies: SlotMap<BlockCopyId, BlockCopy>,
     by_hash: FxHashMap<SequenceHash, SmallVec<[BlockCopyId; 1]>>,
-    /// Ordinary LRU: lower timestamp is evicted first.
-    inactive: BTreeMap<u64, BlockCopyId>,
-    next_lru: u64,
+    /// Intrusive inactive LRU, oldest at the head and newest at the tail.
+    inactive_head: Option<BlockCopyId>,
+    inactive_tail: Option<BlockCopyId>,
+    inactive_len: usize,
     reserved: usize,
 }
 
@@ -79,8 +84,9 @@ impl VllmBlockPool {
             capacity,
             copies: SlotMap::with_key(),
             by_hash: FxHashMap::default(),
-            inactive: BTreeMap::new(),
-            next_lru: 0,
+            inactive_head: None,
+            inactive_tail: None,
+            inactive_len: 0,
             reserved: 0,
         }
     }
@@ -120,6 +126,33 @@ impl VllmBlockPool {
             })
             .collect::<Vec<_>>();
 
+        self.reserve_hits(hits, fresh)
+    }
+
+    /// Resolve the longest resident prefix and reserve its remaining fresh
+    /// suffix in one pool traversal.
+    pub(crate) fn reserve_resident_prefix(
+        &mut self,
+        candidates: impl IntoIterator<Item = SequenceHash>,
+        total: usize,
+    ) -> Option<ReserveOutcome> {
+        let mut hits = Vec::new();
+        for hash in candidates {
+            assert!(hits.len() < total, "prefix candidates exceed layout");
+            let Some(id) = self.first_copy(hash) else {
+                break;
+            };
+            hits.push((hash, id));
+        }
+        let fresh = total - hits.len();
+        self.reserve_hits(hits, fresh)
+    }
+
+    fn reserve_hits(
+        &mut self,
+        hits: Vec<(SequenceHash, BlockCopyId)>,
+        fresh: usize,
+    ) -> Option<ReserveOutcome> {
         let free = self.free_capacity();
         let needed_evictions = fresh.saturating_sub(free);
         if needed_evictions > 0 {
@@ -128,7 +161,7 @@ impl VllmBlockPool {
                 .filter_map(|(_, id)| self.is_inactive(*id).then_some(*id))
                 .collect::<FxHashSet<_>>()
                 .len();
-            let evictable_after_pins = self.inactive.len().saturating_sub(inactive_hits);
+            let evictable_after_pins = self.inactive_len.saturating_sub(inactive_hits);
             if needed_evictions > evictable_after_pins {
                 return None;
             }
@@ -146,19 +179,21 @@ impl VllmBlockPool {
         }
         self.reserved += fresh;
 
-        Some(ReserveOutcome {
+        let outcome = ReserveOutcome {
             reservation: BlockReservation {
                 prefix: hits,
                 fresh,
             },
             removed,
-        })
+        };
+        self.debug_assert_invariants();
+        Some(outcome)
     }
 
     fn reserve_fresh(&mut self, fresh: usize) -> Option<ReserveOutcome> {
         let free = self.free_capacity();
         let needed_evictions = fresh.saturating_sub(free);
-        if needed_evictions > self.inactive.len() {
+        if needed_evictions > self.inactive_len {
             return None;
         }
 
@@ -170,13 +205,15 @@ impl VllmBlockPool {
         }
         self.reserved += fresh;
 
-        Some(ReserveOutcome {
+        let outcome = ReserveOutcome {
             reservation: BlockReservation {
                 prefix: Vec::new(),
                 fresh,
             },
             removed,
-        })
+        };
+        self.debug_assert_invariants();
+        Some(outcome)
     }
 
     /// Convert all cached-prefix pins into request references.
@@ -190,6 +227,7 @@ impl VllmBlockPool {
             self.activate_pin(id, hash);
             ids.push(id);
         }
+        self.debug_assert_invariants();
         ids
     }
 
@@ -199,9 +237,11 @@ impl VllmBlockPool {
         reservation.fresh -= 1;
         self.reserved -= 1;
 
-        self.copies.insert(BlockCopy {
+        let id = self.copies.insert(BlockCopy {
             state: CopyState::Private,
-        })
+        });
+        self.debug_assert_invariants();
+        id
     }
 
     /// Allocate a transferred/computed full block directly into the cache.
@@ -231,9 +271,10 @@ impl VllmBlockPool {
             hash,
             refs: 1,
             pins: 0,
-            inactive_at: None,
+            inactive: None,
         };
         self.by_hash.entry(hash).or_default().push(id);
+        self.debug_assert_invariants();
         became_visible
     }
 
@@ -245,6 +286,7 @@ impl VllmBlockPool {
         };
         if matches!(copy.state, CopyState::Private) {
             self.copies.remove(id);
+            self.debug_assert_invariants();
             return;
         }
 
@@ -259,6 +301,7 @@ impl VllmBlockPool {
         if should_deactivate {
             self.insert_inactive(id);
         }
+        self.debug_assert_invariants();
     }
 
     /// Release all unconsumed capacity and prefix pins.
@@ -275,10 +318,11 @@ impl VllmBlockPool {
             "pool reserved-capacity underflow"
         );
         self.reserved -= reservation.fresh;
+        self.debug_assert_invariants();
     }
 
     pub(crate) fn num_active(&self) -> usize {
-        self.copies.len() - self.inactive.len() + self.reserved
+        self.copies.len() - self.inactive_len + self.reserved
     }
 
     pub(crate) fn num_active_refs(&self) -> usize {
@@ -292,7 +336,7 @@ impl VllmBlockPool {
     }
 
     pub(crate) fn num_inactive(&self) -> usize {
-        self.inactive.len()
+        self.inactive_len
     }
 
     pub(crate) fn capacity(&self) -> usize {
@@ -316,27 +360,24 @@ impl VllmBlockPool {
         matches!(
             &self.copies[id].state,
             CopyState::Cached {
-                inactive_at: Some(_),
+                inactive: Some(_),
                 ..
             }
         )
     }
 
     fn pin(&mut self, id: BlockCopyId) {
-        let inactive_at = {
-            let CopyState::Cached {
-                pins, inactive_at, ..
-            } = &mut self.copies[id].state
-            else {
+        let was_inactive = {
+            let CopyState::Cached { pins, inactive, .. } = &mut self.copies[id].state else {
                 panic!("prefix hash points to a private copy")
             };
             *pins = pins
                 .checked_add(1)
                 .unwrap_or_else(|| panic!("pin count overflow"));
-            inactive_at.take()
+            inactive.is_some()
         };
-        if let Some(timestamp) = inactive_at {
-            assert_eq!(self.inactive.remove(&timestamp), Some(id));
+        if was_inactive {
+            self.remove_inactive(id);
         }
     }
 
@@ -374,23 +415,101 @@ impl VllmBlockPool {
     }
 
     fn insert_inactive(&mut self, id: BlockCopyId) {
-        let timestamp = self.next_lru;
-        self.next_lru = self
-            .next_lru
-            .checked_add(1)
-            .unwrap_or_else(|| panic!("LRU timestamp overflow"));
-        let CopyState::Cached { inactive_at, .. } = &mut self.copies[id].state else {
+        let previous = self.inactive_tail;
+        if let Some(previous) = previous {
+            let CopyState::Cached {
+                inactive: Some(links),
+                ..
+            } = &mut self.copies[previous].state
+            else {
+                panic!("inactive tail is not linked")
+            };
+            assert!(links.next.replace(id).is_none());
+        } else {
+            assert!(self.inactive_head.replace(id).is_none());
+        }
+
+        let CopyState::Cached { inactive, .. } = &mut self.copies[id].state else {
             panic!("private copy cannot enter inactive LRU")
         };
-        assert!(inactive_at.replace(timestamp).is_none());
-        assert!(self.inactive.insert(timestamp, id).is_none());
+        assert!(
+            inactive
+                .replace(InactiveLinks {
+                    previous,
+                    next: None,
+                })
+                .is_none()
+        );
+        self.inactive_tail = Some(id);
+        self.inactive_len = self
+            .inactive_len
+            .checked_add(1)
+            .unwrap_or_else(|| panic!("inactive LRU length overflow"));
+    }
+
+    fn remove_inactive(&mut self, id: BlockCopyId) {
+        let links = match &self.copies[id].state {
+            CopyState::Cached {
+                inactive: Some(links),
+                ..
+            } => *links,
+            _ => panic!("copy is not in the inactive LRU"),
+        };
+
+        if let Some(previous) = links.previous {
+            let CopyState::Cached {
+                inactive: Some(previous_links),
+                ..
+            } = &mut self.copies[previous].state
+            else {
+                panic!("inactive predecessor is not linked")
+            };
+            assert_eq!(
+                std::mem::replace(&mut previous_links.next, links.next),
+                Some(id)
+            );
+        } else {
+            assert_eq!(
+                std::mem::replace(&mut self.inactive_head, links.next),
+                Some(id)
+            );
+        }
+
+        if let Some(next) = links.next {
+            let CopyState::Cached {
+                inactive: Some(next_links),
+                ..
+            } = &mut self.copies[next].state
+            else {
+                panic!("inactive successor is not linked")
+            };
+            assert_eq!(
+                std::mem::replace(&mut next_links.previous, links.previous),
+                Some(id)
+            );
+        } else {
+            assert_eq!(
+                std::mem::replace(&mut self.inactive_tail, links.previous),
+                Some(id)
+            );
+        }
+
+        let CopyState::Cached { inactive, .. } = &mut self.copies[id].state else {
+            unreachable!()
+        };
+        assert_eq!(inactive.take(), Some(links));
+        self.inactive_len = self
+            .inactive_len
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("inactive LRU length underflow"));
     }
 
     /// Evict one physical copy. A hash is returned only on its final copy.
     fn evict_one(&mut self) -> Option<SequenceHash> {
-        let Some((timestamp, id)) = self.inactive.pop_first() else {
+        let Some(id) = self.inactive_head else {
             panic!("prechecked inactive capacity disappeared")
         };
+        self.remove_inactive(id);
         let Some(copy) = self.copies.remove(id) else {
             panic!("inactive LRU points to a missing copy")
         };
@@ -398,14 +517,14 @@ impl VllmBlockPool {
             hash,
             refs,
             pins,
-            inactive_at,
+            inactive,
         } = copy.state
         else {
             panic!("inactive LRU points to a private copy")
         };
         assert_eq!(refs, 0);
         assert_eq!(pins, 0);
-        assert_eq!(inactive_at, Some(timestamp));
+        assert_eq!(inactive, None);
 
         let remove_hash = {
             let Some(copies) = self.by_hash.get_mut(&hash) else {
@@ -419,11 +538,107 @@ impl VllmBlockPool {
         };
         if remove_hash {
             self.by_hash.remove(&hash);
+            self.debug_assert_invariants();
             Some(hash)
         } else {
+            self.debug_assert_invariants();
             None
         }
     }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_invariants(&self) {
+        assert!(
+            self.copies.len() + self.reserved <= self.capacity,
+            "block-pool occupancy exceeds capacity"
+        );
+        assert_eq!(
+            self.inactive_head.is_none(),
+            self.inactive_tail.is_none(),
+            "inactive LRU endpoints disagree"
+        );
+
+        let mut seen = FxHashSet::default();
+        let mut current = self.inactive_head;
+        let mut previous = None;
+        while let Some(id) = current {
+            assert!(seen.insert(id), "inactive LRU contains a cycle");
+            let Some(copy) = self.copies.get(id) else {
+                panic!("inactive LRU points to a missing copy")
+            };
+            let CopyState::Cached {
+                refs,
+                pins,
+                inactive: Some(links),
+                ..
+            } = &copy.state
+            else {
+                panic!("inactive LRU points to an active or private copy")
+            };
+            assert_eq!(*refs, 0, "inactive copy retains request references");
+            assert_eq!(*pins, 0, "inactive copy retains reservation pins");
+            assert_eq!(links.previous, previous, "inactive predecessor mismatch");
+            previous = Some(id);
+            current = links.next;
+        }
+        assert_eq!(previous, self.inactive_tail, "inactive tail mismatch");
+        assert_eq!(seen.len(), self.inactive_len, "inactive length mismatch");
+
+        for (id, copy) in &self.copies {
+            match &copy.state {
+                CopyState::Private => {}
+                CopyState::Cached {
+                    hash,
+                    refs,
+                    pins,
+                    inactive,
+                } => {
+                    let indexed = self
+                        .by_hash
+                        .get(hash)
+                        .is_some_and(|copies| copies.contains(&id));
+                    assert!(indexed, "cached copy is missing from its hash index");
+                    if inactive.is_some() {
+                        assert!(seen.contains(&id), "inactive copy is missing from the LRU");
+                        assert_eq!(*refs, 0);
+                        assert_eq!(*pins, 0);
+                    } else {
+                        assert!(
+                            *refs > 0 || *pins > 0,
+                            "unreferenced cached copy is missing from the inactive LRU"
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut indexed = FxHashSet::default();
+        for (hash, copies) in &self.by_hash {
+            assert!(!copies.is_empty(), "hash index contains an empty copy list");
+            for id in copies {
+                assert!(indexed.insert(*id), "copy appears in multiple hash entries");
+                let Some(copy) = self.copies.get(*id) else {
+                    panic!("hash index points to a missing copy")
+                };
+                assert!(
+                    matches!(&copy.state, CopyState::Cached { hash: actual, .. } if actual == hash),
+                    "hash index points to the wrong cached copy"
+                );
+            }
+        }
+        assert_eq!(
+            indexed.len(),
+            self.copies
+                .values()
+                .filter(|copy| matches!(copy.state, CopyState::Cached { .. }))
+                .count(),
+            "hash index does not cover every cached copy"
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[inline(always)]
+    fn debug_assert_invariants(&self) {}
 }
 
 #[cfg(test)]
@@ -509,5 +724,77 @@ mod tests {
         assert!(pool.prefix_hit(7).is_some());
         assert!(pool.prefix_hit(8).is_none());
         pool.cancel(pressure.reservation);
+    }
+
+    #[test]
+    fn intrusive_lru_unlinks_middle_and_requeues_it_as_newest() {
+        let mut pool = VllmBlockPool::new(3);
+        let mut seed = reserve(&mut pool, &[], 3).reservation;
+        let first = pool.allocate_private(&mut seed);
+        let middle = pool.allocate_private(&mut seed);
+        let last = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(first, 1));
+        assert!(pool.cache_private(middle, 2));
+        assert!(pool.cache_private(last, 3));
+        pool.release(first);
+        pool.release(middle);
+        pool.release(last);
+
+        let middle_pin = reserve(&mut pool, &[2], 0);
+        pool.cancel(middle_pin.reservation);
+
+        let mut blockers = Vec::new();
+        for expected in [1, 3, 2] {
+            let pressure = reserve(&mut pool, &[], 1);
+            assert_eq!(pressure.removed, vec![expected]);
+            let mut reservation = pressure.reservation;
+            blockers.push(pool.allocate_private(&mut reservation));
+            pool.cancel(reservation);
+        }
+        assert_eq!(pool.num_inactive(), 0);
+        for blocker in blockers {
+            pool.release(blocker);
+        }
+    }
+
+    #[test]
+    fn fused_prefix_reservation_stops_at_first_cache_miss() {
+        let mut pool = VllmBlockPool::new(3);
+        let mut seed = reserve(&mut pool, &[], 2).reservation;
+        let first = pool.allocate_private(&mut seed);
+        let later = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(first, 7));
+        assert!(pool.cache_private(later, 9));
+        pool.release(first);
+        pool.release(later);
+
+        let outcome = pool
+            .reserve_resident_prefix([7, 8, 9], 3)
+            .expect("one prefix hit plus two fresh blocks should fit");
+        assert_eq!(outcome.reservation.prefix.len(), 1);
+        assert_eq!(outcome.reservation.fresh_len(), 2);
+        assert_eq!(outcome.removed, vec![9]);
+        pool.cancel(outcome.reservation);
+    }
+
+    #[test]
+    fn failed_fused_prefix_reservation_is_atomic() {
+        let mut pool = VllmBlockPool::new(2);
+        let mut seed = reserve(&mut pool, &[], 2).reservation;
+        let first = pool.allocate_private(&mut seed);
+        let second = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(first, 7));
+        assert!(pool.cache_private(second, 8));
+        pool.release(first);
+        pool.release(second);
+
+        assert!(pool.reserve_resident_prefix([7, 8], 3).is_none());
+        assert_eq!(pool.num_active(), 0);
+        assert_eq!(pool.num_inactive(), 2);
+
+        let retry = reserve(&mut pool, &[7, 8], 0);
+        pool.cancel(retry.reservation);
+        assert_eq!(pool.num_active(), 0);
+        assert_eq!(pool.num_inactive(), 2);
     }
 }

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -1050,6 +1050,65 @@ mod tests {
     }
 
     #[test]
+    fn destination_without_prefix_caching_reserves_every_block_fresh() {
+        let mut manager =
+            VllmKvManager::new_with_event_sink(2, 4, false, KvEventPublishers::default(), 0);
+        let owner = Uuid::from_u128(1);
+        let layout = VllmBlockLayout::new(
+            vec![UniqueBlock::FullBlock(7), UniqueBlock::FullBlock(8)],
+            vec![107, 108],
+            None,
+            None,
+        );
+
+        let reservation = ready(manager.reserve_destination_at(owner, Some(layout), None));
+        assert_eq!(reservation.len(), 2);
+        assert_eq!(reservation.transferable_prompt_tokens(4), 8);
+
+        manager.activate_destination(reservation);
+        assert_eq!(manager.request_block_count(owner), 2);
+        assert_eq!(manager.num_active_blocks(), 2);
+        assert!(manager.pool.prefix_hit(7).is_none());
+        assert!(manager.pool.prefix_hit(8).is_none());
+    }
+
+    #[test]
+    fn destination_partial_block_stops_prefix_reuse() {
+        let mut manager =
+            VllmKvManager::new_with_event_sink(4, 4, true, KvEventPublishers::default(), 0);
+        let seed = Uuid::from_u128(1);
+        ready(use_full(&mut manager, seed, &[7, 9], 0));
+        manager.finalize_computed_prefix(seed, 0, 8);
+        manager.deref_for_request(
+            seed,
+            &[UniqueBlock::FullBlock(9), UniqueBlock::FullBlock(7)],
+        );
+
+        let owner = Uuid::from_u128(2);
+        let layout = VllmBlockLayout::new(
+            vec![
+                UniqueBlock::FullBlock(7),
+                UniqueBlock::PartialBlock(Uuid::from_u128(3)),
+                UniqueBlock::FullBlock(9),
+            ],
+            vec![107, 109],
+            None,
+            None,
+        );
+
+        let reservation = ready(manager.reserve_destination_at(owner, Some(layout), None));
+        assert_eq!(reservation.len(), 3);
+        assert_eq!(reservation.transferable_prompt_tokens(4), 8);
+
+        manager.activate_destination(reservation);
+        assert_eq!(manager.request_block_count(owner), 3);
+        assert_eq!(manager.num_active_blocks(), 3);
+        assert_eq!(manager.num_inactive_blocks(), 1);
+        assert!(manager.pool.prefix_hit(7).unwrap().is_active);
+        assert!(!manager.pool.prefix_hit(9).unwrap().is_active);
+    }
+
+    #[test]
     fn request_release_evicts_leaf_before_parent() {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -332,7 +332,7 @@ impl VllmKvManager {
             !self.request_blocks.contains_key(&request_id),
             "destination request already owns a block table"
         );
-        let (prefix, fresh) = match layout.as_ref() {
+        let outcome = match layout.as_ref() {
             Some(VllmBlockLayout {
                 blocks,
                 local_hashes,
@@ -346,13 +346,21 @@ impl VllmKvManager {
                     parent.as_ref(),
                 );
                 self.validate_fresh_partials(blocks);
-                let prefix = self.resident_prefix(blocks);
-                let fresh = blocks.len() - prefix.len();
-                (prefix, fresh)
+                if self.enable_prefix_caching {
+                    self.pool.reserve_resident_prefix(
+                        blocks.iter().map_while(|block| match block {
+                            UniqueBlock::FullBlock(hash) => Some(*hash),
+                            UniqueBlock::PartialBlock(_) => None,
+                        }),
+                        blocks.len(),
+                    )
+                } else {
+                    self.pool.reserve(&[], blocks.len())
+                }
             }
-            None => (Vec::new(), 0),
+            None => self.pool.reserve(&[], 0),
         };
-        let Some(outcome) = self.pool.reserve(&prefix, fresh) else {
+        let Some(outcome) = outcome else {
             return VllmAcquire::CapacityExhausted;
         };
         self.publish_removed(outcome.removed);
@@ -633,21 +641,6 @@ impl VllmKvManager {
             );
             first_partial.get_or_insert(*uuid);
         }
-    }
-
-    fn resident_prefix(&self, blocks: &[UniqueBlock]) -> Vec<SequenceHash> {
-        if !self.enable_prefix_caching {
-            return Vec::new();
-        }
-        blocks
-            .iter()
-            .map_while(|block| match block {
-                UniqueBlock::FullBlock(hash) if self.pool.prefix_hit(*hash).is_some() => {
-                    Some(*hash)
-                }
-                _ => None,
-            })
-            .collect()
     }
 
     /// Release request blocks in caller-provided eviction-priority order.


### PR DESCRIPTION
## Overview

Streamline native-G1 mocker block-pool hot paths while preserving physical-capacity, prefix-reuse, and eviction semantics.

## Summary

- replace the timestamp-keyed inactive `BTreeMap` with an intrusive oldest-to-newest LRU
- resolve and reserve a destination's resident prefix in one block-pool traversal
- derive inactive membership from zero references and zero pins, avoiding a separate membership discriminant
- keep constant-time invariant checks in debug builds and exhaustive structural validation in unit tests
- validate intrusive-list updates before mutation so failed invariants cannot leave a partially updated list

## Details

The native block pool now stores optional predecessor and successor IDs directly in each cached copy. Inactive membership is derived from `refs == 0 && pins == 0`; active entries carry empty links. Pinning removes an inactive entry before incrementing its pin count, and insertion/removal validates the target, neighbors, endpoints, and length before changing the list.

`reserve_resident_prefix` walks candidates until the first partial block or cache miss, pins the resident prefix, and reserves the fresh suffix atomically. Its hit vector is preallocated from the layout length.

Ordinary debug builds perform only constant-time occupancy and endpoint checks. The full LRU/hash-index sweep is compiled only for tests and runs once per logical operation rather than inside eviction loops or twice during cached allocation.

### Performance evidence

The performance run predates the review-fix commit. It compared control `329aba5d0c91c4520c5ce8a1707310fa68fccc69` with performance commit `97f68ec59d9085d18944ffd9bfe2e7c9bd9e981f`. The follow-up commit `c87c93a5a38101dca8f4e938b041ee025d54c9ac` was not rebenchmarked.

Both arms used one native-G1 mocker with 32 workers on CPUs `12-23`, frontend/AIPerf on CPUs `0-11`, 128,000 blocks per worker, block size 16, concurrency 512, all 336 Weka trace entries, a 120-second measured phase, and basic `taskset` isolation only.

| Metric | Control | Performance commit | Delta |
|---|---:|---:|---:|
| Mocker CPU ms/request | 23.5446 | 22.4133 | **-4.80%** |
| Mocker CPU s / 1M modeled tokens | 0.301957 | 0.286989 | **-4.96%** |
| Throughput (req/s) | 255.429 | 258.795 | **+1.32%** |
| Peak RSS (MiB) | 7107.2 | 7183.8 | +1.08% |

Both arms registered all 32 workers and completed with zero request errors or cancellations. This was intentionally one accepted run per arm; unrelated host activity remained on the mocker CPU mask.

The aggregated-worker workload exercises the intrusive LRU but not disaggregated destination reservation, so the measured CPU improvement should primarily be attributed to the LRU change. Prefix fusion is correctness-tested but not performance-qualified by this run.

The measured RSS value reflects the earlier `Option<InactiveLinks>` representation. The review follow-up removes that outer discriminant, eliminating up to 31.25 MiB of embedded cached-copy state at the benchmark's aggregate 4,096,000-block capacity, but that reduction was not measured in a new E2E run.

## Where should the reviewer start?

1. `lib/mocker/src/cache/vllm_block_pool.rs`: cached-copy state, intrusive-list validation/mutation, and invariant-check boundaries.
2. `lib/mocker/src/kv_manager/vllm_backend.rs`: destination prefix reservation and the native-manager coverage for disabled prefix caching and partial-block termination.

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed — no related issue

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker` — 641 passed, 1 ignored
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- pre-review release-like Python binding build with DWARF; build ID `7c1d0bf8bf0ea539407a6355e6f174c9b79de257`
- pre-review E2E gates: 32/32 workers, enforced affinities, zero AIPerf errors, zero cancellations, and full process-group teardown
