### PR TITLE
feat(vllm): add local sidecar launchers

### DIFF
--- a/examples/backends/vllm/launch/sidecar_agg.sh
+++ b/examples/backends/vllm/launch/sidecar_agg.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving through vLLM's native gRPC server (1 GPU).
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_vllm_gpu_mem_args
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+MODEL="Qwen/Qwen3-0.6B"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --model"
+                echo "Use --help for usage information"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model <name>] [vLLM engine options...]"
+            echo
+            echo "Additional options are passed to the managed vLLM engine."
+            echo
+            echo "Environment overrides:"
+            echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
+            echo "  VLLM_RS_HTTP_PORT       vLLM HTTP port (default: 8100)"
+            echo "  VLLM_GRPC_PORT          vLLM gRPC port (default: 50051)"
+            echo "  MAX_MODEL_LEN           Maximum model length (default: 4096)"
+            echo "  MAX_CONCURRENT_SEQS     Maximum concurrent sequences (default: 2)"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+trap dynamo_exit_trap EXIT
+
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+VLLM_RS_HTTP_PORT="${VLLM_RS_HTTP_PORT:-8100}"
+VLLM_GRPC_PORT="${VLLM_GRPC_PORT:-50051}"
+
+# Default KV cache cap from profiling (2x safety over min=560 MiB); ~3.8 GiB peak VRAM.
+# The profiler/test framework can override this value through the environment.
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=1119388000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching vLLM Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HTTP_PORT" \
+    "vLLM HTTP:  http://127.0.0.1:${VLLM_RS_HTTP_PORT}" \
+    "vLLM gRPC:  127.0.0.1:${VLLM_GRPC_PORT}"
+
+python -m dynamo.frontend &
+
+# vllm-rs manages the headless Python engine and exposes native gRPC on loopback.
+# Arguments after -- are forwarded to the managed engine.
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+vllm-rs serve "$MODEL" \
+    --host 127.0.0.1 \
+    --port "$VLLM_RS_HTTP_PORT" \
+    --grpc-port "$VLLM_GRPC_PORT" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    -- \
+    --enforce-eager \
+    --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+    dynamo-vllm-sidecar \
+    --vllm-endpoint "127.0.0.1:${VLLM_GRPC_PORT}" \
+    --model-path "$MODEL" &
+
+wait_any_exit

