### PR TITLE
feat(skills): add reviewer selection workflows

### DIFF
--- a/.agents/skills/reviewers-slack/SKILL.md
+++ b/.agents/skills/reviewers-slack/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: reviewers-slack
+description: Turns the canonical reviewers plan for an ai-dynamo/dynamo pull request linked from a Slack thread into a stable, group-scoped Slack request, without re-notifying existing reviewers, and marks requested groups complete as reviews arrive. Use when invoked as /reviewers-slack with a Slack thread URL, including DM-only test runs before live thread posting is enabled.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - github
+    - slack
+    - pull-request
+    - reviewers
+---
+
+# Slack PR Reviewers
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Turn the repository's canonical `reviewers` plan into a stable Slack request. Reuse
+that skill for CODEOWNERS scope, review coverage, candidate ranking, and path
+summaries; own only Slack discovery, identity mapping, rendering, and persisted state
+here.
+
+## Deployment guard
+
+Operate in **DM-only test mode** until the user explicitly authorizes live thread
+writes in a later request.
+
+- Read the supplied thread when access permits, but never write to it.
+- Send the rendered request to the authenticated user's self-DM.
+- Render real Slack group and user mentions exactly as they would appear live.
+- On repeated runs, edit the existing managed DM message instead of sending another.
+- Allow `--pr <GitHub PR URL>` only in test mode when the source thread is inaccessible.
+- Do not infer live authorization from the slash-command invocation.
+
+## Input and source thread
+
+Accept:
+
+```text
+/reviewers-slack <Slack thread URL>
+/reviewers-slack <Slack thread URL> --pr <GitHub PR URL>
+```
+
+Parse the permalink with `scripts/reviewers_slack_state.py parse-url`. Require a
+message permalink containing a channel ID and parent timestamp; reject channel-only
+links.
+
+Read the parent and every reply, then extract
+`https://github.com/ai-dynamo/dynamo/pull/<N>` links:
+
+- Use the only open Dynamo PR when exactly one is present.
+- If multiple open Dynamo PRs are present, ask which one is in scope.
+- If the thread is inaccessible, report the Slack error. Continue only in test mode
+  with an explicit `--pr` override.
+- Never use a PR override for a live thread write.
+
+Resolve the authenticated Slack profile. In test mode, find the real self-DM
+conversation (`D...`) from visible IM conversations; never construct a DM ID.
+
+## Managed message
+
+Read destination history fresh and find a message authored by the authenticated user
+containing either marker form:
+
+```text
+reviewers-slack:v1 repo=ai-dynamo/dynamo pr=<N> scope=<12 hex chars>
+reviewers-slack:v1:repo=ai-dynamo/dynamo:pr=<N>:scope=<12 hex chars>
+```
+
+Treat the marker as managed state. Never edit another user's message. Stop if more
+than one matching managed message exists.
+
+Write every managed message in English.
+
+## Canonical reviewer plan
+
+Use the `reviewers` skill to produce the canonical plan for the resolved PR. Compute
+the scope fingerprint from its sorted `scope` records:
+
+```json
+{
+  "repo": "ai-dynamo/dynamo",
+  "pr": 11946,
+  "files": [
+    {"path": ".github/workflows/foo.yml", "owners": ["@ai-dynamo/dynamo-ops-codeowners"]}
+  ]
+}
+```
+
+```bash
+python3 scripts/reviewers_slack_state.py fingerprint scope.json
+```
+
+The fingerprint excludes the head SHA and patch contents. New commits touching the
+same owned paths do not churn reviewer assignments; changed paths or CODEOWNERS
+mappings do.
+
+Apply the plan according to managed state:
+
+- **No managed message:** omit groups already covered. Use the canonical reviewers
+  and path summaries only for uncovered groups. If all groups are covered, write
+  nothing.
+- **Same fingerprint:** preserve every existing requested block, reviewer list, and
+  path wording. Use current plan coverage only to refresh completion styling.
+- **Different fingerprint:** remove no-longer-required groups. Preserve existing
+  groups and update their paths and completion. Add only newly required, uncovered
+  groups using the canonical plan. Replace the message in place.
+
+Never select or rank reviewers independently in this wrapper.
+
+## Resolve Slack mentions
+
+For each new visible group:
+
+- Resolve the same-named Slack user group live and render `<!subteam^S...>`.
+- Resolve each canonical GitHub reviewer to `<@U...>` through a verified mapping,
+  exact corporate email, or unambiguous exact-name lookup.
+- Skip an unresolved candidate and take the next eligible candidate from the
+  canonical ranking. Never invent a Slack handle or render a bare GitHub login.
+- Select up to three people; keep two when later candidates cannot be resolved or
+  lack meaningful evidence.
+- Repeat the same person normally under every applicable group.
+
+## Render new request blocks
+
+For each visible group render:
+
+1. the Slack group mention followed once by two or three user mentions, with no label;
+2. one or two canonical path summaries directly below it, never more than three.
+
+```text
+<!subteam^S123> <@U123> <@U456>
+- `components/src/dynamo/frontend/` — Adds separate HTTP and TCP TLS options.
+- `components/src/dynamo/common/configuration/` — Propagates TLS settings through runtime configuration.
+```
+
+Use 4–8 word implementation summaries. Do not describe review concerns or desired
+verification.
+
+Render only Slack mentions for individuals; do not show GitHub logins.
+
+## Persist reviewer mappings
+
+Store the GitHub-to-Slack mapping for visible groups in ranked order:
+
+```json
+{"groups":{"dynamo-runtime-codeowners":[{"github":"nnshah1","slack_id":"U123"}]}}
+```
+
+Encode it with:
+
+```bash
+python3 scripts/reviewers_slack_state.py encode-reviewers reviewers.json
+```
+
+Append exactly one seed link as the final nonblank line, separated from the final
+block by a blank line. Use a single period as its complete visible label:
+
+```text
+[.](https://github.com/ai-dynamo/dynamo/pull/10921#reviewers-slack:v1:repo=ai-dynamo/dynamo:pr=10921:scope=0123456789ab:state=<encoded-state>)
+```
+
+Keep the link outside all group blocks and strikethrough. On updates, preserve the
+`.` label and replace its target. Remove legacy visible request headings or state
+prose when migrating a managed message.
+
+In test mode, begin with `TEST — would update <thread permalink>`.
+
+## Update completion
+
+Coverage comes from the current canonical plan, not the stored reviewer list. A
+counted review by any current member of an exact owner team completes its visible
+block.
+
+Retain completed requested blocks, strike through every visible line separately, and
+append `✅` to the struck-through heading:
+
+```text
+~~<!subteam^S123> <@U123> <@U456>~~ ✅
+- ~~`components/src/dynamo/frontend/` — Adds separate HTTP and TCP TLS options.~~
+```
+
+Remove stale completion styling when current coverage disappears. Completion means a
+counted review exists, not necessarily approval. Never add a completed block that was
+omitted from the initial request.
+
+## Write safely
+
+Immediately before writing, reread the active Slack outgoing-message formatting rules.
+
+- **First run:** send one managed message containing only uncovered groups to the
+  self-DM. Write nothing when all groups are covered.
+- **Repeated run:** edit the existing managed message by its real `D...` conversation
+  ID and timestamp.
+- Never write to the source thread while the deployment guard is active.
+- Return the Slack permalink or message ID and state whether the message was created
+  or updated.
+
+Use `scripts/reviewers_slack_state.py` for permalink parsing, deterministic scope
+hashing, marker parsing, and reviewer-state encoding.

