### PR TITLE
[not for merge] docs(spica): draft AISim/Spica API boundaries

### DIFF
--- a/dynosim-mocker-api-boundary.md
+++ b/dynosim-mocker-api-boundary.md
@@ -13,9 +13,9 @@ Only the following contracts cross component boundaries:
 
 | Components | Contract |
 | --- | --- |
-| `Replayer` ↔ `Generalized Mocker Engine` | engine request, control, and pass effects |
+| `Replayer` ↔ `Generalized Mocker Engine` | `GeneralizedMockerEngine`, `EnginePassResult`, and `EngineEffects` |
+| `Live Mocker` ↔ `Generalized Mocker Engine` | `GeneralizedMockerEngine`, `EnginePassResult`, and `EngineEffects` |
 | `Replayer` ↔ `Router Adapter` | `PlacementPolicy<Request>` |
-| `Live Mocker` ↔ `Generalized Mocker Engine` | `LiveBoundaryCore` and `LivePassExecution` |
 | `Replayer` ↔ `Planner Adapter` | TODO |
 
 The contracts are owned by AISim. Dynamo implements the adapters and converts
@@ -23,110 +23,338 @@ between Dynamo-specific and AISim-neutral types.
 
 ## Generalized Mocker Engine API
 
-Both `Replayer` and `Live Mocker` drive the same `Generalized Mocker Engine`.
-The target component boundary reuses the existing engine operations while
-keeping Replayer-owned state, such as `TraceCollector`, out of their
-signatures:
+### Summary
 
-```rust
-receive(DirectRequest) -> Uuid
-apply_command_effects(SchedulerCommand, ...) -> SchedulerCommandEffects
-retry_pending_destinations() -> Vec<SchedulerLifecycleEvent>
-execute_pass(now_ms) -> EnginePassResult
+A `Generalized Mocker Engine` models one logical inference worker. It has two
+layers:
+
+1. A **single-rank engine** models one rank.
+2. An **attention-DP engine** composes multiple single-rank engines into one
+   logical worker.
+
+Both layers expose the same request, control, execution, and effect contract.
+`Replayer` drives that contract with a virtual clock. `Live Mocker` drives the
+same contract with Tokio and a wall clock.
+
+```mermaid
+flowchart LR
+    RP["Replayer<br/>virtual clock"] --> GE["Generalized Mocker Engine contract"]
+    LM["Live Mocker<br/>wall clock"] --> GE
+    GE -->|"dp_size = 1"| SR["Single-rank engine"]
+    GE -->|"dp_size > 1"| DP["Attention-DP engine"]
+    DP --> R0["Single-rank engine 0"]
+    DP --> R1["Single-rank engine 1"]
+    DP --> RN["Single-rank engine N"]
+    SR --> C["EngineCore"]
+    R0 --> C0["EngineCore"]
+    R1 --> C1["EngineCore"]
+    RN --> CN["EngineCore"]
 ```
 
-Inputs crossing into the engine are:
+### Engine composition
 
-- engine-relevant configuration;
-- `DirectRequest`;
-- `SchedulerCommand`;
-- caller-provided simulation time.
+#### Single-rank engine
 
-`EnginePassResult` returns:
+The single-rank engine owns exactly one `EngineCore`, backed by `VllmCore` or
+`SglangCore`. It owns all state whose behavior belongs to that rank:
 
-- modeled pass completion time;
-- output signals and request completions;
-- admissions and lifecycle effects;
-- neutral KV observations;
-- forward-pass and engine metrics.
+- local request queues and scheduling policy;
+- native G1 KV allocation and eviction;
+- framework-native G2 offload;
+- preemption and request lifecycle state;
+- local forward-pass timing and metrics;
+- pending destination and scheduler-command state.
 
-The caller owns the clock and execution loop. The engine does not sleep,
-advance a global event queue, write a replay report, or publish Dynamo events.
-`TraceCollector`, Dynamo `RouterEvent`, runtime handles, and event publishers
-do not cross this boundary.
+It does not own worker startup, draining, removal, Planner scaling, a global
+clock, or a replay report.
 
-Native G1 management and framework-native G2 offload are internal to the
-`Generalized Mocker Engine`. There is no KVBM or KVBM Adapter API in this
-design.
+#### Attention-DP engine
+
+The attention-DP engine owns a fixed group of single-rank engines. It is the
+logical worker visible to `Replayer` and `Live Mocker`, and owns:
+
+- DP-rank membership and rank-core construction;
+- request and control dispatch to the correct rank;
+- sibling-rank readiness;
+- barrier and lockstep pass execution;
+- aggregation of rank-local effects into one logical-engine result;
+- group completion time, defined as `max(rank end_ms)`;
+- group-level empty, drained, and next-deadline state.
+
+An empty rank still participates in the barrier when a sibling executes a pass.
+The attention-DP engine aligns all participating ranks to the group completion
+time before it exposes pass-completion effects.
+
+For `dp_size == 1`, the same contract is implemented by the single-rank engine
+without an additional behavioral distinction for callers.
+
+#### Ownership split
+
+| Component | Owns |
+| --- | --- |
+| Single-rank engine | One `EngineCore`; rank-local scheduler, KV, preemption, timing, and metrics |
+| Attention-DP engine | Rank group, rank construction, readiness, barriers, lockstep execution, and group result aggregation |
+| `Replayer` | Fleet of logical workers, startup/draining/removal, Planner scaling, virtual clock, global event queue, completion visibility, `TraceCollector`, and adapter observations |
+| `Live Mocker` | Dynamo runtime integration, Tokio tasks, wall-clock waiting, channels, responses, handoff transport, event publication, and production metrics |
+
+`Replayer` scales logical workers, not individual DP ranks. Creating or removing
+an attention-DP worker creates or removes its full rank group.
+
+### Generalized Mocker Engine contract
+
+Both engine implementations satisfy the same source-level Rust contract.
+`Replayer` and `Live Mocker` call it directly; it does not require a plugin,
+dynamic dispatch, or an ABI.
+
+```rust
+trait GeneralizedMockerEngine {
+    type ObservationBatch: EngineEventBatch;
+
+    fn new(config: GeneralizedEngineConfig) -> Result<Self>
+    where
+        Self: Sized;
+
+    fn receive(&mut self, request: DirectRequest) -> Uuid;
+
+    fn apply_command_effects(
+        &mut self,
+        command: SchedulerCommand,
+        allow_destination_admission: bool,
+        now_ms: f64,
+    ) -> Result<SchedulerCommandEffects<Self::ObservationBatch>>;
+
+    fn retry_pending_destinations(
+        &mut self,
+        now_ms: f64,
+    ) -> Vec<SchedulerLifecycleEvent>;
+
+    fn is_ready(&self) -> bool;
+    fn execute_pass(
+        &mut self,
+        now_ms: f64,
+    ) -> Result<Option<EnginePassResult<Self::ObservationBatch>>>;
+    fn complete_pass(
+        &mut self,
+        pass_id: EnginePassId,
+        now_ms: f64,
+    ) -> Result<EngineEffects<Self::ObservationBatch>>;
+
+    fn next_internal_deadline_ms(&self) -> Option<f64>;
+    fn process_internal_work(
+        &mut self,
+        now_ms: f64,
+    ) -> Result<EngineEffects<Self::ObservationBatch>>;
+
+    fn is_empty(&self) -> bool;
+    fn is_drained(&self) -> bool;
+    fn num_requests(&self) -> usize;
+}
+```
+
+`GeneralizedEngineConfig` contains only engine behavior: backend engine type,
+DP size, scheduler configuration, native G1 configuration, framework-native G2
+configuration, and timing data. Worker startup delay, Planner policy, Dynamo
+transport, and output configuration stay with the caller.
+
+`DirectRequest.dp_rank` selects the target rank. Commands containing only a
+request or handoff ID use rank ownership already recorded by the engine. A
+single-rank implementation accepts only its own rank identity.
+
+#### Pass lifecycle
+
+`execute_pass(now_ms)` starts at most one logical-worker pass. It marks the
+engine busy and returns:
+
+```rust
+struct EnginePassResult<E: EngineEventBatch> {
+    pass_id: EnginePassId,
+    end_ms: f64,
+    start_effects: EngineEffects<E>,
+}
+```
+
+For an attention-DP engine, `end_ms` is `max(rank end_ms)`. The engine retains
+all pass-completion state behind `pass_id`, including pending outputs and
+rank-local completion effects. This lets commands received during a pass update
+the pending result without exposing it to the caller.
+
+`EnginePassId` is opaque and unique within one engine. `is_ready()` remains
+false until the active pass is completed.
+
+At `end_ms`, the caller passes `pass_id` back to
+`complete_pass(pass_id, now_ms)`. The engine then:
+
+- releases all ranks from the barrier;
+- commits request-completion and rank-local accounting;
+- retries destinations made eligible by the completion;
+- returns the effects that become visible at pass completion.
+
+A zero-duration pass is completed immediately at the same `now_ms`. The caller
+does not call `execute_pass` again while a pass is in flight, and
+`complete_pass` rejects a stale ID or a timestamp earlier than `end_ms`.
+
+#### Effects
+
+The same neutral effect envelope is used for pass start, pass completion,
+commands, and framework-native G2 work:
+
+```rust
+struct EngineEffects<E: EngineEventBatch> {
+    ranks: Vec<RankEngineEffects<E>>,
+}
+
+struct RankEngineEffects<E: EngineEventBatch> {
+    dp_rank: u32,
+    admissions: Vec<AdmissionEvent>,
+    completed_requests: usize,
+    output_signals: Vec<OutputSignal>,
+    lifecycle_events: Vec<SchedulerLifecycleEvent>,
+    observations: E,
+    fpm: Option<ForwardPassSnapshot>,
+    metrics: MockerMetrics,
+}
+```
+
+For a single-rank engine, `ranks` contains one entry. For an attention-DP
+engine, it preserves the rank identity of every effect while returning one
+group result.
+
+`SchedulerCommandEffects` contains its current `SchedulerCommandResult` plus
+the same neutral `EngineEffects`. `EngineEventBatch` carries engine
+observations such as native KV allocation, eviction, and G2 residency changes
+without exposing Dynamo `RouterEvent`; the `Router Adapter` performs that
+conversion when needed.
+
+#### Internal timed work
+
+`next_internal_deadline_ms()` reports the next time at which engine-owned work
+can make progress. For an attention-DP engine, it is the minimum deadline
+across all ranks.
+
+At that time, the caller invokes `process_internal_work(now_ms)`. Native G1 and
+framework-native G2 update their internal state and return effects through the
+same `EngineEffects` envelope. The engine never sleeps or advances a clock.
+
+#### Replayer and Live Mocker use
+
+| Contract step | `Replayer` | `Live Mocker` |
+| --- | --- | --- |
+| Supply time | Passes virtual `now_ms` | Passes wall-clock elapsed milliseconds |
+| Start pass | Applies `start_effects` and enqueues `(end_ms, pass_id)` | Applies `start_effects` and waits until `end_ms` with Tokio |
+| Complete pass | Calls `complete_pass` from the virtual event queue | Calls `complete_pass` after the wall-clock wait |
+| Internal deadline | Adds it to the virtual event queue | Arms or updates a Tokio timer |
+| Consume effects | Updates `TraceCollector` and adapter observations | Produces responses, publishes observations, FPM, and metrics |
+
+Neither caller implements rank grouping or pass barriers. Both construct one
+generalized engine per logical worker and use the same methods and effect
+types.
+
+#### Boundary constraints
+
+The engine does not depend on `TraceCollector`, replay-report types, Dynamo
+runtime, NATS, ZMQ, event publishers, Router, or Planner. Those dependencies
+remain in `Replayer`, `Live Mocker`, and their adapters.
+
+Native G1 and framework-native G2 are engine internals. KVBM types and a KVBM
+Adapter do not cross this boundary, and the design does not preserve the
+KVBM-based G1-G4 paths.
 
 ## Replayer API
 
-`Replayer` accepts a resolved workload, deployment topology, and engine
-configuration, and returns `TraceSimulationReport`.
-
-`Replayer` owns:
-
-- workload admission;
-- the virtual clock and event queue;
-- worker topology and lifecycle;
-- request completion and report collection;
-- composition with optional placement and Planner policies.
-
-Engine observations needed by an extension cross the Replayer boundary through
-`EngineEventBatch`, `ReplayEngineObservation`, and `Observation::Batch`.
-
-## Router Adapter API
-
-The boundary between `Replayer` and Dynamo `Router Adapter` is:
+`Replayer` is the replay entrypoint used by Spica. One Spica candidate produces
+one `ReplaySpec`; `Replayer` executes it and returns one report:
 
 ```rust
