### PR TITLE
refactor(operator): move Grove reconciliation into its workload program

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -36,7 +36,6 @@ import (
 
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -581,7 +580,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(
 		func() (bool, string, map[string]nvidiacomv1beta1.ComponentReplicaStatus) {
 			// Grove readiness: all underlying PodCliques and PodCliqueScalingGroups have replicas == availableReplicas.
 			// A transient (non-NotFound) read error is handled authoritatively by
-			// reconcileGroveResources, which re-evaluates and returns the error so
+			// groveProgram, which re-evaluates and returns the error so
 			// the reconcile retries; here we defensively treat it as not-ready so a
 			// read blip can never surface as "ready".
 			allComponentsReady, reason, componentStatuses, readErr := dynamo.GetComponentReadinessAndServiceReplicaStatuses(ctx, r.Client, dynamoDeployment)
@@ -991,200 +990,6 @@ func findPodTemplateContainer(podTemplate *corev1.PodTemplateSpec, containerName
 		}
 	}
 	return nil, fmt.Errorf("checkpoint job pod template: pod spec has no container named %q", containerName)
-}
-
-func (r *DynamoGraphDeploymentReconciler) reconcileGroveResources(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment, restartState *dynamo.RestartState, checkpointInfos map[string]*checkpoint.CheckpointInfo) (ReconcileResult, error) {
-	logger := log.FromContext(ctx)
-
-	renderDeployment, existingPodCliqueSet, err := r.prepareGroveRenderDeployment(ctx, dynamoDeployment)
-	if err != nil {
-		return ReconcileResult{}, err
-	}
-
-	grovePodCliqueSetAsResource, err := r.reconcileGrovePodCliqueSet(ctx, dynamoDeployment, renderDeployment, existingPodCliqueSet, restartState, checkpointInfos)
-	if err != nil {
-		logger.Error(err, "failed to reconcile the Grove PodClique Set")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile the Grove PodClique Set: %w", err)
-	}
-
-	// Handle Grove scaling operations after structural changes
-	if err := r.reconcileGroveScaling(ctx, dynamoDeployment, checkpointInfos); err != nil {
-		logger.Error(err, "failed to reconcile Grove scaling")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile Grove scaling: %w", err)
-	}
-
-	// Reconcile headless services for model endpoint discovery
-	if err := dynamo.ReconcileModelServicesForComponents(
-		ctx,
-		r,
-		dynamoDeployment,
-		dynamo.ComponentsByName(dynamoDeployment),
-		dynamoDeployment.Namespace,
-	); err != nil {
-		logger.Error(err, "failed to reconcile model services")
-		return ReconcileResult{}, fmt.Errorf("failed to reconcile model services: %w", err)
-	}
-
-	resources := []Resource{grovePodCliqueSetAsResource}
-	for i := range renderDeployment.Spec.Components {
-		component := &renderDeployment.Spec.Components[i]
-		componentName := component.ComponentName
-
-		// if k8s discovery is enabled, create a service for each component
-		// else, only create for the frontend component
-		isK8sDiscoveryEnabled := commoncontroller.IsK8sDiscoveryEnabled(r.Config.Discovery.Backend, dynamoDeployment.Annotations)
-		if isK8sDiscoveryEnabled || string(component.ComponentType) == consts.ComponentTypeFrontend {
-			dynamoNamespace := renderDeployment.GetDynamoNamespaceForComponent(component)
-			mainComponentService, err := dynamo.GenerateComponentService(dynamo.ComponentServiceParams{
-				ServiceName:     dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""),
-				Namespace:       dynamoDeployment.Namespace,
-				ComponentType:   string(component.ComponentType),
-				DynamoNamespace: dynamoNamespace,
-				ComponentName:   componentName,
-				Labels:          dynamo.GetDGDComponentResourceLabels(renderDeployment, componentName, component),
-				Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component),
-				IsK8sDiscovery:  isK8sDiscoveryEnabled,
-			})
-			if err != nil {
-				logger.Error(err, "failed to generate the main component service")
-				return ReconcileResult{}, fmt.Errorf("failed to generate the main component service: %w", err)
-			}
-			_, syncedMainComponentService, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*corev1.Service, bool, error) {
-				return mainComponentService, false, nil
-			})
-			if err != nil {
-				logger.Error(err, "failed to sync the main component service")
-				return ReconcileResult{}, fmt.Errorf("failed to sync the main component service: %w", err)
-			}
-			if syncedMainComponentService != nil {
-				if syncedMainComponentService.Annotations == nil {
-					syncedMainComponentService.Annotations = make(map[string]string)
-				}
-				desiredAnnotations := dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component)
-				var updateAnnotations bool
-				for key, value := range desiredAnnotations {
-					if val, ok := syncedMainComponentService.Annotations[key]; !ok || val != value {
-						syncedMainComponentService.Annotations[key] = value
-						updateAnnotations = true
-					}
-				}
-				if updateAnnotations {
-					err = r.Update(ctx, syncedMainComponentService)
-					if err != nil {
-						logger.Error(err, fmt.Sprintf("Failed to update main component service %s.", componentName))
-						r.GetRecorder().Eventf(dynamoDeployment, corev1.EventTypeWarning, "UpdateService", "Failed to update Service %s: %s", componentName, err)
-						return ReconcileResult{}, fmt.Errorf("failed to update main component service %s: %w", componentName, err)
-					}
-				}
-				mainComponentServiceAsResource, err := commoncontroller.NewResource(syncedMainComponentService,
-					func() (bool, string) {
-						return true, ""
-					})
-				if err != nil {
-					return ReconcileResult{}, fmt.Errorf("failed to sync the main component service: %w", err)
-				}
-				resources = append(resources, mainComponentServiceAsResource)
-			}
-		}
-
-		if string(component.ComponentType) == consts.ComponentTypeFrontend {
-			// generate the main component ingress
-			ingressSpec := dynamo.GenerateDefaultIngressSpec(dynamoDeployment, r.Config.Ingress)
-			if preservedIngressSpec, ok := dynamo.GetDGDComponentPreservedIngressSpec(dynamoDeployment, componentName); ok {
-				ingressSpec = preservedIngressSpec
-			}
-			mainComponentIngress := dynamo.GenerateComponentIngress(ctx, dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""), dynamoDeployment.Namespace, ingressSpec)
-			_, syncedMainComponentIngress, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*networkingv1.Ingress, bool, error) {
-				if !ingressSpec.Enabled || ingressSpec.IngressControllerClassName == nil {
-					logger.Info("Ingress is not enabled")
-					return mainComponentIngress, true, nil
-				}
-				return mainComponentIngress, false, nil
-			})
-			if err != nil {
-				logger.Error(err, "failed to sync the main component ingress")
-				return ReconcileResult{}, fmt.Errorf("failed to sync the main component ingress: %w", err)
-			}
-			if syncedMainComponentIngress != nil {
-				mainComponentIngressAsResource, err := commoncontroller.NewResource(syncedMainComponentIngress,
-					func() (bool, string) {
-						return true, ""
-					})
-				if err != nil {
-					return ReconcileResult{}, fmt.Errorf("failed to create the main component ingress resource: %w", err)
-				}
-				resources = append(resources, mainComponentIngressAsResource)
-			}
-			// generate the main component virtual service
-			if r.Config.Ingress.UseVirtualService() {
-				mainComponentVirtualService := dynamo.GenerateComponentVirtualService(ctx, dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""), dynamoDeployment.Namespace, ingressSpec)
-				_, syncedMainComponentVirtualService, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*networkingv1beta1.VirtualService, bool, error) {
-					if !ingressSpec.IsVirtualServiceEnabled() {
-						logger.Info("VirtualService is not enabled")
-						return mainComponentVirtualService, true, nil
-					}
-					return mainComponentVirtualService, false, nil
-				})
-				if err != nil {
-					logger.Error(err, "failed to sync the main component virtual service")
-					return ReconcileResult{}, fmt.Errorf("failed to sync the main component virtual service: %w", err)
-				}
-				if syncedMainComponentVirtualService != nil {
-					mainComponentVirtualServiceAsResource, err := commoncontroller.NewResource(syncedMainComponentVirtualService,
-						func() (bool, string) {
-							return true, ""
-						})
-					if err != nil {
-						return ReconcileResult{}, fmt.Errorf("failed to create the main component virtual service resource: %w", err)
-					}
-					resources = append(resources, mainComponentVirtualServiceAsResource)
-				}
-			}
-		}
-	}
-
-	// Check resource readiness and overlay the Grove-specific Ready reason.
-	// Extracted to keep this function's cyclomatic complexity within the
-	// gocyclo limit.
-	return r.checkGroveResourcesReadiness(ctx, dynamoDeployment, resources)
-}
-
-// checkGroveResourcesReadiness computes the readiness result for the synced
-// Grove resources and overlays the Grove-specific Ready reason
-// classification on a not-ready result. A transient Grove read error is
-// returned (not folded into the result) so the reconcile retries and does not
-// advance ObservedGeneration on a blip.
-func (r *DynamoGraphDeploymentReconciler) checkGroveResourcesReadiness(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment, resources []Resource) (ReconcileResult, error) {
-	result := r.checkResourcesReadiness(resources)
-	if err := r.applyGroveReadyClassification(ctx, dynamoDeployment, &result); err != nil {
-		return ReconcileResult{}, err
-	}
-	return result, nil
-}
-
-// applyGroveReadyClassification replaces the generic not-ready reason on result
-// with a Grove-specific classification (insufficient_capacity / pods_not_ready /
-// updating / mixed_not_ready_reasons / some_resources_are_not_ready) computed
-// from Grove PodClique / PodCliqueScalingGroup status (REQ 1). It only overrides
-// when the result is not successful; the ready path keeps checkResourcesReadiness's
-// success result.
-//
-// A non-nil error is a transient (non-NotFound) Grove read failure: the caller
-// should return it so the reconcile retries rather than publishing a possibly
-// wrong not-ready diagnosis and advancing ObservedGeneration. NotFound is not an
-// error and is classified as a legitimate not-ready state.
-func (r *DynamoGraphDeploymentReconciler) applyGroveReadyClassification(ctx context.Context, dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment, result *ReconcileResult) error {
-	if result.State == nvidiacomv1beta1.DGDStateSuccessful {
-		return nil
-	}
-	classification, err := dynamo.ClassifyGroveReadiness(ctx, r.Client, dynamoDeployment)
-	if err != nil {
-		return err
-	}
-	if classification != "" {
-		result.Reason = Reason(classification)
-	}
-	return nil
 }
 
 // isNewRestartRequest checks if the current spec.restart.id represents a new restart request

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2282,7 +2282,7 @@ func TestDynamoGraphDeploymentReconciler_isGrovePathway(t *testing.T) {
 	}
 }
 
