### PR TITLE
ci(release): publish AI Simulate wheel

### DIFF
--- a/.github/scripts/apply_dev_version.py
+++ b/.github/scripts/apply_dev_version.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 PYPROJECT_TARGETS = [
     "pyproject.toml",
+    "aisimulate/pyproject.toml",
     "lib/bindings/python/pyproject.toml",
     "lib/bindings/kvbm/pyproject.toml",
     "lib/gpu_memory_service/pyproject.toml",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
       ngc_version_tag: ${{ steps.rc_tag.outputs.ngc_version_tag }}
       helm_chart_version: ${{ steps.rc_tag.outputs.helm_chart_version }}
       wheel_version: ${{ steps.rc_tag.outputs.wheel_version }}
+      aisimulate_wheel_version: ${{ steps.rc_tag.outputs.aisimulate_wheel_version }}
     steps:
       - name: Extract version and validate inputs
         id: extract
@@ -142,6 +143,11 @@ jobs:
             echo "Error: cannot parse base version from pyproject.toml (got '${BASE_VERSION}')"
             exit 1
           fi
+          AISIMULATE_BASE_VERSION=$(awk '/^version = / {gsub(/"/, "", $3); print $3; exit}' aisimulate/pyproject.toml)
+          if [[ ! "${AISIMULATE_BASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: cannot parse base version from aisimulate/pyproject.toml (got '${AISIMULATE_BASE_VERSION}')"
+            exit 1
+          fi
 
           if [[ "${NIGHTLY}" == "true" ]]; then
             DATE_UTC=$(date -u +%Y%m%d)
@@ -151,12 +157,15 @@ jobs:
             # the bare date+sha (e.g. 20260520-abc1234).
             NGC_VERSION_TAG="${DATE_UTC}-${SHORT_SHA}"
             WHEEL_VERSION="${BASE_VERSION}.dev${DATE_UTC}"
+            AISIMULATE_WHEEL_VERSION="${AISIMULATE_BASE_VERSION}.dev${DATE_UTC}"
             echo "rc_number=" >> $GITHUB_OUTPUT
             echo "ngc_version_tag=${NGC_VERSION_TAG}" >> $GITHUB_OUTPUT
             echo "helm_chart_version=" >> $GITHUB_OUTPUT
             echo "wheel_version=${WHEEL_VERSION}" >> $GITHUB_OUTPUT
+            echo "aisimulate_wheel_version=${AISIMULATE_WHEEL_VERSION}" >> $GITHUB_OUTPUT
             echo "Nightly NGC tag: ${NGC_VERSION_TAG}"
-            echo "Nightly wheel version: ${WHEEL_VERSION}"
+            echo "Nightly Dynamo wheel version: ${WHEEL_VERSION}"
+            echo "Nightly AI Simulate wheel version: ${AISIMULATE_WHEEL_VERSION}"
             exit 0
           fi
 
@@ -190,14 +199,17 @@ jobs:
           HELM_CHART_VERSION="${SEMVER_VERSION}-rc${NEXT_RC}"
 
           WHEEL_VERSION="${BASE_VERSION}"
+          AISIMULATE_WHEEL_VERSION="${AISIMULATE_BASE_VERSION}"
 
           echo "rc_number=${NEXT_RC}" >> $GITHUB_OUTPUT
           echo "ngc_version_tag=${VERSION}rc${NEXT_RC}" >> $GITHUB_OUTPUT
           echo "helm_chart_version=${HELM_CHART_VERSION}" >> $GITHUB_OUTPUT
           echo "wheel_version=${WHEEL_VERSION}" >> $GITHUB_OUTPUT
+          echo "aisimulate_wheel_version=${AISIMULATE_WHEEL_VERSION}" >> $GITHUB_OUTPUT
           echo "RC number: ${NEXT_RC}"
           echo "Helm chart version: ${HELM_CHART_VERSION}"
-          echo "RC wheel version: ${WHEEL_VERSION}"
+          echo "RC Dynamo wheel version: ${WHEEL_VERSION}"
+          echo "RC AI Simulate wheel version: ${AISIMULATE_WHEEL_VERSION}"
 
   # ============================================================================
   # NGC PUBLISH: crane copy to NGC, Helm chart push
@@ -583,6 +595,7 @@ jobs:
           crane export --platform=linux/amd64 "${ECR_IMAGE}" - \
             | tar -x -C "${STAGE}/amd64" \
                 --wildcards \
+                'opt/dynamo/wheelhouse/aisimulate-*py3-none-any.whl' \
                 'opt/dynamo/wheelhouse/ai_dynamo-*py3-none-any.whl' \
                 'opt/dynamo/wheelhouse/ai_dynamo_runtime-*x86_64*.whl' \
                 'opt/dynamo/wheelhouse/kvbm-*x86_64*.whl'
@@ -622,23 +635,26 @@ jobs:
       - name: Verify wheel versions match prepare-release expected tag
         env:
           EXPECTED_WHEEL_VERSION: ${{ needs.prepare-release.outputs.wheel_version }}
+          EXPECTED_AISIMULATE_WHEEL_VERSION: ${{ needs.prepare-release.outputs.aisimulate_wheel_version }}
           UPLOAD_DIR: ${{ steps.extract.outputs.upload_dir }}
         run: |
           set -euo pipefail
 
           # Catches UTC-midnight drift between the build-time version stamp and
-          # prepare-release's wheel_version; ai_dynamo and ai_dynamo_runtime must agree.
+          # prepare-release's expected versions.
           shopt -s nullglob
+          AISIMULATE_WHEELS=("${UPLOAD_DIR}"/aisimulate-*-py3-none-any.whl)
           AI_DYNAMO_WHEELS=("${UPLOAD_DIR}"/ai_dynamo-*-py3-none-any.whl)
           AI_DYNAMO_RUNTIME_WHEELS=("${UPLOAD_DIR}"/ai_dynamo_runtime-*.whl)
           shopt -u nullglob
 
-          if [ ${#AI_DYNAMO_WHEELS[@]} -eq 0 ] || [ ${#AI_DYNAMO_RUNTIME_WHEELS[@]} -eq 0 ]; then
-            echo "::error::Missing ai_dynamo or ai_dynamo_runtime wheel in ${UPLOAD_DIR}"
+          if [ ${#AISIMULATE_WHEELS[@]} -eq 0 ] || [ ${#AI_DYNAMO_WHEELS[@]} -eq 0 ] || [ ${#AI_DYNAMO_RUNTIME_WHEELS[@]} -eq 0 ]; then
+            echo "::error::Missing aisimulate, ai_dynamo, or ai_dynamo_runtime wheel in ${UPLOAD_DIR}"
             exit 1
           fi
 
-          echo "Expected wheel version: ${EXPECTED_WHEEL_VERSION}"
+          echo "Expected Dynamo wheel version: ${EXPECTED_WHEEL_VERSION}"
+          echo "Expected AI Simulate wheel version: ${EXPECTED_AISIMULATE_WHEEL_VERSION}"
 
           mismatch=0
           for path in "${AI_DYNAMO_WHEELS[@]}" "${AI_DYNAMO_RUNTIME_WHEELS[@]}"; do
@@ -655,9 +671,22 @@ jobs:
               mismatch=1
             fi
           done
+          for path in "${AISIMULATE_WHEELS[@]}"; do
+            file="$(basename "${path}")"
+            rest="${file#*-}"
+            version="${rest%%-*}"
+            if [ -z "${version}" ]; then
+              echo "::error::Empty version parsed from ${file}"
+              exit 1
+            fi
+            echo "  ${file} -> ${version}"
+            if [ "${version}" != "${EXPECTED_AISIMULATE_WHEEL_VERSION}" ]; then
+              mismatch=1
+            fi
+          done
 
           if [ "${mismatch}" -ne 0 ]; then
-            echo "::error::Wheel version mismatch — expected '${EXPECTED_WHEEL_VERSION}' for all wheels above. dynamo-pipeline and prepare-release likely computed dev_suffix on different UTC days."
+            echo "::error::Wheel version mismatch. dynamo-pipeline and prepare-release likely computed dev_suffix on different UTC days."
             exit 1
           fi
 
@@ -734,6 +763,7 @@ jobs:
           ART_RESULT:       ${{ needs.stage-wheels-artifactory.result }}
           NGC_VERSION_TAG:  ${{ needs.prepare-release.outputs.ngc_version_tag }}
           WHEEL_VERSION:    ${{ needs.prepare-release.outputs.wheel_version }}
+          AISIMULATE_WHEEL_VERSION: ${{ needs.prepare-release.outputs.aisimulate_wheel_version }}
           RUN_URL:          ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         shell: bash
         run: |
@@ -767,6 +797,7 @@ jobs:
             --arg art_result "${ART_RESULT}" \
             --arg ngc_tag    "${NGC_VERSION_TAG}" \
             --arg wheel      "${WHEEL_VERSION}" \
+            --arg aisimulate "${AISIMULATE_WHEEL_VERSION}" \
             --arg run_url    "${RUN_URL}" \
             '{
               channel: $channel,
@@ -780,7 +811,7 @@ jobs:
                     { type: "mrkdwn",
                       text: ($ngc_emoji + " *NGC publish:* " + $ngc_result + "\n`" + $ngc_tag + "`") },
                     { type: "mrkdwn",
-                      text: ($art_emoji + " *Artifactory wheels:* " + $art_result + "\n`" + $wheel + "`") }
+                      text: ($art_emoji + " *Artifactory wheels:* " + $art_result + "\nDynamo `" + $wheel + "`, AI Simulate `" + $aisimulate + "`") }
                   ] },
                 { type: "context",
                   elements: [ { type: "mrkdwn", text: ("<" + $run_url + "|GitHub Actions run>") } ] }
@@ -830,6 +861,7 @@ jobs:
           VERSION:              ${{ needs.prepare-release.outputs.version }}
           NGC_VERSION_TAG:      ${{ needs.prepare-release.outputs.ngc_version_tag }}
           WHEEL_VERSION:        ${{ needs.prepare-release.outputs.wheel_version }}
+          AISIMULATE_WHEEL_VERSION: ${{ needs.prepare-release.outputs.aisimulate_wheel_version }}
           COMMIT_SHA:           ${{ needs.prepare-release.outputs.commit_sha }}
           NIGHTLY:              ${{ needs.prepare-release.outputs.nightly }}
           RC_NUMBER:            ${{ needs.prepare-release.outputs.rc_number }}
@@ -878,6 +910,7 @@ jobs:
             --form "variables[NIGHTLY_TAG]=${NIGHTLY_TAG}" \
             --form "variables[RC_TAG]=${RC_TAG}" \
             --form "variables[WHEEL_VERSION]=${WHEEL_VERSION}" \
+            --form "variables[AISIMULATE_WHEEL_VERSION]=${AISIMULATE_WHEEL_VERSION}" \
             --form "variables[CONTAINER_TAG]=${NGC_VERSION_TAG}" \
             --form "variables[COMMIT_SHA]=${COMMIT_SHA}" \
             --form "variables[GITHUB_RUN_ID]=${GITHUB_RUN_ID}" \
@@ -916,6 +949,8 @@ jobs:
             echo "| PIPELINE_TYPE | ${PIPELINE_TYPE} |"
             echo "| RELEASE_TYPE | ${RELEASE_TYPE} |"
             echo "| Version | ${VERSION} |"
+            echo "| Dynamo wheel version | ${WHEEL_VERSION} |"
+            echo "| AI Simulate wheel version | ${AISIMULATE_WHEEL_VERSION} |"
             echo "| NGC tag | ${NGC_VERSION_TAG} |"
             echo "| Commit | ${COMMIT_SHA} |"
             echo "| Artifacts | ${ARTIFACTS} |"

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -589,10 +589,11 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     fi && \
     /tmp/use-sccache.sh show-stats "Dynamo Runtime"
 
-{% if target == "planner" %}
-# AI Simulate is a separate Python distribution. Build it only for the planner
-# image, after the Dynamo wheels so Python-only changes do not invalidate the
-# expensive Rust build layers above.
+{% if framework == "dynamo" and target in ("planner", "runtime") %}
+# AI Simulate is a separate Python distribution. Build it for the Planner image
+# and the Dynamo runtime image used to stage release wheels. Keep it after the
+# Dynamo wheels so Python-only changes do not invalidate the expensive Rust
+# build layers above.
 COPY aisimulate/ /opt/dynamo/aisimulate/
 RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv && \


### PR DESCRIPTION
Depends on #11986.

## Summary

- build the standalone `aisimulate` wheel in the Dynamo runtime image that supplies release artifacts, while retaining the existing Planner-image build
- extract and stage `aisimulate-*.whl` with the Dynamo wheels in the Artifactory release job
- preserve AI Simulate's independent `0.1.0` version line, apply the nightly `.devYYYYMMDD` suffix, and validate it separately from Dynamo's `1.4.0` wheel version
- forward `AISIMULATE_WHEEL_VERSION` to release summaries, Slack staging output, and the downstream GitLab release pipeline

## Why

#11923 added AI Simulate as a standalone distribution, but its wheel was built only for installation inside the Planner image. The release pipeline publishes wheels extracted from the separate `dynamo-runtime` image, so `aisimulate` never reached the publish path. This PR closes that gap on top of #11986 so the released wheel carries the paired AIC 0.11 dependency contract.

## Validation

- `pre-commit run --files .github/scripts/apply_dev_version.py .github/workflows/release.yml container/templates/wheel_builder.Dockerfile`
- `uv build --wheel --out-dir ../aisimulate-dist ./aisimulate`
- inspected wheel metadata: `aisimulate==0.1.0`, `aiconfigurator==0.11.0`, Python 3.10-3.12
- rendered Dynamo `runtime` and `planner` Dockerfiles and confirmed both build the AI Simulate wheel
- rendered the vLLM runtime Dockerfile and confirmed it does not build the AI Simulate wheel
- exercised `apply_dev_version.py` on a disposable checkout and confirmed `aisimulate==0.1.0.dev20991231` alongside Dynamo `1.4.0.dev20991231`
- `git diff --check`