### PR TITLE
perf(mocker): use intrusive inactive block LRU

### DIFF
--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -7,8 +7,6 @@
 //! the pool models occupancy, reference/pin state, and LRU eviction without
 //! reproducing vLLM's numeric block IDs or null block.
 
-use std::collections::BTreeMap;
-
 use dynamo_tokens::SequenceHash;
 use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
@@ -21,11 +19,15 @@ new_key_type! {
 #[derive(Debug)]
 enum CopyState {
     Private,
+    /// A cached copy is linked into the inactive LRU if and only if both
+    /// `refs` and `pins` are zero. Any future cached sub-state must preserve or
+    /// explicitly revise that membership invariant.
     Cached {
         hash: SequenceHash,
         refs: usize,
         pins: usize,
-        inactive_at: Option<u64>,
+        inactive_prev: Option<BlockCopyId>,
+        inactive_next: Option<BlockCopyId>,
     },
 }
 
@@ -66,9 +68,10 @@ pub(crate) struct VllmBlockPool {
     capacity: usize,
     copies: SlotMap<BlockCopyId, BlockCopy>,
     by_hash: FxHashMap<SequenceHash, SmallVec<[BlockCopyId; 1]>>,
-    /// Ordinary LRU: lower timestamp is evicted first.
-    inactive: BTreeMap<u64, BlockCopyId>,
-    next_lru: u64,
+    /// Intrusive ordinary LRU: head is evicted first, tail was released last.
+    inactive_head: Option<BlockCopyId>,
+    inactive_tail: Option<BlockCopyId>,
+    inactive_len: usize,
     reserved: usize,
 }
 
@@ -79,8 +82,9 @@ impl VllmBlockPool {
             capacity,
             copies: SlotMap::with_key(),
             by_hash: FxHashMap::default(),
-            inactive: BTreeMap::new(),
-            next_lru: 0,
+            inactive_head: None,
+            inactive_tail: None,
+            inactive_len: 0,
             reserved: 0,
         }
     }