--- a/.agents/skills/reviewers-slack/agents/openai.yaml
+++ b/.agents/skills/reviewers-slack/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Slack Reviewers"
+  short_description: "Find and track PR reviewers from a Slack thread"
+  default_prompt: "Use $reviewers-slack on this Slack thread to request and track PR reviewers."

--- a/.agents/skills/reviewers-slack/scripts/reviewers_slack_state.py
+++ b/.agents/skills/reviewers-slack/scripts/reviewers_slack_state.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic state helpers for the reviewers-slack skill."""
+
+import argparse
+import base64
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+THREAD_PATH = re.compile(r"^/archives/(?P<channel>[CDG][A-Z0-9]+)/p(?P<digits>\d{16})$")
+MARKER = re.compile(
+    r"reviewers-slack:v1(?:\s+|:)repo=(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)"
+    r"(?:\s+|:)pr=(?P<pr>\d+)(?:\s+|:)scope=(?P<scope>[0-9a-f]{12})"
+    r"(?:(?:\s+|:)state=(?P<state>[A-Za-z0-9_-]+))?"
+)
+SLACK_USER_ID = re.compile(r"^U[A-Z0-9]+$")
+
+
+def read_json(path: str):
+    if path == "-":
+        return json.load(sys.stdin)
+    with Path(path).open(encoding="utf-8") as stream:
+        return json.load(stream)
+
+
+def read_text(path: str) -> str:
+    if path == "-":
+        return sys.stdin.read()
+    return Path(path).read_text(encoding="utf-8")
+
+
+def parse_thread_url(value: str) -> dict[str, str]:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc.endswith(".slack.com"):
+        raise ValueError("expected an https://<workspace>.slack.com thread permalink")
+    match = THREAD_PATH.fullmatch(parsed.path.rstrip("/"))
+    if not match:
+        raise ValueError("expected /archives/<channel-id>/p<16-digit-message-ts>")
+    digits = match.group("digits")
+    message_ts = f"{digits[:10]}.{digits[10:]}"
+    thread_ts = parse_qs(parsed.query).get("thread_ts", [message_ts])[0]
+    if not re.fullmatch(r"\d{10}\.\d{6}", thread_ts):
+        raise ValueError("thread_ts query parameter is not a Slack timestamp")
+    return {
+        "workspace": parsed.netloc,
+        "channel_id": match.group("channel"),
+        "message_ts": thread_ts,
+        "permalink": value,
+    }
+
+
+def normalized_scope(document: dict) -> dict:
+    repo = document.get("repo")
+    pr = document.get("pr")
+    files = document.get("files")
+    if not isinstance(repo, str) or "/" not in repo:
+        raise ValueError("scope JSON requires repo as owner/name")
+    if not isinstance(pr, int) or pr <= 0:
+        raise ValueError("scope JSON requires a positive integer pr")
+    if not isinstance(files, list):
+        raise ValueError("scope JSON requires a files list")
+
+    normalized_files = []
+    seen_paths = set()
+    for entry in files:
+        if not isinstance(entry, dict):
+            raise ValueError("each files entry must be an object")
+        path = entry.get("path")
+        owners = entry.get("owners")
+        if not isinstance(path, str) or not path or path in seen_paths:
+            raise ValueError("each changed path must be non-empty and unique")
+        if not isinstance(owners, list) or not all(
+            isinstance(owner, str) for owner in owners
+        ):
+            raise ValueError(f"owners for {path!r} must be a string list")
+        seen_paths.add(path)
+        normalized_files.append({"path": path, "owners": sorted(set(owners))})
+
+    sorted_files = sorted(normalized_files, key=lambda item: item["path"])
+    return {"repo": repo, "pr": pr, "files": sorted_files}
+
+
+def fingerprint(document: dict) -> str:
+    payload = json.dumps(
+        normalized_scope(document), sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+def normalized_reviewers(document: dict) -> dict:
+    groups = document.get("groups")
+    if not isinstance(groups, dict) or not groups:
+        raise ValueError("reviewer JSON requires a non-empty groups object")
+
+    normalized_groups = {}
+    for group, reviewers in sorted(groups.items()):
+        if not isinstance(group, str) or not group:
+            raise ValueError("reviewer group names must be non-empty strings")
+        if not isinstance(reviewers, list) or not reviewers:
+            raise ValueError(f"reviewers for {group!r} must be a non-empty list")
+
+        normalized_group = []
+        seen_github = set()
+        seen_slack = set()
+        for reviewer in reviewers:
+            if not isinstance(reviewer, dict):
+                raise ValueError(f"each reviewer for {group!r} must be an object")
+            github = reviewer.get("github")
+            slack_id = reviewer.get("slack_id")
+            if not isinstance(github, str) or not github:
+                raise ValueError(f"reviewer for {group!r} requires a GitHub login")
+            if not isinstance(slack_id, str) or not SLACK_USER_ID.fullmatch(slack_id):
+                raise ValueError(f"reviewer {github!r} requires a Slack U... user ID")
+            if github in seen_github or slack_id in seen_slack:
+                raise ValueError(f"duplicate reviewer in group {group!r}")
+            seen_github.add(github)
+            seen_slack.add(slack_id)
+            normalized_group.append({"github": github, "slack_id": slack_id})
+        normalized_groups[group] = normalized_group
+
+    return {"groups": normalized_groups}
+
+
+def encode_reviewers(document: dict) -> str:
+    payload = json.dumps(
+        normalized_reviewers(document), sort_keys=True, separators=(",", ":")
+    ).encode()
+    return base64.urlsafe_b64encode(payload).decode().rstrip("=")
+
+
+def decode_reviewers(token: str) -> dict:
+    if not re.fullmatch(r"[A-Za-z0-9_-]+", token):
+        raise ValueError("encoded reviewer state is not base64url")
+    padding = "=" * (-len(token) % 4)
+    try:
+        document = json.loads(base64.urlsafe_b64decode(token + padding))
+    except (ValueError, json.JSONDecodeError) as error:
+        raise ValueError("encoded reviewer state is invalid") from error
+    return normalized_reviewers(document)
+
+
+def parse_marker(text: str) -> dict[str, object]:
+    matches = list(MARKER.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one reviewers-slack marker, found {len(matches)}"
+        )
+    values = matches[0].groupdict()
+    parsed = {"repo": values["repo"], "pr": int(values["pr"]), "scope": values["scope"]}
+    if values["state"]:
+        parsed["reviewers"] = decode_reviewers(values["state"])
+    return parsed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_url_parser = subparsers.add_parser(
+        "parse-url", help="parse a Slack thread permalink"
+    )
+    parse_url_parser.add_argument("url")
+
+    fingerprint_parser = subparsers.add_parser(
+        "fingerprint", help="hash normalized PR scope JSON"
+    )
+    fingerprint_parser.add_argument("json_file", help="JSON file path, or - for stdin")
+
+    marker_parser = subparsers.add_parser(
+        "parse-marker", help="parse one managed-message marker"
+    )
+    marker_parser.add_argument("text_file", help="text file path, or - for stdin")
+
+    encode_parser = subparsers.add_parser(
+        "encode-reviewers", help="encode GitHub-to-Slack reviewer state"
+    )
+    encode_parser.add_argument("json_file", help="JSON file path, or - for stdin")
+
+    decode_parser = subparsers.add_parser(
+        "decode-reviewers", help="decode GitHub-to-Slack reviewer state"
+    )
+    decode_parser.add_argument("token")
+
+    args = parser.parse_args()
+    try:
+        if args.command == "parse-url":
+            print(json.dumps(parse_thread_url(args.url), sort_keys=True))
+        elif args.command == "fingerprint":
+            print(fingerprint(read_json(args.json_file)))
+        elif args.command == "parse-marker":
+            print(json.dumps(parse_marker(read_text(args.text_file)), sort_keys=True))
+        elif args.command == "encode-reviewers":
+            print(encode_reviewers(read_json(args.json_file)))
+        elif args.command == "decode-reviewers":
+            print(json.dumps(decode_reviewers(args.token), sort_keys=True))
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        parser.error(str(error))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/reviewers/SKILL.md
+++ b/.agents/skills/reviewers/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: reviewers
+description: Finds active, eligible GitHub approvers for a pull request or local diff using CODEOWNERS, submitted reviews, current team membership, recent review activity, changed-code blame, and component history. Use when the user asks who should review or approve a PR, invokes /reviewers or $reviewers, or wants a reviewer plan directly in Codex. Returns grouped GitHub reviewers and scoped path summaries without using Slack, sending messages, or persisting state.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - github
+    - pull-request
+    - reviewers
+---
+
+# GitHub PR Reviewers
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+Build the canonical reviewer plan for an `ai-dynamo/dynamo` pull request and render
+it directly in Codex. Own reviewer scope, coverage, ranking, and path summaries here.
+Slack-specific workflows must reuse this plan instead of reimplementing selection.
+
+## Input
+
+Accept a GitHub PR URL, a PR number inside the matching clone, or no argument:
+
+1. **Explicit PR:** Use the supplied URL or number.
+2. **Current branch:** Run `gh pr view` when no PR was supplied.
+3. **Local diff:** If the branch has no PR, compare `HEAD` with the merge base of
+   the repository's default branch. Local diffs have no submitted-review coverage.
+
+Require a local clone because CODEOWNERS matching and old-side blame use repository
+objects. Report the resolved mode before the reviewer plan.
+
+Default to two candidates per owner group. Use three only when the third candidate
+has meaningful evidence. Honor `--per-team N` or `-n N` when supplied.
+
+## Output contract
+
+Write human-readable output in English. Render only uncovered owner groups. Use
+GitHub team names and logins, never Slack handles or IDs:
+
+```text
+@ai-dynamo/dynamo-ops-codeowners — @nv-tusharma @dillon-cullinan
+- `.github/{actions,workflows}/` — Adds DGDR deploy-test CI wiring.
+- `.github/filters.yaml` — Routes DGDR changes into deploy CI.
+```
+
+For each group:
+
+- Put the exact CODEOWNERS team first, followed by two or three ranked candidates.
+- Add one or two scoped path bullets; never exceed three.
+- Summarize at a component or parent-directory level. Use brace notation when useful.
+- Describe the implementation in 4–8 words, not a concern or desired verification.
+- Repeat a candidate under every owner group they can cover; do not label them as
+  cross-group.
+
+If all required groups are covered, say no additional reviewer request is needed. If
+a group has no eligible active candidate, explain the missing signal instead of
+inventing a reviewer.
+
+Do not send messages, resolve Slack identities, emit Slack mention syntax, or persist
+selection state.
+
+## Canonical reviewer plan
+
+Keep this structure internally so wrapper skills can consume it:
+
+```json
+{
+  "repo": "ai-dynamo/dynamo",
+  "pr": 11946,
+  "url": "https://github.com/ai-dynamo/dynamo/pull/11946",
+  "author": "sttts",
+  "scope": [
+    {"path": ".github/workflows/", "owners": ["@ai-dynamo/dynamo-ops-codeowners"]}
+  ],
+  "groups": [
+    {
+      "owner": "@ai-dynamo/dynamo-ops-codeowners",
+      "covered": false,
+      "reviewers": ["nv-tusharma", "dillon-cullinan"],
+      "paths": [
+        {
+          "path": ".github/{actions,workflows}/",
+          "summary": "Adds DGDR deploy-test CI wiring."
+        }
+      ]
+    }
+  ]
+}
+```
+
+`scope` contains every sorted changed `{path, owners}` record, including covered
+groups. `groups` contains every required owner group with current coverage. Populate
+`reviewers` only for uncovered groups.
+
+## Workflow
+
+### 1. Resolve PR metadata
+
+For a PR, fetch:
+
+```bash
+gh pr view <N> --repo <owner/repo> \
+  --json number,title,url,state,author,baseRefName,baseRefOid,headRefOid,files,reviews
+gh api repos/<owner>/<repo>/pulls/<N>/files --paginate
+```
+
+Reject a closed or merged PR unless the user requests historical analysis. Fetch the
+base branch when `baseRefOid` is missing locally.
+
+For a local diff, synthesize equivalent metadata from the merge base, current `HEAD`,
+`git diff`, and the authenticated GitHub user.
+
+### 2. Resolve required owners
+
+Read `CODEOWNERS` at `baseRefOid`; fall back to the working tree only when the object
+cannot be read. Apply GitHub semantics exactly:
+
+- last matching pattern wins;
+- leading `/`, trailing `/`, `*`, and `**` retain CODEOWNERS behavior;
+- an empty owner list explicitly clears ownership;
+- co-owned paths require one group per owner team.
+
+Map every changed path to its final owner set and keep sorted `{path, owners}` records.
+
+### 3. Resolve coverage
+
+Fetch current membership for every required GitHub owner team. Count human submitted
+reviews in states `APPROVED`, `CHANGES_REQUESTED`, and `COMMENTED`. Ignore `PENDING`,
+`DISMISSED`, bots, and ordinary issue comments.
+
+Treat a group as covered when any counted reviewer is a current member of that exact
+team. The same review may cover multiple groups. Keep covered groups in the internal
+plan but omit them from direct output.
+
+### 4. Select eligible candidates
+
+For each uncovered group:
+
+1. Start with current members of the exact GitHub owner team.
+2. Exclude the PR author, bots, departed members, and everyone who already submitted
+   a counted review on this PR.
+3. Require at least one `ai-dynamo/dynamo` pull-request review contribution in the
+   last 90 days. Prefer GraphQL `pullRequestReviewContributions`; use general activity
+   only when contribution data is unavailable.
+4. Rank remaining candidates by:
+   - old-side blame counts on modified source hunks at `baseRefOid`;
+   - recent reviews of PRs touching the same paths or component;
+   - eligibility across other still-uncovered owner groups;
+   - outstanding review-request load only as a tie-breaker.
+
+Skip pure additions for blame. Downweight generated files and lockfiles unless that
+owner group explicitly owns them.
+
+When blame has no useful signal, use recent component review history, then recent
+commits under the changed directories. Never select solely because someone belongs
+to many teams.
+
+### 5. Build path summaries
+
+Group changed files by meaningful component or parent directory for each owner team.
+Prefer the smallest set that explains why the group is required. Generate terse,
+implementation-focused summaries from the patch.
+
+### 6. Render
+
+Report the resolved mode, then render uncovered groups using the output contract.
+Mention covered groups once in a short trailing note. Do not append a flat mention
+list.
+
+## Edge cases
+
+- If no changed path has an owner, report that no CODEOWNERS group matched.
+- If a team lookup returns 404 or permission denied, report that group as unresolved.
+- If recent review-contribution data is unavailable, state which fallback was used.

--- a/.agents/skills/reviewers/agents/openai.yaml
+++ b/.agents/skills/reviewers/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Reviewers"
+  short_description: "Rank active CODEOWNERS reviewers for a PR"
+  default_prompt: "Use $reviewers to find the best active reviewers for this pull request."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dynamo-kv-replay-parity` — validate offline KV replay parity and performance
 - `graham-code-review` — strict Rust/systems review in Graham King's style
 - `pr-monitor` — CI health check, failure root-cause, and skip analysis
+- `reviewers` — rank active CODEOWNERS reviewers for a PR or local diff
+- `reviewers-slack` — request and track active PR reviewers from a Slack thread
 - `visual-review` — interactive HTML code-review dashboards with diagrams and annotated diffs
 
 **For deploying and operating Dynamo:**


### PR DESCRIPTION
## Summary

- add a canonical `reviewers` skill that derives uncovered CODEOWNERS groups and ranks active, eligible GitHub reviewers
- add a `reviewers-slack` wrapper that reuses the canonical plan, resolves Slack mentions, and keeps reviewer requests stable across repeated runs
- add deterministic helpers for Slack permalink parsing, scope fingerprints, managed-message markers, and reviewer-state encoding
- register both skills in the repository skill index

Related Linear issue: [OPS-7668](https://linear.app/nvidia/issue/OPS-7668/land-codeowners-contributor-tooling-pr-stack-rollout-tasks)

## Validation

- `uvx pre-commit run --files AGENTS.md .agents/skills/reviewers/SKILL.md .agents/skills/reviewers/agents/openai.yaml .agents/skills/reviewers-slack/SKILL.md .agents/skills/reviewers-slack/agents/openai.yaml .agents/skills/reviewers-slack/scripts/reviewers_slack_state.py`
- exercised `parse-url`, `fingerprint`, `encode-reviewers`, `decode-reviewers`, and `parse-marker` against representative inputs
