### PR TITLE
docs(runtime): clarify DRT instance lifecycle [DYN-3847]

### DIFF
--- a/lib/runtime/src/distributed.rs
+++ b/lib/runtime/src/distributed.rs
@@ -40,8 +40,15 @@ use tokio_util::sync::CancellationToken;
 type EndpointDiscoverySourceMap = HashMap<Endpoint, Weak<EndpointDiscoverySource>>;
 type RoutingOccupancyMap = HashMap<Endpoint, Weak<RoutingOccupancyState>>;
 
-/// Distributed [Runtime] which provides access to shared resources across the cluster, this includes
-/// communication protocols and transports.
+/// Distributed [Runtime] providing cluster-wide communication, transport, and discovery resources.
+///
+/// `DistributedRuntime` is not a process singleton. Calling [`DistributedRuntime::new`] more than
+/// once creates independent DRT instances with distinct discovery connection IDs, even when they
+/// share a process. Cloning a DRT continues to share the original instance and connection ID.
+///
+/// Production services should normally treat one DRT per service replica/process as a soft
+/// invariant. Multiple DRTs in one process are primarily supported for single-process test
+/// topologies and for the mocker, which models multiple isolated workers in one process.
 #[derive(Clone)]
 pub struct DistributedRuntime {
     // local runtime
@@ -342,6 +349,10 @@ impl DistributedRuntime {
         &self.metadata_artifacts
     }
 
+    /// Returns this DRT instance's discovery identity.
+    ///
+    /// This identifies the DRT, not the operating-system process. Multiple DRTs in one process
+    /// receive distinct connection IDs.
     pub fn connection_id(&self) -> u64 {
         self.discovery_client.instance_id()
     }


### PR DESCRIPTION
## Summary

- document that `DistributedRuntime` is an instance identity, not a process singleton
- state the soft production invariant of one DRT per service replica/process
- explain that multiple in-process DRTs primarily support test topologies and isolated mocker workers
- clarify that `connection_id()` identifies the DRT rather than the operating-system process

## Validation

- `(cd lib/runtime && cargo clippy --no-default-features -- -D warnings)`
- `(cd lib/runtime && cargo fmt)`
- commit-time pre-commit hooks
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12321" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how independent distributed runtime instances and their clones share or receive discovery connection identities.
  * Documented that discovery identities are assigned per runtime instance, not per operating system process.
  * Added guidance on using multiple runtime instances within a process for testing and mock topologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->