-func Test_reconcileGroveResources(t *testing.T) {
+func TestGroveProgram_ReconcileWorkloads(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
@@ -2639,7 +2639,10 @@ func Test_reconcileGroveResources(t *testing.T) {
 				},
 			}
 
-			result, err := reconciler.reconcileGroveResources(ctx, dgd, nil, nil)
+			result, err := (&groveProgram{reconciler: reconciler}).reconcileWorkloads(
+				ctx,
+				workloadReconcileRequest{DGD: dgd},
+			)
 			if tt.wantErrSubstring != "" {
 				g.Expect(err).To(gomega.HaveOccurred())
 				g.Expect(err.Error()).To(gomega.ContainSubstring(tt.wantErrSubstring))
@@ -2652,7 +2655,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 	}
 }
 
-func Test_reconcileGroveResources_UsesPreservedAlphaServiceIngress(t *testing.T) {
+func TestGroveProgram_ReconcileWorkloadsUsesPreservedAlphaServiceIngress(t *testing.T) {
 	ctx := context.Background()
 	g := gomega.NewGomegaWithT(t)
 
@@ -2709,7 +2712,10 @@ func Test_reconcileGroveResources_UsesPreservedAlphaServiceIngress(t *testing.T)
 		},
 	}
 
-	_, err := reconciler.reconcileGroveResources(ctx, dgd, nil, nil)
+	_, err := (&groveProgram{reconciler: reconciler}).reconcileWorkloads(
+		ctx,
+		workloadReconcileRequest{DGD: dgd},
+	)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	ingress := &networkingv1.Ingress{}