-PlacementPolicy<Request>
-    type Metadata
-    type Observation
-
-    place(...) -> PlacementEffects
-    observe(...) -> Vec<Placement>
-
-    cancel_pending(...)
-    request_terminal(...)
-    prefill_completed(...)
-    pending_count()
-
-    worker_ready(...)
-    worker_draining(...)
-    worker_removed(...)
-    topology_settled(...)
+pub fn replay(spec: ReplaySpec) -> Result<TraceSimulationReport>;
 ```
 
-The contract exchanges only these neutral placement types:
+`ReplaySpec` is serializable and contains:
 
-- `Placement`;
-- `PlacementDecision`;
-- `PlacementEffects`;
-- `WorkerTopology`.
+- the resolved workload or synthetic workload specification;
+- aggregated or disaggregated worker-pool topology;
+- one `GeneralizedEngineConfig` per worker role;
+- resolved Router and Planner adapter configuration;
+- replay limits, SLA thresholds, and report options.
 
-`PlacementEffects` may decide the current request and release requests
-previously queued by a stateful policy.
+Trace-file parsing, candidate generation, and adapter search-space generation
+happen before this call. Their configuration is materialized through the
+corresponding adapter boundaries; Spica does not construct Rust engine or
+placement-policy objects.
 
-`AggregatedRoundRobinPlacement`, `PoolRoundRobinPlacement`, and
-`KvRouterPlacement` implement the same contract. `KvRouterPlacement` is the
-Dynamo `Router Adapter`; it converts production `Router` results and event
-batches to the neutral placement and observation types.
+Inside the call, `Replayer` owns the virtual clock, event queue, logical-worker
+fleet, worker lifecycle, `TraceCollector`, and adapter observations. It creates
+one `GeneralizedMockerEngine` per logical worker and scales complete logical
+workers rather than individual DP ranks.
+
+The interaction with each generalized engine is:
+
+| Replay action | `GeneralizedMockerEngine` call |
+| --- | --- |
+| Create or scale up a logical worker | `new` |
+| Dispatch a placed request to its worker and DP rank | `receive` |
+| Apply cancellation or handoff control | `apply_command_effects` |
+| Start ready model work at virtual `now_ms` | `execute_pass` |
+| Reach the pass's scheduled `end_ms` | `complete_pass` |
+| Arm and process native G1/G2 timed work | `next_internal_deadline_ms` and `process_internal_work` |
+| Evaluate scale-down or replay completion | `is_drained` and `num_requests` |
+
+`Replayer` consumes `EngineEffects` at their returned virtual timestamps:
+admissions and outputs update `TraceCollector`, observations go to the Router
+adapter, and FPM/metrics go to the report and Planner adapter.
+
+Replay ends when the workload and adapter queues are empty, all generalized
+engines are drained, and no engine or lifecycle events remain. If the
+configured time limit is reached first, remaining requests are reported as
+incomplete.
 
 ## Live Mocker API
 
-The boundary follows the existing `LiveBoundaryCore` and
-`LivePassExecution` split. `Live Mocker` submits `DirectRequest`, scheduler
-control commands, and the current time to the `Generalized Mocker Engine`. It
-receives pass outputs, lifecycle effects, KV observations, FPM, and metrics.
+`Live Mocker` is the Dynamo serving wrapper around the same
+`GeneralizedMockerEngine` used by `Replayer`. Its external API remains the
+existing live component surface:
 
-`Live Mocker` owns:
+```rust
+pub fn new(args: MockEngineArgs) -> MockEngine
+pub async fn start(&self, endpoint: Endpoint) -> Result<()>
 
