### PR TITLE
perf(mocker): flatten native G1 sequences

### DIFF
--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -4,9 +4,95 @@
 use crate::common::protocols::MoveBlock;
 use derive_getters::Getters;
 use dynamo_tokens::blocks::UniqueBlock;
-use dynamo_tokens::{BlockHash, PositionalLineageHash, TokenBlockSequence, Tokens};
+use dynamo_tokens::{
+    BlockHash, PositionalLineageHash, SaltHash, TokenBlockSequence, Tokens,
+    compute_block_hash_for_tokens, compute_next_sequence_hash,
+};
 use rand::random;
 use validator::Validate;
+
+const MOCKER_SALT_HASH: SaltHash = 1337;
+
+#[derive(Debug)]
+struct FlatTokens {
+    retained: Vec<u32>,
+    retained_start: usize,
+}
+
+impl FlatTokens {
+    fn new(
+        mut tokens: Vec<u32>,
+        output_capacity_hint: usize,
+        block_size: usize,
+        retain_history: bool,
+    ) -> Self {
+        if retain_history {
+            tokens.reserve_exact(output_capacity_hint);
+            return Self {
+                retained: tokens,
+                retained_start: 0,
+            };
+        }
+
+        let retained_start = tokens.len() - (tokens.len() % block_size);
+        // Lazy promotion runs after the next block's first token is pushed, so
+        // the retained window must hold one complete block plus that token.
+        let mut retained = Vec::with_capacity(
+            block_size
+                .checked_add(1)
+                .expect("flat token tail capacity overflow"),
+        );
+        retained.extend_from_slice(&tokens[retained_start..]);
+        Self {
+            retained,
+            retained_start,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.retained_start
+            .checked_add(self.retained.len())
+            .expect("flat token length overflow")
+    }
+
+    fn push(&mut self, token: u32) {
+        self.retained.push(token);
+    }
+
+    fn pop(&mut self) -> Option<u32> {
+        self.retained.pop()
+    }
+
+    fn complete_block(&self, position: usize, block_size: usize) -> Option<&[u32]> {
+        let start = position.checked_mul(block_size)?;
+        debug_assert!(
+            start >= self.retained_start,
+            "promoted block precedes retained flat-token window"
+        );
+        let end = start.checked_add(block_size)?;
+        let local_start = start.checked_sub(self.retained_start)?;
+        let local_end = end.checked_sub(self.retained_start)?;
+        self.retained.get(local_start..local_end)
+    }
+
+    fn discard_through(&mut self, absolute_end: usize) {
+        let local_end = absolute_end
+            .checked_sub(self.retained_start)
+            .expect("promoted block precedes retained flat-token window");
+        assert!(
+            local_end <= self.retained.len(),
+            "promoted block extends beyond retained flat-token window"
+        );
+        self.retained.drain(..local_end);
+        self.retained_start = absolute_end;
+    }
+}
+
+#[derive(Debug)]
+enum SequenceTokens {
+    Legacy(TokenBlockSequence),
+    Flat(FlatTokens),
+}
 
 /// Create unique blocks, block hashes, and positional-lineage hashes from a
 /// [`TokenBlockSequence`].
@@ -44,6 +130,53 @@ fn create_sequence_cache(
     (unique_blocks, block_hashes, plhs)
 }
 
+/// Build the native-G1 block metadata directly over a flat token vector.
+fn create_flat_sequence_cache(
+    tokens: &[u32],
+    block_size: usize,
+    enable_prefix_caching: bool,
+    completion_blocks: usize,
+) -> (Vec<UniqueBlock>, Vec<BlockHash>, Vec<PositionalLineageHash>) {
+    let mut unique_blocks = Vec::with_capacity(completion_blocks);
+    let mut block_hashes = if enable_prefix_caching {
+        Vec::with_capacity(completion_blocks)
+    } else {
+        Vec::new()
+    };
+    let mut plhs = Vec::with_capacity(completion_blocks);
+    let mut parent_hash = None;
+
+    for (position, block) in tokens.chunks_exact(block_size).enumerate() {
+        if enable_prefix_caching {
+            let block_hash = compute_block_hash_for_tokens(block, MOCKER_SALT_HASH);
+            let sequence_hash = parent_hash
+                .map(|parent| compute_next_sequence_hash(parent, block_hash))
+                .unwrap_or(block_hash);
+            block_hashes.push(block_hash);
+            unique_blocks.push(UniqueBlock::FullBlock(sequence_hash));
+            plhs.push(PositionalLineageHash::new(
+                sequence_hash,
+                parent_hash,
+                position as u64,
+            ));
+            parent_hash = Some(sequence_hash);
+        } else {
+            unique_blocks.push(UniqueBlock::FullBlock(random::<u64>()));
+            plhs.push(PositionalLineageHash::new(
+                random::<u64>(),
+                None,
+                position as u64,
+            ));
+        }
+    }
+
+    if !tokens.len().is_multiple_of(block_size) {
+        unique_blocks.push(UniqueBlock::default());
+    }
+
+    (unique_blocks, block_hashes, plhs)
+}
+
 /// A sequence that is actively being built, with the ability to add tokens and commit to hashes
 /// TODO: reuse tokens
 #[derive(Debug, Getters, Validate)]
@@ -52,7 +185,8 @@ pub struct ActiveSequence {
     block_hashes: Vec<BlockHash>,
     plhs: Vec<PositionalLineageHash>,
 
-    tokens: TokenBlockSequence,
+    #[getter(skip)]
+    tokens: SequenceTokens,
 
     #[getter(copy)]
     #[validate(range(min = 2))]
@@ -107,28 +241,69 @@ impl ActiveSequence {
             return None;
         };
 
-        let last_complete = self.tokens.last_complete_block().unwrap_or_else(|| {
-            panic!("partial sequence tail cannot be promoted without a complete token block")
-        });
-        let last_seq_hash = if self.enable_prefix_caching {
-            last_complete.sequence_hash()
-        } else {
-            random::<u64>()
-        };
-        let last_block_hash = self
-            .enable_prefix_caching
-            .then(|| last_complete.block_hash());
-        // With prefix caching off, the sequence hash and PLH must both remain
-        // request-unique so another identical prompt cannot reuse this slot.
-        let last_plh = if self.enable_prefix_caching {
-            last_complete.positional_lineage_hash()
-        } else {
-            PositionalLineageHash::new(random::<u64>(), None, self.plhs.len() as u64)
-        };
-        let promote_token_ids = if self.emit_token_ids {
-            Some(last_complete.tokens().to_vec())
-        } else {
-            None
+        let parent_hash = self.unique_blocks[..self.unique_blocks.len() - 1]
+            .last()
+            .map(|block| match block {
+                UniqueBlock::FullBlock(hash) => *hash,
+                UniqueBlock::PartialBlock(_) => panic!("partial block cannot be a parent"),
+            });
+        let position = self.plhs.len();
+        debug_assert_eq!(position + 1, self.len() / self.block_size);
+        let (last_seq_hash, last_block_hash, last_plh, promote_token_ids) = match &self.tokens {
+            SequenceTokens::Legacy(tokens) => {
+                let last_complete = tokens.last_complete_block().unwrap_or_else(|| {
+                    panic!(
+                        "partial sequence tail cannot be promoted without a complete token block"
+                    )
+                });
+                let last_seq_hash = if self.enable_prefix_caching {
+                    last_complete.sequence_hash()
+                } else {
+                    random::<u64>()
+                };
+                let last_block_hash = self
+                    .enable_prefix_caching
+                    .then(|| last_complete.block_hash());
+                // With prefix caching off, the sequence hash and PLH must both remain
+                // request-unique so another identical prompt cannot reuse this slot.
+                let last_plh = if self.enable_prefix_caching {
+                    last_complete.positional_lineage_hash()
+                } else {
+                    PositionalLineageHash::new(random::<u64>(), None, position as u64)
+                };
+                let promote_token_ids = if self.emit_token_ids {
+                    Some(last_complete.tokens().to_vec())
+                } else {
+                    None
+                };
+                (last_seq_hash, last_block_hash, last_plh, promote_token_ids)
+            }
+            SequenceTokens::Flat(tokens) => {
+                let complete = tokens
+                    .complete_block(position, self.block_size)
+                    .unwrap_or_else(|| {
+                    panic!(
+                        "partial flat sequence tail cannot be promoted without a complete token block"
+                    )
+                });
+                let last_block_hash = self
+                    .enable_prefix_caching
+                    .then(|| compute_block_hash_for_tokens(complete, MOCKER_SALT_HASH));
+                let last_seq_hash = last_block_hash
+                    .map(|block_hash| {
+                        parent_hash
+                            .map(|parent| compute_next_sequence_hash(parent, block_hash))
+                            .unwrap_or(block_hash)
+                    })
+                    .unwrap_or_else(random::<u64>);
+                let last_plh = if self.enable_prefix_caching {
+                    PositionalLineageHash::new(last_seq_hash, parent_hash, position as u64)
+                } else {
+                    PositionalLineageHash::new(random::<u64>(), None, position as u64)
+                };
+                let promote_token_ids = self.emit_token_ids.then(|| complete.to_vec());
+                (last_seq_hash, last_block_hash, last_plh, promote_token_ids)
+            }
         };
         if let Some(last_block_hash) = last_block_hash {
             self.block_hashes.push(last_block_hash);
@@ -136,13 +311,19 @@ impl ActiveSequence {
         self.plhs.push(last_plh);
         self.unique_blocks.pop();
 
-        // After pop, the last element is the parent block.
-        let parent_hash = self.unique_blocks.last().map(|block| match block {
-            UniqueBlock::FullBlock(hash) => *hash,
-            UniqueBlock::PartialBlock(_) => panic!("partial block cannot be a parent"),
-        });
         self.unique_blocks
             .push(UniqueBlock::FullBlock(last_seq_hash));
+
+        if !self.emit_token_ids {
+            let promoted_end = position
+                .checked_add(1)
+                .and_then(|blocks| blocks.checked_mul(self.block_size))
+                .expect("promoted flat-token boundary overflow");
+            if let SequenceTokens::Flat(tokens) = &mut self.tokens {
+                tokens.discard_through(promoted_end);
+            }
+        }
+        self.debug_assert_flat_token_invariants();
 
         Some(MoveBlock::Promote(
             uuid,
@@ -183,7 +364,7 @@ impl ActiveSequence {
         let block_size = block_size.unwrap_or(64);
         let num_input_tokens = tokens.len();
 
-        let tokens = Tokens::from(tokens).into_sequence(block_size as u32, Some(1337));
+        let tokens = Tokens::from(tokens).into_sequence(block_size as u32, Some(MOCKER_SALT_HASH));
         let (unique_blocks, block_hashes, plhs) =
             create_sequence_cache(&tokens, block_size, enable_prefix_caching);
 
@@ -191,7 +372,7 @@ impl ActiveSequence {
             unique_blocks,
             block_hashes,
             plhs,
-            tokens,
+            tokens: SequenceTokens::Legacy(tokens),
             block_size,
             max_output_tokens,
             generated_tokens: 0,
@@ -205,16 +386,67 @@ impl ActiveSequence {
         seq
     }
 
+    /// Build a native-G1 sequence directly over the request's flat token vector.
+    ///
+    /// `output_capacity_hint` controls eager allocation only. The logical
+    /// generation limit remains `max_output_tokens`, and the vectors can grow
+    /// if the scheduler realizes more output than the hint.
+    pub(crate) fn new_flat_with_planned_output_ids(
+        tokens: Vec<u32>,
+        max_output_tokens: usize,
+        output_capacity_hint: usize,
+        block_size: usize,
+        enable_prefix_caching: bool,
+        emit_token_ids: bool,
+        planned_output_ids: Option<Vec<u32>>,
+    ) -> Self {
+        let num_input_tokens = tokens.len();
+        let emit_token_ids = emit_token_ids && enable_prefix_caching;
+        let output_capacity_hint = output_capacity_hint.min(max_output_tokens);
+        let completion_blocks = num_input_tokens
+            .checked_add(output_capacity_hint)
+            .expect("native sequence completion length overflow")
+            .div_ceil(block_size);
+        let (unique_blocks, block_hashes, plhs) = create_flat_sequence_cache(
+            &tokens,
+            block_size,
+            enable_prefix_caching,
+            completion_blocks,
+        );
+        let tokens = FlatTokens::new(tokens, output_capacity_hint, block_size, emit_token_ids);
+
+        let seq = Self {
+            unique_blocks,
+            block_hashes,
+            plhs,
+            tokens: SequenceTokens::Flat(tokens),
+            block_size,
+            max_output_tokens,
+            generated_tokens: 0,
+            planned_output_ids,
+            num_input_tokens,
+            num_allocated_tokens: 0,
+            enable_prefix_caching,
+            emit_token_ids,
+        };
+        seq.validate().expect("invalid flat ActiveSequence");
+        seq.debug_assert_flat_token_invariants();
+        seq
+    }
+
     pub fn extra_tokens(&self) -> u32 {
         (self.len() % self.block_size) as u32
     }
 
     pub fn len(&self) -> usize {
-        self.tokens.total_tokens()
+        match &self.tokens {
+            SequenceTokens::Legacy(tokens) => tokens.total_tokens(),
+            SequenceTokens::Flat(tokens) => tokens.len(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.tokens.total_tokens() == 0
+        self.len() == 0
     }
 
     /// Current known sequence footprint in blocks: prompt plus generated tokens.
@@ -258,12 +490,7 @@ impl ActiveSequence {
         let plhs = self.plhs[plh_start..plh_end].to_vec();
 
         let token_ids = if self.emit_token_ids && hash_start < hash_end {
-            Some(
-                self.tokens.blocks()[hash_start..hash_end]
-                    .iter()
-                    .map(|b| b.tokens().to_vec())
-                    .collect(),
-            )
+            Some(self.block_token_ids_in(hash_start, hash_end))
         } else {
             None
         };
@@ -282,12 +509,37 @@ impl ActiveSequence {
         &self.plhs
     }
 
+    fn block_token_ids_in(&self, start: usize, end: usize) -> Vec<Vec<u32>> {
+        match &self.tokens {
+            SequenceTokens::Legacy(tokens) => tokens.blocks()[start..end]
+                .iter()
+                .map(|block| block.tokens().to_vec())
+                .collect(),
+            SequenceTokens::Flat(tokens) => {
+                assert!(
+                    self.emit_token_ids && tokens.retained_start == 0,
+                    "flat sequences retain full token history only when token-ID events are enabled"
+                );
+                tokens
+                    .retained
+                    .chunks_exact(self.block_size)
+                    .skip(start)
+                    .take(end - start)
+                    .map(<[u32]>::to_vec)
+                    .collect()
+            }
+        }
+    }
+
+    /// Materialize every complete block's token IDs.
+    ///
+    /// # Panics
+    ///
+    /// Panics for native flat sequences that were created without token-ID
+    /// event emission, because those sequences intentionally discard completed
+    /// prompt and decode blocks.
     pub fn block_token_ids(&self) -> Vec<Vec<u32>> {
-        self.tokens
-            .blocks()
-            .iter()
-            .map(|block| block.tokens().to_vec())
-            .collect()
+        self.block_token_ids_in(0, self.len() / self.block_size)
     }
 
     /// Commit a successful allocation by advancing `num_allocated_tokens`.
@@ -328,8 +580,14 @@ impl ActiveSequence {
     /// Push a token to the sequence
     #[cfg_attr(feature = "profile", inline(never))]
     pub fn push(&mut self, token: u32) -> Option<Vec<MoveBlock>> {
-        self.tokens.append(token).expect("Token push failed.");
+        match &mut self.tokens {
+            SequenceTokens::Legacy(tokens) => {
+                tokens.append(token).expect("Token push failed.");
+            }
+            SequenceTokens::Flat(tokens) => tokens.push(token),
+        }
         self.generated_tokens += 1;
+        self.debug_assert_flat_token_invariants();
 
         if self.len() % self.block_size != 1 {
             return None;
@@ -354,6 +612,7 @@ impl ActiveSequence {
             None,
             None,
         ));
+        self.debug_assert_flat_token_invariants();
         Some(signals)
     }
 
@@ -450,27 +709,90 @@ impl ActiveSequence {
     /// must be in the current partial block, so we only need to drop the trailing
     /// partial `UniqueBlock` when the sequence length returns to an exact block
     /// boundary. Using this to unwind arbitrary prompt history would be incorrect.
+    ///
+    /// If this contract is violated in release builds, legacy token storage
+    /// preserves its historical no-op on an empty buffer, while flat storage
+    /// panics to surface the invalid rollback.
     pub fn pop(&mut self) {
-        self.tokens.pop();
+        debug_assert!(
+            self.generated_tokens > 0,
+            "sequence rollback requires a freshly generated token"
+        );
+        match &mut self.tokens {
+            SequenceTokens::Legacy(tokens) => {
+                tokens.pop();
+            }
+            SequenceTokens::Flat(tokens) => {
+                debug_assert!(
+                    !tokens.retained.is_empty(),
+                    "flat rollback token must be retained"
+                );
+                tokens.pop().expect("flat rollback token must be retained");
+            }
+        }
         self.generated_tokens = self.generated_tokens.saturating_sub(1);
 
         // Reverts to the last full block
-        if self.tokens.total_tokens().is_multiple_of(self.block_size) {
+        if self.len().is_multiple_of(self.block_size) {
             self.unique_blocks.pop();
         }
+        self.debug_assert_flat_token_invariants();
+    }
+
+    fn debug_assert_flat_token_invariants(&self) {
+        if let SequenceTokens::Flat(tokens) = &self.tokens {
+            debug_assert_eq!(
+                tokens.len(),
+                self.num_input_tokens + self.generated_tokens,
+                "flat retained-token window must cover the logical sequence suffix"
+            );
+            if self.emit_token_ids {
+                debug_assert_eq!(
+                    tokens.retained_start, 0,
+                    "token-ID events require complete flat-token history"
+                );
+            } else {
+                debug_assert!(
+                    tokens.retained.len() <= self.block_size + 1,
+                    "non-emitting flat sequences retain at most one block plus the next token"
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn uses_flat_tokens(&self) -> bool {
+        matches!(self.tokens, SequenceTokens::Flat(_))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn flat_storage_capacities(&self) -> Option<(usize, usize, usize, usize)> {
+        let SequenceTokens::Flat(tokens) = &self.tokens else {
+            return None;
+        };
+        Some((
+            tokens.retained.capacity(),
+            self.unique_blocks.capacity(),
+            self.block_hashes.capacity(),
+            self.plhs.capacity(),
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_tokens::SequenceHash;
 
     fn block_hashes_from_tokens(seq: &ActiveSequence) -> Vec<BlockHash> {
-        seq.tokens
-            .blocks()
-            .iter()
-            .map(|block| block.block_hash())
-            .collect()
+        match &seq.tokens {
+            SequenceTokens::Legacy(tokens) => tokens
+                .blocks()
+                .iter()
+                .map(|block| block.block_hash())
+                .collect(),
+            SequenceTokens::Flat(_) => seq.block_hashes().clone(),
+        }
     }
 
     fn assert_cached_hashes_match_promoted_blocks(seq: &ActiveSequence) {
@@ -774,5 +1096,484 @@ mod tests {
         // current partial block; this is the replay/preemption path we rely on.
         seq.pop();
         assert_cached_hashes_match_promoted_blocks(&seq);
+    }
+
+    #[derive(Debug, PartialEq)]
+    enum SignalShape {
+        Use {
+            blocks: Vec<Option<u64>>,
+            hashes: Vec<BlockHash>,
+            plhs: Vec<PositionalLineageHash>,
+            token_ids: Option<Vec<Vec<u32>>>,
+            parent: Option<Option<u64>>,
+        },
+        Deref(Vec<Option<u64>>),
+        Promote {
+            sequence_hash: SequenceHash,
+            parent_hash: Option<u64>,
+            block_hash: Option<BlockHash>,
+            plh: PositionalLineageHash,
+            token_ids: Option<Vec<u32>>,
+        },
+    }
+
+    fn block_shape(block: &UniqueBlock) -> Option<u64> {
+        match block {
+            UniqueBlock::FullBlock(hash) => Some(*hash),
+            UniqueBlock::PartialBlock(_) => None,
+        }
+    }
+
+    fn signal_shape(signal: MoveBlock) -> SignalShape {
+        match signal {
+            MoveBlock::Use(blocks, hashes, plhs, token_ids, parent) => SignalShape::Use {
+                blocks: blocks.iter().map(block_shape).collect(),
+                hashes,
+                plhs,
+                token_ids,
+                parent: parent.as_ref().map(block_shape),
+            },
+            MoveBlock::Deref(blocks) => {
+                SignalShape::Deref(blocks.iter().map(block_shape).collect())
+            }
+            MoveBlock::Promote(_, sequence_hash, parent_hash, block_hash, plh, token_ids) => {
+                SignalShape::Promote {
+                    sequence_hash,
+                    parent_hash,
+                    block_hash,
+                    plh,
+                    token_ids,
+                }
+            }
+        }
+    }
+
+    fn signal_shapes(signals: impl IntoIterator<Item = MoveBlock>) -> Vec<SignalShape> {
+        signals.into_iter().map(signal_shape).collect()
+    }
+
+    fn sequence_pair(
+        prompt: Vec<u32>,
+        output_ids: Vec<u32>,
+        block_size: usize,
+        emit_token_ids: bool,
+    ) -> (ActiveSequence, ActiveSequence) {
+        let legacy = ActiveSequence::new_with_planned_output_ids(
+            prompt.clone(),
+            output_ids.len(),
+            Some(block_size),
+            true,
+            emit_token_ids,
+            Some(output_ids.clone()),
+        );
+        let flat = ActiveSequence::new_flat_with_planned_output_ids(
+            prompt,
+            output_ids.len(),
+            output_ids.len(),
+            block_size,
+            true,
+            emit_token_ids,
+            Some(output_ids),
+        );
+        assert!(!legacy.uses_flat_tokens());
+        assert!(flat.uses_flat_tokens());
+        (legacy, flat)
+    }
+
+    fn assert_sequence_parity(legacy: &ActiveSequence, flat: &ActiveSequence) {
+        assert_eq!(legacy.len(), flat.len());
+        assert_eq!(legacy.extra_tokens(), flat.extra_tokens());
+        assert_eq!(legacy.emit_token_ids(), flat.emit_token_ids());
+        assert_eq!(legacy.block_hashes(), flat.block_hashes());
+        assert_eq!(
+            legacy.positional_lineage_hashes(),
+            flat.positional_lineage_hashes()
+        );
+        assert_eq!(
+            legacy
+                .unique_blocks()
+                .iter()
+                .map(block_shape)
+                .collect::<Vec<_>>(),
+            flat.unique_blocks()
+                .iter()
+                .map(block_shape)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(legacy.generated_tokens(), flat.generated_tokens());
+        assert_eq!(legacy.num_input_tokens(), flat.num_input_tokens());
+        assert_eq!(legacy.num_allocated_tokens(), flat.num_allocated_tokens());
+        if flat.emit_token_ids() {
+            assert_eq!(legacy.block_token_ids(), flat.block_token_ids());
+        } else {
+            let SequenceTokens::Flat(tokens) = &flat.tokens else {
+                panic!("expected flat token storage");
+            };
+            assert!(
+                tokens.retained.len() <= flat.block_size() + 1,
+                "non-emitting flat storage exceeded one block plus one token"
+            );
+        }
+    }
+
+    #[test]
+    fn flat_sequence_matches_legacy_across_prompt_and_output_boundaries() {
+        const BLOCK_SIZE: usize = 16;
+        for promote_eagerly in [true, false] {
+            for emit_token_ids in [false, true] {
+                for prompt_len in [0, 1, BLOCK_SIZE - 1, BLOCK_SIZE, BLOCK_SIZE + 1, 53] {
+                    let prompt: Vec<u32> = (0..prompt_len as u32).collect();
+                    let outputs: Vec<u32> =
+                        (10_000..10_000 + (BLOCK_SIZE * 2 + 3) as u32).collect();
+                    let (mut legacy, mut flat) =
+                        sequence_pair(prompt, outputs.clone(), BLOCK_SIZE, emit_token_ids);
+                    let SequenceTokens::Flat(tokens) = &flat.tokens else {
+                        panic!("expected flat token storage");
+                    };
+                    let token_capacity = tokens.retained.capacity();
+                    let mut push_promotions = 0;
+
+                    assert_sequence_parity(&legacy, &flat);
+                    assert_eq!(
+                        legacy.take_creation_signal().map(signal_shape),
+                        flat.take_creation_signal().map(signal_shape)
+                    );
+
+                    for expected_token in outputs {
+                        let (legacy_token, legacy_signals) = legacy.generate_token();
+                        let (flat_token, flat_signals) = flat.generate_token();
+                        assert_eq!(legacy_token, expected_token);
+                        assert_eq!(flat_token, expected_token);
+
+                        let legacy_push_promoted = legacy_signals
+                            .iter()
+                            .any(|signal| matches!(signal, MoveBlock::Promote(..)));
+                        let flat_push_promoted = flat_signals
+                            .iter()
+                            .any(|signal| matches!(signal, MoveBlock::Promote(..)));
+                        assert_eq!(legacy_push_promoted, flat_push_promoted);
+                        if flat_push_promoted {
+                            push_promotions += 1;
+                        }
+                        assert_eq!(signal_shapes(legacy_signals), signal_shapes(flat_signals));
+                        assert_sequence_parity(&legacy, &flat);
+
+                        let SequenceTokens::Flat(tokens) = &flat.tokens else {
+                            panic!("expected flat token storage");
+                        };
+                        assert_eq!(tokens.retained.capacity(), token_capacity);
+                        if flat_push_promoted && !emit_token_ids {
+                            assert_eq!(tokens.retained.len(), 1);
+                            assert_eq!(tokens.retained_start + 1, flat.len());
+                        }
+
+                        if promote_eagerly
+                            && legacy.generated_tokens() < legacy.max_output_tokens()
+                            && legacy.len().is_multiple_of(BLOCK_SIZE)
+                        {
+                            assert_eq!(
+                                legacy.promote_computed_tail(legacy.len()).map(signal_shape),
+                                flat.promote_computed_tail(flat.len()).map(signal_shape)
+                            );
+                            assert_sequence_parity(&legacy, &flat);
+                        }
+                    }
+
+                    if promote_eagerly {
+                        assert_eq!(push_promotions, 0);
+                    } else {
+                        assert!(push_promotions > 0);
+                    }
+                    assert_eq!(
+                        signal_shapes(legacy.terminal_signals()),
+                        signal_shapes(flat.terminal_signals())
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn flat_sequence_matches_chunked_token_id_allocations() {
+        const BLOCK_SIZE: usize = 4;
+        let prompt: Vec<u32> = (0..12).collect();
+        let (mut legacy, mut flat) = sequence_pair(prompt.clone(), Vec::new(), BLOCK_SIZE, true);
+
+        for cumulative_tokens in [4, 8, 12] {
+            let legacy_signal = legacy
+                .prepare_allocation(cumulative_tokens)
+                .expect("legacy chunk should allocate");
+            let flat_signal = flat
+                .prepare_allocation(cumulative_tokens)
+                .expect("flat chunk should allocate");
+            assert_eq!(
+                signal_shape(legacy_signal),
+                signal_shape(flat_signal.clone())
+            );
+            let MoveBlock::Use(_, _, _, Some(token_ids), _) = flat_signal else {
+                panic!("chunked native allocation must include token IDs");
+            };
+            let start = cumulative_tokens - BLOCK_SIZE;
+            assert_eq!(token_ids, vec![prompt[start..cumulative_tokens].to_vec()]);
+            legacy.commit_allocation(cumulative_tokens);
+            flat.commit_allocation(cumulative_tokens);
+        }
+    }
+
+    #[test]
+    fn flat_sequence_capacities_do_not_grow_during_decode() {
+        const BLOCK_SIZE: usize = 16;
+        let prompt: Vec<u32> = (0..17).collect();
+        let outputs: Vec<u32> = (1_000..1_037).collect();
+
+        for emit_token_ids in [false, true] {
+            let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
+                prompt.clone(),
+                outputs.len(),
+                outputs.len(),
+                BLOCK_SIZE,
+                true,
+                emit_token_ids,
+                Some(outputs.clone()),
+            );
+            let metadata_capacities = (
+                flat.unique_blocks.capacity(),
+                flat.block_hashes.capacity(),
+                flat.plhs.capacity(),
+            );
+            let SequenceTokens::Flat(tokens) = &flat.tokens else {
+                panic!("expected flat token storage");
+            };
+            let token_capacity = tokens.retained.capacity();
+            if emit_token_ids {
+                assert!(token_capacity >= prompt.len() + outputs.len());
+            } else {
+                assert!(token_capacity > BLOCK_SIZE);
+                assert_eq!(tokens.retained_start, BLOCK_SIZE);
+                assert_eq!(tokens.retained, prompt[BLOCK_SIZE..]);
+            }
+
+            for _ in &outputs {
+                flat.generate_token();
+                if flat.generated_tokens() < flat.max_output_tokens()
+                    && flat.len().is_multiple_of(BLOCK_SIZE)
+                {
+                    flat.promote_computed_tail(flat.len());
+                }
+
+                assert_eq!(
+                    metadata_capacities,
+                    (
+                        flat.unique_blocks.capacity(),
+                        flat.block_hashes.capacity(),
+                        flat.plhs.capacity(),
+                    )
+                );
+                let SequenceTokens::Flat(tokens) = &flat.tokens else {
+                    panic!("expected flat token storage");
+                };
+                assert_eq!(tokens.retained.capacity(), token_capacity);
+                if emit_token_ids {
+                    assert_eq!(tokens.retained_start, 0);
+                } else {
+                    assert!(tokens.retained.len() <= BLOCK_SIZE + 1);
+                }
+            }
+        }
+    }
+
+    fn assert_uncached_signal_parity(left: Vec<MoveBlock>, right: Vec<MoveBlock>) {
+        assert_eq!(left.len(), right.len());
+        for (left, right) in left.into_iter().zip(right) {
+            match (left, right) {
+                (
+                    MoveBlock::Use(lb, lh, lp, lt, lparent),
+                    MoveBlock::Use(rb, rh, rp, rt, rparent),
+                ) => {
+                    assert_eq!(
+                        lb.iter()
+                            .map(block_shape)
+                            .map(|hash| hash.is_some())
+                            .collect::<Vec<_>>(),
+                        rb.iter()
+                            .map(block_shape)
+                            .map(|hash| hash.is_some())
+                            .collect::<Vec<_>>()
+                    );
+                    assert_eq!(lh.len(), rh.len());
+                    assert_eq!(lp.len(), rp.len());
+                    assert_eq!(lt.is_some(), rt.is_some());
+                    assert_eq!(lparent.is_some(), rparent.is_some());
+                }
+                (
+                    MoveBlock::Promote(_, _, lp, lbh, lplh, lt),
+                    MoveBlock::Promote(_, _, rp, rbh, rplh, rt),
+                ) => {
+                    assert_eq!(lp.is_some(), rp.is_some());
+                    assert_eq!(lbh.is_some(), rbh.is_some());
+                    assert_eq!(lplh.position(), rplh.position());
+                    assert_eq!(lt.is_some(), rt.is_some());
+                }
+                (MoveBlock::Deref(lb), MoveBlock::Deref(rb)) => {
+                    assert_eq!(lb.len(), rb.len());
+                    assert_eq!(
+                        lb.iter()
+                            .map(block_shape)
+                            .map(|hash| hash.is_some())
+                            .collect::<Vec<_>>(),
+                        rb.iter()
+                            .map(block_shape)
+                            .map(|hash| hash.is_some())
+                            .collect::<Vec<_>>()
+                    );
+                }
+                (left, right) => panic!("signal variants differ: {left:?} != {right:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn flat_sequence_matches_uncached_legacy_structure() {
+        const BLOCK_SIZE: usize = 4;
+        let prompt: Vec<u32> = (0..9).collect();
+        let outputs: Vec<u32> = (100..108).collect();
+        let mut legacy = ActiveSequence::new_with_planned_output_ids(
+            prompt.clone(),
+            outputs.len(),
+            Some(BLOCK_SIZE),
+            false,
+            true,
+            Some(outputs.clone()),
+        );
+        let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
+            prompt,
+            outputs.len(),
+            outputs.len(),
+            BLOCK_SIZE,
+            false,
+            true,
+            Some(outputs),
+        );
+
+        assert!(!legacy.emit_token_ids());
+        assert!(!flat.emit_token_ids());
+        assert!(legacy.block_hashes().is_empty());
+        assert!(flat.block_hashes().is_empty());
+        assert_eq!(legacy.unique_blocks().len(), flat.unique_blocks().len());
+        assert_eq!(
+            legacy
+                .positional_lineage_hashes()
+                .iter()
+                .map(PositionalLineageHash::position)
+                .collect::<Vec<_>>(),
+            flat.positional_lineage_hashes()
+                .iter()
+                .map(PositionalLineageHash::position)
+                .collect::<Vec<_>>()
+        );
+        assert_uncached_signal_parity(
+            legacy.take_creation_signal().into_iter().collect(),
+            flat.take_creation_signal().into_iter().collect(),
+        );
+
+        while legacy.generated_tokens() < legacy.max_output_tokens() {
+            let (_, legacy_signals) = legacy.generate_token();
+            let (_, flat_signals) = flat.generate_token();
+            assert_uncached_signal_parity(legacy_signals, flat_signals);
+        }
+        assert_uncached_signal_parity(legacy.terminal_signals(), flat.terminal_signals());
+    }
+
+    #[test]
+    #[should_panic(expected = "partial block cannot be a parent")]
+    fn flat_promotion_rejects_partial_parent() {
+        let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
+            (0..15).collect(),
+            1,
+            1,
+            16,
+            true,
+            false,
+            Some(vec![99]),
+        );
+        flat.push(99);
+        flat.unique_blocks.insert(0, UniqueBlock::default());
+        flat.promote_computed_tail(flat.len());
+    }
+
+    #[test]
+    #[should_panic(expected = "flat sequences retain full token history")]
+    fn non_emitting_flat_sequence_rejects_token_materialization() {
+        let flat = ActiveSequence::new_flat_with_planned_output_ids(
+            (0..16).collect(),
+            1,
+            1,
+            16,
+            true,
+            false,
+            None,
+        );
+        flat.block_token_ids();
+    }
+
+    #[test]
+    fn flat_sequence_matches_legacy_reset_and_one_token_rollback() {
+        const BLOCK_SIZE: usize = 16;
+        let prompt: Vec<u32> = (0..BLOCK_SIZE as u32).collect();
+        let (mut legacy, mut flat) = sequence_pair(prompt, vec![1_001, 1_002], BLOCK_SIZE, false);
+
+        legacy.take_creation_signal();
+        flat.take_creation_signal();
+        assert_eq!(
+            signal_shapes(legacy.push(1_001).unwrap()),
+            signal_shapes(flat.push(1_001).unwrap())
+        );
+        legacy.pop();
+        flat.pop();
+        assert_sequence_parity(&legacy, &flat);
+
+        legacy.commit_allocation(legacy.len());
+        flat.commit_allocation(flat.len());
+        assert_eq!(
+            signal_shapes(legacy.reset_with_signal()),
+            signal_shapes(flat.reset_with_signal())
+        );
+    }
+
+    #[test]
+    fn flat_sequence_preserves_uncached_random_identity_behavior() {
+        let make = || {
+            ActiveSequence::new_flat_with_planned_output_ids(
+                (0..17).collect(),
+                16,
+                16,
+                16,
+                false,
+                true,
+                None,
+            )
+        };
+        let mut first = make();
+        let second = make();
+
+        assert!(first.block_hashes().is_empty());
+        assert_ne!(first.unique_blocks()[0], second.unique_blocks()[0]);
+        assert_ne!(
+            first.positional_lineage_hashes()[0],
+            second.positional_lineage_hashes()[0]
+        );
+
+        for token in 0..15 {
+            first.push(token);
+        }
+        let promote = first
+            .promote_computed_tail(first.len())
+            .expect("completed uncached block should promote");
+        let MoveBlock::Promote(_, _, _, block_hash, plh, token_ids) = promote else {
+            panic!("expected promote signal");
+        };
+        assert!(block_hash.is_none());
+        assert_eq!(plh.parent_hash_fragment(), 0);
+        assert!(token_ids.is_none());
     }
 }

--- a/lib/mocker/src/kv_manager/g1_manager.rs
+++ b/lib/mocker/src/kv_manager/g1_manager.rs
@@ -487,6 +487,9 @@ impl G1Manager {
         }
     }
 
+    /// Returns whether the legacy KVBM backend has a lower-tier offload
+    /// engine. Native G1 always returns `false`, so native requests cannot
+    /// enter the KVBM swap-in lifecycle.
     #[cfg(feature = "kvbm-offload")]
     pub fn has_offload_engine(&self) -> bool {
         match &self.backend {

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -12,8 +12,8 @@ use uuid::Uuid;
 
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::{
-    DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
-    PrefillCost, WorkerType,
+    DirectRequest, G1Backend, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal,
+    PreemptionMode, PrefillCost, SchedulingPolicy, WorkerType,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
@@ -549,6 +549,14 @@ impl VllmCore {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn request_uses_flat_tokens(&self, uuid: Uuid) -> bool {
+        self.state
+            .requests
+            .get(&uuid)
+            .is_some_and(|request| request.sequence.uses_flat_tokens())
+    }
+
     pub(crate) fn apply_command(
         &mut self,
         command: SchedulerCommand,
@@ -807,6 +815,28 @@ impl VllmCore {
         Ok(())
     }
 
+    /// Output tokens worth reserving storage for when materializing a request.
+    ///
+    /// This is only an allocation hint. The sequence retains the request's
+    /// logical `max_output_tokens`; scheduling separately enforces the model
+    /// and physical KV limits.
+    fn output_capacity_hint(&self, prompt_len: usize, max_output_tokens: usize) -> usize {
+        let kv_remaining = self
+            .args
+            .num_gpu_blocks
+            .saturating_mul(self.args.block_size)
+            .saturating_sub(prompt_len);
+        let model_remaining = if self.args.scheduling_policy() == SchedulingPolicy::Vllm {
+            self.args
+                .max_model_len
+                .map(|limit| limit.saturating_sub(prompt_len))
+                .unwrap_or(usize::MAX)
+        } else {
+            usize::MAX
+        };
+        max_output_tokens.min(kv_remaining).min(model_remaining)
+    }
+
     fn submit(&mut self, mut request: DirectRequest) -> anyhow::Result<Uuid> {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         request.uuid = Some(uuid);
@@ -827,6 +857,7 @@ impl VllmCore {
         status: RequestStatus,
     ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        let prompt_len = request.tokens.len();
         let mut max_output_tokens = request.max_output_tokens;
         let planned_output_ids = request.output_token_ids;
         if let Some(planned_output_ids) = planned_output_ids.as_ref()
@@ -842,7 +873,7 @@ impl VllmCore {
         }
         if let Some(clamped) = policy::normalize_max_output_tokens(
             self.args.scheduling_policy(),
-            request.tokens.len(),
+            prompt_len,
             max_output_tokens,
             self.args.num_gpu_blocks,
             self.args.block_size,
@@ -856,14 +887,27 @@ impl VllmCore {
         // The `None` case (a TRT-LLM prompt alone leaves no decode room) is
         // unchanged here. The waiting-admission policy owns terminal rejection
         // because that path can emit the lifecycle signal.
-        let sequence = ActiveSequence::new_with_planned_output_ids(
-            request.tokens,
-            max_output_tokens,
-            Some(self.args.block_size),
-            self.args.enable_prefix_caching,
-            self.args.zmq_kv_events_port.is_some(),
-            planned_output_ids,
-        );
+        let output_capacity_hint = self.output_capacity_hint(prompt_len, max_output_tokens);
+        let sequence = if self.args.g1_backend == G1Backend::Native {
+            ActiveSequence::new_flat_with_planned_output_ids(
+                request.tokens,
+                max_output_tokens,
+                output_capacity_hint,
+                self.args.block_size,
+                self.args.enable_prefix_caching,
+                self.args.zmq_kv_events_port.is_some(),
+                planned_output_ids,
+            )
+        } else {
+            ActiveSequence::new_with_planned_output_ids(
+                request.tokens,
+                max_output_tokens,
+                Some(self.args.block_size),
+                self.args.enable_prefix_caching,
+                self.args.zmq_kv_events_port.is_some(),
+                planned_output_ids,
+            )
+        };
         VllmRequestState {
             sequence,
             status,
@@ -1160,6 +1204,11 @@ impl VllmCore {
     /// releases the remaining swap-in resources.
     #[cfg(feature = "kvbm-offload")]
     fn complete_swap_in(&mut self, aws: AwaitingSwapIn) {
+        debug_assert_eq!(
+            self.args.g1_backend,
+            G1Backend::Kvbm,
+            "KVBM swap-in completion requires legacy sequence storage"
+        );
         let count = aws.handle.block_count();
         let skip = aws.skip_blocks;
         let entries: Vec<_> = {

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -78,6 +78,107 @@ fn router_args() -> MockEngineArgs {
         .unwrap()
 }
 
+#[test]
+fn flat_tokens_cover_every_native_g1_configuration() {
+    let args = |engine_type: EngineType,
+                backend: G1Backend,
+                prefix_caching: bool,
+                emit_token_ids: bool| {
+        MockEngineArgs::builder()
+            .engine_type(engine_type)
+            .g1_backend(backend)
+            .block_size(4)
+            .num_gpu_blocks(32)
+            .max_num_batched_tokens(Some(32))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(prefix_caching)
+            .zmq_kv_events_port(emit_token_ids.then_some(12_345))
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap()
+    };
+    let mut next_uuid = 80_001_u128;
+
+    for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
+        for prefix_caching in [false, true] {
+            for emit_token_ids in [false, true] {
+                let uuid = Uuid::from_u128(next_uuid);
+                next_uuid += 1;
+                let mut core = VllmCore::new(args(
+                    engine_type,
+                    G1Backend::Native,
+                    prefix_caching,
+                    emit_token_ids,
+                ));
+                core.receive(DirectRequest {
+                    tokens: (0..9).collect(),
+                    max_output_tokens: 2,
+                    uuid: Some(uuid),
+                    ..Default::default()
+                });
+                assert!(core.request_uses_flat_tokens(uuid));
+            }
+        }
+    }
+
+    let uuid = Uuid::from_u128(next_uuid);
+    let mut kvbm = VllmCore::new(args(EngineType::Vllm, G1Backend::Kvbm, true, false));
+    kvbm.receive(DirectRequest {
+        tokens: (0..9).collect(),
+        max_output_tokens: 2,
+        uuid: Some(uuid),
+        ..Default::default()
+    });
+    assert!(!kvbm.request_uses_flat_tokens(uuid));
+}
+
+#[test]
+fn flat_storage_capacity_is_bounded_by_realizable_output() {
+    const BLOCK_SIZE: usize = 4;
+    const MAX_OUTPUT_TOKENS: usize = 1_000_000;
+
+    for (prompt_len, expected_output_capacity) in [(10_usize, 2_usize), (17, 0)] {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Vllm)
+            .g1_backend(G1Backend::Native)
+            .block_size(BLOCK_SIZE)
+            .num_gpu_blocks(4)
+            .max_model_len(Some(12))
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(4))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .zmq_kv_events_port(Some(12_345))
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let uuid = Uuid::new_v4();
+        core.receive(DirectRequest {
+            tokens: (0..prompt_len as u32).collect(),
+            max_output_tokens: MAX_OUTPUT_TOKENS,
+            uuid: Some(uuid),
+            ..Default::default()
+        });
+
+        let sequence = &core.state().requests[&uuid].sequence;
+        assert_eq!(sequence.max_output_tokens(), MAX_OUTPUT_TOKENS);
+        let (token_capacity, unique_capacity, hash_capacity, lineage_capacity) = sequence
+            .flat_storage_capacities()
+            .expect("native G1 must use flat storage");
+        let bounded_blocks = (prompt_len + expected_output_capacity).div_ceil(BLOCK_SIZE);
+        let unbounded_blocks = (prompt_len + MAX_OUTPUT_TOKENS).div_ceil(BLOCK_SIZE);
+
+        assert!(token_capacity >= prompt_len + expected_output_capacity);
+        assert!(token_capacity < prompt_len + MAX_OUTPUT_TOKENS);
+        for capacity in [unique_capacity, hash_capacity, lineage_capacity] {
+            assert!(capacity >= bounded_blocks);
+            assert!(capacity < unbounded_blocks);
+        }
+    }
+}
+
 #[rstest]
 #[case(EngineType::Vllm)]
 #[case(EngineType::Trtllm)]
@@ -2865,7 +2966,9 @@ mod offload {
     use uuid::Uuid;
 
     use crate::common::handoff::HandoffId;
-    use crate::common::protocols::{DirectRequest, MockEngineArgs, MoveBlock, WorkerType};
+    use crate::common::protocols::{
+        DirectRequest, G1Backend, MockEngineArgs, MoveBlock, WorkerType,
+    };
     use crate::common::sequence::ActiveSequence;
     use crate::kv_manager::G1Acquire;
     use crate::kvbm_offload::shared_g3::shared_g3_test_guard_blocking;
@@ -2975,6 +3078,22 @@ mod offload {
         engine.tick(0.0);
         engine.attach_runtime(runtime);
         core.kv_manager.attach_new_offload_engine(engine);
+    }
+
+    #[test]
+    #[should_panic(expected = "legacy kvbm-offload cannot be attached to native G1")]
+    fn native_g1_cannot_enter_kvbm_swap_in() {
+        let args = MockEngineArgs::builder()
+            .num_gpu_blocks(4)
+            .block_size(4)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .g1_backend(G1Backend::Native)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        assert!(!core.kv_manager.has_offload_engine());
+        attach_g1_offload_engine(&mut core);
     }
 
     #[test]

--- a/lib/tokens/src/lib.rs
+++ b/lib/tokens/src/lib.rs
@@ -149,6 +149,16 @@ pub fn compute_block_hash(block_bytes: &[u8], salt: SaltHash) -> BlockHash {
     compute_hash_v2(block_bytes, salt)
 }
 
+/// Canonical [`BlockHash`] construction for a token-only block.
+///
+/// Multimodal token sequences must first route through
+/// [`compute_block_bytes_with_mm`] so placeholder slots use their multimodal
+/// identities instead of their token IDs.
+#[inline]
+pub fn compute_block_hash_for_tokens(tokens: &[Token], salt: SaltHash) -> BlockHash {
+    compute_block_hash(cast_slice(tokens), salt)
+}
+
 /// Canonical [`SaltHash`] construction from a pre-canonicalized salt-payload byte
 /// buffer. Application-layer callers should use `dynamo_kv_hashing::Request::salt_hash`
 /// which canonicalizes `(salt, lora_name)` first; this function is the low-level path.
@@ -1064,7 +1074,7 @@ struct TokenBlockChunk {
 impl TokenBlockChunk {
     /// Creates a new chunk from [`Tokens`], calculating the [`BlockHash`].
     fn new(tokens: Tokens, salt_hash: SaltHash) -> Self {
-        let block_hash = compute_block_hash(cast_slice(&tokens), salt_hash);
+        let block_hash = compute_block_hash_for_tokens(&tokens, salt_hash);
         Self {
             tokens,
             salt_hash,
@@ -1074,7 +1084,7 @@ impl TokenBlockChunk {
 
     /// Creates a new chunk from a slice of `&[Token]`, calculating the [`BlockHash`].
     fn from_tokens(tokens: &[Token], salt_hash: SaltHash) -> Self {
-        let block_hash = compute_block_hash(cast_slice(tokens), salt_hash);
+        let block_hash = compute_block_hash_for_tokens(tokens, salt_hash);
         Self {
             tokens: tokens.into(), // Converts slice to owned Tokens
             salt_hash,
@@ -1901,6 +1911,19 @@ mod tests {
     const SEQ_HASH_5_8: SequenceHash = 4945711292740353085; // hash([SEQ_HASH_1_4, HASH_5_8], CHAIN_XXH3_SEED)
     const HASH_9_12: BlockHash = 483935686894639516; // hash([9,10,11,12], 1337)
     const SEQ_HASH_9_12: SequenceHash = 12583592247330656132; // hash([SEQ_HASH_5_8, HASH_9_12], CHAIN_XXH3_SEED)
+
+    #[test]
+    fn token_hash_helper_matches_canonical_byte_encoding() {
+        let tokens = [1u32, 2, 3, 4];
+        assert_eq!(
+            compute_block_hash_for_tokens(&tokens, TEST_SALT_HASH),
+            compute_block_hash(cast_slice(&tokens), TEST_SALT_HASH)
+        );
+        assert_eq!(
+            compute_block_hash_for_tokens(&tokens, TEST_SALT_HASH),
+            HASH_1_4
+        );
+    }
 
     impl PartialTokenBlock {
         /// Attempts to remove the last token from the block.


### PR DESCRIPTION
## Summary

- keep each VLLM/TRT-LLM native-G1 request in one flat token representation
- build native block hashes, sequence hashes, lineage, and identities directly,
  avoiding `TokenBlockSequence` and per-block token allocations
- retain complete token history only when token-ID KV events require it;
  otherwise retain at most the current partial block plus one token
- bound eager flat-storage capacity to output realizable under the model and
  physical KV limits while preserving the logical request maximum
- preserve `TokenBlockSequence` for KVBM and leave SGLang unchanged

The optimized path applies to both offline replay and the live mocker, with
prefix caching enabled or disabled and with or without ZMQ KV-event output.
The public surface changes add the canonical `compute_block_hash_for_tokens`
helper and remove the unused `ActiveSequence::tokens()` getter. In addition,
`block_token_ids()` rejects native flat sequences whose token history was
intentionally discarded; its only production caller is the KVBM-only swap-in
path. Flat `pop()` also requires a retained freshly generated token and panics
on contract violation, while legacy storage preserves its historical no-op.
CLI options, event formats, and serialization formats are unchanged.

### Measured main versus PR: 16-worker / 16-session AgentX

Exact main control `a96a2a8c48` and measured PR build `8ac610d6f6` were built
from the same lockfile with identical release optimization, DWARF,
`x86-64-v3`, frame pointers, and the stock allocator. The PR arm ran first,
followed by main, with full teardown between arms and CPU 0 affinity. Current
head `366ff0ef52` includes subsequent review fixes, including bounded eager
capacity for overdeclared or rejected requests. The table therefore describes
the measured `8ac610d6f6` build rather than a rerun of the final head.

| Metric | Main control `a96a2a8c48` | PR build `8ac610d6f6` | Change |
| --- | ---: | ---: | ---: |
| Replay time | 8.108080 s | 5.881516 s | **-27.46% / 1.379x** |
| Host request throughput | 396.02 req/s | 545.95 req/s | **+37.86%** |
| Host processed-token throughput | 59.62M tok/s | 82.19M tok/s | **+37.86%** |
| `mprof` peak RSS | 253.590 MiB | 219.797 MiB | **-13.33%** |

Both arms completed exactly 3,211 requests, 479,843,008 input tokens,
3,552,472 output tokens, and 483,395,480 processed tokens. Deterministic report
metrics matched exactly (0.0 ppm).

### 128-worker / 128-session CPU profile

The established main/#12244 capture and the latest equivalent PR-patch capture
used the same 128-worker / 128-session AgentX workload:

| Targeted inclusive attribution | Main baseline | PR branch | Change |
| --- | ---: | ---: | ---: |
| `TokenBlockSequence::split_tokens` | 13.989% | 0.000% | **eliminated** |
| `ActiveSequence` construction | 15.187% legacy | 2.158% flat | **-85.79%** |
| Flat hashing | n/a | 0.320% | below 5% gate |
| Flat token-vector growth | n/a | 0.000% | no measured growth |
| Native metadata-vector growth | n/a | 0.000% | no measured growth |
| Flat tail promotion | n/a | 0.084% | below 5% gate |
| Flat tail compaction | n/a | 0.000% | no measured compaction |
| Token-ID materialization | n/a | 0.000% | no measured materialization |
| Unresolved leaf cycles | 0.419% | 0.302% | usable symbols |

The PR capture contains 5,940 samples, zero lost samples, and usable DWARF
symbols. No hashing, metadata-growth, tail-compaction, or token-materialization
path exceeds 5% self CPU. These fixed-window shares are CPU attribution rather
than a completed-throughput comparison; the completed A/B is reported above.

> **Follow-up:** Native G1’s retained-token buffer now overlaps with SGLang’s flat sequence storage. A separate PR can evaluate extracting shared token-storage and canonical hashing primitives while preserving the distinct native-G1 and SGLang KV-cache lifecycles. This refactor is intentionally out of scope here.

## Validation

- focused flat/legacy sequence parity and native-path selection tests
- eager and push-driven promotion parity, including bounded retained capacity
- eager-capacity regression for model-capped and post-materialization-rejected requests
- native ZMQ store/promotion token-ID payload parity
- prefix-caching-on hash/lineage parity and prefix-caching-off random identity
- canonical token-hash helper and shared-salt parity
- bounded retained-token storage and stable token/metadata decode capacities
- chunked token-ID allocation with a nonzero start offset
- partial-parent, promotion-position, reset, and rollback invariants
- native-G1 rejection of the legacy KVBM swap-in lifecycle
- `cargo test -p dynamo-mocker flat_`
- `cargo test -p dynamo-mocker scheduler::vllm`
- `cargo test -p dynamo-mocker replay::offline`
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline`
- locked metadata and clippy in the root, Python, runtime-example, and KVBM workspaces
- `cargo clippy -p dynamo-tokens -p dynamo-mocker --all-targets -- -D warnings`
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact main-control versus PR 16-worker / 16-session comparison with `mprof`
- 128-worker / 128-session AgentX `perf` capture