### PR TITLE
docs(xpu): add Intel GPU compatibility and workflow guidance

### DIFF
--- a/docs/fern/backends/vllm/README.md
+++ b/docs/fern/backends/vllm/README.md
@@ -2,13 +2,15 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: vLLM
+subtitle: Run vLLM engines with Dynamo on NVIDIA or Intel GPUs
 ---
 
-Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
+Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime on NVIDIA and Intel GPUs. It enables disaggregated serving, KV-aware routing, and request cancellation while maintaining compatibility with vLLM's native engine arguments. Dynamo uses vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and prefill/decode (P/D) disaggregation.
 
 ## Installation
 
-### Install Latest Release
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 We recommend using [uv](https://github.com/astral-sh/uv) to install:
 
@@ -19,11 +21,9 @@ uv pip install "ai-dynamo[vllm]"
 
 This installs Dynamo with the compatible vLLM version.
 
----
+### Container Image
 
-### Container
-
-We have public images available on [NGC Catalog](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo/artifacts):
+Use the published runtime image from the [NGC Catalog](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/ai-dynamo/collections/ai-dynamo/artifacts):
 
 ```bash
 docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:<version>
@@ -35,19 +35,58 @@ docker pull nvcr.io/nvidia/ai-dynamo/vllm-runtime:<version>
 ```bash
 python container/render.py --framework vllm --output-short-filename
 docker build -f container/rendered.Dockerfile -t dynamo:latest-vllm .
-```
 
-```bash
 ./container/run.sh -it --framework VLLM [--mount-workspace]
 ```
 
 </Accordion>
 
+</Tab>
+<Tab title="Intel GPU">
+
+Build the vLLM XPU runtime image from the Dynamo source tree. XPU images support `amd64` hosts:
+
+```bash
+python3 container/render.py \
+  --framework vllm \
+  --device xpu \
+  --target runtime \
+  --output-short-filename
+
+docker build \
+  --file container/rendered.Dockerfile \
+  --tag dynamo:latest-vllm-xpu \
+  .
+```
+
+Run the image with access to the Intel GPU devices under `/dev/dri`:
+
+```bash
+./container/run.sh \
+  -it \
+  --framework VLLM \
+  --device xpu \
+  --image dynamo:latest-vllm-xpu \
+  --mount-workspace
+```
+
+The `--device xpu` option mounts `/dev/dri`, adds the host render group when available, and disables
+the NVIDIA container runtime. Inside the container, XPU launchers set `VLLM_TARGET_DEVICE=xpu` and
+use `ZE_AFFINITY_MASK` to select devices.
+
+</Tab>
+</Tabs>
+
 ### Development Setup
 
-For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree/main/.devcontainer) which has all dependencies pre-installed.
+For NVIDIA GPU development, use the
+[devcontainer](https://github.com/ai-dynamo/dynamo/tree/main/.devcontainer), which has the CUDA
+dependencies pre-installed. For Intel GPU development, use the source-built XPU runtime image.
 
 ## Feature Support Matrix
+
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 | Feature | Status | Notes |
 |---------|--------|-------|
@@ -62,26 +101,57 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 | **WideEP** | ✅ | Support for DeepEP |
 | **DP Rank Routing** | ✅ | [Hybrid load balancing](https://docs.vllm.ai/en/stable/serving/data_parallel_deployment/?h=external+dp#hybrid-load-balancing) via external DP rank control |
 | [**LoRA**](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/launch/lora/README.md) | ✅ | Dynamic loading/unloading from S3-compatible storage |
-| **GB200 Support** | ✅ | Container functional on main |
+| [**Tool Calling**](../../tool-calling/README.mdx) | ✅ | |
+| **GB200 Support** | ✅ | Container supported |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Feature | Status | Intel GPU Notes |
+|---------|--------|-----------------|
+| [**Disaggregated Serving**](../../design-docs/disagg-serving.md) | ✅ | P/D and multimodal E/P/D launchers use NIXL with XPU KV buffers |
+| [**KV-Aware Routing**](../../components/router/README.md) | ✅ | KV events and approximate cache tracking |
+| [**SLA-Based Planner**](../../components/planner/planner-guide.md) | ✅ | XPU P/D deployment manifest includes the Planner |
+| [**KVBM**](../../components/kvbm/README.md) | — | |
+| [**LMCache**](../../cli/kv-cache-offloading.mdx) | ✅ | Aggregated and multiprocess deployments |
+| [**FlexKV**](../../cli/kv-cache-offloading.mdx) | — | |
+| [**Multimodal Support**](../../features/multimodal/multimodal-vllm.md) | ✅ | Image and video input, frontend decoding, and multimodal KV routing |
+| [**Observability**](vllm-observability.md) | ✅ | Metrics and tracing deployment manifests |
+| **WideEP** | — | |
+| **DP Rank Routing** | — | |
+| **LoRA** | — | |
+| [**Tool Calling**](../../tool-calling/README.mdx) | ✅ | Multimodal tool calling with the `hermes` parser |
+
+> [!NOTE]
+> An em dash means the feature is not supported on Intel GPU.
+
+</Tab>
+</Tabs>
 
 ## Feature Interactions
 
-vLLM offers the broadest feature coverage in Dynamo, with full support for disaggregated serving, KV-aware routing, KV block management, LoRA adapters, and multimodal inference including video and audio. The matrix below shows which feature pairs are validated to work together.
+vLLM offers the broadest feature coverage in Dynamo, including disaggregated serving, KV-aware
+routing, KV block management, LoRA adapters, and multimodal inference. Select an accelerator to see
+the supported feature pairs.
+
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 **Legend:** ✅ Supported &nbsp;|&nbsp; 🚧 Work in Progress / Experimental / Limited
+&nbsp;|&nbsp; — Not supported &nbsp;|&nbsp; N/A Same feature
 
 | Feature | Disaggregated Serving | KV-Aware Routing | SLA-Based Planner | KV Block Manager | Multimodal | Request Migration | Request Cancellation | LoRA | Tool Calling | Speculative Decoding |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| **Disaggregated Serving** | — | | | | | | | | | |
-| **KV-Aware Routing** | ✅ | — | | | | | | | | |
-| **SLA-Based Planner** | ✅ | ✅ | — | | | | | | | |
-| **KV Block Manager** | ✅ | ✅ | ✅ | — | | | | | | |
-| **Multimodal** | ✅ | ✅<sup>1</sup> | — | ✅ | — | | | | | |
-| **Request Migration** | ✅ | ✅ | ✅ | ✅ | ✅ | — | | | | |
-| **Request Cancellation** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | | | |
-| **LoRA** | ✅ | ✅<sup>2</sup> | — | ✅ | — | ✅ | ✅ | — | | |
-| **Tool Calling** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | — | |
-| **Speculative Decoding** | ✅ | ✅ | — | ✅ | — | ✅ | ✅ | — | ✅ | — |
+| **Disaggregated Serving** | N/A | | | | | | | | | |
+| **KV-Aware Routing** | ✅ | N/A | | | | | | | | |
+| **SLA-Based Planner** | ✅ | ✅ | N/A | | | | | | | |
+| **KV Block Manager** | ✅ | ✅ | ✅ | N/A | | | | | | |
+| **Multimodal** | ✅ | ✅<sup>1</sup> | ✅ | ✅ | N/A | | | | | |
+| **Request Migration** | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | | | | |
+| **Request Cancellation** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | | | |
+| **LoRA** | ✅ | ✅<sup>2</sup> | — | ✅ | — | ✅ | ✅ | N/A | | |
+| **Tool Calling** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | N/A | |
+| **Speculative Decoding** | ✅ | ✅ | ✅ | ✅ | — | ✅ | ✅ | — | ✅ | N/A |
 
 > **Notes:**
 > 1. **Multimodal + KV-Aware Routing**: Image-aware KV routing is supported in the documented vLLM paths. The default Rust frontend path supports model families handled by `llm-multimodal`; the Python chat-processor path delegates to vLLM's multimodal processor. ([Source](../../features/multimodal/multimodal-kv-routing.md))
@@ -89,6 +159,40 @@ vLLM offers the broadest feature coverage in Dynamo, with full support for disag
 > 3. **Audio Support**: vLLM supports audio models like Qwen2-Audio (experimental). ([Source](../../features/multimodal/multimodal-vllm.md))
 > 4. **Video Support**: vLLM supports video input with frame sampling. ([Source](../../features/multimodal/multimodal-vllm.md))
 > 5. **Speculative Decoding**: Eagle3 support documented. ([Source](../../features/speculative-decoding/speculative-decoding-vllm.md))
+
+</Tab>
+<Tab title="Intel GPU">
+
+**Legend:** ✅ Supported &nbsp;|&nbsp; — Not supported &nbsp;|&nbsp; N/A Same feature
+
+| Feature | Disaggregated Serving | KV-Aware Routing | SLA-Based Planner | KV Block Manager | Multimodal | Request Migration | Request Cancellation | LoRA | Tool Calling | Speculative Decoding |
+| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| **Disaggregated Serving** | N/A | | | | | | | | | |
+| **KV-Aware Routing** | ✅ | N/A | | | | | | | | |
+| **SLA-Based Planner** | ✅ | ✅ | N/A | | | | | | | |
+| **KV Block Manager** | — | — | — | N/A | | | | | | |
+| **Multimodal** | ✅ | ✅ | ✅ | — | N/A | | | | | |
+| **Request Migration** | ✅ | ✅ | ✅ | — | ✅ | N/A | | | | |
+| **Request Cancellation** | ✅ | ✅ | ✅ | — | ✅ | ✅ | N/A | | | |
+| **LoRA** | — | — | — | — | — | — | — | N/A | | |
+| **Tool Calling** | ✅ | ✅ | ✅ | — | ✅ | ✅ | ✅ | — | N/A | |
+| **Speculative Decoding** | ✅ | ✅ | ✅ | — | — | ✅ | ✅ | — | ✅ | N/A |
+
+> **Notes:**
+> 1. **Disaggregated + KV-Aware Routing**: The XPU GDR launcher and Kubernetes manifest combine P/D
+>    disaggregation with KV-aware routing.
+> 2. **Disaggregated + Multimodal**: The XPU launcher provides encode/prefill/decode disaggregation.
+> 3. **Multimodal + KV-Aware Routing**: XPU launchers cover the Rust multimodal router and the vLLM
+>    chat-processor path.
+> 4. **Request Lifecycle Features**: Request migration and cancellation run in Dynamo's request
+>    plane and do not depend on accelerator-specific engine code.
+> 5. **Speculative Decoding**: The vLLM XPU build supports N-gram speculative decoding.
+> 6. **SLA-Based Planner**: The Planner operates on runtime metrics and replica state. It supports
+>    multimodal deployments and consumes speculative decode metadata without accelerator-specific
+>    code paths.
+
+</Tab>
+</Tabs>
 
 ## Quick Start
 
@@ -100,10 +204,33 @@ docker compose -f dev/docker-compose.yml up -d
 
 Launch an aggregated serving deployment:
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm
 bash launch/agg.sh
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+Run these commands inside the XPU runtime container from the
+[Installation](#installation) section:
+
+```bash
+cd $DYNAMO_HOME/examples/backends/vllm
+bash launch/xpu/agg_xpu.sh
+```
+
+The launcher defaults to `ZE_AFFINITY_MASK=0`. Set it before launch to select another Intel GPU:
+
+```bash
+ZE_AFFINITY_MASK=1 bash launch/xpu/agg_xpu.sh
+```
+
+</Tab>
+</Tabs>
 
 > **Running launch scripts standalone.** The `launch/*.sh` scripts expect etcd and NATS to be reachable on localhost. Bring them up first (run from the repo root, or use the absolute path shown):
 >
@@ -112,6 +239,18 @@ bash launch/agg.sh
 > ```
 >
 > Then run the launch script. Without these, workers register but the frontend cannot discover them and requests hang.
+
+Verify the deployment:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
 
 ### Rust Backend Preview
 
@@ -154,6 +293,7 @@ reaches feature and operational parity with the Python vLLM backend.
 
 - **[Reference Guide](vllm-reference-guide.md)**: Configuration, arguments, and operational details
 - **[Examples](vllm-examples.mdx)**: Local deployment launch scripts
+- **[Intel GPU Examples](vllm-examples.mdx#xpu)**: XPU launchers and configuration
 - **[KV Cache Offloading](vllm-kv-offloading.md)**: KVBM, LMCache, and FlexKV integrations
 - **[Observability](vllm-observability.md)**: Metrics and monitoring
 - **[vLLM-Omni](../../features/diffusion/README.md)**: Multimodal model serving

--- a/docs/fern/backends/vllm/vllm-examples.mdx
+++ b/docs/fern/backends/vllm/vllm-examples.mdx
@@ -1130,54 +1130,6 @@ The default model is `Qwen/Qwen3-VL-2B-Instruct`.
 ### Aggregated
 
 <AccordionGroup>
-<Accordion title="LoRA Adapters with KV-Aware Routing">
-
-Runs LoRA-capable vLLM workers on Intel XPU devices behind the KV router.
-
-The script expects MinIO at `http://localhost:9000` and loads adapters from the `my-loras` bucket.
-Run `launch/lora/setup_minio.sh --start` first to start MinIO and upload the example adapter.
-
-The default model is `Qwen/Qwen3-0.6B`.
-
-**Configuration**
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `DYN_SYSTEM_PORT1` | `8081` | System and metrics port for the first worker. |
-| `DYN_SYSTEM_PORT2` | `8082` | System and metrics port for the second worker. |
-| `DYN_HTTP_PORT` | `8000` | HTTP port exposed by the Dynamo frontend. |
-
-```bash
-./launch/lora/xpu/agg_lora_router_xpu.sh
-```
-
-[View the launch script.](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/lora/xpu/agg_lora_router_xpu.sh)
-</Accordion>
-<Accordion title="Dynamic LoRA Adapter Serving">
-
-Runs one LoRA-capable vLLM worker on an Intel XPU device.
-
-The script expects MinIO at `http://localhost:9000` and loads adapters from the `my-loras` bucket.
-Run `launch/lora/setup_minio.sh --start` first to start MinIO and upload the example adapter.
-
-The default model is `Qwen/Qwen3-0.6B`.
-
-**Configuration**
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `DYN_SYSTEM_PORT1` | `8081` | System and metrics port for the first worker. |
-| `DYN_HTTP_PORT` | `8000` | HTTP port exposed by the Dynamo frontend. |
-| `MAX_MODEL_LEN` | `4096` | Maximum model context length. |
-| `MAX_CONCURRENT_SEQS` | `2` | Maximum number of sequences scheduled concurrently. |
-| `BLOCK_SIZE` | `64` | KV-cache block size; it must match the backend block size for KV routing. |
-
-```bash
-./launch/lora/xpu/agg_lora_xpu.sh
-```
-
-[View the launch script.](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/lora/xpu/agg_lora_xpu.sh)
-</Accordion>
 <Accordion title="LMCache with Multiprocess Metrics">
 
 Runs LMCache on Intel XPU while configuring the Prometheus multiprocess directory used by

--- a/docs/fern/components/CompatibilityHero.tsx
+++ b/docs/fern/components/CompatibilityHero.tsx
@@ -13,16 +13,22 @@ import { useEffect, useMemo, useState } from "react";
 
 import {
   RELEASES,
+  INTEL_RELEASES,
   MAIN_TOT,
+  INTEL_MAIN_TOT,
   CURRENT_VERSION,
   CUDA_HISTORY,
+  XPU_HISTORY,
   PLATFORM,
+  INTEL_PLATFORM,
   type BackendPins,
   type Release,
 } from "./releases.data";
 
 const VERSION_PARAM = "compat-version";
+const HARDWARE_PARAM = "compat-hardware";
 const MAIN_VALUE = "main";
+type Hardware = "nvidia" | "intel";
 
 const HERO_CSS = `
 .dynref-hero-header {
@@ -50,6 +56,56 @@ const HERO_CSS = `
     display: grid;
     gap: 5px;
     min-width: min(100%, 220px);
+}
+
+.dynref-hero-selectors {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: flex-end;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.dynref-hero-hardware {
+    display: grid;
+    gap: 5px;
+}
+
+.dynref-hero-hardware-rail {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 8px;
+}
+
+.dynref-hero-hardware-pill {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    padding: 6px 10px;
+    border: 1px solid var(--border, var(--grayscale-a5));
+    border-radius: 999px;
+    background: transparent;
+    color: var(--pst-color-text-base);
+    font: inherit;
+    font-size: 12.5px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.dynref-hero-hardware-pill:hover {
+    border-color: var(--nv-color-green, #76B900);
+}
+
+.dynref-hero-hardware-pill[aria-pressed="true"] {
+    border-color: var(--nv-color-green, #76B900);
+    box-shadow: 0 0 0 1px var(--nv-color-green, #76B900);
+    background: rgba(118, 185, 0, 0.08);
+    font-weight: 700;
+}
+
+.dynref-hero-hardware-pill:focus-visible {
+    outline: 2px solid var(--nv-color-green, #76B900);
+    outline-offset: 1px;
 }
 
 .dynref-hero-selector {
@@ -148,6 +204,8 @@ const HERO_CSS = `
 }
 
 @media (max-width: 520px) {
+    .dynref-hero-selectors { flex-wrap: wrap; width: 100%; }
+    .dynref-hero-hardware-rail { flex-wrap: wrap; }
     .dynref-hero-selector-wrap { width: 100%; }
     .dynref-hero-reqs { grid-template-columns: 1fr; gap: 4px; }
 }
@@ -181,11 +239,49 @@ function optionLabel(release: Release): string {
   return `${release.version} — ${suffix}`;
 }
 
+function HardwareSelector({
+  hardware,
+  onChange,
+}: {
+  hardware: Hardware;
+  onChange: (hardware: Hardware) => void;
+}) {
+  return (
+    <div className="dynref-hero-hardware">
+      <span className="dynref-label">Accelerator</span>
+      <div className="dynref-hero-hardware-rail" role="group" aria-label="Accelerator">
+        <button
+          className="dynref-hero-hardware-pill"
+          type="button"
+          aria-pressed={hardware === "nvidia"}
+          onClick={() => onChange("nvidia")}
+        >
+          NVIDIA GPU
+        </button>
+        <button
+          className="dynref-hero-hardware-pill"
+          type="button"
+          aria-pressed={hardware === "intel"}
+          onClick={() => onChange("intel")}
+        >
+          Intel GPU
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function CompatibilityHero() {
+  const [hardware, setHardware] = useState<Hardware>("nvidia");
   const [selectedVersion, setSelectedVersion] = useState(CURRENT_VERSION);
 
   useEffect(() => {
-    const requested = new URLSearchParams(window.location.search).get(VERSION_PARAM);
+    const params = new URLSearchParams(window.location.search);
+    const requestedHardware = params.get(HARDWARE_PARAM);
+    const requested = params.get(VERSION_PARAM);
+    if (requestedHardware === "intel" || requestedHardware === "nvidia") {
+      setHardware(requestedHardware);
+    }
     if (requested === MAIN_VALUE || RELEASES.some((release) => release.version === requested)) {
       setSelectedVersion(requested);
     }
@@ -211,6 +307,33 @@ export function CompatibilityHero() {
     window.history.replaceState({}, "", url);
   }
 
+  function selectHardware(nextHardware: Hardware) {
+    const nextVersion =
+      nextHardware === "intel" &&
+      selectedVersion !== MAIN_VALUE &&
+      !INTEL_RELEASES.some((release) => release.version === selectedVersion)
+        ? CURRENT_VERSION
+        : selectedVersion;
+    setHardware(nextHardware);
+    setSelectedVersion(nextVersion);
+    const url = new URL(window.location.href);
+    if (nextHardware === "nvidia") url.searchParams.delete(HARDWARE_PARAM);
+    else url.searchParams.set(HARDWARE_PARAM, nextHardware);
+    if (nextVersion === CURRENT_VERSION) url.searchParams.delete(VERSION_PARAM);
+    else url.searchParams.set(VERSION_PARAM, nextVersion);
+    window.history.replaceState({}, "", url);
+  }
+
+  if (hardware === "intel") {
+    return (
+      <IntelCompatibilityHero
+        selectedVersion={selectedVersion}
+        onVersionChange={selectVersion}
+        onHardwareChange={selectHardware}
+      />
+    );
+  }
+
   return (
     <>
       <style>{HERO_CSS}</style>
@@ -224,21 +347,24 @@ export function CompatibilityHero() {
             </div>
           </div>
 
-          <label className="dynref-hero-selector-wrap">
-            <span className="dynref-label">Dynamo version</span>
-            <select
-              className="dynref-hero-selector"
-              value={selectedVersion}
-              onChange={(event) => selectVersion(event.target.value)}
-            >
-              <option value={MAIN_VALUE}>main branch — development</option>
-              {RELEASES.map((release) => (
-                <option value={release.version} key={release.version}>
-                  {optionLabel(release)}
-                </option>
-              ))}
-            </select>
-          </label>
+          <div className="dynref-hero-selectors">
+            <HardwareSelector hardware={hardware} onChange={selectHardware} />
+            <label className="dynref-hero-selector-wrap">
+              <span className="dynref-label">Dynamo version</span>
+              <select
+                className="dynref-hero-selector"
+                value={selectedVersion}
+                onChange={(event) => selectVersion(event.target.value)}
+              >
+                <option value={MAIN_VALUE}>main branch — development</option>
+                {RELEASES.map((release) => (
+                  <option value={release.version} key={release.version}>
+                    {optionLabel(release)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
 
         <p className="dynref-muted dynref-hero-meta">
@@ -340,6 +466,152 @@ export function CompatibilityHero() {
         <p className="dynref-muted dynref-grid-note">
           Backend versions listed are the versions tested and supported for the selected release.
           TensorRT-LLM does not support Python 3.11.
+        </p>
+      </section>
+    </>
+  );
+}
+
+function IntelCompatibilityHero({
+  selectedVersion,
+  onVersionChange,
+  onHardwareChange,
+}: {
+  selectedVersion: string;
+  onVersionChange: (version: string) => void;
+  onHardwareChange: (hardware: Hardware) => void;
+}) {
+  const isMain = selectedVersion === MAIN_VALUE;
+  const selectedRelease = isMain
+    ? undefined
+    : INTEL_RELEASES.find((candidate) => candidate.version === selectedVersion);
+  const pins: BackendPins = isMain ? INTEL_MAIN_TOT : (selectedRelease?.pins ?? {});
+  const badge = releaseType(selectedRelease);
+  const xpuVersion = selectedVersion.replace(/^v/, "");
+
+  return (
+    <>
+      <style>{HERO_CSS}</style>
+      <section className="dynref-panel" aria-labelledby="intel-compatibility-selection-title">
+        <div className="dynref-hero-header">
+          <div>
+            <p className="dynref-eyebrow">Compatibility by version</p>
+            <div className="dynref-hero-title" id="intel-compatibility-selection-title">
+              {isMain
+                ? "Dynamo main branch"
+                : `Dynamo ${selectedRelease?.version ?? selectedVersion}`}
+              <span className={`dynref-badge dynref-badge--${badge.variant}`}>{badge.label}</span>
+            </div>
+          </div>
+
+          <div className="dynref-hero-selectors">
+            <HardwareSelector hardware="intel" onChange={onHardwareChange} />
+            <label className="dynref-hero-selector-wrap">
+              <span className="dynref-label">Dynamo version</span>
+              <select
+                className="dynref-hero-selector"
+                value={selectedVersion}
+                onChange={(event) => onVersionChange(event.target.value)}
+              >
+                <option value={MAIN_VALUE}>main branch — development</option>
+                {INTEL_RELEASES.map((candidate) => (
+                  <option value={candidate.version} key={candidate.version}>
+                    {optionLabel(candidate)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        <p className="dynref-muted dynref-hero-meta">
+          {isMain ? (
+            "Unreleased dependency pins from the tip of the main branch."
+          ) : selectedRelease ? (
+            <>
+              Released {selectedRelease.date ?? "date unavailable"}
+              {selectedRelease.github && (
+                <>
+                  {" · "}
+                  <a href={selectedRelease.github}>Release notes</a>
+                </>
+              )}
+              {selectedRelease.ucx && (
+                <>
+                  {" · "}UCX <span className="dynref-mono">{selectedRelease.ucx}</span>
+                </>
+              )}
+            </>
+          ) : (
+            "Release data unavailable."
+          )}
+        </p>
+
+        <div className="dynref-hero-backends">
+          {BACKENDS.filter((backend) => pins[backend.key]).map((backend) => {
+            const xpuRows = XPU_HISTORY.filter(
+              (row) => row.version === xpuVersion && row.backend === backend.label,
+            );
+            return (
+              <div className="dynref-hero-backend" key={backend.label}>
+                <span className="dynref-hero-backend-name">{backend.label}</span>
+                <span className="dynref-mono dynref-hero-pin">{pins[backend.key]}</span>
+                <div className="dynref-hero-dependency">
+                  <span className="dynref-label">NIXL</span>
+                  <span className="dynref-mono">{pins[backend.nixlKey] ?? "—"}</span>
+                </div>
+                {xpuRows.map((row) => (
+                  <div
+                    className="dynref-hero-cuda-row"
+                    key={`${row.version}-${row.backend}`}
+                  >
+                    <span className="dynref-chip dynref-chip--cuda">
+                      oneAPI {row.oneapi}
+                    </span>
+                    <span className="dynref-muted">
+                      Driver <span className="dynref-mono">{row.minDriver}</span>
+                    </span>
+                  </div>
+                ))}
+                {xpuRows.length === 0 && (
+                  <p className="dynref-hero-empty">
+                    oneAPI and driver requirements are published at release.
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {!isMain && (
+          <div className="dynref-hero-reqs">
+          <span className="dynref-label">GPU</span>
+          <div className="dynref-hero-req-values">
+            {INTEL_PLATFORM.gpus.map((gpu) => (
+              <span className="dynref-chip dynref-chip--gpu" key={gpu}>{gpu}</span>
+            ))}
+          </div>
+
+          <span className="dynref-label">OS</span>
+          <div className="dynref-hero-req-values">
+            {INTEL_PLATFORM.os.map((row) => (
+              <span className={`dynref-chip dynref-chip--${row.chip}`} key={`${row.name} ${row.version}`}>
+                {row.name} {row.version}
+              </span>
+            ))}
+          </div>
+
+          <span className="dynref-label">Arch</span>
+          <div className="dynref-hero-req-values">
+            {INTEL_PLATFORM.arch.map((arch) => (
+              <span className="dynref-chip dynref-chip--arch" key={arch}>{arch}</span>
+            ))}
+          </div>
+          </div>
+        )}
+
+        <p className="dynref-muted dynref-grid-note">
+          Backend versions listed are the versions tested and supported for the selected release.
         </p>
       </section>
     </>

--- a/docs/fern/components/FeatureHeatmap.tsx
+++ b/docs/fern/components/FeatureHeatmap.tsx
@@ -21,7 +21,13 @@
 
 import { Fragment } from "react";
 
-import { FEATURES, type FeatureCell } from "./releases.data";
+import {
+  FEATURES,
+  INTEL_FEATURES,
+  type Feature,
+  type FeatureCell,
+  type IntelFeature,
+} from "./releases.data";
 
 const HEAT_CSS = `
 .dynref-heat-legend {
@@ -78,6 +84,10 @@ const HEAT_CSS = `
     grid-template-columns: minmax(0, 1.6fr) repeat(3, minmax(64px, 1fr));
     gap: 6px;
     font-size: 13px;
+}
+
+.dynref-heat-grid--two {
+    grid-template-columns: minmax(0, 1.6fr) repeat(2, minmax(64px, 1fr));
 }
 
 .dynref-heat-colhead {
@@ -171,7 +181,14 @@ const BACKENDS = [
   { key: "vllm", label: "vLLM" },
 ] as const;
 
+const INTEL_BACKENDS = [
+  { key: "sglang", label: "SGLang" },
+  { key: "vllm", label: "vLLM" },
+] as const;
+
 type BackendKey = (typeof BACKENDS)[number]["key"];
+type Backend = { key: BackendKey; label: string };
+type FeatureRow = Feature | IntelFeature;
 
 const STATUS_LABEL: Record<FeatureCell["status"], string> = {
   yes: "Supported",
@@ -186,26 +203,43 @@ interface Footnote {
   note: string;
 }
 
-/** Every noted cell, numbered in row-major grid order (derived, never hardcoded). */
-const FOOTNOTES: Footnote[] = FEATURES.flatMap((feature) =>
-  BACKENDS.flatMap((backend) => {
-    const note = feature[backend.key].note;
-    return note ? [{ feature: feature.name, backend: backend.label, note }] : [];
-  }),
-);
+function featureCell(feature: FeatureRow, key: BackendKey): FeatureCell {
+  if (key === "trtllm") {
+    if (!("trtllm" in feature)) {
+      throw new Error("TensorRT-LLM cannot be rendered from an Intel feature row");
+    }
+    return feature.trtllm;
+  }
+  return feature[key];
+}
+
+function footnotes(features: readonly FeatureRow[], backends: readonly Backend[]): Footnote[] {
+  return features.flatMap((feature) =>
+    backends.flatMap((backend) => {
+      const note = featureCell(feature, backend.key).note;
+      return note ? [{ feature: feature.name, backend: backend.label, note }] : [];
+    }),
+  );
+}
 
 /** 1-based footnote number for a noted cell; undefined when the cell has no note. */
-function footnoteIndex(feature: string, backend: string): number | undefined {
-  const i = FOOTNOTES.findIndex((fn) => fn.feature === feature && fn.backend === backend);
+function footnoteIndex(
+  feature: string,
+  backend: string,
+  featureFootnotes: Footnote[],
+): number | undefined {
+  const i = featureFootnotes.findIndex(
+    (footnote) => footnote.feature === feature && footnote.backend === backend,
+  );
   return i === -1 ? undefined : i + 1;
 }
 
-function coverageScore(key: BackendKey): string {
-  const supported = FEATURES.filter((feature) => {
-    const status = feature[key].status;
+function coverageScore(key: BackendKey, features: readonly FeatureRow[]): string {
+  const supported = features.filter((feature) => {
+    const status = featureCell(feature, key).status;
     return status === "yes" || status === "caveat";
   }).length;
-  return `${supported} / ${FEATURES.length}`;
+  return `${supported} / ${features.length}`;
 }
 
 function CheckGlyph() {
@@ -272,7 +306,17 @@ function StatusCellContent({ status }: { status: FeatureCell["status"] }) {
   return <span className="dynref-heat-dash">&mdash;</span>;
 }
 
-function StatusCell({ cell, feature, backend }: { cell: FeatureCell; feature: string; backend: string }) {
+function StatusCell({
+  cell,
+  feature,
+  backend,
+  featureFootnotes,
+}: {
+  cell: FeatureCell;
+  feature: string;
+  backend: string;
+  featureFootnotes: Footnote[];
+}) {
   const classes = [
     "dynref-heat-cell",
     `dynref-heat-cell--${cell.status}`,
@@ -281,7 +325,7 @@ function StatusCell({ cell, feature, backend }: { cell: FeatureCell; feature: st
     .filter(Boolean)
     .join(" ");
   const label = `${feature} on ${backend}: ${STATUS_LABEL[cell.status]}${cell.note ? ` — ${cell.note}` : ""}`;
-  const index = cell.note ? footnoteIndex(feature, backend) : undefined;
+  const index = cell.note ? footnoteIndex(feature, backend, featureFootnotes) : undefined;
   return (
     <div className={classes} title={cell.note} role="img" aria-label={label}>
       <StatusCellContent status={cell.status} />
@@ -290,7 +334,16 @@ function StatusCell({ cell, feature, backend }: { cell: FeatureCell; feature: st
   );
 }
 
-export function FeatureHeatmap() {
+export function FeatureHeatmap({
+  accelerator = "nvidia",
+}: {
+  accelerator?: "nvidia" | "intel";
+}) {
+  const features = accelerator === "intel" ? INTEL_FEATURES : FEATURES;
+  const backends: readonly Backend[] =
+    accelerator === "intel" ? INTEL_BACKENDS : BACKENDS;
+  const featureFootnotes = footnotes(features, backends);
+
   return (
     <div className="dynref-panel">
       <style>{HEAT_CSS}</style>
@@ -315,38 +368,49 @@ export function FeatureHeatmap() {
           </span>
         </div>
       </div>
-      <div className="dynref-heat-grid">
+      <div
+        className={`dynref-heat-grid${
+          backends.length === 2 ? " dynref-heat-grid--two" : ""
+        }`}
+      >
         <div />
-        {BACKENDS.map((backend) => (
+        {backends.map((backend) => (
           <div key={backend.key} className="dynref-heat-colhead">
             {backend.label}
-            <span className="dynref-heat-score dynref-mono">{coverageScore(backend.key)}</span>
+            <span className="dynref-heat-score dynref-mono">
+              {coverageScore(backend.key, features)}
+            </span>
           </div>
         ))}
-        {FEATURES.map((feature) => (
+        {features.map((feature) => (
           <Fragment key={feature.name}>
             <div className="dynref-heat-feature">{feature.name}</div>
-            {BACKENDS.map((backend) => (
+            {backends.map((backend) => (
               <StatusCell
                 key={backend.key}
-                cell={feature[backend.key]}
+                cell={featureCell(feature, backend.key)}
                 feature={feature.name}
                 backend={backend.label}
+                featureFootnotes={featureFootnotes}
               />
             ))}
           </Fragment>
         ))}
       </div>
-      {FOOTNOTES.length > 0 && (
+      {featureFootnotes.length > 0 && (
         <ol className="dynref-heat-footnotes">
-          {FOOTNOTES.map((fn) => (
+          {featureFootnotes.map((fn) => (
             <li key={`${fn.feature}-${fn.backend}`}>
               {fn.feature} &middot; {fn.backend}: {fn.note}
             </li>
           ))}
         </ol>
       )}
-      <p className="dynref-grid-note">Superscripts reference the numbered notes above; full per-backend detail follows.</p>
+      <p className="dynref-grid-note">
+        {accelerator === "nvidia"
+          ? "Superscripts reference the numbered notes above; full per-backend detail follows."
+          : "Superscripts reference the numbered notes above. Experimental marks a known implementation limitation or incomplete code path."}
+      </p>
     </div>
   );
 }

--- a/docs/fern/components/ReferenceStyles.tsx
+++ b/docs/fern/components/ReferenceStyles.tsx
@@ -275,6 +275,10 @@ const REFERENCE_CSS = `
     border-color: var(--dynref-amber-border);
 }
 
+.dynref-badge--bang::before {
+    content: "\\21";
+}
+
 
 .dynref-badge--gray {
     background: rgba(120, 120, 120, 0.1);

--- a/docs/fern/components/RunsWhereWizard.tsx
+++ b/docs/fern/components/RunsWhereWizard.tsx
@@ -24,7 +24,15 @@
  * Only the .dynref-ww-* layout classes are defined here.
  */
 
-import { ARTIFACTS, CUDA_HISTORY, CURRENT_TAG, RELEASES, type CudaRow } from "./releases.data";
+import {
+  ARTIFACTS,
+  CUDA_HISTORY,
+  CURRENT_TAG,
+  INTEL_RELEASES,
+  RELEASES,
+  XPU_HISTORY,
+  type CudaRow,
+} from "./releases.data";
 
 interface BackendOption {
   id: string;
@@ -39,10 +47,28 @@ const BACKENDS: BackendOption[] = [
   { id: "vllm", label: "vLLM", backend: "vLLM", runtime: "vllm-runtime" },
 ];
 
+const INTEL_BACKENDS = BACKENDS.filter((backend) =>
+  XPU_HISTORY.some((row) => row.backend === backend.backend),
+);
+
 interface CudaOption {
   major: string;
   /** Driver floor for the major's current toolkits, e.g. "580.xx+". */
   floor: string;
+}
+
+interface XpuOption {
+  id: string;
+  oneapi: string;
+}
+
+function xpuOptions(): XpuOption[] {
+  const options = new Map<string, XpuOption>();
+  for (const row of XPU_HISTORY) {
+    const id = row.oneapi.replaceAll(".", "-");
+    options.set(id, { id, oneapi: row.oneapi });
+  }
+  return [...options.values()].sort((a, b) => b.oneapi.localeCompare(a.oneapi));
 }
 
 /** Distinct CUDA toolkit majors in the history, newest first, each with the
@@ -71,6 +97,16 @@ interface WizardRow {
   isCurrent: boolean;
   /** Full image reference to copy — current release only. */
   pull?: string;
+}
+
+interface XpuWizardRow {
+  backendId: string;
+  optionId: string;
+  version: string;
+  href: string;
+  oneapi: string;
+  minDriver: string;
+  isCurrent: boolean;
 }
 
 function pullCommandFor(runtime: string): string | undefined {
@@ -106,6 +142,31 @@ function rowsFor(backend: BackendOption, major: string): WizardRow[] {
   return rows;
 }
 
+function rowsForXpu(backend: BackendOption, option: XpuOption): XpuWizardRow[] {
+  const rows: XpuWizardRow[] = [];
+  for (const release of INTEL_RELEASES) {
+    if (release.kind !== "stable" && release.kind !== "patch") continue;
+    const bare = release.version.replace(/^v/, "");
+    const matches = XPU_HISTORY.filter(
+      (row) =>
+        row.version === bare &&
+        row.backend === backend.backend &&
+        row.oneapi === option.oneapi,
+    );
+    if (matches.length === 0) continue;
+    rows.push({
+      backendId: backend.id,
+      optionId: option.id,
+      version: release.version,
+      href: release.notesHref ?? release.github ?? "https://github.com/ai-dynamo/dynamo/releases",
+      oneapi: matches[0].oneapi,
+      minDriver: matches[0].minDriver,
+      isCurrent: bare === CURRENT_TAG,
+    });
+  }
+  return rows;
+}
+
 const WW_CSS = `
 /* Inputs are hidden by the shared .dynref-vh (visually hidden, focusable)
    class so the rails stay keyboard-operable; focus rules are generated in
@@ -122,6 +183,10 @@ const WW_CSS = `
     display: flex;
     flex-direction: column;
     gap: 6px;
+}
+
+.dynref-ww-accelerator {
+    flex-basis: 100%;
 }
 
 .dynref-ww-rail {
@@ -230,10 +295,34 @@ const WW_CSS = `
  *  keyboard focus ring per input, plus the two independent hide rules whose
  *  intersection leaves only rows matching both the checked backend and the
  *  checked CUDA major. */
-function filterCss(cuda: CudaOption[]): string {
+function filterCss(cuda: CudaOption[], xpu: XpuOption[]): string {
   const inputs = [
-    ...BACKENDS.map((b) => ({ id: `ww-b-${b.id}`, attr: "data-backend", value: b.id })),
-    ...cuda.map((c) => ({ id: `ww-c-${c.major}`, attr: "data-cuda", value: c.major })),
+    { id: "ww-h-nvidia", hardware: undefined, attr: "data-hardware", value: "nvidia" },
+    { id: "ww-h-intel", hardware: undefined, attr: "data-hardware", value: "intel" },
+    ...BACKENDS.map((b) => ({
+      id: `ww-nb-${b.id}`,
+      hardware: "nvidia",
+      attr: "data-backend",
+      value: b.id,
+    })),
+    ...cuda.map((c) => ({
+      id: `ww-nc-${c.major}`,
+      hardware: "nvidia",
+      attr: "data-driver",
+      value: c.major,
+    })),
+    ...INTEL_BACKENDS.map((b) => ({
+      id: `ww-ib-${b.id}`,
+      hardware: "intel",
+      attr: "data-backend",
+      value: b.id,
+    })),
+    ...xpu.map((option) => ({
+      id: `ww-ix-${option.id}`,
+      hardware: "intel",
+      attr: "data-driver",
+      value: option.id,
+    })),
   ];
   const pillRules = inputs
     .map((i) => `#${i.id}:checked ~ .dynref-ww-rails label[for="${i.id}"]`)
@@ -242,10 +331,15 @@ function filterCss(cuda: CudaOption[]): string {
     .map((i) => `#${i.id}:focus-visible ~ .dynref-ww-rails label[for="${i.id}"]`)
     .join(",\n");
   const hideRules = inputs
-    .map(
-      (i) =>
-        `#${i.id}:checked ~ .dynref-ww-list [${i.attr}]:not([${i.attr}="${i.value}"]) { display: none; }`,
-    )
+    .map((i) => {
+      if (i.attr === "data-hardware") {
+        return [
+          `#${i.id}:checked ~ .dynref-ww-rails [data-hardware]:not([data-hardware="${i.value}"]) { display: none; }`,
+          `#${i.id}:checked ~ .dynref-ww-list [data-hardware]:not([data-hardware="${i.value}"]) { display: none; }`,
+        ].join("\n");
+      }
+      return `#${i.id}:checked ~ .dynref-ww-list [data-hardware="${i.hardware}"][${i.attr}]:not([${i.attr}="${i.value}"]) { display: none; }`;
+    })
     .join("\n");
   return `
 ${pillRules} {
@@ -264,7 +358,12 @@ ${hideRules}
 
 function WizardDataRow({ row, backendLabel }: { row: WizardRow; backendLabel: string }) {
   return (
-    <div className="dynref-ww-row" data-backend={row.backendId} data-cuda={row.major}>
+    <div
+      className="dynref-ww-row"
+      data-hardware="nvidia"
+      data-backend={row.backendId}
+      data-driver={row.major}
+    >
       <span className="dynref-ww-version">
         <a className="dynref-mono dynref-ww-link" href={row.href}>
           {row.version}
@@ -304,13 +403,45 @@ function WizardDataRow({ row, backendLabel }: { row: WizardRow; backendLabel: st
   );
 }
 
+function XpuWizardDataRow({ row }: { row: XpuWizardRow }) {
+  return (
+    <div
+      className="dynref-ww-row"
+      data-hardware="intel"
+      data-backend={row.backendId}
+      data-driver={row.optionId}
+    >
+      <span className="dynref-ww-version">
+        <a className="dynref-mono dynref-ww-link" href={row.href}>
+          {row.version}
+        </a>
+      </span>
+      <span>
+        <span className="dynref-chip dynref-chip--cuda">oneAPI {row.oneapi}</span>
+      </span>
+      <span className="dynref-ww-driver">
+        driver <span className="dynref-mono">{row.minDriver}</span>
+      </span>
+      <span className="dynref-ww-pullslot">
+        {row.isCurrent && <span className="dynref-badge dynref-badge--green">Current</span>}
+      </span>
+    </div>
+  );
+}
+
 export function RunsWhereWizard() {
   const cuda = cudaOptions();
+  const xpu = xpuOptions();
   const defaultBackend = BACKENDS[0];
+  const defaultIntelBackend = INTEL_BACKENDS[0];
   const defaultCuda = cuda[0];
+  const defaultXpu = xpu[0];
 
   const combos = BACKENDS.flatMap((backend) =>
     cuda.map((option) => ({ backend, option, rows: rowsFor(backend, option.major) })),
+  );
+  const xpuCombos = INTEL_BACKENDS.flatMap((backend) =>
+    xpu.map((option) => ({ backend, option, rows: rowsForXpu(backend, option) })),
   );
 
   /* CUDA majors (newest first, cudaOptions order) that DO have qualifying
@@ -327,15 +458,28 @@ export function RunsWhereWizard() {
 
   return (
     <>
-      <style>{WW_CSS + filterCss(cuda)}</style>
+      <style>{WW_CSS + filterCss(cuda, xpu)}</style>
       <section className="dynref-panel">
+        <input
+          className="dynref-ww-filter dynref-vh"
+          type="radio"
+          id="ww-h-nvidia"
+          name="dynref-ww-hardware"
+          defaultChecked
+        />
+        <input
+          className="dynref-ww-filter dynref-vh"
+          type="radio"
+          id="ww-h-intel"
+          name="dynref-ww-hardware"
+        />
         {BACKENDS.map((backend) => (
           <input
             key={backend.id}
             className="dynref-ww-filter dynref-vh"
             type="radio"
-            id={`ww-b-${backend.id}`}
-            name="dynref-ww-backend"
+            id={`ww-nb-${backend.id}`}
+            name="dynref-ww-backend-nvidia"
             defaultChecked={backend.id === defaultBackend.id}
           />
         ))}
@@ -344,9 +488,29 @@ export function RunsWhereWizard() {
             key={option.major}
             className="dynref-ww-filter dynref-vh"
             type="radio"
-            id={`ww-c-${option.major}`}
-            name="dynref-ww-cuda"
+            id={`ww-nc-${option.major}`}
+            name="dynref-ww-driver-nvidia"
             defaultChecked={option.major === defaultCuda.major}
+          />
+        ))}
+        {INTEL_BACKENDS.map((backend) => (
+          <input
+            key={backend.id}
+            className="dynref-ww-filter dynref-vh"
+            type="radio"
+            id={`ww-ib-${backend.id}`}
+            name="dynref-ww-backend-intel"
+            defaultChecked={backend.id === defaultIntelBackend.id}
+          />
+        ))}
+        {xpu.map((option) => (
+          <input
+            key={option.id}
+            className="dynref-ww-filter dynref-vh"
+            type="radio"
+            id={`ww-ix-${option.id}`}
+            name="dynref-ww-driver-intel"
+            defaultChecked={option.id === defaultXpu.id}
           />
         ))}
 
@@ -358,22 +522,49 @@ export function RunsWhereWizard() {
         </div>
 
         <div className="dynref-ww-rails">
-          <div className="dynref-ww-group">
+          <div className="dynref-ww-group dynref-ww-accelerator">
+            <span className="dynref-label">Accelerator</span>
+            <div className="dynref-ww-rail">
+              <label className="dynref-ww-pill" htmlFor="ww-h-nvidia">NVIDIA GPU</label>
+              <label className="dynref-ww-pill" htmlFor="ww-h-intel">Intel GPU</label>
+            </div>
+          </div>
+          <div className="dynref-ww-group" data-hardware="nvidia">
             <span className="dynref-label">Backend</span>
             <div className="dynref-ww-rail">
               {BACKENDS.map((backend) => (
-                <label key={backend.id} className="dynref-ww-pill" htmlFor={`ww-b-${backend.id}`}>
+                <label key={backend.id} className="dynref-ww-pill" htmlFor={`ww-nb-${backend.id}`}>
                   {backend.label}
                 </label>
               ))}
             </div>
           </div>
-          <div className="dynref-ww-group">
+          <div className="dynref-ww-group" data-hardware="nvidia">
             <span className="dynref-label">CUDA driver situation</span>
             <div className="dynref-ww-rail">
               {cuda.map((option) => (
-                <label key={option.major} className="dynref-ww-pill" htmlFor={`ww-c-${option.major}`}>
+                <label key={option.major} className="dynref-ww-pill" htmlFor={`ww-nc-${option.major}`}>
                   CUDA {option.major} driver ({option.floor})
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="dynref-ww-group" data-hardware="intel">
+            <span className="dynref-label">Backend</span>
+            <div className="dynref-ww-rail">
+              {INTEL_BACKENDS.map((backend) => (
+                <label key={backend.id} className="dynref-ww-pill" htmlFor={`ww-ib-${backend.id}`}>
+                  {backend.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <div className="dynref-ww-group" data-hardware="intel">
+            <span className="dynref-label">oneAPI situation</span>
+            <div className="dynref-ww-rail">
+              {xpu.map((option) => (
+                <label key={option.id} className="dynref-ww-pill" htmlFor={`ww-ix-${option.id}`}>
+                  oneAPI {option.oneapi}
                 </label>
               ))}
             </div>
@@ -394,8 +585,9 @@ export function RunsWhereWizard() {
               <div
                 key={`${backend.id}-${option.major}-empty`}
                 className="dynref-ww-empty"
+                data-hardware="nvidia"
                 data-backend={backend.id}
-                data-cuda={option.major}
+                data-driver={option.major}
               >
                 No release ships {backend.label} for a CUDA {option.major} driver.
                 {(shippedMajors.get(backend.id) ?? []).length > 0 && (
@@ -409,11 +601,31 @@ export function RunsWhereWizard() {
               </div>
             ),
           )}
+          {xpuCombos.map(({ backend, option, rows }) =>
+            rows.length > 0 ? (
+              rows.map((row) => (
+                <XpuWizardDataRow
+                  key={`${backend.id}-${option.id}-${row.version}`}
+                  row={row}
+                />
+              ))
+            ) : (
+              <div
+                key={`${backend.id}-${option.id}-empty`}
+                className="dynref-ww-empty"
+                data-hardware="intel"
+                data-backend={backend.id}
+                data-driver={option.id}
+              >
+                No release ships {backend.label} for oneAPI {option.oneapi}.
+              </div>
+            ),
+          )}
         </div>
 
         <p className="dynref-grid-note">
-          Driver floors from the CUDA & driver history; pull commands shown for the current release
-          only.
+          Driver floors come from the CUDA and XPU histories; pull commands are shown for published
+          current-release images only.
         </p>
       </section>
     </>

--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -1017,3 +1017,145 @@ export const RELEASE_STATS: Record<string, ReleaseStats> = {
 
 export const NIGHTLIES_NOTE =
   "ai-dynamo and ai-dynamo-runtime nightly builds from main publish wheels tagged *.devYYYYMMDD (since Apr 24, 2026). Install with pip or uv using --pre and the NVIDIA extra-index pattern shown above.";
+
+export const INTEL_MAIN_TOT: BackendPins = {
+  sglang: "0.5.11",
+  vllm: "0.24.0",
+  nixlSglang: "1.1.0",
+  nixlVllm: "1.1.0",
+};
+
+export const INTEL_RELEASES: Release[] = [
+  {
+    version: "v1.3.0",
+    notesHref: "/dynamo/dev/reference/releases/v1-3-0",
+    date: "Jul 20, 2026",
+    kind: "stable",
+    github: `${GH}v1.3.0`,
+    pins: {
+      sglang: "0.5.11",
+      vllm: "0.24.0",
+      nixlSglang: "1.1.0",
+      nixlVllm: "1.1.0",
+    },
+    ucx: "1.20.x",
+  },
+];
+
+export interface XpuRow {
+  version: string;
+  backend: "SGLang" | "vLLM";
+  oneapi: string;
+  minDriver: string;
+}
+
+export const XPU_HISTORY: XpuRow[] = [
+  {
+    version: "1.3.0",
+    backend: "SGLang",
+    oneapi: "2025.3",
+    minDriver: "25.48.36300.8",
+  },
+  {
+    version: "1.3.0",
+    backend: "vLLM",
+    oneapi: "2025.3",
+    minDriver: "26.18.38308.1",
+  },
+];
+
+export interface IntelFeature {
+  name: string;
+  sglang: FeatureCell;
+  vllm: FeatureCell;
+}
+
+export const INTEL_FEATURES: IntelFeature[] = [
+  {
+    name: "Disaggregated Serving",
+    sglang: { status: "yes" },
+    vllm: {
+      status: "yes",
+      note: "Prefill/decode separation with NIXL over UCX",
+    },
+  },
+  {
+    name: "KV-Aware Routing",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "SLA-Based Planner",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "KV Block Manager",
+    sglang: { status: "no" },
+    vllm: { status: "no" },
+  },
+  {
+    name: "Multimodal (Image)",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "Multimodal (Video)",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "Multimodal (Audio)",
+    sglang: { status: "no" },
+    vllm: { status: "no" },
+  },
+  {
+    name: "Request Migration",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "Request Cancellation",
+    sglang: {
+      status: "wip",
+      note: "Remote-prefill-phase cancellation is not supported in disaggregated mode",
+    },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "LoRA",
+    sglang: { status: "yes" },
+    vllm: { status: "no" },
+  },
+  {
+    name: "Tool Calling",
+    sglang: { status: "yes" },
+    vllm: { status: "yes" },
+  },
+  {
+    name: "Speculative Decoding",
+    sglang: {
+      status: "wip",
+      note: "Only runtime metadata hooks are implemented",
+    },
+    vllm: {
+      status: "yes",
+      note: "The vLLM XPU build includes N-gram speculative decoding support",
+    },
+  },
+  {
+    name: "Dynamo Snapshot",
+    sglang: { status: "no" },
+    vllm: { status: "no" },
+  },
+];
+
+export const INTEL_PLATFORM = {
+  gpus: ["Arc Pro", "Data Center GPU Max Series"],
+  os: [
+    { name: "Ubuntu", version: "24.04", arch: "x86_64", status: "Supported", chip: "ubuntu" },
+  ],
+  arch: ["x86_64"],
+  wheelsNote: "Intel XPU runtime images are built from source.",
+  csp: [],
+};

--- a/docs/fern/features/diffusion/README.md
+++ b/docs/fern/features/diffusion/README.md
@@ -55,6 +55,8 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
       <Card title="vLLM-Omni">
         <Badge intent="info" minimal>Broadest modality coverage</Badge>
 
+        **Accelerators:** NVIDIA GPU and Intel GPU.
+
         **Best for:** Mixed media workloads, text-to-audio, or disaggregated multi-stage serving.
 
         **Supports:** Text-to-image, text-to-video, image-to-video, and text-to-audio.
@@ -63,6 +65,8 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
       </Card>
       <Card title="SGLang">
         <Badge intent="info" minimal>LLM diffusion</Badge>
+
+        **Accelerator:** NVIDIA GPU.
 
         **Best for:** Diffusion alongside an existing SGLang deployment or text-to-text diffusion models.
 
@@ -73,6 +77,8 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
       <Card title="TensorRT-LLM">
         <Badge intent="warning" minimal>Experimental</Badge>
 
+        **Accelerator:** NVIDIA GPU.
+
         **Best for:** NVIDIA-optimized image and video generation when experimental status is acceptable.
 
         **Supports:** Text-to-image and text-to-video.
@@ -81,6 +87,8 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
       </Card>
       <Card title="FastVideo">
         <Badge intent="success" minimal>Kubernetes</Badge>
+
+        **Accelerator:** NVIDIA GPU.
 
         **Best for:** Fast, production-oriented text-to-video generation on Kubernetes.
 
@@ -101,6 +109,7 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
         **Prerequisites**
 
         - A working [vLLM backend setup](../../backends/vllm/README.md).
+        - A supported NVIDIA GPU or Intel GPU vLLM runtime.
         - An `amd64` host. Dynamo container builds do not install vLLM-Omni on `arm64`.
 
         Dynamo container images include vLLM-Omni. A PyPI installation of `ai-dynamo[vllm]` does not include it automatically. For a source installation, pin the vLLM-Omni release that matches your vLLM version:
@@ -128,6 +137,7 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
         **Prerequisites**
 
         - A working [SGLang backend setup](../../backends/sglang/README.md).
+        - An NVIDIA GPU runtime.
 
         No separate installation is required. Select the worker mode for your workload:
 
@@ -202,6 +212,9 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
 
 ## Support Matrix
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 | Workflow | vLLM-Omni | SGLang | TensorRT-LLM | FastVideo |
 |----------|-----------|--------|--------------|-----------|
 | Text-to-Image | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="warning" minimal>Experimental</Badge> | — |
@@ -209,3 +222,17 @@ The built-in backends expose OpenAI-compatible endpoints for images (`/v1/images
 | Image-to-Video | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="success" minimal>Yes</Badge> | — | — |
 | Text-to-Audio | <Badge intent="success" minimal>Yes</Badge> | — | — | — |
 | Text-to-Text | — | <Badge intent="success" minimal>Yes</Badge> | — | — |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Workflow | vLLM-Omni | SGLang | TensorRT-LLM | FastVideo |
+|----------|-----------|--------|--------------|-----------|
+| Text-to-Image | <Badge intent="success" minimal>Yes</Badge> | — | — | — |
+| Text-to-Video | <Badge intent="success" minimal>Yes</Badge> | — | — | — |
+| Image-to-Video | <Badge intent="success" minimal>Yes</Badge> | — | — | — |
+| Text-to-Audio | — | — | — | — |
+| Text-to-Text | — | — | — | — |
+
+</Tab>
+</Tabs>

--- a/docs/fern/features/multimodal/custom-vision-encoder.md
+++ b/docs/fern/features/multimodal/custom-vision-encoder.md
@@ -28,6 +28,9 @@ process and GPU, and no embedding transfer occurs.
 | Cross-request batching | Yes |
 | CUDA graph bucket selection | Reserved for future support; current dispatch is eager |
 
+> [!IMPORTANT]
+> The custom encoder contract lets an implementation choose its compute device, but the included `agg_custom.sh` launcher and example backend are currently wired for NVIDIA GPU through `CUDA_VISIBLE_DEVICES`. An Intel XPU custom-encoder launcher is not available.
+
 The custom-encoder path requires `--enable-multimodal` and
 `--enable-prompt-embeds`. It is incompatible with frontend decoding, the vLLM
 tokenizer mode, legacy multimodal worker roles, and non-aggregated disaggregation

--- a/docs/fern/features/multimodal/embedding-cache.md
+++ b/docs/fern/features/multimodal/embedding-cache.md
@@ -27,6 +27,9 @@ If your workload consists entirely of unique multimodal content, the cache provi
 ## Configuration
 
 <Tabs>
+<Tab title="NVIDIA GPU">
+
+<Tabs>
   <Tab title="vLLM" language="vllm">
     Launch a disaggregated multimodal deployment with the embedding cache enabled:
 
@@ -57,6 +60,21 @@ If your workload consists entirely of unique multimodal content, the cache provi
   </Tab>
 </Tabs>
 
+</Tab>
+<Tab title="Intel GPU">
+
+Use the vLLM aggregated cache connector. The connector detects the XPU device and moves cached embeddings between XPU memory and its CPU-side LRU store:
+
+```bash
+cd $DYNAMO_HOME
+bash examples/backends/vllm/launch/xpu/agg_multimodal_xpu.sh \
+  --model Qwen/Qwen3-VL-2B-Instruct \
+  --multimodal-embedding-cache-capacity-gb 10
+```
+
+</Tab>
+</Tabs>
+
 Set `--multimodal-embedding-cache-capacity-gb` based on your expected working set of unique multimodal content. A larger cache holds more embeddings but consumes more host memory.
 
 See the backend-specific documentation ([vLLM](multimodal-vllm.md#embedding-cache), [TRT-LLM](multimodal-trtllm.md#embedding-cache)) for more details.
@@ -79,10 +97,25 @@ flowchart LR
 
 ## Support Matrix
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 | Backend | Aggregated | Disaggregated (E/PD) | Notes |
 |---------|------------|----------------------|-------|
 | **vLLM** | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="success" minimal>Yes</Badge> | Aggregated uses vLLM-native `ec_both`; disaggregated uses Dynamo `EmbeddingCacheManager` |
 | **TensorRT-LLM** | — | <Badge intent="success" minimal>Yes</Badge> | Dynamo `MultimodalEmbeddingCacheManager` in PD worker |
 | **SGLang** | — | <Badge intent="success" minimal>Yes</Badge> | Dynamo `MultimodalEmbeddingCacheManager` in the encode worker |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Backend | Aggregated | Disaggregated |
+|---------|------------|---------------|
+| **vLLM** | <Badge intent="success" minimal>Yes</Badge> | — |
+| **SGLang** | — | — |
+| **TensorRT-LLM** | — | — |
+
+</Tab>
+</Tabs>
 
 This support requires vLLM `0.17.0` or newer.

--- a/docs/fern/features/multimodal/encoder-disaggregation.md
+++ b/docs/fern/features/multimodal/encoder-disaggregation.md
@@ -47,6 +47,9 @@ For simple deployments or development/testing, the aggregated (EPD) pattern is e
 ## Launching
 
 <Tabs>
+<Tab title="NVIDIA GPU">
+
+<Tabs>
   <Tab title="vLLM" language="vllm">
     ```bash
     cd $DYNAMO_HOME/examples/backends/vllm
@@ -82,12 +85,42 @@ For simple deployments or development/testing, the aggregated (EPD) pattern is e
   </Tab>
 </Tabs>
 
+</Tab>
+<Tab title="Intel GPU">
+
+The vLLM XPU E/P/D launcher selects `ZE_AFFINITY_MASK` and configures vLLM's NIXL connector for XPU buffers:
+
+```bash
+cd $DYNAMO_HOME/examples/backends/vllm
+DEVICE_PLATFORM=xpu VLLM_TARGET_DEVICE=xpu \
+  bash launch/xpu/disagg_multimodal_epd_xpu.sh \
+  --model Qwen/Qwen3-VL-2B-Instruct
+```
+
+</Tab>
+</Tabs>
+
 See the backend-specific documentation ([vLLM](multimodal-vllm.md), [TRT-LLM](multimodal-trtllm.md), [SGLang](multimodal-sglang.md)) for full configuration details and component flags.
 
 ## Support Matrix
+
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 | Backend | E/PD | E/P/D | Notes |
 |---------|------|-------|-------|
 | **vLLM** | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="success" minimal>Yes</Badge> | Separate encode worker currently handles `image_url` inputs; `video_url` inputs stay on the prefill/PD path |
 | **TensorRT-LLM** | — | <Badge intent="success" minimal>Yes</Badge> | Supports image URLs (via `MultimodalEncoder`) and pre-computed embeddings (via NIXL) |
 | **SGLang** | <Badge intent="success" minimal>Yes</Badge> | <Badge intent="success" minimal>Yes</Badge> | NIXL for embeddings; bootstrap mechanism for P/D KV transfer |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Backend | E/PD | E/P/D |
+|---------|------|-------|
+| **vLLM** | — | <Badge intent="success" minimal>Yes</Badge> |
+| **SGLang** | — | — |
+| **TensorRT-LLM** | — | — |
+
+</Tab>
+</Tabs>

--- a/docs/fern/features/multimodal/multimodal-kv-routing.md
+++ b/docs/fern/features/multimodal/multimodal-kv-routing.md
@@ -59,6 +59,9 @@ The routing flow in general has three steps:
 ## Launch
 
 <Tabs>
+<Tab title="NVIDIA GPU">
+
+<Tabs>
   <Tab title="vLLM" language="vllm">
     Use the Python chat processor when you need vLLM's model-native multimodal processor or want to transfer processed multimodal inputs from the frontend. Otherwise, use the default Rust frontend.
 
@@ -100,7 +103,33 @@ The routing flow in general has three steps:
   </Tab>
 </Tabs>
 
+</Tab>
+<Tab title="Intel GPU">
+
+<Tabs>
+  <Tab title="vLLM — Rust frontend">
+    ```bash
+    cd $DYNAMO_HOME
+    ZE_AFFINITY_MASK=0,1 \
+      bash examples/backends/vllm/launch/xpu/agg_multimodal_router_xpu.sh
+    ```
+  </Tab>
+  <Tab title="vLLM — Python chat processor">
+    ```bash
+    cd $DYNAMO_HOME
+    ZE_AFFINITY_MASK=0,1 \
+      bash examples/backends/vllm/launch/xpu/agg_multimodal_router_chat_processor_xpu.sh
+    ```
+  </Tab>
+</Tabs>
+
+</Tab>
+</Tabs>
+
 ## Support Matrix
+
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 | Backend | Routing Path | Status | Notes |
 |---------|--------------|--------|-------|
@@ -108,3 +137,16 @@ The routing flow in general has three steps:
 | [vLLM](multimodal-vllm.md#multimodal-kv-routing) | Python chat processor | <Badge intent="success" minimal>Yes</Badge> | Uses vLLM’s own multimodal processor — supports any VLM that vLLM supports. |
 | [SGLang](multimodal-sglang.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Dynamo's SGLang image includes hash-forwarding support; custom installations must add it. |
 | [TensorRT-LLM](multimodal-trtllm.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Supported model scope is the Qwen2-VL family (Qwen2-VL / Qwen2.5-VL / Qwen3-VL) and Kimi (Kimi-K2.5 / Kimi-K2.6). Other multimodal models fall back to text-prefix routing. |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Backend | Routing Path | Status |
+|---------|--------------|--------|
+| [vLLM](multimodal-vllm.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> |
+| [vLLM](multimodal-vllm.md#multimodal-kv-routing) | Python chat processor | <Badge intent="success" minimal>Yes</Badge> |
+| SGLang | — | — |
+| TensorRT-LLM | — | — |
+
+</Tab>
+</Tabs>

--- a/docs/fern/features/multimodal/multimodal-sglang.md
+++ b/docs/fern/features/multimodal/multimodal-sglang.md
@@ -6,6 +6,9 @@ title: SGLang Multimodal
 
 This document provides a comprehensive guide for multimodal inference using SGLang backend in Dynamo. SGLang multimodal supports native **EPD** and **EP/D** flows where the SGLang engine performs media encoding, plus explicit encode-worker **E/PD** and **E/P/D** flows with NIXL (RDMA) for zero-copy tensor transfer.
 
+> [!IMPORTANT]
+> The Dynamo SGLang multimodal path currently supports NVIDIA GPU only. Its encode and worker handlers use CuPy and CUDA device APIs, and the provided launchers assign workers with `CUDA_VISIBLE_DEVICES`.
+
 ## Support Matrix
 
 | Modality | Input Format | Aggregated | Disaggregated | Notes |

--- a/docs/fern/features/multimodal/multimodal-trtllm.md
+++ b/docs/fern/features/multimodal/multimodal-trtllm.md
@@ -6,6 +6,9 @@ title: TensorRT-LLM Multimodal
 
 This document provides a comprehensive guide for multimodal inference using TensorRT-LLM backend in Dynamo.
 
+> [!IMPORTANT]
+> TensorRT-LLM multimodal serving requires an NVIDIA GPU. Intel GPU deployments should use the supported vLLM XPU paths described in [vLLM Multimodal](multimodal-vllm.md).
+
 You can provide multimodal inputs in the following ways:
 - By sending image URLs
 - By providing paths to pre-computed embedding files

--- a/docs/fern/features/multimodal/multimodal-vllm.md
+++ b/docs/fern/features/multimodal/multimodal-vllm.md
@@ -17,11 +17,26 @@ This document provides a comprehensive guide for multimodal inference using the 
 
 ## Support Matrix
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 | Modality | Aggregated | P/D | Separate encode worker |
 | --- | --- | --- | --- |
 | **Image** | Yes | Yes | Legacy entry point only |
 | **Video** | Yes | Yes | Processed by the language-model worker |
 | **Audio** | Yes | Yes, with decode reload | Not routed to the separate encoder |
+
+</Tab>
+<Tab title="Intel GPU">
+
+| Modality | Aggregated | P/D | Separate encode worker |
+| --- | --- | --- | --- |
+| **Image** | Yes | E/P/D only | E/P/D |
+| **Video** | Yes | — | — |
+| **Audio** | Experimental | — | — |
+
+</Tab>
+</Tabs>
 
 ### Supported URL Formats
 
@@ -41,6 +56,7 @@ The main multimodal vLLM launchers in this repo are:
 | P/D | CUDA | `disagg_multimodal_p_d.sh` | `--unified` | Prefill/decode separation without a dedicated encoder |
 | E/PD (Encode + PD) | CUDA | `disagg_multimodal_e_pd.sh` | No | Separate encoder and embedding-cache workflows |
 | E/P/D (Full Disaggregation) | CUDA | `disagg_multimodal_epd.sh` | No | Separate encode, prefill, and decode workers |
+| E/P/D (Full Disaggregation) | XPU | `xpu/disagg_multimodal_epd_xpu.sh` | No | Separate encode, prefill, and decode workers |
 
 ### Custom Vision Encoders
 
@@ -80,12 +96,27 @@ The default path keeps multimodal processing on the worker:
 
 For `data:` URIs, the frontend hashes the decoded bytes. For HTTP URLs, it hashes the full URL by default. Set `--frontend-decoding` on the worker to register frontend media decoding and use decoded image content as the hash input. Content-addressed hashing lets different URLs for identical image bytes share a routing key.
 
-Launch the default path:
+Launch the default path for your accelerator:
+
+<Tabs>
+<Tab title="NVIDIA GPU">
 
 ```bash
 cd $DYNAMO_HOME
 bash examples/backends/vllm/launch/agg_multimodal_router.sh
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+cd $DYNAMO_HOME
+ZE_AFFINITY_MASK=0,1 \
+  bash examples/backends/vllm/launch/xpu/agg_multimodal_router_xpu.sh
+```
+
+</Tab>
+</Tabs>
 
 Key settings:
 
@@ -101,10 +132,25 @@ Key settings:
 
 Use the Python path when the model is supported by vLLM but not by the Rust model registry, or when the frontend should preprocess images:
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 cd $DYNAMO_HOME
 bash examples/backends/vllm/launch/agg_multimodal_router_chat_processor.sh
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+cd $DYNAMO_HOME
+ZE_AFFINITY_MASK=0,1 \
+  bash examples/backends/vllm/launch/xpu/agg_multimodal_router_chat_processor_xpu.sh
+```
+
+</Tab>
+</Tabs>
 
 This launcher sets `--dyn-chat-processor vllm`. The frontend runs vLLM's Hugging Face processor, extracts hashes and expanded multimodal inputs, builds routing metadata, and transfers processed `mm_kwargs` to the selected worker. This path supports any VLM handled by vLLM's multimodal processor.
 
@@ -126,18 +172,31 @@ Dynamo supports multimodal image and video requests for Vision Language Models (
 
 Use the single-worker aggregated launcher for the simplest image/video setup:
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm
 
-# GPU deployment
 bash launch/agg_multimodal.sh --model Qwen/Qwen3-VL-2B-Instruct
 
 # Unified backend
 bash launch/agg_multimodal.sh --unified --model Qwen/Qwen3-VL-2B-Instruct
-
-# XPU deployment
-bash launch/xpu/agg_multimodal_xpu.sh --model Qwen/Qwen3-VL-2B-Instruct
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+cd $DYNAMO_HOME/examples/backends/vllm
+
+ZE_AFFINITY_MASK=0 \
+  bash launch/xpu/agg_multimodal_xpu.sh \
+  --model Qwen/Qwen3-VL-2B-Instruct
+```
+
+</Tab>
+</Tabs>
 
 **Image request:**
 
@@ -213,11 +272,28 @@ worker.
 For an aggregated worker, enable Dynamo's CPU embedding cache alongside the
 vLLM processor cache:
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 bash launch/agg_multimodal.sh --model Qwen/Qwen3-VL-2B-Instruct \
   --mm-processor-cache-gb 4 \
   --multimodal-embedding-cache-capacity-gb 1
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+ZE_AFFINITY_MASK=0 \
+  bash launch/xpu/agg_multimodal_xpu.sh \
+  --model Qwen/Qwen3-VL-2B-Instruct \
+  --mm-processor-cache-gb 4 \
+  --multimodal-embedding-cache-capacity-gb 1
+```
+
+</Tab>
+</Tabs>
 
 The caches store different data. The vLLM processor cache retains the processed
 media metadata required to resolve a UUID-only request. Dynamo's embedding cache
@@ -262,7 +338,8 @@ router and worker.
 ### P/D Serving
 
 Use the P/D launcher to separate prefill and decode without deploying a
-dedicated multimodal encoder:
+dedicated multimodal encoder. This launcher is currently available for NVIDIA
+GPU only:
 
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm
@@ -290,7 +367,8 @@ model families use the expanded prompt token IDs produced during prefill.
 Pass `--unified` to the aggregated or P/D launchers to run
 `python -m dynamo.vllm.unified_main`. The unified path supports HTTP URLs,
 data URLs, frontend-decoded images, `mm_processor_kwargs`, frontend-provided
-multimodal hashes, and Kimi-style `vision_chunk` inputs.
+multimodal hashes, and Kimi-style `vision_chunk` inputs. The unified launch
+commands in this section are currently available for NVIDIA GPU only.
 
 The Python vLLM frontend can pre-render multimodal processor inputs and send
 them to an aggregated unified worker. Shared memory is the same-node default;
@@ -323,7 +401,7 @@ raw-media-derived metadata for the decode handoff.
 
 ### E/PD Serving (Encode + PD)
 
-Use `disagg_multimodal_e_pd.sh` when you want a separate encode worker and a combined prefill/decode worker. This path is primarily useful for image-centric workloads and embedding-cache experiments.
+Use `disagg_multimodal_e_pd.sh` when you want a separate encode worker and a combined prefill/decode worker. This NVIDIA GPU path is primarily useful for image-centric workloads and embedding-cache experiments.
 
 > [!WARNING]
 > When a separate encode worker is deployed with the current vLLM path, only `image_url` inputs are routed to it. `video_url` inputs are still processed on the combined PD worker.
@@ -341,20 +419,34 @@ bash launch/disagg_multimodal_e_pd.sh --model Qwen/Qwen3-VL-2B-Instruct --single
 
 ### E/P/D Serving (Full Disaggregation)
 
-Use `disagg_multimodal_epd.sh` when you want separate encode, prefill, and decode workers for multimodal workloads.
+Use the E/P/D launcher when you want separate encode, prefill, and decode workers for multimodal workloads.
 
 > [!WARNING]
 > In the current vLLM implementation, the separate encode worker is only used for `image_url` inputs. `video_url` inputs are still processed on the prefill worker, not on the encode worker.
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 cd $DYNAMO_HOME/examples/backends/vllm
-
-# Multi-GPU deployment
 bash launch/disagg_multimodal_epd.sh --model Qwen/Qwen3-VL-2B-Instruct
 
-# Single-GPU (functional testing with small models)
+# Single-device functional test
 bash launch/disagg_multimodal_epd.sh --model Qwen/Qwen3-VL-2B-Instruct --single-gpu
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+cd $DYNAMO_HOME/examples/backends/vllm
+DEVICE_PLATFORM=xpu VLLM_TARGET_DEVICE=xpu \
+  bash launch/xpu/disagg_multimodal_epd_xpu.sh \
+  --model Qwen/Qwen3-VL-2B-Instruct
+```
+
+</Tab>
+</Tabs>
 
 ## Audio Serving
 
@@ -364,17 +456,32 @@ Dynamo supports `audio_url` requests for audio-capable models. Audio is loaded b
 
 Use the same aggregated multimodal launcher with an audio-capable model:
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 pip install 'vllm[audio]'  # installs librosa and other audio dependencies
 cd $DYNAMO_HOME/examples/backends/vllm
 
-# GPU deployment
 bash launch/agg_multimodal.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct
-
-# XPU deployment
-DYN_CHAT_PROCESSOR=vllm \
-  bash launch/xpu/agg_multimodal_xpu.sh --model Qwen/Qwen3-Omni-30B-A3B-Instruct
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+**Experimental.** Intel GPU audio serving is not covered by the XPU CI suite on `main`.
+
+```bash
+pip install 'vllm[audio]'  # installs librosa and other audio dependencies
+cd $DYNAMO_HOME/examples/backends/vllm
+
+ZE_AFFINITY_MASK=0 DYN_CHAT_PROCESSOR=vllm \
+  bash launch/xpu/agg_multimodal_xpu.sh \
+  --model Qwen/Qwen3-Omni-30B-A3B-Instruct
+```
+
+</Tab>
+</Tabs>
 
 ```mermaid
 flowchart LR
@@ -441,12 +548,27 @@ flowchart LR
 
 **Launch with Dynamo:**
 
+<Tabs>
+<Tab title="NVIDIA GPU">
+
 ```bash
 bash examples/backends/vllm/launch/agg_multimodal.sh \
     --unified \
     --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
     --multimodal-embedding-cache-capacity-gb 10
 ```
+
+</Tab>
+<Tab title="Intel GPU">
+
+```bash
+bash examples/backends/vllm/launch/xpu/agg_multimodal_xpu.sh \
+    --model Qwen/Qwen3-VL-2B-Instruct \
+    --multimodal-embedding-cache-capacity-gb 10
+```
+
+</Tab>
+</Tabs>
 
 Both `dynamo.vllm` and `dynamo.vllm.unified_main` automatically configure
 `ec_both` mode with `DynamoMultimodalEmbeddingCacheConnector` when capacity is
@@ -455,6 +577,8 @@ multimodal hashes are reused as cache identities so routing and embedding-cache
 lookups agree.
 
 **Launch with `vllm serve` (standalone, no Dynamo):**
+
+The standalone command below uses the NVIDIA GPU model configuration:
 
 ```bash
 vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
@@ -471,6 +595,8 @@ The `multimodal_embedding_cache_capacity_gb` parameter controls the CPU-side LRU
 ### Disaggregated Encoder (Embedding Cache in Prefill Worker)
 
 In the disaggregated setting, the Prefill Worker (P) owns a CPU-side LRU embedding cache (`EmbeddingCacheManager`). On each request P checks the cache first — on a hit, the Encode Worker is skipped entirely. On a miss, P routes to the Encode Worker (E), receives embeddings via NIXL, saves them to the cache, and then feeds the embeddings along with the request into the vLLM Instance for prefill.
+
+This E/PD launcher is currently available for NVIDIA GPU only.
 
 ```mermaid
 ---

--- a/docs/fern/reference/compatibility.mdx
+++ b/docs/fern/reference/compatibility.mdx
@@ -14,7 +14,7 @@ import { RunsWhereWizard } from "@/components/RunsWhereWizard";
 
 <CompatibilityHero />
 
-For extended driver compatibility beyond the listed minimums, including forward compatibility and `cuda-compat` packages, see the [CUDA Compatibility documentation](https://docs.nvidia.com/deploy/cuda-compatibility/).
+For NVIDIA GPUs, see the [CUDA Compatibility documentation](https://docs.nvidia.com/deploy/cuda-compatibility/) for extended driver compatibility beyond the listed minimums, including forward compatibility and `cuda-compat` packages.
 
 <Note>
 See [Release Artifacts](release-artifacts.mdx) for the full artifact inventory — container images, wheels, Helm charts, and crates — and [Model Early Access Builds](model-early-access-builds.mdx) for per-model early access container builds.
@@ -22,23 +22,39 @@ See [Release Artifacts](release-artifacts.mdx) for the full artifact inventory �
 
 ## Find a Compatible Release
 
-Pick your backend and the CUDA generation your host driver supports to see which Dynamo releases you can run — and what to pull for the current one.
+Pick your accelerator, backend, and supported driver generation to see which Dynamo releases you can run — and what to pull for the current one.
 
 <RunsWhereWizard />
 
 ## Platform Notes
 
-Dynamo ships multi-arch (x86_64 + ARM64) container images. Wheels are built in a manylinux_2_28-compatible environment and validated on CentOS Stream 9 and Ubuntu 22.04/24.04; other Linux distributions are expected to work but are not officially verified.
+<Tabs>
+  <Tab title="NVIDIA GPU">
 
-### Cloud Service Providers
+    Dynamo ships multi-arch (x86_64 + ARM64) NVIDIA GPU container images. Wheels are built in a manylinux_2_28-compatible environment and validated on CentOS Stream 9 and Ubuntu 22.04/24.04; other Linux distributions are expected to work but are not officially verified.
 
-**Amazon Linux 2023** (AWS) · x86_64 · Supported
+    ### Cloud Service Providers
 
-<Warning>
-**AL2023 TensorRT-LLM limitation:** there is a known issue with the TensorRT-LLM framework when running the AL2023 container locally with `docker run --network host ...` due to a [bug](https://github.com/mpi4py/mpi4py/discussions/491#discussioncomment-12660609) in mpi4py. Replace the `--network host` flag with precise networking configuration by mapping only the necessary ports (4222 for NATS, 2379/2380 for etcd, 8000 for the frontend).
-</Warning>
+    **Amazon Linux 2023** (AWS) · x86_64 · Supported
+
+    <Warning>
+    **AL2023 TensorRT-LLM limitation:** there is a known issue with the TensorRT-LLM framework when running the AL2023 container locally with `docker run --network host ...` due to a [bug](https://github.com/mpi4py/mpi4py/discussions/491#discussioncomment-12660609) in mpi4py. Replace the `--network host` flag with precise networking configuration by mapping only the necessary ports (4222 for NATS, 2379/2380 for etcd, 8000 for the frontend).
+    </Warning>
+
+  </Tab>
+  <Tab title="Intel GPU">
+
+    Dynamo supports Intel Arc Pro and Intel Data Center GPU Max Series on Ubuntu 24.04 x86_64. Build the SGLang or vLLM XPU runtime image from source; Intel XPU runtime images and wheels are not published as release artifacts.
+
+    For Kubernetes requirements and deployment steps, see the [Kubernetes Quickstart](../kubernetes/quickstart.mdx).
+
+  </Tab>
+</Tabs>
 
 ## Feature Support
+
+<Tabs>
+  <Tab title="NVIDIA GPU">
 
 <FeatureHeatmap />
 
@@ -99,7 +115,7 @@ TensorRT-LLM delivers maximum inference performance and optimization, with full 
 | **KV Block Manager**      | <span className="dynref-badge dynref-badge--green">✓</span> |                                                                                                                                                                               |
 | **Multimodal**            | <span className="dynref-badge dynref-badge--green">✓</span> | Image only (URLs + pre-computed embeddings). Disagg: EP/D + E/P/D. With KV-aware routing, via dedicated MM Router Worker (requires KV event publishing) ([Source][mm-trtllm]) |
 | **Request Migration**     | <span className="dynref-badge dynref-badge--green">✓</span> | Work in progress with multimodal                                                                                                                                                             |
-| **Request Cancellation**  | <span className="dynref-badge dynref-badge--amber">!</span> | Engine temporarily not notified of cancellations — resources for cancelled requests are not freed (known issue)                                                               |
+| **Request Cancellation**  | <span className="dynref-badge dynref-badge--amber dynref-badge--bang" aria-label="Caveat"></span> | Engine temporarily not notified of cancellations — resources for cancelled requests are not freed (known issue)                                                               |
 | **LoRA**                  | <span className="dynref-badge dynref-badge--gray">—</span> | Not supported                                                                                                                                                                 |
 | **Tool Calling**          | <span className="dynref-badge dynref-badge--green">✓</span> |                                                                                                                                                                               |
 | **Speculative Decoding**  | <span className="dynref-badge dynref-badge--green">✓</span> |                                                                                                                                                                               |
@@ -175,6 +191,16 @@ Pairwise feature-by-feature compatibility within each backend. Each cell reports
 > 1. **Multimodal Disaggregation**: Supports **EP/D** (Traditional) and **E/P/D** (Full Disaggregation) image flows, including image URLs and pre-computed embeddings. ([Source][mm-trtllm])
 > 2. **Multimodal + KV-Aware Routing**: The native Rust frontend routes supported models using image-aware KV overlap. TRT-LLM workers must publish KV events with block reuse enabled. ([Source][mm-kv-routing])
 > 3. **Request Cancellation**: Due to known issues, the TensorRT-LLM engine is temporarily not notified of request cancellations, meaning allocated resources for cancelled requests are not freed.
+
+  </Tab>
+  <Tab title="Intel GPU">
+
+<FeatureHeatmap accelerator="intel" />
+
+Intel GPU statuses reflect the current XPU container builds, launch scripts, and implementation paths. Missing XPU-specific tests do not reduce support for accelerator-independent features.
+
+  </Tab>
+</Tabs>
 
 [vllm-readme]: ../backends/vllm/README.md
 [sglang-readme]: ../backends/sglang/README.md


### PR DESCRIPTION
## Overview:

Adds Intel GPU/XPU support guidance across Dynamo’s compatibility, vLLM, diffusion, and multimodal documentation. The update introduces accelerator-aware compatibility views and separates NVIDIA and Intel GPU workflows where setup or commands differ.

## Details:

- add Intel GPU release, oneAPI, driver, backend, and feature compatibility data
- document XPU vLLM installation and multimodal workflows with accelerator tabs
- clarify NVIDIA-only paths and remove unsupported XPU LoRA examples

## Where should the reviewer start?

- docs/fern/reference/compatibility.mdx 
- docs/fern/components/releases.data.ts 
- docs/fern/components/RunsWhereWizard.tsx 
- docs/fern/backends/vllm/README.md 
- docs/fern/features/multimodal/multimodal-vllm.md 

## Related Issues

- Relates to #10912


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Intel GPU compatibility views, release information, feature matrices, and hardware-aware filtering.
  * Added NVIDIA and Intel GPU tabs across backend, multimodal, diffusion, and cache documentation.
  * Added Intel GPU launch commands, setup guidance, verification steps, and platform notes.
  * Expanded vLLM compatibility coverage, including Tool Calling and GB200 support.

* **Documentation**
  * Clarified NVIDIA-only requirements and Intel GPU limitations across supported features.
  * Added Intel GPU examples and updated compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->