### PR TITLE
ci: Publish all containers for dynamo nightly 

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -249,7 +249,7 @@ jobs:
 
   vllm-build:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
-    needs: [create-fresh-builder, resolve-source-sha]
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: vllm
@@ -269,11 +269,16 @@ jobs:
       diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
     secrets: inherit
 
   sglang-build:
     name: sglang-runtime # This name overlaps with other sglang jobs to group them in the UI
-    needs: [create-fresh-builder, resolve-source-sha]
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: sglang
@@ -290,11 +295,16 @@ jobs:
       diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
     secrets: inherit
 
   trtllm-build:
     name: trtllm-runtime # This name overlaps with other trtllm jobs to group them in the UI
-    needs: [create-fresh-builder, resolve-source-sha]
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
@@ -311,10 +321,16 @@ jobs:
       diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
     secrets: inherit
 
   # ============================================================================
-  # OPERATOR + PLANNER (nightly-published non-runtime images)
+  # OPTIONAL NIGHTLY IMAGES (operator, planner, frontend, snapshot agent,
+  # runtime EFA variants)
   # ============================================================================
   # Built HERE — not reused from post-merge — for two reasons:
   #   1. OSRB from the get-go: GitLab's nvbug:attach-compliance resolves
@@ -323,10 +339,11 @@ jobs:
   #   2. Tag isolation (same invariant as the runtime builds): the -nightly
   #      ECR tag suffix means a missing or failed nightly build can never
   #      fall through to — or overwrite — the post-merge image at the same SHA.
-  # Neither job gates the release below: release.yml copies both fail-soft
-  # (crane-manifest probe, warn-skip) so an operator/planner build flake
-  # cannot block the runtime nightly. resolve-source-sha is always GITHUB_SHA
-  # here, so github.sha-keyed tags match the resolved source.
+  # None of these jobs gates the release below: release.yml copies each
+  # fail-soft (build-result gate + crane-manifest probe, warn-skip) so a
+  # flake in any optional image cannot block the runtime nightly.
+  # resolve-source-sha is always GITHUB_SHA here, so github.sha-keyed tags
+  # match the resolved source.
 
   operator-build:
     name: kubernetes-operator
@@ -359,7 +376,7 @@ jobs:
 
   planner-build:
     name: dynamo-planner
-    needs: [create-fresh-builder, resolve-source-sha]
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: dynamo
@@ -378,6 +395,137 @@ jobs:
       diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
+    secrets: inherit
+
+  frontend-build:
+    name: dynamo-frontend
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: dynamo
+      target: frontend
+      cuda_version: '[""]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
+      inline_compliance: true
+      build_timeout_minutes: 45
+      archive_sources: false
+      # Compliance artifact is compliance-<sha>-dynamo-frontend
+      # (target_tag_plain — no -nightly suffix), matching the OSRB token.
+      diff_event_context: nightly
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
+    secrets: inherit
+
+  snapshot-build:
+    name: snapshot-agent
+    needs: [create-fresh-builder, resolve-source-sha]
+    runs-on: prod-default-v2
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        # Do not use fetch-depth: 0 — it fetches all 1600+ branches (~3 min)
+      - name: Build and push snapshot agent (nightly tag)
+        id: build
+        uses: ./.github/actions/build-deploy-component
+        with:
+          component: snapshot
+          image_tag: ${{ github.sha }}-snapshot-agent-nightly
+          # Canonical compliance artifact name — OSRB attach tokens and the
+          # nightly diff-baseline lookup key on compliance-<sha>-snapshot-agent,
+          # independent of the -nightly image-tag suffix.
+          artifact_tag: ${{ github.sha }}-snapshot-agent
+          builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
+          aws_default_region: ${{ secrets.AWS_DEFAULT_REGION }}
+          aws_account_id: ${{ secrets.AWS_ACCOUNT_ID }}
+          # OSRB CSV diff baseline: previous successful scheduled nightly run
+          # (first nightly soft-degrades to baseline_unavailable).
+          diff_event_context: nightly
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
+
+  vllm-efa-build:
+    name: vllm-runtime-efa
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: vllm
+      target: runtime
+      cuda_version: '["13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
+      inline_compliance: true
+      build_timeout_minutes: 120
+      archive_sources: false
+      diff_event_context: nightly
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
+    secrets: inherit
+
+  sglang-efa-build:
+    name: sglang-runtime-efa
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: sglang
+      target: runtime
+      cuda_version: '["13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
+      inline_compliance: true
+      build_timeout_minutes: 120
+      archive_sources: false
+      diff_event_context: nightly
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
+    secrets: inherit
+
+  trtllm-efa-build:
+    name: trtllm-runtime-efa
+    needs: [create-fresh-builder, resolve-source-sha, compute-dev-version]
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: trtllm
+      target: runtime
+      cuda_version: '["13.1"]'
+      platform: 'linux/amd64,linux/arm64'
+      make_efa: true
+      builder_name: ${{ needs.create-fresh-builder.outputs.builder_name }}
+      inline_compliance: true
+      build_timeout_minutes: 120
+      archive_sources: false
+      diff_event_context: nightly
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+      # Stamp the checkout with the shared nightly dev suffix BEFORE the build
+      # (apply_dev_version.py in shared-build-image), so the wheels embedded in
+      # the image report X.Y.Z.devYYYYMMDD — matching the Artifactory-published
+      # nightly wheels and the dynamo-runtime image from dynamo-pipeline.
+      dev_version_suffix: ${{ needs.compute-dev-version.outputs.dev_suffix }}
     secrets: inherit
 
   # ============================================================================
