### PR TITLE
test(ci): preserve vLLM and Nsight stabilizations

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -43,6 +43,7 @@ def _make_config(**overrides) -> Mock:
         "route_to_encoder": False,
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
+        "gms_shadow_mode": False,
     }
     defaults.update(overrides)
     return Mock(**defaults)

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -151,7 +151,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    curl --retry 3 --retry-delay 5 -fsSL -o /tmp/nsys.deb \
+    curl --retry 5 --retry-delay 5 --retry-all-errors -fsSL -o /tmp/nsys.deb \
         "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nsight-systems-2025.5.1_2025.5.1.121-1_${TARGETARCH}.deb" && \
     apt-get install -y --no-install-recommends /tmp/nsys.deb gh && \
     rm -f /tmp/nsys.deb && \


### PR DESCRIPTION
## Summary

- default `gms_shadow_mode` to `false` in the vLLM worker-factory test mock
- strengthen the existing direct Nsight download with five retries and `--retry-all-errors`

## Why

These CI stabilizations were discovered while iterating on #10494, but they are independent of runtime-version admission and belong in a focused follow-up.

## Validation

- commit hooks passed
- tests not run (changes were split from #10494 without additional execution)
