### PR TITLE
fix(mocker): stabilize replay KVBM ordering [DYN-3850]

### DIFF
--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -31,6 +31,8 @@ ckf-diagnostics = ["dynamo-llm/ckf-diagnostics"]
 slot-tracker = ["dep:clap", "dep:tracing-subscriber", "dynamo-kv-router/standalone-slot-tracker"]
 select-service = ["dep:clap", "dep:tracing-subscriber", "dynamo-kv-router/standalone-selection"]
 mocker-kvbm-offload = ["dynamo-mocker/kvbm-offload"]
+# Stable request identities and deterministic replay tie-breaking for parity builds.
+replay-bench = ["dynamo-mocker/replay-bench"]
 aic-forward-pass = ["dynamo-mocker/aic-forward-pass", "dep:aiconfigurator-core"]
 nvtx = ["dynamo-runtime/nvtx"]
 # Enable in-process MM-aware KV routing

--- a/lib/kvbm-engine/src/offload/pipeline.rs
+++ b/lib/kvbm-engine/src/offload/pipeline.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use futures::future::Either;
-use tokio::sync::{Semaphore, mpsc, watch};
+use tokio::sync::{Semaphore, mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
 use crate::leader::InstanceLeader;
@@ -87,6 +87,11 @@ pub struct PipelineConfig<Src: BlockMetadata, Dst: BlockMetadata> {
     /// Setting this higher can improve throughput at the cost of memory.
     /// Default: 1 (sequential execution)
     pub max_concurrent_transfers: usize,
+    /// Whether transfer reservations must start in batch-input order.
+    ///
+    /// This keeps concurrent transfers but removes executor scheduling from
+    /// the order in which a synchronous worker observes their reservations.
+    pub ordered_transfer_starts: bool,
     /// Pending tracker for duplicate prevention.
     ///
     /// If provided, this tracker is used. If None, the pipeline creates its own.
@@ -115,6 +120,7 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> Default for PipelineConfig<Src, Dst
             sweep_interval: Duration::from_millis(10),
             skip_transfers: false,
             max_concurrent_transfers: 1,
+            ordered_transfer_starts: false,
             pending_tracker: None,
             max_concurrent_precondition_awaits: 8,
             _marker: PhantomData,
@@ -195,6 +201,12 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> PipelineBuilder<Src, Dst> {
     /// 1 (sequential execution)
     pub fn max_concurrent_transfers(mut self, n: usize) -> Self {
         self.config.max_concurrent_transfers = n.max(1);
+        self
+    }
+
+    /// Preserve batch-input order for synchronous transfer reservation.
+    pub fn ordered_transfer_starts(mut self, ordered: bool) -> Self {
+        self.config.ordered_transfer_starts = ordered;
         self
     }
 
@@ -372,6 +384,7 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> Pipeline<Src, Dst> {
             dst_layout,
             skip_transfers: config.skip_transfers,
             max_concurrent_transfers: config.max_concurrent_transfers,
+            ordered_transfer_starts: config.ordered_transfer_starts,
             chain_tx,
             settlement: settlement.clone(),
             _src_marker: PhantomData::<Src>,
@@ -1336,6 +1349,8 @@ struct BlockTransferExecutor<Src: BlockMetadata, Dst: BlockMetadata> {
     skip_transfers: bool,
     /// Maximum concurrent transfers
     max_concurrent_transfers: usize,
+    /// Whether synchronous transfer reservations start in batch-input order.
+    ordered_transfer_starts: bool,
     /// Channel to send registered blocks for chaining to downstream pipeline
     chain_tx: Option<mpsc::Sender<ChainOutput<Dst>>>,
     settlement: PipelineSettlementTracker,
@@ -1350,6 +1365,39 @@ struct SharedBlockExecutorState<Dst: BlockMetadata> {
     dst_layout: LogicalLayoutHandle,
     skip_transfers: bool,
     chain_tx: Option<mpsc::Sender<ChainOutput<Dst>>>,
+}
+
+struct OrderedTransferStart {
+    predecessor: Option<oneshot::Receiver<()>>,
+    successor: Option<oneshot::Sender<()>>,
+}
+
+impl OrderedTransferStart {
+    fn next(predecessor: &mut Option<oneshot::Receiver<()>>) -> Self {
+        let (successor, next_predecessor) = oneshot::channel();
+        Self {
+            predecessor: predecessor.replace(next_predecessor),
+            successor: Some(successor),
+        }
+    }
+
+    async fn wait(&mut self) {
+        if let Some(predecessor) = self.predecessor.take() {
+            let _ = predecessor.await;
+        }
+    }
+
+    fn release(&mut self) {
+        if let Some(successor) = self.successor.take() {
+            let _ = successor.send(());
+        }
+    }
+}
+
+impl Drop for OrderedTransferStart {
+    fn drop(&mut self) {
+        self.release();
+    }
 }
 
 impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
@@ -1370,6 +1418,7 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
         });
         let settlement = self.settlement.clone();
         let run_guard = PipelineRunGuard::new(settlement.clone(), "block transfer executor");
+        let mut transfer_start_predecessor = None;
 
         while let Some(batch) = self.input_rx.recv().await {
             if batch.is_empty() {
@@ -1416,8 +1465,21 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             // Spawn transfer task
             let shared_clone = shared.clone();
             let mut phase = BatchPhaseGuard::starting(settlement.clone(), transfer_permit);
+            let mut transfer_start = self
+                .ordered_transfer_starts
+                .then(|| OrderedTransferStart::next(&mut transfer_start_predecessor));
             tokio::spawn(async move {
-                match Self::execute_transfer(&shared_clone, upgraded, &mut phase).await {
+                if let Some(transfer_start) = &mut transfer_start {
+                    transfer_start.wait().await;
+                }
+                match Self::execute_transfer(
+                    &shared_clone,
+                    upgraded,
+                    &mut phase,
+                    transfer_start.as_mut(),
+                )
+                .await
+                {
                     Ok(()) => phase.finish_success(),
                     Err(error) => {
                         tracing::error!("BlockTransferExecutor: transfer failed: {}", error);
@@ -1459,6 +1521,7 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
         shared: &SharedBlockExecutorState<Dst>,
         mut batch: ResolvedBatch<Src>,
         phase: &mut BatchPhaseGuard,
+        mut transfer_start: Option<&mut OrderedTransferStart>,
     ) -> anyhow::Result<()> {
         nvtx_range!("offload::transfer");
         if batch.is_empty() {
@@ -1522,6 +1585,9 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
                 state_guard.mark_in_flight(block_ids.iter().copied());
             }
             phase.mark_in_flight();
+            if let Some(transfer_start) = &mut transfer_start {
+                transfer_start.release();
+            }
 
             // Wait for transfer completion
             if let Err(error) = notification.await {
@@ -1622,6 +1688,9 @@ impl<Src: BlockMetadata, Dst: BlockMetadata> BlockTransferExecutor<Src, Dst> {
             }
         } else {
             phase.mark_in_flight();
+            if let Some(transfer_start) = &mut transfer_start {
+                transfer_start.release();
+            }
             phase.mark_settling();
             for (state, block_ids) in transfer_states.values() {
                 let mut state_guard = state.lock().unwrap();
@@ -2101,6 +2170,31 @@ mod tests {
         assert!(config.policies.is_empty());
         assert!(!config.auto_chain);
         assert_eq!(config.sweep_interval, Duration::from_millis(10));
+        assert!(!config.ordered_transfer_starts);
+    }
+
+    #[tokio::test]
+    async fn ordered_transfer_starts_ignore_task_schedule_order() {
+        let observed = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let mut predecessor = None;
+        let starts = (0..3)
+            .map(|_| OrderedTransferStart::next(&mut predecessor))
+            .collect::<Vec<_>>();
+        let mut tasks = Vec::new();
+
+        for (index, mut start) in starts.into_iter().enumerate().rev() {
+            let observed = observed.clone();
+            tasks.push(tokio::spawn(async move {
+                start.wait().await;
+                observed.lock().await.push(index);
+                start.release();
+            }));
+        }
+        for task in tasks {
+            task.await.unwrap();
+        }
+
+        assert_eq!(*observed.lock().await, vec![0, 1, 2]);
     }
 
     /// Mock ObjectBlockOps that fails specific hashes.

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -308,6 +308,7 @@ impl MockOffloadEngine {
             .pending_tracker(g1_to_g2_pending)
             .batch_size(config.offload_batch_size)
             .max_concurrent_transfers(config.offload_batch_size)
+            .ordered_transfer_starts(cfg!(feature = "replay-bench"))
             .build();
 
         let mut engine_builder = OffloadEngine::builder(leader.clone())
@@ -448,6 +449,11 @@ impl MockOffloadEngine {
                 }
             }
         }
+        #[cfg(feature = "replay-bench")]
+        router_events.sort_by_key(|event| match event {
+            G2RouterEvent::Stored(metadata) => metadata.seq_hash,
+            G2RouterEvent::Removed { seq_hash } => *seq_hash,
+        });
         router_events
     }
 

--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -13,6 +13,10 @@
 //! the caller — live replay feeds wall-clock time, offline replay feeds
 //! virtual time.
 
+#[cfg(feature = "replay-bench")]
+use std::cmp::Reverse;
+#[cfg(feature = "replay-bench")]
+use std::collections::BinaryHeap;
 use std::future::Future;
 use std::net::TcpListener;
 use std::pin::Pin;
@@ -164,6 +168,84 @@ pub(crate) struct G2OffloadBlock {
 pub(crate) enum G2RouterEvent {
     Stored(G2BlockEventMetadata),
     Removed { seq_hash: RouterSequenceHash },
+}
+
+#[cfg(feature = "replay-bench")]
+fn g2_router_event_hash(event: &G2RouterEvent) -> RouterSequenceHash {
+    match event {
+        G2RouterEvent::Stored(metadata) => metadata.seq_hash,
+        G2RouterEvent::Removed { seq_hash } => *seq_hash,
+    }
+}
+
+#[cfg(feature = "replay-bench")]
+fn order_g2_router_events(router_events: &mut Vec<G2RouterEvent>) {
+    let event_count = router_events.len();
+    let mut events = std::mem::take(router_events)
+        .into_iter()
+        .map(Some)
+        .collect::<Vec<_>>();
+    let mut stored_by_hash = FxHashMap::default();
+    for (index, event) in events.iter().enumerate() {
+        let Some(G2RouterEvent::Stored(metadata)) = event else {
+            continue;
+        };
+        stored_by_hash.entry(metadata.seq_hash).or_insert(index);
+    }
+
+    let mut successors = vec![Vec::new(); event_count];
+    let mut incoming_edges = vec![0; event_count];
+    for (index, event) in events.iter().enumerate() {
+        let Some(G2RouterEvent::Stored(metadata)) = event else {
+            continue;
+        };
+        let Some(parent_hash) = metadata.parent_hash else {
+            continue;
+        };
+        let Some(&parent_index) = stored_by_hash.get(&parent_hash) else {
+            continue;
+        };
+        if parent_index == index {
+            continue;
+        }
+        successors[parent_index].push(index);
+        incoming_edges[index] += 1;
+    }
+
+    let mut ready = BinaryHeap::new();
+    for (index, event) in events.iter().enumerate() {
+        if incoming_edges[index] == 0 {
+            ready.push(Reverse((
+                g2_router_event_hash(event.as_ref().unwrap()),
+                index,
+            )));
+        }
+    }
+
+    let mut ordered = Vec::with_capacity(event_count);
+    while let Some(Reverse((_, index))) = ready.pop() {
+        ordered.push(events[index].take().unwrap());
+        for successor in successors[index].drain(..) {
+            incoming_edges[successor] -= 1;
+            if incoming_edges[successor] == 0 {
+                ready.push(Reverse((
+                    g2_router_event_hash(events[successor].as_ref().unwrap()),
+                    successor,
+                )));
+            }
+        }
+    }
+
+    if ordered.len() < event_count {
+        let mut remaining = events
+            .into_iter()
+            .enumerate()
+            .filter_map(|(index, event)| event.map(|event| (index, event)))
+            .collect::<Vec<_>>();
+        remaining.sort_by_key(|(index, event)| (g2_router_event_hash(event), *index));
+        ordered.extend(remaining.into_iter().map(|(_, event)| event));
+    }
+    *router_events = ordered;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -450,10 +532,7 @@ impl MockOffloadEngine {
             }
         }
         #[cfg(feature = "replay-bench")]
-        router_events.sort_by_key(|event| match event {
-            G2RouterEvent::Stored(metadata) => metadata.seq_hash,
-            G2RouterEvent::Removed { seq_hash } => *seq_hash,
-        });
+        order_g2_router_events(&mut router_events);
         router_events
     }
 
@@ -1646,6 +1725,30 @@ mod tests {
             .expect("allocate G1 slots");
         assert!(evicted.is_empty());
         (manager, slots)
+    }
+
+    #[cfg(feature = "replay-bench")]
+    #[test]
+    fn replay_router_event_order_preserves_parent_chain() {
+        let stored = |seq_hash, parent_hash| {
+            G2RouterEvent::Stored(G2BlockEventMetadata {
+                seq_hash,
+                parent_hash,
+                local_hash: None,
+                token_ids: None,
+            })
+        };
+        let mut events = vec![
+            stored(10, Some(100)),
+            stored(50, None),
+            stored(100, None),
+            stored(1, Some(10)),
+        ];
+
+        order_g2_router_events(&mut events);
+
+        let seq_hashes = events.iter().map(g2_router_event_hash).collect::<Vec<_>>();
+        assert_eq!(seq_hashes, vec![50, 100, 10, 1]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add an opt-in `ordered_transfer_starts` pipeline mode that preserves batch-input order through synchronous transfer reservation/publication
- enable that mode, plus stable G2 router-event publication ordering, only for `replay-bench`
- preserve transfer concurrency by releasing each successor immediately after the current transfer has reserved its notification and entered the in-flight phase
- forward `replay-bench` through the Python binding crate for high-level replay builds

Production behavior is unchanged by default: `ordered_transfer_starts` defaults to `false`, and the mocker enables it only behind the existing replay feature.

## Root cause

An intermittent vLLM-disaggregated replay mismatch shifted a subset of decode-admit, destination-activation, and terminal timestamps by exact 0.123076 ms increments. Event-level instrumentation showed that Tokio could schedule same-batch G1→G2 tasks in different reservation orders (for example `32,32,32,29` versus `32,29,32,32`). That changed which block group completed first and, independently, same-timestamp lifecycle publication could assign router-event IDs in executor order.

The fix orders only the synchronous reservation start and replay router-event publication. It does not serialize transfer completion or the data path.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p kvbm-engine --no-default-features ordered_transfer_starts_ignore_task_schedule_order`
- `cargo test -p dynamo-mocker --features replay-bench,kvbm-offload g1_to_g2_completion_feeds_g3_with_presence_policy`
- requested `clean` lint/format matrix passed for `lib/kvbm-engine`, `lib/mocker`, and `lib/bindings/python`
- adversarial fresh-state alternating-process soak, small offload batches: baseline 8/8 and fixed build 8/8 produced one shared digest (`3bbd0fe36efb8ddfe1af7fceae1c6ab3357fcf9d5aebb3c5b1ae2a2a4cebb98b`)
- 3072-block control: baseline 8/8 and fixed build 8/8 produced one shared digest (`9f7c4c2f027b30df6b95e14db6d6603f904284625849eb68c35e730f7e23ae90`)
- authoritative 5,000-row vLLM-disaggregated replay: both baseline reps and both fixed reps matched byte-for-byte (`f0fef647a549713ec261fdc4ff558478caaf78001042f1c5bb933b8f7774f40e`)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12326" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional mode that starts data transfers in a predictable input order.
  * Added replay-benchmark support for consistent request sequencing and event ordering.
* **Bug Fixes**
  * Improved consistency of replay results by ensuring collected events follow their expected sequence.
* **Tests**
  * Added coverage verifying that transfer operations begin in the configured order, regardless of scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->