--- a/examples/backends/vllm/launch/sidecar_disagg.sh
+++ b/examples/backends/vllm/launch/sidecar_disagg.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Disaggregated serving through vLLM's native gRPC servers (2 GPUs).
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_vllm_gpu_mem_args
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+MODEL="Qwen/Qwen3-0.6B"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for --model"
+                echo "Use --help for usage information"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model <name>] [vLLM engine options...]"
+            echo
+            echo "Additional options are passed to both managed vLLM engines."
+            echo
+            echo "Environment overrides:"
+            echo "  DYN_HTTP_PORT                   Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT1                Decode sidecar system port (default: 8081)"
+            echo "  DYN_SYSTEM_PORT2                Prefill sidecar system port (default: 8082)"
+            echo "  VLLM_DECODE_HTTP_PORT           Decode vLLM HTTP port (default: 8100)"
+            echo "  VLLM_DECODE_GRPC_PORT           Decode vLLM gRPC port (default: 50051)"
+            echo "  VLLM_PREFILL_HTTP_PORT          Prefill vLLM HTTP port (default: 8110)"
+            echo "  VLLM_PREFILL_GRPC_PORT          Prefill vLLM gRPC port (default: 50052)"
+            echo "  VLLM_DECODE_NIXL_SIDE_CHANNEL_PORT  Decode NIXL port (default: 5600)"
+            echo "  VLLM_PREFILL_NIXL_SIDE_CHANNEL_PORT Prefill NIXL port (default: 20097)"
+            echo "  VLLM_PREFILL_KV_EVENT_PORT      Prefill KV event port (default: 20081)"
+            echo "  VLLM_DECODE_GPU                 Decode GPU index (default: 0)"
+            echo "  VLLM_PREFILL_GPU                Prefill GPU index (default: 1)"
+            echo "  MAX_MODEL_LEN                   Maximum model length (default: 4096)"
+            echo "  MAX_CONCURRENT_SEQS             Maximum concurrent sequences (default: 2)"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+trap dynamo_exit_trap EXIT
+
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+VLLM_DECODE_HTTP_PORT="${VLLM_DECODE_HTTP_PORT:-8100}"
+VLLM_DECODE_GRPC_PORT="${VLLM_DECODE_GRPC_PORT:-50051}"
+VLLM_PREFILL_HTTP_PORT="${VLLM_PREFILL_HTTP_PORT:-8110}"
+VLLM_PREFILL_GRPC_PORT="${VLLM_PREFILL_GRPC_PORT:-50052}"
+VLLM_DECODE_GPU="${VLLM_DECODE_GPU:-0}"
+VLLM_PREFILL_GPU="${VLLM_PREFILL_GPU:-1}"
+VLLM_DECODE_NIXL_SIDE_CHANNEL_PORT="${VLLM_DECODE_NIXL_SIDE_CHANNEL_PORT:-5600}"
+VLLM_PREFILL_NIXL_SIDE_CHANNEL_PORT="${VLLM_PREFILL_NIXL_SIDE_CHANNEL_PORT:-20097}"
+VLLM_PREFILL_KV_EVENT_PORT="${VLLM_PREFILL_KV_EVENT_PORT:-20081}"
+
+# Default KV cache cap from profiling (2x safety over min=560 MiB); ~3.8 GiB
+# peak VRAM per engine. The profiler/test framework can override this value.
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=1119388000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching vLLM Native-gRPC Sidecar Disaggregated Serving (2 GPUs)" "$MODEL" "$HTTP_PORT" \
+    "Decode:      GPU ${VLLM_DECODE_GPU}, gRPC 127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
+    "Prefill:     GPU ${VLLM_PREFILL_GPU}, gRPC 127.0.0.1:${VLLM_PREFILL_GRPC_PORT}"
+
+python -m dynamo.frontend &
+
+# vllm-rs manages the headless Python engines and exposes native gRPC on
+# loopback. Arguments after -- are forwarded to each managed engine.
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+CUDA_VISIBLE_DEVICES="$VLLM_DECODE_GPU" \
+VLLM_NIXL_SIDE_CHANNEL_PORT="$VLLM_DECODE_NIXL_SIDE_CHANNEL_PORT" \
+vllm-rs serve "$MODEL" \
+    --host 127.0.0.1 \
+    --port "$VLLM_DECODE_HTTP_PORT" \
+    --grpc-port "$VLLM_DECODE_GRPC_PORT" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    -- \
+    --enforce-eager \
+    --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+CUDA_VISIBLE_DEVICES="$VLLM_PREFILL_GPU" \
+VLLM_NIXL_SIDE_CHANNEL_PORT="$VLLM_PREFILL_NIXL_SIDE_CHANNEL_PORT" \
+vllm-rs serve "$MODEL" \
+    --host 127.0.0.1 \
+    --port "$VLLM_PREFILL_HTTP_PORT" \
+    --grpc-port "$VLLM_PREFILL_GRPC_PORT" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    -- \
+    --enforce-eager \
+    --max-num-seqs "$MAX_CONCURRENT_SEQS" \
+    --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
+    --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_PREFILL_KV_EVENT_PORT}\",\"enable_kv_cache_events\":true}" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+OTEL_SERVICE_NAME=dynamo-worker-decode \
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT1:-8081}" \
+    dynamo-vllm-sidecar \
+    --vllm-endpoint "127.0.0.1:${VLLM_DECODE_GRPC_PORT}" \
+    --model-path "$MODEL" \
+    --disaggregation-mode decode &
+
+# Register prefill separately so the frontend routes each disaggregated stage.
+OTEL_SERVICE_NAME=dynamo-worker-prefill \
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT2:-8082}" \
+    dynamo-vllm-sidecar \
+    --vllm-endpoint "127.0.0.1:${VLLM_PREFILL_GRPC_PORT}" \
+    --model-path "$MODEL" \
+    --component prefill \
+    --disaggregation-mode prefill &
+
+wait_any_exit

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -217,15 +217,17 @@ fn build_kv_parameters(
             );
             Some(serde_json::Value::Object(params))
         }
