### PR TITLE
fix(ci): clarify unsigned commit CI message

### DIFF
--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -27,8 +27,9 @@
 #
 # All paths require every commit currently in the PR to have a signature that GitHub reports as
 # verified. If any commit is unsigned, the workflow does not post `/ok to test`. For PRs authored
-# by maintainers, it also explains which commits failed verification. Non-maintainer contributors
-# do not receive the unsigned-commit comment and instead wait for manual approval. Repository-
+# by maintainers, it explains which commits failed verification. Approved external contributors
+# receive guidance for either signing the commits or requesting manual approval. Other external
+# contributors wait for manual approval without receiving an unsigned-commit comment. Repository-
 # permission lookup failures fail closed for the maintainer paths, and malformed contributor-list
 # configuration fails closed for the approved-author path.
 #
@@ -91,21 +92,22 @@ jobs:
         id: author_permission_check
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
+          REPOSITORY: ${{ github.repository }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
           # This checks effective repository permission, not organization membership.
           if ! author_permission=$(gh api \
-            "repos/$REPO_OWNER/$REPO_NAME/collaborators/$PR_AUTHOR/permission" \
+            "repos/$REPOSITORY/collaborators/$PR_AUTHOR/permission" \
             --jq '.permission' 2>/dev/null); then
             echo "Author $PR_AUTHOR does not have maintainer repository permission."
             echo "is_maintainer=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # The endpoint returns one legacy base permission. Maintain maps to "write", while
+          # admin remains "admin", so both returned values that grant write access are accepted.
           case "$author_permission" in
-            admin|maintain|write)
+            admin|write)
               echo "Author $PR_AUTHOR has $author_permission repository permission."
               echo "is_maintainer=true" >> "$GITHUB_OUTPUT"
               ;;
@@ -119,23 +121,24 @@ jobs:
         if: github.event.action == 'synchronize' && steps.author_check.outputs.is_approved != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO_OWNER: ${{ github.repository_owner }}
-          REPO_NAME: ${{ github.event.repository.name }}
+          REPOSITORY: ${{ github.repository }}
           TRIGGERING_ACTOR: ${{ github.actor }}
         run: |
           # This checks effective repository permission, not organization membership. GitHub's
           # collaborator-permission endpoint supports the repository-scoped GitHub App installation
           # token provided by github.token and requires only repository Metadata read access.
           if ! actor_permission=$(gh api \
-            "repos/$REPO_OWNER/$REPO_NAME/collaborators/$TRIGGERING_ACTOR/permission" \
+            "repos/$REPOSITORY/collaborators/$TRIGGERING_ACTOR/permission" \
             --jq '.permission'); then
             echo "Warning: Could not determine repository permission for $TRIGGERING_ACTOR." >&2
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
+          # The endpoint returns one legacy base permission. Maintain maps to "write", while
+          # admin remains "admin", so both returned values that grant write access are accepted.
           case "$actor_permission" in
-            admin|maintain|write)
+            admin|write)
               echo "Actor $TRIGGERING_ACTOR has $actor_permission repository permission."
               echo "is_approved=true" >> "$GITHUB_OUTPUT"
               ;;
