### PR TITLE
fix(mocker): import Arc/Mutex for kvbm-offload live scheduler tests

### DIFF
--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -4,6 +4,8 @@
 use std::time::Instant;
 
 #[cfg(all(test, feature = "kvbm-offload"))]
+use std::sync::{Arc, Mutex};
+#[cfg(all(test, feature = "kvbm-offload"))]
 use std::time::Duration;
 
 use tokio::sync::mpsc;


### PR DESCRIPTION
## Overview:

Fix a pre-existing compile failure in `dynamo-mocker`'s `kvbm-offload` feature that breaks the pre-merge "Run KVBM offload Mooncake trace test" CI step for any PR touching Rust code, regardless of what that PR actually changes.

## Details:

`lib/mocker/src/scheduler/vllm/live.rs`'s `#[cfg(feature = "kvbm-offload")] mod tests` block does `use super::*;` expecting to inherit `Arc`/`Mutex` from the parent module, but `live.rs` never imports those types itself (conditionally or otherwise), so the glob import brings in nothing. Building with `--features kvbm-offload` then fails with `E0425`/`E0433` ("cannot find type `Mutex`/`Arc` in this scope").

This was introduced by #11917 ("feat(mocker): add live request engine") and is only exercised by the CI step that explicitly enables `kvbm-offload`, so it silently breaks `rust-tests (.)` on every Rust PR without being caused by that PR's own diff. Discovered while investigating an unrelated CI failure on #12064.

Fix: add `use std::sync::{Arc, Mutex};` gated the same way the existing `Duration` import is (`#[cfg(all(test, feature = "kvbm-offload"))]`).

## Where should the reviewer start?

- `lib/mocker/src/scheduler/vllm/live.rs` (top-of-file imports, lines 6-9)

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #12252
