### PR TITLE
refactor(aic): remove pre-0.11 compatibility paths

### DIFF
--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
     "aiconfigurator==0.11.0.dev20260728",
+    "aiconfigurator-core==0.11.0.dev20260728",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",

--- a/aisimulate/src/aisimulate/spica/evaluator.py
+++ b/aisimulate/src/aisimulate/spica/evaluator.py
@@ -34,7 +34,6 @@ replay entrypoints.
 
 from __future__ import annotations
 
-import inspect
 import json
 
 from .config import OptimizationGoal, Workload
@@ -63,40 +62,6 @@ def _unwrap(report) -> dict[str, float]:
     if hasattr(report, "total_ticks"):
         trace_report["planner_total_ticks"] = float(report.total_ticks)
     return trace_report
-
-
-def _replay_accepts_kw(func, name: str) -> bool:
-    params = inspect.signature(func).parameters
-    return name in params or any(
-        param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()
-    )
-
-
-def _replay_kwargs(func, kwargs: dict) -> dict:
-    params = inspect.signature(func).parameters
-    if any(param.kind is inspect.Parameter.VAR_KEYWORD for param in params.values()):
-        return kwargs
-    return {name: value for name, value in kwargs.items() if name in params}
-
-
-def _check_planner_supported(func, planner_config: dict | None) -> None:
-    if planner_config is not None and not _replay_accepts_kw(func, "planner_config"):
-        raise RuntimeError(
-            "installed Dynamo replay API does not accept planner_config; use static planner_scaling_policy='disabled'"
-        )
-
-
-def _run_trace_replay_compat(func, trace_path: str, kwargs: dict):
-    _check_planner_supported(func, kwargs.get("planner_config"))
-    if "trace_file" in inspect.signature(func).parameters:
-        return func(trace_path, **_replay_kwargs(func, kwargs))
-    kwargs = dict(kwargs, trace_files=trace_path)
-    return func(**_replay_kwargs(func, kwargs))
-
-
-def _run_synthetic_trace_replay_compat(func, kwargs: dict):
-    _check_planner_supported(func, kwargs.get("planner_config"))
-    return func(**_replay_kwargs(func, kwargs))
 
 
 def _require_goodput_metric(
@@ -208,24 +173,22 @@ class ReplayEvaluator:
         )
         if plan.deployment_mode == "agg":
             extra = MockEngineArgs.from_json(json.dumps(plan.agg_engine_args))
-            report = _run_trace_replay_compat(
-                run_trace_replay,
-                wl.trace_path,
-                dict(extra_engine_args=extra, num_workers=plan.num_workers, **common),
+            report = run_trace_replay(
+                trace_files=wl.trace_path,
+                extra_engine_args=extra,
+                num_workers=plan.num_workers,
+                **common,
             )
         else:
             prefill = MockEngineArgs.from_json(json.dumps(plan.prefill_engine_args))
             decode = MockEngineArgs.from_json(json.dumps(plan.decode_engine_args))
-            report = _run_trace_replay_compat(
-                run_trace_replay,
-                wl.trace_path,
-                dict(
-                    prefill_engine_args=prefill,
-                    decode_engine_args=decode,
-                    num_prefill_workers=plan.num_prefill_workers,
-                    num_decode_workers=plan.num_decode_workers,
-                    **common,
-                ),
+            report = run_trace_replay(
+                trace_files=wl.trace_path,
+                prefill_engine_args=prefill,
+                decode_engine_args=decode,
+                num_prefill_workers=plan.num_prefill_workers,
+                num_decode_workers=plan.num_decode_workers,
+                **common,
             )
         return _unwrap(report)
 
@@ -251,21 +214,19 @@ class ReplayEvaluator:
         )
         if plan.deployment_mode == "agg":
             extra = MockEngineArgs.from_json(json.dumps(plan.agg_engine_args))
-            report = _run_synthetic_trace_replay_compat(
-                run_synthetic_trace_replay,
-                dict(extra_engine_args=extra, num_workers=plan.num_workers, **common),
+            report = run_synthetic_trace_replay(
+                extra_engine_args=extra,
+                num_workers=plan.num_workers,
+                **common,
             )
         else:
             prefill = MockEngineArgs.from_json(json.dumps(plan.prefill_engine_args))
             decode = MockEngineArgs.from_json(json.dumps(plan.decode_engine_args))
-            report = _run_synthetic_trace_replay_compat(
-                run_synthetic_trace_replay,
-                dict(
-                    prefill_engine_args=prefill,
-                    decode_engine_args=decode,
-                    num_prefill_workers=plan.num_prefill_workers,
-                    num_decode_workers=plan.num_decode_workers,
-                    **common,
-                ),
+            report = run_synthetic_trace_replay(
+                prefill_engine_args=prefill,
+                decode_engine_args=decode,
+                num_prefill_workers=plan.num_prefill_workers,
+                num_decode_workers=plan.num_decode_workers,
+                **common,
             )
         return _unwrap(report)

--- a/aisimulate/src/aisimulate/spica/kv_estimate.py
+++ b/aisimulate/src/aisimulate/spica/kv_estimate.py
@@ -24,13 +24,10 @@ because it mis-models MoE expert sharding.
 
 from __future__ import annotations
 
-import importlib
-from collections.abc import Callable, Iterable
-from typing import Any
+from collections.abc import Iterable
 
-from aiconfigurator.sdk.perf_database import get_latest_database_version
-
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
+from aiconfigurator_core.sdk.memory import estimate_kv_cache
+from aiconfigurator_core.sdk.perf_database import get_latest_database_version
 
 from .parallel_enum import ParallelShape
 
@@ -42,27 +39,6 @@ DEFAULT_MEMORY_FRACTION = 0.9
 
 class NoPerfDatabase(RuntimeError):
     """No perf database for this ``(hardware_sku, backend)`` — cannot estimate KV cache."""
-
-
-def _load_memory_estimator() -> Callable[..., dict[str, Any]]:
-    """Load AIC's optional unified KV-cache estimator on first use.
-
-    AIC 0.9, which Dynamo currently supports, does not provide
-    ``aiconfigurator.sdk.memory``. Keep ordinary Spica imports working with that
-    release, while preserving transitive import failures from an otherwise present
-    estimator module.
-    """
-    try:
-        memory = importlib.import_module("aiconfigurator.sdk.memory")
-    except ModuleNotFoundError as exc:
-        if exc.name == "aiconfigurator.sdk.memory":
-            raise AicMemoryEstimatorUnavailableError(
-                "aiconfigurator.sdk.memory is required for experimental Spica "
-                "KV-cache estimation; install an AIConfigurator release with the "
-                "compatible estimator (AIC 0.10 or newer)"
-            ) from exc
-        raise
-    return memory.estimate_kv_cache
 
 
 def memory_fraction_kind(backend: str) -> str:
@@ -99,7 +75,7 @@ def estimate_kv_tokens(
     Genuine estimation errors (bad inputs, unsupported model) propagate.
     """
     try:
-        est = _load_memory_estimator()(
+        est = estimate_kv_cache(
             model_name,
             hardware_sku,
             backend,

--- a/aisimulate/src/aisimulate/spica/model_hw.py
+++ b/aisimulate/src/aisimulate/spica/model_hw.py
@@ -8,7 +8,7 @@ It directly reuses AIConfigurator:
 
 - ``check_is_moe``                  -> is_moe
 - ``_estimate_model_weight_bytes``  -> model weight size (-> wideEP heuristic)
-- ``_get_system_config``            -> the SKU's VRAM / GPUs-per-node
+- ``load_system_spec``              -> the SKU's VRAM / GPUs-per-node
 
 Validity is **KV-cache based**: :func:`parallel_configs_for` enumerates shapes
 from 1 GPU/worker and keeps a shape iff its estimated KV capacity exceeds the

--- a/aisimulate/src/aisimulate/spica/model_hw.py
+++ b/aisimulate/src/aisimulate/spica/model_hw.py
@@ -19,20 +19,12 @@ replaces the old BF16 min-GPU weight floor entirely.
 
 from __future__ import annotations
 
-import os
-import warnings
 from dataclasses import dataclass
-from typing import Any
 
-from aiconfigurator.generator.naive import (
-    _estimate_model_weight_bytes,
-    _get_system_config,
-)
-from aiconfigurator.sdk import perf_database
-from aiconfigurator.sdk.models import check_is_moe
-from aiconfigurator.sdk.utils import get_model_config_from_model_path
-
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
+from aiconfigurator.generator.naive import _estimate_model_weight_bytes
+from aiconfigurator_core.sdk import perf_database
+from aiconfigurator_core.sdk.models import check_is_moe
+from aiconfigurator_core.sdk.utils import get_model_config_from_model_path
 
 from .kv_estimate import (
     DEFAULT_MAX_BATCH_SIZE,
@@ -54,39 +46,6 @@ _GQA_MOE_ARCHITECTURES = frozenset({"Qwen3MoeForCausalLM"})
 
 class NoViableParallelConfig(ValueError):
     """No parallel config can hold the model+sequence within the GPU budget."""
-
-
-def _aic_model_system_facts(
-    model_name: str, hardware_sku: str
-) -> tuple[dict[str, Any], int]:
-    """Isolate the AIConfigurator 0.9 private-helper compatibility boundary.
-
-    AIConfigurator 0.9 has no public equivalents for its normalized system config
-    and weight estimator. Keeping both calls here makes that dependency explicit and
-    gives the pinned integration contract one focused test boundary.
-    """
-    return _get_system_config(hardware_sku), _estimate_model_weight_bytes(model_name)
-
-
-def _validate_hardware_sku(hardware_sku: str) -> None:
-    """Raise if ``hardware_sku`` has no system YAML on AIC's systems path.
-
-    ``_get_system_config`` silently falls back to default VRAM / GPUs-per-node
-    when the SKU file is missing, so an unknown/typo SKU would otherwise resolve
-    to a wrong-but-plausible spec. Fail loudly instead.
-    """
-    available = []
-    for systems_root in perf_database.get_systems_paths():
-        if os.path.isfile(os.path.join(systems_root, f"{hardware_sku}.yaml")):
-            return
-        if os.path.isdir(systems_root):
-            available.extend(
-                sorted(f[:-5] for f in os.listdir(systems_root) if f.endswith(".yaml"))
-            )
-    raise ValueError(
-        f"unknown hardware_sku {hardware_sku!r}: no system config found on the AIConfigurator "
-        f"systems path. Available SKUs: {', '.join(sorted(set(available)))}"
-    )
 
 
 @dataclass(frozen=True)
@@ -117,10 +76,15 @@ def resolve_model_hardware(
     mla = is_moe and not allow_pure_tp
     max_context = model_config.get("context")
 
-    _validate_hardware_sku(hardware_sku)
-    sys_cfg, weight_bytes = _aic_model_system_facts(model_name, hardware_sku)
-    vram_per_gpu = sys_cfg["vram_per_gpu"]
-    gpus_per_node = sys_cfg["gpus_per_node"]
+    system_spec = perf_database.load_system_spec(hardware_sku)
+    if not system_spec:
+        raise ValueError(
+            f"unknown hardware_sku {hardware_sku!r}: no system config found on "
+            "AIConfigurator Core's systems path"
+        )
+    vram_per_gpu = int(system_spec["gpu"]["mem_capacity"])
+    gpus_per_node = int(system_spec["node"]["num_gpus_per_node"])
+    weight_bytes = _estimate_model_weight_bytes(model_name)
 
     # Large MoE (a node can't hold ~2x the weights) auto-enables multi-node wideEP.
     enable_wideep = is_moe and gpus_per_node * vram_per_gpu < 2 * weight_bytes
@@ -203,28 +167,16 @@ def parallel_configs_for(
         shapes = [c.shape for c in configs]
     else:
         shapes = [c.prefill.shape for c in configs] + [c.decode.shape for c in configs]
-    try:
-        feasible = feasible_shape_tokens(
-            shapes,
-            model_name=model_name,
-            hardware_sku=hardware_sku,
-            backend=backend,
-            max_seq_len=seq_len,
-            max_num_tokens=max_num_tokens,
-            max_batch_size=max_batch_size,
-            memory_fraction=memory_fraction,
-        )
-    except AicMemoryEstimatorUnavailableError as exc:
-        warnings.warn(
-            "[EXPERIMENTAL] Spica cannot apply KV-capacity filtering because "
-            f"the AIC memory estimator is unavailable: {exc}. Continuing with "
-            "the enumerated GPU-budget-compatible configurations. Trace and "
-            "fixed-concurrency workloads remain available; kv_load_ratio requires "
-            "a compatible estimator and will fail closed.",
-            UserWarning,
-            stacklevel=2,
-        )
-        return configs
+    feasible = feasible_shape_tokens(
+        shapes,
+        model_name=model_name,
+        hardware_sku=hardware_sku,
+        backend=backend,
+        max_seq_len=seq_len,
+        max_num_tokens=max_num_tokens,
+        max_batch_size=max_batch_size,
+        memory_fraction=memory_fraction,
+    )
     if deployment_mode == "agg":
         kept = [c for c in configs if c.shape in feasible]
     else:

--- a/aisimulate/src/aisimulate/spica/search.py
+++ b/aisimulate/src/aisimulate/spica/search.py
@@ -39,7 +39,7 @@ from tqdm import tqdm
 from .config import Candidate, OptimizationGoal, SmartSearchConfig
 from .deploy import build_deployment
 from .evaluator import ReplayEvaluator
-from .kv_estimate import _load_memory_estimator, resolve_backend_version
+from .kv_estimate import resolve_backend_version
 from .kv_load import InfeasibleKVCapacity, resolve_kv_load
 from .load_predictor_sweep import LoadPredictorResult, sweep_load_predictor
 from .planner import filter_scaling_policies, scaling_fields
@@ -232,13 +232,6 @@ def run_smart_search(
     candidate evaluations (live feasible/failed tally + best score) and prints a
     one-line summary at the end; set False for quiet/non-interactive runs.
     """
-    # AIConfigurator 0.9 does not provide the memory estimator needed to turn a
-    # candidate-relative KV ratio into concrete concurrency. Detect that unsupported
-    # mode before branch enumeration/Vizier work instead of returning an empty result
-    # after every candidate fails to build.
-    if config.workload.kv_load_ratio is not None:
-        _load_memory_estimator()
-
     goal = config.goal
     # Predictive throughput scaling only works under the planner's "sla" target
     # (a goodput sweep). For throughput/latency sweeps, drop the throughput-scaling

--- a/aisimulate/tests/spica/test_evaluator.py
+++ b/aisimulate/tests/spica/test_evaluator.py
@@ -1,8 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E402
-
 """ReplayEvaluator dispatch across 3 load shapes x {static, planner} (dynamo stubbed)."""
 
 import dataclasses
@@ -11,8 +9,6 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-
-pytest.importorskip("dynamo.mocker")
 
 import dynamo.mocker
 import dynamo.replay.api
@@ -115,72 +111,27 @@ def test_static_path_threads_goodput_sla(monkeypatch):
     )  # SLA threaded to the plain path
 
 
-def test_current_trace_api_filters_legacy_kwargs_and_fails_closed_without_goodput(
-    monkeypatch,
-):
-    # Current Dynamo replay wrappers do not accept planner_config, benchmark_granularity,
-    # or SLA kwargs on static replay. Aggregate means cannot reconstruct per-request
-    # goodput, so an incompatible wrapper must fail instead of fabricating a score.
+def test_goodput_goal_fails_closed_without_goodput_metric(monkeypatch):
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
-    rec = {}
-
-    def run_trace_replay(
-        trace_file,
-        *,
-        extra_engine_args=None,
-        num_workers=1,
-        replay_concurrency=None,
-        router_mode=None,
-    ):
-        rec.update(
-            trace_file=trace_file,
-            extra_engine_args=extra_engine_args,
-            num_workers=num_workers,
-            replay_concurrency=replay_concurrency,
-            router_mode=router_mode,
-        )
-        return {
+    monkeypatch.setattr(
+        dynamo.replay.api,
+        "run_trace_replay",
+        lambda **kwargs: {
             "output_throughput_tok_s": 77.0,
             "mean_ttft_ms": 10.0,
             "mean_tpot_ms": 2.0,
             "mean_e2e_latency_ms": 42.0,
-        }
-
-    monkeypatch.setattr(dynamo.replay.api, "run_trace_replay", run_trace_replay)
+        },
+    )
     goal = OptimizationGoal(
         target=OptimizationTarget.GOODPUT_PER_GPU,
         sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0),
     )
     with pytest.raises(RuntimeError, match="per-request SLA accounting"):
         ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=True))