@@ -246,6 +249,31 @@ jobs:
           ${table}
 
           Please sign your commits and push again. See the [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for help."
+
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO_OWNER/$REPO_NAME" \
+            --body "$body"
+      - name: Comment unsigned commits for approved external contributor
+        if: steps.author_check.outputs.is_approved == 'true' && steps.author_permission_check.outputs.is_maintainer != 'true' && steps.signature_check.outputs.all_signed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          UNSIGNED_COMMITS: ${{ steps.signature_check.outputs.unsigned_commits }}
+        run: |
+          table=$(echo "$UNSIGNED_COMMITS" | jq -r '.[] | "| `\(.sha)` | \(.reason) |"')
+          body="<!-- dynamo-ext-contributor: unsigned -->
+          ## Automatic CI Approval Skipped
+
+          Automatic approval requires every commit to have a signature that GitHub reports as verified. The following commits do not meet that requirement:
+
+          | Commit | Reason |
+          |--------|--------|
+          ${table}
+
+          To use automatic approval, sign the listed commits and push again. Alternatively, a maintainer can review this head and comment \`/ok to test $PR_SHA\`; you do not need to rewrite the commits for that manual approval path."
 
           gh pr comment "$PR_NUMBER" \
             --repo "$REPO_OWNER/$REPO_NAME" \

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -196,19 +196,24 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
           UNSIGNED_COMMITS: ${{ steps.signature_check.outputs.unsigned_commits }}
         run: |
           table=$(echo "$UNSIGNED_COMMITS" | jq -r '.[] | "| `\(.sha)` | \(.reason) |"')
           body="<!-- dynamo-ext-contributor: unsigned -->
-          ## Unsigned Commits Detected
+          ## Automatic CI Approval Skipped
 
-          The following commits are not GPG-signed and must be signed before CI can run:
+          This signature check applies only to the automatic CI approval path for internal or otherwise approved contributors, or to a PR head updated by a maintainer. That path requires every commit to have a signature that GitHub reports as verified.
+
+          The following commits do not meet that requirement:
 
           | Commit | Reason |
           |--------|--------|
           ${table}
 
-          Please sign your commits and push again. See the [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for help."
+          Commit signing is not required for a maintainer-approved CI run. External contributors do not need to rewrite their commit history. A maintainer can review the current head and comment \`/ok to test $PR_SHA\` instead. If that exact SHA has already been approved, no action is needed.
+
+          If you are eligible for automatic approval and want to use it, sign the listed commits and push again. See the [GitHub docs on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for help."
 
           gh pr comment "$PR_NUMBER" \
             --repo "$REPO_OWNER/$REPO_NAME" \

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -17,7 +17,7 @@
 # A fork PR can reach the signature check through any of these approval paths:
 #
 # 1. The PR author has write, maintain, or admin access to this repository. This path applies when
-#    the PR is opened, synchronized, or reopened.
+#    the PR is opened or reopened. A synchronized update must also be pushed by a maintainer.
 # 2. The PR author is listed in the `APPROVED_EXTERNAL_CONTRIBUTORS` environment secret. This path
 #    applies when the PR is opened, synchronized, or reopened.
 # 3. A user with write, maintain, or admin access to this repository synchronizes the PR branch.
@@ -116,7 +116,7 @@ jobs:
           esac
       - name: Validate triggering actor
         id: actor_check
-        if: github.event.action == 'synchronize' && steps.author_check.outputs.is_approved != 'true' && steps.author_permission_check.outputs.is_maintainer != 'true'
+        if: github.event.action == 'synchronize' && steps.author_check.outputs.is_approved != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -150,8 +150,13 @@ jobs:
           AUTHOR_APPROVED: ${{ steps.author_check.outputs.is_approved }}
           AUTHOR_MAINTAINER: ${{ steps.author_permission_check.outputs.is_maintainer }}
           ACTOR_APPROVED: ${{ steps.actor_check.outputs.is_approved }}
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
-          if [[ "$AUTHOR_APPROVED" == "true" || "$AUTHOR_MAINTAINER" == "true" || "$ACTOR_APPROVED" == "true" ]]; then
+          if [[ "$AUTHOR_APPROVED" == "true" ]]; then
+            echo "is_approved=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_ACTION" == "synchronize" && "$ACTOR_APPROVED" == "true" ]]; then
+            echo "is_approved=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$EVENT_ACTION" != "synchronize" && "$AUTHOR_MAINTAINER" == "true" ]]; then
             echo "is_approved=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_approved=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/trigger-ci-approval-flow.yml
+++ b/.github/workflows/trigger-ci-approval-flow.yml
@@ -14,19 +14,23 @@
 # new push, or reopened. The job is skipped for branches in this repository because those branches
 # use the normal internal-contributor CI path.
 #
-# A fork PR can reach the signature check through either of these approval paths:
+# A fork PR can reach the signature check through any of these approval paths:
 #
-# 1. The PR author is listed in the `APPROVED_EXTERNAL_CONTRIBUTORS` environment secret. This path
+# 1. The PR author has write, maintain, or admin access to this repository. This path applies when
+#    the PR is opened, synchronized, or reopened.
+# 2. The PR author is listed in the `APPROVED_EXTERNAL_CONTRIBUTORS` environment secret. This path
 #    applies when the PR is opened, synchronized, or reopened.
-# 2. A user with write, maintain, or admin access to this repository synchronizes the PR branch.
+# 3. A user with write, maintain, or admin access to this repository synchronizes the PR branch.
 #    For example, a maintainer may merge `main` into a contributor's branch. This path approves
 #    only the head created by that synchronization; it does not make the PR or contributor trusted
 #    for later pushes.
 #
-# Both paths require every commit currently in the PR to have a signature that GitHub reports as
-# verified. If any commit is unsigned, the workflow explains which commits failed verification and
-# does not post `/ok to test`. Repository-permission lookup failures fail closed for the maintainer
-# path, and malformed contributor-list configuration fails closed for the approved-author path.
+# All paths require every commit currently in the PR to have a signature that GitHub reports as
+# verified. If any commit is unsigned, the workflow does not post `/ok to test`. For PRs authored
+# by maintainers, it also explains which commits failed verification. Non-maintainer contributors
+# do not receive the unsigned-commit comment and instead wait for manual approval. Repository-
+# permission lookup failures fail closed for the maintainer paths, and malformed contributor-list
+# configuration fails closed for the approved-author path.
 #
 # Why a contributor's PR may not trigger trusted CI
 # -------------------------------------------------
@@ -83,9 +87,36 @@ jobs:
             echo "Author $PR_AUTHOR is not in APPROVED_EXTERNAL_CONTRIBUTORS."
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
           fi
+      - name: Validate PR author permission
+        id: author_permission_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO_OWNER: ${{ github.repository_owner }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # This checks effective repository permission, not organization membership.
+          if ! author_permission=$(gh api \
+            "repos/$REPO_OWNER/$REPO_NAME/collaborators/$PR_AUTHOR/permission" \
+            --jq '.permission' 2>/dev/null); then
+            echo "Author $PR_AUTHOR does not have maintainer repository permission."
+            echo "is_maintainer=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          case "$author_permission" in
+            admin|maintain|write)
+              echo "Author $PR_AUTHOR has $author_permission repository permission."
+              echo "is_maintainer=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Author $PR_AUTHOR does not have maintainer repository permission."
+              echo "is_maintainer=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
       - name: Validate triggering actor
         id: actor_check
-        if: github.event.action == 'synchronize' && steps.author_check.outputs.is_approved != 'true'
+        if: github.event.action == 'synchronize' && steps.author_check.outputs.is_approved != 'true' && steps.author_permission_check.outputs.is_maintainer != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           REPO_OWNER: ${{ github.repository_owner }}
@@ -117,9 +148,10 @@ jobs:
         id: approval_check
         env:
           AUTHOR_APPROVED: ${{ steps.author_check.outputs.is_approved }}
+          AUTHOR_MAINTAINER: ${{ steps.author_permission_check.outputs.is_maintainer }}
           ACTOR_APPROVED: ${{ steps.actor_check.outputs.is_approved }}
         run: |
-          if [[ "$AUTHOR_APPROVED" == "true" || "$ACTOR_APPROVED" == "true" ]]; then
+          if [[ "$AUTHOR_APPROVED" == "true" || "$AUTHOR_MAINTAINER" == "true" || "$ACTOR_APPROVED" == "true" ]]; then
             echo "is_approved=true" >> "$GITHUB_OUTPUT"
           else
             echo "is_approved=false" >> "$GITHUB_OUTPUT"
@@ -190,30 +222,25 @@ jobs:
               gh api --method DELETE "repos/$REPO_OWNER/$REPO_NAME/issues/comments/$comment_id"
             done
       - name: Comment unsigned commits
-        if: steps.approval_check.outputs.is_approved == 'true' && steps.signature_check.outputs.all_signed == 'false'
+        if: steps.approval_check.outputs.is_approved == 'true' && steps.author_permission_check.outputs.is_maintainer == 'true' && steps.signature_check.outputs.all_signed == 'false'
         env:
           GH_TOKEN: ${{ secrets.AUTO_VERIFIER_CI_TOKEN }}
           REPO_OWNER: ${{ github.repository_owner }}
           REPO_NAME: ${{ github.event.repository.name }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
           UNSIGNED_COMMITS: ${{ steps.signature_check.outputs.unsigned_commits }}
         run: |
           table=$(echo "$UNSIGNED_COMMITS" | jq -r '.[] | "| `\(.sha)` | \(.reason) |"')
           body="<!-- dynamo-ext-contributor: unsigned -->
-          ## Automatic CI Approval Skipped
+          ## Unsigned Commits Detected
 
-          This signature check applies only to the automatic CI approval path for internal or otherwise approved contributors, or to a PR head updated by a maintainer. That path requires every commit to have a signature that GitHub reports as verified.
-
-          The following commits do not meet that requirement:
+          The following commits are not GPG-signed and must be signed before CI can run:
 
           | Commit | Reason |
           |--------|--------|
           ${table}
 
-          Commit signing is not required for a maintainer-approved CI run. External contributors do not need to rewrite their commit history. A maintainer can review the current head and comment \`/ok to test $PR_SHA\` instead. If that exact SHA has already been approved, no action is needed.
-
-          If you are eligible for automatic approval and want to use it, sign the listed commits and push again. See the [GitHub docs on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for help."
+          Please sign your commits and push again. See the [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) for help."
 
           gh pr comment "$PR_NUMBER" \
             --repo "$REPO_OWNER/$REPO_NAME" \


### PR DESCRIPTION
## Overview

  Fix the unsigned-commit bot behavior so external, non-maintainer contributors are not told to rewrite and sign
  their commit history before CI can run.

  Maintainer-authored fork PRs retain the existing unsigned-commit warning. Non-maintainer contributors receive
  no signing warning and can wait for manual CI approval.

  ## Details

  - Check the PR author’s effective repository permission.
  - Treat write, maintain, and admin permissions as maintainer access.
  - Fail closed when the author’s permission cannot be determined.
  - Include maintainer authors in the automatic CI approval path.
  - Post the existing unsigned-commit warning only when the PR author is a maintainer.
  - Preserve automatic approval for approved external contributors whose commits are verified.
  - Preserve the maintainer /ok to test <sha> flow for external contributors.

  This addresses the misleading behavior observed in PR #11551
  (https://github.com/ai-dynamo/dynamo/pull/11551#issuecomment-5064874729).

  ## Where should the reviewer start?

  Review .github/workflows/trigger-ci-approval-flow.yml, particularly:

  - Validate PR author permission
  - Determine CI approval
  - Comment unsigned commits

  ## Validation

  - pre-commit run check-yaml --files .github/workflows/trigger-ci-approval-flow.yml
  - Tested permission handling for admin, maintain, write, read, and lookup failures.
  - Tested each automatic approval input independently.
  - git diff --check

  ## Related Issues

  🚫 This PR is NOT linked to an issue:

  - [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Workflow**
  * Updated pull request approval handling to recognize repository maintainers as an additional approval path.
  * Improved validation of pull request authors and triggering actors during CI approval checks.
  * Restricted unsigned-commit notifications to applicable maintainer-authored pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->