### PR TITLE
docs(mocker): document eager replay execution [DYN-3850]

### DIFF
--- a/lib/mocker/src/replay/offline/CLAUDE.md
+++ b/lib/mocker/src/replay/offline/CLAUDE.md
@@ -16,6 +16,10 @@ not be mistaken for virtual-time progress or quiescence.
 - Stop same-time iteration when no observable state changed, but only after the
   owning subsystem can account for how unfinished work will wake.
 
+For now, preserve the current replay behavior and the balanced checks above.
+Changes to async settlement belong to DEP #11018; do not approximate them here
+with replay-level timing tricks or new hard assertions.
+
 ## Eager forward-pass execution
 
 Offline replay intentionally executes each non-preemptive forward pass eagerly,
@@ -38,7 +42,3 @@ pass-start visibility remain visible at the pass start.
   preemptive behavior. Do not add engine-core snapshotting, transactional
   rollback, or speculative-state recovery without a demonstrated semantic
   need.
-
-For now, preserve the current replay behavior and the balanced checks above.
-Changes to async settlement belong to DEP #11018; do not approximate them here
-with replay-level timing tricks or new hard assertions.

--- a/lib/mocker/src/replay/offline/CLAUDE.md
+++ b/lib/mocker/src/replay/offline/CLAUDE.md
@@ -22,16 +22,17 @@ with replay-level timing tricks or new hard assertions.
 
 ## Eager forward-pass execution
 
-Offline replay intentionally executes each non-preemptive forward pass eagerly,
-mutating the participating `EngineCore` instances to their post-pass state
-before virtual time reaches the pass-completion timestamp. Completion effects
-remain deferred until that timestamp; observations whose backend contract is
-pass-start visibility remain visible at the pass start.
+Starting an epoch commits one non-preemptive batch. Here, non-preemptive means
+later arrivals or commands cannot interrupt that batch or change its outcome;
+they may affect only queued or post-pass state, or be deferred.
 
-- The pass batch is closed when the epoch starts. While its worker or
-  attention-DP group is busy, later arrivals and commands must affect only
-  queued or post-pass state, or be deferred. They must not alter the committed
-  pass outcome.
+Offline replay executes the committed batch eagerly at epoch start, finalizing
+its participating `EngineCore` state changes and scheduled completion payload
+before virtual time reaches the completion timestamp. Visibility is split:
+
+- Admission observations and `PassStart` events are visible at epoch start.
+- Request outputs, lifecycle events, FPM publications, and `PassEnd` events
+  wait for the shared completion boundary.
 - All ranks in an attention-DP group, including ranks with no work in the
   current epoch, share the slowest-rank completion boundary.
 - Do not generalize this guarantee to the whole `EngineComponent` or to other

--- a/lib/mocker/src/replay/offline/CLAUDE.md
+++ b/lib/mocker/src/replay/offline/CLAUDE.md
@@ -16,6 +16,29 @@ not be mistaken for virtual-time progress or quiescence.
 - Stop same-time iteration when no observable state changed, but only after the
   owning subsystem can account for how unfinished work will wake.
 
+## Eager forward-pass execution
+
+Offline replay intentionally executes each non-preemptive forward pass eagerly,
+mutating the participating `EngineCore` instances to their post-pass state
+before virtual time reaches the pass-completion timestamp. Completion effects
+remain deferred until that timestamp; observations whose backend contract is
+pass-start visibility remain visible at the pass start.
+
+- The pass batch is closed when the epoch starts. While its worker or
+  attention-DP group is busy, later arrivals and commands must affect only
+  queued or post-pass state, or be deferred. They must not alter the committed
+  pass outcome.
+- All ranks in an attention-DP group, including ranks with no work in the
+  current epoch, share the slowest-rank completion boundary.
+- Do not generalize this guarantee to the whole `EngineComponent` or to other
+  replay components. KVBM transport, disaggregated handoffs, worker startup,
+  planner actions, and router queues may have independent deadlines or
+  explicitly revocable events.
+- Preserve eager pass execution unless the modeled engine gains genuinely
+  preemptive behavior. Do not add engine-core snapshotting, transactional
+  rollback, or speculative-state recovery without a demonstrated semantic
+  need.
+
 For now, preserve the current replay behavior and the balanced checks above.
 Changes to async settlement belong to DEP #11018; do not approximate them here
 with replay-level timing tricks or new hard assertions.


### PR DESCRIPTION
## Summary

- document that offline replay intentionally evaluates non-preemptive forward passes eagerly while deferring completion visibility to the modeled boundary
- define the busy-epoch and attention-DP group invariants that keep later arrivals from altering a committed pass
- scope the guarantee away from KVBM transport, disaggregated handoffs, startup, planner, and router events, and discourage rollback machinery without a demonstrated semantic need

## Validation

- `git diff --check`
- repository commit hooks, including codespell, conflict, line-ending, and trailing-whitespace checks
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance describing eager forward-pass execution during offline replay.
  * Documented timing and state-handling behavior for pass completion, including constraints on later arrivals and commands.
  * Clarified synchronization requirements across attention-processing ranks and when eager execution should be preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->