### PR TITLE
fix(sidecar): make vLLM disaggregation work end-to-end

### DIFF
--- a/lib/backend-common/src/disagg.rs
+++ b/lib/backend-common/src/disagg.rs
@@ -58,6 +58,16 @@ impl DisaggregationMode {
         }
     }
 
+    /// Discovery component a worker of this role registers under, so the
+    /// frontend can route the disaggregated prefill/decode handoff separately.
+    /// Prefill registers as `prefill`; decode and aggregated share `backend`.
+    pub fn discovery_component(&self) -> &'static str {
+        match self {
+            Self::Prefill => "prefill",
+            Self::Aggregated | Self::Decode | Self::Encode => "backend",
+        }
+    }
+
     /// `true` when this worker only runs the prefill phase.
     pub fn is_prefill(&self) -> bool {
         matches!(self, Self::Prefill)
@@ -173,6 +183,16 @@ mod tests {
         assert!(!DisaggregationMode::Aggregated.is_prefill());
         assert!(!DisaggregationMode::Aggregated.is_decode());
         assert!(!DisaggregationMode::Aggregated.is_encode());
+    }
+
+    #[test]
+    fn discovery_component_splits_prefill_from_the_rest() {
+        assert_eq!(DisaggregationMode::Prefill.discovery_component(), "prefill");
+        assert_eq!(DisaggregationMode::Decode.discovery_component(), "backend");
+        assert_eq!(
+            DisaggregationMode::Aggregated.discovery_component(),
+            "backend"
+        );
     }
 
     #[test]

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -87,7 +87,7 @@ impl SglangSidecarEngine {
 
         let config = WorkerConfig {
             namespace: args.namespace,
-            component: component_for_mode(disaggregation_mode).to_string(),
+            component: disaggregation_mode.discovery_component().to_string(),
             endpoint: args.endpoint,
             endpoint_types: args.endpoint_types,
             custom_jinja_template: args.custom_jinja_template,
@@ -418,14 +418,6 @@ fn discovery_mode(discovery: &Discovery) -> Result<DisaggregationMode, DynamoErr
         mode => Err(client::protocol_error(format!(
             "unsupported SGLang disaggregation_mode `{mode}`"
         ))),
-    }
-}
-
-fn component_for_mode(mode: DisaggregationMode) -> &'static str {
-    if mode.is_prefill() {
-        "prefill"
-    } else {
-        "backend"
     }
 }
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -217,15 +217,19 @@ fn build_kv_parameters(
             );
             Some(serde_json::Value::Object(params))
         }
