### PR TITLE
feat(trtllm): add local sidecar launcher

### DIFF
--- a/examples/backends/trtllm/launch/sidecar_agg.sh
+++ b/examples/backends/trtllm/launch/sidecar_agg.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated serving through TensorRT-LLM's native gRPC server (1 GPU).
+
+set -e
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+
+MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model|--model-path)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "Missing value for $1"
+                echo "Use --help for usage information"
+                exit 1
+            fi
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model-path <name>] [TensorRT-LLM engine options...]"
+            echo
+            echo "Additional options are passed to the TensorRT-LLM engine."
+            echo
+            echo "Environment overrides:"
+            echo "  MODEL                   Model to serve (default: Qwen/Qwen3-0.6B)"
+            echo "  TRTLLM_PYTHON           Python with TensorRT-LLM installed (default: python3)"
+            echo "  CUDA_VISIBLE_DEVICES    GPU assignment (default: 0)"
+            echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
+            echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
+            echo "  TRTLLM_GRPC_PORT        TensorRT-LLM gRPC port (default: 50051)"
+            echo "  TRTLLM_CONTEXT_LENGTH   Registered model context length (default: 4096)"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+trap dynamo_exit_trap EXIT
+
+TRTLLM_PYTHON="${TRTLLM_PYTHON:-python3}"
+TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
+TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+print_launch_banner "Launching TensorRT-LLM Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HTTP_PORT" \
+    "TensorRT-LLM gRPC: 127.0.0.1:${TRTLLM_GRPC_PORT}" \
+    "Context length:    ${TRTLLM_CONTEXT_LENGTH}"
+
+python3 -m dynamo.frontend &
+
+# TensorRT-LLM's native gRPC listener is unauthenticated; keep it on loopback.
+CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
+"$TRTLLM_PYTHON" -m tensorrt_llm.commands.serve "$MODEL" \
+    --grpc \
+    --host 127.0.0.1 \
+    --port "$TRTLLM_GRPC_PORT" \
+    "${EXTRA_ARGS[@]}" &
+
+DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
+    dynamo-trtllm-sidecar \
+    --trtllm-endpoint "127.0.0.1:${TRTLLM_GRPC_PORT}" \
+    --model-path "$MODEL" \
+    --context-length "$TRTLLM_CONTEXT_LENGTH" &
+
+wait_any_exit

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -7,8 +7,9 @@
 set -e
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+export DYNAMO_HOME="${DYNAMO_HOME:-$(readlink -f "$SCRIPT_DIR/../../../..")}"
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
-source "$SCRIPT_DIR/../../../common/launch_utils.sh" # print_launch_banner, wait_any_exit
+source "$DYNAMO_HOME/examples/common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
 

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -38,8 +38,6 @@ while [[ $# -gt 0 ]]; do
             echo "  CUDA_VISIBLE_DEVICES    GPU assignment (default: 0)"
             echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
             echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
-            echo "  DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS"
-            echo "                          Sidecar connection deadline (default: 900)"
             echo "  TRTLLM_GRPC_PORT        TensorRT-LLM gRPC port (default: 50051)"
             echo "  TRTLLM_CONTEXT_LENGTH   Registered model context length (default: 4096)"
             exit 0
@@ -65,7 +63,6 @@ trap trtllm_exit_trap EXIT
 TRTLLM_PYTHON="${TRTLLM_PYTHON:-python3}"
 TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
 TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
-DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS="${DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS:-900}"
 CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
@@ -93,7 +90,6 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
     "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
-DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS="$DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS" \
     dynamo-trtllm-sidecar \
     --trtllm-endpoint "127.0.0.1:${TRTLLM_GRPC_PORT}" \
     --model-path "$MODEL" \

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -38,6 +38,8 @@ while [[ $# -gt 0 ]]; do
             echo "  CUDA_VISIBLE_DEVICES    GPU assignment (default: 0)"
             echo "  DYN_HTTP_PORT           Dynamo frontend port (default: 8000)"
             echo "  DYN_SYSTEM_PORT         Dynamo sidecar system port (default: 8081)"
+            echo "  DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS"
+            echo "                          Sidecar connection deadline (default: 900)"
             echo "  TRTLLM_GRPC_PORT        TensorRT-LLM gRPC port (default: 50051)"
             echo "  TRTLLM_CONTEXT_LENGTH   Registered model context length (default: 4096)"
             exit 0
@@ -63,6 +65,7 @@ trap trtllm_exit_trap EXIT
 TRTLLM_PYTHON="${TRTLLM_PYTHON:-python3}"
 TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
 TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
+DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS="${DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS:-900}"
 CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
@@ -90,6 +93,7 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
     "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \
+DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS="$DYN_SIDECAR_GRPC_STARTUP_DEADLINE_SECS" \
     dynamo-trtllm-sidecar \
     --trtllm-endpoint "127.0.0.1:${TRTLLM_GRPC_PORT}" \
     --model-path "$MODEL" \

--- a/lib/sidecar/trtllm/launch/agg.sh
+++ b/lib/sidecar/trtllm/launch/agg.sh
@@ -9,6 +9,8 @@ set -e
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 export DYNAMO_HOME="${DYNAMO_HOME:-$(readlink -f "$SCRIPT_DIR/../../../..")}"
 # shellcheck disable=SC1091 # Resolved relative to this script at runtime.
+source "$DYNAMO_HOME/examples/common/gpu_utils.sh"   # build_trtllm_override_args_with_mem
+# shellcheck disable=SC1091 # Resolved relative to this script at runtime.
 source "$DYNAMO_HOME/examples/common/launch_utils.sh" # print_launch_banner, wait_any_exit
 
 MODEL="${MODEL:-Qwen/Qwen3-0.6B}"
@@ -26,7 +28,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         -h|--help)
-            echo "Usage: $0 [--model-path <name>] [TensorRT-LLM engine options...]"
+            echo "Usage: $0 [--model|--model-path <name>] [TensorRT-LLM engine options...]"
             echo
             echo "Additional options are passed to the TensorRT-LLM engine."
             echo
@@ -47,7 +49,16 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-trap dynamo_exit_trap EXIT
+TRTLLM_EXTRA_CONFIG=""
+trtllm_exit_trap() {
+    local rc=$?
+    if [[ -n "$TRTLLM_EXTRA_CONFIG" ]]; then
+        rm -f -- "$TRTLLM_EXTRA_CONFIG"
+    fi
+    echo "Cleaning up..."
+    dynamo_reap_and_exit "$rc"
+}
+trap trtllm_exit_trap EXIT
 
 TRTLLM_PYTHON="${TRTLLM_PYTHON:-python3}"
 TRTLLM_GRPC_PORT="${TRTLLM_GRPC_PORT:-50051}"
@@ -55,6 +66,14 @@ TRTLLM_CONTEXT_LENGTH="${TRTLLM_CONTEXT_LENGTH:-4096}"
 CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0}"
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+GPU_MEM_ARGS=$(build_trtllm_override_args_with_mem)
+TRTLLM_GPU_MEM_ARGS=()
+if [[ -n "$GPU_MEM_ARGS" ]]; then
+    TRTLLM_EXTRA_CONFIG=$(mktemp "${TMPDIR:-/tmp}/dynamo-trtllm-sidecar.XXXXXX.yaml")
+    printf '%s\n' "$GPU_MEM_ARGS" > "$TRTLLM_EXTRA_CONFIG"
+    TRTLLM_GPU_MEM_ARGS=(--extra_llm_api_options "$TRTLLM_EXTRA_CONFIG")
+fi
+
 print_launch_banner "Launching TensorRT-LLM Native-gRPC Sidecar (1 GPU)" "$MODEL" "$HTTP_PORT" \
     "TensorRT-LLM gRPC: 127.0.0.1:${TRTLLM_GRPC_PORT}" \
     "Context length:    ${TRTLLM_CONTEXT_LENGTH}"
@@ -67,6 +86,7 @@ CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
     --grpc \
     --host 127.0.0.1 \
     --port "$TRTLLM_GRPC_PORT" \
+    "${TRTLLM_GPU_MEM_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" &
 
 DYN_SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}" \


### PR DESCRIPTION
## Overview:

Adds a one-command local aggregated launcher for Dynamo's TensorRT-LLM native-gRPC sidecar. The launcher keeps TensorRT-LLM's unauthenticated gRPC listener on loopback and exposes requests through the Dynamo frontend.

Internal tracking: [DIS-2536](https://linear.app/nvidia/issue/DIS-2536/add-a-local-tensorrt-llm-sidecar-launch-script)

## Details:

- Adds a one-GPU aggregated launcher for the Dynamo frontend, `tensorrt_llm.commands.serve --grpc`, and `dynamo-trtllm-sidecar`.
- Reuses the shared launch banner, GPU-memory profile helper, first-child-exit supervision, and process-group cleanup helpers.
- Passes the selected GPU-memory profile through a temporary TensorRT-LLM options file and removes that file during cleanup.
- Keeps the TensorRT-LLM native-gRPC listener on loopback.
- Supports `--model`/`--model-path`, additional TensorRT-LLM engine arguments, and environment overrides for Python, GPU selection, ports, and registered context length.
- Defaults to `Qwen/Qwen3-0.6B` and registers a 4096-token context length when the server does not report one.

### Validation

- `bash -n lib/sidecar/trtllm/launch/agg.sh`
- `shellcheck lib/sidecar/trtllm/launch/agg.sh`
- Launcher `--help` path
- Missing `--model-path` value error path
- GPU-memory helper self-test: 13/13 passed
- `git diff --check`
- Computelab job `3323646` at commit `49010a9c3848018496ea8692520a6819e9c8f294` on one H800 NVL GPU.
- Public Docker Hub base `docker.io/pytorch/pytorch:2.10.0-cuda13.0-cudnn9-devel` (`sha256:48af19ebb88034e0325decc2b6142e5b9bfc276eaa5197ab6d94582f1d78ea4c`) with the public `tensorrt-llm==1.3.0rc22` and `torchao==0.17.0` release wheels; no private or NGC image was used.
- The default model registered through the native-gRPC sidecar, a streamed `/v1/chat/completions` request returned choices and `data: [DONE]`, and the `max_tokens: 4096` GPU-memory override was applied.
- Terminating the launcher removed the frontend, TensorRT-LLM server and managed worker, sidecar, and temporary options file.

## Where should the reviewer start?

- `lib/sidecar/trtllm/launch/agg.sh`

## Related Issues

> ⚠️ **This section is required.**

**🔗 This PR is linked to an issue:**

- Internal tracking: [DIS-2536](https://linear.app/nvidia/issue/DIS-2536/add-a-local-tensorrt-llm-sidecar-launch-script)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a launcher for running TensorRT-LLM serving with a local aggregation sidecar on a single GPU.
  * Supports model selection, custom engine arguments, configurable ports and context length, and environment-based overrides.
  * Added built-in help and usage guidance for available launch options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