@@ -128,7 +132,7 @@ impl VllmBlockPool {
                 .filter_map(|(_, id)| self.is_inactive(*id).then_some(*id))
                 .collect::<FxHashSet<_>>()
                 .len();
-            let evictable_after_pins = self.inactive.len().saturating_sub(inactive_hits);
+            let evictable_after_pins = self.inactive_len.saturating_sub(inactive_hits);
             if needed_evictions > evictable_after_pins {
                 return None;
             }
@@ -158,7 +162,7 @@ impl VllmBlockPool {
     fn reserve_fresh(&mut self, fresh: usize) -> Option<ReserveOutcome> {
         let free = self.free_capacity();
         let needed_evictions = fresh.saturating_sub(free);
-        if needed_evictions > self.inactive.len() {
+        if needed_evictions > self.inactive_len {
             return None;
         }
 
@@ -231,7 +235,8 @@ impl VllmBlockPool {
             hash,
             refs: 1,
             pins: 0,
-            inactive_at: None,
+            inactive_prev: None,
+            inactive_next: None,
         };
         self.by_hash.entry(hash).or_default().push(id);
         became_visible
@@ -278,7 +283,7 @@ impl VllmBlockPool {
     }
 
     pub(crate) fn num_active(&self) -> usize {
-        self.copies.len() - self.inactive.len() + self.reserved
+        self.copies.len() - self.inactive_len + self.reserved
     }
 
     pub(crate) fn num_active_refs(&self) -> usize {
@@ -292,7 +297,7 @@ impl VllmBlockPool {
     }
 
     pub(crate) fn num_inactive(&self) -> usize {
-        self.inactive.len()
+        self.inactive_len
     }
 
     pub(crate) fn capacity(&self) -> usize {
@@ -313,31 +318,24 @@ impl VllmBlockPool {
     }
 
     fn is_inactive(&self, id: BlockCopyId) -> bool {
-        matches!(
-            &self.copies[id].state,
-            CopyState::Cached {
-                inactive_at: Some(_),
-                ..
-            }
-        )
+        let CopyState::Cached { refs, pins, .. } = &self.copies[id].state else {
+            return false;
+        };
+        *refs == 0 && *pins == 0
     }
 
     fn pin(&mut self, id: BlockCopyId) {
-        let inactive_at = {
-            let CopyState::Cached {
-                pins, inactive_at, ..
-            } = &mut self.copies[id].state
-            else {
-                panic!("prefix hash points to a private copy")
-            };
-            *pins = pins
-                .checked_add(1)
-                .unwrap_or_else(|| panic!("pin count overflow"));
-            inactive_at.take()
-        };
-        if let Some(timestamp) = inactive_at {
-            assert_eq!(self.inactive.remove(&timestamp), Some(id));
+        // Must unlink before bumping pins: list membership is derived from
+        // refs and pins.
+        if self.is_inactive(id) {
+            self.unlink_inactive(id);
         }
+        let CopyState::Cached { pins, .. } = &mut self.copies[id].state else {
+            panic!("prefix hash points to a private copy")
+        };
+        *pins = pins
+            .checked_add(1)
+            .unwrap_or_else(|| panic!("pin count overflow"));
     }
 
     fn activate_pin(&mut self, id: BlockCopyId, expected_hash: SequenceHash) {
@@ -374,38 +372,209 @@ impl VllmBlockPool {
     }
 
     fn insert_inactive(&mut self, id: BlockCopyId) {
-        let timestamp = self.next_lru;
-        self.next_lru = self
-            .next_lru
+        debug_assert!(
+            self.is_inactive(id),
+            "only an unreferenced, unpinned cached copy can enter the inactive LRU"
+        );
+        // A singleton has no links, so head membership is its only
+        // double-insertion signal.
+        debug_assert_ne!(
+            self.inactive_head,
+            Some(id),
+            "copy is already in the inactive LRU"
+        );
+        let previous_tail = self.inactive_tail;
+        {
+            let (prev, next) = self.inactive_links_mut(id);
+            debug_assert!(
+                prev.is_none() && next.is_none(),
+                "copy entering the inactive LRU still has list links"
+            );
+            *prev = previous_tail;
+        }
+        if let Some(tail) = previous_tail {
+            let (_, next) = self.inactive_links_mut(tail);
+            let old_next = next.replace(id);
+            debug_assert!(
+                old_next.is_none(),
+                "inactive LRU tail already has a successor"
+            );
+        } else {
+            let old_head = self.inactive_head.replace(id);
+            debug_assert!(old_head.is_none(), "empty inactive LRU still has a head");
+        }
+        self.inactive_tail = Some(id);
+        self.inactive_len = self
+            .inactive_len
             .checked_add(1)
-            .unwrap_or_else(|| panic!("LRU timestamp overflow"));
-        let CopyState::Cached { inactive_at, .. } = &mut self.copies[id].state else {
-            panic!("private copy cannot enter inactive LRU")
+            .unwrap_or_else(|| panic!("inactive block count overflow"));
+    }
+
+    fn inactive_links_mut(
+        &mut self,
+        id: BlockCopyId,
+    ) -> (&mut Option<BlockCopyId>, &mut Option<BlockCopyId>) {
+        let CopyState::Cached {
+            inactive_prev,
+            inactive_next,
+            ..
+        } = &mut self.copies[id].state
+        else {
+            panic!("inactive LRU link target is not a cached copy")
         };
-        assert!(inactive_at.replace(timestamp).is_none());
-        assert!(self.inactive.insert(timestamp, id).is_none());
+        (inactive_prev, inactive_next)
+    }
+
+    fn unlink_inactive(&mut self, id: BlockCopyId) {
+        debug_assert!(
+            self.is_inactive(id),
+            "only an unreferenced, unpinned cached copy can leave the inactive LRU"
+        );
+        let (previous, next) = {
+            let (previous, next) = self.inactive_links_mut(id);
+            (previous.take(), next.take())
+        };
+
+        if let Some(previous) = previous {
+            let (_, previous_next) = self.inactive_links_mut(previous);
+            let old_next = std::mem::replace(previous_next, next);
+            debug_assert_eq!(
+                old_next,
+                Some(id),
+                "inactive LRU predecessor does not point to the removed copy"
+            );
+        } else {
+            let old_head = std::mem::replace(&mut self.inactive_head, next);
+            debug_assert_eq!(
+                old_head,
+                Some(id),
+                "inactive LRU head does not match the removed copy"
+            );
+        }
+
+        if let Some(next) = next {
+            let (next_previous, _) = self.inactive_links_mut(next);
+            let old_previous = std::mem::replace(next_previous, previous);
+            debug_assert_eq!(
+                old_previous,
+                Some(id),
+                "inactive LRU successor does not point to the removed copy"
+            );
+        } else {
+            let old_tail = std::mem::replace(&mut self.inactive_tail, previous);
+            debug_assert_eq!(
+                old_tail,
+                Some(id),
+                "inactive LRU tail does not match the removed copy"
+            );
+        }
+
+        self.inactive_len = self
+            .inactive_len
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("inactive block count underflow"));
+    }
+
+    #[cfg(test)]
+    fn assert_lru_consistent(&self) {
+        let mut linked = FxHashSet::default();
+        let mut previous = None;
+        let mut cursor = self.inactive_head;
+
+        while let Some(id) = cursor {
+            assert!(linked.insert(id), "inactive LRU contains a cycle");
+            let Some(copy) = self.copies.get(id) else {
+                panic!("inactive LRU points to a missing copy")
+            };
+            let CopyState::Cached {
+                refs,
+                pins,
+                inactive_prev,
+                inactive_next,
+                ..
+            } = &copy.state
+            else {
+                panic!("inactive LRU contains a private copy")
+            };
+            assert_eq!(
+                (*refs, *pins),
+                (0, 0),
+                "active copy is linked into the inactive LRU"
+            );
+            assert_eq!(
+                *inactive_prev, previous,
+                "inactive LRU contains a broken back-pointer"
+            );
+            previous = Some(id);
+            cursor = *inactive_next;
+        }
+
+        assert_eq!(
+            linked.len(),
+            self.inactive_len,
+            "inactive LRU length does not match its reachable copies"
+        );
+        assert_eq!(
+            self.inactive_tail, previous,
+            "inactive LRU tail does not match its final reachable copy"
+        );
+        assert_eq!(
+            self.inactive_head.is_none(),
+            self.inactive_tail.is_none(),
+            "inactive LRU head and tail emptiness disagree"
+        );
+
+        for (id, copy) in self.copies.iter() {
+            let CopyState::Cached {
+                refs,
+                pins,
+                inactive_prev,
+                inactive_next,
+                ..
+            } = &copy.state
+            else {
+                assert!(!linked.contains(&id), "private copy is in the inactive LRU");
+                continue;
+            };
+            let should_be_linked = *refs == 0 && *pins == 0;
+            assert_eq!(
+                linked.contains(&id),
+                should_be_linked,
+                "cached copy membership disagrees with its refs and pins"
+            );
+            if !should_be_linked {
+                assert!(
+                    inactive_prev.is_none() && inactive_next.is_none(),
+                    "active cached copy retains inactive LRU links"
+                );
+            }
+        }
     }
 
     /// Evict one physical copy. A hash is returned only on its final copy.
     fn evict_one(&mut self) -> Option<SequenceHash> {
-        let Some((timestamp, id)) = self.inactive.pop_first() else {
+        let Some(id) = self.inactive_head else {
             panic!("prechecked inactive capacity disappeared")
         };
+        let CopyState::Cached { inactive_prev, .. } = &self.copies[id].state else {
+            panic!("inactive LRU points to a private copy")
+        };
+        assert!(
+            inactive_prev.is_none(),
+            "inactive LRU head has a predecessor"
+        );
+        self.unlink_inactive(id);
         let Some(copy) = self.copies.remove(id) else {
             panic!("inactive LRU points to a missing copy")
         };
         let CopyState::Cached {
-            hash,
-            refs,
-            pins,
-            inactive_at,
+            hash, refs, pins, ..
         } = copy.state
         else {
             panic!("inactive LRU points to a private copy")
         };
-        assert_eq!(refs, 0);
-        assert_eq!(pins, 0);
-        assert_eq!(inactive_at, Some(timestamp));
+        assert_eq!(refs, 0, "evicted cached copy still has references");
+        assert_eq!(pins, 0, "evicted cached copy is still pinned");
 
         let remove_hash = {
             let Some(copies) = self.by_hash.get_mut(&hash) else {
@@ -450,6 +619,7 @@ mod tests {
         pool.release(first_id);
         pool.release(second_id);
         assert_eq!(pool.num_inactive(), 2);
+        pool.assert_lru_consistent();
     }
 
     #[test]
@@ -463,6 +633,7 @@ mod tests {
         assert!(pool.reserve(&[9], 1).is_none());
         assert_eq!(pool.num_active(), 0);
         assert_eq!(pool.num_inactive(), 1);
+        pool.assert_lru_consistent();
     }
 
     #[test]
@@ -484,6 +655,7 @@ mod tests {
         let second_eviction = reserve(&mut pool, &[], 2);
         assert_eq!(second_eviction.removed, vec![3]);
         pool.cancel(second_eviction.reservation);
+        pool.assert_lru_consistent();
     }
 
     #[test]
@@ -509,5 +681,72 @@ mod tests {
         assert!(pool.prefix_hit(7).is_some());
         assert!(pool.prefix_hit(8).is_none());
         pool.cancel(pressure.reservation);
+        pool.assert_lru_consistent();
+    }
+
+    #[test]
+    fn pinning_middle_inactive_copy_preserves_lru_order() {
+        let mut pool = VllmBlockPool::new(3);
+        let mut seed = reserve(&mut pool, &[], 3).reservation;
+        let first = pool.allocate_private(&mut seed);
+        let middle = pool.allocate_private(&mut seed);
+        let last = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(first, 1));
+        assert!(pool.cache_private(middle, 2));
+        assert!(pool.cache_private(last, 3));
+        pool.release(first);
+        pool.release(middle);
+        pool.release(last);
+        pool.assert_lru_consistent();
+
+        let pinned = reserve(&mut pool, &[2], 1);
+        assert_eq!(pinned.removed, vec![1]);
+        pool.assert_lru_consistent();
+        pool.cancel(pinned.reservation);
+        pool.assert_lru_consistent();
+
+        let pressure = reserve(&mut pool, &[], 2);
+        assert_eq!(pressure.removed, vec![3]);
+        pool.assert_lru_consistent();
+        pool.cancel(pressure.reservation);
+        pool.assert_lru_consistent();
+    }
+
+    #[test]
+    fn activated_prefix_reenters_inactive_lru_on_release() {
+        let mut pool = VllmBlockPool::new(1);
+        let mut seed = reserve(&mut pool, &[], 1).reservation;
+        let id = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(id, 7));
+        pool.release(id);
+
+        let mut activation = reserve(&mut pool, &[7], 0).reservation;
+        assert_eq!(pool.activate_prefix(&mut activation), vec![id]);
+        pool.cancel(activation);
+        assert_eq!(pool.num_inactive(), 0);
+        pool.assert_lru_consistent();
+
+        pool.release(id);
+        assert_eq!(pool.num_inactive(), 1);
+        pool.assert_lru_consistent();
+
+        let pressure = reserve(&mut pool, &[], 1);
+        assert_eq!(pressure.removed, vec![7]);
+        pool.cancel(pressure.reservation);
+        pool.assert_lru_consistent();
+    }
+
+    #[test]
+    #[should_panic(expected = "inactive LRU head has a predecessor")]
+    fn eviction_rejects_head_with_predecessor() {
+        let mut pool = VllmBlockPool::new(1);
+        let mut seed = reserve(&mut pool, &[], 1).reservation;
+        let id = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(id, 7));
+        pool.release(id);
+
+        let (previous, _) = pool.inactive_links_mut(id);
+        *previous = Some(id);
+        let _ = pool.evict_one();
     }
 }


### PR DESCRIPTION
## Summary

- replace the native `VllmBlockPool` inactive-copy `BTreeMap` with an intrusive
  doubly linked LRU stored directly in each cached copy
- make release-to-tail, pin/unlink, and head eviction constant-time without
  allocating or rebalancing tree nodes
- preserve the existing ordinary-LRU ordering and add coverage for unlinking a
  pinned copy from the middle of the inactive list

This builds on #12242, which is now merged. The branch is rebased onto current
`main` and contains only the block-pool commit.

## Performance

Native-G1 AgentX offline replay, KV routing, CPU 0, stock allocator.

The 128-worker / 128-session candidate `perf` capture used the same workload,
CPU, event, and 60-second window as the prior #12242 profile. Total sampled
cycles differed by 0.055%, and both captures lost zero samples.

- selected direct inactive-LRU/tree self-time: 14.66% -> 1.52% (-89.7%)
- `VllmBlockPool::insert_inactive`: 5.02% -> 0.30% (-93.9% sampled cycles)
- primary `BTreeMap::remove`: 4.95% -> 0.03% (-99.3% sampled cycles)
- replacement `VllmBlockPool::unlink_inactive`: 1.06%

Completed 16-worker / 16-session A/B, one arm at a time:

| Metric | #12242 control | Intrusive LRU | Change |
| --- | ---: | ---: | ---: |
| Replay time | 8.0715 s | 5.8251 s | -27.83% / 1.386x |
| Host request rate | 397.82 req/s | 551.24 req/s | +38.56% |
| Host token rate | 59.889M tok/s | 82.985M tok/s | +38.56% |
| Peak RSS | 248,680 KiB | 233,752 KiB | -6.00% |

Both arms completed exactly 3,211 requests and 483,395,480 processed tokens.
The simulated-duration difference was 0.112 ppm.

Post-review candidate sanity on #12242's reviewed head (`08a1bb31`) before it
merged:

- 5.5281 s replay time, 580.85 host req/s, and 87.443M host tok/s
- 236,152 KiB peak RSS
- exact request and token totals; simulated-duration drift of 0.449 ppm
- 5.1% faster than the original candidate run

This is a regression sanity check rather than a fresh matched A/B because it
also includes #12242's review fixes. The completed table above remains the
matched end-to-end comparison.

## Validation

- `cargo test -p dynamo-mocker cache::vllm_block_pool::tests` (7 passed)
- `cargo test -p dynamo-mocker
  native_g1_runs_through_offline_replay_entrypoint` (2 passed: vLLM and
  TensorRT-LLM)
- `cargo test --release -p dynamo-mocker
  cache::vllm_block_pool::tests::eviction_rejects_head_with_predecessor` (1
  passed)
- `cargo test -p dynamo-mocker replay::offline` (174 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` (177
  passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- focused middle-node ordering and activated-prefix reinsertion regression tests
- 128-worker / 128-session `perf record`: 5,941 samples, zero lost
