### PR TITLE
fix(operator): gate readiness on webhook server

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -130,6 +130,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
         resources: {{- toYaml .Values.controllerManager.manager.resources | nindent
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -510,7 +510,7 @@ func main() {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)
 	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("webhook-server", webhookServer.StartedChecker()); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}

--- a/deploy/operator/config/manager/manager.yaml
+++ b/deploy/operator/config/manager/manager.yaml
@@ -99,6 +99,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
         resources:
           limits:
             cpu: 1024m


### PR DESCRIPTION
## Summary

This PR closes the operator-owned admission-webhook false-ready windows exposed by the shared vCluster CI:

- Dynamo reports Ready only after controller-runtime starts its webhook server.
- Dynamo's Helm and kustomize readiness probes use a 5-second timeout because `/readyz` now performs a TLS connection.
- The bundled Grove operator enables its existing health probes, and CI waits for both operator containers before starting deploy tests.

The PR does not patch Pod status, Services, or EndpointSlices. The separate vCluster host/tenant version-skew failure remains tracked in [#12266](https://github.com/ai-dynamo/dynamo/issues/12266).

## Details

### Dynamo webhook readiness

Dynamo previously registered `healthz.Ping` for `/readyz`. Controller-runtime can start its health server before the webhook runnable, so Kubernetes could mark the Pod Ready before the TLS listener on port 9443 accepted connections.

The readiness check now uses `webhookServer.StartedChecker()`. Liveness remains an independent ping.

### Grove webhook readiness

After the Dynamo fix, the [vLLM aggregated deployment job](https://github.com/ai-dynamo/dynamo/actions/runs/30353383283/job/90257708438) exposed the same local false-ready window in bundled Grove:

```text
failed calling webhook "pcs.defaulting.webhooks.grove.io":
Post "https://grove-operator.default.svc:9443/webhooks/default-podcliqueset":
connect: connection refused
```

Grove already gates `/readyz` on certificate and webhook-server readiness, but its chart disables health probes by default. The Platform chart now enables them and checks the rendered pinned Grove Deployment for a readiness probe.

The existing host-side wait covers both operators and compares ready with total container counts instead of assuming `1/1`.

## Validation

- `go test ./cmd/...` in `deploy/operator`
- `pre-commit run --files` for every changed file
- Platform Helm chart lint: 1 chart linted, 0 failures
- Platform Helm chart tests: 7 suites and 31 tests passed
- Rendered manifests verified:
  - Grove liveness `/healthz` and readiness `/readyz` on port 9444
  - Dynamo readiness `timeoutSeconds: 5` in Helm and kustomize
  - no `publishNotReadyAddresses`
  - no Pod-status workaround

## Related

- [#12266](https://github.com/ai-dynamo/dynamo/issues/12266) — vCluster Pod-status corruption under host/tenant Kubernetes version skew
- [DYN-3452](https://linear.app/nvidia/issue/DYN-3452/expand-operator-live-cluster-e2e-coverage-in-ci-using-the-shared)