--- a/deploy/operator/internal/controller/dynamographdeployment_grove_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_grove_program.go
@@ -1,0 +1,347 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type groveProgram struct {
+	// The DGD reconciler temporarily supplies shared controller dependencies and
+	// Grove rendering, scaling, and persistence helpers. Later extractions can
+	// narrow this without moving Grove orchestration back into the common flow.
+	reconciler *DynamoGraphDeploymentReconciler
+	lwsEnabled bool
+}
+
+// Reconcile composes the complete Grove pathway. Each earlier operation
+// returns a typed value consumed by later operations. Non-status DGD changes
+// are persisted through req.DGD; status accumulates in the returned result.
+func (p *groveProgram) Reconcile(
+	ctx context.Context,
+	req workloadProgramRequest,
+) (programResult workloadProgramResult, retErr error) {
+	programResult = newWorkloadProgramResult(req.DGD)
+	defer func() {
+		if retErr != nil {
+			reason := reasonFailedToReconcileResources
+			if classified, ok := workloadProgramFailureReason(retErr); ok {
+				reason = classified
+			}
+			programResult.Fail(req.DGD.Generation, reason, retErr)
+		}
+		p.reconciler.propagateTopologyCondition(ctx, req.DGD, &programResult)
+	}()
+	log.FromContext(ctx).Info(
+		"Reconciling Grove resources",
+		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
+		"lwsEnabled", p.lwsEnabled,
+	)
+
+	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, req.DGD); err != nil {
+		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
+		return programResult, failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
+	}
+	if err := reconcileUnsupportedWorkerRollout(ctx, p.reconciler, req.DGD, true); err != nil {
+		return programResult, err
+	}
+	inputs, err := p.reconciler.reconcileProgramInputs(ctx, req.DGD)
+	if inputs.CheckpointStatuses != nil {
+		programResult.Status.Checkpoints = inputs.CheckpointStatuses
+	}
+	if err != nil {
+		return programResult, err
+	}
+	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, &programResult.Status, &programResult)
+	programResult.Status.Restart = restart.Status
+
+	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
+		DGD:             req.DGD,
+		RestartState:    restart.State,
+		CheckpointInfos: inputs.CheckpointInfos,
+	})
+	if err != nil {
+		return programResult, fmt.Errorf("failed to reconcile Grove workloads: %w", err)
+	}
+	result, err = p.reconciler.reconcileProgramResult(ctx, req.DGD, inputs, restart, result)
+	if err != nil {
+		return programResult, err
+	}
+
+	programResult.applyReconcileResult(req.DGD.Generation, result)
+	return programResult, nil
+}
+
+// reconcileWorkloads owns the Grove pathway's complete provider workload
+// sequence. The lower-level rendering and persistence helpers remain on the
+// DGD reconciler temporarily, but the program owns when and how they compose.
+func (p *groveProgram) reconcileWorkloads(
+	ctx context.Context,
+	req workloadReconcileRequest,
+) (ReconcileResult, error) {
+	r := p.reconciler
+	dynamoDeployment := req.DGD
+	logger := log.FromContext(ctx)
+
+	renderDeployment, existingPodCliqueSet, err := r.prepareGroveRenderDeployment(ctx, dynamoDeployment)
+	if err != nil {
+		return ReconcileResult{}, err
+	}
+
+	grovePodCliqueSetAsResource, err := r.reconcileGrovePodCliqueSet(
+		ctx,
+		dynamoDeployment,
+		renderDeployment,
+		existingPodCliqueSet,
+		req.RestartState,
+		req.CheckpointInfos,
+	)
+	if err != nil {
+		logger.Error(err, "failed to reconcile the Grove PodClique Set")
+		return ReconcileResult{}, fmt.Errorf("failed to reconcile the Grove PodClique Set: %w", err)
+	}
+
+	// Handle Grove scaling operations after structural changes.
+	if err := r.reconcileGroveScaling(ctx, dynamoDeployment, req.CheckpointInfos); err != nil {
+		logger.Error(err, "failed to reconcile Grove scaling")
+		return ReconcileResult{}, fmt.Errorf("failed to reconcile Grove scaling: %w", err)
+	}
+
+	// Reconcile headless services for model endpoint discovery.
+	if err := dynamo.ReconcileModelServicesForComponents(
+		ctx,
+		r,
+		dynamoDeployment,
+		dynamo.ComponentsByName(dynamoDeployment),
+		dynamoDeployment.Namespace,
+	); err != nil {
+		logger.Error(err, "failed to reconcile model services")
+		return ReconcileResult{}, fmt.Errorf("failed to reconcile model services: %w", err)
+	}
+
+	resources := []Resource{grovePodCliqueSetAsResource}
+	for i := range renderDeployment.Spec.Components {
+		component := &renderDeployment.Spec.Components[i]
+		componentName := component.ComponentName
+
+		// If Kubernetes discovery is enabled, create a Service for each
+		// component; otherwise create one only for the frontend.
+		isK8sDiscoveryEnabled := commoncontroller.IsK8sDiscoveryEnabled(
+			r.Config.Discovery.Backend,
+			dynamoDeployment.Annotations,
+		)
+		if isK8sDiscoveryEnabled || string(component.ComponentType) == commonconsts.ComponentTypeFrontend {
+			dynamoNamespace := renderDeployment.GetDynamoNamespaceForComponent(component)
+			mainComponentService, err := dynamo.GenerateComponentService(dynamo.ComponentServiceParams{
+				ServiceName:     dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""),
+				Namespace:       dynamoDeployment.Namespace,
+				ComponentType:   string(component.ComponentType),
+				DynamoNamespace: dynamoNamespace,
+				ComponentName:   componentName,
+				Labels:          dynamo.GetDGDComponentResourceLabels(renderDeployment, componentName, component),
+				Annotations:     dynamo.GetDGDComponentResourceAnnotations(renderDeployment, componentName, component),
+				IsK8sDiscovery:  isK8sDiscoveryEnabled,
+			})
+			if err != nil {
+				logger.Error(err, "failed to generate the main component service")
+				return ReconcileResult{}, fmt.Errorf("failed to generate the main component service: %w", err)
+			}
+			_, syncedMainComponentService, err := commoncontroller.SyncResource(
+				ctx,
+				r,
+				dynamoDeployment,
+				func(context.Context) (*corev1.Service, bool, error) {
+					return mainComponentService, false, nil
+				},
+			)
+			if err != nil {
+				logger.Error(err, "failed to sync the main component service")
+				return ReconcileResult{}, fmt.Errorf("failed to sync the main component service: %w", err)
+			}
+			if syncedMainComponentService != nil {
+				if syncedMainComponentService.Annotations == nil {
+					syncedMainComponentService.Annotations = make(map[string]string)
+				}
+				desiredAnnotations := dynamo.GetDGDComponentResourceAnnotations(
+					renderDeployment,
+					componentName,
+					component,
+				)
+				var updateAnnotations bool
+				for key, value := range desiredAnnotations {
+					if val, ok := syncedMainComponentService.Annotations[key]; !ok || val != value {
+						syncedMainComponentService.Annotations[key] = value
+						updateAnnotations = true
+					}
+				}
+				if updateAnnotations {
+					if err := r.Update(ctx, syncedMainComponentService); err != nil {
+						logger.Error(err, fmt.Sprintf("Failed to update main component service %s.", componentName))
+						r.GetRecorder().Eventf(
+							dynamoDeployment,
+							corev1.EventTypeWarning,
+							"UpdateService",
+							"Failed to update Service %s: %s",
+							componentName,
+							err,
+						)
+						return ReconcileResult{}, fmt.Errorf("failed to update main component service %s: %w", componentName, err)
+					}
+				}
+				mainComponentServiceAsResource, err := commoncontroller.NewResource(
+					syncedMainComponentService,
+					func() (bool, string) {
+						return true, ""
+					},
+				)
+				if err != nil {
+					return ReconcileResult{}, fmt.Errorf("failed to sync the main component service: %w", err)
+				}
+				resources = append(resources, mainComponentServiceAsResource)
+			}
+		}
+
+		if string(component.ComponentType) == commonconsts.ComponentTypeFrontend {
+			ingressSpec := dynamo.GenerateDefaultIngressSpec(dynamoDeployment, r.Config.Ingress)
+			if preservedIngressSpec, ok := dynamo.GetDGDComponentPreservedIngressSpec(dynamoDeployment, componentName); ok {
+				ingressSpec = preservedIngressSpec
+			}
+			mainComponentIngress := dynamo.GenerateComponentIngress(
+				ctx,
+				dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""),
+				dynamoDeployment.Namespace,
+				ingressSpec,
+			)
+			_, syncedMainComponentIngress, err := commoncontroller.SyncResource(
+				ctx,
+				r,
+				dynamoDeployment,
+				func(context.Context) (*networkingv1.Ingress, bool, error) {
+					if !ingressSpec.Enabled || ingressSpec.IngressControllerClassName == nil {
+						logger.Info("Ingress is not enabled")
+						return mainComponentIngress, true, nil
+					}
+					return mainComponentIngress, false, nil
+				},
+			)
+			if err != nil {
+				logger.Error(err, "failed to sync the main component ingress")
+				return ReconcileResult{}, fmt.Errorf("failed to sync the main component ingress: %w", err)
+			}
+			if syncedMainComponentIngress != nil {
+				mainComponentIngressAsResource, err := commoncontroller.NewResource(
+					syncedMainComponentIngress,
+					func() (bool, string) {
+						return true, ""
+					},
+				)
+				if err != nil {
+					return ReconcileResult{}, fmt.Errorf("failed to create the main component ingress resource: %w", err)
+				}
+				resources = append(resources, mainComponentIngressAsResource)
+			}
+
+			if r.Config.Ingress.UseVirtualService() {
+				mainComponentVirtualService := dynamo.GenerateComponentVirtualService(
+					ctx,
+					dynamo.GetDCDResourceName(dynamoDeployment, componentName, ""),
+					dynamoDeployment.Namespace,
+					ingressSpec,
+				)
+				_, syncedMainComponentVirtualService, err := commoncontroller.SyncResource(
+					ctx,
+					r,
+					dynamoDeployment,
+					func(context.Context) (*networkingv1beta1.VirtualService, bool, error) {
+						if !ingressSpec.IsVirtualServiceEnabled() {
+							logger.Info("VirtualService is not enabled")
+							return mainComponentVirtualService, true, nil
+						}
+						return mainComponentVirtualService, false, nil
+					},
+				)
+				if err != nil {
+					logger.Error(err, "failed to sync the main component virtual service")
+					return ReconcileResult{}, fmt.Errorf("failed to sync the main component virtual service: %w", err)
+				}
+				if syncedMainComponentVirtualService != nil {
+					mainComponentVirtualServiceAsResource, err := commoncontroller.NewResource(
+						syncedMainComponentVirtualService,
+						func() (bool, string) {
+							return true, ""
+						},
+					)
+					if err != nil {
+						return ReconcileResult{}, fmt.Errorf("failed to create the main component virtual service resource: %w", err)
+					}
+					resources = append(resources, mainComponentVirtualServiceAsResource)
+				}
+			}
+		}
+	}
+
+	return p.checkResourcesReadiness(ctx, dynamoDeployment, resources)
+}
+
+// checkResourcesReadiness computes the readiness result for the synced Grove
+// resources and overlays the Grove-specific Ready reason classification on a
+// not-ready result. A transient Grove read error is returned so reconciliation
+// retries without advancing ObservedGeneration.
+func (p *groveProgram) checkResourcesReadiness(
+	ctx context.Context,
+	dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment,
+	resources []Resource,
+) (ReconcileResult, error) {
+	result := p.reconciler.checkResourcesReadiness(resources)
+	if err := p.applyReadyClassification(ctx, dynamoDeployment, &result); err != nil {
+		return ReconcileResult{}, err
+	}
+	return result, nil
+}
+
+// applyReadyClassification replaces the generic not-ready reason with the
+// Grove-specific classification derived from PodClique and
+// PodCliqueScalingGroup status. Successful results retain the common ready
+// reason.
+func (p *groveProgram) applyReadyClassification(
+	ctx context.Context,
+	dynamoDeployment *nvidiacomv1beta1.DynamoGraphDeployment,
+	result *ReconcileResult,
+) error {
+	if result.State == nvidiacomv1beta1.DGDStateSuccessful {
+		return nil
+	}
+	classification, err := dynamo.ClassifyGroveReadiness(ctx, p.reconciler.Client, dynamoDeployment)
+	if err != nil {
+		return err
+	}
+	if classification != "" {
+		result.Reason = Reason(classification)
+	}
+	return nil
+}

