### PR TITLE
perf(mocker): drive only ready offline worker groups

### DIFF
--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -49,10 +49,6 @@ where
     ready_groups: BTreeSet<usize>,
     /// Ready groups that made no observable progress during the prior drive.
     deferred_ready_groups: BTreeSet<usize>,
-    /// Counter for generating the next stable scheduler ID.
-    next_id: usize,
-    /// Counter for generating the next stable mocker worker ID.
-    next_worker_id: usize,
     /// Mocker workers marked for removal — skipped by round-robin, removed when drained.
     pending_removal: BTreeSet<usize>,
     /// Mocker workers still starting up — excluded from active set until ready.
@@ -91,8 +87,6 @@ where
             live_group_count: count,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
-            next_id: count,
-            next_worker_id: count,
             pending_removal: BTreeSet::new(),
             pending_startup: BTreeSet::new(),
             args: MockEngineArgs::default(),
@@ -139,8 +133,6 @@ where
             live_group_count: num_workers,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
-            next_id: num_workers.saturating_mul(dp_size),
-            next_worker_id: num_workers,
             pending_removal: BTreeSet::new(),
             pending_startup: BTreeSet::new(),
             args,
@@ -243,12 +235,10 @@ where
     /// Add a new mocker worker and all of its DP-rank schedulers, returning
     /// the stable mocker worker ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
-        let worker_id = self.next_worker_id;
-        self.next_worker_id += 1;
+        let worker_id = self.worker_groups.len();
         let mut rank_ids = Vec::with_capacity(self.args.dp_size.max(1) as usize);
         for dp_rank in 0..self.args.dp_size.max(1) {
-            let rank_id = self.next_id;
-            self.next_id += 1;
+            let rank_id = self.workers.len();
             let worker = OfflineWorkerState::new_with_rank(
                 rank_id,
                 worker_id as u64,
@@ -746,7 +736,7 @@ where
 
     #[cfg(test)]
     pub(in crate::replay::offline) fn rank_id_capacity(&self) -> usize {
-        self.next_id
+        self.workers.len()
     }
 
     #[cfg(feature = "kvbm-offload")]
@@ -1133,6 +1123,15 @@ mod tests {
         assert!(newly_marked.is_empty());
         assert_eq!(engine.active_worker_ids().len(), 2);
         assert_eq!(engine.worker_count(), 2);
+
+        // Tombstoned stable IDs are never reused. The next worker and rank
+        // come from the append-only vector tails.
+        let (added, newly_marked, removed) = engine.apply_target_count(3);
+        assert_eq!(added, vec![4]);
+        assert!(newly_marked.is_empty());
+        assert!(removed.is_empty());
+        assert_eq!(engine.worker_groups[4].as_deref(), Some(&[4][..]));
+        assert_eq!(engine.rank_id_capacity(), 5);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
 use anyhow::bail;
+use smallvec::SmallVec;
 
 use super::super::core::{EngineEventBatch, EngineProgress, NoEngineEvents, WorkerTopology};
 use super::super::events::SimulationWorkerStage;
@@ -20,8 +21,7 @@ use super::{
 };
 use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
-use crate::scheduler::RouterEventVisibility;
-use crate::scheduler::SchedulerCommand;
+use crate::scheduler::{EnginePassResult, RouterEventVisibility, SchedulerCommand};
 
 fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
     snapshot.num_prefill_requests > 0 || snapshot.num_decode_requests > 0
@@ -34,9 +34,13 @@ where
     stage: SimulationWorkerStage,
     pass_mode: EnginePassMode,
     /// DP-rank schedulers keyed by stable ID (monotonic, never reused).
-    workers: BTreeMap<usize, OfflineWorkerState>,
+    workers: Vec<Option<OfflineWorkerState>>,
     /// Mocker worker IDs mapped to their per-rank scheduler IDs.
-    worker_groups: BTreeMap<usize, Vec<usize>>,
+    worker_groups: Vec<Option<Vec<usize>>>,
+    /// Logical workers that can start a pass, ordered by stable worker ID.
+    ready_groups: BTreeSet<usize>,
+    /// Ready groups that made no observable progress during the prior drive.
+    deferred_ready_groups: BTreeSet<usize>,
     /// Counter for generating the next stable scheduler ID.
     next_id: usize,
     /// Counter for generating the next stable mocker worker ID.
@@ -62,13 +66,15 @@ where
         workers: Vec<OfflineWorkerState>,
     ) -> Self {
         let count = workers.len();
-        let map: BTreeMap<usize, OfflineWorkerState> = workers.into_iter().enumerate().collect();
-        let worker_groups = (0..count).map(|id| (id, vec![id])).collect();
-        Self {
+        let workers = workers.into_iter().map(Some).collect();
+        let worker_groups = (0..count).map(|id| Some(vec![id])).collect();
+        let mut component = Self {
             stage,
             pass_mode,
-            workers: map,
+            workers,
             worker_groups,
+            ready_groups: BTreeSet::new(),
+            deferred_ready_groups: BTreeSet::new(),
             next_id: count,
             next_worker_id: count,
             pending_removal: BTreeSet::new(),
@@ -76,7 +82,9 @@ where
             args: MockEngineArgs::default(),
             capture_raw: Observation::CAPTURE_RAW,
             observation: PhantomData,
-        }
+        };
+        component.refresh_all_groups();
+        component
     }
 
     /// Build one scheduler core per DP rank while retaining the live mocker's
@@ -88,31 +96,32 @@ where
         num_workers: usize,
     ) -> Self {
         let dp_size = args.dp_size.max(1) as usize;
-        let mut workers = BTreeMap::new();
-        let mut worker_groups = BTreeMap::new();
+        let mut workers = Vec::with_capacity(num_workers.saturating_mul(dp_size));
+        let mut worker_groups = Vec::with_capacity(num_workers);
         for worker_id in 0..num_workers {
             let mut rank_ids = Vec::with_capacity(dp_size);
             for dp_rank in 0..dp_size {
                 let rank_id = worker_id * dp_size + dp_rank;
-                workers.insert(
+                debug_assert_eq!(rank_id, workers.len());
+                workers.push(Some(OfflineWorkerState::new_with_rank(
                     rank_id,
-                    OfflineWorkerState::new_with_rank(
-                        rank_id,
-                        worker_id as u64,
-                        dp_rank as u32,
-                        args.clone(),
-                        Observation::CAPTURE_RAW,
-                    ),
-                );
+                    worker_id as u64,
+                    dp_rank as u32,
+                    args.clone(),
+                    Observation::CAPTURE_RAW,
+                )));
                 rank_ids.push(rank_id);
             }
-            worker_groups.insert(worker_id, rank_ids);
+            debug_assert_eq!(worker_id, worker_groups.len());
+            worker_groups.push(Some(rank_ids));
         }
         Self {
             stage,
             pass_mode,
             workers,
             worker_groups,
+            ready_groups: BTreeSet::new(),
+            deferred_ready_groups: BTreeSet::new(),
             next_id: num_workers.saturating_mul(dp_size),
             next_worker_id: num_workers,
             pending_removal: BTreeSet::new(),
@@ -133,6 +142,52 @@ where
         self.capture_raw = capture_raw;
     }
 
+    fn worker(&self, rank_id: usize) -> Option<&OfflineWorkerState> {
+        self.workers.get(rank_id)?.as_ref()
+    }
+
+    fn worker_mut(&mut self, rank_id: usize) -> Option<&mut OfflineWorkerState> {
+        self.workers.get_mut(rank_id)?.as_mut()
+    }
+
+    fn group_is_ready(&self, worker_id: usize) -> bool {
+        let Some(rank_ids) = self.worker_groups.get(worker_id).and_then(Option::as_ref) else {
+            return false;
+        };
+        !rank_ids.iter().any(|&rank_id| {
+            self.worker(rank_id)
+                .is_some_and(OfflineWorkerState::is_busy)
+        }) && rank_ids.iter().any(|&rank_id| {
+            self.worker(rank_id)
+                .is_some_and(OfflineWorkerState::is_ready)
+        })
+    }
+
+    fn refresh_group(&mut self, worker_id: usize) {
+        self.deferred_ready_groups.remove(&worker_id);
+        if self.group_is_ready(worker_id) {
+            self.ready_groups.insert(worker_id);
+        } else {
+            self.ready_groups.remove(&worker_id);
+        }
+    }
+
+    fn refresh_rank(&mut self, rank_id: usize) {
+        let Some(worker_id) = self
+            .worker(rank_id)
+            .and_then(|worker| usize::try_from(worker.rank_identity().0).ok())
+        else {
+            return;
+        };
+        self.refresh_group(worker_id);
+    }
+
+    fn refresh_all_groups(&mut self) {
+        for worker_id in 0..self.worker_groups.len() {
+            self.refresh_group(worker_id);
+        }
+    }
+
     /// Add a new mocker worker and all of its DP-rank schedulers, returning
     /// the stable mocker worker ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
@@ -149,10 +204,12 @@ where
                 self.args.clone(),
                 self.capture_raw,
             );
-            self.workers.insert(rank_id, worker);
+            debug_assert_eq!(rank_id, self.workers.len());
+            self.workers.push(Some(worker));
             rank_ids.push(rank_id);
         }
