### PR TITLE
fix: forward logprob_token_ids through the OpenAI frontend

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -798,7 +798,14 @@ def build_sampling_params(
     # Apply output_options (logprobs, prompt_logprobs, etc.)
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
-    if logprobs is not None:
+    # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
+    # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
+    # in this case and let `num_logprobs` derive the width from the id list; mirror
+    # that here, otherwise `SamplingParams.verify()` rejects the pair unless the
+    # caller happens to set `top_logprobs == len(logprob_token_ids)`.
+    if getattr(sampling_params, "logprob_token_ids", None):
+        sampling_params.logprobs = None
+    elif logprobs is not None:
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -788,7 +788,14 @@ def build_sampling_params(
     # Apply output_options (logprobs, prompt_logprobs, etc.)
     output_options = request.get("output_options", {}) or {}
     logprobs, prompt_logprobs = _shared_logprobs.parse_logprob_options(output_options)
-    if logprobs is not None:
+    # Explicit `logprob_token_ids` replace vLLM's natural top-k selection, so the
+    # requested width no longer applies. vLLM's own OpenAI adapters null `logprobs`
+    # in this case and let `num_logprobs` derive the width from the id list; mirror
+    # that here, otherwise `SamplingParams.verify()` rejects the pair unless the
+    # caller happens to set `top_logprobs == len(logprob_token_ids)`.
+    if getattr(sampling_params, "logprob_token_ids", None):
+        sampling_params.logprobs = None
+    elif logprobs is not None:
         sampling_params.logprobs = logprobs
     if prompt_logprobs is not None:
         sampling_params.prompt_logprobs = prompt_logprobs

--- a/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_tito_parity.py
@@ -211,6 +211,41 @@ class TestTokenInSamplingDefaults:
         assert sp.top_p == pytest.approx(1.0)
 
 
+class TestLogprobTokenIds:
+    """Explicit `logprob_token_ids` must null the top-k width, as vLLM's own
+    OpenAI adapters do, so `SamplingParams.verify()` accepts the pair."""
+
+    @staticmethod
+    def _build(output_options, sampling_options=None):
+        from dynamo.vllm.handlers import build_sampling_params
+
+        return build_sampling_params(
+            {
+                "token_ids": [1, 2, 3],
+                "sampling_options": sampling_options or {},
+                "stop_conditions": {},
+                "output_options": output_options,
+            },
+            {},
+        )
+
+    def test_explicit_ids_null_requested_width(self):
+        sp = self._build(
+            {"logprobs": 5}, sampling_options={"logprob_token_ids": [5000]}
+        )
+        assert sp.logprob_token_ids == [5000]
+        assert sp.logprobs is None
+        assert sp.num_logprobs == 1
+
+    def test_requested_width_kept_without_explicit_ids(self):
+        sp = self._build({"logprobs": 5})
+        assert sp.logprobs == 5
+
+    def test_empty_id_list_falls_through_to_top_k(self):
+        sp = self._build({"logprobs": 5}, sampling_options={"logprob_token_ids": []})
+        assert sp.logprobs == 5
+
+
 class TestFlattenLogprobs:
     def test_nested_lists_are_fully_flattened(self):
         from dynamo.vllm.handlers import _flatten_logprobs

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -539,7 +539,12 @@ impl OpenAIPreprocessor {
         let mut sampling_passthrough = serde_json::Map::new();
 
         if let Some(fields) = request.unsupported_fields() {
-            for key in ["detokenize", "allowed_token_ids", "bad_words_token_ids"] {
+            for key in [
+                "detokenize",
+                "allowed_token_ids",
+                "bad_words_token_ids",
+                "logprob_token_ids",
+            ] {
                 if let Some(value) = fields.get(key) {
                     sampling_passthrough.insert(key.to_string(), value.clone());
                 }
@@ -4942,6 +4947,7 @@ mod tests {
             "detokenize": false,
             "allowed_token_ids": [10, 11],
             "bad_words_token_ids": [[12, 13]],
+            "logprob_token_ids": [14, 15],
             "nvext": {
                 "cache_salt": "step_7",
                 "extra_fields": ["completion_token_ids"],
@@ -4973,6 +4979,10 @@ mod tests {
         assert_eq!(
             extra_args["sampling_options"]["bad_words_token_ids"],
             serde_json::json!([[12, 13]])
+        );
+        assert_eq!(
+            extra_args["sampling_options"]["logprob_token_ids"],
+            serde_json::json!([14, 15])
         );
     }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -635,7 +635,12 @@ impl OpenAIPreprocessor {
         let mut sampling_passthrough = serde_json::Map::new();
 
         if let Some(fields) = request.unsupported_fields() {
-            for key in ["detokenize", "allowed_token_ids", "bad_words_token_ids"] {
+            for key in [
+                "detokenize",
+                "allowed_token_ids",
+                "bad_words_token_ids",
+                "logprob_token_ids",
+            ] {
                 if let Some(value) = fields.get(key) {
                     sampling_passthrough.insert(key.to_string(), value.clone());
                 }
@@ -5070,6 +5075,7 @@ mod tests {
             "detokenize": false,
             "allowed_token_ids": [10, 11],
             "bad_words_token_ids": [[12, 13]],
+            "logprob_token_ids": [14, 15],
             "nvext": {
                 "cache_salt": "step_7",
                 "extra_fields": ["completion_token_ids"],
@@ -5101,6 +5107,10 @@ mod tests {
         assert_eq!(
             extra_args["sampling_options"]["bad_words_token_ids"],
             serde_json::json!([[12, 13]])
+        );
+        assert_eq!(
+            extra_args["sampling_options"]["logprob_token_ids"],
+            serde_json::json!([14, 15])
         );
     }
 

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -108,6 +108,7 @@ pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     "detokenize",
     "allowed_token_ids",
     "bad_words_token_ids",
+    "logprob_token_ids",
 ];
 
 static IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS: LazyLock<bool> =
@@ -870,6 +871,12 @@ mod tests {
 
         let err = validate_response_format(&Some(response_format)).unwrap_err();
         assert!(err.to_string().contains("schema` is required"));
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_accepts_logprob_token_ids() {
+        let fields = HashMap::from([("logprob_token_ids".to_string(), json!([14, 15]))]);
+        validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -163,6 +163,10 @@ fn validate_no_unsupported_fields_with_ignore(
             |_| anyhow::anyhow!("`bad_words_token_ids` must be an array of token ID arrays"),
         )?;
     }
+    if let Some(value) = unsupported_fields.get("logprob_token_ids") {
+        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
+            .map_err(|_| anyhow::anyhow!("`logprob_token_ids` must be an array of token IDs"))?;
+    }
     Ok(())
 }
 
@@ -877,6 +881,15 @@ mod tests {
     fn validate_no_unsupported_fields_accepts_logprob_token_ids() {
         let fields = HashMap::from([("logprob_token_ids".to_string(), json!([14, 15]))]);
         validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_rejects_malformed_logprob_token_ids() {
+        for bad in [json!(["notanint"]), json!(7), json!([[1, 2]]), json!([-1])] {
+            let fields = HashMap::from([("logprob_token_ids".to_string(), bad)]);
+            let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
+            assert!(err.to_string().contains("must be an array of token IDs"));
+        }
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -163,6 +163,10 @@ fn validate_no_unsupported_fields_with_ignore(
             |_| anyhow::anyhow!("`bad_words_token_ids` must be an array of token ID arrays"),
         )?;
     }
+    if let Some(value) = unsupported_fields.get("logprob_token_ids") {
+        serde_json::from_value::<Vec<crate::types::TokenIdType>>(value.clone())
+            .map_err(|_| anyhow::anyhow!("`logprob_token_ids` must be an array of token IDs"))?;
+    }
     Ok(())
 }
 
@@ -897,6 +901,15 @@ mod tests {
     fn validate_no_unsupported_fields_accepts_logprob_token_ids() {
         let fields = HashMap::from([("logprob_token_ids".to_string(), json!([14, 15]))]);
         validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_rejects_malformed_logprob_token_ids() {
+        for bad in [json!(["notanint"]), json!(7), json!([[1, 2]]), json!([-1])] {
+            let fields = HashMap::from([("logprob_token_ids".to_string(), bad)]);
+            let err = validate_no_unsupported_fields_with_ignore(&fields, false).unwrap_err();
+            assert!(err.to_string().contains("must be an array of token IDs"));
+        }
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -108,6 +108,7 @@ pub const PASSTHROUGH_EXTRA_FIELDS: &[&str] = &[
     "detokenize",
     "allowed_token_ids",
     "bad_words_token_ids",
+    "logprob_token_ids",
 ];
 
 static IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS: LazyLock<bool> =
@@ -890,6 +891,12 @@ mod tests {
 
         let err = validate_response_format(&Some(response_format)).unwrap_err();
         assert!(err.to_string().contains("schema` is required"));
+    }
+
+    #[test]
+    fn validate_no_unsupported_fields_accepts_logprob_token_ids() {
+        let fields = HashMap::from([("logprob_token_ids".to_string(), json!([14, 15]))]);
+        validate_no_unsupported_fields_with_ignore(&fields, false).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
vLLM has supported `logprob_token_ids` on `SamplingParams` since v0.20 (vllm-project/vllm#34539) and exposed it on its own OpenAI HTTP schema in v0.26.0 (vllm-project/vllm#43463). It pins the set of vocab ids whose logprobs appear in the response, independent of top-k rank — the primitive used for classifier-style scoring, where a small fixed label set must be read at the first decoded position even when a label would not surface in top-k.

Dynamo does not serve vLLM's OpenAI app, so the field landed in `unsupported_fields` and was rejected with `400 Unsupported parameter(s)` before reaching the worker. Two allowlists gate it:

- `PASSTHROUGH_EXTRA_FIELDS` (validate.rs), checked at the HTTP layer
- `sampling_passthrough_args` (preprocessor.rs), which forwards into `extra_args.sampling_options`

Add the field to both. `build_sampling_params` already applies these generically via setattr, so no worker-side change is needed.

Verified end-to-end against a Dynamo image built on vllm/vllm-openai:v0.23.0 serving Qwen3-0.6B: a request pinning three class tokens returns logprobs for exactly those ids, and the values are discriminative across prompts.

Note for callers: vLLM's `SamplingParams.verify()` requires `logprobs == len(logprob_token_ids)` when both are set, so `top_logprobs` must match the number of pinned ids. vLLM's own frontend sidesteps this by nulling `logprobs`; this change forwards `top_logprobs` as-is rather than changing existing semantics.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for `logprob_token_ids` in sampling options.
  * Requests using `logprob_token_ids` are now accepted and correctly forwarded for backend processing.
  * Preserved compatibility with existing sampling parameters and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->