--- a/deploy/operator/internal/controller/dynamographdeployment_program.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program.go
@@ -194,15 +194,6 @@ func workloadProgramFailureReason(err error) (Reason, bool) {
 	return failure.reason, true
 }
 
-// groveReconcileFunc is the temporary strangler seam around the existing Grove
-// pathway. It disappears when Grove reconciliation moves into groveProgram.
-type groveReconcileFunc func(
-	context.Context,
-	*nvidiacomv1beta1.DynamoGraphDeployment,
-	*dynamo.RestartState,
-	map[string]*checkpoint.CheckpointInfo,
-) (ReconcileResult, error)
-
 type componentProgram struct {
 	// The DGD reconciler temporarily supplies shared controller dependencies and
 	// managed rolling-update helpers. Later extractions can narrow this without
@@ -594,89 +585,12 @@ func (p *componentProgram) preserveExistingBackendFramework(
 	return nil
 }
 
-type groveProgram struct {
-	reconciler *DynamoGraphDeploymentReconciler
-	reconcile  groveReconcileFunc
-	lwsEnabled bool
-}
-
-// Reconcile composes the current Grove pathway around its temporary workload
-// adapter while keeping shared resource ordering and result publication
-// identical to the component program.
-func (p *groveProgram) Reconcile(
-	ctx context.Context,
-	req workloadProgramRequest,
-) (programResult workloadProgramResult, retErr error) {
-	programResult = newWorkloadProgramResult(req.DGD)
-	defer func() {
-		if retErr != nil {
-			reason := reasonFailedToReconcileResources
-			if classified, ok := workloadProgramFailureReason(retErr); ok {
-				reason = classified
-			}
-			programResult.Fail(req.DGD.Generation, reason, retErr)
-		}
-		p.reconciler.propagateTopologyCondition(ctx, req.DGD, &programResult)
-	}()
-	log.FromContext(ctx).Info(
-		"Reconciling Grove resources",
-		"hasMultinode", req.DGD.HasAnyMultinodeComponent(),
-		"lwsEnabled", p.lwsEnabled,
-	)
-
-	if err := p.reconciler.migrateCurrentWorkerHashIfNeeded(ctx, req.DGD); err != nil {
-		log.FromContext(ctx).Error(err, "Failed to migrate worker hash")
-		return programResult, failWorkloadProgram(reasonFailedToMigrateWorkerHash, err)
-	}
-	if err := reconcileUnsupportedWorkerRollout(ctx, p.reconciler, req.DGD, true); err != nil {
-		return programResult, err
-	}
-	inputs, err := p.reconciler.reconcileProgramInputs(ctx, req.DGD)
-	if inputs.CheckpointStatuses != nil {
-		programResult.Status.Checkpoints = inputs.CheckpointStatuses
-	}
-	if err != nil {
-		return programResult, err
-	}
-	restart := p.reconciler.resolveProgramRestartState(ctx, req.DGD, &programResult.Status, &programResult)
-	programResult.Status.Restart = restart.Status
-
-	result, err := p.reconcileWorkloads(ctx, workloadReconcileRequest{
-		DGD:             req.DGD,
-		RestartState:    restart.State,
-		CheckpointInfos: inputs.CheckpointInfos,
-	})
-	if err != nil {
-		return programResult, fmt.Errorf("failed to reconcile Grove workloads: %w", err)
-	}
-	result, err = p.reconciler.reconcileProgramResult(ctx, req.DGD, inputs, restart, result)
-	if err != nil {
-		return programResult, err
-	}
-
-	programResult.applyReconcileResult(req.DGD.Generation, result)
-	return programResult, nil
-}
-
-func (p *groveProgram) reconcileWorkloads(
-	ctx context.Context,
-	req workloadReconcileRequest,
-) (ReconcileResult, error) {
-	return p.reconcile(
-		ctx,
-		req.DGD,
-		req.RestartState,
-		req.CheckpointInfos,
-	)
-}
-
 func (r *DynamoGraphDeploymentReconciler) selectWorkloadProgram(
 	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
 ) workloadProgram {
 	if r.isGrovePathway(dgd) {
 		return &groveProgram{
 			reconciler: r,
-			reconcile:  r.reconcileGroveResources,
 			lwsEnabled: r.RuntimeConfig.Gate.Enabled(features.LWS),
 		}
 	}

--- a/deploy/operator/internal/controller/dynamographdeployment_program_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_program_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
@@ -247,77 +246,6 @@ func TestWorkloadProgramResultOwnsReadyAndObservedGeneration(t *testing.T) {
 	})
 }
 
