### PR TITLE
chore(trtllm): bump NIXL to v1.3.1

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -141,7 +141,7 @@ trtllm:
     runtime_image_tag: 1.3.0rc22
     # Per-arch baseline stem (re-captured against tensorrt-llm/release, both arches).
     baseline_sbom: release@36d6146d
-  nixl_ref: v1.0.1
+  nixl_ref: v1.3.1
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
   enable_kvbm: "true"


### PR DESCRIPTION
## Summary

Bump the trtllm `nixl_ref` from `v1.0.1` to `v1.3.1` (one line in `container/context.yaml`).



## Validation

Built the trtllm runtime image locally with `nixl_ref=v1.3.1`:

- `nixl-sys` compiles from the v1.3.1 source; `nixl` / `nixl-cu13` install at **1.3.1**; NIXL initializes cleanly (`NixlTransferAgent … UCX`, no undefined-symbol/version errors).
- Ran `examples/backends/trtllm/launch/disagg_same_gpu.sh` (Qwen3-0.6B, prefill + decode on one GPU): `/v1/chat/completions` returned `status=success` with **distinct `prefill_worker_id` and `decode_worker_id`** (elapsed 190 ms, ttft 131 ms) — the NIXL 1.3.1 prefill→decode KV handoff works over UCX.

> [!NOTE]
> The local single-host disagg run required working around a **pre-existing, NIXL-independent** rc22 issue: `disagg_machine_id = int(endpoint.connection_id()) % 1021` (`components/src/dynamo/trtllm/workers/llm_worker.py:778`) can exceed TRT-LLM rc22's `NODE_ID_SPACE = 256`, raising `ValueError: node_id must be in range [0, 256)` before the transfer runs. It derives from the runtime connection id (not NIXL), so it is unrelated to this bump. This is already fixed by #12203 (splits the 10-bit `machine_id` into rc22's 8-bit `node_id` + 6-bit `process_id`); once that lands on `main`, disagg works without any workaround.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12322" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the TensorRT-LLM runtime to use NIXL version 1.3.1.
  * Added consistent NIXL version configuration across runtime environments.
* **Bug Fixes**
  * Improved NIXL installation reliability by validating the configured release and ensuring matching package versions are installed.
  * Added installation verification details to help detect runtime version or library loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