-        DisaggregationMode::Decode => Some(
-            prefill_result
+        DisaggregationMode::Decode => {
+            let mut params = prefill_result
                 .ok_or_else(|| {
                     client::invalid_argument(
                         "decode request is missing the prefill_result KV payload",
                     )
                 })?
-                .disaggregated_params,
-        ),
+                .disaggregated_params;
+            normalize_remote_port(&mut params)?;
+            Some(params)
+        }
         DisaggregationMode::Encode => {
             return Err(client::invalid_argument(
                 "encode mode is not supported by the vLLM sidecar",
@@ -238,6 +240,41 @@ fn build_kv_parameters(
         cache_salt: cache_salt.unwrap_or_default(),
         kv_transfer_params: kv_transfer_params.map(json_to_struct).transpose()?,
     })
+}
+
+fn normalize_remote_port(params: &mut serde_json::Value) -> Result<(), DynamoError> {
+    let serde_json::Value::Object(params) = params else {
+        return Err(client::invalid_argument(
+            "prefill_result KV payload must be a JSON object",
+        ));
+    };
+    let Some(remote_port) = params.get_mut("remote_port") else {
+        return Ok(());
+    };
+    if remote_port.is_string() {
+        return Ok(());
+    }
+    let serde_json::Value::Number(number) = remote_port else {
+        return Err(client::invalid_argument(
+            "prefill_result remote_port must be an integer or string",
+        ));
+    };
+    let value = number
+        .as_u64()
+        .or_else(|| {
+            number.as_f64().and_then(|value| {
+                (value.is_finite() && value.fract() == 0.0 && value >= 0.0).then_some(value as u64)
+            })
+        })
+        .filter(|value| (1..=u16::MAX as u64).contains(value))
+        .ok_or_else(|| {
+            client::invalid_argument(format!(
+                "prefill_result remote_port must be between 1 and {}; got {number}",
+                u16::MAX
+            ))
+        })?;
+    *remote_port = serde_json::Value::String(value.to_string());
+    Ok(())
 }
 
 fn bool_extra(

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -525,7 +525,9 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
         let requests = server.service.requests.lock().await;
         let decode_wire = requests.last().unwrap().kv.as_ref().unwrap();
         let decoded = struct_to_json(decode_wire.kv_transfer_params.clone().unwrap()).unwrap();
-        assert_eq!(decoded, handoff);
+        let mut expected = handoff;
+        expected["remote_port"] = json!("20097");
+        assert_eq!(decoded, expected);
     }
 }
 


### PR DESCRIPTION
## Overview:

Adds one-command local aggregated and disaggregated launchers for Dynamo's vLLM native-gRPC sidecar. The launchers keep vLLM's unauthenticated gRPC listeners on loopback and expose requests through the Dynamo frontend.

Internal tracking: [DIS-2534](https://linear.app/nvidia/issue/DIS-2534/add-local-vllm-sidecar-launch-scripts)

## Details:

- Adds a one-GPU aggregated launcher for the Dynamo frontend, one `vllm-rs` server, and one `dynamo-vllm-sidecar`.
- Adds a two-GPU disaggregated launcher with separate decode and prefill `vllm-rs` servers and sidecars.
- Registers the prefill sidecar under its own component so the frontend routes the two disaggregated stages separately.
- Reuses the shared GPU-memory, launch-banner, first-child-exit, and process-group cleanup helpers.
- Supports model selection, managed-engine arguments, and environment overrides for ports, GPU selection, model length, and concurrency.
- Normalizes the prefill handoff's `remote_port` before the decode RPC. Protobuf `Struct` represents numeric values as doubles, while vLLM's NIXL connector requires a valid integer port string.
- Extends the existing prefill/decode handoff test to cover the normalized wire value.

### Validation

- `bash -n examples/backends/vllm/launch/sidecar_agg.sh examples/backends/vllm/launch/sidecar_disagg.sh`
- `shellcheck examples/backends/vllm/launch/sidecar_agg.sh examples/backends/vllm/launch/sidecar_disagg.sh`
- Both launcher `--help` paths
- `cargo fmt --all -- --check`
- `cargo test --locked -p dynamo-vllm-sidecar --lib` — 13 passed
- `git diff --check`
- Real-process GPU smoke on 2× NVIDIA H100 NVL with `docker.io/vllm/vllm-openai:nightly-49f31d7cee425a6d38f8c5bc76877986daf832ed` and the default `Qwen/Qwen3-0.6B` model:
  - Aggregated: worker registration, streamed `/v1/chat/completions`, coordinated shutdown, and no surviving frontend, `vllm-rs`, managed-engine, or sidecar processes.
  - Disaggregated: prefill/decode registration, NIXL KV handoff, streamed `/v1/chat/completions`, coordinated shutdown, and no surviving frontend, `vllm-rs`, managed-engine, or sidecar processes.
  - Both GPUs returned to 0 MiB process memory after each smoke.

## Where should the reviewer start?

- `examples/backends/vllm/launch/sidecar_agg.sh`
- `examples/backends/vllm/launch/sidecar_disagg.sh`
- `lib/sidecar/vllm/src/convert.rs`

## Related Issues

> ⚠️ **This section is required.**

**🔗 This PR is linked to an issue:**

- Internal tracking: [DIS-2534](https://linear.app/nvidia/issue/DIS-2534/add-local-vllm-sidecar-launch-scripts)