-func TestGroveProgram_ReconcileWorkloadsAdapter(t *testing.T) {
-	reconcileErr := errors.New("reconcile failed")
-	tests := []struct {
-		name         string
-		returned     ReconcileResult
-		reconcileErr error
-		wantResult   ReconcileResult
-		wantErr      error
-	}{
-		{
-			name: "Grove program records a successful result",
-			returned: ReconcileResult{
-				State:  nvidiacomv1beta1.DGDStatePending,
-				Reason: "grove_pending",
-			},
-			wantResult: ReconcileResult{
-				State:  nvidiacomv1beta1.DGDStatePending,
-				Reason: "grove_pending",
-			},
-		},
-		{
-			name: "Grove program preserves prior state on error",
-			returned: ReconcileResult{
-				State:  nvidiacomv1beta1.DGDStateSuccessful,
-				Reason: "must_not_be_committed",
-			},
-			reconcileErr: reconcileErr,
-			wantErr:      reconcileErr,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Log("Build typed workload inputs that must be passed unchanged")
-			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
-			restartState := &dynamo.RestartState{Timestamp: "restart"}
-			checkpointInfos := map[string]*checkpoint.CheckpointInfo{
-				"worker": {CheckpointName: "checkpoint"},
-			}
-			req := workloadReconcileRequest{
-				DGD:             dgd,
-				RestartState:    restartState,
-				CheckpointInfos: checkpointInfos,
-			}
-			called := false
-			reconcile := func(
-				_ context.Context,
-				gotDGD *nvidiacomv1beta1.DynamoGraphDeployment,
-				gotRestartState *dynamo.RestartState,
-				gotCheckpointInfos map[string]*checkpoint.CheckpointInfo,
-			) (ReconcileResult, error) {
-				called = true
-				require.Same(t, dgd, gotDGD)
-				require.Same(t, restartState, gotRestartState)
-				require.Equal(t, checkpointInfos, gotCheckpointInfos)
-				return tt.returned, tt.reconcileErr
-			}
-
-			t.Log("Run the temporary Grove workload adapter")
-			result, err := (&groveProgram{reconcile: reconcile}).reconcileWorkloads(context.Background(), req)
-
-			t.Log("Verify the adapter forwards inputs and outputs unchanged")
-			require.True(t, called)
-			require.ErrorIs(t, err, tt.wantErr)
-			if tt.reconcileErr == nil {
-				assert.Equal(t, tt.wantResult, result)
-			}
-		})
-	}
-}
-
 func TestComponentProgram_ReconcilePreservesResultOnError(t *testing.T) {
 	t.Log("Inject a component-path API failure before new status is produced")
 	reconcileErr := errors.New("reconcile failed")
@@ -378,15 +306,6 @@ func TestGroveProgram_ReconcilePreservesResultOnError(t *testing.T) {
 		reconciler: &DynamoGraphDeploymentReconciler{
 			Client:   kubeClient,
 			Recorder: record.NewFakeRecorder(10),
-		},
-		reconcile: func(
-			context.Context,
-			*nvidiacomv1beta1.DynamoGraphDeployment,
-			*dynamo.RestartState,
-			map[string]*checkpoint.CheckpointInfo,
-		) (ReconcileResult, error) {
-			t.Fatal("Grove workload reconciliation must not run after rollout preparation fails")
-			return ReconcileResult{}, nil
 		},
 	}
 	dgd.Status = nvidiacomv1beta1.DynamoGraphDeploymentStatus{


### PR DESCRIPTION
## Summary

This MR makes `groveProgram` directly own the complete Grove workload reconciliation sequence.

The Grove program now composes:

1. Worker-hash migration and unsupported-path rollout handling.
2. Shared resource and checkpoint input reconciliation.
3. Restart-state resolution.
4. Grove render preparation.
5. PodCliqueSet generation and reconciliation.
6. Grove scaling.
7. Model-discovery and component Service reconciliation.
8. Frontend Ingress and VirtualService reconciliation.
9. Grove-specific readiness classification.
10. Shared checkpoint-readiness and scaling-adapter result processing.

The temporary `groveReconcileFunc` adapter and `DynamoGraphDeploymentReconciler.reconcileGroveResources` entry point have been removed.

This MR is stacked on the preceding workload-program request/result contract MR.

## Motivation

Although the outer controller already selected a complete `groveProgram`, the program still delegated its entire workload phase back to an injected `DynamoGraphDeploymentReconciler.reconcileGroveResources` method.

That left Grove control-flow ownership indirect:

```text
DGD controller
    -> selects groveProgram
        -> invokes injected DGD reconciler method
            -> drives Grove reconciliation
```

After this change, the selected program visibly owns the complete sequence:

```text
DGD controller
    -> selects groveProgram
        -> prepares Grove rendering
        -> reconciles the PodCliqueSet
        -> applies Grove scaling
        -> reconciles networking resources
        -> evaluates Grove readiness
```

This removes the temporary adapter without introducing provider lifecycle callbacks or a generic reconciliation framework.

## Design

### Direct GroveProgram ownership

`groveProgram.Reconcile` continues to own the graph-level Grove composition, including shared inputs, restart resolution, workload reconciliation, and result processing.

Its `reconcileWorkloads` method now contains the provider-specific Grove sequence directly rather than invoking an injected function.

### Dedicated program file

The Grove program implementation now lives in `dynamographdeployment_grove_program.go`, keeping provider-specific orchestration and readiness logic separate from the common workload-program contract and the component program.

### Temporary low-level dependencies

Low-level Grove rendering, scaling, Kubernetes persistence, and compatibility helpers remain on `DynamoGraphDeploymentReconciler` temporarily.

This MR moves control-flow ownership only. Narrowing those dependencies, extracting the Grove renderer, and localizing watches can happen as focused follow-up changes without combining package movement or renderer redesign with this ownership change.

### Status ownership

Status behavior is unchanged:

- The Grove program accumulates its proposed DGD status in the program result.
- Grove-specific readiness classification is performed by the Grove program.
- The outer DGD reconciler remains the only status-subresource writer.
- The outer reconciler continues to own `Ready`, `ObservedGeneration`, common condition projection, and the final `Status().Update()`.

## Behavior and compatibility

This is intended to be a behavior-preserving refactor:

- Grove pathway selection is unchanged.
- Grove retains its existing unsupported managed-rollout behavior.
- Shared resource ordering is unchanged.
- Restart state is still resolved before Grove resource generation.
- Render preparation still preserves legacy worker selectors.
- PodCliqueSet reconciliation still precedes Grove scaling.
- Model-discovery Services, component Services, Ingresses, and VirtualServices are reconciled in the same order.
- Grove readiness classification and transient read-error propagation are unchanged.
- Checkpoint startup readiness and scaling-adapter ordering are unchanged.
- Existing scheduler, queue, topology, naming, and replica behavior are unchanged.
- Finalizer, watch registration, resource ownership, and status persistence remain with their existing owners.

There are no CRD, rendered-resource, watch-registration, owner-reference, or persisted-state changes.


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->