### PR TITLE
perf(kvbm): avoid redundant event payload copies

### DIFF
--- a/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
+++ b/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
@@ -152,13 +152,12 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
                 return;
             }
 
-            let token_chunks: Vec<Vec<u32>> =
-                token_ids.chunks(block_size).map(|c| c.to_vec()).collect();
+            let token_chunk_count = token_ids.chunks(block_size).len();
 
-            if token_chunks.len() != block_hashes.len() {
+            if token_chunk_count != block_hashes.len() {
                 tracing::warn!(
                     "Token chunks ({}) don't match block hashes ({}), skipping event",
-                    token_chunks.len(),
+                    token_chunk_count,
                     block_hashes.len()
                 );
                 return;
@@ -169,13 +168,15 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
                 .filter(|namespace| !namespace.is_empty())
                 .map(Arc::<str>::from);
 
-            for (i, block_hash) in block_hashes.into_iter().enumerate() {
+            for (block_hash, block_tokens) in
+                block_hashes.into_iter().zip(token_ids.chunks(block_size))
+            {
                 let hash_str = block_hash.into_u64().to_string();
                 tracker.handle_store_input(StoreInput::new(
                     engine_source,
                     hash_str.clone(),
-                    current_parent.clone(),
-                    token_chunks[i].clone(),
+                    current_parent.take(),
+                    block_tokens.to_vec(),
                     block_size,
                     lora_name.clone(),
                     cache_namespace.clone(),

--- a/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
+++ b/lib/llm/src/block_manager/kv_consolidator/subscriber.rs
@@ -42,6 +42,10 @@ impl VllmEventBatch {
         &self.1
     }
 
+    fn into_events(self) -> Vec<RawKvEvent> {
+        self.1
+    }
+
     fn data_parallel_rank(&self) -> Option<i32> {
         self.2
     }
@@ -137,8 +141,8 @@ async fn run_listener_loop(
 
                 // Process events
                 let mut tracker_guard = tracker.write().await;
-                for event in batch.events() {
-                    process_event(&mut **tracker_guard, event.clone(), dp_rank, engine_source);
+                for event in batch.into_events() {
+                    process_event(&mut **tracker_guard, event, dp_rank, engine_source);
                 }
             }
         }
@@ -197,16 +201,12 @@ fn process_event(
                 return;
             }
 
-            // token_ids is already Vec<u32>; split directly into per-block chunks
-            let token_chunks: Vec<Vec<u32>> = token_ids
-                .chunks(block_size)
-                .map(|chunk| chunk.to_vec())
-                .collect();
+            let token_chunk_count = token_ids.chunks(block_size).len();
 
-            if token_chunks.len() != block_hashes.len() {
+            if token_chunk_count != block_hashes.len() {
                 tracing::warn!(
                     "Token chunks ({}) don't match block hashes ({}), skipping event",
-                    token_chunks.len(),
+                    token_chunk_count,
                     block_hashes.len()
                 );
                 return;
@@ -215,15 +215,16 @@ fn process_event(
             // For batches, chain the blocks: each block's parent is the previous block
             let mut current_parent = parent_block_hash.map(|h| h.into_u64().to_string());
 
-            for (i, block_hash) in block_hashes.into_iter().enumerate() {
-                let block_tokens = token_chunks[i].clone();
+            for (block_hash, block_tokens) in
+                block_hashes.into_iter().zip(token_ids.chunks(block_size))
+            {
                 let block_hash_u64 = block_hash.into_u64();
 
                 tracker.handle_store(StoreEventInput {
                     block_hash: block_hash_u64.to_string(),
                     source: engine_source,
-                    token_ids: block_tokens,
-                    parent_hash: current_parent.clone(),
+                    token_ids: block_tokens.to_vec(),
+                    parent_hash: current_parent.take(),
                     block_size,
                     lora_name: lora_name.clone(),
                     tier: Some(storage_tier),
@@ -339,5 +340,56 @@ mod tests {
                 ..
             }]
         ));
+    }
+
+    #[test]
+    fn block_stored_preserves_token_chunks_and_parent_chain() {
+        let mut tracker = PassthroughCacheStatusTracker::new();
+        let event = RawKvEvent::BlockStored {
+            block_hashes: vec![BlockHashValue::Unsigned(10), BlockHashValue::Unsigned(11)],
+            parent_block_hash: Some(BlockHashValue::Unsigned(9)),
+            token_ids: vec![1, 2, 3, 4],
+            block_size: 2,
+            medium: None,
+            lora_name: Some("adapter".to_string()),
+            cache_namespace: None,
+            block_mm_infos: None,
+            is_eagle: None,
+            group_idx: None,
+            kv_cache_spec_kind: None,
+            kv_cache_spec_sliding_window: None,
+            locality: None,
+        };
+
+        process_event(&mut tracker, event, Some(3), EventSource::Vllm);
+
+        let events = tracker.drain_events();
+        let expected = [
+            ("10", Some("9"), vec![1, 2]),
+            ("11", Some("10"), vec![3, 4]),
+        ];
+        assert_eq!(events.len(), expected.len());
+
+        for (event, (expected_hash, expected_parent, expected_tokens)) in
+            events.into_iter().zip(expected)
+        {
+            let ConsolidatedEvent::Store {
+                block_hash,
+                parent_hash,
+                token_ids,
+                block_size,
+                lora_name,
+                ..
+            } = event
+            else {
+                panic!("expected store event");
+            };
+
+            assert_eq!(block_hash, expected_hash);
+            assert_eq!(parent_hash.as_deref(), expected_parent);
+            assert_eq!(token_ids, expected_tokens);
+            assert_eq!(block_size, 2);
+            assert_eq!(lora_name.as_deref(), Some("adapter"));
+        }
     }
 }


### PR DESCRIPTION
## Overview

KV event ingress currently copies deserialized event payloads before processing and then materializes every token chunk twice. This adds allocation and copy work while the consolidators hold or repeatedly acquire their tracker write locks.

## Summary

- Consume deserialized events directly in the LLM consolidator instead of cloning each event.
- Validate token/hash cardinality without first allocating a `Vec<Vec<u32>>`.
- Move each parent hash into the tracker before advancing the parent chain.
- Apply the same ownership pattern to both active KV event consolidator implementations.
- Add regression coverage for multi-block token splitting and parent chaining in the LLM path.

## Details

Both ingress paths already own the event payload. After cardinality validation, they now zip owned block hashes with borrowed token slices and allocate each final tracker-owned token vector exactly once. `current_parent.take()` transfers the parent string that would otherwise be cloned immediately before the variable is overwritten.

This does not change block hashes, token boundaries, LoRA metadata, storage tiers, data-parallel ranks, or parent-chain ordering.

A local allocation-counting microbenchmark using 64 blocks with 32 tokens per block showed:

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Allocations per batch | 390 | 261 | -33% |
| Allocated bytes per batch | 34,317 | 24,460 | -29% |
| 100,000 iterations | 1.43–1.46 s | 1.03–1.05 s | -27–29% |

## Validation

- `cargo test -p kvbm-consolidator --features testing` — 50 passed, 1 ignored
- `cargo test -p dynamo-llm --lib kv_consolidator` — 21 passed
- `cargo clippy -p kvbm-consolidator -p dynamo-llm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `python3 -m pre_commit run --files lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs lib/llm/src/block_manager/kv_consolidator/subscriber.rs`

## Where should the reviewer start?

`lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs` contains the core token-chunk ownership change. The LLM consolidator applies the same pattern and includes the regression test.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of stored blocks by validating token and block counts before handling events.
  * Preserved correct parent-hash chaining across blocks.
  * Added safeguards to skip malformed events instead of processing inconsistent data.

* **Tests**
  * Added coverage verifying token chunk handling and parent-chain construction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->