### PR TITLE
revert(container): remove nsight-systems 404 workaround

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -134,13 +134,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # Add external repos (NVIDIA devtools, GitHub CLI) and install in one pass.
 # Cache apt downloads; sharing=locked avoids apt/dpkg races with concurrent builds.
-#
-# ==================== TEMPORARY WORKAROUND ====================
-# The devtools repo index lists "Filename: ./nsight-systems-...deb", so apt
-# requests the "/./" literally and that bucket 404s on it (the CUDA repo
-# normalizes fine). Fetch the normalized URL directly instead of by name.
-# Revert to a plain apt-get install once NVIDIA fixes the bucket.
-# ==============================================================
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     wget -qO - "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nvidia.pub" \
         | gpg --dearmor -o /etc/apt/keyrings/nvidia-devtools.gpg && \
@@ -151,10 +144,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     echo "deb [arch=${TARGETARCH} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
         | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
-    curl --retry 3 --retry-delay 5 -fsSL -o /tmp/nsys.deb \
-        "https://developer.download.nvidia.com/devtools/repos/ubuntu2404/${TARGETARCH}/nsight-systems-2025.5.1_2025.5.1.121-1_${TARGETARCH}.deb" && \
-    apt-get install -y --no-install-recommends /tmp/nsys.deb gh && \
-    rm -f /tmp/nsys.deb && \
+    apt-get install -y --no-install-recommends nsight-systems-2025.5.1 gh && \
     rm -rf /var/lib/apt/lists/*
 
 # ======================================================================


### PR DESCRIPTION
## Summary

- Reverts all changes from #12232 (`cbe1acf4596cdce910cdababee7e98f9d2e820a2`).
- Restores installation of `nsight-systems-2025.5.1` through `apt-get` by package name.

## Validation

- `git diff --check origin/main...HEAD`
- Verified `container/templates/dev.Dockerfile` exactly matches its pre-#12232 state with `git diff --exit-code cbe1acf4596cdce910cdababee7e98f9d2e820a2^ HEAD -- container/templates/dev.Dockerfile`.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12274" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the development environment setup to install the latest NVIDIA Nsight Systems tooling and GitHub CLI through their official package sources.
  - Simplified development image configuration by removing the previous manual package download and installation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->