### PR TITLE
feat(sglang): standardize local sidecar launchers

### DIFF
--- a/examples/backends/sglang/launch/sidecar_agg.sh
+++ b/examples/backends/sglang/launch/sidecar_agg.sh
@@ -3,25 +3,45 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Aggregated serving through SGLang's native gRPC server (1 GPU).
-# Requires an SGLang build containing PR #23508 and, until it merges, PR #25185.
+# Requires an SGLang build with native gRPC sidecar support.
 
 set -e
-trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
-source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
-MODEL="Qwen/Qwen3-0.6B"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+
 EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --model-path)
+        --model|--model-path)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for $1"
+                echo "Use --help for usage information"
+                exit 1
+            fi
             MODEL="$2"
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--model-path <name>] [SGLang options...]"
+            echo "Usage: $0 [--model-path <name>] [SGLang engine options...]"
+            echo
+            echo "Additional options are passed to the SGLang engine."
+            echo
+            echo "Environment overrides:"
+            echo "  MODEL                   Model to serve (default: Qwen/Qwen3-0.6B)"
+            echo "  SGLANG_PYTHON           Python with SGLang installed (default: python3)"
+            echo "  CUDA_VISIBLE_DEVICES    GPU assignment (default: 0)"
+            echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
+            echo "  SGLANG_HTTP_PORT        SGLang HTTP port (default: 30000)"
+            echo "  SGLANG_GRPC_PORT        SGLang gRPC port (default: 30001)"
+            echo "  MAX_MODEL_LEN           Maximum model length (default: 4096)"
+            echo "  MAX_CONCURRENT_SEQS     Maximum concurrent sequences (default: 2)"
             exit 0
             ;;
         *)
@@ -31,26 +51,39 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-SGLANG_HOST="${SGLANG_HOST:-127.0.0.1}"
+trap dynamo_exit_trap EXIT
+
+SGLANG_PYTHON="${SGLANG_PYTHON:-python3}"
+SGLANG_HOST="127.0.0.1"
 SGLANG_HTTP_PORT="${SGLANG_HTTP_PORT:-30000}"
 SGLANG_GRPC_PORT="${SGLANG_GRPC_PORT:-30001}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
 
-print_launch_banner "Launching SGLang Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HTTP_PORT"
+print_launch_banner "Launching SGLang Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HTTP_PORT" \
+    "SGLang HTTP: http://${SGLANG_HOST}:${SGLANG_HTTP_PORT}" \
+    "SGLang gRPC: ${SGLANG_HOST}:${SGLANG_GRPC_PORT}"
 
 python3 -m dynamo.frontend &
 
 # --grpc-port enables the native Rust gRPC server alongside SGLang's HTTP API.
-python3 -m sglang.launch_server \
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
+CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
+"$SGLANG_PYTHON" -m sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_HTTP_PORT" \
     --grpc-port "$SGLANG_GRPC_PORT" \
+    --context-length "$MAX_MODEL_LEN" \
+    --max-running-requests "$MAX_CONCURRENT_SEQS" \
     $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 
-DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
     dynamo-sglang-sidecar \
     --sglang-endpoint "${SGLANG_HOST}:${SGLANG_GRPC_PORT}" &
 

--- a/examples/backends/sglang/launch/sidecar_disagg.sh
+++ b/examples/backends/sglang/launch/sidecar_disagg.sh
@@ -3,21 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Disaggregated serving through two SGLang native gRPC servers (2 GPUs).
-# Requires SGLang PR #25185 plus server-side DisaggregatedParams forwarding.
+# Requires an SGLang build with native gRPC sidecar and disaggregated serving support.
 
 set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
-source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
-MODEL="Qwen/Qwen3-0.6B"
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+
 EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --model-path)
+        --model|--model-path)
             if [[ $# -lt 2 || "$2" == -* ]]; then
-                echo "Missing value for --model-path"
+                echo "Missing value for $1"
                 echo "Use --help for usage information"
                 exit 1
             fi
@@ -25,9 +28,26 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--model-path <name>] [SGLang options...]"
+            echo "Usage: $0 [--model-path <name>] [SGLang engine options...]"
             echo
-            echo "Set SGLANG_PYTHON to the Python executable containing the patched SGLang build."
+            echo "Additional options are passed to both SGLang engines."
+            echo
+            echo "Environment overrides:"
+            echo "  MODEL                                   Model to serve (default: Qwen/Qwen3-0.6B)"
+            echo "  SGLANG_PYTHON                           Python with SGLang installed (default: python3)"
+            echo "  SGLANG_PREFILL_GPU                      Prefill GPU assignment (default: 0)"
+            echo "  SGLANG_DECODE_GPU                       Decode GPU assignment (default: 1)"
+            echo "  DYN_HTTP_PORT                           Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT1                        Prefill sidecar system port (default: 8081)"
+            echo "  DYN_SYSTEM_PORT2                        Decode sidecar system port (default: 8082)"
+            echo "  SGLANG_PREFILL_HTTP_PORT                Prefill HTTP port (default: 30000)"
+            echo "  SGLANG_PREFILL_GRPC_PORT                Prefill gRPC port (default: 30001)"
+            echo "  SGLANG_DECODE_HTTP_PORT                 Decode HTTP port (default: 30010)"
+            echo "  SGLANG_DECODE_GRPC_PORT                 Decode gRPC port (default: 30011)"
+            echo "  SGLANG_DISAGGREGATION_BOOTSTRAP_PORT    KV-transfer bootstrap port (default: 8998)"
+            echo "  SGLANG_BOOTSTRAP_HOST                   Advertised bootstrap host (default: 127.0.0.1)"
+            echo "  MAX_MODEL_LEN                           Maximum model length (default: 4096)"
+            echo "  MAX_CONCURRENT_SEQS                     Maximum concurrent sequences per engine (default: 2)"
             exit 0
             ;;
         *)