-- `DistributedRuntime` and `AsyncEngine` integration;
-- Tokio tasks, channels, cancellation, and wall-clock waiting;
-- streaming response assembly;
-- handoff orchestration;
-- conversion and publication of Dynamo events and production metrics.
+async fn generate(
+    &self,
+    input: SingleIn<PreprocessedRequest>,
+) -> Result<ManyOut<LLMEngineOutput>, Error>
+```
+
+`start` creates one grouped generalized engine for the live logical worker.
+`MockEngineArgs` fields that control scheduler, timing, native G1, and
+framework-native G2 behavior are passed into `GeneralizedEngineConfig`.
+Dynamo endpoint, startup, transport, handoff, and publication configuration
+remain in `Live Mocker`.
+
+For each request, `generate` resolves its DP rank, converts
+`PreprocessedRequest` to `DirectRequest`, and calls `receive`. Disaggregated
+handoff and cancellation use `apply_command_effects`.
+
+The remaining engine calls differ from `Replayer` only in how time is supplied:
+
+| Live action | `GeneralizedMockerEngine` call |
+| --- | --- |
+| Start the logical worker | `new` |
+| Submit a request or control command | `receive` or `apply_command_effects` |
+| Start ready model work using wall-clock elapsed `now_ms` | `execute_pass` |
+| Reach the returned `end_ms` after a Tokio wait | `complete_pass` |
+| Arm and process native G1/G2 work | `next_internal_deadline_ms` and `process_internal_work` |
+
+`Live Mocker` publishes `EngineEffects` through Dynamo facilities:
+
+- output signals become the request's `LLMEngineOutput` stream;
+- lifecycle effects drive handoff sessions and cancellation;
+- neutral engine observations are converted and sent to live event publishers;
+- FPM and engine metrics are sent to production metrics publishers.
+
+`Live Mocker` owns `DistributedRuntime` and `AsyncEngine` integration, Tokio
+tasks and wall-clock waiting, request channels, response streams, bootstrap and
+handoff transport, cancellation, event publication, and production metrics.
+The generalized engine owns DP-rank grouping, barriers, scheduler/KV state, and
+pending pass effects.
 
 The dependency is one-way:
 
@@ -134,8 +362,79 @@ The dependency is one-way:
 Dynamo Live Mocker -> AISim Generalized Mocker Engine
 ```
 
-The engine does not depend on Dynamo runtime, NATS, ZMQ, handoff sessions, live
-event publishers, or the offline `Replayer`.
+`Live Mocker` does not create unrelated generalized engines for individual DP
+ranks. The generalized engine does not depend on Dynamo runtime, NATS, ZMQ,
+publishers, or the offline `Replayer`. `ReplaySpec`, the virtual event queue,
+and `TraceCollector` do not cross the live boundary.
+
+## Router Adapter API
+
+This is an internal boundary between `Replayer` and a placement policy. Spica
+selects and configures the Router adapter through `ReplaySpec`; it does not call
+this Rust trait directly.
+
+```rust
+trait PlacementPolicy<Request> {
+    type Metadata;
+    type Observation;
+
+    fn place(
+        &mut self,
+        request: &Request,
+        metadata: Self::Metadata,
+        session_id: Option<String>,
+        now_ms: f64,
+    ) -> Result<PlacementEffects>;
+    fn observe(&mut self, observation: Self::Observation, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn cancel_pending(&mut self, request_id: Uuid) -> bool;
+    fn request_terminal(&mut self, request_id: Uuid, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn prefill_completed(&mut self, request_id: Uuid, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn pending_count(&self) -> usize;
+
+    fn worker_ready(&mut self, worker: WorkerTopology, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn worker_draining(&mut self, worker: WorkerTopology, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn worker_removed(&mut self, worker: WorkerTopology, now_ms: f64)
+        -> Result<Vec<Placement>>;
+    fn topology_settled(&mut self, now_ms: f64)
+        -> Result<Vec<Placement>>;
+}
+```
+
+`Metadata` is request-scoped data prepared for the selected policy. Round-robin
+uses `()`; the KV Router adapter uses replay hashes and other KV-routing input.
+
+`Observation` is the neutral `EngineEventBatch` taken from
+`EngineEffects.observations`. Round-robin ignores it. The KV Router adapter
+converts it to the production Router event representation inside the adapter.
+Dynamo `RouterEvent` does not cross into `Replayer`.
+
+The contract returns only neutral `Placement`, `PlacementDecision`,
+`PlacementEffects`, and `WorkerTopology` values. `PlacementEffects` contains
+an immediate-or-queued decision for the current request plus any placements
+released from a stateful policy queue. Observation, terminal, and topology
+methods may also release queued placements.
+
+`WorkerTopology` identifies one logical worker and the stable scheduler IDs of
+its DP ranks. The policy selects a `scheduler_id`; `Replayer` resolves it to the
+logical worker and `dp_rank`. The Router adapter does not construct or drive
+workers.
+
+`AggregatedRoundRobinPlacement`, `PoolRoundRobinPlacement`, and
+`KvRouterPlacement` implement this same contract. The round-robin policies are
+AISim-owned. `KvRouterPlacement` is the Dynamo Router adapter: it translates
+neutral requests and observations into production Router calls, then converts
+Router admissions into neutral `PlacementEffects`.
+
+Before crate extraction, the current `RouterEventBatch` observation must be
+neutralized so it no longer wraps Dynamo `RouterEvent`. The
+`PlannerCacheSample` field currently carried by `Placement` must also be
+renamed or reshaped as neutral cache-admission data rather than a Planner-owned
+type.
 
 ## Planner Adapter API
 

--- a/dynosim-mocker-api-boundary.md
+++ b/dynosim-mocker-api-boundary.md
@@ -261,8 +261,31 @@ KVBM-based G1-G4 paths.
 
 ## Replayer API
 