-    assert rec["trace_file"] == TRACE
-    assert set(rec) == {
-        "trace_file",
-        "extra_engine_args",
-        "num_workers",
-        "replay_concurrency",
-        "router_mode",
-    }
 
 
-def test_current_trace_api_rejects_planner_config(monkeypatch):
-    monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
-
-    def run_trace_replay(trace_file, *, extra_engine_args=None, num_workers=1):
-        return {"output_throughput_tok_s": 1.0}
-
-    monkeypatch.setattr(dynamo.replay.api, "run_trace_replay", run_trace_replay)
-    goal = OptimizationGoal(
-        target=OptimizationTarget.GOODPUT_PER_GPU,
-        sla=SLATarget(ttft_ms=2000.0, itl_ms=30.0),
-    )
-    with pytest.raises(RuntimeError, match="does not accept planner_config"):
-        ReplayEvaluator(_wl(), goal).evaluate(_agg_plan(static=False))
-
-
-def test_scaling_agg_threads_planner_config_when_supported(monkeypatch):
-    # Older Dynamo replay wrappers accept planner_config directly; keep threading it
-    # when the installed API advertises that kwarg.
+def test_scaling_agg_threads_planner_config(monkeypatch):
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
@@ -263,9 +214,7 @@ def test_static_trace_threads_replay_concurrency(monkeypatch):
     assert rec["replay_concurrency"] == 32
 
 
-def test_scaling_trace_threads_replay_concurrency_when_supported(monkeypatch):
-    # closed-loop concurrency over a trace + planner works when the replay wrapper
-    # accepts planner_config.
+def test_scaling_trace_threads_replay_concurrency(monkeypatch):
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
@@ -340,8 +289,7 @@ def test_concurrency_override_drives_cap_and_request_count(monkeypatch):
     assert rec["planner_config"] is None
 
 
-def test_synthetic_planner_threads_planner_config_when_supported(monkeypatch):
-    # synthetic + planner -> run_synthetic_trace_replay with planner_config when supported.
+def test_synthetic_planner_threads_planner_config(monkeypatch):
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
     rec = {}
     monkeypatch.setattr(
@@ -383,7 +331,7 @@ def test_static_trace_disagg_uses_plain_path(monkeypatch):
     assert "num_workers" not in rec and "extra_engine_args" not in rec
 
 
-def test_scaling_trace_disagg_threads_planner_config_when_supported(monkeypatch):
+def test_scaling_trace_disagg_threads_planner_config(monkeypatch):
     # disagg + trace + planner -> run_trace_replay with per-role workers and planner_config
     # when supported.
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)
@@ -440,7 +388,7 @@ def test_synthetic_static_disagg_uses_run_synthetic_trace_replay(monkeypatch):
     assert "num_workers" not in rec and "extra_engine_args" not in rec
 
 
-def test_synthetic_planner_disagg_threads_planner_config_when_supported(monkeypatch):
+def test_synthetic_planner_disagg_threads_planner_config(monkeypatch):
     # disagg + synthetic + planner -> run_synthetic_trace_replay with per-role workers and
     # planner_config when supported.
     monkeypatch.setattr(dynamo.mocker, "MockEngineArgs", _FakeArgs, raising=False)

--- a/aisimulate/tests/spica/test_kv_estimate.py
+++ b/aisimulate/tests/spica/test_kv_estimate.py
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""KV-cache feasibility wrapper around AIC's optional memory estimator."""
-
-import types
+"""KV-cache feasibility wrapper around AIC Core's memory estimator."""
 
 import pytest
 
@@ -16,7 +14,6 @@ from aisimulate.spica.kv_estimate import (
     resolve_backend_version,
 )
 from aisimulate.spica.parallel_enum import ParallelShape
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
 
 _COMMON = dict(model_name="m", hardware_sku="hw", backend="trtllm", backend_version="v")
 
@@ -30,8 +27,8 @@ def test_memory_fraction_kind():
 def test_estimate_kv_tokens_returns_capacity(monkeypatch):
     monkeypatch.setattr(
         kv_estimate_mod,
-        "_load_memory_estimator",
-        lambda: lambda *args, **kwargs: {"total_kv_size_tokens": 123456},
+        "estimate_kv_cache",
+        lambda *args, **kwargs: {"total_kv_size_tokens": 123456},
     )
     sh = ParallelShape(tp=4, dp=1, moe_tp=1, moe_ep=4)
     assert estimate_kv_tokens(sh, **_COMMON) == 123456
@@ -43,7 +40,7 @@ def test_estimate_kv_tokens_oom_returns_none(monkeypatch):
             "no KV budget: non-KV memory (361903882240 bytes) meets/exceeds the KV-cacheable budget"
         )
 
-    monkeypatch.setattr(kv_estimate_mod, "_load_memory_estimator", lambda: boom)
+    monkeypatch.setattr(kv_estimate_mod, "estimate_kv_cache", boom)
     sh = ParallelShape(tp=1, dp=2, moe_tp=1, moe_ep=2)
     assert estimate_kv_tokens(sh, **_COMMON) is None
 
@@ -52,7 +49,7 @@ def test_estimate_kv_tokens_propagates_other_errors(monkeypatch):
     def boom(*a, **k):
         raise ValueError("incompatible memory fraction")
 
-    monkeypatch.setattr(kv_estimate_mod, "_load_memory_estimator", lambda: boom)
+    monkeypatch.setattr(kv_estimate_mod, "estimate_kv_cache", boom)
     sh = ParallelShape(tp=1, dp=1, moe_tp=1, moe_ep=1)
     with pytest.raises(ValueError, match="incompatible"):
         estimate_kv_tokens(sh, **_COMMON)
@@ -68,7 +65,7 @@ def test_feasible_shape_tokens_filters_short_and_oom_and_dedups(monkeypatch):
             raise ValueError("no KV budget: ...")
         return {"total_kv_size_tokens": tp_size * 10000}
 
