### PR TITLE
fix(recipes): nemotron-3-super-fp8 TRT-LLM disagg cannot initialize without max_tokens_in_buffer

### DIFF
--- a/recipes/nemotron-3-super-fp8/README.md
+++ b/recipes/nemotron-3-super-fp8/README.md
@@ -7,16 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 
 Functional deployments for **nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8** (~124B hybrid Mamba/Attention/MoE) across multiple backends.
 
-These recipes target **Dynamo 1.0**. See [Dynamo 0.9.1 Compatibility](#dynamo-091-compatibility) for notes on running with older containers.
+These recipes target **Dynamo 1.3.0** (image tags below). See [Dynamo 0.9.1 Compatibility](#dynamo-091-compatibility) for notes on running with older containers.
 
 ## Available Configurations
 
 | Configuration | GPUs | Backend | Mode | Description |
 |--------------|------|---------|------|-------------|
 | [**vllm/agg**](vllm/agg/) | 4x H100/H200 | vLLM | Aggregated | TP=4, KV-aware routing |
-| [**sglang/agg**](sglang/agg/) | 4x H100/H200 | SGLang | Aggregated | TP=4, KV-aware routing (not working on 0.9.1) |
+| [**sglang/agg**](sglang/agg/) | 4x H100/H200 | SGLang | Aggregated | TP=4, KV-aware routing |
 | [**trtllm/disagg**](trtllm/disagg/) | 4x H100/H200 | TensorRT-LLM | Disaggregated | TP=2 P/D split, UCX KV transfer |
-| [**sglang/disagg**](sglang/disagg/) | 4x H100/H200 | SGLang | Disaggregated | TP=2 P/D split, nixl KV transfer (not working on 0.9.1) |
+| [**sglang/disagg**](sglang/disagg/) | 4x H100/H200 | SGLang | Disaggregated | TP=2 P/D split, nixl KV transfer |
 
 ## Prerequisites
 

--- a/recipes/nemotron-3-super-fp8/sglang/disagg/deploy.yaml
+++ b/recipes/nemotron-3-super-fp8/sglang/disagg/deploy.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Disaggregated SGLang deployment: prefill/decode split with nixl KV transfer.
-# Tested with dynamo 1.0 (SGLang 0.5.9).
+# Tested with dynamo 1.0 (SGLang 0.5.9); re-validated on dynamo 1.3.0 (4x B200).
 #
 # Uses TP=2 per worker (prefill: 2 GPUs, decode: 2 GPUs) for a total of 4 GPUs.
 # KV cache is transferred between workers via nixl (GPU-direct).

--- a/recipes/nemotron-3-super-fp8/trtllm/disagg/deploy.yaml
+++ b/recipes/nemotron-3-super-fp8/trtllm/disagg/deploy.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Disaggregated TRT-LLM deployment: prefill/decode split with UCX KV transfer.
-# Tested with Dynamo v1.0.0 (TRT-LLM PyTorch backend).
+# Tested with Dynamo v1.0.0 (TRT-LLM PyTorch backend); re-validated on
+# Dynamo v1.3.0 with 4x B200 (requires max_tokens_in_buffer, set below).
 #
 # Uses TP=2 per worker (prefill: 2 GPUs, decode: 2 GPUs) for a total of 4 GPUs.
 # KV cache (attention + Mamba SSM state) is transferred between workers via UCX.
@@ -47,6 +48,17 @@ data:
       # UCX is required for hybrid Mamba+Attention models.
       # NIXL/MOONCAKE do not support Mamba SSM state transfer.
       backend: UCX
+      # Cap the transceiver transfer buffer. Without this, it is sized from the
+      # engine's derived max_seq_len (~3 MiB/token/rank for this model; ~195 GB),
+      # and executor creation fails with "insufficient GPU memory" on any GPU.
+      # Sizing: GPU memory cost ~= value x 3 MiB x 2 (send+recv) per rank, and the
+      # value must EXCEED your longest expected input (shorter buffers risk a
+      # transfer deadlock under load; see docs/backends/trtllm/trtllm-known-issues.md).
+      # 16384 (~105 GB/rank) is validated on 4x B200 (180 GB). It does NOT fit
+      # H100/H200 after weights; on those, a value low enough to fit is below
+      # max_num_tokens (8192) and therefore deadlock-prone. See PR discussion:
+      # this profile's H100/H200 hardware claim needs owner review.
+      max_tokens_in_buffer: 16384
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 16
@@ -79,6 +91,17 @@ data:
       # UCX is required for hybrid Mamba+Attention models.
       # NIXL/MOONCAKE do not support Mamba SSM state transfer.
       backend: UCX
+      # Cap the transceiver transfer buffer. Without this, it is sized from the
+      # engine's derived max_seq_len (~3 MiB/token/rank for this model; ~195 GB),
+      # and executor creation fails with "insufficient GPU memory" on any GPU.
+      # Sizing: GPU memory cost ~= value x 3 MiB x 2 (send+recv) per rank, and the
+      # value must EXCEED your longest expected input (shorter buffers risk a
+      # transfer deadlock under load; see docs/backends/trtllm/trtllm-known-issues.md).
+      # 16384 (~105 GB/rank) is validated on 4x B200 (180 GB). It does NOT fit
+      # H100/H200 after weights; on those, a value low enough to fit is below
+      # max_num_tokens (8192) and therefore deadlock-prone. See PR discussion:
+      # this profile's H100/H200 hardware claim needs owner review.
+      max_tokens_in_buffer: 16384
     cuda_graph_config:
       enable_padding: true
       max_batch_size: 16


### PR DESCRIPTION
## Problem

`recipes/nemotron-3-super-fp8/trtllm/disagg/deploy.yaml` cannot initialize as published. Both workers fail with:

```
RuntimeError: Executor creation failed due to insufficient GPU memory.
The following component could not be created: Additional executor resources (temporary for KV cache size estimation)
```

The failure is insensitive to `free_gpu_memory_fraction` (tested 0.85/0.70/0.60, byte-identical) and to `max_seq_len` capping. The actual mechanism, from the worker logs: `cache_transceiver_config` sets no `max_tokens_in_buffer`, so the UCX cache transceiver sizes its transfer buffer from the engine's derived max_seq_len at ~3 MiB/token/rank:

```
BaseTransBufferManager: mMaxNumTokens:65536 ... mTransferBufferSize:209280466944   # 194.9 GiB
```

which `cudaMalloc` cannot satisfy on any single GPU. Every other TRT-LLM disagg recipe in this repo sets this knob (gpt-oss-120b: 9216, deepseek-r1 wide_ep: 4608, deepseek-v32-fp4: 120000); this one does not.

## Fix

Add `max_tokens_in_buffer: 16384` to both worker `cache_transceiver_config` blocks, with a sizing comment (memory ≈ value × 3 MiB × 2 per rank; value must exceed max expected ISL per the deadlock caveat in `docs/backends/trtllm/trtllm-known-issues.md`).

Also: retarget the README version note to 1.3.0 (matching the image pins), remove two stale "(not working on 0.9.1)" table parentheticals (the dedicated 0.9.1 compat section still covers old containers), and record 1.3.0 re-validation in the SGLang disagg manifest header.

## Validation

Dynamo v1.3.0 stock containers, 4x B200, TP2 prefill / TP2 decode:

- With **only** this line added, the profile initializes first-try (previously: CrashLoopBackOff, 9+ restarts across config permutations).
- Correctness: greedy-exact arithmetic; needle retrieval from ~6k and ~12k-token prompts (exercises Mamba SSM-state transfer through the UCX path); multi-turn.
- AIPerf smoke (ISL~512/OSL~128, streaming): c4 40/40, TTFT avg 581 ms, ITL 6.98 ms, 337 tok/s aggregate; c16 80/80, ITL 7.21 ms (flat vs c4, std 0.07), 2.62 req/s, 0 errors — no deadlock behavior with ISL below the buffer, as designed.
- A single 19.7k-token request (ISL > buffer) completed correctly at c1; the buffer limit is a load-deadlock risk, not a hard request cap.

## Open question for recipe owners: the H100/H200 hardware claim

The README lists this profile at 4x H100/H200. The buffer math makes that questionable: at 16384 the pre-allocation is ~105 GB/rank, which fits B200 (180 GB) after TP2 weights but not H200 (~80 GB free) or H100-80GB (~20 GB free). A value small enough for H100 (~3k tokens) is below the profile's own `max_num_tokens: 8192`, i.e. in the documented deadlock zone. We validated B200 only. Owners should either publish per-SKU buffer values or revisit the hardware table for the disagg profile.

## Out of scope, noted for follow-up

- The `Frontend` service in these recipes has no `envFromSecret`/`HF_HOME`, so it re-fetches tokenizer/config from HF unauthenticated (rate-limit exposure).
- Recipes ship no GPU tolerations; on clusters that taint GPU nodes, nothing schedules (gang schedulers hold back the whole graph, including the CPU frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Nemotron-3 Super FP8 recipe guidance for Dynamo 1.3.0.
  * Clarified the SGLang aggregated configuration status and deployment validation details.
  * Added guidance for configuring transceiver buffer capacity in 4x B200 TensorRT-LLM deployments.

* **Bug Fixes**
  * Improved deployment reliability by setting the required token buffer capacity for prefill and decode workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->