-`Replayer` is the replay entrypoint used by Spica. One Spica candidate produces
-one `ReplaySpec`; `Replayer` executes it and returns one report:
+There are two replay compositions:
+
+| Replay | Composition |
+| --- | --- |
+| **AISim Replay** | The standalone replay implementation in the AISim repo. It owns `Replayer`, uses the `Generalized Mocker Engine`, and includes built-in round-robin placement. It has no Dynamo dependency. |
+| **Dynamo Replay** | The Dynamo-side composition. It depends on AISim Replay and adds Dynamo adapters such as `KvRouterPlacement` and the Planner adapter. |
+
+Unless explicitly qualified, `Replayer` and `replay` in this document refer to
+**AISim Replay**. Dynamo Replay reuses this Replayer rather than implementing a
+second replay event loop.
+
+The dependency direction is:
+
+```text
+Dynamo Replay -> AISim Replay -> Generalized Mocker Engine
+       |
+       +------> Dynamo Router and Planner adapters
+```
+
+Every replay has a `PlacementPolicy`; AISim Replay uses its built-in
+round-robin policy by default. Dynamo Replay may keep that default or select
+`KvRouterPlacement`.
+
+One Spica candidate produces one `ReplaySpec`; the selected replay composition
+invokes `Replayer` and returns one report:
 
 ```rust
 pub fn replay(spec: ReplaySpec) -> Result<TraceSimulationReport>;
@@ -280,6 +303,17 @@ Trace-file parsing, candidate generation, and adapter search-space generation
 happen before this call. Their configuration is materialized through the
 corresponding adapter boundaries; Spica does not construct Rust engine or
 placement-policy objects.
+
+Router and Planner fields in `ReplaySpec` are serializable policy
+configuration, not Rust or Python policy objects. AISim Replay constructs its
+built-in policies from this configuration. Dynamo Replay constructs the
+selected Dynamo adapters before driving the same Replayer.
+
+This is static source-level composition; it does not require a dynamic plugin,
+shared-object ABI, or RPC boundary. After repo extraction, the AISim Replay
+manifest has no direct Dynamo workspace dependencies. `dynamo-kv-router` and
+other Dynamo integration dependencies remain in Dynamo Replay, while
+`kvbm-logical` is removed rather than added back.
 
 Inside the call, `Replayer` owns the virtual clock, event queue, logical-worker
 fleet, worker lifecycle, `TraceCollector`, and adapter observations. It creates

--- a/dynosim-mocker-api-boundary.md
+++ b/dynosim-mocker-api-boundary.md
@@ -1,0 +1,142 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# AISim/Dynamo API Boundaries
+
+Status: Draft for review
+
+## Boundary map
+
+Only the following contracts cross component boundaries:
+
+| Components | Contract |
+| --- | --- |
+| `Replayer` ↔ `Generalized Mocker Engine` | engine request, control, and pass effects |
+| `Replayer` ↔ `Router Adapter` | `PlacementPolicy<Request>` |
+| `Live Mocker` ↔ `Generalized Mocker Engine` | `LiveBoundaryCore` and `LivePassExecution` |
+| `Replayer` ↔ `Planner Adapter` | TODO |
+
+The contracts are owned by AISim. Dynamo implements the adapters and converts
+between Dynamo-specific and AISim-neutral types.
+
+## Generalized Mocker Engine API
+
+Both `Replayer` and `Live Mocker` drive the same `Generalized Mocker Engine`.
+The target component boundary reuses the existing engine operations while
+keeping Replayer-owned state, such as `TraceCollector`, out of their
+signatures:
+
+```rust
+receive(DirectRequest) -> Uuid
+apply_command_effects(SchedulerCommand, ...) -> SchedulerCommandEffects
+retry_pending_destinations() -> Vec<SchedulerLifecycleEvent>
+execute_pass(now_ms) -> EnginePassResult
+```
+
+Inputs crossing into the engine are:
+
+- engine-relevant configuration;
+- `DirectRequest`;
+- `SchedulerCommand`;
+- caller-provided simulation time.
+
+`EnginePassResult` returns:
+
+- modeled pass completion time;
+- output signals and request completions;
+- admissions and lifecycle effects;
+- neutral KV observations;
+- forward-pass and engine metrics.
+
+The caller owns the clock and execution loop. The engine does not sleep,
+advance a global event queue, write a replay report, or publish Dynamo events.
+`TraceCollector`, Dynamo `RouterEvent`, runtime handles, and event publishers
+do not cross this boundary.
+
+Native G1 management and framework-native G2 offload are internal to the
+`Generalized Mocker Engine`. There is no KVBM or KVBM Adapter API in this
+design.
+
+## Replayer API
+
+`Replayer` accepts a resolved workload, deployment topology, and engine
+configuration, and returns `TraceSimulationReport`.
+
+`Replayer` owns:
+
+- workload admission;
+- the virtual clock and event queue;
+- worker topology and lifecycle;
+- request completion and report collection;
+- composition with optional placement and Planner policies.
+
+Engine observations needed by an extension cross the Replayer boundary through
+`EngineEventBatch`, `ReplayEngineObservation`, and `Observation::Batch`.
+
+## Router Adapter API
+
+The boundary between `Replayer` and Dynamo `Router Adapter` is:
+
+```rust
+PlacementPolicy<Request>
+    type Metadata
+    type Observation
+
+    place(...) -> PlacementEffects
+    observe(...) -> Vec<Placement>
+
+    cancel_pending(...)
+    request_terminal(...)
+    prefill_completed(...)
+    pending_count()
+
+    worker_ready(...)
+    worker_draining(...)
+    worker_removed(...)
+    topology_settled(...)
+```
+
+The contract exchanges only these neutral placement types:
+
+- `Placement`;
+- `PlacementDecision`;
+- `PlacementEffects`;
+- `WorkerTopology`.
+
+`PlacementEffects` may decide the current request and release requests
+previously queued by a stateful policy.
+
+`AggregatedRoundRobinPlacement`, `PoolRoundRobinPlacement`, and
+`KvRouterPlacement` implement the same contract. `KvRouterPlacement` is the
+Dynamo `Router Adapter`; it converts production `Router` results and event
+batches to the neutral placement and observation types.
+
+## Live Mocker API
+
+The boundary follows the existing `LiveBoundaryCore` and
+`LivePassExecution` split. `Live Mocker` submits `DirectRequest`, scheduler
+control commands, and the current time to the `Generalized Mocker Engine`. It
+receives pass outputs, lifecycle effects, KV observations, FPM, and metrics.
+
+`Live Mocker` owns:
+
+- `DistributedRuntime` and `AsyncEngine` integration;
+- Tokio tasks, channels, cancellation, and wall-clock waiting;
+- streaming response assembly;
+- handoff orchestration;
+- conversion and publication of Dynamo events and production metrics.
+
+The dependency is one-way:
+
+```text
+Dynamo Live Mocker -> AISim Generalized Mocker Engine
+```
+
+The engine does not depend on Dynamo runtime, NATS, ZMQ, handoff sessions, live
+event publishers, or the offline `Replayer`.
+
+## Planner Adapter API
+
+TODO: Hongkuan will add this section.

--- a/dynosim-mocker-api-boundary.md
+++ b/dynosim-mocker-api-boundary.md
@@ -16,7 +16,7 @@ Only the following contracts cross component boundaries:
 | `Replayer` ↔ `Generalized Mocker Engine` | `GeneralizedMockerEngine`, `EnginePassResult`, and `EngineEffects` |
 | `Live Mocker` ↔ `Generalized Mocker Engine` | `GeneralizedMockerEngine`, `EnginePassResult`, and `EngineEffects` |
 | `Replayer` ↔ `Router Adapter` | `PlacementPolicy<Request>` |
-| `Replayer` ↔ `Planner Adapter` | TODO |
+| `Replayer` ↔ `Planner Adapter` | `ScalingPolicy` |
 
 The contracts are owned by AISim. Dynamo implements the adapters and converts
 between Dynamo-specific and AISim-neutral types.
@@ -472,4 +472,166 @@ type.
 
 ## Planner Adapter API
 
-TODO: Hongkuan will add this section.
+The Planner adapter is an optional internal boundary between `Replayer` and a
+scaling policy. AISim Replay owns the neutral scaling contract. Dynamo Replay
+constructs and injects the Dynamo Planner adapter when Planner configuration is
+present.
+
+AISim Replay does not import Planner, interpret `PlannerConfig`, construct
+predictors, or implement Planner policy. Planner-disabled and Planner-enabled
+runs use the same `Replayer` event loop.
+
+The runtime boundary is:
+
+```rust
+trait ScalingPolicy {
+    fn initial_tick_ms(&mut self) -> Result<Option<f64>>;
+
+    fn on_tick(
+        &mut self,
+        observation: ScalingObservation,
+    ) -> Result<ScalingEffects>;
+}
+
+struct ScalingObservation {
+    now_ms: f64,
+    pools: Vec<WorkerPoolObservation>,
+    traffic: TrafficWindow,
+}
+
+struct WorkerPoolObservation {
+    role: WorkerRole,
+    active_worker_ids: Vec<usize>,
+    total_workers: usize,
+    fpm: Vec<WorkerFpmSnapshot>,
+}
+
+enum WorkerRole {
+    Aggregated,
+    Prefill,
+    Decode,
+}
+
+struct WorkerFpmSnapshot {
+    worker_id: usize,
+    dp_rank: u32,
+    snapshot: ForwardPassSnapshot,
+}
+
+struct ScalingEffects {
+    targets: Vec<WorkerPoolTarget>,
+    next_tick_ms: Option<f64>,
+}
+
+struct WorkerPoolTarget {
+    role: WorkerRole,
+    logical_workers: usize,
+}
+```
+
+`initial_tick_ms` returns the absolute simulated time of the first scaling tick.
+`None` disables scaling ticks. `on_tick` returns absolute logical-worker targets
+and the absolute simulated time of the next tick. Omitting a worker role leaves
+that pool unchanged; `next_tick_ms == None` stops the recurring tick.
+
+An aggregated replay exposes only the `Aggregated` pool. A disaggregated replay
+exposes `Prefill` and `Decode` pools. Scaling targets always refer to complete
+logical workers. A Planner adapter cannot add or remove individual attention-DP
+ranks.
+
+### Tick and scaling semantics
+
+`Replayer` owns the scaling tick as an event in its virtual event queue. At a
+tick timestamp, it first settles request arrivals, pass completions, engine
+internal work, worker readiness, placement releases, and worker removals at the
+same timestamp. The scaling policy therefore observes a consistent
+post-settlement snapshot.
+
+For each tick, `Replayer`:
+
+1. builds one `WorkerPoolObservation` for every configured worker role;
+2. drains the traffic window ending at `now_ms`;
+3. calls `ScalingPolicy::on_tick`;
+4. validates the returned targets;
+5. applies scale-up or scale-down through the existing worker lifecycle;
+6. schedules the next tick when requested.
+
+Scale-up constructs complete `GeneralizedMockerEngine` logical workers and
+honors the configured startup delay. Scale-down removes the selected workers
+from placement, marks them draining, and removes them only after they satisfy
+the normal drain conditions. The Planner adapter does not construct engines,
+mutate the event queue, or drive worker lifecycle directly.
+
+A policy error fails the replay candidate. Dynamo Replay is responsible for
+closing the adapter and preserving adapter-specific error context.
+
+### Observation and metric ownership
+
+The `Generalized Mocker Engine` produces rank-scoped FPM and neutral engine
+effects. `Replayer` owns the virtual-time aggregation required to build
+`ScalingObservation`:
+
+- FPM is keyed by logical worker and DP rank;
+- the latest FPM sample for each worker/rank since the previous tick is exposed;
+- active ranks with no forward pass may receive neutral idle samples at the
+  configured sampling cadence;
+- active worker IDs contain ready, non-draining workers;
+- total worker counts include workers represented in the current lifecycle,
+  including pending startup or removal as defined by replay scaling semantics;
+- `TrafficWindow` covers the interval since the previous scaling tick and
+  carries the counts needed to merge weighted averages exactly.
+
+Cache-hit and overlap information used by traffic metrics must be represented as
+neutral placement or admission observations. Dynamo `RouterEvent` and the
+current `PlannerCacheSample` type do not cross this boundary.
+
+Planner-specific interpretation remains in the Dynamo Planner adapter. This
+includes regression inputs, partial-window merging across different Planner
+cadences, load prediction, SLA evaluation, scaling-target calculation, GPU-hour
+accounting, and Planner diagnostics.
+
+Normal `TraceCollector` and replay-report metrics remain enabled independently
+of Planner. When no `ScalingPolicy` is attached, `Replayer` does not create
+scaling-tick events or maintain Planner-only FPM and traffic buffers.
+
+### Dynamo Planner composition
+
+Planner configuration in `ReplaySpec` is serializable data, not a Rust or
+Python policy object. When Planner is selected, Dynamo Replay:
+
+1. resolves the selected Planner runtime-hook descriptor;
+2. loads the Planner provider;
+3. constructs the Dynamo `ReplayPlannerAdapter`;
+4. wraps it in an in-process implementation of `ScalingPolicy`;
+5. injects that policy before invoking the same `Replayer::run` loop.
+
+For the current Python Planner, the PyO3 wrapper calls the adapter's
+`initial_tick_ms()` and `on_tick(observation)` methods. This wrapper implements
+only the neutral Rust contract; Planner configuration, predictor state, and
+decision logic remain in the Python Planner component.
+
+When Planner is not selected, Dynamo Replay does not resolve or import the
+Planner provider and runs `Replayer` without a scaling policy. Missing
+Planner-only optional dependencies therefore fail only when a Planner hook is
+requested.
+
+The scaling contract controls the replay only while it is running. After
+`Replayer` returns the base `TraceSimulationReport`, Dynamo Replay may ask the
+Planner adapter to finalize its scaling events and diagnostics and attach them
+to Dynamo-specific report metadata. Adapter finalization is not part of the
+AISim Replay contract.
+
+### Boundary constraints
+
+The Planner adapter:
+
+- does not receive a `GeneralizedMockerEngine` handle;
+- does not advance the virtual clock or pop replay events;
+- does not construct, start, drain, or remove workers directly;
+- does not select request placement;
+- does not write base `TraceCollector` state;
+- does not introduce a separate Planner replay entry point.
+
+AISim Replay depends only on the neutral `ScalingPolicy` contract. Dynamo
+Planner configuration, Python integration, predictor dependencies, and
+diagnostics remain on the Dynamo Replay side of the dependency boundary.

--- a/spica-aisimulate-refactor-plan.md
+++ b/spica-aisimulate-refactor-plan.md
@@ -20,6 +20,9 @@ sweep package while keeping it in the Dynamo repository for now.
 - Spica owns process management, parallelism, candidate timeouts, and result
   collection. Actual replay execution is provided through an injected
   `RunnerFactory`.
+- Replay is being decoupled in parallel: backend-only Spica calls standalone
+  Dynamo-independent AISim Replay, while Spica with Dynamo adapters calls the
+  Dynamo Replay composition built on top of the same AISim Replayer.
 - The eventual physical move of the core/backend package to the AIConfigurator
   repository is out of scope, but the resulting package boundary must allow that
   move without further Dynamo-specific cleanup.
@@ -30,11 +33,14 @@ flowchart LR
     E["Selected adapter entry points"] --> A["Adapter search-space generation"]
     A --> S
     S --> V["Optimizer candidate"]
-    V --> M["Backend and adapter materialization"]
+    V --> M["Build concrete ReplaySpec"]
     M --> R["Serializable ReplaySpec"]
-    RF["Injected RunnerFactory"] --> W["Spica worker processes"]
-    R --> W
-    W --> P["ReplayReport"]
+    R --> W["Spica worker processes"]
+    RF["Injected RunnerFactory"] --> W
+    W -->|"no Dynamo hooks"| AR["AISim Replay<br/>no Dynamo dependency"]
+    W -->|"Dynamo hooks"| DR["Dynamo Replay<br/>AISim Replay + Dynamo runtime adapters"]
+    AR --> P["ReplayReport"]
+    DR --> P
     P --> S
 ```
 