-    monkeypatch.setattr(kv_estimate_mod, "_load_memory_estimator", lambda: fake)
+    monkeypatch.setattr(kv_estimate_mod, "estimate_kv_cache", fake)
     big = ParallelShape(tp=4, dp=1, moe_tp=1, moe_ep=4)  # 40000 -> feasible
     small = ParallelShape(
         tp=2, dp=1, moe_tp=1, moe_ep=2
@@ -112,102 +109,32 @@ def test_resolve_backend_version_missing(monkeypatch):
         resolve_backend_version("nosuch_sku", "trtllm")
 
 
-def test_memory_estimator_is_imported_lazily(monkeypatch):
-    calls = []
-    memory = types.SimpleNamespace(estimate_kv_cache=lambda: None)
-
-    def import_module(module_name):
-        calls.append(module_name)
-        return memory
-
-    monkeypatch.setattr(kv_estimate_mod.importlib, "import_module", import_module)
-
-    assert kv_estimate_mod._load_memory_estimator() is memory.estimate_kv_cache
-    assert calls == ["aiconfigurator.sdk.memory"]
-
-
-def test_missing_memory_estimator_has_actionable_error(monkeypatch):
-    def missing_memory(module_name):
-        raise ModuleNotFoundError(name=module_name)
-
-    monkeypatch.setattr(kv_estimate_mod.importlib, "import_module", missing_memory)
-
-    with pytest.raises(
-        AicMemoryEstimatorUnavailableError,
-        match=r"aiconfigurator\.sdk\.memory.*AIC 0\.10",
-    ):
-        kv_estimate_mod._load_memory_estimator()
-
-
-def test_memory_estimator_propagates_nested_import_error(monkeypatch):
-    missing_dependency = ModuleNotFoundError(name="aiconfigurator_core")
-
-    def broken_memory_module(_module_name):
-        raise missing_dependency
-
-    monkeypatch.setattr(
-        kv_estimate_mod.importlib, "import_module", broken_memory_module
-    )
-
-    with pytest.raises(ModuleNotFoundError) as exc_info:
-        kv_estimate_mod._load_memory_estimator()
-
-    assert exc_info.value is missing_dependency
-
-
-# --- integration: real native estimate (skipped without a perf DB / model) ---
-
-
-def _skip_if_native_unavailable(exc: ValueError) -> None:
-    if "unsupported model/backend/GPU" in str(exc):
-        pytest.skip(f"native KV build unavailable (perf DB / model?): {exc}")
-    raise exc
-
-
-def _require_memory_estimator() -> None:
-    try:
-        kv_estimate_mod._load_memory_estimator()
-    except AicMemoryEstimatorUnavailableError as exc:
-        pytest.skip(str(exc))
+# --- integration: real AIC Core estimate ---
 
 
 @pytest.mark.model("Qwen/Qwen3-32B")
 def test_real_estimate_dense_qwen_feasible():
-    _require_memory_estimator()
-    try:
-        ver = resolve_backend_version("h200_sxm", "trtllm")
-    except NoPerfDatabase:
-        pytest.skip("no h200_sxm/trtllm perf DB")
+    ver = resolve_backend_version("h200_sxm", "trtllm")
     sh = ParallelShape(tp=2, dp=1, moe_tp=1, moe_ep=1)  # dense Qwen3-32B
-    try:
-        tokens = estimate_kv_tokens(
-            sh,
-            model_name="Qwen/Qwen3-32B",
-            hardware_sku="h200_sxm",
-            backend="trtllm",
-            backend_version=ver,
-        )
-    except ValueError as exc:
-        _skip_if_native_unavailable(exc)
+    tokens = estimate_kv_tokens(
+        sh,
+        model_name="Qwen/Qwen3-32B",
+        hardware_sku="h200_sxm",
+        backend="trtllm",
+        backend_version=ver,
+    )
     assert tokens is not None and tokens > 0
 
 
 @pytest.mark.model("deepseek-ai/DeepSeek-V3")
 def test_real_estimate_deepseek_two_gpus_oom():
-    _require_memory_estimator()
-    try:
-        ver = resolve_backend_version("gb200", "trtllm")
-    except NoPerfDatabase:
-        pytest.skip("no gb200/trtllm perf DB")
+    ver = resolve_backend_version("gb200", "trtllm")
     sh = ParallelShape(tp=2, dp=1, moe_tp=1, moe_ep=2)  # MoE TEP at 2 GPUs
-    try:
-        tokens = estimate_kv_tokens(
-            sh,
-            model_name="deepseek-ai/DeepSeek-V3",
-            hardware_sku="gb200",
-            backend="trtllm",
-            backend_version=ver,
-        )
-    except ValueError as exc:
-        _skip_if_native_unavailable(exc)
+    tokens = estimate_kv_tokens(
+        sh,
+        model_name="deepseek-ai/DeepSeek-V3",
+        hardware_sku="gb200",
+        backend="trtllm",
+        backend_version=ver,
+    )
     assert tokens is None  # 2 GPUs cannot hold DeepSeek-V3 -> no KV budget

--- a/aisimulate/tests/spica/test_kv_load.py
+++ b/aisimulate/tests/spica/test_kv_load.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 
-import aisimulate.spica.kv_estimate as kv_estimate_mod
 from aisimulate.spica.config import Workload
 from aisimulate.spica.kv_load import InfeasibleKVCapacity, resolve_kv_load
 from aisimulate.spica.parallel_enum import (
@@ -13,7 +12,6 @@ from aisimulate.spica.parallel_enum import (
     ParallelShape,
     ReplicaParallelConfig,
 )
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
 
 
 def _sample(mode: str) -> dict:
@@ -162,31 +160,6 @@ def test_average_tokens_per_request_must_be_positive(monkeypatch):
         resolve_kv_load(
             _sample("agg"),
             workload=SimpleNamespace(isl=0, osl=0),
-            parallel_config=config,
-            ratio=1.0,
-            backend_version="v",
-        )
-
-
-def test_kv_load_fails_closed_without_memory_estimator(monkeypatch):
-    config = ReplicaParallelConfig(
-        ParallelShape(tp=1, dp=1, moe_tp=1, moe_ep=1), replicas=1
-    )
-
-    def missing_memory(module_name):
-        raise ModuleNotFoundError(name=module_name)
-
-    monkeypatch.setattr(kv_estimate_mod.importlib, "import_module", missing_memory)
-
-    with pytest.raises(
-        AicMemoryEstimatorUnavailableError,
-        match=r"compatible estimator.*AIC 0\.10",
-    ):
-        resolve_kv_load(
-            _sample("agg"),
-            workload=Workload(
-                isl=100, osl=100, kv_load_ratio=1.0, num_request_ratio=10
-            ),
             parallel_config=config,
             ratio=1.0,
             backend_version="v",

--- a/aisimulate/tests/spica/test_load_predictor_sweep_integration.py
+++ b/aisimulate/tests/spica/test_load_predictor_sweep_integration.py
@@ -1,21 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E402
-
 """Integration tests that exercise the real dynamo planner predictors and the
-densify-fixed trace->window tool. Skipped unless the ``dynamo`` extra is
-installed (Rust runtime + prophet/pmdarima/filterpy)."""
+densify-fixed trace->window tool in the planner test environment."""
 
 import json
 
 import pytest
 
-pytest.importorskip("dynamo.planner.core.load.predictors")
-pytest.importorskip("dynamo.planner.offline.trace_data")
-
 from aisimulate.spica import SmartSearchConfig, sweep_load_predictor
 from aisimulate.spica.load_predictor_sweep import build_windows
+
+# FilterPy 1.4.5 contains non-raw math docstrings that Python 3.12 reports while
+# importing the planner predictors.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:invalid escape sequence.*:SyntaxWarning"
+)
 
 
 def _trace(tmp_path, rows):

--- a/aisimulate/tests/spica/test_model_hw.py
+++ b/aisimulate/tests/spica/test_model_hw.py
@@ -1,35 +1,21 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E402
-
 """Model/hardware resolution + KV-cache parallel-config validity via AIConfigurator.
 
-Skipped unless ``aiconfigurator`` is importable. Uses models whose configs
-resolve without HF auth (DeepSeek-V3, Qwen3-32B)."""
+Uses models whose configs resolve without HF auth (DeepSeek-V3, Qwen3-32B)."""
 
 import pytest
 
-pytest.importorskip("aiconfigurator")
-
 import aisimulate.spica.model_hw as mh_mod
-from aisimulate.spica.kv_estimate import NoPerfDatabase, _load_memory_estimator
 from aisimulate.spica.model_hw import (
     NoViableParallelConfig,
     parallel_configs_for,
     resolve_model_hardware,
 )
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
 
 DEEPSEEK = "deepseek-ai/DeepSeek-V3"
 QWEN = "Qwen/Qwen3-32B"
-
-
-def _require_memory_estimator() -> None:
-    try:
-        _load_memory_estimator()
-    except AicMemoryEstimatorUnavailableError as exc:
-        pytest.skip(str(exc))
 
 
 @pytest.mark.model(DEEPSEEK)
@@ -56,25 +42,35 @@ def test_unknown_hardware_sku_raises():
         resolve_model_hardware(QWEN, "h200_typo", backend="trtllm")
 
 
-def test_aic_private_helper_compatibility_boundary(monkeypatch):
-    seen = []
+def test_aic_core_system_spec_contract(monkeypatch):
     monkeypatch.setattr(
         mh_mod,
-        "_get_system_config",
-        lambda hardware: seen.append(("system", hardware))
-        or {"vram_per_gpu": 80, "gpus_per_node": 8},
+        "get_model_config_from_model_path",
+        lambda model: {
+            "architecture": "Qwen3ForCausalLM",
+            "context": 40960,
+        },
+    )
+    monkeypatch.setattr(mh_mod, "check_is_moe", lambda model_config: False)
+    monkeypatch.setattr(
+        mh_mod.perf_database,
+        "load_system_spec",
+        lambda hardware: {
+            "gpu": {"mem_capacity": 80},
+            "node": {"num_gpus_per_node": 8},
+        },
     )
     monkeypatch.setattr(
         mh_mod,
         "_estimate_model_weight_bytes",
-        lambda model: seen.append(("weight", model)) or 123,
+        lambda model: 123,
     )
 
-    system, weight_bytes = mh_mod._aic_model_system_facts("model", "hardware")
+    mh = resolve_model_hardware("model", "hardware", backend="trtllm")
 
-    assert system == {"vram_per_gpu": 80, "gpus_per_node": 8}
-    assert weight_bytes == 123
-    assert seen == [("system", "hardware"), ("weight", "model")]
+    assert mh.vram_per_gpu == 80
+    assert mh.gpus_per_node == 8
+    assert mh.weight_bytes == 123
 
 
 @pytest.mark.model(DEEPSEEK)
@@ -153,48 +149,15 @@ def test_kv_filter_no_feasible_shape_raises(monkeypatch):
 
 
 @pytest.mark.model(DEEPSEEK)
-def test_missing_memory_estimator_warns_and_keeps_enumerated_configs(monkeypatch):
-    def unavailable(*args, **kwargs):
-        raise AicMemoryEstimatorUnavailableError("estimator unavailable")
-
-    monkeypatch.setattr(mh_mod, "feasible_shape_tokens", unavailable)
-
-    with pytest.warns(
-        UserWarning,
-        match=r"\[EXPERIMENTAL\].*Continuing.*kv_load_ratio.*fail closed",
-    ):
-        configs = parallel_configs_for(
-            DEEPSEEK,
-            "gb200",
-            gpu_budget=16,
-            deployment_mode="agg",
-            backend="trtllm",
-            max_seq_len=8192,
-        )
-
-    assert configs
-    assert all(config.total_gpus <= 16 for config in configs)
-
-
-@pytest.mark.model(DEEPSEEK)
 def test_kv_path_end_to_end_deepseek_gb200():
-    # Real native estimate; skipped without the gb200 perf DB / model build.
-    _require_memory_estimator()
-    try:
-        cfgs = parallel_configs_for(
-            DEEPSEEK,
-            "gb200",
-            gpu_budget=16,
-            deployment_mode="agg",
-            backend="trtllm",
-            max_seq_len=8192,
-        )
-    except NoPerfDatabase:
-        pytest.skip("no gb200/trtllm perf DB")
-    except ValueError as exc:
-        if "unsupported model/backend/GPU" in str(exc):
-            pytest.skip(f"native KV build unavailable: {exc}")
-        raise
+    cfgs = parallel_configs_for(
+        DEEPSEEK,
+        "gb200",
+        gpu_budget=16,
+        deployment_mode="agg",
+        backend="trtllm",
+        max_seq_len=8192,
+    )
     assert cfgs
     # DeepSeek-V3 OOMs at 2 GPUs/worker; smallest feasible worker is >= 4 GPUs.
     assert all(c.shape.gpus_per_worker >= 4 for c in cfgs)
@@ -204,8 +167,7 @@ def test_kv_path_end_to_end_deepseek_gb200():
 @pytest.mark.model(DEEPSEEK)
 def test_kv_path_tiny_budget_raises():
     # 2 GPUs cannot hold DeepSeek-V3 at any shape -> no feasible config.
-    _require_memory_estimator()
-    try:
+    with pytest.raises(NoViableParallelConfig):
         parallel_configs_for(
             DEEPSEEK,
             "gb200",
@@ -214,12 +176,3 @@ def test_kv_path_tiny_budget_raises():
             backend="trtllm",
             max_seq_len=8192,
         )
-    except NoPerfDatabase:
-        pytest.skip("no gb200/trtllm perf DB")
-    except NoViableParallelConfig:
-        return  # expected
-    except ValueError as exc:
-        if "unsupported model/backend/GPU" in str(exc):
-            pytest.skip(f"native KV build unavailable: {exc}")
-        raise
-    pytest.fail("expected NoViableParallelConfig for a 2-GPU DeepSeek-V3 budget")

--- a/aisimulate/tests/spica/test_replay_integration.py
+++ b/aisimulate/tests/spica/test_replay_integration.py
@@ -1,16 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E402
-
 """End-to-end integration against the REAL dynamo replay (no stubs).
 
 Drives the full pipeline on a tiny mooncake trace: enumerate -> sample ->
 build_deployment -> ReplayEvaluator (planner bridge) -> score, and the whole
 ``run_smart_search`` loop with the Vizier sampler.
 
-Requires the dynamo bindings built with the ``aic-forward-pass`` Cargo feature
-(the AIC perf model the mocker needs); skips otherwise. See README "Real replay".
+Requires the planner image's ``aic-forward-pass`` and ``mocker-kvbm-offload``
+Cargo features. See README "Real replay".
 
 Uses meta-llama/Meta-Llama-3.1-8B / gb200 / trtllm: a dense GQA model the AIC perf
 DB fully covers (PASS in the gb200 support matrix). Bare ``deepseek-ai/DeepSeek-V3``
@@ -24,10 +22,6 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("dynamo.mocker")
-
-import dynamo._core as _core
-import dynamo.replay.main as _replay_main
 from aisimulate.spica.config import OptimizationTarget, SLATarget, SmartSearchConfig
 from aisimulate.spica.deploy import build_deployment
 from aisimulate.spica.evaluator import ReplayEvaluator
@@ -37,22 +31,11 @@ from aisimulate.spica.score import objective_value
 from aisimulate.spica.search import run_smart_search
 from aisimulate.spica.search_space import enumerate_branches
 
+# FilterPy 1.4.5 contains non-raw math docstrings that Python 3.12 reports while
+# importing the planner predictors.
 pytestmark = pytest.mark.filterwarnings(
-    "ignore:\\[EXPERIMENTAL\\] Spica cannot apply KV-capacity filtering.*:UserWarning"
+    "ignore:invalid escape sequence.*:SyntaxWarning"
 )
-
-if not hasattr(_core, "RustEnginePerfModel"):
-    pytest.skip(
-        "dynamo bindings built without the aic-forward-pass feature (no AIC perf model)",
-        allow_module_level=True,
-    )
-
-if not hasattr(_replay_main, "SyntheticWorkload"):
-    pytest.skip(
-        "installed dynamo predates the planner load-modes API (ai-dynamo/dynamo#10888); "
-        "repin the [dynamo] dependency + rebuild to run these integration tests",
-        allow_module_level=True,
-    )
 
 TRACE = str(Path(__file__).parent / "data" / "mooncake_tiny.jsonl")
 
@@ -143,10 +126,6 @@ def test_static_path_emits_goodput():
     assert report["gpu_hours"] > 0.0
 
 
-@pytest.mark.skipif(
-    not getattr(_core, "MOCKER_KVBM_OFFLOAD_ENABLED", False),
-    reason="planner wheel is required for the mocker-kvbm-offload feature",
-)
 def test_static_path_runs_with_kvbm_host_offload():
     """The planner wheel must initialize and run replay with Spica's G2 knobs."""
 

--- a/aisimulate/tests/spica/test_replay_integration.py
+++ b/aisimulate/tests/spica/test_replay_integration.py
@@ -30,6 +30,7 @@ from aisimulate.spica.sample import unroll_sample
 from aisimulate.spica.score import objective_value
 from aisimulate.spica.search import run_smart_search
 from aisimulate.spica.search_space import enumerate_branches
+from dynamo import _core
 
 # FilterPy 1.4.5 contains non-raw math docstrings that Python 3.12 reports while
 # importing the planner predictors.
@@ -129,6 +130,9 @@ def test_static_path_emits_goodput():
 def test_static_path_runs_with_kvbm_host_offload():
     """The planner wheel must initialize and run replay with Spica's G2 knobs."""
 
+    assert (
+        _core.MOCKER_KVBM_OFFLOAD_ENABLED
+    ), "planner wheel must enable mocker-kvbm-offload"
     cfg = _config()
     cfg = cfg.model_copy(
         update={

--- a/aisimulate/tests/spica/test_sampler.py
+++ b/aisimulate/tests/spica/test_sampler.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Vizier-backed sampler. Needs the pinned Vizier/JAX stack; skips otherwise."""
+"""Vizier-backed sampler using the pinned Vizier/JAX stack."""
 
 import json
 import uuid
@@ -22,8 +22,6 @@ from aisimulate.spica.sampler import (
     make_branch_sampler,
 )
 from aisimulate.spica.search_space import BranchSpace
-
-pytest.importorskip("vizier")
 
 pytestmark = [
     pytest.mark.timeout(300),

--- a/aisimulate/tests/spica/test_search.py
+++ b/aisimulate/tests/spica/test_search.py
@@ -18,7 +18,6 @@ from aisimulate.spica.parallel_enum import ParallelShape, ReplicaParallelConfig
 from aisimulate.spica.sampler import Suggestion
 from aisimulate.spica.search import run_smart_search
 from aisimulate.spica.search_space import BranchSpace
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
 
 TRACE = str(Path(__file__).parent / "data" / "mooncake_tiny.jsonl")
 
@@ -105,7 +104,6 @@ def _branch(parallel_config):
 
 
 def _stub(monkeypatch, branch):
-    monkeypatch.setattr(search_mod, "_load_memory_estimator", lambda: object())
     monkeypatch.setattr(
         search_mod, "enumerate_branches", lambda config, *, max_seq_len=None: [branch]
     )
@@ -154,21 +152,6 @@ def test_show_progress_is_forwarded_to_load_predictor_sweep(monkeypatch):
     )
 
     assert seen == [False]
-
-
-def test_kv_load_fails_before_starting_search_without_memory_estimator(monkeypatch):
-    def missing_estimator():
-        raise AicMemoryEstimatorUnavailableError("AIC 0.10 or newer is required")
-
-    monkeypatch.setattr(search_mod, "_load_memory_estimator", missing_estimator)
-    monkeypatch.setattr(
-        search_mod,
-        "enumerate_branches",
-        lambda *args, **kwargs: pytest.fail("search must not enumerate branches"),
-    )
-
-    with pytest.raises(AicMemoryEstimatorUnavailableError, match=r"0\.10"):
-        run_smart_search(_pareto_config(), show_progress=False)
 
 
 def test_parallel_batch_uses_worker_sized_timeout_waves(monkeypatch):

--- a/aisimulate/tests/spica/test_search_space.py
+++ b/aisimulate/tests/spica/test_search_space.py
@@ -1,23 +1,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# ruff: noqa: E402
-
 """Per-branch candidate space. The branch enumeration calls the KV-feasibility
-path, so it needs aiconfigurator + a perf DB (skips otherwise)."""
+path against the AIC Core performance database."""
 
 from pathlib import Path
 
 import pytest
 
-pytest.importorskip("aiconfigurator")
-
 from aisimulate.spica.config import SmartSearchConfig
-from aisimulate.spica.kv_estimate import NoPerfDatabase, _load_memory_estimator
+from aisimulate.spica.kv_estimate import NoPerfDatabase
 from aisimulate.spica.model_hw import NoViableParallelConfig
 from aisimulate.spica.parallel_enum import ParallelShape, ReplicaParallelConfig
 from aisimulate.spica.search_space import branch_knob_choices, enumerate_branches
-from dynamo._internal.aic import AicMemoryEstimatorUnavailableError
 
 TRACE = str(Path(__file__).parent / "data" / "mooncake_tiny.jsonl")
 
@@ -32,13 +27,6 @@ def _config(**ss_overrides) -> SmartSearchConfig:
     }
     ss.update(ss_overrides)
     return SmartSearchConfig(search_space=ss, workload={"trace_path": TRACE})
-
-
-def _require_memory_estimator() -> None:
-    try:
-        _load_memory_estimator()
-    except AicMemoryEstimatorUnavailableError as exc:
-        pytest.skip(str(exc))
 
 
 def test_branch_knob_choices_by_mode():
@@ -117,20 +105,10 @@ def test_mixed_planner_policies_keep_dependent_knobs():
     assert "planner_load_sensitivity" in choices
 
 
-@pytest.mark.filterwarnings(
-    "ignore:\\[EXPERIMENTAL\\] Spica cannot apply KV-capacity filtering.*:UserWarning"
-)
 def test_enumerate_branches_deepseek_gb200():
     cfg = _config(deployment_mode=["agg", "disagg"], backend=["trtllm"], gpu_budget=16)
-    try:
-        with pytest.warns(UserWarning, match="disagg.*replay-incompatible.*trtllm"):
-            branches = enumerate_branches(cfg)
-    except (NoPerfDatabase, NoViableParallelConfig):
-        pytest.skip("no gb200/trtllm perf DB")
-    except ValueError as exc:
-        if "unsupported model/backend/GPU" in str(exc):
-            pytest.skip(f"native KV build unavailable: {exc}")
-        raise
+    with pytest.warns(UserWarning, match="disagg.*replay-incompatible.*trtllm"):
+        branches = enumerate_branches(cfg)
     # Dynamo replay rejects TRT-LLM disaggregation, so only agg is searchable.
     assert {b.deployment_mode for b in branches} == {"agg"}
     for b in branches:
@@ -177,26 +155,19 @@ def test_replay_incompatible_backend_is_removed_before_sampling(monkeypatch):
 
 def test_pinned_parallel_configs_replace_the_menu():
     # a dense, KV-trivial model so the pinned shapes are guaranteed feasible
-    _require_memory_estimator()
     cfg = _config(
         model_name="meta-llama/Meta-Llama-3.1-8B",
         deployment_mode=["agg"],
         gpu_budget=32,
         parallel_configs=[{"tp": 4, "replicas": 2}, {"tp": 8, "replicas": 1}],
     )
-    try:
-        branches = enumerate_branches(cfg)
-    except NoPerfDatabase:
-        pytest.skip("no gb200/trtllm perf DB")
+    branches = enumerate_branches(cfg)
     (branch,) = branches
     menu = {(c.shape.tp, c.replicas) for c in branch.parallel_configs}
     assert menu == {(4, 2), (8, 1)}  # exactly the pinned set, not the full enumeration
     assert all(c.total_gpus == 8 for c in branch.parallel_configs)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:\\[EXPERIMENTAL\\] Spica cannot apply KV-capacity filtering.*:UserWarning"
-)
 def test_pinned_parallel_config_illegal_is_rejected():
     cfg = _config(
         model_name="meta-llama/Meta-Llama-3.1-8B",
@@ -204,11 +175,8 @@ def test_pinned_parallel_config_illegal_is_rejected():
         gpu_budget=32,
         parallel_configs=[{"tp": 3, "replicas": 1}],  # tp=3 not on the GPU ladder
     )
-    try:
-        with pytest.raises(NoViableParallelConfig):
-            enumerate_branches(cfg)
-    except NoPerfDatabase:
-        pytest.skip("no gb200/trtllm perf DB")
+    with pytest.raises(NoViableParallelConfig):
+        enumerate_branches(cfg)
 
 
 # --- per-mode failure policy: skip an infeasible mode, keep the viable ones --------

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -3,21 +3,17 @@
 
 import argparse
 import json
-import logging
 import os
 import socket
 
 from dynamo._internal.aic import (
     DEFAULT_GPU_MEMORY_UTILIZATION,
     DEFAULT_MEM_FRACTION_STATIC,
-    AicMemoryEstimatorUnavailableError,
     estimate_num_gpu_blocks,
 )
 from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import ModelRuntimeConfig
 from dynamo.mocker import MockEngineArgs, ReasoningConfig, SglangArgs, TrtllmArgs
-
-logger = logging.getLogger(__name__)
 
 _DEFAULT_NUM_GPU_BLOCKS = 16384
 _DEFAULT_MAX_NUM_SEQS = 256
@@ -110,44 +106,34 @@ def _estimate_aic_num_gpu_blocks(
     resolved_block_size = _resolve_block_size_for_capacity(
         engine_type, block_size, sglang_page_size
     )
-    try:
-        return estimate_num_gpu_blocks(
-            backend_name=aic_backend,
-            system=aic_system or _DEFAULT_AIC_SYSTEM,
-            model_path=aic_model_path,
-            tp_size=aic_tp_size if aic_tp_size is not None else 1,
-            block_size=resolved_block_size,
-            max_num_batched_tokens=(
-                max_num_batched_tokens
-                if max_num_batched_tokens is not None
-                else _DEFAULT_MAX_NUM_BATCHED_TOKENS
-            ),
-            gpu_memory_utilization=(
-                gpu_memory_utilization
-                if gpu_memory_utilization is not None
-                else DEFAULT_GPU_MEMORY_UTILIZATION
-            ),
-            mem_fraction_static=(
-                mem_fraction_static
-                if mem_fraction_static is not None
-                else DEFAULT_MEM_FRACTION_STATIC
-            ),
-            # None -> aic.py applies the TRT-LLM default (0.9).
-            free_gpu_memory_fraction=free_gpu_memory_fraction,
-            backend_version=aic_backend_version,
-            moe_tp_size=aic_moe_tp_size,
-            moe_ep_size=aic_moe_ep_size,
-            attention_dp_size=aic_attention_dp_size,
-        )
-    except AicMemoryEstimatorUnavailableError as exc:
-        logger.warning(
-            "AIC KV-cache capacity estimation is unavailable: %s. Falling back "
-            "to default num_gpu_blocks=%d; upgrade aiconfigurator or set "
-            "--num-gpu-blocks-override explicitly.",
-            exc,
-            _DEFAULT_NUM_GPU_BLOCKS,
-        )
-        return _DEFAULT_NUM_GPU_BLOCKS
+    return estimate_num_gpu_blocks(
+        backend_name=aic_backend,
+        system=aic_system or _DEFAULT_AIC_SYSTEM,
+        model_path=aic_model_path,
+        tp_size=aic_tp_size if aic_tp_size is not None else 1,
+        block_size=resolved_block_size,
+        max_num_batched_tokens=(
+            max_num_batched_tokens
+            if max_num_batched_tokens is not None
+            else _DEFAULT_MAX_NUM_BATCHED_TOKENS
+        ),
+        gpu_memory_utilization=(
+            gpu_memory_utilization
+            if gpu_memory_utilization is not None
+            else DEFAULT_GPU_MEMORY_UTILIZATION
+        ),
+        mem_fraction_static=(
+            mem_fraction_static
+            if mem_fraction_static is not None
+            else DEFAULT_MEM_FRACTION_STATIC
+        ),
+        # None -> aic.py applies the TRT-LLM default.
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        backend_version=aic_backend_version,
+        moe_tp_size=aic_moe_tp_size,
+        moe_ep_size=aic_moe_ep_size,
+        attention_dp_size=aic_attention_dp_size,
+    )
 
 
 def _resolve_num_gpu_blocks(

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -704,21 +704,16 @@ def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):
     ]
 
 
-def test_build_mocker_engine_args_falls_back_when_aic_estimator_missing(
-    monkeypatch, caplog
-):
-    def missing_memory(module_name):
-        raise ModuleNotFoundError(name=module_name)
+def test_build_mocker_engine_args_propagates_aic_estimator_error(monkeypatch):
+    def invalid_capacity(**_kwargs):
+        raise ValueError("invalid capacity request")
 
-    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
+    monkeypatch.setattr(CONFIG, "estimate_num_gpu_blocks", invalid_capacity)
 
-    engine_args = CONFIG.build_mocker_engine_args(
-        make_args(aic_perf_model=True, model_path="/models/mock")
-    )
-
-    assert engine_args.num_gpu_blocks == 16384
-    assert "Falling back to default num_gpu_blocks=16384" in caplog.text
-    assert "--num-gpu-blocks-override" in caplog.text
+    with pytest.raises(ValueError, match="invalid capacity request"):
+        CONFIG.build_mocker_engine_args(
+            make_args(aic_perf_model=True, model_path="/models/mock")
+        )
 
 
 def test_aic_capacity_estimation_preserves_explicit_zero_inputs(monkeypatch):

--- a/components/src/dynamo/replay/main.py
+++ b/components/src/dynamo/replay/main.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import importlib
 import json
-import logging
 import os
 import sys
 from collections.abc import Sequence
@@ -21,7 +20,6 @@ if TYPE_CHECKING:
 from dynamo._internal.aic import (
     DEFAULT_GPU_MEMORY_UTILIZATION,
     DEFAULT_MEM_FRACTION_STATIC,
-    AicMemoryEstimatorUnavailableError,
     _normalize_aic_quant_mode,
     estimate_num_gpu_blocks,
 )
@@ -35,15 +33,12 @@ from dynamo.mocker.utils.kv_cache import compute_kv_bytes_per_token
 from dynamo.replay import run_synthetic_trace_replay, run_trace_replay
 from dynamo.replay.reporting import format_report_table, write_report_json
 
-logger = logging.getLogger(__name__)
-
 
 class PlannerProfileDataResult(Protocol):
     npz_path: Path | None
 
 
 _DEFAULT_AIC_SYSTEM = "h200_sxm"
-_DEFAULT_NUM_GPU_BLOCKS = 16384
 _DEFAULT_MAX_NUM_BATCHED_TOKENS = 8192
 _DEFAULT_VLLM_BLOCK_SIZE = 64
 
@@ -146,53 +141,42 @@ def _resolve_aic_num_gpu_blocks(raw: dict) -> None:
     mem_fraction_static = raw.get("mem_fraction_static")
     free_gpu_memory_fraction = raw.get("free_gpu_memory_fraction")
 
-    try:
-        per_rank_blocks = estimate_num_gpu_blocks(
-            backend_name=aic_backend,
-            system=raw.get("aic_system") or _DEFAULT_AIC_SYSTEM,
-            model_path=aic_model_path,
-            tp_size=cast(int, tp_size if tp_size is not None else 1),
-            block_size=_resolve_block_size_for_capacity(raw),
-            max_num_batched_tokens=cast(
-                int,
-                max_num_batched_tokens
-                if max_num_batched_tokens is not None
-                else _DEFAULT_MAX_NUM_BATCHED_TOKENS,
-            ),
-            gpu_memory_utilization=cast(
-                float,
-                gpu_memory_utilization
-                if gpu_memory_utilization is not None
-                else DEFAULT_GPU_MEMORY_UTILIZATION,
-            ),
-            mem_fraction_static=cast(
-                float,
-                mem_fraction_static
-                if mem_fraction_static is not None
-                else DEFAULT_MEM_FRACTION_STATIC,
-            ),
-            # None -> aic.py applies the TRT-LLM default (0.9).
-            free_gpu_memory_fraction=free_gpu_memory_fraction,
-            backend_version=raw.get("aic_backend_version"),
-            moe_tp_size=raw.get("aic_moe_tp_size"),
-            moe_ep_size=raw.get("aic_moe_ep_size"),
-            attention_dp_size=raw.get("aic_attention_dp_size"),
-            gemm_dtype=_aic_quant_mode(raw, "aic_gemm_dtype"),
-            moe_dtype=_aic_quant_mode(raw, "aic_moe_dtype"),
-            fmha_dtype=_aic_quant_mode(raw, "aic_fmha_dtype"),
-            kv_cache_dtype=_aic_quant_mode(raw, "aic_kv_cache_dtype"),
-            comm_dtype=_aic_quant_mode(raw, "aic_comm_dtype"),
-        )
-    except AicMemoryEstimatorUnavailableError as exc:
-        logger.warning(
-            "AIC KV-cache capacity estimation is unavailable during replay: %s. "
-            "Falling back to default num_gpu_blocks=%d; upgrade aiconfigurator "
-            "or set num_gpu_blocks explicitly.",
-            exc,
-            _DEFAULT_NUM_GPU_BLOCKS,
-        )
-        raw["num_gpu_blocks"] = _DEFAULT_NUM_GPU_BLOCKS
-        return
+    per_rank_blocks = estimate_num_gpu_blocks(
+        backend_name=aic_backend,
+        system=raw.get("aic_system") or _DEFAULT_AIC_SYSTEM,
+        model_path=aic_model_path,
+        tp_size=cast(int, tp_size if tp_size is not None else 1),
+        block_size=_resolve_block_size_for_capacity(raw),
+        max_num_batched_tokens=cast(
+            int,
+            max_num_batched_tokens
+            if max_num_batched_tokens is not None
+            else _DEFAULT_MAX_NUM_BATCHED_TOKENS,
+        ),
+        gpu_memory_utilization=cast(
+            float,
+            gpu_memory_utilization
+            if gpu_memory_utilization is not None
+            else DEFAULT_GPU_MEMORY_UTILIZATION,
+        ),
+        mem_fraction_static=cast(
+            float,
+            mem_fraction_static
+            if mem_fraction_static is not None
+            else DEFAULT_MEM_FRACTION_STATIC,
+        ),
+        # None -> aic.py applies the TRT-LLM default.
+        free_gpu_memory_fraction=free_gpu_memory_fraction,
+        backend_version=raw.get("aic_backend_version"),
+        moe_tp_size=raw.get("aic_moe_tp_size"),
+        moe_ep_size=raw.get("aic_moe_ep_size"),
+        attention_dp_size=raw.get("aic_attention_dp_size"),
+        gemm_dtype=_aic_quant_mode(raw, "aic_gemm_dtype"),
+        moe_dtype=_aic_quant_mode(raw, "aic_moe_dtype"),
+        fmha_dtype=_aic_quant_mode(raw, "aic_fmha_dtype"),
+        kv_cache_dtype=_aic_quant_mode(raw, "aic_kv_cache_dtype"),
+        comm_dtype=_aic_quant_mode(raw, "aic_comm_dtype"),
+    )
     # AIC returns a per-rank (per-GPU) block count. Under attention-DP the offline runtime
     # mirrors the live path (lib/llm/src/mocker.rs): each mocker worker owns `dp`
     # independent per-rank schedulers and KV pools. Keep the per-rank count; engine-wide

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -75,7 +75,8 @@ RUN --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/t
         --requirement /tmp/requirements.planner.txt \
         --requirement /tmp/requirements.benchmark.txt \
         /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
-        /opt/dynamo/wheelhouse/ai_dynamo*any.whl
+        /opt/dynamo/wheelhouse/ai_dynamo*any.whl \
+        /opt/dynamo/wheelhouse/aisimulate*.whl
 
 # Copy only the subset of the repository needed for planner/profiler service
 # startup and the component-local planner-family test suites. AI Simulate

--- a/lib/bindings/python/rust/llm/aic_callback.rs
+++ b/lib/bindings/python/rust/llm/aic_callback.rs
@@ -5,10 +5,8 @@
 //!
 //! [`RustAicCallback`] wraps a compiled `aiconfigurator_core::AicEngine` and
 //! answers the mocker/router latency predictions purely in Rust — no GIL on the
-//! predict hot path. AIC 0.9 wheels that predate the compiled-engine Python
-//! modules use [`PyAicCallback`] against the same AIC perf database. Once the
-//! compiled SDK is present, build failures remain hard errors. KV-block sizing
-//! still crosses into Python via [`estimate_aic_num_gpu_blocks`].
+//! predict hot path. Engine build failures are hard errors. KV-block sizing still
+//! crosses into Python via [`estimate_aic_num_gpu_blocks`].
 
 #[cfg(feature = "aic-forward-pass")]
 use std::collections::HashMap;
@@ -18,8 +16,6 @@ use std::sync::{Mutex, OnceLock};
 #[cfg(feature = "aic-forward-pass")]
 use std::time::Duration;
 
-#[cfg(feature = "aic-forward-pass")]
-use pyo3::exceptions::PyModuleNotFoundError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -27,127 +23,6 @@ use pyo3::types::PyDict;
 use aiconfigurator_core::{AicEngine, AicEngineBuilder, BackendKind};
 use dynamo_kv_router::PrefillLoadEstimator;
 use dynamo_mocker::common::perf_model::AicCallback;
-
-/// GIL-bound compatibility callback for AIC 0.9 releases that predate the
-/// compiled-engine Python modules. The Python helper still uses AIC's real
-/// perf database and operation model; only the execution path is slower.
-#[cfg(feature = "aic-forward-pass")]
-pub(super) struct PyAicCallback {
-    session: Py<PyAny>,
-}
-
-#[cfg(feature = "aic-forward-pass")]
-impl PyAicCallback {
-    fn predict_prefill_ms(
-        &self,
-        batch_size: usize,
-        effective_isl: usize,
-        prefix: usize,
-    ) -> PyResult<f64> {
-        Python::with_gil(|py| {
-            self.session
-                .call_method1(py, "predict_prefill", (batch_size, effective_isl, prefix))
-                .and_then(|result| result.extract::<f64>(py))
-        })
-    }
-}
-
-#[cfg(feature = "aic-forward-pass")]
-impl AicCallback for PyAicCallback {
-    fn predict_prefill(
-        &self,
-        batch_size: usize,
-        effective_isl: usize,
-        prefix: usize,
-    ) -> anyhow::Result<f64> {
-        self.predict_prefill_ms(batch_size, effective_isl, prefix)
-            .map_err(|error| anyhow::anyhow!("AIC predict_prefill (python) failed: {error}"))
-    }
-
-    fn predict_decode(&self, batch_size: usize, isl: usize, osl: usize) -> anyhow::Result<f64> {
-        Python::with_gil(|py| {
-            self.session
-                .call_method1(py, "predict_decode", (batch_size, isl, osl))
-                .and_then(|result| result.extract::<f64>(py))
-        })
-        .map_err(|error| anyhow::anyhow!("AIC predict_decode (python) failed: {error}"))
-    }
-}
-
-#[cfg(feature = "aic-forward-pass")]
-impl PrefillLoadEstimator for PyAicCallback {
-    fn predict_prefill_duration(
-        &self,
-        batch_size: usize,
-        effective_isl: usize,
-        prefix: usize,
-    ) -> anyhow::Result<Duration> {
-        let latency_ms = self.predict_prefill_ms(batch_size, effective_isl, prefix)?;
-        Ok(Duration::from_secs_f64(latency_ms / 1000.0))
-    }
-}
-
-#[cfg(feature = "aic-forward-pass")]
-fn compiled_engine_sdk_available(py: Python<'_>) -> PyResult<bool> {
-    match py.import("aiconfigurator.sdk.engine") {
-        Ok(_) => Ok(true),
-        Err(error) if error.is_instance_of::<PyModuleNotFoundError>(py) => {
-            let missing_module = error
-                .value(py)
-                .getattr("name")
-                .and_then(|name| name.extract::<String>())?;
-            if missing_module == "aiconfigurator.sdk.engine" {
-                Ok(false)
-            } else {
-                Err(error)
-            }
-        }
-        Err(error) => Err(error),
-    }
-}
-
-#[cfg(feature = "aic-forward-pass")]
-#[allow(clippy::too_many_arguments)]
-fn create_python_aic_callback(
-    py: Python<'_>,
-    backend_name: &str,
-    system: &str,
-    model_path: &str,
-    tp_size: usize,
-    backend_version: Option<&str>,
-    moe_tp_size: Option<usize>,
-    moe_ep_size: Option<usize>,
-    attention_dp_size: Option<usize>,
-    gemm_dtype: Option<&str>,
-    moe_dtype: Option<&str>,
-    fmha_dtype: Option<&str>,
-    kv_cache_dtype: Option<&str>,
-    comm_dtype: Option<&str>,
-    nextn: Option<usize>,
-    nextn_accept_rates: Option<&str>,
-) -> PyResult<PyAicCallback> {
-    let module = py.import("dynamo._internal.aic")?;
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("backend_name", backend_name)?;
-    kwargs.set_item("system", system)?;
-    kwargs.set_item("model_path", model_path)?;
-    kwargs.set_item("tp_size", tp_size)?;
-    kwargs.set_item("backend_version", backend_version)?;
-    kwargs.set_item("moe_tp_size", moe_tp_size)?;
-    kwargs.set_item("moe_ep_size", moe_ep_size)?;
-    kwargs.set_item("attention_dp_size", attention_dp_size)?;
-    kwargs.set_item("gemm_dtype", gemm_dtype)?;
-    kwargs.set_item("moe_dtype", moe_dtype)?;
-    kwargs.set_item("fmha_dtype", fmha_dtype)?;
-    kwargs.set_item("kv_cache_dtype", kv_cache_dtype)?;
-    kwargs.set_item("comm_dtype", comm_dtype)?;
-    kwargs.set_item("nextn", nextn)?;
-    kwargs.set_item("nextn_accept_rates", nextn_accept_rates)?;
-    let session = module.call_method("create_session", (), Some(&kwargs))?;
-    Ok(PyAicCallback {
-        session: session.unbind(),
-    })
-}
 
 /// Pure-Rust AIC callback: wraps an `aiconfigurator_core::AicEngine`
 /// compiled once at startup and answers predict calls with NO PyO3 / GIL on the
@@ -361,30 +236,6 @@ pub(super) fn create_aic_callback(
 ) -> PyResult<Arc<dyn AicCallback>> {
     #[cfg(feature = "aic-forward-pass")]
     {
-        if !compiled_engine_sdk_available(py)? {
-            tracing::warn!(
-                "AIC compiled-engine SDK is unavailable; using the GIL-bound Python \
-                 perf-model compatibility path"
-            );
-            return Ok(Arc::new(create_python_aic_callback(
-                py,
-                backend_name,
-                system,
-                model_path,
-                tp_size,
-                backend_version,
-                moe_tp_size,
-                moe_ep_size,
-                attention_dp_size,
-                gemm_dtype,
-                moe_dtype,
-                fmha_dtype,
-                kv_cache_dtype,
-                comm_dtype,
-                nextn,
-                nextn_accept_rates,
-            )?));
-        }
         let engine = build_rust_engine(
             py,
             backend_name,
@@ -412,8 +263,7 @@ pub(super) fn create_aic_callback(
 }
 
 /// Build the AIC prefill-load estimator for the KV router / live path. Requires
-/// the `aic-forward-pass` feature. AIC 0.9 uses the Python compatibility path;
-/// compiled-engine build failures remain hard errors.
+/// the `aic-forward-pass` feature; compiled-engine build failures are hard errors.
 #[cfg_attr(not(feature = "aic-forward-pass"), allow(unused_variables))]
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create_aic_prefill_load_estimator(
@@ -436,30 +286,6 @@ pub(super) fn create_aic_prefill_load_estimator(
 ) -> PyResult<Arc<dyn PrefillLoadEstimator>> {
     #[cfg(feature = "aic-forward-pass")]
     {
-        if !compiled_engine_sdk_available(py)? {
-            tracing::warn!(
-                "AIC compiled-engine SDK is unavailable; using the GIL-bound Python \
-                 prefill-load compatibility path"
-            );
-            return Ok(Arc::new(create_python_aic_callback(
-                py,
-                backend_name,
-                system,
-                model_path,
-                tp_size,
-                backend_version,
-                moe_tp_size,
-                moe_ep_size,
-                attention_dp_size,
-                gemm_dtype,
-                moe_dtype,
-                fmha_dtype,
-                kv_cache_dtype,
-                comm_dtype,
-                nextn,
-                nextn_accept_rates,
-            )?));
-        }
         let engine = build_rust_engine(
             py,
             backend_name,

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -1767,12 +1767,6 @@ fn load_optional_replay_mocker_args(
         .transpose()
 }
 
-fn is_aic_memory_estimator_unavailable(py: Python<'_>, error: &PyErr) -> bool {
-    py.import("dynamo._internal.aic")
-        .and_then(|module| module.getattr("AicMemoryEstimatorUnavailableError"))
-        .is_ok_and(|exception_type| error.is_instance(py, &exception_type))
-}
-
 fn materialize_replay_mocker_args(
     py: Python<'_>,
     extra_args: MockEngineArgs,
@@ -1808,7 +1802,7 @@ fn materialize_replay_mocker_args(
         // `dp_size` independent per-rank schedulers, each with a per-rank KV pool.
         // The topology applies whether KV capacity is explicit or estimated.
         if !num_gpu_blocks_explicit {
-            let capacity = estimate_aic_num_gpu_blocks(
+            let per_rank_blocks = estimate_aic_num_gpu_blocks(
                 py,
                 &backend,
                 &system,
@@ -1830,32 +1824,19 @@ fn materialize_replay_mocker_args(
                 fmha_dtype.as_deref(),
                 kv_cache_dtype.as_deref(),
                 comm_dtype.as_deref(),
-            );
-            match capacity {
-                Ok(per_rank_blocks) => {
-                    // AIC returns a per-rank (per-GPU) block count. When replicating
-                    // attention-DP into per-rank workers, each worker owns this per-rank
-                    // pool (engine-wide capacity stays `per_rank * dp`, now partitioned
-                    // per rank as on real hardware). With dp == 1 the per-rank pool is
-                    // the engine-wide pool.
-                    args.num_gpu_blocks = per_rank_blocks;
-                }
-                Err(error) if is_aic_memory_estimator_unavailable(py, &error) => {
-                    tracing::warn!(
-                        %error,
-                        num_gpu_blocks = args.num_gpu_blocks,
-                        "AIC KV-cache capacity estimation is unavailable during replay; \
-                         using the default block count. Upgrade aiconfigurator or set \
-                         num_gpu_blocks explicitly"
-                    );
-                }
-                Err(error) => {
-                    return Err(PyException::new_err(format!(
-                        "Failed to estimate AIC KV cache capacity \
-                         (--aic-perf-model was requested): {error}"
-                    )));
-                }
-            }
+            )
+            .map_err(|error| {
+                PyException::new_err(format!(
+                    "Failed to estimate AIC KV cache capacity \
+                     (--aic-perf-model was requested): {error}"
+                ))
+            })?;
+            // AIC returns a per-rank (per-GPU) block count. When replicating
+            // attention-DP into per-rank workers, each worker owns this per-rank
+            // pool (engine-wide capacity stays `per_rank * dp`, now partitioned
+            // per rank as on real hardware). With dp == 1 the per-rank pool is
+            // the engine-wide pool.
+            args.num_gpu_blocks = per_rank_blocks;
         }
         let callback = create_aic_callback(
             py,

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -141,9 +141,9 @@ def _load_aiconfigurator():
             get_database,
             get_supported_databases,
         )
-    except (
-        ImportError
-    ) as exc:  # pragma: no cover - exercised in integration environments
+    except ModuleNotFoundError as exc:
+        if exc.name != "aiconfigurator_core":
+            raise
         raise RuntimeError(
             "aiconfigurator-core is required for AIC perf modeling but is not installed"
         ) from exc

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import importlib
 import logging
 import math
 import os
@@ -27,10 +26,6 @@ DEFAULT_STATIC_STRIDE = 32
 DEFAULT_GPU_MEMORY_UTILIZATION = 0.9
 DEFAULT_MEM_FRACTION_STATIC = 0.88
 DEFAULT_FREE_GPU_MEMORY_FRACTION = 0.9
-
-
-class AicMemoryEstimatorUnavailableError(RuntimeError):
-    """Raised when the optional AIC KV-cache estimator cannot be imported."""
 
 
 def _validate_kv_capacity_backend(backend_name: str) -> None:
@@ -448,34 +443,31 @@ def estimate_num_gpu_blocks(
         memory_fraction_kind = "of_total"
         memory_fraction_value = gpu_memory_utilization
 
-    # Imported lazily: aiconfigurator-core is an optional dependency (the `mocker`
-    # extra), so importing it at module scope would break callers that never run
-    # AIC estimation. Report a typed error so callers can choose their policy:
-    # mocker warns and uses its existing default block count, while direct callers
-    # still receive an actionable error. Mirrors `_load_aiconfigurator`.
+    # Imported lazily because aiconfigurator-core is provided by the optional
+    # `mocker` extra. An AIC-backed call requires that extra and fails fast when
+    # it is absent.
     # TODO: account for whether specdec is enabled (pass `nextn=...`). Currently
     #   omitted due to a downstream AIC bug where `_get_memory_usage` predicts
     #   negative KV capacity with Eagle.
     try:
-        memory = importlib.import_module("aiconfigurator_core.sdk.memory")
-    except ModuleNotFoundError as exc:
-        if exc.name == "aiconfigurator_core.sdk.memory":
-            raise AicMemoryEstimatorUnavailableError(
-                "aiconfigurator_core.sdk.memory is required for AIC KV-cache "
-                "estimation; install a compatible aiconfigurator-core version"
-            ) from exc
-        if exc.name in {"aiconfigurator_core", "aiconfigurator_core.sdk"}:
+        from aiconfigurator_core.sdk.memory import (
+            estimate_num_gpu_blocks as aic_estimate_num_gpu_blocks,
+        )
+    except ImportError as exc:
+        missing = exc.name or ""
+        if missing == "aiconfigurator_core" or missing.startswith(
+            "aiconfigurator_core."
+        ):
             raise RuntimeError(
-                "aiconfigurator-core is required for AIC KV-cache estimation but is not "
-                "installed; install the 'mocker' extra or set num_gpu_blocks "
-                "explicitly (e.g. --num-gpu-blocks-override)"
+                "aiconfigurator-core is required for AIC KV-cache estimation but is "
+                "not installed; install the 'mocker' extra"
             ) from exc
         raise
 
     # AIC's non-KV memory is independent of batch size (activations track
     # max_num_tokens), so the fixed max_batch_size here does not affect the result.
     return int(
-        memory.estimate_num_gpu_blocks(
+        aic_estimate_num_gpu_blocks(
             model_path,
             system,
             backend_name,

--- a/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
+++ b/lib/bindings/python/tests/replay/test_replay_aic_capacity.py
@@ -5,7 +5,6 @@ import json
 
 import pytest
 
-import dynamo._core as _core
 import dynamo._internal.aic as aic_helpers
 import dynamo.replay.main as replay_main
 from dynamo.mocker import MockEngineArgs
@@ -159,40 +158,6 @@ def test_resolve_aic_blocks_keeps_per_rank_capacity_for_attention_dp(monkeypatch
     assert _resolve(8) == (1000, 8)
     assert _resolve(1) == (1000, None)
     assert _resolve(None) == (1000, None)
-
-
-def test_resolve_aic_blocks_falls_back_when_memory_estimator_is_unavailable(
-    monkeypatch, caplog
-):
-    def unavailable(**_kwargs):
-        raise replay_main.AicMemoryEstimatorUnavailableError("estimator unavailable")
-
-    monkeypatch.setattr(replay_main, "estimate_num_gpu_blocks", unavailable)
-    raw = {
-        "aic_backend": "vllm",
-        "aic_model_path": "/models/mock",
-        "aic_tp_size": 1,
-    }
-
-    replay_main._resolve_aic_num_gpu_blocks(raw)
-
-    assert raw["num_gpu_blocks"] == 16384
-    assert "Falling back to default num_gpu_blocks=16384" in caplog.text
-
-
-@pytest.mark.skipif(
-    not hasattr(_core, "RustEnginePerfModel"),
-    reason="bindings built without the aic-forward-pass feature",
-)
-def test_direct_replay_falls_back_when_memory_estimator_is_unavailable(monkeypatch):
-    def unavailable(**_kwargs):
-        raise aic_helpers.AicMemoryEstimatorUnavailableError("estimator unavailable")
-
-    monkeypatch.setattr(aic_helpers, "estimate_num_gpu_blocks", unavailable)
-
-    report = _run_direct_aic_replay()
-
-    assert report["completed_requests"] == 1
 
 
 def test_direct_replay_preserves_other_capacity_errors(monkeypatch):

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -11,7 +11,6 @@ from dynamo._internal.aic import (
     _NEXTN_ACCEPT_RATES_LEN,
     DEFAULT_FREE_GPU_MEMORY_FRACTION,
     DEFAULT_MEM_FRACTION_STATIC,
-    AicMemoryEstimatorUnavailableError,
     _normalize_aic_quant_mode,
     _pad_nextn_accept_rates,
     _resolve_quant_mode,
@@ -197,16 +196,18 @@ def test_estimate_num_gpu_blocks_rejects_unsupported_backend():
 
 
 def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
-    # The low-level helper reports a typed, actionable error so mocker can apply
-    # its fallback without masking unrelated estimator failures.
-    def missing_memory(module_name):
-        raise ModuleNotFoundError(name=module_name)
+    real_import = builtins.__import__
 
-    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
+    def missing_memory(name, *args, **kwargs):
+        if name == "aiconfigurator_core.sdk.memory":
+            raise ModuleNotFoundError(name="aiconfigurator_core")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", missing_memory)
 
     with pytest.raises(
-        AicMemoryEstimatorUnavailableError,
-        match=r"aiconfigurator_core\.sdk\.memory is required",
+        RuntimeError,
+        match=r"aiconfigurator-core.*install the 'mocker' extra",
     ):
         estimate_num_gpu_blocks(
             backend_name="vllm",
@@ -219,14 +220,15 @@ def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
 
 
 def test_estimate_num_gpu_blocks_propagates_transitive_import_error(monkeypatch):
+    real_import = builtins.__import__
     missing_dependency = ModuleNotFoundError(name="transitive_dependency")
 
-    def broken_memory_module(_module_name):
-        raise missing_dependency
+    def broken_memory_module(name, *args, **kwargs):
+        if name == "aiconfigurator_core.sdk.memory":
+            raise missing_dependency
+        return real_import(name, *args, **kwargs)
 
-    monkeypatch.setattr(
-        "dynamo._internal.aic.importlib.import_module", broken_memory_module
-    )
+    monkeypatch.setattr(builtins, "__import__", broken_memory_module)
 
     with pytest.raises(ModuleNotFoundError) as exc_info:
         estimate_num_gpu_blocks(

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -72,6 +72,27 @@ def test_runtime_loader_does_not_import_upper_aiconfigurator(monkeypatch):
     }
 
 
+def test_runtime_loader_propagates_internal_missing_module(monkeypatch):
+    import dynamo._internal.aic as aic_mod
+
+    real_import = builtins.__import__
+    missing_internal = ModuleNotFoundError(
+        name="aiconfigurator_core.sdk.internal_dependency"
+    )
+
+    def broken_core_module(name, *args, **kwargs):
+        if name == "aiconfigurator_core.sdk":
+            raise missing_internal
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", broken_core_module)
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        aic_mod._load_aiconfigurator()
+
+    assert exc_info.value is missing_internal
+
+
 def test_estimate_num_gpu_blocks_maps_vllm_to_total_fraction(monkeypatch):
     calls = _patch_memory(monkeypatch, 45)
 

--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -26,7 +26,7 @@ pub trait DecodeInterpolator: Send + Sync {
 }
 
 /// Callback trait for direct AIC SDK calls.
-/// Implementors call the Python AIC SDK via PyO3 GIL.
+/// Implementors call the Rust AIC core API.
 pub trait AicCallback: Send + Sync {
     /// Predict prefill latency in ms.
     /// Parameters: (batch_size, effective_isl, prefix)
@@ -223,10 +223,15 @@ impl PerfModel {
     /// - Polynomial/Interpolated: uses total new tokens across the batch
     ///   (`batch_size * (isl - prefix)`), modeling GPU processing total tokens in parallel
     /// - Aiconfigurator: passes (batch_size, isl - prefix, prefix) to the AIC SDK
-    pub fn predict_prefill_time(&self, batch_size: usize, isl: usize, prefix: usize) -> f64 {
+    pub fn predict_prefill_time(
+        &self,
+        batch_size: usize,
+        isl: usize,
+        prefix: usize,
+    ) -> Result<f64> {
         let new_tokens_per_req = isl.saturating_sub(prefix);
         if batch_size == 0 || new_tokens_per_req == 0 {
-            return 0.0;
+            return Ok(0.0);
         }
         let time = match self {
             PerfModel::Polynomial => polynomial_prefill_time(batch_size, new_tokens_per_req),
@@ -236,9 +241,9 @@ impl PerfModel {
             }
             PerfModel::Aiconfigurator { callback } => callback
                 .predict_prefill(batch_size, new_tokens_per_req, prefix)
-                .unwrap_or_else(|error| panic!("AIC prefill prediction failed: {error}")),
+                .context("AIC prefill prediction failed")?,
         };
-        time.max(0.0)
+        Ok(time.max(0.0))
     }
 
     /// Predict decode time in milliseconds.
@@ -253,9 +258,9 @@ impl PerfModel {
         active_kv_tokens: usize,
         context_length: usize,
         total_kv_tokens: usize,
-    ) -> f64 {
+    ) -> Result<f64> {
         if batch_size == 0 {
-            return 0.0;
+            return Ok(0.0);
         }
         let time = match self {
             PerfModel::Polynomial => polynomial_decode_time(active_kv_tokens, total_kv_tokens),
@@ -264,14 +269,14 @@ impl PerfModel {
                 .unwrap_or(0.0),
             PerfModel::Aiconfigurator { callback } => callback
                 .predict_decode(batch_size, context_length, 2)
-                .unwrap_or_else(|error| panic!("AIC decode prediction failed: {error}")),
+                .context("AIC decode prediction failed")?,
         };
         // Token-emitting decode steps should not collapse onto the same timestamp.
         let result = time.max(1.0);
         tracing::trace!(
             "Decode time prediction: batch_size={batch_size}, active_kv_tokens={active_kv_tokens}, context_length={context_length}, time={result:.2}ms"
         );
-        result
+        Ok(result)
     }
 }
 
@@ -342,20 +347,39 @@ mod tests {
 
     #[test]
     fn fully_cached_prompt_skips_prefill() {
-        assert_eq!(PerfModel::default().predict_prefill_time(1, 128, 128), 0.0);
+        assert_eq!(
+            PerfModel::default()
+                .predict_prefill_time(1, 128, 128)
+                .unwrap(),
+            0.0
+        );
     }
 
     #[test]
     fn aic_forwards_scheduler_local_batch() {
         let model = PerfModel::from_aic_callback(Arc::new(EchoBatchCallback));
 
-        assert_eq!(model.predict_prefill_time(7, 128, 0), 7.0);
-        assert_eq!(model.predict_decode_time(9, 0, 128, 0), 9.0);
+        assert_eq!(model.predict_prefill_time(7, 128, 0).unwrap(), 7.0);
+        assert_eq!(model.predict_decode_time(9, 0, 128, 0).unwrap(), 9.0);
     }
 
     #[test]
-    #[should_panic(expected = "AIC prefill prediction failed")]
-    fn aic_prediction_errors_fail_fast() {
-        PerfModel::from_aic_callback(Arc::new(FailingCallback)).predict_prefill_time(2, 128, 32);
+    fn aic_prefill_prediction_errors_propagate() {
+        let error = PerfModel::from_aic_callback(Arc::new(FailingCallback))
+            .predict_prefill_time(2, 128, 32)
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "AIC prefill prediction failed");
+        assert_eq!(error.root_cause().to_string(), "missing AIC prefill point");
+    }
+
+    #[test]
+    fn aic_decode_prediction_errors_propagate() {
+        let error = PerfModel::from_aic_callback(Arc::new(FailingCallback))
+            .predict_decode_time(2, 64, 128, 1024)
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "AIC decode prediction failed");
+        assert_eq!(error.root_cause().to_string(), "missing AIC decode point");
     }
 }

--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -14,7 +14,6 @@ use ndarray_interp::interp1d::{Interp1DBuilder, Linear};
 use ndarray_interp::interp2d::{Bilinear, Interp2DBuilder};
 use std::path::Path;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Trait to abstract over 1D interpolation for prefill timing
 pub trait PrefillInterpolator: Send + Sync {
@@ -88,12 +87,9 @@ pub enum PerfModel {
         prefill_interp: Arc<dyn PrefillInterpolator>,
         decode_interp: Arc<dyn DecodeInterpolator>,
     },
-    /// AI Configurator SDK calls via Python callback.
+    /// AI Configurator SDK calls through the configured callback.
     /// Passes the reduced prefill inputs (batch_size, effective_isl, prefix).
-    Aiconfigurator {
-        callback: Arc<dyn AicCallback>,
-        fallback_warned: Arc<AtomicBool>,
-    },
+    Aiconfigurator { callback: Arc<dyn AicCallback> },
 }
 
 impl Clone for PerfModel {
@@ -107,12 +103,8 @@ impl Clone for PerfModel {
                 prefill_interp: Arc::clone(prefill_interp),
                 decode_interp: Arc::clone(decode_interp),
             },
-            PerfModel::Aiconfigurator {
-                callback,
-                fallback_warned,
-            } => PerfModel::Aiconfigurator {
+            PerfModel::Aiconfigurator { callback } => PerfModel::Aiconfigurator {
                 callback: Arc::clone(callback),
-                fallback_warned: Arc::clone(fallback_warned),
             },
         }
     }
@@ -222,10 +214,7 @@ impl PerfModel {
 
     /// Create an Aiconfigurator perf model from a callback.
     pub fn from_aic_callback(callback: Arc<dyn AicCallback>) -> Self {
-        PerfModel::Aiconfigurator {
-            callback,
-            fallback_warned: Arc::new(AtomicBool::new(false)),
-        }
+        PerfModel::Aiconfigurator { callback }
     }
 
     /// Predict prefill time in milliseconds.
@@ -245,15 +234,9 @@ impl PerfModel {
                 let tokens = (batch_size * new_tokens_per_req) as f64;
                 prefill_interp.interp(tokens).unwrap_or(0.0)
             }
-            PerfModel::Aiconfigurator {
-                callback,
-                fallback_warned,
-            } => callback
+            PerfModel::Aiconfigurator { callback } => callback
                 .predict_prefill(batch_size, new_tokens_per_req, prefix)
-                .unwrap_or_else(|error| {
-                    warn_aic_fallback(fallback_warned, "prefill", &error);
-                    polynomial_prefill_time(batch_size, new_tokens_per_req)
-                }),
+                .unwrap_or_else(|error| panic!("AIC prefill prediction failed: {error}")),
         };
         time.max(0.0)
     }
@@ -279,15 +262,9 @@ impl PerfModel {
             PerfModel::Interpolated { decode_interp, .. } => decode_interp
                 .interp(active_kv_tokens as f64, context_length as f64)
                 .unwrap_or(0.0),
-            PerfModel::Aiconfigurator {
-                callback,
-                fallback_warned,
-            } => callback
+            PerfModel::Aiconfigurator { callback } => callback
                 .predict_decode(batch_size, context_length, 2)
-                .unwrap_or_else(|error| {
-                    warn_aic_fallback(fallback_warned, "decode", &error);
-                    polynomial_decode_time(active_kv_tokens, total_kv_tokens)
-                }),
+                .unwrap_or_else(|error| panic!("AIC decode prediction failed: {error}")),
         };
         // Token-emitting decode steps should not collapse onto the same timestamp.
         let result = time.max(1.0);
@@ -312,16 +289,6 @@ fn polynomial_decode_time(active_kv_tokens: usize, total_kv_tokens: usize) -> f6
         1.0
     };
     -25.74 * active_perc.powi(2) + 54.01 * active_perc + 5.74
-}
-
-fn warn_aic_fallback(warned: &AtomicBool, phase: &str, error: &anyhow::Error) {
-    if !warned.swap(true, Ordering::Relaxed) {
-        tracing::warn!(
-            phase,
-            error = %error,
-            "AIC timing prediction failed; falling back to the mocker polynomial model"
-        );
-    }
 }
 
 #[cfg(test)]
@@ -387,17 +354,8 @@ mod tests {
     }
 
     #[test]
-    fn aic_prediction_error_falls_back_without_panicking() {
-        let model = PerfModel::from_aic_callback(Arc::new(FailingCallback));
-        let polynomial = PerfModel::default();
-
-        assert_eq!(
-            model.predict_prefill_time(2, 128, 32),
-            polynomial.predict_prefill_time(2, 128, 32)
-        );
-        assert_eq!(
-            model.predict_decode_time(2, 64, 128, 256),
-            polynomial.predict_decode_time(2, 64, 128, 256)
-        );
+    #[should_panic(expected = "AIC prefill prediction failed")]
+    fn aic_prediction_errors_fail_fast() {
+        PerfModel::from_aic_callback(Arc::new(FailingCallback)).predict_prefill_time(2, 128, 32);
     }
 }

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -326,7 +326,7 @@ impl PrefillCost {
         &self,
         new_tokens: Option<usize>,
         perf_model: &PerfModel,
-    ) -> f64 {
+    ) -> anyhow::Result<f64> {
         let tokens = new_tokens.unwrap_or(self.new_tokens);
         let isl = self.cached_tokens + tokens;
         perf_model.predict_prefill_time(1, isl, self.cached_tokens)

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -550,11 +550,11 @@ where
                             bail!("offline replay visible engine pass requires a collector");
                         };
                         Self::required_worker_mut(&mut self.workers, rank_id)
-                            .execute_pass(collector, now_ms)
+                            .try_execute_pass(collector, now_ms)
                     }
                     EnginePassMode::Hidden => Self::required_worker_mut(&mut self.workers, rank_id)
-                        .execute_hidden_pass(now_ms),
-                };
+                        .try_execute_hidden_pass(now_ms),
+                }?;
                 executed_by_rank.push(Some(executed));
             }
 

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -69,7 +69,7 @@ impl ReplayWorkerCore {
         &mut self,
         collector: &mut TraceCollector,
         now_ms: f64,
-    ) -> EnginePassResult {
-        self.core.execute_pass(collector, now_ms)
+    ) -> anyhow::Result<EnginePassResult> {
+        self.core.try_execute_pass(collector, now_ms)
     }
 }

--- a/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
@@ -174,7 +174,7 @@ pub(in crate::replay) fn generate_trace_worker_artifacts_with_visibility(
         }
 
         let pass_start_ms = current_time_ms;
-        let pass = worker.execute_pass(&mut collector, current_time_ms);
+        let pass = worker.execute_pass(&mut collector, current_time_ms)?;
         current_time_ms = pass.end_ms;
 
         let router_event_visibility =

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -212,7 +212,7 @@ impl SingleRuntime {
         let requests_before = self.worker.num_requests();
         let pass = self
             .worker
-            .execute_pass(&mut self.collector, self.current_time_ms);
+            .execute_pass(&mut self.collector, self.current_time_ms)?;
         self.current_time_ms = pass.end_ms;
         let made_progress = self.current_time_ms > pass_start_ms
             || self.worker.num_requests() < requests_before
@@ -545,7 +545,9 @@ mod tests {
                 continue;
             }
 
-            let pass = worker.execute_pass(&mut collector, current_time_ms);
+            let pass = worker
+                .execute_pass(&mut collector, current_time_ms)
+                .unwrap();
             record_manual_terminals(&mut collector, &pass);
             if first_decode_end_ms == 0.0 && !pass.output_signals.is_empty() {
                 first_decode_end_ms = pass.end_ms;
@@ -599,7 +601,9 @@ mod tests {
                 break;
             }
 
-            let pass = worker.execute_pass(&mut collector, current_time_ms);
+            let pass = worker
+                .execute_pass(&mut collector, current_time_ms)
+                .unwrap();
             record_manual_terminals(&mut collector, &pass);
             current_time_ms = pass.end_ms;
         }

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -432,16 +432,25 @@ impl OfflineWorkerState {
             .expect("offline worker completed more requests than it owned");
     }
 
-    pub(crate) fn execute_pass(
+    pub(crate) fn try_execute_pass(
         &mut self,
         collector: &mut TraceCollector,
         now_ms: f64,
-    ) -> EnginePassResult {
-        self.core.execute_pass(collector, now_ms)
+    ) -> anyhow::Result<EnginePassResult> {
+        self.core.try_execute_pass(collector, now_ms)
     }
 
+    #[cfg(test)]
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
-        self.core.execute_hidden_pass(now_ms)
+        self.try_execute_hidden_pass(now_ms)
+            .expect("offline worker hidden scheduler pass failed")
+    }
+
+    pub(crate) fn try_execute_hidden_pass(
+        &mut self,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
+        self.core.try_execute_hidden_pass(now_ms)
     }
 
     #[cfg(feature = "kvbm-offload")]

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -63,7 +63,8 @@ pub(crate) trait LiveBoundaryCore {
         None
     }
 
-    fn execute_live_pass(&mut self, scheduler_start: &Instant) -> LivePassExecution;
+    fn execute_live_pass(&mut self, scheduler_start: &Instant)
+    -> anyhow::Result<LivePassExecution>;
 
     fn output_delivery_failed(&mut self, _signals: Vec<OutputSignal>) {}
 
@@ -231,7 +232,7 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
 
         let iteration_start = Instant::now();
         let metrics_before = core.live_metrics();
-        let execution = core.execute_live_pass(&scheduler_start);
+        let execution = core.execute_live_pass(&scheduler_start)?;
         let mut pending = publisher.capture_pass(execution.pass);
         let zero_progress =
             execution.duration.is_zero() && !pending.made_progress_since(&metrics_before);

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -42,7 +42,10 @@ impl LiveBoundaryCore for FakeCore {
 
     fn receive_live_request(&mut self, _request: DirectRequest) {}
 
-    fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
+    fn execute_live_pass(
+        &mut self,
+        _scheduler_start: &Instant,
+    ) -> anyhow::Result<LivePassExecution> {
         let live_pass_limit = self
             .live_pass_limit
             .as_ref()
@@ -56,10 +59,10 @@ impl LiveBoundaryCore for FakeCore {
         pass.admissions.clear();
         pass.lifecycle_events.clear();
         pass.fpm = None;
-        LivePassExecution {
+        Ok(LivePassExecution {
             pass,
             duration: Duration::ZERO,
-        }
+        })
     }
 
     fn apply_live_command(

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -286,21 +286,30 @@ impl EngineCore {
         }
     }
 
-    pub(crate) fn execute_pass(
+    pub(crate) fn try_execute_pass(
         &mut self,
         collector: &mut crate::replay::TraceCollector,
         now_ms: f64,
-    ) -> EnginePassResult {
+    ) -> anyhow::Result<EnginePassResult> {
         match self {
-            Self::Vllm(core) => core.execute_pass(collector, now_ms),
-            Self::Sglang(core) => core.execute_pass(collector, now_ms),
+            Self::Vllm(core) => core.try_execute_pass(collector, now_ms),
+            Self::Sglang(core) => core.try_execute_pass(collector, now_ms),
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
+        self.try_execute_hidden_pass(now_ms)
+            .expect("engine hidden scheduler pass failed")
+    }
+
+    pub(crate) fn try_execute_hidden_pass(
+        &mut self,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
         match self {
-            Self::Vllm(core) => core.execute_hidden_pass(now_ms),
-            Self::Sglang(core) => core.execute_hidden_pass(now_ms),
+            Self::Vllm(core) => core.try_execute_hidden_pass(now_ms),
+            Self::Sglang(core) => core.try_execute_hidden_pass(now_ms),
         }
     }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -559,23 +559,52 @@ impl SglangCore {
             .unwrap_or_default()
     }
 
+    #[cfg(test)]
     pub(crate) fn execute_pass(
         &mut self,
         collector: &mut TraceCollector,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.execute_pass_internal(Some(collector), now_ms)
+        self.try_execute_pass(collector, now_ms)
+            .expect("SGLang scheduler pass failed")
     }
 
+    pub(crate) fn try_execute_pass(
+        &mut self,
+        collector: &mut TraceCollector,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
+        self.try_execute_pass_internal(Some(collector), now_ms)
+    }
+
+    #[cfg(test)]
     pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
-        self.execute_pass_internal(None, now_ms)
+        self.try_execute_hidden_pass(now_ms)
+            .expect("SGLang hidden scheduler pass failed")
     }
 
+    pub(crate) fn try_execute_hidden_pass(
+        &mut self,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
+        self.try_execute_pass_internal(None, now_ms)
+    }
+
+    #[cfg(test)]
     pub(super) fn execute_pass_internal(
+        &mut self,
+        collector: Option<&mut TraceCollector>,
+        now_ms: f64,
+    ) -> EnginePassResult {
+        self.try_execute_pass_internal(collector, now_ms)
+            .expect("SGLang scheduler pass failed")
+    }
+
+    pub(super) fn try_execute_pass_internal(
         &mut self,
         mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
-    ) -> EnginePassResult {
+    ) -> anyhow::Result<EnginePassResult> {
         let mut admissions = self.promote_prebuilt_ready();
         let materialized_waiting = !self.prebuilt_ready.is_empty();
         apply_schedule_policy(&mut self.waiting, &self.kv_manager, &self.config);
@@ -612,7 +641,7 @@ impl SglangCore {
         let mean_isl = admit.total_isl.checked_div(batch_size).unwrap_or(0);
         let mean_prefix = admit.total_prefix.checked_div(batch_size).unwrap_or(0);
         let prefill_time =
-            simulate_prefill_duration(batch_size, mean_isl, mean_prefix, &self.config, true);
+            simulate_prefill_duration(batch_size, mean_isl, mean_prefix, &self.config, true)?;
 
         for mut req in admit.can_run {
             if req.materialized_tokens < req.current_sequence_len() {
@@ -639,7 +668,7 @@ impl SglangCore {
             self.speculative_sampler.as_mut(),
             decode_start_ms,
             true,
-        );
+        )?;
 
         for request in decode.completed_requests.drain(..) {
             self.complete_source(request);
@@ -727,7 +756,7 @@ impl SglangCore {
         let (accept_length_output_tokens, accept_length_decode_forwards) =
             accept_length_sample(&decode.output_signals);
         debug_assert_sglang_scheduler_state(&self.waiting, &self.running, self.config.block_size);
-        EnginePassResult {
+        Ok(EnginePassResult {
             end_ms: decode.end_ms,
             completed_requests: decode
                 .output_signals
@@ -748,7 +777,7 @@ impl SglangCore {
             fpm: Some(fpm),
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        }
+        })
     }
 
     fn active_kv_blocks(&self) -> u64 {
@@ -779,21 +808,23 @@ fn simulate_prefill_duration(
     mean_prefix: usize,
     config: &SglangConfig,
     apply_speedup: bool,
-) -> Duration {
+) -> anyhow::Result<Duration> {
     if batch_size == 0 || config.worker_type == WorkerType::Decode {
-        return Duration::ZERO;
+        return Ok(Duration::ZERO);
     }
 
     let prefill_time = config
         .perf_model
-        .predict_prefill_time(batch_size, mean_isl, mean_prefix);
+        .predict_prefill_time(batch_size, mean_isl, mean_prefix)?;
     let total_time = Duration::from_secs_f64(prefill_time / 1000.0);
 
     if !apply_speedup || config.speedup_ratio <= 0.0 || total_time <= Duration::ZERO {
-        return total_time;
+        return Ok(total_time);
     }
 
-    Duration::from_secs_f64(total_time.as_secs_f64() / config.speedup_ratio)
+    Ok(Duration::from_secs_f64(
+        total_time.as_secs_f64() / config.speedup_ratio,
+    ))
 }
 
 fn debug_assert_sglang_scheduler_state(

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -148,7 +148,8 @@ pub(super) fn simulate_decode_step(
         None,
         current_time_ms,
         apply_speedup,
-    );
+    )
+    .expect("SGLang decode simulation failed");
     for mut request in result.completed_requests.drain(..) {
         cleanup_completed_request(&mut request, kv_manager, config.block_size);
     }
@@ -175,12 +176,12 @@ pub(super) fn simulate_decode_step_with_sampler(
     mut sampler: Option<&mut SpeculativeDecodeSampler>,
     current_time_ms: f64,
     apply_speedup: bool,
-) -> DecodeResult {
+) -> anyhow::Result<DecodeResult> {
     if running.is_empty() {
-        return DecodeResult {
+        return Ok(DecodeResult {
             end_ms: current_time_ms,
             ..DecodeResult::default()
-        };
+        });
     }
 
     // Terminal requests have no decode work and otherwise remain in `running` forever.
@@ -216,12 +217,12 @@ pub(super) fn simulate_decode_step_with_sampler(
     completed_requests.reverse();
 
     if running.is_empty() {
-        return DecodeResult {
+        return Ok(DecodeResult {
             completed_requests,
             output_signals,
             end_ms: current_time_ms,
             ..DecodeResult::default()
-        };
+        });
     }
 
     let max_burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
@@ -232,13 +233,13 @@ pub(super) fn simulate_decode_step_with_sampler(
     let retracted = check_decode_mem_for_burst(running, kv_manager, config, max_burst);
     let retracted_any = !retracted.is_empty();
     if running.is_empty() {
-        return DecodeResult {
+        return Ok(DecodeResult {
             completed_requests,
             output_signals,
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
-        };
+        });
     }
 
     let total_context: usize = running
@@ -252,7 +253,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         active_kv_tokens,
         avg_context,
         config.total_kv_tokens,
-    );
+    )?;
     let unscaled_time = Duration::from_secs_f64(decode_time / 1000.0);
     let effective_ratio = config.speedup_ratio * config.decode_speedup_ratio;
     let total_time = if apply_speedup && effective_ratio > 0.0 && unscaled_time > Duration::ZERO {
@@ -268,13 +269,13 @@ pub(super) fn simulate_decode_step_with_sampler(
             reserved_pages,
             "Failed to reserve speculative decode pages after capacity preflight"
         );
-        return DecodeResult {
+        return Ok(DecodeResult {
             completed_requests,
             output_signals,
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
-        };
+        });
     };
 
     output_signals.reserve(running.len());
@@ -334,11 +335,11 @@ pub(super) fn simulate_decode_step_with_sampler(
     newly_completed_requests.reverse();
     completed_requests.extend(newly_completed_requests);
 
-    DecodeResult {
+    Ok(DecodeResult {
         requests: retracted,
         completed_requests,
         output_signals,
         retracted_any,
         end_ms: current_time_ms + total_time.as_secs_f64() * 1000.0,
-    }
+    })
 }

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -144,9 +144,12 @@ impl LiveBoundaryCore for SglangCore {
         pass_metrics
     }
 
-    fn execute_live_pass(&mut self, _scheduler_start: &Instant) -> LivePassExecution {
-        let pass = self.execute_pass_internal(None, 0.0);
+    fn execute_live_pass(
+        &mut self,
+        _scheduler_start: &Instant,
+    ) -> anyhow::Result<LivePassExecution> {
+        let pass = self.try_execute_pass_internal(None, 0.0)?;
         let duration = std::time::Duration::from_secs_f64(pass.end_ms / 1000.0);
-        LivePassExecution { pass, duration }
+        Ok(LivePassExecution { pass, duration })
     }
 }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -153,7 +153,8 @@ fn zero_output_completion_survives_decode_reservation_failure() {
         None,
         0.0,
         false,
-    );
+    )
+    .unwrap();
 
     assert_eq!(running.len(), 1);
     assert_eq!(running[0].uuid, normal_uuid);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1059,15 +1059,28 @@ impl VllmCore {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn execute_pass(
         &mut self,
         collector: &mut TraceCollector,
         now_ms: f64,
     ) -> EnginePassResult {
+        self.try_execute_pass(collector, now_ms)
+            .expect("vLLM scheduler pass failed")
+    }
+
+    pub(crate) fn try_execute_pass(
+        &mut self,
+        collector: &mut TraceCollector,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
         self.execute_pass_internal(Some(collector), now_ms, None)
     }
 
-    pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
+    pub(crate) fn try_execute_hidden_pass(
+        &mut self,
+        now_ms: f64,
+    ) -> anyhow::Result<EnginePassResult> {
         self.execute_pass_internal(None, now_ms, None)
     }
 
@@ -1341,7 +1354,7 @@ impl VllmCore {
         mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
         admission_tx: Option<&mpsc::UnboundedSender<AdmissionEvent>>,
-    ) -> EnginePassResult {
+    ) -> anyhow::Result<EnginePassResult> {
         let requests_before = self.state.requests.len();
         #[cfg(feature = "kvbm-offload")]
         self.tick_and_promote_swap_ins(now_ms);
@@ -1531,9 +1544,10 @@ impl VllmCore {
         }
 
         let prefill_time =
-            predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args);
+            predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args)?;
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let (decode_time, mut output_signals) = self.emit_ready_tokens(collector, decode_start_ms);
+        let (decode_time, mut output_signals) =
+            self.emit_ready_tokens(collector, decode_start_ms)?;
         // Emit the terminal signals for the requests the gate rejected above
         // (see the gate comment for why this can't be done inline).
         for uuid in rejected_uuids {
@@ -1567,7 +1581,7 @@ impl VllmCore {
         let (accept_length_output_tokens, accept_length_decode_forwards) =
             accept_length_sample(&output_signals);
         self.state.debug_assert_invariants();
-        EnginePassResult {
+        Ok(EnginePassResult {
             end_ms,
             completed_requests: requests_before.saturating_sub(self.state.requests.len()),
             output_signals,
@@ -1583,7 +1597,7 @@ impl VllmCore {
             fpm: Some(fpm),
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        }
+        })
     }
 
     pub(super) fn drop_request(&mut self, uuid: Uuid) {
@@ -1985,7 +1999,7 @@ impl VllmCore {
         &mut self,
         mut collector: Option<&mut TraceCollector>,
         decode_start_ms: f64,
-    ) -> (Duration, Vec<OutputSignal>) {
+    ) -> anyhow::Result<(Duration, Vec<OutputSignal>)> {
         let mut ready = Vec::with_capacity(self.state.running.len());
         let mut already_complete = Vec::new();
         let mut total_length = 0usize;
@@ -2031,7 +2045,7 @@ impl VllmCore {
             if !output_signals.is_empty() {
                 self.state.compact_running();
             }
-            return (Duration::ZERO, output_signals);
+            return Ok((Duration::ZERO, output_signals));
         }
 
         if self.speculative_sampler.is_some() {
@@ -2041,9 +2055,9 @@ impl VllmCore {
 
             self.state.compact_running();
             let (decode_time, mut speculative_signals) =
-                self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
+                self.emit_speculative_ready_tokens(ready, collector, decode_start_ms)?;
             output_signals.append(&mut speculative_signals);
-            return (decode_time, output_signals);
+            return Ok((decode_time, output_signals));
         }
 
         // For prefill workers, the first decode token is produced as part of
@@ -2059,7 +2073,7 @@ impl VllmCore {
                 active_kv_tokens,
                 context_length,
                 total_kv_tokens,
-            );
+            )?;
             let dt = scale_decode_time(decode_ms, &self.args);
             (dt, decode_start_ms + dt.as_secs_f64() * 1000.0)
         };
@@ -2189,13 +2203,13 @@ impl VllmCore {
             if running_changed {
                 self.state.compact_running();
             }
-            return (Duration::ZERO, output_signals);
+            return Ok((Duration::ZERO, output_signals));
         }
 
         if running_changed {
             self.state.compact_running();
         }
-        (decode_time, output_signals)
+        Ok((decode_time, output_signals))
     }
 
     fn emit_speculative_ready_tokens(
@@ -2203,7 +2217,7 @@ impl VllmCore {
         mut ready: Vec<Uuid>,
         collector: Option<&mut TraceCollector>,
         decode_start_ms: f64,
-    ) -> (Duration, Vec<OutputSignal>) {
+    ) -> anyhow::Result<(Duration, Vec<OutputSignal>)> {
         let max_burst = if self.args.worker_type == WorkerType::Prefill {
             1
         } else {
@@ -2214,7 +2228,7 @@ impl VllmCore {
         };
         for uuid in ready.iter().copied() {
             if self.refresh_request_offload_dependency(uuid).is_some() {
-                return (Duration::ZERO, Vec::new());
+                return Ok((Duration::ZERO, Vec::new()));
             }
         }
         let mut running_changed = false;
@@ -2253,7 +2267,7 @@ impl VllmCore {
                             .expect("speculative dependency request must remain active");
                         request.offload_dependency = dependency;
                     }
-                    return (Duration::ZERO, Vec::new());
+                    return Ok((Duration::ZERO, Vec::new()));
                 }
                 G1Acquire::RetryNow { .. } => {
                     panic!("speculative reservation must consume bounded RetryNow internally")
@@ -2265,7 +2279,7 @@ impl VllmCore {
                 if running_changed {
                     self.state.compact_running();
                 }
-                return (Duration::ZERO, Vec::new());
+                return Ok((Duration::ZERO, Vec::new()));
             };
             running_changed = true;
             for signal in preempted.signals {
@@ -2292,7 +2306,7 @@ impl VllmCore {
             }
             if ready.is_empty() {
                 self.state.compact_running();
-                return (Duration::ZERO, Vec::new());
+                return Ok((Duration::ZERO, Vec::new()));
             }
         };
 
@@ -2316,7 +2330,7 @@ impl VllmCore {
                 active_kv_tokens,
                 context_length,
                 total_kv_tokens,
-            );
+            )?;
             let duration = scale_decode_time(decode_ms, &self.args);
             (duration, decode_start_ms + duration.as_secs_f64() * 1000.0)
         };
@@ -2449,7 +2463,7 @@ impl VllmCore {
         if running_changed {
             self.state.compact_running();
         }
-        (decode_time, output_signals)
+        Ok((decode_time, output_signals))
     }
 }
 
@@ -2458,21 +2472,23 @@ fn predict_prefill_duration(
     batch_total_isl: usize,
     batch_total_prefix: usize,
     args: &MockEngineArgs,
-) -> Duration {
+) -> anyhow::Result<Duration> {
     if batch_count == 0 || args.worker_type == WorkerType::Decode {
-        return Duration::ZERO;
+        return Ok(Duration::ZERO);
     }
 
     let mean_isl = batch_total_isl / batch_count;
     let mean_prefix = batch_total_prefix / batch_count;
     let prefill_ms = args
         .perf_model
-        .predict_prefill_time(batch_count, mean_isl, mean_prefix);
+        .predict_prefill_time(batch_count, mean_isl, mean_prefix)?;
     let total_time = Duration::from_secs_f64(prefill_ms / 1000.0);
     if args.speedup_ratio <= 0.0 || total_time <= Duration::ZERO {
-        return total_time;
+        return Ok(total_time);
     }
-    Duration::from_secs_f64(total_time.as_secs_f64() / args.speedup_ratio)
+    Ok(Duration::from_secs_f64(
+        total_time.as_secs_f64() / args.speedup_ratio,
+    ))
 }
 
 fn scale_decode_time(decode_ms: f64, args: &MockEngineArgs) -> Duration {

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -215,13 +215,16 @@ impl LiveBoundaryCore for VllmCore {
         }
     }
 
-    fn execute_live_pass(&mut self, scheduler_start: &Instant) -> LivePassExecution {
+    fn execute_live_pass(
+        &mut self,
+        scheduler_start: &Instant,
+    ) -> anyhow::Result<LivePassExecution> {
         // Wall-clock elapsed time drives the PS bandwidth models across
         // vLLM passes; SGLang reports a duration directly from each pass.
         let now_ms = scheduler_start.elapsed().as_secs_f64() * 1000.0;
-        let pass = self.execute_pass_internal(None, now_ms, None);
+        let pass = self.execute_pass_internal(None, now_ms, None)?;
         let duration = std::time::Duration::from_secs_f64((pass.end_ms - now_ms).max(0.0) / 1000.0);
-        LivePassExecution { pass, duration }
+        Ok(LivePassExecution { pass, duration })
     }
 
     fn output_delivery_failed(&mut self, signals: Vec<OutputSignal>) {

--- a/tests/dependencies/test_aiconfigurator_consistency.py
+++ b/tests/dependencies/test_aiconfigurator_consistency.py
@@ -125,7 +125,7 @@ def test_all_aiconfigurator_dependencies_use_one_release() -> None:
     )
 
     assert set(root_requirements) == {"aiconfigurator-core"}
-    assert set(aisimulate_requirements) == {"aiconfigurator"}
+    assert set(aisimulate_requirements) == AIC_PACKAGES
     assert set(benchmark_requirements) == {"aiconfigurator-core"}
     assert set(planner_requirements) == AIC_PACKAGES
 
@@ -147,6 +147,10 @@ def test_all_aiconfigurator_dependencies_use_one_release() -> None:
         "AI Simulate upper": _python_exact_version(
             aisimulate_requirements["aiconfigurator"],
             package="aiconfigurator",
+        ),
+        "AI Simulate core": _python_exact_version(
+            aisimulate_requirements["aiconfigurator-core"],
+            package="aiconfigurator-core",
         ),
         "benchmarks core": _python_exact_version(
             benchmark_requirements["aiconfigurator-core"],


### PR DESCRIPTION
## Summary

- consume the AIC 0.11 core estimator, system, and model APIs directly in AI Simulate and Dynamo capacity estimation
- remove the AIC 0.9 Python callback, replay-signature probing, default-capacity, and polynomial timing fallbacks; AIC errors now fail fast instead of silently changing behavior
- enable the Spica Vizier, planner, replay, and KVBM integration coverage that was skipped or gated for older AIC/runtime combinations

This is stacked on #11986 and targets its `agent/update-aic-nextn-accepted` branch. It was rebased onto the branch after the switch to the published `0.11.0.dev20260728` AIC artifacts.

## Validation

- `PYTHONPATH=components/src:lib/bindings/python/src .venv/bin/pytest -q aisimulate/tests/spica` — 248 passed
- `PYTHONPATH=components/src:lib/bindings/python/src .venv/bin/pytest -q --noconftest lib/bindings/python/tests/test_aic_capacity.py components/src/dynamo/mocker/tests/unit/test_config.py lib/bindings/python/tests/replay/test_replay_aic_capacity.py` — 83 passed
- `cargo test --locked -p dynamo-mocker --features aic-forward-pass common::perf_model::tests -- --nocapture` — 3 passed
- `cargo clippy --locked --no-deps -p dynamo-mocker --features aic-forward-pass --all-targets -- -D warnings`
- `cargo clippy --locked --no-deps --features aic-forward-pass,mocker-kvbm-offload --all-targets -- -D warnings` (`lib/bindings/python`)
- `cargo fmt --all -- --check`
- changed-files pre-commit hooks