@@ -37,10 +57,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-trap 'echo Cleaning up...; kill 0' EXIT
+trap dynamo_exit_trap EXIT
 
 SGLANG_PYTHON="${SGLANG_PYTHON:-python3}"
-SGLANG_HOST="${SGLANG_HOST:-127.0.0.1}"
+SGLANG_HOST="127.0.0.1"
 SGLANG_BOOTSTRAP_HOST="${SGLANG_BOOTSTRAP_HOST:-$SGLANG_HOST}"
 SGLANG_DISAGGREGATION_BOOTSTRAP_PORT="${SGLANG_DISAGGREGATION_BOOTSTRAP_PORT:-8998}"
 SGLANG_PREFILL_HTTP_PORT="${SGLANG_PREFILL_HTTP_PORT:-30000}"
@@ -49,16 +69,22 @@ SGLANG_DECODE_HTTP_PORT="${SGLANG_DECODE_HTTP_PORT:-30010}"
 SGLANG_DECODE_GRPC_PORT="${SGLANG_DECODE_GRPC_PORT:-30011}"
 SGLANG_PREFILL_GPU="${SGLANG_PREFILL_GPU:-0}"
 SGLANG_DECODE_GPU="${SGLANG_DECODE_GPU:-1}"
-HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_CONCURRENT_SEQS="${MAX_CONCURRENT_SEQS:-2}"
 
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 GPU_MEM_ARGS=$(build_sglang_gpu_mem_args)
 
-print_launch_banner "Launching SGLang Native-gRPC Disaggregated Serving (2 GPUs)" "$MODEL" "$HTTP_PORT"
+print_launch_banner "Launching SGLang Native-gRPC Sidecar (Disaggregated, 2 GPUs)" "$MODEL" "$HTTP_PORT" \
+    "Prefill:     GPU ${SGLANG_PREFILL_GPU}, HTTP http://${SGLANG_HOST}:${SGLANG_PREFILL_HTTP_PORT}, gRPC ${SGLANG_HOST}:${SGLANG_PREFILL_GRPC_PORT}" \
+    "Decode:      GPU ${SGLANG_DECODE_GPU}, HTTP http://${SGLANG_HOST}:${SGLANG_DECODE_HTTP_PORT}, gRPC ${SGLANG_HOST}:${SGLANG_DECODE_GRPC_PORT}" \
+    "Bootstrap:   ${SGLANG_BOOTSTRAP_HOST}:${SGLANG_DISAGGREGATION_BOOTSTRAP_PORT}"
 
 python3 -m dynamo.frontend &
 
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL_GPU" \
-    "$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_PREFILL_HTTP_PORT" \
@@ -66,11 +92,14 @@ CUDA_VISIBLE_DEVICES="$SGLANG_PREFILL_GPU" \
     --disaggregation-mode prefill \
     --disaggregation-bootstrap-port "$SGLANG_DISAGGREGATION_BOOTSTRAP_PORT" \
     --disaggregation-transfer-backend nixl \
+    --context-length "$MAX_MODEL_LEN" \
+    --max-running-requests "$MAX_CONCURRENT_SEQS" \
     $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 
+# shellcheck disable=SC2086 # GPU_MEM_ARGS intentionally expands into multiple flags.
 CUDA_VISIBLE_DEVICES="$SGLANG_DECODE_GPU" \
-    "$SGLANG_PYTHON" -m sglang.launch_server \
+"$SGLANG_PYTHON" -m sglang.launch_server \
     --model-path "$MODEL" \
     --host "$SGLANG_HOST" \
     --port "$SGLANG_DECODE_HTTP_PORT" \
@@ -78,6 +107,8 @@ CUDA_VISIBLE_DEVICES="$SGLANG_DECODE_GPU" \
     --disaggregation-mode decode \
     --disaggregation-bootstrap-port "$SGLANG_DISAGGREGATION_BOOTSTRAP_PORT" \
     --disaggregation-transfer-backend nixl \