@@ -165,6 +171,9 @@ Spica exposes an injected runner boundary:
 
 ```python
 class RunnerFactory(Protocol):
+    def capabilities(self) -> RunnerCapabilities:
+        ...
+
     def create(self, worker_id: int) -> Runner:
         ...
 
@@ -195,6 +204,9 @@ Runner behavior is constrained as follows:
 - `runner_factory` is a required keyword-only argument; core provides no Dynamo
   default Runner.
 - The factory must be multiprocessing-serializable.
+- Before starting the optimizer, Spica compares every requested runtime hook
+  with `RunnerFactory.capabilities()` and fails early if the selected replay
+  composition cannot execute it.
 - Each worker creates and reuses one Runner, then closes it during worker
   shutdown.
 - Spica retains ownership of worker processes, evaluation parallelism,
@@ -216,10 +228,15 @@ Runner behavior is constrained as follows:
 - workload and SLA measurement information;
 - namespaced `AdapterReplaySpec` objects;
 - runtime hooks represented as
-  `RuntimeHookSpec(provider, kind, config)`.
+  `RuntimeHookSpec(provider, kind, api_version, config)`.
 
 Runtime hook descriptors contain data, not Python callback objects. The injected
 Runner owns hook resolution and invocation.
+
+`RunnerCapabilities` declares the supported `ReplaySpec` version and runtime
+hook provider/kind/version tuples. A Dynamo-independent AISim Replay runner
+supports the neutral spec and built-in policies only. A Dynamo Replay runner
+adds support for the selected Dynamo Router and Planner hook contracts.
 
 `ReplayReport` contains at least:
 
@@ -232,6 +249,48 @@ class ReplayReport:
 The core reads `metrics` for feasibility checks, scalar scoring, goodput
 validation, and Pareto ranking. Runner- or adapter-specific diagnostics remain in
 `metadata`.
+
+## Parallel Replay Refactor
+
+Spica and Replay are separate parallel workstreams joined by the AISim-owned
+`ReplaySpec`, `ReplayReport`, runtime-hook, and runner contracts. Neither
+workstream waits for the other's concrete implementation after these contracts
+and their fixtures are frozen.
+
+There is one Spica core and one AISim Replayer, with two compositions rather
+than two forked implementations:
+
+| Path | Spica composition | Replay composition |
+| --- | --- | --- |
+| Backend-only | AISimulate Spica without Dynamo adapters | AISim Replay with built-in neutral placement, initially round-robin |
+| Dynamo features | The same Spica core with selected Dynamo search adapters | Dynamo Replay, which reuses AISim Replay and injects Dynamo Router and/or Planner runtime policies |
+
+The dependency direction is:
+
+```text
+backend-only Spica -> AISim Replay -> Generalized Mocker Engine
+
+Dynamo-enabled Spica -> Dynamo Replay -> AISim Replay -> Generalized Mocker Engine
+                              |
+                              +-> Dynamo Router and Planner runtime adapters
+```
+
+The Spica-side entry point and Replay-side runtime hook have different jobs:
+
+- The Spica adapter validates an adapter-owned search space, performs optional
+  preparation such as the Planner load-predictor pre-sweep, and materializes
+  serializable policy configuration into `ReplaySpec`.
+- AISim Replay owns the virtual clock, event loop, worker fleet, built-in neutral
+  policies, and base report. It has no Dynamo dependency.
+- Dynamo Replay resolves the runtime-hook descriptors, constructs the Dynamo
+  `PlacementPolicy` and `ScalingPolicy` adapters, and injects them into the same
+  AISim Replayer. It does not implement a second replay loop.
+
+During parallel development, Spica is implemented and tested against a contract
+`RunnerFactory`; Replay is implemented against versioned `ReplaySpec` fixtures.
+No temporary import of the current `dynamo.replay` is added back to AISimulate.
+If an integration bridge is temporarily required, it lives on the Dynamo Replay
+side and implements the same runner contract.
 
 ## Code Separation
 
@@ -322,25 +381,31 @@ they model backend/GPU behavior independently of KVBM.
 
 ## Implementation Sequence
 
-1. Create or update the Dynamo Enhancement Proposal to lock the package
-   boundary, Adapter ABI v1, ReplaySpec, and RunnerFactory contract.
-2. Add the core protocols, entry-point resolver, namespaced adapter
-   configuration, and fake adapter/runner test infrastructure.
-3. Refactor the search loop to:
-   adapter preparation, merged search-space generation, backend/adapter
-   candidate materialization, ReplaySpec construction, Runner execution, and
-   scoring.
-4. Split out `BackendDeploymentSpec` and remove the Dynamo ReplayEvaluator from
-   core.
-5. Move Planner and Router behavior into their component adapters and register
-   their entry points.
-6. Remove KVBM fields, legacy flat schema, direct Dynamo imports, and unused
-   dependencies.
-7. Update installation guidance, Python API examples, and backend/Planner/Router
-   sweep examples.
+1. Freeze the shared contract first in the Dynamo Enhancement Proposal:
+   Adapter ABI v1, ReplaySpec v1, RuntimeHookSpec, RunnerCapabilities,
+   RunnerFactory, ReplayReport, and canonical serialized fixtures.
+2. In the Spica workstream, add the core protocols, entry-point resolver,
+   namespaced adapter configuration, and contract fake runner.
+3. Refactor the Spica search loop to perform adapter preparation, merge search
+   spaces, build a concrete ReplaySpec, validate runner capabilities, execute
+   through Runner, and score ReplayReport.
+4. In parallel, the Replay workstream extracts AISim Replay and the Generalized
+   Mocker Engine without Dynamo dependencies, then implements the
+   Dynamo-independent RunnerFactory.
+5. On the Dynamo side, implement Dynamo Replay as a composition over AISim
+   Replay, resolve the Router and Planner runtime hooks, and expose a
+   Dynamo-capable RunnerFactory.
+6. Move Planner and Router search behavior into their component adapters and
+   register their Spica entry points.
+7. Remove the mixed DeploymentPlan/ReplayEvaluator path, KVBM fields, legacy
+   flat schema, direct Dynamo imports, and unused dependencies.
+8. Run the shared contract suite followed by backend-only and Dynamo-enabled
+   end-to-end integration, then update installation and sweep examples.
 
-The refactor should land atomically, with reviewable commits following this
-sequence, so the main branch never contains mismatched core and adapter ABIs.
+Each workstream remains buildable against the frozen contract and fake fixtures.
+The real integration path is enabled only when Spica and the selected replay
+composition advertise compatible contract versions; no unversioned intermediate
+API is accepted.
 
 ## Test Plan
 
@@ -386,6 +451,8 @@ sequence, so the main branch never contains mismatched core and adapter ABIs.
 ### Runner and sweep orchestration
 
 - Round-trip serialize every ReplaySpec model.
+- Validate ReplaySpec and runtime-hook requirements against RunnerCapabilities
+  before starting the optimizer.
 - Create one Runner per worker and close it on normal and abnormal shutdown.
 - Cover sequential and spawned parallel execution.
 - Preserve candidate timeout, worker crash, runner exception, failed candidate,
@@ -393,6 +460,20 @@ sequence, so the main branch never contains mismatched core and adapter ABIs.
 - Preserve scalar, goodput, and Pareto scoring from `ReplayReport.metrics`.
 - Exercise Planner and Router adapters together and verify their parameters,
   configs, and hooks remain namespaced.
+
+### Cross-workstream Replay contract
+
+- Use the same canonical ReplaySpec fixtures in the Spica and Replay test suites.
+- Run a backend-only Spica candidate through AISim Replay without installing or
+  importing Dynamo.
+- Run Planner- and Router-enabled candidates through Dynamo Replay and verify it
+  reuses the AISim Replayer while constructing the requested runtime policies.
+- Reject a Dynamo runtime hook when the caller injects the
+  Dynamo-independent AISim Replay RunnerFactory.
+- Verify the same base ReplayReport metrics and serialization version across
+  AISim Replay and Dynamo Replay when no Dynamo runtime hook is selected.
+- Add dependency firewalls proving AISim Replay and the Generalized Mocker
+  Engine have no Dynamo workspace or Python dependencies.
 
 ### Breaking schema and KVBM
 
@@ -414,6 +495,10 @@ sequence, so the main branch never contains mismatched core and adapter ABIs.
   behavior.
 - Spica requires an injected `RunnerFactory` and continues to own evaluation
   process lifecycle and timeouts.
+- Backend-only Spica invokes Dynamo-independent AISim Replay.
+- Spica with Dynamo adapters invokes Dynamo Replay, which composes the same AISim
+  Replayer with Dynamo runtime policies instead of forking the replay loop.
+- A runner/spec capability mismatch fails before any candidate execution.
 - KVBM fields and behavior are fully removed with explicit validation errors.
 - The core/backend package can later move to the AIConfigurator repository
   without removing additional Dynamo-specific logic.
@@ -422,5 +507,7 @@ sequence, so the main branch never contains mismatched core and adapter ABIs.
 
 - Physically moving `aisimulate` to the AIConfigurator repository.
 - Implementing native G2 support.
-- Implementing the real replay Runner or completing the replay-engine split.
+- Replay event-loop and Generalized Mocker Engine implementation details; those
+  belong to the parallel Replay workstream, while their public contract and
+  Spica integration are in scope here.
 - Maintaining compatibility with the old flat Planner/Router/KVBM schema.

--- a/spica-aisimulate-refactor-plan.md
+++ b/spica-aisimulate-refactor-plan.md
@@ -1,0 +1,426 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Spica / AISimulate Dynamo Decoupling Refactor Plan
+
+## Summary
+
+This refactor establishes `aisimulate` as a Dynamo-independent simulation and
+sweep package while keeping it in the Dynamo repository for now.
+
+- `aisimulate` retains simulation backend functionality, Spica core sweep logic,
+  scoring, parallel execution, and public simulation protocols.
+- `aisimulate` does not depend on or statically import `ai-dynamo`.
+- Dynamo Planner and Router simulation behavior moves into adapters under their
+  corresponding Dynamo components and is loaded only when selected.
+- KVBM sweep support is removed without a compatibility layer; native G2 support
+  is out of scope for this refactor.
+- Spica owns process management, parallelism, candidate timeouts, and result
+  collection. Actual replay execution is provided through an injected
+  `RunnerFactory`.
+- The eventual physical move of the core/backend package to the AIConfigurator
+  repository is out of scope, but the resulting package boundary must allow that
+  move without further Dynamo-specific cleanup.
+
+```mermaid
+flowchart LR
+    C["SmartSearchConfig"] --> S["AISimulate sweep core"]
+    E["Selected adapter entry points"] --> A["Adapter search-space generation"]
+    A --> S
+    S --> V["Optimizer candidate"]
+    V --> M["Backend and adapter materialization"]
+    M --> R["Serializable ReplaySpec"]
+    RF["Injected RunnerFactory"] --> W["Spica worker processes"]
+    R --> W
+    W --> P["ReplayReport"]
+    P --> S
+```
+
+## Public Configuration
+
+Core and adapter search spaces are explicitly separated:
+
+```yaml
+search_space:
+  model_name: Qwen/Qwen3-32B
+  hardware_sku: h200_sxm
+  gpu_budget: 32
+  backend: [vllm, sglang]
+  deployment_mode: [agg, disagg]
+
+adapters:
+  dynamo.planner:
+    search_space:
+      scaling_policy: [disabled, throughput_180_5, load_180_5]
+      fpm_sampling: [default, fine]
+      load_sensitivity: [default, conservative]
+      load_predictor_candidates: [constant_last, prophet_w20_raw]
+
+  dynamo.router:
+    search_space:
+      mode: [round_robin, kv_router]
+      overlap_score_credit: [0.0, 0.5, 1.0]
+      prefill_load_scale: [0.0, 1.0, 4.0]
+      temperature: [0.0, 0.2]
+```
+
+The adapter receives a search space, not a concrete Planner or Router
+configuration. A concrete configuration is generated only when materializing an
+optimizer candidate.
+
+The new schema is intentionally breaking:
+
+- Old flat Planner and Router fields are not converted automatically.
+- Validation errors identify the replacement
+  `adapters.<adapter-name>.search_space` path.
+- Removed KVBM fields produce a specific error explaining that no native G2
+  migration exists yet.
+
+## Adapter ABI v1
+
+The core defines a Dynamo-neutral adapter protocol:
+
+```python
+class SimulationAdapter(Protocol):
+    name: str
+    api_version: int
+
+    def generate_search_space(
+        self,
+        search_spec: Mapping[str, JSONValue],
+        context: SweepContext,
+    ) -> AdapterSearchPlan:
+        ...
+
+    def materialize_replay(
+        self,
+        plan: AdapterSearchPlan,
+        selection: Mapping[str, JSONValue],
+        context: CandidateContext,
+    ) -> AdapterReplaySpec:
+        ...
+```
+
+The supporting contracts have the following responsibilities:
+
+- `SweepContext` exposes immutable core context such as workload, optimization
+  goal, SLA, and backend search context.
+- `AdapterSearchPlan` contains a generic `SearchSpaceFragment`, adapter-owned
+  prepared state, and optional preparation diagnostics.
+- Core automatically namespaces every adapter parameter using the adapter name.
+- `CandidateContext` contains the selected core/backend candidate and resolved
+  values such as backend version, concurrency, and parallel configuration.
+- `AdapterReplaySpec` contains the candidate-specific adapter configuration and
+  serializable runtime-hook descriptors.
+- Adapter code neither constructs a shell command nor runs replay.
+- The initial resolver requires exact `api_version == 1`; incompatible adapters
+  fail before the optimizer starts.
+
+### Planner pre-sweep
+
+The Planner adapter preserves the existing load-predictor pre-sweep:
+
+1. Decode scaling policies and extract distinct throughput intervals.
+2. For a trace workload, run the independent predictor grid search once per
+   interval and record the winner and loss diagnostics.
+3. Return the Planner parameters used by the main optimizer together with this
+   prepared state.
+4. During candidate materialization, select the predictor winner corresponding
+   to that candidate's scaling interval.
+5. Preserve the current constant-predictor fallback for non-trace or
+   non-informative workloads.
+
+Planner goal mapping, SLA compatibility filtering, and policy pruning are owned
+by this adapter rather than the sweep core.
+
+## Adapter Discovery
+
+The `ai-dynamo` wheel registers the adapters through Python package metadata:
+
+```toml
+[project.entry-points."aisimulate.adapters"]
+"dynamo.planner" = "dynamo.planner.simulation:create_adapter"
+"dynamo.router" = "dynamo.router.simulation:create_adapter"
+```
+
+Resolution follows these rules:
+
+1. Resolve only adapter names present in the input configuration.
+2. A programmatically injected adapter with the same name takes precedence,
+   enabling tests and embedded use without installed entry-point metadata.
+3. Otherwise query the `aisimulate.adapters` entry-point group and call `.load()`
+   only on the selected provider.
+4. Reject missing adapters, duplicate registrations, invalid factories, and ABI
+   mismatches with separate actionable errors.
+5. Do not provide a hard-coded Dynamo import fallback.
+
+Reading entry-point metadata does not import Dynamo. Dynamo is imported only
+when a selected Dynamo provider is loaded.
+
+## Replay and Runner ABI
+
+Spica exposes an injected runner boundary:
+
+```python
+class RunnerFactory(Protocol):
+    def create(self, worker_id: int) -> Runner:
+        ...
+
+
+class Runner(Protocol):
+    def run(self, spec: ReplaySpec) -> ReplayReport:
+        ...
+
+    def close(self) -> None:
+        ...
+```
+
+The public sweep entry point becomes:
+
+```python
+run_smart_search(
+    config,
+    *,
+    runner_factory,
+    adapters=None,
+    sampler_factory=...,
+    ...
+)
+```
+
+Runner behavior is constrained as follows:
+
+- `runner_factory` is a required keyword-only argument; core provides no Dynamo
+  default Runner.
+- The factory must be multiprocessing-serializable.
+- Each worker creates and reuses one Runner, then closes it during worker
+  shutdown.
+- Spica retains ownership of worker processes, evaluation parallelism,
+  per-candidate timeouts, worker crash handling, progress reporting, and result
+  collection.
+- Adapter preparation and candidate materialization run in the main process.
+  Workers receive only a serializable `ReplaySpec`.
+- The effective-candidate cache key is derived from the canonical `ReplaySpec`
+  rather than the raw optimizer selection. This collapses choices ignored by an
+  adapter, such as Router knobs under round-robin routing.
+
+### ReplaySpec
+
+`ReplaySpec` is a strict, serializable core model containing:
+
+- backend deployment and engine specification;
+- resolved backend version, parallel configuration, worker counts, and
+  concurrency;
+- workload and SLA measurement information;
+- namespaced `AdapterReplaySpec` objects;
+- runtime hooks represented as
+  `RuntimeHookSpec(provider, kind, config)`.
+
+Runtime hook descriptors contain data, not Python callback objects. The injected
+Runner owns hook resolution and invocation.
+
+`ReplayReport` contains at least:
+
+```python
+class ReplayReport:
+    metrics: dict[str, float]
+    metadata: dict[str, JSONValue]
+```
+
+The core reads `metrics` for feasibility checks, scalar scoring, goodput
+validation, and Pareto ranking. Runner- or adapter-specific diagnostics remain in
+`metadata`.
+
+## Code Separation
+
+### AISimulate core
+
+Retain and generalize:
+
+- Vizier-backed sampling, branch enumeration, ask/tell orchestration, and
+  parallel projection.
+- Backend engine parameters, model/hardware resolution, and legal parallel
+  configuration enumeration.
+- Generic GPU KV-capacity estimation and `kv_load_ratio`; these are not KVBM
+  features.
+- Workload, optimization goals, SLA, scoring, Pareto ranking, and candidate
+  models.
+- Adapter discovery and ABI models.
+- `ReplaySpec`, `ReplayReport`, `Runner`, and `RunnerFactory` protocols.
+- Backend-only sample materialization.
+
+Refactor or remove:
+
+- Replace the mixed `DeploymentPlan` with a backend-only
+  `BackendDeploymentSpec`.
+- Remove `ReplayEvaluator` calls to `dynamo.replay`, `dynamo.mocker`, and
+  `KvRouterConfig`.
+- Remove Planner presets, predictor search, Planner goal mapping, policy
+  filtering, and Planner config generation from core.
+- Remove Router search fields, conditional pruning, and Router config generation
+  from core.
+- Replace `dynamo._internal.aic` exception imports with a local or
+  AIConfigurator-owned exception.
+- Remove the standalone sweep CLI execution path. `python -m
+  aisimulate.spica` should emit a concise error directing callers to the Python
+  API and required `RunnerFactory`.
+- Remove the `ai-dynamo` dependency and move Planner-only predictor
+  dependencies out of the `aisimulate` package.
+
+### Dynamo Planner adapter
+
+Place the Planner adapter under the Planner component. It owns:
+
+- Planner search-space schema and preset decoding;
+- scaling, FPM sampling, and load-sensitivity parameters;
+- goal-to-Planner optimization-target mapping;
+- SLA and scaling-policy compatibility checks;
+- load-predictor trace aggregation and pre-sweep;
+- candidate-specific Planner config generation;
+- Planner runtime-hook descriptors and factories.
+
+### Dynamo Router adapter
+
+Place the Router adapter under the Router component. It owns:
+
+- round-robin and KV-routing search dimensions;
+- Router-specific conditional pruning and validation;
+- candidate-specific Router config generation;
+- Router runtime-hook descriptors and factories.
+
+Planner-only optional dependencies move to a Dynamo simulation extra. The
+dependency direction is:
+
+```text
+ai-dynamo[simulation] -> aisimulate
+```
+
+No dependency from `aisimulate` to `ai-dynamo` is permitted.
+
+## KVBM Removal
+
+Remove the following from schema, search-space generation, candidate
+materialization, deployment/replay specifications, tests, examples, and
+documentation:
+
+- `num_g2_blocks`
+- `kv_bytes_per_token`
+- `bandwidth_g1_to_g2_gbps`
+- `bandwidth_g2_to_g1_gbps`
+- `offload_batch_size`
+- `host_cache_hit_weight`
+- `disk_cache_hit_weight`
+
+Input containing any of these fields fails validation with a message stating
+that KVBM support has been removed and that native G2 is not part of this
+refactor.
+
+GPU KV capacity, memory-utilization settings, and `kv_load_ratio` remain because
+they model backend/GPU behavior independently of KVBM.
+
+## Implementation Sequence
+
+1. Create or update the Dynamo Enhancement Proposal to lock the package
+   boundary, Adapter ABI v1, ReplaySpec, and RunnerFactory contract.
+2. Add the core protocols, entry-point resolver, namespaced adapter
+   configuration, and fake adapter/runner test infrastructure.
+3. Refactor the search loop to:
+   adapter preparation, merged search-space generation, backend/adapter
+   candidate materialization, ReplaySpec construction, Runner execution, and
+   scoring.
+4. Split out `BackendDeploymentSpec` and remove the Dynamo ReplayEvaluator from
+   core.
+5. Move Planner and Router behavior into their component adapters and register
+   their entry points.
+6. Remove KVBM fields, legacy flat schema, direct Dynamo imports, and unused
+   dependencies.
+7. Update installation guidance, Python API examples, and backend/Planner/Router
+   sweep examples.
+
+The refactor should land atomically, with reviewable commits following this
+sequence, so the main branch never contains mismatched core and adapter ABIs.
+
+## Test Plan
+
+### Core isolation
+
+- Install and import `aisimulate` in an environment without `ai-dynamo`.
+- Run a backend-only sweep with a fake `RunnerFactory`.
+- Assert that backend-only execution does not add `dynamo` modules to
+  `sys.modules`.
+- Add a source/import firewall preventing `aisimulate` from importing
+  `dynamo.*`.
+- Verify the `aisimulate` wheel dependency metadata does not contain
+  `ai-dynamo`.
+
+### Adapter discovery and ABI
+
+- No adapter is loaded when `adapters` is empty.
+- Only explicitly selected entry points are loaded.
+- Cover missing adapter, duplicate entry point, invalid factory, provider import
+  failure, and ABI mismatch.
+- Verify programmatic injection overrides an installed provider of the same
+  name.
+- Verify the built `ai-dynamo` wheel advertises both adapter entry points.
+
+### Planner adapter
+
+- Validate Planner search-space inputs independently of core.
+- Cover scaling-interval extraction and one predictor pre-sweep per distinct
+  interval.
+- Cover trace winners, short-trace fallback, non-trace fallback, and predictor
+  diagnostics.
+- Cover goal/SLA policy filtering, including e2e-only SLA behavior.
+- Verify candidate selection produces the expected concrete Planner config and
+  runtime-hook descriptors.
+
+### Router adapter
+
+- Validate round-robin and KV-routing spaces.
+- Verify round-robin omits KV Router runtime hooks.
+- Verify KV Router choices produce the expected concrete config and hooks.
+- Verify inactive Router knobs do not create different effective ReplaySpecs.
+
+### Runner and sweep orchestration
+
+- Round-trip serialize every ReplaySpec model.
+- Create one Runner per worker and close it on normal and abnormal shutdown.
+- Cover sequential and spawned parallel execution.
+- Preserve candidate timeout, worker crash, runner exception, failed candidate,
+  progress, result cache, and optimizer ask/tell behavior.
+- Preserve scalar, goodput, and Pareto scoring from `ReplayReport.metrics`.
+- Exercise Planner and Router adapters together and verify their parameters,
+  configs, and hooks remain namespaced.
+
+### Breaking schema and KVBM
+
+- Every old flat Planner/Router field emits a clear replacement path.
+- Every removed KVBM field emits the dedicated removal error.
+- Candidate output uses backend plus namespaced adapter configurations.
+- Existing backend-only candidate and scoring fixtures remain equivalent.
+- Planner/Router fixtures compare generated ReplaySpecs with the behavior of the
+  current implementation, excluding KVBM.
+
+## Acceptance Criteria
+
+- `aisimulate` source and package metadata have no dependency on Dynamo.
+- A backend-only sweep completes without Dynamo installed or imported.
+- Selecting a Dynamo adapter imports only its registered provider.
+- Planner and Router search spaces are supplied through their adapters, and
+  concrete configs are produced only during candidate materialization.
+- Planner load-predictor pre-sweep retains its existing interval-dependent
+  behavior.
+- Spica requires an injected `RunnerFactory` and continues to own evaluation
+  process lifecycle and timeouts.
+- KVBM fields and behavior are fully removed with explicit validation errors.
+- The core/backend package can later move to the AIConfigurator repository
+  without removing additional Dynamo-specific logic.
+
+## Out of Scope
+
+- Physically moving `aisimulate` to the AIConfigurator repository.
+- Implementing native G2 support.
+- Implementing the real replay Runner or completing the replay-engine split.
+- Maintaining compatibility with the old flat Planner/Router/KVBM schema.


### PR DESCRIPTION
## Summary

- Defines the draft API boundaries among the AISim Replayer, Generalized Mocker Engine, Dynamo Router Adapter, and Dynamo Live Mocker.
- Keeps native G1 and framework-native G2 inside the Generalized Mocker Engine and excludes a KVBM Adapter API.
- Leaves the Planner Adapter API section for Hongkuan to complete.

This is a collaboration-only draft PR and is not intended to merge.

## Collaboration

- Yongming: Replayer, Generalized Mocker Engine, Router Adapter, KV ownership, and Live Mocker boundaries.
- Hongkuan: Planner Adapter boundary.

## Validation

- `git diff --cached --check`
- Documentation-only change; no runtime tests required.