-        DisaggregationMode::Decode => Some(
-            prefill_result
+        DisaggregationMode::Decode => {
+            let mut params = prefill_result
                 .ok_or_else(|| {
                     client::invalid_argument(
                         "decode request is missing the prefill_result KV payload",
                     )
                 })?
-                .disaggregated_params,
-        ),
+                .disaggregated_params;
+            // The prefill handoff carries the NIXL side-channel port; normalize it
+            // so vLLM builds a valid ZMQ URL (see stringify_remote_port).
+            stringify_remote_port(&mut params);
+            Some(params)
+        }
         DisaggregationMode::Encode => {
             return Err(client::invalid_argument(
                 "encode mode is not supported by the vLLM sidecar",
@@ -238,6 +242,34 @@ fn build_kv_parameters(
         cache_salt: cache_salt.unwrap_or_default(),
         kv_transfer_params: kv_transfer_params.map(json_to_struct).transpose()?,
     })
+}
+
+/// vLLM's NIXL connector builds the decode->prefill side-channel address by
+/// f-stringing `remote_port` (`f"tcp://{host}:{port}"`). The value reaches the
+/// engine through a `google.protobuf.Struct`, whose numbers are always `double`,
+/// so an integer port arrives as `5600.0` and the ZMQ URL fails to parse. Send it
+/// as a string instead — vLLM renders `5600` and only ever uses it to build that
+/// URL. Remove once vLLM coerces the port itself.
+fn stringify_remote_port(params: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = params else {
+        return;
+    };
+    // struct_to_json recovers a whole port as an integer; coerce a whole float
+    // defensively so a bare `5600.0` never slips through unmodified.
+    let port = map.get("remote_port").and_then(|value| {
+        value.as_u64().or_else(|| {
+            value
+                .as_f64()
+                .filter(|f| f.fract() == 0.0 && *f >= 0.0)
+                .map(|f| f as u64)
+        })
+    });
+    if let Some(port) = port {
+        map.insert(
+            "remote_port".to_string(),
+            serde_json::Value::String(port.to_string()),
+        );
+    }
 }
 
 fn bool_extra(

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -104,7 +104,13 @@ impl VllmSidecarEngine {
         };
         let config = WorkerConfig {
             namespace: args.sidecar.common.namespace,
-            component: args.sidecar.common.component,
+            // Prefill/decode must register under fixed role components so the
+            // frontend can route the disaggregated handoff; aggregated keeps the
+            // operator-configured component (`--component` / `DYN_COMPONENT`).
+            component: match mode {
+                DisaggregationMode::Aggregated => args.sidecar.common.component,
+                _ => mode.discovery_component().to_string(),
+            },
             endpoint: args.sidecar.common.endpoint,
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -525,8 +525,38 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
         let requests = server.service.requests.lock().await;
         let decode_wire = requests.last().unwrap().kv.as_ref().unwrap();
         let decoded = struct_to_json(decode_wire.kv_transfer_params.clone().unwrap()).unwrap();
-        assert_eq!(decoded, handoff);
+        // Every field round-trips opaquely except remote_port, which the sidecar
+        // stringifies so vLLM builds a valid NIXL side-channel URL (a protobuf
+        // Struct number would reach the engine as `20097.0`).
+        let mut expected = handoff.clone();
+        expected["remote_port"] = json!("20097");
+        assert_eq!(decoded, expected);
     }
+}
+
+#[test]
+fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
+    let component = |extra: &[&str]| {
+        let mut argv = vec![
+            "dynamo-vllm-sidecar",
+            "--vllm-endpoint",
+            "127.0.0.1:50051",
+            "--model-path",
+            "test-model",
+            "--component",
+            "custom",
+        ];
+        argv.extend_from_slice(extra);
+        VllmSidecarEngine::from_args(Some(argv.iter().map(|s| s.to_string()).collect()))
+            .expect("from_args")
+            .1
+            .component
+    };
+    // Aggregated keeps the operator-configured component.
+    assert_eq!(component(&[]), "custom");
+    // Disaggregated roles override to fixed names so the frontend can route.
+    assert_eq!(component(&["--disaggregation-mode", "prefill"]), "prefill");
+    assert_eq!(component(&["--disaggregation-mode", "decode"]), "backend");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Two fixes to the vLLM sidecar's disaggregated path so prefill→decode actually works. Both are in the sidecar — no upstream vLLM change and no engine patching.

- **`backend-common` + `engine.rs`** — register prefill/decode under distinct discovery components (`prefill` vs `backend`) so the frontend can route the handoff; previously both used the same operator-injected component (`worker`) and requests went straight to decode → `BackendInvalidArgument: decode request is missing the prefill_result KV payload`. The mapping lives on `DisaggregationMode::discovery_component` in `backend-common` (zero-duplication rule); the **SGLang sidecar's identical local `component_for_mode` was removed** in favor of it. Per review, **aggregated workers keep their operator-configured `--component`/`DYN_COMPONENT`** — only the disagg roles override to the fixed names (a `from_args` test covers this).

- **`convert.rs`** — send `remote_port` in `kv_transfer_params` as a string. vLLM's NIXL connector f-strings the port into the side-channel ZMQ URL (`make_zmq_path` → `f"tcp://{host}:{port}"`), but the value crosses vLLM's gRPC contract as a `google.protobuf.Struct`, whose numbers are always `double`. An integer port therefore arrived as `5600.0`, producing `tcp://<ip>:5600.0`, which fails to parse → KV load failure → **zero generated tokens**. As a string vLLM renders `5600`; it only uses this value to build the URL (verified against vLLM `main`, which does not int-cast it in `make_zmq_path` or `nixl/metadata.py`). Includes a unit test; marked removable once vLLM coerces the port itself.

## Validation

Validated end-to-end on an amd64 GPU cluster (co-located prefill+decode, NIXL/UCX over EFA, no RDMA):

- Aggregated: worker `2/2`, registers `backend.generate`, `/v1/models` + `/v1/chat/completions` return normally (no regression from the component change).
- Disaggregated: prefill + decode `2/2`, register `prefill.generate` / `backend.generate` with **no `--component` flag**, engine left **unpatched**, decode log shows `Transfer plan: TransferTopology(...)`, end-to-end completion returned (`completion_tokens > 0`). Before this change the same setup returned 0 tokens.
- Full `cargo test -p dynamo-vllm-sidecar` green (14 tests), incl. the updated `prefill_decode_handoff_is_opaque_and_repeatable` boundary test (expects only `remote_port` stringified) and the new `component_honors_config_for_aggregated_but_fixes_disagg_roles`.

Companion deploy example: ai-dynamo/dynamo#12238 (uses `kv_role=kv_producer`/`kv_consumer`).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed inference configuration by ensuring remote port values are transmitted in the expected format.
  * Corrected worker routing so requests are directed to the appropriate prefill or backend component based on the selected processing mode.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->