-        self.worker_groups.insert(worker_id, rank_ids);
+        debug_assert_eq!(worker_id, self.worker_groups.len());
+        self.worker_groups.push(Some(rank_ids));
         worker_id
     }
 
@@ -167,11 +224,14 @@ where
     /// Remove all marked workers that have fully drained, returning their IDs.
     pub(in crate::replay::offline) fn try_remove_drained(&mut self) -> Vec<usize> {
         let mut removed = Vec::new();
+        let worker_groups = &self.worker_groups;
+        let workers = &self.workers;
         self.pending_removal.retain(|&id| {
-            if let Some(rank_ids) = self.worker_groups.get(&id) {
+            if let Some(rank_ids) = worker_groups.get(id).and_then(Option::as_ref) {
                 if rank_ids.iter().all(|rank_id| {
-                    self.workers
-                        .get(rank_id)
+                    workers
+                        .get(*rank_id)
+                        .and_then(Option::as_ref)
                         .is_none_or(OfflineWorkerState::is_drained)
                 }) {
                     removed.push(id);
@@ -184,9 +244,13 @@ where
             true // keep in pending set
         });
         for &id in &removed {
-            if let Some(rank_ids) = self.worker_groups.remove(&id) {
+            self.ready_groups.remove(&id);
+            self.deferred_ready_groups.remove(&id);
+            if let Some(rank_ids) = self.worker_groups.get_mut(id).and_then(Option::take) {
                 for rank_id in rank_ids {
-                    self.workers.remove(&rank_id);
+                    if let Some(worker) = self.workers.get_mut(rank_id) {
+                        worker.take();
+                    }
                 }
             }
         }
@@ -234,9 +298,13 @@ where
                 .collect();
             for &id in &to_cancel {
                 self.pending_startup.remove(&id);
-                if let Some(rank_ids) = self.worker_groups.remove(&id) {
+                self.ready_groups.remove(&id);
+                self.deferred_ready_groups.remove(&id);
+                if let Some(rank_ids) = self.worker_groups.get_mut(id).and_then(Option::take) {
                     for rank_id in rank_ids {
-                        self.workers.remove(&rank_id);
+                        if let Some(worker) = self.workers.get_mut(rank_id) {
+                            worker.take();
+                        }
                     }
                 }
             }
@@ -257,9 +325,14 @@ where
     /// Return stable mocker worker IDs that are active for new admissions.
     pub(in crate::replay::offline) fn active_group_ids(&self) -> Vec<usize> {
         self.worker_groups
-            .keys()
-            .filter(|id| !self.pending_removal.contains(id) && !self.pending_startup.contains(id))
-            .copied()
+            .iter()
+            .enumerate()
+            .filter(|(id, group)| {
+                group.is_some()
+                    && !self.pending_removal.contains(id)
+                    && !self.pending_startup.contains(id)
+            })
+            .map(|(id, _)| id)
             .collect()
     }
 
@@ -267,7 +340,13 @@ where
     pub(in crate::replay::offline) fn active_worker_ids(&self) -> Vec<usize> {
         self.active_group_ids()
             .into_iter()
-            .flat_map(|worker_id| self.worker_groups[&worker_id].iter().copied())
+            .flat_map(|worker_id| {
+                self.worker_groups[worker_id]
+                    .as_deref()
+                    .into_iter()
+                    .flatten()
+                    .copied()
+            })
             .collect()
     }
 
@@ -277,7 +356,7 @@ where
     ) -> Option<WorkerTopology> {
         Some(WorkerTopology {
             worker_id,
-            scheduler_ids: self.worker_groups.get(&worker_id)?.clone(),
+            scheduler_ids: self.worker_groups.get(worker_id)?.as_ref()?.clone(),
         })
     }
 
@@ -295,7 +374,7 @@ where
     /// Return the logical mocker worker and DP rank represented by a stable
     /// scheduler ID.
     pub(in crate::replay::offline) fn rank_identity(&self, rank_id: usize) -> Option<(usize, u32)> {
-        let (worker_id, dp_rank) = self.workers.get(&rank_id)?.rank_identity();
+        let (worker_id, dp_rank) = self.worker(rank_id)?.rank_identity();
         Some((usize::try_from(worker_id).ok()?, dp_rank))
     }
 
@@ -315,7 +394,15 @@ where
     /// was actually pending startup (and is now active), `false` if the worker
     /// was already cancelled or unknown (stale event).
     pub(in crate::replay::offline) fn mark_worker_ready(&mut self, worker_id: usize) -> bool {
-        self.pending_startup.remove(&worker_id) && self.worker_groups.contains_key(&worker_id)
+        let ready = self.pending_startup.remove(&worker_id)
+            && self
+                .worker_groups
+                .get(worker_id)
+                .is_some_and(Option::is_some);
+        if ready {
+            self.refresh_group(worker_id);
+        }
+        ready
     }
 
     pub(in crate::replay::offline) fn dispatch(
@@ -323,11 +410,10 @@ where
         worker_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        let worker = self
-            .workers
-            .get_mut(&worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
-        worker.receive_request(request);
+        self.worker_mut(worker_id)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?
+            .receive_request(request);
+        self.refresh_rank(worker_id);
         Ok(())
     }
 
@@ -336,17 +422,18 @@ where
         worker_id: usize,
         command: SchedulerCommand,
     ) -> anyhow::Result<ObservedCommandEffects<Observation::Batch>> {
-        let worker = self
-            .workers
-            .get_mut(&worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
-        let mut effects = worker.apply_command(command)?;
+        let mut effects = self
+            .worker_mut(worker_id)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?
+            .apply_command(command)?;
         let engine_events = Observation::take_command_events(&mut effects);
-        Ok(ObservedCommandEffects {
+        let observed = ObservedCommandEffects {
             result: effects.result,
             lifecycle_events: effects.lifecycle_events,
             engine_events,
-        })
+        };
+        self.refresh_rank(worker_id);
+        Ok(observed)
     }
 
     pub(in crate::replay::offline) fn worker_is_busy(
@@ -354,8 +441,7 @@ where
         worker_id: usize,
     ) -> anyhow::Result<bool> {
         let worker = self
-            .workers
-            .get(&worker_id)
+            .worker(worker_id)
             .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
         Ok(worker.is_busy())
     }
@@ -365,28 +451,40 @@ where
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects<Observation::Batch>> {
-        // Iterating `self.worker_groups` in place relies on disjoint field borrows:
-        // the loop body only mutates `self.workers`, never the group map itself.
-        for rank_ids in self.worker_groups.values() {
+        // The serial coordinator may make another component observable at the
+        // same virtual timestamp. Match the former full scan by retrying
+        // effect-free groups on the next coordinator drive, but not again
+        // within this call.
+        let deferred = std::mem::take(&mut self.deferred_ready_groups);
+        for worker_id in deferred {
+            self.refresh_group(worker_id);
+        }
+
+        while let Some(worker_id) = self.ready_groups.pop_first() {
+            let Some(rank_ids) = self.worker_groups.get(worker_id).and_then(Option::as_ref) else {
+                continue;
+            };
             // A logical attention-DP worker advances in group-owned epochs.
             // A rank that received work mid-epoch must wait until every sibling
             // has crossed the prior completion boundary.
             if rank_ids
                 .iter()
-                .any(|rank_id| self.workers.get(rank_id).unwrap().is_busy())
+                .any(|&rank_id| self.workers[rank_id].as_ref().unwrap().is_busy())
             {
                 continue;
             }
             if !rank_ids
                 .iter()
-                .any(|rank_id| self.workers.get(rank_id).unwrap().is_ready())
+                .any(|&rank_id| self.workers[rank_id].as_ref().unwrap().is_ready())
             {
                 continue;
             }
 
-            let mut executed_by_rank = BTreeMap::new();
+            let mut executed_by_rank: SmallVec<[Option<EnginePassResult>; 1]> =
+                SmallVec::with_capacity(rank_ids.len());
             for &rank_id in rank_ids {
-                if !self.workers.get(&rank_id).unwrap().is_ready() {
+                if !self.workers[rank_id].as_ref().unwrap().is_ready() {
+                    executed_by_rank.push(None);
                     continue;
                 }
                 let executed = match self.pass_mode {
@@ -394,33 +492,33 @@ where
                         let Some(collector) = collector.as_deref_mut() else {
                             bail!("offline replay visible engine pass requires a collector");
                         };
-                        self.workers
-                            .get_mut(&rank_id)
+                        self.workers[rank_id]
+                            .as_mut()
                             .unwrap()
                             .execute_pass(collector, now_ms)
                     }
-                    EnginePassMode::Hidden => self
-                        .workers
-                        .get_mut(&rank_id)
+                    EnginePassMode::Hidden => self.workers[rank_id]
+                        .as_mut()
                         .unwrap()
                         .execute_hidden_pass(now_ms),
                 };
-                executed_by_rank.insert(rank_id, executed);
+                executed_by_rank.push(Some(executed));
             }
 
             let group_end_ms = executed_by_rank
-                .values()
+                .iter()
+                .filter_map(Option::as_ref)
                 .map(|executed| executed.end_ms)
                 .fold(now_ms, f64::max);
             let group_wall_time_secs = (group_end_ms - now_ms).max(0.0) / 1000.0;
             let mut effects = EngineEffects::default();
 
-            for &rank_id in rank_ids {
-                let Some(mut executed) = executed_by_rank.remove(&rank_id) else {
+            for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
+                let Some(mut executed) = executed else {
                     if group_end_ms > now_ms {
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
-                        self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                        self.workers[rank_id].as_mut().unwrap().mark_busy();
                         effects
                             .scheduled_completions
                             .push(ScheduledWorkerCompletion {
@@ -493,7 +591,7 @@ where
                 };
 
                 if group_end_ms > now_ms {
-                    self.workers.get_mut(&rank_id).unwrap().mark_busy();
+                    self.workers[rank_id].as_mut().unwrap().mark_busy();
                     effects
                         .scheduled_completions
                         .push(ScheduledWorkerCompletion {
@@ -522,6 +620,9 @@ where
             if !effects.is_empty() {
                 return Ok(effects);
             }
+            if self.group_is_ready(worker_id) {
+                self.deferred_ready_groups.insert(worker_id);
+            }
         }
 
         Ok(EngineEffects::default())
@@ -538,11 +639,9 @@ where
                 payload.stage
             );
         }
-        let worker = self.workers.get_mut(&payload.worker_idx).ok_or_else(|| {
-            anyhow::anyhow!(
-                "offline replay completion for unknown worker {}",
-                payload.worker_idx
-            )
+        let rank_id = payload.worker_idx;
+        let worker = self.worker_mut(rank_id).ok_or_else(|| {
+            anyhow::anyhow!("offline replay completion for unknown worker {}", rank_id)
         })?;
         worker.mark_idle();
         worker.mark_completed(payload.completed_requests);
@@ -554,22 +653,27 @@ where
         payload.progress.had_raw_observations |= observed.had_raw_observations;
         payload.progress.made_progress |= observed.had_raw_observations;
         payload.engine_events.append(observed.events);
+        self.refresh_rank(rank_id);
         Ok(payload)
     }
 
     pub(in crate::replay::offline) fn in_flight(&self) -> usize {
         self.workers
-            .values()
+            .iter()
+            .filter_map(Option::as_ref)
             .map(OfflineWorkerState::in_flight)
             .sum()
     }
 
     pub(in crate::replay::offline) fn is_drained(&self) -> bool {
-        self.workers.values().all(OfflineWorkerState::is_drained)
+        self.workers
+            .iter()
+            .filter_map(Option::as_ref)
+            .all(OfflineWorkerState::is_drained)
     }
 
     pub(in crate::replay::offline) fn worker_count(&self) -> usize {
-        self.worker_groups.len()
+        self.worker_groups.iter().flatten().count()
     }
 
     #[cfg(test)]
@@ -580,7 +684,8 @@ where
     #[cfg(feature = "kvbm-offload")]
     pub(in crate::replay::offline) fn earliest_offload_deadline(&self) -> Option<f64> {
         self.workers
-            .values()
+            .iter()
+            .filter_map(Option::as_ref)
             .filter_map(OfflineWorkerState::earliest_offload_deadline)
             .reduce(f64::min)
     }
@@ -595,7 +700,7 @@ where
             lifecycle_events: Vec::new(),
             progress: EngineProgress::default(),
         };
-        for worker in self.workers.values_mut() {
+        for worker in self.workers.iter_mut().filter_map(Option::as_mut) {
             let mut worker_effects = if worker.is_busy() {
                 worker.tick_offload_transport_only(now_ms)
             } else {
@@ -610,13 +715,15 @@ where
                 .lifecycle_events
                 .extend(worker_effects.lifecycle_events);
         }
+        self.refresh_all_groups();
         effects
     }
 
     #[cfg(test)]
     pub(crate) fn debug_snapshots(&self) -> Vec<OfflineWorkerSnapshot> {
         self.workers
-            .values()
+            .iter()
+            .filter_map(Option::as_ref)
             .map(OfflineWorkerState::debug_snapshot)
             .collect()
     }
@@ -828,6 +935,32 @@ mod tests {
     }
 
     #[test]
+    fn ready_groups_preserve_lowest_worker_id_order() {
+        let args = MockEngineArgs::default();
+        let workers = (0..2)
+            .map(|rank_id| OfflineWorkerState::new(rank_id, args.clone(), false))
+            .collect();
+        let mut engine = EngineComponent::<NoEngineEvents>::new(
+            SimulationWorkerStage::Aggregated,
+            EnginePassMode::Visible,
+            workers,
+        );
+        engine
+            .dispatch(0, timed_request(Uuid::from_u128(51), 4))
+            .unwrap();
+        engine
+            .dispatch(1, timed_request(Uuid::from_u128(52), 4))
+            .unwrap();
+
+        let effects = engine
+            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .unwrap();
+        let completion = take_only_completion(effects);
+
+        assert_eq!(completion.worker_idx, 0);
+    }
+
+    #[test]
     fn kv_visibility_follows_backend_contract_and_fpm_waits_for_completion() {
         let make_engine = |engine_type| {
             let args = MockEngineArgs::builder()
@@ -1011,6 +1144,8 @@ mod tests {
 
         let first = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(first.is_empty());
+        assert!(engine.ready_groups.is_empty());
+        assert_eq!(engine.deferred_ready_groups, BTreeSet::from([0]));
         assert_eq!(
             engine.debug_snapshots(),
             vec![OfflineWorkerSnapshot {
@@ -1023,6 +1158,7 @@ mod tests {
 
         let retry = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(retry.is_empty());
+        assert_eq!(engine.deferred_ready_groups, BTreeSet::from([0]));
     }
 
     #[test]
@@ -1186,7 +1322,7 @@ mod tests {
         });
         // Model a reservation attempt at the t=0 boundary, before the GPU
         // compute interval becomes externally busy.
-        engine.workers.get_mut(&0).unwrap().mark_idle();
+        engine.worker_mut(0).unwrap().mark_idle();
 
         let handoff_id = HandoffId::from(Uuid::from_u128(102));
         let reserve = engine
@@ -1209,7 +1345,7 @@ mod tests {
             .expect("reservation eviction should start G1 to G2 DMA");
         assert!((deadline - 20.0).abs() < 0.01);
 
-        engine.workers.get_mut(&0).unwrap().mark_busy();
+        engine.worker_mut(0).unwrap().mark_busy();
         assert_eq!(engine.earliest_offload_deadline(), Some(deadline));
         let transport = engine.tick_offload_engines(deadline);
         assert!(transport.lifecycle_events.is_empty());

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -33,10 +33,18 @@ where
 {
     stage: SimulationWorkerStage,
     pass_mode: EnginePassMode,
-    /// DP-rank schedulers keyed by stable ID (monotonic, never reused).
+    /// DP-rank schedulers indexed by stable ID (monotonic, never reused).
+    ///
+    /// Removed ranks leave unreclaimed tombstones so storage and scans scale
+    /// with the total number of ranks ever created, not only the live rank
+    /// count. This preserves stable IDs across autoscaling churn.
     workers: Vec<Option<OfflineWorkerState>>,
     /// Mocker worker IDs mapped to their per-rank scheduler IDs.
+    ///
+    /// Removed groups also leave tombstones to preserve stable IDs.
     worker_groups: Vec<Option<Vec<usize>>>,
+    /// Number of non-tombstoned worker groups.
+    live_group_count: usize,
     /// Logical workers that can start a pass, ordered by stable worker ID.
     ready_groups: BTreeSet<usize>,
     /// Ready groups that made no observable progress during the prior drive.
@@ -66,6 +74,13 @@ where
         workers: Vec<OfflineWorkerState>,
     ) -> Self {
         let count = workers.len();
+        debug_assert!(
+            workers
+                .iter()
+                .enumerate()
+                .all(|(worker_id, worker)| worker.rank_identity().0 == worker_id as u64),
+            "EngineComponent::new assumes worker_id equals its stable index"
+        );
         let workers = workers.into_iter().map(Some).collect();
         let worker_groups = (0..count).map(|id| Some(vec![id])).collect();
         let mut component = Self {
@@ -73,6 +88,7 @@ where
             pass_mode,
             workers,
             worker_groups,
+            live_group_count: count,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
             next_id: count,
@@ -115,11 +131,12 @@ where
             debug_assert_eq!(worker_id, worker_groups.len());
             worker_groups.push(Some(rank_ids));
         }
-        Self {
+        let mut component = Self {
             stage,
             pass_mode,
             workers,
             worker_groups,
+            live_group_count: num_workers,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
             next_id: num_workers.saturating_mul(dp_size),
@@ -129,7 +146,9 @@ where
             args,
             capture_raw: Observation::CAPTURE_RAW,
             observation: PhantomData,
-        }
+        };
+        component.refresh_all_groups();
+        component
     }
 
     /// Set the engine args used when adding workers dynamically.
@@ -150,17 +169,39 @@ where
         self.workers.get_mut(rank_id)?.as_mut()
     }
 
+    fn required_worker(
+        workers: &[Option<OfflineWorkerState>],
+        rank_id: usize,
+    ) -> &OfflineWorkerState {
+        workers
+            .get(rank_id)
+            .and_then(Option::as_ref)
+            .expect("live worker group referenced a missing rank")
+    }
+
+    fn required_worker_mut(
+        workers: &mut [Option<OfflineWorkerState>],
+        rank_id: usize,
+    ) -> &mut OfflineWorkerState {
+        workers
+            .get_mut(rank_id)
+            .and_then(Option::as_mut)
+            .expect("live worker group referenced a missing rank")
+    }
+
     fn group_is_ready(&self, worker_id: usize) -> bool {
         let Some(rank_ids) = self.worker_groups.get(worker_id).and_then(Option::as_ref) else {
             return false;
         };
-        !rank_ids.iter().any(|&rank_id| {
-            self.worker(rank_id)
-                .is_some_and(OfflineWorkerState::is_busy)
-        }) && rank_ids.iter().any(|&rank_id| {
-            self.worker(rank_id)
-                .is_some_and(OfflineWorkerState::is_ready)
-        })
+        // A ready rank is itself idle. The separate busy check enforces the
+        // sibling barrier for the rest of the logical worker's DP ranks.
+        let any_busy = rank_ids
+            .iter()
+            .any(|&rank_id| Self::required_worker(&self.workers, rank_id).is_busy());
+        let any_ready = rank_ids
+            .iter()
+            .any(|&rank_id| Self::required_worker(&self.workers, rank_id).is_ready());
+        !any_busy && any_ready
     }
 
     fn refresh_group(&mut self, worker_id: usize) {
@@ -188,6 +229,17 @@ where
         }
     }
 
+    #[cfg(debug_assertions)]
+    fn debug_assert_ready_frontier(&self) {
+        let expected = (0..self.worker_groups.len())
+            .filter(|&worker_id| self.group_is_ready(worker_id))
+            .collect::<BTreeSet<_>>();
+        debug_assert_eq!(
+            self.ready_groups, expected,
+            "readiness frontier drifted from a full scan"
+        );
+    }
+
     /// Add a new mocker worker and all of its DP-rank schedulers, returning
     /// the stable mocker worker ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
@@ -210,7 +262,32 @@ where
         }
         debug_assert_eq!(worker_id, self.worker_groups.len());
         self.worker_groups.push(Some(rank_ids));
+        self.live_group_count += 1;
         worker_id
+    }
+
+    fn tombstone_group(&mut self, worker_id: usize) -> bool {
+        self.ready_groups.remove(&worker_id);
+        self.deferred_ready_groups.remove(&worker_id);
+        let Some(rank_ids) = self.worker_groups.get_mut(worker_id).and_then(Option::take) else {
+            return false;
+        };
+        for rank_id in rank_ids {
+            self.workers
+                .get_mut(rank_id)
+                .and_then(Option::take)
+                .expect("live worker group referenced a missing rank");
+        }
+        self.live_group_count = self
+            .live_group_count
+            .checked_sub(1)
+            .expect("live worker group count underflow");
+        debug_assert_eq!(
+            self.live_group_count,
+            self.worker_groups.iter().flatten().count(),
+            "live worker group count drifted from storage"
+        );
+        true
     }
 
     /// Mark a worker for removal. Round-robin routing skips marked workers;
@@ -244,15 +321,8 @@ where
             true // keep in pending set
         });
         for &id in &removed {
-            self.ready_groups.remove(&id);
-            self.deferred_ready_groups.remove(&id);
-            if let Some(rank_ids) = self.worker_groups.get_mut(id).and_then(Option::take) {
-                for rank_id in rank_ids {
-                    if let Some(worker) = self.workers.get_mut(rank_id) {
-                        worker.take();
-                    }
-                }
-            }
+            let tombstoned = self.tombstone_group(id);
+            debug_assert!(tombstoned);
         }
         removed
     }
@@ -298,15 +368,8 @@ where
                 .collect();
             for &id in &to_cancel {
                 self.pending_startup.remove(&id);
-                self.ready_groups.remove(&id);
-                self.deferred_ready_groups.remove(&id);
-                if let Some(rank_ids) = self.worker_groups.get_mut(id).and_then(Option::take) {
-                    for rank_id in rank_ids {
-                        if let Some(worker) = self.workers.get_mut(rank_id) {
-                            worker.take();
-                        }
-                    }
-                }
+                let tombstoned = self.tombstone_group(id);
+                debug_assert!(tombstoned);
             }
 
             // Mark active workers for removal if more excess remains.
@@ -407,24 +470,24 @@ where
 
     pub(in crate::replay::offline) fn dispatch(
         &mut self,
-        worker_id: usize,
+        rank_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        self.worker_mut(worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?
+        self.worker_mut(rank_id)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?
             .receive_request(request);
-        self.refresh_rank(worker_id);
+        self.refresh_rank(rank_id);
         Ok(())
     }
 
     pub(in crate::replay::offline) fn apply_command(
         &mut self,
-        worker_id: usize,
+        rank_id: usize,
         command: SchedulerCommand,
     ) -> anyhow::Result<ObservedCommandEffects<Observation::Batch>> {
         let mut effects = self
-            .worker_mut(worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?
+            .worker_mut(rank_id)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?
             .apply_command(command)?;
         let engine_events = Observation::take_command_events(&mut effects);
         let observed = ObservedCommandEffects {
@@ -432,17 +495,17 @@ where
             lifecycle_events: effects.lifecycle_events,
             engine_events,
         };
-        self.refresh_rank(worker_id);
+        self.refresh_rank(rank_id);
         Ok(observed)
     }
 
     pub(in crate::replay::offline) fn worker_is_busy(
         &self,
-        worker_id: usize,
+        rank_id: usize,
     ) -> anyhow::Result<bool> {
         let worker = self
-            .worker(worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
+            .worker(rank_id)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
         Ok(worker.is_busy())
     }
 
@@ -459,23 +522,27 @@ where
         for worker_id in deferred {
             self.refresh_group(worker_id);
         }
+        #[cfg(debug_assertions)]
+        self.debug_assert_ready_frontier();
 
         while let Some(worker_id) = self.ready_groups.pop_first() {
-            let Some(rank_ids) = self.worker_groups.get(worker_id).and_then(Option::as_ref) else {
-                continue;
-            };
+            let rank_ids = self
+                .worker_groups
+                .get(worker_id)
+                .and_then(Option::as_ref)
+                .expect("readiness frontier referenced a missing worker group");
             // A logical attention-DP worker advances in group-owned epochs.
             // A rank that received work mid-epoch must wait until every sibling
             // has crossed the prior completion boundary.
             if rank_ids
                 .iter()
-                .any(|&rank_id| self.workers[rank_id].as_ref().unwrap().is_busy())
+                .any(|&rank_id| Self::required_worker(&self.workers, rank_id).is_busy())
             {
                 continue;
             }
             if !rank_ids
                 .iter()
-                .any(|&rank_id| self.workers[rank_id].as_ref().unwrap().is_ready())
+                .any(|&rank_id| Self::required_worker(&self.workers, rank_id).is_ready())
             {
                 continue;
             }
@@ -483,7 +550,7 @@ where
             let mut executed_by_rank: SmallVec<[Option<EnginePassResult>; 1]> =
                 SmallVec::with_capacity(rank_ids.len());
             for &rank_id in rank_ids {
-                if !self.workers[rank_id].as_ref().unwrap().is_ready() {
+                if !Self::required_worker(&self.workers, rank_id).is_ready() {
                     executed_by_rank.push(None);
                     continue;
                 }
@@ -492,14 +559,10 @@ where
                         let Some(collector) = collector.as_deref_mut() else {
                             bail!("offline replay visible engine pass requires a collector");
                         };
-                        self.workers[rank_id]
-                            .as_mut()
-                            .unwrap()
+                        Self::required_worker_mut(&mut self.workers, rank_id)
                             .execute_pass(collector, now_ms)
                     }
-                    EnginePassMode::Hidden => self.workers[rank_id]
-                        .as_mut()
-                        .unwrap()
+                    EnginePassMode::Hidden => Self::required_worker_mut(&mut self.workers, rank_id)
                         .execute_hidden_pass(now_ms),
                 };
                 executed_by_rank.push(Some(executed));
@@ -518,7 +581,7 @@ where
                     if group_end_ms > now_ms {
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
-                        self.workers[rank_id].as_mut().unwrap().mark_busy();
+                        Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
                         effects
                             .scheduled_completions
                             .push(ScheduledWorkerCompletion {
@@ -591,7 +654,7 @@ where
                 };
 
                 if group_end_ms > now_ms {
-                    self.workers[rank_id].as_mut().unwrap().mark_busy();
+                    Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
                     effects
                         .scheduled_completions
                         .push(ScheduledWorkerCompletion {
@@ -618,6 +681,11 @@ where
             }
 
             if !effects.is_empty() {
+                if group_end_ms <= now_ms {
+                    // A zero-duration pass can remain ready. Re-arm it here
+                    // without depending on caller completion processing.
+                    self.refresh_group(worker_id);
+                }
                 return Ok(effects);
             }
             if self.group_is_ready(worker_id) {
@@ -673,7 +741,7 @@ where
     }
 
     pub(in crate::replay::offline) fn worker_count(&self) -> usize {
-        self.worker_groups.iter().flatten().count()
+        self.live_group_count
     }
 
     #[cfg(test)]
@@ -952,12 +1020,18 @@ mod tests {
             .dispatch(1, timed_request(Uuid::from_u128(52), 4))
             .unwrap();
 
-        let effects = engine
+        let first = engine
             .drive_ready(0.0, Some(&mut TraceCollector::default()))
             .unwrap();
-        let completion = take_only_completion(effects);
+        let first = take_only_completion(first);
+        assert_eq!(first.worker_idx, 0);
+        assert_eq!(engine.ready_groups, BTreeSet::from([1]));
 
-        assert_eq!(completion.worker_idx, 0);
+        let second = engine
+            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .unwrap();
+        let second = take_only_completion(second);
+        assert_eq!(second.worker_idx, 1);
     }
 
     #[test]
@@ -1043,10 +1117,16 @@ mod tests {
         assert_eq!(engine.worker_count(), 4);
 
         // Scale down to 3 — should cancel 1 startup worker, not mark any active.
+        engine.ready_groups.insert(3);
+        engine.deferred_ready_groups.insert(3);
         let (_added, newly_marked, _) = engine.apply_target_count(3);
         assert!(newly_marked.is_empty());
         assert_eq!(engine.active_worker_ids().len(), 2);
         assert_eq!(engine.worker_count(), 3); // 2 active + 1 still starting
+        assert!(!engine.ready_groups.contains(&3));
+        assert!(!engine.deferred_ready_groups.contains(&3));
+        assert!(engine.worker_groups[3].is_none());
+        assert!(engine.workers[3].is_none());
 
         // Scale down to 2 — should cancel the remaining startup worker.
         let (_added, newly_marked, _) = engine.apply_target_count(2);
@@ -1075,8 +1155,14 @@ mod tests {
         let new_id = added[0];
 
         assert_eq!(engine.active_worker_ids().len(), 1);
+        engine
+            .worker_mut(new_id)
+            .unwrap()
+            .receive_request(timed_request(Uuid::from_u128(60), 4));
+        assert!(!engine.ready_groups.contains(&new_id));
         assert!(engine.mark_worker_ready(new_id));
         assert_eq!(engine.active_worker_ids().len(), 2);
+        assert!(engine.ready_groups.contains(&new_id));
     }
 
     #[test]
@@ -1111,6 +1197,7 @@ mod tests {
         assert_eq!(second.completed_requests, 0);
         assert!(second.output_signals.is_empty());
         assert!(second.lifecycle_events.is_empty());
+        assert_eq!(engine.ready_groups, BTreeSet::from([0]));
         engine.on_scheduled_completion(second).unwrap();
 
         let final_pass = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
@@ -1264,8 +1351,14 @@ mod tests {
             .apply_command(0, SchedulerCommand::CancelDestination { handoff_id })
             .unwrap();
         assert_eq!(effects.result, SchedulerCommandResult::Applied);
+        engine.ready_groups.insert(0);
+        engine.deferred_ready_groups.insert(0);
         assert_eq!(engine.try_remove_drained(), vec![0]);
         assert_eq!(engine.worker_count(), 0);
+        assert!(!engine.ready_groups.contains(&0));
+        assert!(!engine.deferred_ready_groups.contains(&0));
+        assert!(engine.worker_groups[0].is_none());
+        assert!(engine.workers[0].is_none());
     }
 
     #[cfg(feature = "kvbm-offload")]

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -61,6 +61,7 @@ pub(crate) enum DisaggTransition {
     DestinationAccepted { uuid: Uuid },
     DestinationReserved { uuid: Uuid },
     TransferQueued { uuid: Uuid },
+    DecodeDriveQuiesced,
     DestinationActivated { uuid: Uuid },
     SourceReleased { uuid: Uuid },
     HandoffCompleted { uuid: Uuid },
@@ -1942,6 +1943,10 @@ where
                 .decode_engine
                 .drive_ready(self.now_ms, Some(&mut self.collector))?;
             if effects.is_empty() {
+                #[cfg(test)]
+                self.stats
+                    .transition_log
+                    .push(DisaggTransition::DecodeDriveQuiesced);
                 return Ok(changed);
             }
             changed = true;

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -707,6 +707,61 @@ fn test_source_release_waits_for_destination_activation() {
     }
 }
 
+#[test]
+fn same_timestamp_destination_activation_precedes_next_decode_drive() {
+    let config = disagg_config();
+    let uuid = Uuid::from_u128(1);
+    let pending =
+        crate::replay::normalize_trace_requests(vec![request(1, 128, 2, 0.0)], 1.0).unwrap();
+    let (collector, stats) = DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        pending,
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap()
+    .with_per_request_records(true)
+    .run()
+    .unwrap();
+
+    let transitions = &stats.transition_log;
+    let reserved = transition_index(transitions, DisaggTransition::DestinationReserved { uuid });
+    let activated = transition_index(transitions, DisaggTransition::DestinationActivated { uuid });
+    let admitted = transition_index(transitions, DisaggTransition::DecodeAdmitted { uuid });
+    let next_quiesced = transitions
+        .iter()
+        .enumerate()
+        .skip(activated + 1)
+        .find_map(|(index, transition)| {
+            (*transition == DisaggTransition::DecodeDriveQuiesced).then_some(index)
+        })
+        .expect("decode coordinator must quiesce after processing activated work");
+    let completed = transition_index(transitions, DisaggTransition::RequestMarkedDone { uuid });
+    assert!(
+        !transitions[reserved + 1..activated].contains(&DisaggTransition::DecodeDriveQuiesced),
+        "same-timestamp activation must be drained before the next decode drive: {transitions:?}"
+    );
+    assert!(reserved < activated);
+    assert!(activated < admitted);
+    assert!(admitted < next_quiesced);
+    assert!(admitted < completed);
+
+    let report = collector.finish();
+    assert_eq!(report.request_counts.completed_requests, 1);
+    assert_eq!(report.per_request.len(), 1);
+    assert_eq!(
+        report.per_request[0].destination_reserved_ms,
+        report.per_request[0].destination_activated_ms,
+        "destination activation must wake the decode coordinator at the same timestamp"
+    );
+    assert_eq!(
+        report.per_request[0].terminal_status,
+        ReplayTerminalStatus::Completed
+    );
+}
+
 #[rstest::rstest]
 #[case(EngineType::Vllm)]
 #[case(EngineType::Sglang)]


### PR DESCRIPTION
## Summary

- replace ordered maps for monotonic offline worker and rank IDs with direct-indexed, tombstoned vectors
- maintain an ordered readiness frontier so `drive_ready` visits only logical workers that can execute, while preserving lowest-worker-ID ordering and coordinator-turn retries for effect-free passes
- replace the temporary per-DP-pass `BTreeMap` with an inline `SmallVec`
- make zero-duration re-arming self-contained, assert the frontier against a debug-only full scan, and centralize group tombstoning with an O(1) live-group count
- pin rank/group storage invariants and cover ordering, startup activation, and both removal paths directly
- keep KVBM refresh behavior and the DP>1 `SmallVec<[...; 1]>` behavior unchanged pending dedicated profiles

Builds on #12240, which is now merged. This branch has been rebased onto its merge commit and contains only the readiness-frontier change.

## Where should the reviewer start?

Start in `lib/mocker/src/replay/offline/components/engine.rs` at `group_is_ready`, `refresh_group`, and `drive_ready` for the readiness-frontier invariant and zero-duration re-arming. Then review `tombstone_group` and `live_group_count` for lifecycle bookkeeping, followed by the focused tests at the bottom of the same file.

## Performance

AgentX + native G1 + KV routing, 128,000 blocks per worker, release build with DWARF and normal compiler inlining, pinned to CPU 0.

| Workload | #12240 control | Candidate | Change |
| --- | ---: | ---: | ---: |
| 16 workers / 16 sessions replay time | 8.9098 s | 8.1361 s | 1.095x speedup |
| 16 workers / 16 sessions requests/s | 360.4 | 394.6 | +9.51% |
| 16 workers / 16 sessions tokens/s | 54.26M | 59.41M | +9.51% |
| 16 workers / 16 sessions max RSS | 242,528 KiB | 247,356 KiB | +1.99% |

The completed A/B used one run per arm, candidate first. Both arms completed the same 3,211 requests, 479,843,008 input tokens, 3,552,472 output tokens, and total simulated duration.

A matched 60-second `perf record -e cpu_core/cycles/u -F 99 --call-graph dwarf,16384` comparison at 128 workers / 128 AgentX sessions shows the targeted cost collapsing. The candidate profile below was repeated after the review fixes:

| `EngineComponent::drive_ready` | Existing #12240 profile | Reviewed candidate profile | Change |
| --- | ---: | ---: | ---: |
| Self CPU | 49.65% | 1.06% | -48.59 pp |
| Sampled cycles | 160.86B | 3.46B | -97.85% / 46.5x less |

The two captures observed effectively identical total cycles over 60 seconds (323.98B vs 324.91B), and both lost zero samples. The large workload was stopped after each capture; the profile comparison is targeted CPU attribution, not a completed 128-worker throughput claim.

## Validation

- `cargo test -p dynamo-mocker replay::offline::components::engine::tests` (15 passed)
- `cargo test -p dynamo-mocker same_timestamp_destination_activation_precedes_next_decode_drive` (1 passed)
- `cargo test -p dynamo-mocker replay::offline` (174 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` (177 passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact KV replay parity at `08a1bb313b` versus #12240: PASS for vLLM aggregated/disaggregated KVBM and SGLang aggregated/disaggregated; not rerun for the mechanical `f8df6564ba` cleanup
- completed 16-worker / 16-session AgentX native-G1 A/B
- repeated 60-second 128-worker / 128-session candidate perf capture after the review fixes: 5,941 samples, zero lost samples, `drive_ready` at 1.06% self CPU

## Related Issues

- [x] No related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved offline replay worker scheduling and readiness handling.
  * Enhanced consistency when workers are drained, removed, or scaled down.
  * Preserved deterministic scheduling order for ready worker groups.
  * Updated readiness and offload behavior for more reliable replay execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->