### PR TITLE
fix(recipes): publish vLLM KV events in gpt-oss-120b agg recipes

### DIFF
--- a/recipes/gpt-oss-120b/perf/README.md
+++ b/recipes/gpt-oss-120b/perf/README.md
@@ -58,6 +58,18 @@ This is the default `TRACE_FILE` in `perf.yaml`. The full trace and 30% subset (
 > The rejected set is identical on every run, so comparisons across configs and concurrencies remain valid — just expect
 > the error count in the aiperf export to be non-zero.
 
+> **Note:** The vLLM deploy YAMLs enable the harmony reasoning parser (`--dyn-reasoning-parser gpt_oss`), which
+> routes generated tokens into `reasoning_content` until the model emits the harmony `final`-channel marker. A request
+> whose `output_length` runs out before that transition returns an empty `content`, and aiperf discards the whole
+> record as `InvalidInferenceResultError` ("No responses with actual content were received from the server").
+> On the agentic trace (median OSL 400) this can void roughly a fifth of all requests. Their decode work still counts
+> toward `benchmark_duration` but is excluded from `total_output_tokens`, so reported throughput is **understated**,
+> and because the transition point shifts with batch composition the undercount is not stable across runs.
+>
+> Check `Processed N valid requests and M errors` in the Job log: if `M` materially exceeds the ~7% context-overflow
+> set above, this is why. To measure raw throughput, drop `--dyn-reasoning-parser` from the worker args so all tokens
+> land in `content` — that changes response shaping only, not the GPU work.
+
 ## KV-cache setup
 
 KV-offload defaults differ by SKU: **B200 agg ships prefix-caching only** (net-neutral there) while **H200 agg ships CPU offload ON** (`--kv-transfer-config=$(KV_TRANSFER_CONFIG)`, +9% at the 50-tps floor, quality-neutral). Details:

--- a/recipes/gpt-oss-120b/perf/perf.yaml
+++ b/recipes/gpt-oss-120b/perf/perf.yaml
@@ -40,6 +40,13 @@ spec:
         image: python:3.12-slim
         imagePullPolicy: IfNotPresent
         workingDir: /workspace
+        # aiperf runs up to --workers-max worker processes plus record processors, all on this pod.
+        # The podAffinity above co-locates it with the DGD frontend, which may be a small or busy
+        # node, so reserve CPU explicitly. Without a reservation the client can be starved by
+        # co-tenants, which appears as connection-probe timeouts during startup and then a hang
+        # after "sending complete" with requests still in flight while the GPUs sit idle.
+        resources:
+          requests: {cpu: "16", memory: "32Gi"}
         command:
         - /bin/bash
         - -c

--- a/recipes/gpt-oss-120b/vllm/agg-b200-agentic/deploy.yaml
+++ b/recipes/gpt-oss-120b/vllm/agg-b200-agentic/deploy.yaml
@@ -67,6 +67,13 @@ spec:
                 - --max-num-batched-tokens=32768
                 - --enable-chunked-prefill
                 - --enable-prefix-caching
+                # Required for KV-aware routing: the Frontend above runs --router-kv-events, but
+                # dynamo.vllm only publishes vLLM KV-cache events when this flag is passed
+                # explicitly (see create_kv_events_config in components/src/dynamo/vllm/args.py).
+                # Without it the worker logs use_kv_events=False, the router scores
+                # overlap_blocks=0 on every request, and --router-mode kv silently degrades to
+                # pure load balancing.
+                - '--kv-events-config={"enable_kv_cache_events":true}'
                 - --async-scheduling
                 - --enable-flashinfer-autotune
                 - --compilation-config=$(COMPILATION_CONFIG)

--- a/recipes/gpt-oss-120b/vllm/agg-h200-agentic/deploy.yaml
+++ b/recipes/gpt-oss-120b/vllm/agg-h200-agentic/deploy.yaml
@@ -68,6 +68,13 @@ spec:
                 - --max-num-batched-tokens=32768
                 - --enable-chunked-prefill
                 - --enable-prefix-caching
+                # Required for KV-aware routing: the Frontend above runs --router-kv-events, but
+                # dynamo.vllm only publishes vLLM KV-cache events when this flag is passed
+                # explicitly (see create_kv_events_config in components/src/dynamo/vllm/args.py).
+                # Without it the worker logs use_kv_events=False, the router scores
+                # overlap_blocks=0 on every request, and --router-mode kv silently degrades to
+                # pure load balancing.
+                - '--kv-events-config={"enable_kv_cache_events":true}'
                 - --async-scheduling
                 - --enable-flashinfer-autotune
                 - --compilation-config=$(COMPILATION_CONFIG)


### PR DESCRIPTION
## Summary

The gpt-oss-120b vLLM **aggregated** recipes start the Frontend with `--router-kv-events`, but the worker never enabled KV-cache event publishing. `dynamo.vllm` only builds a `KVEventsConfig` when `--kv-events-config` is passed explicitly — enabling prefix caching is necessary but not sufficient. `create_kv_events_config` in `components/src/dynamo/vllm/args.py` returns `None` without it, and `main.py` then skips publisher setup entirely.

Observed on the shipped recipe:

- worker: `Using kv_events_config for publishing vLLM kv events over zmq: None (use_kv_events=False)`
- frontend: `router_mode="kv" ... overlap_blocks=0` on **every request**, for the whole run

So `--router-mode kv` was silently degrading to pure load balancing. The ~81% prefix-cache hit rate the recipe does achieve comes from vLLM's *local* prefix cache getting incidental hits, not from the router steering a request to the replica already holding its prefix.

Sibling vLLM recipes already do this correctly — `deepseek-v4-pro`, `llama-3-70b` and `qwen3-0.6b` all pass `--kv-events-config '{"enable_kv_cache_events":true}'`. gpt-oss-120b is the outlier.

Two smaller fixes to the benchmark harness are included:

- **`perf/perf.yaml`**: the aiperf container declared no CPU/memory requests while `podAffinity` co-locates it with the Frontend. On a small or busy node this starves the client — 90s connection-probe timeouts at startup, then a permanent hang after `sending complete` with requests in flight while every GPU sat idle. Now reserves `cpu: 16 / memory: 32Gi`.
- **`perf/README.md`**: documents that the harmony reasoning parser makes aiperf void any record whose output ends before the `final`-channel marker (`InvalidInferenceResultError`). On the agentic trace this can void ~20% of requests; their decode work stays in `benchmark_duration` but leaves `total_output_tokens`, so **reported throughput is understated**, and the undercount shifts with batch composition.

## Validation

Measured on 8xB200, aggregated, with the recipe's own agentic trace (64k/400/90%-KV, 15% subset) at `CONCURRENCY=384`, via `recipes/gpt-oss-120b/perf/perf.yaml`.

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| **output tok/s/GPU** | 2650.1 | **2858.9** | **+7.88%** |
| prefix cache read / ISL | 0.8181 | 0.8449 | +3.27% |
| TTFT p90 | 2651.6 ms | 2005.3 ms | -24.37% |
| TTFT p95 | 4607.7 ms | 4124.0 ms | -10.50% |
| tok/s/user avg | 68.55 | 67.43 | -1.63% (SLO >=50 held) |
| benchmark duration | 331.58 s | 307.36 s | -7.30% |

Both runs served **3266 requests and produced byte-identical `total_output_tokens` (7,029,693)** with the same 275 deterministic context-overflow rejections, so the delta is a pure rate difference rather than a workload or accounting artifact.

Engagement verified before reading any metric:

- worker: `use_kv_events=True`, `KVEventsConfig(enable_kv_cache_events=True, publisher='zmq', endpoint='tcp://*:5557')`
- worker: `KV event publisher for dp_rank=0 subscribing to vLLM at tcp://127.0.0.1:5557`
- router: `overlap_blocks` 0 -> **691** on a repeated prefix (0 on the cold first request), which also confirms the Frontend's `--kv-cache-block-size 64` and the worker's engine-derived event block size agree

Measurement caveats, stated plainly: single run per configuration (AIPerf confidence intervals are degraded and unusable), and the run used a synthetic-acceptance EAGLE3 proxy (`rejection_sample_method: synthetic`, AL=2.72) with the reasoning parser disabled, so absolute numbers are internally comparable rather than directly comparable to the recipe's published table. The +7.88% is ~16x the 0.5% noise floor and corroborated by the identical-work/shorter-duration decomposition.

## Scope / follow-ups

- **agg-b200**: fix measured as above.
- **agg-h200**: same defect, same one-line fix, **not measured on hardware** — identical code path and manifest structure.
- **disagg-b200 / disagg-h200**: these also run `--router-kv-events` without `--kv-events-config`, so they are very likely affected too. Deliberately **not** changed here: I have not tested disaggregated bring-up, and the decode worker takes a different path (`create_kv_events_config` returns `None` for `DisaggregationMode.DECODE` by design). Worth a follow-up from someone who can validate P/D.
- Separately, `--router-kv-overlap-score-credit` documents *"values above 1.0 give device overlap extra credit"*, but the runtime validator rejects anything above `1.0` (`ValueError: overlap_score_credit must be between 0.0 and 1.0`) and crashes the frontend. Since the default is already `1.0`, the help text advertises a capability that does not exist. Not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