+    --context-length "$MAX_MODEL_LEN" \
+    --max-running-requests "$MAX_CONCURRENT_SEQS" \
     $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 

--- a/lib/sidecar/sglang/launch/agg.sh
+++ b/lib/sidecar/sglang/launch/agg.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--model-path <name>] [SGLang engine options...]"
+            echo "Usage: $0 [--model|--model-path <name>] [SGLang engine options...]"
             echo
             echo "Additional options are passed to the SGLang engine."
             echo

--- a/lib/sidecar/sglang/launch/agg.sh
+++ b/lib/sidecar/sglang/launch/agg.sh
@@ -8,10 +8,11 @@
 set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+export DYNAMO_HOME="${DYNAMO_HOME:-$(readlink -f "$SCRIPT_DIR/../../../..")}"
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
+source "$DYNAMO_HOME/examples/common/gpu_utils.sh"   # build_sglang_gpu_mem_args
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
-source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+source "$DYNAMO_HOME/examples/common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
 

--- a/lib/sidecar/sglang/launch/disagg.sh
+++ b/lib/sidecar/sglang/launch/disagg.sh
@@ -29,7 +29,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--model-path <name>] [SGLang engine options...]"
+            echo "Usage: $0 [--model|--model-path <name>] [SGLang engine options...]"
             echo
             echo "Additional options are passed to both SGLang engines."
             echo

--- a/lib/sidecar/sglang/launch/disagg.sh
+++ b/lib/sidecar/sglang/launch/disagg.sh
@@ -8,10 +8,11 @@
 set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+export DYNAMO_HOME="${DYNAMO_HOME:-$(readlink -f "$SCRIPT_DIR/../../../..")}"
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"   # build_sglang_gpu_mem_args
+source "$DYNAMO_HOME/examples/common/gpu_utils.sh"   # build_sglang_gpu_mem_args
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
-source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+source "$DYNAMO_HOME/examples/common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
 


### PR DESCRIPTION
## Overview:

Standardizes the one-command local aggregated and two-GPU disaggregated launchers for Dynamo's SGLang native-gRPC sidecar. Both launch modes keep SGLang's unauthenticated listeners on loopback and expose requests through the Dynamo frontend.

Internal tracking: [DIS-2535](https://linear.app/nvidia/issue/DIS-2535/add-local-sglang-sidecar-launch-scripts)

## Details:

- Updates the existing one-GPU aggregated launcher for the Dynamo frontend, `sglang.launch_server`, and `dynamo-sglang-sidecar`.
- Updates the existing two-GPU disaggregated launcher with separate prefill and decode SGLang servers and sidecars.
- Reuses the shared launch banner, first-child-exit supervision, and process-group cleanup helpers in both launch modes.
- Keeps the SGLang HTTP and native-gRPC listeners on loopback.
- Supports `--model`/`--model-path`, additional SGLang engine arguments, and environment overrides for Python, GPU selection, ports, model length, and concurrency.
- Preserves the shared SGLang GPU-memory override used by the profiling framework.
- Updates the SGLang dependency to 0.5.16, the first pinned release that supports the required native-gRPC `--grpc-port`.

### Validation

- `bash -n lib/sidecar/sglang/launch/agg.sh lib/sidecar/sglang/launch/disagg.sh`
- `shellcheck lib/sidecar/sglang/launch/agg.sh lib/sidecar/sglang/launch/disagg.sh`
- Launcher `--help` paths
- Missing `--model-path` value error paths
- `git diff --check`
- Computelab job `3323646` at commit `d1ea3c144ef7ae244f1ff4c924444de4c9370955` on two H800 NVL GPUs with `Qwen/Qwen3-0.6B` and public release image `docker.io/lmsysorg/sglang:v0.5.16-cu130` (`sha256:7b6a35df9839fd593a94a1eaee82d7777f472225d9f3ad1f8a2e0cb2bd1785d0`)
- Aggregate launcher: streamed `/v1/chat/completions` returned choices and `data: [DONE]`; coordinated shutdown left no managed processes
- Disaggregated launcher: streamed `/v1/chat/completions` returned choices and `data: [DONE]`; coordinated shutdown left no managed processes

## Where should the reviewer start?

- `lib/sidecar/sglang/launch/agg.sh`
- `lib/sidecar/sglang/launch/disagg.sh`

## Related Issues

> ⚠️ **This section is required.**

**🔗 This PR is linked to an issue:**

- Internal tracking: [DIS-2535](https://linear.app/nvidia/issue/DIS-2535/add-local-sglang-sidecar-launch-scripts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--model` as an alias for `--model-path` in SGLang launch scripts.
  * Added environment-variable configuration for models, GPU assignments, ports, and runtime limits.
  * Added configurable context length and maximum concurrent requests.
  * Enhanced launch output with HTTP and gRPC endpoint details.
  * Enabled native gRPC support for SGLang services.

* **Bug Fixes**
  * Improved process cleanup when launch scripts exit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

