### PR TITLE
feat(sidecar): add vLLM sidecar deploy examples (agg + disagg)

### DIFF
--- a/lib/backend-common/src/disagg.rs
+++ b/lib/backend-common/src/disagg.rs
@@ -58,6 +58,16 @@ impl DisaggregationMode {
         }
     }
 
+    /// Discovery component a worker of this role registers under, so the
+    /// frontend can route the disaggregated prefill/decode handoff separately.
+    /// Prefill registers as `prefill`; decode and aggregated share `backend`.
+    pub fn discovery_component(&self) -> &'static str {
+        match self {
+            Self::Prefill => "prefill",
+            Self::Aggregated | Self::Decode | Self::Encode => "backend",
+        }
+    }
+
     /// `true` when this worker only runs the prefill phase.
     pub fn is_prefill(&self) -> bool {
         matches!(self, Self::Prefill)
@@ -173,6 +183,16 @@ mod tests {
         assert!(!DisaggregationMode::Aggregated.is_prefill());
         assert!(!DisaggregationMode::Aggregated.is_decode());
         assert!(!DisaggregationMode::Aggregated.is_encode());
+    }
+
+    #[test]
+    fn discovery_component_splits_prefill_from_the_rest() {
+        assert_eq!(DisaggregationMode::Prefill.discovery_component(), "prefill");
+        assert_eq!(DisaggregationMode::Decode.discovery_component(), "backend");
+        assert_eq!(
+            DisaggregationMode::Aggregated.discovery_component(),
+            "backend"
+        );
     }
 
     #[test]

--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -493,6 +493,17 @@ fn require_port(value: &Struct, key: &str) -> BoxedStatusResult<u16> {
         {
             Ok(*value as u16)
         }
+        // The vLLM sidecar sends remote_port as a string so vLLM renders a valid
+        // NIXL side-channel ZMQ URL (a protobuf Struct number would arrive as a
+        // double like `5600.0`); accept a string-encoded port too.
+        Some(Value {
+            kind: Some(Kind::StringValue(text)),
+        }) => text.parse::<u16>().map_err(|_| {
+            Status::invalid_argument(format!(
+                "decode KV transfer field '{key}' must be an integer port",
+            ))
+            .into()
+        }),
         _ => Err(Status::invalid_argument(format!(
             "decode KV transfer field '{key}' must be an integer port",
         ))

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -87,7 +87,7 @@ impl SglangSidecarEngine {
 
         let config = WorkerConfig {
             namespace: args.namespace,
-            component: component_for_mode(disaggregation_mode).to_string(),
+            component: disaggregation_mode.discovery_component().to_string(),
             endpoint: args.endpoint,
             endpoint_types: args.endpoint_types,
             custom_jinja_template: args.custom_jinja_template,
@@ -418,14 +418,6 @@ fn discovery_mode(discovery: &Discovery) -> Result<DisaggregationMode, DynamoErr
         mode => Err(client::protocol_error(format!(
             "unsupported SGLang disaggregation_mode `{mode}`"
         ))),
-    }
-}
-
-fn component_for_mode(mode: DisaggregationMode) -> &'static str {
-    if mode.is_prefill() {
-        "prefill"
-    } else {
-        "backend"
     }
 }
 

--- a/lib/sidecar/vllm/Dockerfile
+++ b/lib/sidecar/vllm/Dockerfile
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal image for the vLLM Rust sidecar (`dynamo-vllm-sidecar`).
+#
+# The sidecar is a pure gRPC connector + tokenizer; it needs no GPU and no vLLM
+# runtime, so it ships in a slim Debian image separate from the heavy vLLM engine
+# container. The two run side by side in one pod and talk over loopback (see
+# deploy/agg.yaml).
+#
+# Build from the repository root (the workspace is needed to compile the crate):
+#   docker build -f lib/sidecar/vllm/Dockerfile -t dynamo-vllm-sidecar:1.3.0 .
+
+# ---- builder ----------------------------------------------------------------
+# Pinned to the workspace toolchain (rust-toolchain.toml: 1.96.1).
+FROM rust:1.96.1-bookworm AS builder
+
+# aws-lc-sys/ring need cmake + a C toolchain (+perl); bindgen needs libclang;
+# tonic-build (build.rs) needs protoc. libprotobuf-dev supplies the well-known
+# protos (vllm_grpc.proto imports google/protobuf/struct.proto). gcc/make/git
+# come with the rust image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        libclang-dev \
+        protobuf-compiler \
+        libprotobuf-dev \
+        perl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Build only the sidecar binary; --locked pins the checked-in Cargo.lock. There
+# is no dependency-cache layer, so a source change recompiles deps — acceptable
+# for this occasional image build.
+RUN cargo build --release --locked -p dynamo-vllm-sidecar \
+    && strip target/release/dynamo-vllm-sidecar
+
+# ---- runtime (minimal) ------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+# ca-certificates: HTTPS to Hugging Face for the tokenizer, and rustls TLS to
+# etcd/NATS. TLS crypto (aws-lc-rs) is statically linked, so no libssl needed.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group sidecar
+
+COPY --from=builder /src/target/release/dynamo-vllm-sidecar /usr/local/bin/dynamo-vllm-sidecar
+
+# Numeric UID (not the name) so Kubernetes runAsNonRoot can verify it; the home
+# dir created above holds the Hugging Face tokenizer cache.
+USER 1000
+# Dynamo system endpoints (/live, /health) — the operator sets DYN_SYSTEM_PORT=9090.
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/dynamo-vllm-sidecar"]

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # vLLM sidecar
 
+> [!WARNING]
+> **Experimental.** This sidecar and its deployment examples are experimental
+> and not yet packaged for distribution. The manifests, flags, and behavior may
+> change without notice.
+
 `dynamo-vllm-sidecar` connects a Dynamo worker to vLLM's native gRPC
 `Generate` service. It is a standalone Rust executable.
 
@@ -24,7 +29,7 @@ parallel routing, encode workers, beam search, or `n > 1`.
 Start vLLM with its released gRPC listener:
 
 ```bash
-vllm-rs serve Qwen/Qwen3-0.6B --grpc-port 50051
+vllm-rs serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051
 ```
 
 This listener is unauthenticated and plaintext. Keep colocated deployments on
@@ -52,9 +57,6 @@ pool. Override them with `--grpc-connect-attempt-timeout-secs`,
 `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or with the
 corresponding `DYN_SIDECAR_GRPC_*` environment variables.
 
-Distribution and container packaging for the executable are intentionally
-deferred to a follow-up change.
-
 ## Test without vLLM or a GPU
 
 Use the CPU-only `dynamo-vllm-mocker-server` to exercise this sidecar against
@@ -74,3 +76,86 @@ cargo run -p dynamo-vllm-sidecar --bin dynamo-vllm-sidecar -- \
 See [`../../mocker/servers/vllm/README.md`](../../mocker/servers/vllm/README.md)
 for aggregated and prefill/decode examples, supported Mocker configuration,
 and fidelity limits.
+
+## Deploy on Kubernetes (quick start)
+
+`deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
+that colocates the sidecar with a vLLM engine). `deploy/disagg.yaml` runs
+disaggregated prefill/decode with NIXL KV transfer.
+
+There is no published vLLM sidecar image yet, so you build and push your own from
+`Dockerfile` — the same pattern as the TensorRT-LLM and SGLang sidecars.
+
+> [!NOTE]
+> vLLM's `vllm-rs` exposes no gRPC health method, so the engine's probes can only
+> confirm the gRPC port accepts connections (not that the model is loaded) —
+> weaker than the TensorRT-LLM and SGLang sidecars, which make a real HealthCheck
+> RPC. The engine image must be a stock vLLM build that ships `vllm-rs` (v0.26.0+).
+
+### Prerequisites
+
+- A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
+  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
+  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
+  `restartPolicy: Always`), which requires that version.
+- `kubectl` set to that cluster, and a namespace to deploy into.
+- A Hugging Face token for the model.
+- A container registry you can push to and the cluster can pull from.
+
+### 1. Build and push the sidecar image
+
+Build a multi-arch image so it runs on any node — `amd64` (x86) or `arm64`
+(GB200/Grace):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f lib/sidecar/vllm/Dockerfile \
+  -t <your-registry>/dynamo-vllm-sidecar:1.3.0 --push .
+```
+
+### 2. Point the manifest at your image
+
+In `deploy/agg.yaml` (and `deploy/disagg.yaml`), set the `main` worker image to
+the one you pushed. Add `imagePullSecrets` if your registry is private.
+
+### 3. Create the Hugging Face token secret
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" -n <namespace>
+```
+
+### 4. Deploy
+
+```bash
+kubectl apply -f lib/sidecar/vllm/deploy/agg.yaml -n <namespace>
+```
+
+Wait for the worker pod to reach `2/2 Running`:
+
+```bash
+kubectl get pods -n <namespace> -w
+```
+
+### 5. Send a request
+
+```bash
+kubectl port-forward -n <namespace> svc/vllm-sidecar-agg-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models | jq .
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+### Disaggregated
+
+`deploy/disagg.yaml` runs prefill and decode as separate worker pods with NIXL
+KV transfer. It needs multiple GPUs and an RDMA fabric, and both worker pods
+must reach `2/2 Running`. Apply it the same way and call the frontend as above.
+
+## Packaging
+
+There is no published image yet; the quick start above builds one from
+`Dockerfile`. Official packaging is deferred to a follow-up change.

--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated vLLM deployment using the Rust sidecar.
+#
+# The worker pod has two containers:
+#   - main: the Dynamo worker (dynamo-vllm-sidecar). No GPU. Handles registration
+#     and talks to the engine over gRPC on 127.0.0.1. The operator adds discovery
+#     env and health probes here, so it must be named "main".
+#   - vllm-engine: the stock vLLM image (ships `vllm-rs`, vLLM's native gRPC
+#     server). Holds the GPU. Runs as a native sidecar; see the initContainers
+#     block below.
+#
+# The engine's gRPC has no auth and no TLS. It is only safe because vllm-rs binds
+# 127.0.0.1 (--host below), keeping it on pod loopback.
+#
+# There is no published vLLM sidecar image yet: build your own from
+# lib/sidecar/vllm/Dockerfile and set <your-registry> below (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-sidecar-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend. No vLLM needed. The operator adds the command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+  - name: VLLMWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        # vllm-engine as a native sidecar (initContainer, restartPolicy: Always):
+        # it starts before `main` and stops after it. Stock multi-arch vLLM image
+        # (v0.26.0 ships vllm-rs; its gRPC matches the sidecar's vendored proto).
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.26.0
+          restartPolicy: Always
+          # vllm-rs exposes no gRPC health method (grpc.health.v1 and any Generate
+          # HealthCheck both return UNIMPLEMENTED), so unlike the TensorRT-LLM and
+          # SGLang sidecars these probes can only confirm the gRPC port accepts a
+          # connection, not that the model is loaded. exec (not tcpSocket) because
+          # the loopback-bound listener is unreachable from the pod IP. The
+          # readinessProbe still drops the worker if the engine dies at runtime
+          # (port closes -> pod NotReady -> frontend stops routing to it).
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60   # ~5 min for model load; raise for big models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase this value for larger models.
+              ephemeral-storage: 2Gi
+          # vllm-rs is not on PATH; resolve it from the installed vllm package.
+          # --host 127.0.0.1 keeps the unauthenticated gRPC on pod loopback.
+          command:
+          - /bin/sh
+          - -c
+          - >-
+            exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051
+        containers:
+        # The sidecar worker. No published image yet, so build your own from
+        # lib/sidecar/vllm/Dockerfile and set <your-registry> below (see README).
+        # Add imagePullSecrets if private.
+        # Must be named "main": the operator injects discovery env + probes by name.
+        - name: main
+          image: <your-registry>/dynamo-vllm-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --vllm-endpoint
+          - 127.0.0.1:50051
+          # vLLM's gRPC does not expose model metadata; the sidecar needs the
+          # model for tokenization, chat templates, and registration.
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/vllm/deploy/disagg.yaml
+++ b/lib/sidecar/vllm/deploy/disagg.yaml
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Disaggregated vLLM deployment using the Rust sidecar.
+#
+# Prefill and decode run as separate worker pods. Each pod has two containers:
+#   - main: the Dynamo worker (dynamo-vllm-sidecar). No GPU. Its
+#     --disaggregation-mode (prefill|decode) sets the gRPC kv_transfer_params
+#     handoff. Must be named "main" (operator injects discovery env + probes).
+#   - vllm-engine: the stock vLLM image running vllm-rs with the NIXL KV
+#     connector. Holds the GPU. KV cache moves prefill -> decode engine-to-engine
+#     over NIXL/RDMA (not through the sidecars). Native sidecar; see initContainers.
+#
+# The frontend routes to a prefill worker, gets kv_transfer_params, then routes
+# to a decode worker with that handoff. This sidecar does NOT publish KV events,
+# so use the default router (not --router-mode kv).
+#
+# kv_role is kv_producer on prefill and kv_consumer on decode (kv_both is
+# deprecated for NixlConnector).
+#
+# PREREQUISITES / CAVEATS:
+#   - Needs a sidecar built from lib/sidecar/vllm/Dockerfile that carries the
+#     disaggregation fixes (component-by-role + NIXL port encoding); older builds
+#     route both roles to one component and generate zero tokens.
+#   - RDMA/NIXL: the engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned
+#     memory (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
+#   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (set via downward API).
+#   - No published vLLM sidecar image yet — build from lib/sidecar/vllm/Dockerfile
+#     and set <your-registry>.
+#
+# The prefill->decode flow was validated on a single node (prefill+decode
+# co-located, NIXL over CUDA-IPC/TCP without rdma/ib); the rdma/ib requests below
+# target a real RDMA fabric.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: vllm-sidecar-disagg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+
+  - name: VLLMPrefillWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.26.0
+          restartPolicy: Always
+          # RDMA/NIXL needs pinned memory + privileged caps. runAsUser: 0 is only
+          # required for the rdma/ib path; drop it if your fabric doesn't need it.
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add: ["IPC_LOCK", "SYS_RESOURCE"]
+          # vllm-rs has no gRPC health method (see agg.yaml), so these probes only
+          # confirm the port accepts a connection. readiness drops a dead engine.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          env:
+          # NIXL side-channel must advertise a routable pod IP (no dynamo.vllm
+          # wrapper here to auto-detect it).
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          # UCX/RDMA tuning — adjust NET_DEVICES to your fabric.
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_NET_DEVICES
+            value: mlx5_0:1
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_RNDV_THRESH
+            value: "0"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          # vllm-rs is not on PATH; resolve it from the installed vllm package.
+          # --host 127.0.0.1 keeps the unauthenticated gRPC on pod loopback (the
+          # NIXL side-channel uses the pod IP via VLLM_NIXL_SIDE_CHANNEL_HOST).
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            VLLM_RS="$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            ulimit -l unlimited && exec "$VLLM_RS" serve Qwen/Qwen3-0.6B \
+              --host 127.0.0.1 --grpc-port 50051 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_producer"}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-vllm-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --vllm-endpoint
+          - 127.0.0.1:50051
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --disaggregation-mode
+          - prefill
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+
+  - name: VLLMDecodeWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: vllm-engine
+          image: vllm/vllm-openai:v0.26.0
+          restartPolicy: Always
+          securityContext:
+            runAsUser: 0
+            capabilities:
+              add: ["IPC_LOCK", "SYS_RESOURCE"]
+          # vllm-rs has no gRPC health method (see agg.yaml), so these probes only
+          # confirm the port accepts a connection. readiness drops a dead engine.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import socket; socket.create_connection(('127.0.0.1', 50051), 2).close()
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          env:
+          - name: VLLM_NIXL_SIDE_CHANNEL_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: UCX_TLS
+            value: rc_x,rc,cuda_copy,cuda_ipc
+          - name: UCX_NET_DEVICES
+            value: mlx5_0:1
+          - name: UCX_IB_ADDR_TYPE
+            value: eth
+          - name: UCX_RNDV_SCHEME
+            value: get_zcopy
+          - name: UCX_RNDV_THRESH
+            value: "0"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          # vllm-rs is not on PATH; resolve it from the installed vllm package.
+          # --host 127.0.0.1 keeps the unauthenticated gRPC on pod loopback (the
+          # NIXL side-channel uses the pod IP via VLLM_NIXL_SIDE_CHANNEL_HOST).
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            VLLM_RS="$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
+            ulimit -l unlimited && exec "$VLLM_RS" serve Qwen/Qwen3-0.6B \
+              --host 127.0.0.1 --grpc-port 50051 \
+              --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_consumer"}'
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-vllm-sidecar:1.3.0
+          command:
+          - dynamo-vllm-sidecar
+          args:
+          - --vllm-endpoint
+          - 127.0.0.1:50051
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --disaggregation-mode
+          - decode
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -217,15 +217,19 @@ fn build_kv_parameters(
             );
             Some(serde_json::Value::Object(params))
         }
-        DisaggregationMode::Decode => Some(
-            prefill_result
+        DisaggregationMode::Decode => {
+            let mut params = prefill_result
                 .ok_or_else(|| {
                     client::invalid_argument(
                         "decode request is missing the prefill_result KV payload",
                     )
                 })?
-                .disaggregated_params,
-        ),
+                .disaggregated_params;
+            // The prefill handoff carries the NIXL side-channel port; normalize it
+            // so vLLM builds a valid ZMQ URL (see stringify_remote_port).
+            stringify_remote_port(&mut params);
+            Some(params)
+        }
         DisaggregationMode::Encode => {
             return Err(client::invalid_argument(
                 "encode mode is not supported by the vLLM sidecar",
@@ -238,6 +242,34 @@ fn build_kv_parameters(
         cache_salt: cache_salt.unwrap_or_default(),
         kv_transfer_params: kv_transfer_params.map(json_to_struct).transpose()?,
     })
+}
+
+/// vLLM's NIXL connector builds the decode->prefill side-channel address by
+/// f-stringing `remote_port` (`f"tcp://{host}:{port}"`). The value reaches the
+/// engine through a `google.protobuf.Struct`, whose numbers are always `double`,
+/// so an integer port arrives as `5600.0` and the ZMQ URL fails to parse. Send it
+/// as a string instead — vLLM renders `5600` and only ever uses it to build that
+/// URL. Remove once vLLM coerces the port itself.
+fn stringify_remote_port(params: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = params else {
+        return;
+    };
+    // struct_to_json recovers a whole port as an integer; coerce a whole float
+    // defensively so a bare `5600.0` never slips through unmodified.
+    let port = map.get("remote_port").and_then(|value| {
+        value.as_u64().or_else(|| {
+            value
+                .as_f64()
+                .filter(|f| f.fract() == 0.0 && *f >= 0.0)
+                .map(|f| f as u64)
+        })
+    });
+    if let Some(port) = port {
+        map.insert(
+            "remote_port".to_string(),
+            serde_json::Value::String(port.to_string()),
+        );
+    }
 }
 
 fn bool_extra(

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -104,7 +104,13 @@ impl VllmSidecarEngine {
         };
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
-            component: args.sidecar.common.component,
+            // Prefill/decode must register under fixed role components so the
+            // frontend can route the disaggregated handoff; aggregated keeps the
+            // operator-configured component (`--component` / `DYN_COMPONENT`).
+            component: match mode {
+                DisaggregationMode::Aggregated => args.sidecar.common.component,
+                _ => mode.discovery_component().to_string(),
+            },
             endpoint: args.sidecar.common.endpoint,
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -525,8 +525,38 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
         let requests = server.service.requests.lock().await;
         let decode_wire = requests.last().unwrap().kv.as_ref().unwrap();
         let decoded = struct_to_json(decode_wire.kv_transfer_params.clone().unwrap()).unwrap();
-        assert_eq!(decoded, handoff);
+        // Every field round-trips opaquely except remote_port, which the sidecar
+        // stringifies so vLLM builds a valid NIXL side-channel URL (a protobuf
+        // Struct number would reach the engine as `20097.0`).
+        let mut expected = handoff.clone();
+        expected["remote_port"] = json!("20097");
+        assert_eq!(decoded, expected);
     }
+}
+
+#[test]
+fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
+    let component = |extra: &[&str]| {
+        let mut argv = vec![
+            "dynamo-vllm-sidecar",
+            "--vllm-endpoint",
+            "127.0.0.1:50051",
+            "--model-path",
+            "test-model",
+            "--component",
+            "custom",
+        ];
+        argv.extend_from_slice(extra);
+        VllmSidecarEngine::from_args(Some(argv.iter().map(|s| s.to_string()).collect()))
+            .expect("from_args")
+            .1
+            .component
+    };
+    // Aggregated keeps the operator-configured component.
+    assert_eq!(component(&[]), "custom");
+    // Disaggregated roles override to fixed names so the frontend can route.
+    assert_eq!(component(&["--disaggregation-mode", "prefill"]), "prefill");
+    assert_eq!(component(&["--disaggregation-mode", "decode"]), "backend");
 }
 
 #[tokio::test]


### PR DESCRIPTION
> [!WARNING]
> **Experimental** — deploy examples for the vLLM sidecar. Aggregated is
> both aggregated and disaggregated are cluster-validated (see Validation).

## Summary

Adds Kubernetes deploy examples plus a minimal image for the vLLM Rust sidecar,
matching the TensorRT-LLM and SGLang sidecars (build-your-own standalone container):

- `lib/sidecar/vllm/Dockerfile` — a minimal (~110 MB) image that builds just the
  `dynamo-vllm-sidecar` binary; no GPU, no vLLM runtime. Adds `libprotobuf-dev`
  for `vllm_grpc.proto`'s `google/protobuf/struct.proto` import.
- `lib/sidecar/vllm/deploy/agg.yaml` — aggregated: a frontend + one worker pod
  colocating the sidecar (`main`) with a **stock multi-arch vLLM v0.26.0** engine
  as a native-sidecar initContainer. `vllm-rs` is resolved from the installed vllm
  package (it is not on PATH) and bound to `127.0.0.1` for loopback-only gRPC.
- `lib/sidecar/vllm/deploy/disagg.yaml` — disaggregated prefill/decode with the
  NIXL KV connector (engine-to-engine over RDMA; pod IP advertised via
  `VLLM_NIXL_SIDE_CHANNEL_HOST`).
- `lib/sidecar/vllm/README.md` — "Deploy on Kubernetes" quick start.

`vllm-rs` exposes **no gRPC health method** (verified: `grpc.health.v1` and any
Generate `HealthCheck` both return `UNIMPLEMENTED`), so the engine's startup and
readiness probes can only confirm the gRPC port accepts a connection — weaker than
the TensorRT-LLM/SGLang HealthCheck probes. This is documented in the manifest and
README; readiness still drops the worker if the engine dies (port closes).

## Validation

- **Aggregated: cluster-validated** on an arm64 GPU cluster with the committed
  manifest (stock `vllm/vllm-openai:v0.26.0` engine + a locally built
  `dynamo-vllm-sidecar` image):
  - worker `2/2 Running`, `main` and engine both `restarts=0`;
  - engine gRPC bound to `127.0.0.1` only (verified via `/proc/net/tcp`);
  - model registered (`Serving Qwen/Qwen3-0.6B on ...worker.generate`, 1 instance);
  - end-to-end: `/v1/models` lists the model, `/v1/chat/completions` returns a real
    completion (14 prompt + 32 completion tokens).
- **Disaggregated: validated end-to-end** — prefill + decode `2/2`, registered
  `prefill.generate` / `backend.generate`, KV transferred prefill→decode over NIXL
  (`Transfer plan: TransferTopology(...)`), real completion returned. Run on a
  single node (prefill+decode co-located, NIXL over CUDA-IPC/TCP; the `rdma/ib`
  requests in the manifest target a real RDMA fabric). `kv_role` is now
  `kv_producer`/`kv_consumer`. **Requires the sidecar disaggregation fixes in
  ai-dynamo/dynamo#12247** (component-by-role + NIXL port encoding) — without them
  disagg routes both roles to one component and generates zero tokens. **Since confirmed on a GPU cluster** (real hardware, prefill→decode KV transfer).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kubernetes quick-start guidance for deploying the experimental vLLM sidecar.
  * Added an aggregated deployment option combining the Dynamo sidecar with a vLLM engine.
  * Added a disaggregated deployment option with separate prefill and decode workers.
  * Documented setup prerequisites, model access configuration, deployment steps, and example requests.

* **Documentation**
  * Clarified the experimental status and noted that manifests, flags, and behavior may change.
  * Added packaging guidance and deployment configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