@@ -754,16 +902,22 @@ jobs:
       - dynamo-pipeline
       - operator-build
       - planner-build
+      - frontend-build
+      - snapshot-build
+      - vllm-efa-build
+      - sglang-efa-build
+      - trtllm-efa-build
     # !cancelled() lets the job evaluate the explicit gates below rather than
     # implicitly requiring every need to succeed (notify-slack-start is
     # best-effort). All three runtime builds and dynamo-pipeline are gated
     # strictly: release.yml copies their -nightly ECR images to NGC and extracts
     # wheels from the dynamo-pipeline image, so a failed build must not publish a
     # partial release. manual-release-approval is `skipped` on cron, `success` on dispatch.
-    # operator-build and planner-build are ORDERING-ONLY needs (deliberately
-    # absent from the gate below): release.yml copies them fail-soft, so a
-    # flake in either must not block the runtime nightly — but the copy step
-    # has to run after they finish or the crane probe would race the builds.
+    # The optional-image builds (operator, planner, frontend, snapshot agent,
+    # EFA variants) are ORDERING-ONLY needs (deliberately absent from the
+    # gate below): release.yml copies them fail-soft, so a flake in any of
+    # them must not block the runtime nightly — but the copy step has to run
+    # after they finish or the crane probe would race the builds.
     if: ${{ !cancelled()
         && needs.compute-release-mode.outputs.release == 'true'
         && needs.vllm-build.result == 'success'
@@ -785,6 +939,11 @@ jobs:
       # existing -nightly ECR tags, matching the runtimes.)
       operator_build_result: ${{ needs.operator-build.result }}
       planner_build_result: ${{ needs.planner-build.result }}
+      frontend_build_result: ${{ needs.frontend-build.result }}
+      snapshot_build_result: ${{ needs.snapshot-build.result }}
+      vllm_efa_build_result: ${{ needs.vllm-efa-build.result }}
+      sglang_efa_build_result: ${{ needs.sglang-efa-build.result }}
+      trtllm_efa_build_result: ${{ needs.trtllm-efa-build.result }}
     secrets: inherit
 
   # ============================================================================
@@ -998,7 +1157,7 @@ jobs:
     name: Clean K8s builder if exists
     runs-on: prod-default-small-v2
     if: always()
-    needs: [vllm-build, sglang-build, trtllm-build, dynamo-pipeline, operator-build, planner-build, create-fresh-builder]
+    needs: [vllm-build, sglang-build, trtllm-build, dynamo-pipeline, operator-build, planner-build, frontend-build, snapshot-build, vllm-efa-build, sglang-efa-build, trtllm-efa-build, create-fresh-builder]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,26 @@ on:
         required: false
         type: string
         default: ''
+      frontend_build_result:
+        required: false
+        type: string
+        default: ''
+      snapshot_build_result:
+        required: false
+        type: string
+        default: ''
+      vllm_efa_build_result:
+        required: false
+        type: string
+        default: ''
+      sglang_efa_build_result:
+        required: false
+        type: string
+        default: ''
+      trtllm_efa_build_result:
+        required: false
+        type: string
+        default: ''
 
 # Note: workflow_dispatch can only be triggered from release/* branches (or main when nightly=true)
 # This is enforced in the prepare-release job via branch validation. workflow_call paths
@@ -237,6 +257,11 @@ jobs:
       NIGHTLY: ${{ needs.prepare-release.outputs.nightly }}
       OPERATOR_BUILD_RESULT: ${{ inputs.operator_build_result }}
       PLANNER_BUILD_RESULT: ${{ inputs.planner_build_result }}
+      FRONTEND_BUILD_RESULT: ${{ inputs.frontend_build_result }}
+      SNAPSHOT_BUILD_RESULT: ${{ inputs.snapshot_build_result }}
+      VLLM_EFA_BUILD_RESULT: ${{ inputs.vllm_efa_build_result }}
+      SGLANG_EFA_BUILD_RESULT: ${{ inputs.sglang_efa_build_result }}
+      TRTLLM_EFA_BUILD_RESULT: ${{ inputs.trtllm_efa_build_result }}
       REGISTRY_IMAGE: ai-dynamo/dynamo
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
     steps:
@@ -420,68 +445,101 @@ jobs:
             SNAPSHOT_TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/snapshot-agent:${NGC_VERSION_TAG}"
             copy_image "${SNAPSHOT_SOURCE}" "${SNAPSHOT_TARGET}" "snapshot-agent:${NGC_VERSION_TAG}"
           else
-            # Operator + planner (nightly): multi-arch images built by THIS
-            # nightly run (operator-build / planner-build, -nightly ECR tags).
-            # Both jobs are ordering-only needs of the release — deliberately
-            # outside its success gate — so a build flake must warn-skip here,
-            # not fail (a bare copy_image failure under set -e would abort the
-            # step and skip the GitLab trigger for the whole nightly).
-            # The PRIMARY gate is the caller-forwarded build result: when
-            # nightly-ci reports a non-success result, skip — SHA-keyed tags
-            # alone can't tell tonight's build from yesterday's when the
-            # resolved SHA is unchanged (quiet-repo day), and a failed build
-            # must never republish a previous run's image. An EMPTY result
-            # means a direct workflow_dispatch (no builds in this run): the
-            # probe alone decides, matching the runtimes — a manual nightly
-            # re-stage copies whatever nightly-built tags exist for the SHA.
-            # A copy that fails with the source PRESENT points at the NGC
-            # target (write access / repo config).
-            echo ""
-            echo "=== Operator Image (nightly) ==="
+            # Optional nightly images — operator, planner, frontend, snapshot
+            # agent and the three runtime EFA variants — are built by THIS
+            # nightly run (ordering-only needs of the release, deliberately
+            # outside its success gate) and staged fail-soft: a build flake
+            # must warn-skip here, not fail (a bare copy_image failure under
+            # set -e would abort the step and skip the GitLab trigger for the
+            # whole nightly).
+            #
+            # stage_optional gates each image in three layers:
+            #   1. Caller-forwarded build result — non-success skips: SHA-keyed
+            #      tags alone can't tell tonight's build from yesterday's when
+            #      the resolved SHA is unchanged (quiet-repo day), and a failed
+            #      build must never republish a previous run's image. An EMPTY
+            #      result means a direct workflow_dispatch (no builds in this
+            #      run): the probe alone decides, matching the runtimes — a
+            #      manual re-stage copies whatever nightly-built tags exist.
+            #   2. crane-manifest probe — push-integrity check on the ECR tag.
+            #   3. copy_image — a failure with the source PRESENT points at
+            #      the NGC target (write access / repo config).
+            # On success it also repushes the image's mutable floating tag on
+            # the stable repo (parity with the runtimes' :nightly aliases);
+            # a floating-tag miss records in FAILED_COPIES but is non-fatal
+            # under set -e (copy_image runs in an if-condition context).
+            stage_optional() {
+              local LABEL="$1" RESULT="$2" SRC="$3" DST="$4" FLOAT_DST="$5" FLOAT_LABEL="$6"
+              echo ""
+              echo "=== ${LABEL} (nightly) ==="
+              if [ -n "${RESULT}" ] && [ "${RESULT}" != "success" ]; then
+                echo "::warning::Skipped ${LABEL} — build result in this run: '${RESULT}'"
+                FAILED_COPIES+=("${LABEL} (build ${RESULT})")
+                return 1
+              elif ! crane manifest "${SRC}" > /dev/null 2>&1; then
+                echo "::warning::Skipped ${LABEL} — ${SRC} not found (no nightly build exists for this SHA)"
+                FAILED_COPIES+=("${LABEL} (source missing)")
+                return 1
+              elif copy_image "${SRC}" "${DST}" "${LABEL}"; then
+                if [ -n "${FLOAT_DST}" ]; then
+                  if ! copy_image "${SRC}" "${FLOAT_DST}" "${FLOAT_LABEL}"; then
+                    echo "::warning::Floating tag push failed for ${FLOAT_LABEL} (dated tag staged fine)"
+                  fi
+                fi
+                return 0
+              else
+                echo "::warning::Copy failed for ${LABEL} — source exists; check NGC write access"
+                return 1
+              fi
+            }
+            ECR_BASE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}"
+            NGC_BASE="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo"
+
             OPERATOR_STAGED=false
-            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-operator${NIGHTLY_TAG_SUFFIX}"
-            TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/kubernetes-operator-nightly:${NGC_VERSION_TAG}"
-            if [ -n "${OPERATOR_BUILD_RESULT}" ] && [ "${OPERATOR_BUILD_RESULT}" != "success" ]; then
-              echo "::warning::Skipped kubernetes-operator-nightly:${NGC_VERSION_TAG} — operator-build result in this run: '${OPERATOR_BUILD_RESULT}'"
-              FAILED_COPIES+=("kubernetes-operator-nightly:${NGC_VERSION_TAG} (build ${OPERATOR_BUILD_RESULT})")
-            elif ! crane manifest "${SOURCE}" > /dev/null 2>&1; then
-              echo "::warning::Skipped kubernetes-operator-nightly:${NGC_VERSION_TAG} — ${SOURCE} not found (no nightly operator build exists for this SHA)"
-              FAILED_COPIES+=("kubernetes-operator-nightly:${NGC_VERSION_TAG} (source missing)")
-            elif copy_image "${SOURCE}" "${TARGET}" "kubernetes-operator-nightly:${NGC_VERSION_TAG}"; then
-              OPERATOR_STAGED=true
-              # Mutable `:nightly` floating tag on the stable repo, matching
-              # the runtimes (no cuda alias — operator has no cuda variants).
-              # `|| true`: a floating-tag miss records in FAILED_COPIES via
-              # copy_image but must not abort the step under set -e.
-              MUTABLE_TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/kubernetes-operator:nightly"
-              copy_image "${SOURCE}" "${MUTABLE_TARGET}" "kubernetes-operator:nightly" || true
-            else
-              echo "::warning::Copy failed for kubernetes-operator-nightly:${NGC_VERSION_TAG} — source exists; check NGC write access to kubernetes-operator-nightly"
-            fi
+            if stage_optional "kubernetes-operator-nightly:${NGC_VERSION_TAG}" "${OPERATOR_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-operator${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/kubernetes-operator-nightly:${NGC_VERSION_TAG}" \
+                "${NGC_BASE}/kubernetes-operator:nightly" "kubernetes-operator:nightly"; then OPERATOR_STAGED=true; fi
 
-            echo ""
-            echo "=== Planner Image (nightly) ==="
             PLANNER_STAGED=false
-            SOURCE="${ECR_HOSTNAME}/${REGISTRY_IMAGE}:${COMMIT_SHA}-dynamo-planner${NIGHTLY_TAG_SUFFIX}"
-            TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/dynamo-planner-nightly:${NGC_VERSION_TAG}"
-            if [ -n "${PLANNER_BUILD_RESULT}" ] && [ "${PLANNER_BUILD_RESULT}" != "success" ]; then
-              echo "::warning::Skipped dynamo-planner-nightly:${NGC_VERSION_TAG} — planner-build result in this run: '${PLANNER_BUILD_RESULT}'"
-              FAILED_COPIES+=("dynamo-planner-nightly:${NGC_VERSION_TAG} (build ${PLANNER_BUILD_RESULT})")
-            elif ! crane manifest "${SOURCE}" > /dev/null 2>&1; then
-              echo "::warning::Skipped dynamo-planner-nightly:${NGC_VERSION_TAG} — ${SOURCE} not found (no nightly planner build exists for this SHA)"
-              FAILED_COPIES+=("dynamo-planner-nightly:${NGC_VERSION_TAG} (source missing)")
-            elif copy_image "${SOURCE}" "${TARGET}" "dynamo-planner-nightly:${NGC_VERSION_TAG}"; then
-              PLANNER_STAGED=true
-              # Mutable `:nightly` floating tag on the stable repo, matching
-              # the runtimes (no cuda alias — planner has no cuda variants).
-              MUTABLE_TARGET="${NGC_REGISTRY}/${NGC_ORG}/ai-dynamo/dynamo-planner:nightly"
-              copy_image "${SOURCE}" "${MUTABLE_TARGET}" "dynamo-planner:nightly" || true
-            else
-              echo "::warning::Copy failed for dynamo-planner-nightly:${NGC_VERSION_TAG} — source exists; check NGC write access to dynamo-planner-nightly"
-            fi
+            if stage_optional "dynamo-planner-nightly:${NGC_VERSION_TAG}" "${PLANNER_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-dynamo-planner${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/dynamo-planner-nightly:${NGC_VERSION_TAG}" \
+                "${NGC_BASE}/dynamo-planner:nightly" "dynamo-planner:nightly"; then PLANNER_STAGED=true; fi
 
-            echo ""
-            echo "=== Skipping EFA / frontend / snapshot (not staged by nightly) ==="
+            FRONTEND_STAGED=false
+            if stage_optional "dynamo-frontend-nightly:${NGC_VERSION_TAG}" "${FRONTEND_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-dynamo-frontend${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/dynamo-frontend-nightly:${NGC_VERSION_TAG}" \
+                "${NGC_BASE}/dynamo-frontend:nightly" "dynamo-frontend:nightly"; then FRONTEND_STAGED=true; fi
+
+            # Snapshot agent is amd64-only by design (cuda-checkpoint has no
+            # arm64 binary); crane copies whatever manifest exists.
+            SNAPSHOT_STAGED=false
+            if stage_optional "snapshot-agent-nightly:${NGC_VERSION_TAG}" "${SNAPSHOT_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-snapshot-agent${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/snapshot-agent-nightly:${NGC_VERSION_TAG}" \
+                "${NGC_BASE}/snapshot-agent:nightly" "snapshot-agent:nightly"; then SNAPSHOT_STAGED=true; fi
+
+            # EFA variants live in the runtime -nightly repos under a -efa tag
+            # suffix, mirroring the RC convention (vllm-runtime:<ver>-efa).
+            VLLM_EFA_STAGED=false
+            if stage_optional "vllm-runtime-nightly:${NGC_VERSION_TAG}-efa" "${VLLM_EFA_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-vllm-runtime-efa${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/vllm-runtime-nightly:${NGC_VERSION_TAG}-efa" \
+                "${NGC_BASE}/vllm-runtime:nightly-efa" "vllm-runtime:nightly-efa"; then VLLM_EFA_STAGED=true; fi
+
+            SGLANG_EFA_STAGED=false
+            if stage_optional "sglang-runtime-nightly:${NGC_VERSION_TAG}-efa" "${SGLANG_EFA_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-sglang-runtime-efa${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/sglang-runtime-nightly:${NGC_VERSION_TAG}-efa" \
+                "${NGC_BASE}/sglang-runtime:nightly-efa" "sglang-runtime:nightly-efa"; then SGLANG_EFA_STAGED=true; fi
+
+            TRTLLM_EFA_STAGED=false
+            if stage_optional "tensorrtllm-runtime-nightly:${NGC_VERSION_TAG}-efa" "${TRTLLM_EFA_BUILD_RESULT}" \
+                "${ECR_BASE}:${COMMIT_SHA}-trtllm-runtime-efa${NIGHTLY_TAG_SUFFIX}" \
+                "${NGC_BASE}/tensorrtllm-runtime-nightly:${NGC_VERSION_TAG}-efa" \
+                "${NGC_BASE}/tensorrtllm-runtime:nightly-efa" "tensorrtllm-runtime:nightly-efa"; then TRTLLM_EFA_STAGED=true; fi
           fi
 
           # ---- Summary ----
@@ -489,6 +547,11 @@ jobs:
           echo "failed_count=${#FAILED_COPIES[@]}" >> $GITHUB_OUTPUT
           echo "operator_staged=${OPERATOR_STAGED:-}" >> $GITHUB_OUTPUT
           echo "planner_staged=${PLANNER_STAGED:-}" >> $GITHUB_OUTPUT
+          echo "frontend_staged=${FRONTEND_STAGED:-}" >> $GITHUB_OUTPUT
+          echo "snapshot_staged=${SNAPSHOT_STAGED:-}" >> $GITHUB_OUTPUT
+          echo "vllm_efa_staged=${VLLM_EFA_STAGED:-}" >> $GITHUB_OUTPUT
+          echo "sglang_efa_staged=${SGLANG_EFA_STAGED:-}" >> $GITHUB_OUTPUT
+          echo "trtllm_efa_staged=${TRTLLM_EFA_STAGED:-}" >> $GITHUB_OUTPUT
 
           printf '%s\n' "${SUCCESSFUL_COPIES[@]}" > /tmp/successful_copies.txt
           printf '%s\n' "${FAILED_COPIES[@]}" > /tmp/failed_copies.txt 2>/dev/null || true
@@ -556,6 +619,11 @@ jobs:
           FAILED_COUNT: ${{ steps.copy_images.outputs.failed_count }}
           OPERATOR_STAGED: ${{ steps.copy_images.outputs.operator_staged }}
           PLANNER_STAGED: ${{ steps.copy_images.outputs.planner_staged }}
+          FRONTEND_STAGED: ${{ steps.copy_images.outputs.frontend_staged }}
+          SNAPSHOT_STAGED: ${{ steps.copy_images.outputs.snapshot_staged }}
+          VLLM_EFA_STAGED: ${{ steps.copy_images.outputs.vllm_efa_staged }}
+          SGLANG_EFA_STAGED: ${{ steps.copy_images.outputs.sglang_efa_staged }}
+          TRTLLM_EFA_STAGED: ${{ steps.copy_images.outputs.trtllm_efa_staged }}
         run: |
           if [[ "${NIGHTLY}" == "true" ]]; then
             echo "## Nightly Build Summary" >> $GITHUB_STEP_SUMMARY
@@ -588,19 +656,29 @@ jobs:
           echo "- \`sglang-runtime${NGC_NAME_SUFFIX}:${NGC_VERSION_TAG}\` / \`sglang-runtime${NGC_NAME_SUFFIX}:${NGC_VERSION_TAG}-cuda13\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`tensorrtllm-runtime${NGC_NAME_SUFFIX}:${NGC_VERSION_TAG}\` / \`tensorrtllm-runtime${NGC_NAME_SUFFIX}:${NGC_VERSION_TAG}-cuda13\`" >> $GITHUB_STEP_SUMMARY
           if [[ "${NIGHTLY}" == "true" ]]; then
-            OP_NOTE=""; [[ "${OPERATOR_STAGED}" == "true" ]] || OP_NOTE=" — **NOT staged this run** (see copy-step warnings)"
-            PL_NOTE=""; [[ "${PLANNER_STAGED}" == "true" ]] || PL_NOTE=" — **NOT staged this run** (see copy-step warnings)"
+            _note() { [[ "$1" == "true" ]] && echo "" || echo " — **NOT staged this run** (see copy-step warnings)"; }
+            OP_NOTE=$(_note "${OPERATOR_STAGED}");   PL_NOTE=$(_note "${PLANNER_STAGED}")
+            FE_NOTE=$(_note "${FRONTEND_STAGED}");   SA_NOTE=$(_note "${SNAPSHOT_STAGED}")
+            VE_NOTE=$(_note "${VLLM_EFA_STAGED}");   SE_NOTE=$(_note "${SGLANG_EFA_STAGED}")
+            TE_NOTE=$(_note "${TRTLLM_EFA_STAGED}")
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "Operator / planner images (built by this nightly run):" >> $GITHUB_STEP_SUMMARY
+            echo "Optional images (built by this nightly run, staged fail-soft):" >> $GITHUB_STEP_SUMMARY
             echo "- \`kubernetes-operator-nightly:${NGC_VERSION_TAG}\`${OP_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`dynamo-planner-nightly:${NGC_VERSION_TAG}\`${PL_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`dynamo-frontend-nightly:${NGC_VERSION_TAG}\`${FE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`snapshot-agent-nightly:${NGC_VERSION_TAG}\`${SA_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`vllm-runtime-nightly:${NGC_VERSION_TAG}-efa\`${VE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`sglang-runtime-nightly:${NGC_VERSION_TAG}-efa\`${SE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`tensorrtllm-runtime-nightly:${NGC_VERSION_TAG}-efa\`${TE_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Mutable floating tags (repushed every nightly):" >> $GITHUB_STEP_SUMMARY
-            echo "- \`vllm-runtime:nightly\` / \`vllm-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
-            echo "- \`sglang-runtime:nightly\` / \`sglang-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
-            echo "- \`tensorrtllm-runtime:nightly\` / \`tensorrtllm-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`vllm-runtime:nightly\` / \`vllm-runtime:nightly-cuda13\` / \`vllm-runtime:nightly-efa\`${VE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`sglang-runtime:nightly\` / \`sglang-runtime:nightly-cuda13\` / \`sglang-runtime:nightly-efa\`${SE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`tensorrtllm-runtime:nightly\` / \`tensorrtllm-runtime:nightly-cuda13\` / \`tensorrtllm-runtime:nightly-efa\`${TE_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`kubernetes-operator:nightly\`${OP_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`dynamo-planner:nightly\`${PL_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`dynamo-frontend:nightly\`${FE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`snapshot-agent:nightly\`${SA_NOTE}" >> $GITHUB_STEP_SUMMARY
           fi
           if [[ "${NIGHTLY}" != "true" ]]; then
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -852,7 +930,7 @@ jobs:
           ART_EMOJI=$(emoji_for "${ART_RESULT}")
 
           if [ "${NGC_RESULT}" = "success" ] && [ "${ART_RESULT}" = "success" ]; then
-            # Copy failures can be non-fatal (operator/planner warn-skip) —
+            # Copy failures can be non-fatal (optional-image warn-skips) —
             # a green job with skipped copies must not read as "complete".
             if [ -n "${NGC_FAILED_COPIES:-}" ] && [ "${NGC_FAILED_COPIES}" != "0" ]; then
               HEADER=":warning: Staging complete with ${NGC_FAILED_COPIES} skipped image copy(ies)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -672,9 +672,15 @@ jobs:
             echo "- \`tensorrtllm-runtime-nightly:${NGC_VERSION_TAG}-efa\`${TE_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "Mutable floating tags (repushed every nightly):" >> $GITHUB_STEP_SUMMARY
-            echo "- \`vllm-runtime:nightly\` / \`vllm-runtime:nightly-cuda13\` / \`vllm-runtime:nightly-efa\`${VE_NOTE}" >> $GITHUB_STEP_SUMMARY
-            echo "- \`sglang-runtime:nightly\` / \`sglang-runtime:nightly-cuda13\` / \`sglang-runtime:nightly-efa\`${SE_NOTE}" >> $GITHUB_STEP_SUMMARY
-            echo "- \`tensorrtllm-runtime:nightly\` / \`tensorrtllm-runtime:nightly-cuda13\` / \`tensorrtllm-runtime:nightly-efa\`${TE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            # Core runtime aliases stage whenever the (release-gating) runtime
+            # build succeeded — never annotate them with the EFA build's fate;
+            # the EFA alias is staged fail-soft and carries its own note.
+            echo "- \`vllm-runtime:nightly\` / \`vllm-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`sglang-runtime:nightly\` / \`sglang-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`tensorrtllm-runtime:nightly\` / \`tensorrtllm-runtime:nightly-cuda13\`" >> $GITHUB_STEP_SUMMARY
+            echo "- \`vllm-runtime:nightly-efa\`${VE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`sglang-runtime:nightly-efa\`${SE_NOTE}" >> $GITHUB_STEP_SUMMARY
+            echo "- \`tensorrtllm-runtime:nightly-efa\`${TE_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`kubernetes-operator:nightly\`${OP_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`dynamo-planner:nightly\`${PL_NOTE}" >> $GITHUB_STEP_SUMMARY
             echo "- \`dynamo-frontend:nightly\`${FE_NOTE}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Overview:

Publish all containers for dynamo nightly 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional artifact tagging for compliance and source archives, enabling clearer artifact naming.
  * Nightly image builds now share consistent development version suffixes across runtime and optional images.
  * Added support for optional operator, planner, frontend, snapshot, and EFA image releases.

* **Bug Fixes**
  * Nightly releases now continue when optional image builds or copies fail.
  * Release summaries and notifications clearly identify skipped, failed, and successfully staged images.
  * Cleanup now waits for all relevant nightly builds to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->