### PR TITLE
perf(mocker): avoid cloning offline worker groups

### DIFF
--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -365,43 +365,42 @@ where
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects<Observation::Batch>> {
-        let stage = self.stage;
-        let pass_mode = self.pass_mode;
-        let worker_groups = &self.worker_groups;
-        let workers = &mut self.workers;
-        for rank_ids in worker_groups.values() {
+        // Iterating `self.worker_groups` in place relies on disjoint field borrows:
+        // the loop body only mutates `self.workers`, never the group map itself.
+        for rank_ids in self.worker_groups.values() {
             // A logical attention-DP worker advances in group-owned epochs.
             // A rank that received work mid-epoch must wait until every sibling
             // has crossed the prior completion boundary.
             if rank_ids
                 .iter()
-                .any(|rank_id| workers.get(rank_id).unwrap().is_busy())
+                .any(|rank_id| self.workers.get(rank_id).unwrap().is_busy())
             {
                 continue;
             }
             if !rank_ids
                 .iter()
-                .any(|rank_id| workers.get(rank_id).unwrap().is_ready())
+                .any(|rank_id| self.workers.get(rank_id).unwrap().is_ready())
             {
                 continue;
             }
 
             let mut executed_by_rank = BTreeMap::new();
             for &rank_id in rank_ids {
-                if !workers.get(&rank_id).unwrap().is_ready() {
+                if !self.workers.get(&rank_id).unwrap().is_ready() {
                     continue;
                 }
-                let executed = match pass_mode {
+                let executed = match self.pass_mode {
                     EnginePassMode::Visible => {
                         let Some(collector) = collector.as_deref_mut() else {
                             bail!("offline replay visible engine pass requires a collector");
                         };
-                        workers
+                        self.workers
                             .get_mut(&rank_id)
                             .unwrap()
                             .execute_pass(collector, now_ms)
                     }
-                    EnginePassMode::Hidden => workers
+                    EnginePassMode::Hidden => self
+                        .workers
                         .get_mut(&rank_id)
                         .unwrap()
                         .execute_hidden_pass(now_ms),
@@ -421,13 +420,13 @@ where
                     if group_end_ms > now_ms {
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
-                        workers.get_mut(&rank_id).unwrap().mark_busy();
+                        self.workers.get_mut(&rank_id).unwrap().mark_busy();
                         effects
                             .scheduled_completions
                             .push(ScheduledWorkerCompletion {
                                 at_ms: group_end_ms,
                                 payload: WorkerCompletionPayload {
-                                    stage,
+                                    stage: self.stage,
                                     worker_idx: rank_id,
                                     completed_requests: 0,
                                     output_signals: Vec::new(),
@@ -449,7 +448,7 @@ where
                 if let Some(fpm) = executed.fpm.as_mut() {
                     fpm.wall_time_secs = group_wall_time_secs;
                 }
-                if pass_mode == EnginePassMode::Visible {
+                if self.pass_mode == EnginePassMode::Visible {
                     collector
                         .as_deref_mut()
                         .expect("visible pass collector checked before execution")
@@ -478,7 +477,7 @@ where
                         observed_events
                     };
                 let payload = WorkerCompletionPayload {
-                    stage,
+                    stage: self.stage,
                     worker_idx: rank_id,
                     completed_requests: executed.completed_requests,
                     output_signals: executed.output_signals,
@@ -494,7 +493,7 @@ where
                 };
 
                 if group_end_ms > now_ms {
-                    workers.get_mut(&rank_id).unwrap().mark_busy();
+                    self.workers.get_mut(&rank_id).unwrap().mark_busy();
                     effects
                         .scheduled_completions
                         .push(ScheduledWorkerCompletion {

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -365,41 +365,43 @@ where
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects<Observation::Batch>> {
-        let worker_groups: Vec<Vec<usize>> = self.worker_groups.values().cloned().collect();
-        for rank_ids in worker_groups {
+        let stage = self.stage;
+        let pass_mode = self.pass_mode;
+        let worker_groups = &self.worker_groups;
+        let workers = &mut self.workers;
+        for rank_ids in worker_groups.values() {
             // A logical attention-DP worker advances in group-owned epochs.
             // A rank that received work mid-epoch must wait until every sibling
             // has crossed the prior completion boundary.
             if rank_ids
                 .iter()
-                .any(|rank_id| self.workers.get(rank_id).unwrap().is_busy())
+                .any(|rank_id| workers.get(rank_id).unwrap().is_busy())
             {
                 continue;
             }
             if !rank_ids
                 .iter()
-                .any(|rank_id| self.workers.get(rank_id).unwrap().is_ready())
+                .any(|rank_id| workers.get(rank_id).unwrap().is_ready())
             {
                 continue;
             }
 
             let mut executed_by_rank = BTreeMap::new();
-            for &rank_id in &rank_ids {
-                if !self.workers.get(&rank_id).unwrap().is_ready() {
+            for &rank_id in rank_ids {
+                if !workers.get(&rank_id).unwrap().is_ready() {
                     continue;
                 }
-                let executed = match self.pass_mode {
+                let executed = match pass_mode {
                     EnginePassMode::Visible => {
                         let Some(collector) = collector.as_deref_mut() else {
                             bail!("offline replay visible engine pass requires a collector");
                         };
-                        self.workers
+                        workers
                             .get_mut(&rank_id)
                             .unwrap()
                             .execute_pass(collector, now_ms)
                     }
-                    EnginePassMode::Hidden => self
-                        .workers
+                    EnginePassMode::Hidden => workers
                         .get_mut(&rank_id)
                         .unwrap()
                         .execute_hidden_pass(now_ms),
@@ -414,18 +416,18 @@ where
             let group_wall_time_secs = (group_end_ms - now_ms).max(0.0) / 1000.0;
             let mut effects = EngineEffects::default();
 
-            for &rank_id in &rank_ids {
+            for &rank_id in rank_ids {
                 let Some(mut executed) = executed_by_rank.remove(&rank_id) else {
                     if group_end_ms > now_ms {
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
-                        self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                        workers.get_mut(&rank_id).unwrap().mark_busy();
                         effects
                             .scheduled_completions
                             .push(ScheduledWorkerCompletion {
                                 at_ms: group_end_ms,
                                 payload: WorkerCompletionPayload {
-                                    stage: self.stage,
+                                    stage,
                                     worker_idx: rank_id,
                                     completed_requests: 0,
                                     output_signals: Vec::new(),
@@ -447,7 +449,7 @@ where
                 if let Some(fpm) = executed.fpm.as_mut() {
                     fpm.wall_time_secs = group_wall_time_secs;
                 }
-                if self.pass_mode == EnginePassMode::Visible {
+                if pass_mode == EnginePassMode::Visible {
                     collector
                         .as_deref_mut()
                         .expect("visible pass collector checked before execution")
@@ -476,7 +478,7 @@ where
                         observed_events
                     };
                 let payload = WorkerCompletionPayload {
-                    stage: self.stage,
+                    stage,
                     worker_idx: rank_id,
                     completed_requests: executed.completed_requests,
                     output_signals: executed.output_signals,
@@ -492,7 +494,7 @@ where
                 };
 
                 if group_end_ms > now_ms {
-                    self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                    workers.get_mut(&rank_id).unwrap().mark_busy();
                     effects
                         .scheduled_completions
                         .push(ScheduledWorkerCompletion {


### PR DESCRIPTION
## Summary

- Iterate `EngineComponent::worker_groups` in place during `drive_ready` instead of cloning every worker-group vector on every call.
- Use disjoint borrows of `worker_groups` and `workers` so worker execution and barrier behavior remain unchanged.
- **This is a worker-count scaling optimization:** the removed clone copied every worker-group vector on every coordinator sweep, so the avoided allocations and copied rank IDs grow with the number of workers. Larger offline-replay topologies therefore benefit more as worker count increases.
- In a matched native-G1 AgentX replay with 16 sessions, 16 workers, and 128,000 blocks per worker, replay time fell from 10.9267 s to 9.3006 s: **14.88% less time / 17.48% higher host throughput**. Peak RSS fell from 244.07 MiB to 238.22 MiB (**2.40%**).

Both arms completed all 3,211 requests with identical input, output, and processed-token counts. Simulated duration differed by 1.146 ppm, which was accepted for this A/B. The benchmark used one run per arm.

## Validation

- `cargo test -p dynamo-mocker replay::offline::components::engine::tests` (14 passed)
- `cargo fmt --all -- --check`
- Matched candidate/baseline native-G1 AgentX replay, pinned to CPU 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal processing efficiency when coordinating worker execution.
  * Preserved existing scheduling, readiness, barrier handling, and completion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->