### PR TITLE
fix(multimodal): defer torch-bound imports in dynamo.common.multimodal

### DIFF
--- a/components/src/dynamo/common/multimodal/__init__.py
+++ b/components/src/dynamo/common/multimodal/__init__.py
@@ -1,44 +1,42 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Multimodal utilities for Dynamo components."""
+"""Multimodal utilities for Dynamo components.
 
-from collections.abc import Callable
+The media loaders (``ImageLoader``, ``AudioLoader``, ``VideoLoader``) are
+imported eagerly: their footprint is PIL/numpy plus local HTTP helpers.
 
-from dynamo.common.constants import EmbeddingTransferMode
-from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
+Everything else is resolved through a PEP 562 module-level ``__getattr__``
+so that importing a media loader does not transitively pull in ``torch``.
+``AsyncEncoderCache`` reaches ``torch`` via
+``dynamo.common.memory.multimodal_embedding_cache_manager``, and
+``embedding_transfer`` imports ``torch`` and ``safetensors.torch``
+directly. Deferring them keeps ``from dynamo.common.multimodal import
+ImageLoader`` cheap while leaving the public API unchanged --- every name in
+``__all__`` still resolves on first attribute access and is then cached into
+``globals()``, so repeat access is free and object identity is stable.
+"""
+
+from typing import TYPE_CHECKING, Any
+
 from dynamo.common.multimodal.audio_loader import AudioLoader
-from dynamo.common.multimodal.embedding_transfer import (
-    AbstractEmbeddingReceiver,
-    AbstractEmbeddingSender,
-    LocalEmbeddingReceiver,
-    LocalEmbeddingSender,
-    NixlReadEmbeddingReceiver,
-    NixlReadEmbeddingSender,
-    NixlWriteEmbeddingReceiver,
-    NixlWriteEmbeddingSender,
-    TransferRequest,
-)
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
 
-EMBEDDING_SENDER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingSender]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingSender,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingSender,
-    EmbeddingTransferMode.NIXL_READ: NixlReadEmbeddingSender,
-}
-
-EMBEDDING_RECEIVER_FACTORIES: dict[
-    EmbeddingTransferMode, Callable[[], AbstractEmbeddingReceiver]
-] = {
-    EmbeddingTransferMode.LOCAL: LocalEmbeddingReceiver,
-    EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingReceiver,
-    # [gluo FIXME] can't use pre-registered tensor as NIXL requires descriptors
-    # to be at matching size, need to overwrite nixl connect library
-    EmbeddingTransferMode.NIXL_READ: lambda: NixlReadEmbeddingReceiver(max_items=0),
-}
+# Declared for static analysis only; resolved at runtime by ``__getattr__``
+# below. Limited to the names in ``__all__`` --- the abstract bases are
+# reachable at runtime too, but re-declaring them here trips ruff's F401.
+if TYPE_CHECKING:
+    from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
+    from dynamo.common.multimodal.embedding_transfer import (
+        LocalEmbeddingReceiver,
+        LocalEmbeddingSender,
+        NixlReadEmbeddingReceiver,
+        NixlReadEmbeddingSender,
+        NixlWriteEmbeddingReceiver,
+        NixlWriteEmbeddingSender,
+        TransferRequest,
+    )
 
 __all__ = [
     "AsyncEncoderCache",
@@ -55,3 +53,87 @@ __all__ = [
     "LocalEmbeddingReceiver",
     "LocalEmbeddingSender",
 ]
+
+# Names re-exported from ``embedding_transfer``, resolved on first access.
+_EMBEDDING_TRANSFER_NAMES = frozenset(
+    {
+        "AbstractEmbeddingReceiver",
+        "AbstractEmbeddingSender",
+        "LocalEmbeddingReceiver",
+        "LocalEmbeddingSender",
+        "NixlReadEmbeddingReceiver",
+        "NixlReadEmbeddingSender",
+        "NixlWriteEmbeddingReceiver",
+        "NixlWriteEmbeddingSender",
+        "TransferRequest",
+    }
+)
+
+_FACTORY_NAMES = frozenset(
+    {"EMBEDDING_RECEIVER_FACTORIES", "EMBEDDING_SENDER_FACTORIES"}
+)
+
+
+def _build_embedding_factories() -> None:
+    """Build both factory dicts and install them into ``globals()``.
+
+    The dicts are built from torch-dependent classes, so their
+    *construction* --- not merely their lookup --- has to be deferred.
+    Installing into ``globals()`` keeps their object identity stable across
+    repeat access, which callers holding a reference rely on.
+    """
+    from collections.abc import Callable
+
+    from dynamo.common.constants import EmbeddingTransferMode
+    from dynamo.common.multimodal.embedding_transfer import (
+        AbstractEmbeddingReceiver,
+        AbstractEmbeddingSender,
+        LocalEmbeddingReceiver,
+        LocalEmbeddingSender,
+        NixlReadEmbeddingReceiver,
+        NixlReadEmbeddingSender,
+        NixlWriteEmbeddingReceiver,
+        NixlWriteEmbeddingSender,
+    )
+
+    sender_factories: dict[
+        EmbeddingTransferMode, Callable[[], AbstractEmbeddingSender]
+    ] = {
+        EmbeddingTransferMode.LOCAL: LocalEmbeddingSender,
+        EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingSender,
+        EmbeddingTransferMode.NIXL_READ: NixlReadEmbeddingSender,
+    }
+
+    receiver_factories: dict[
+        EmbeddingTransferMode, Callable[[], AbstractEmbeddingReceiver]
+    ] = {
+        EmbeddingTransferMode.LOCAL: LocalEmbeddingReceiver,
+        EmbeddingTransferMode.NIXL_WRITE: NixlWriteEmbeddingReceiver,
+        # [gluo FIXME] can't use pre-registered tensor as NIXL requires descriptors
+        # to be at matching size, need to overwrite nixl connect library
+        EmbeddingTransferMode.NIXL_READ: lambda: NixlReadEmbeddingReceiver(max_items=0),
+    }
+
+    globals()["EMBEDDING_SENDER_FACTORIES"] = sender_factories
+    globals()["EMBEDDING_RECEIVER_FACTORIES"] = receiver_factories
+
+
+def __getattr__(name: str) -> Any:
+    if name == "AsyncEncoderCache":
+        from dynamo.common.multimodal.async_encoder_cache import AsyncEncoderCache
+
+        globals()[name] = AsyncEncoderCache
+        return AsyncEncoderCache
+
+    if name in _EMBEDDING_TRANSFER_NAMES:
+        from dynamo.common.multimodal import embedding_transfer
+
+        value = getattr(embedding_transfer, name)
+        globals()[name] = value
+        return value
+
+    if name in _FACTORY_NAMES:
+        _build_embedding_factories()
+        return globals()[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/components/src/dynamo/common/multimodal/audio_loader.py
+++ b/components/src/dynamo/common/multimodal/audio_loader.py
@@ -45,21 +45,21 @@ async def read_decoded_media_via_nixl(*args: Any, **kwargs: Any) -> Any:
     return await _read_decoded_media_via_nixl(*args, **kwargs)
 
 
-try:
-    from vllm.multimodal.media import MediaConnector
-    from vllm.multimodal.media.audio import AudioMediaIO
-except ImportError:
-    MediaConnector = None  # type: ignore[assignment]
-    AudioMediaIO = None  # type: ignore[assignment]
-
-
 def _require_vllm_audio_media() -> tuple[Any, Any]:
-    """Return vLLM's audio media components, raising if not installed."""
-    if MediaConnector is None or AudioMediaIO is None:
+    """Return vLLM's audio media components, raising if not installed.
+
+    Imported lazily because ``vllm.multimodal.media`` pulls in the whole
+    vLLM/torch stack, and this module is imported eagerly by the package
+    ``__init__``. Mirrors ``_require_vllm_video_media`` in ``video_loader``.
+    """
+    try:
+        from vllm.multimodal.media import MediaConnector
+        from vllm.multimodal.media.audio import AudioMediaIO
+    except ImportError as exc:
         raise RuntimeError(
             "vLLM multimodal media components are required to decode `audio_url` "
             "inputs in the vLLM backend."
-        )
+        ) from exc
     return MediaConnector, AudioMediaIO
 
 

--- a/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
+++ b/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
@@ -21,26 +21,62 @@ Importing a media loader from the package must not transitively load
 almost certainly already imported both.
 """
 
+import os
 import subprocess
 import sys
 import textwrap
 
 import pytest
 
+import dynamo.common.multimodal as mm
+
+# Each subprocess measures at ~2s locally; the marker is a backstop well above
+# that, and the inner ``subprocess.run`` timeout is what normally fires so the
+# failure names the stuck child instead of the whole test.
+_SUBPROCESS_TIMEOUT_SECONDS = 120
+
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
+    pytest.mark.timeout(180),
 ]
+
+# Only what a fresh interpreter needs to find this repo's installed packages.
+# Everything else is dropped so ambient Python configuration (notably user
+# site-packages and ``PYTHONSTARTUP``) cannot skew the import-hygiene assertions.
+_ENV_ALLOW_LIST = (
+    "PATH",
+    "HOME",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+    "LD_LIBRARY_PATH",
+    "TMPDIR",
+)
+
+
+def _isolated_env() -> dict[str, str]:
+    """Build a minimal allow-listed environment for the child interpreter."""
+    env = {name: os.environ[name] for name in _ENV_ALLOW_LIST if name in os.environ}
+    env["PYTHONNOUSERSITE"] = "1"
+    return env
 
 
 def _run_in_subprocess(script: str) -> None:
     """Run ``script`` in a fresh interpreter, failing the test on nonzero exit."""
-    result = subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(script)],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            env=_isolated_env(),
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            f"subprocess did not finish within {_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+            f"stdout:\n{exc.stdout}\nstderr:\n{exc.stderr}"
+        )
     if result.returncode != 0:
         pytest.fail(
             "subprocess failed with exit code "
@@ -136,7 +172,5 @@ def test_embedding_factories_cover_every_transfer_mode_with_stable_identity() ->
 
 def test_unknown_attribute_still_raises_attribute_error() -> None:
     """``__getattr__`` must not swallow typos into silence."""
-    import dynamo.common.multimodal as mm
-
     with pytest.raises(AttributeError, match="no attribute 'NotARealSymbol'"):
-        mm.NotARealSymbol
+        _ = mm.NotARealSymbol

--- a/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
+++ b/components/src/dynamo/common/tests/multimodal/test_lazy_imports.py
@@ -1,0 +1,142 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Import-hygiene tests for ``dynamo.common.multimodal``.
+
+Importing a media loader from the package must not transitively load
+``torch`` or ``vllm`` (issue #11172). Every assertion about a pristine
+``sys.modules`` runs in a subprocess, because the ambient pytest session has
+almost certainly already imported both.
+"""
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _run_in_subprocess(script: str) -> None:
+    """Run ``script`` in a fresh interpreter, failing the test on nonzero exit."""
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            "subprocess failed with exit code "
+            f"{result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def test_media_loaders_do_not_import_torch_or_vllm() -> None:
+    """Importing the media loaders must not drag in torch or vLLM.
+
+    This is the regression guard for issue #11172. Before the lazy-import
+    change this failed: ``AsyncEncoderCache`` (via the memory cache manager),
+    ``embedding_transfer``, and ``audio_loader``'s module-level vLLM import
+    each pulled in torch at package-import time.
+    """
+    _run_in_subprocess(
+        """
+        import sys
+
+        from dynamo.common.multimodal import AudioLoader, ImageLoader, VideoLoader
+
+        assert ImageLoader is not None
+        assert AudioLoader is not None
+        assert VideoLoader is not None
+
+        assert "torch" not in sys.modules, (
+            "importing the media loaders pulled in torch: "
+            + repr(sorted(m for m in sys.modules if m.startswith("torch")))[:400]
+        )
+        assert "vllm" not in sys.modules, (
+            "importing the media loaders pulled in vllm: "
+            + repr(sorted(m for m in sys.modules if m.startswith("vllm")))[:400]
+        )
+        """
+    )
+
+
+def test_deferred_members_still_resolve_and_load_torch_on_demand() -> None:
+    """The heavy members are deferred, not deleted.
+
+    Negative control: every name in ``__all__`` still resolves, and torch
+    becomes loaded only once a torch-dependent member is actually touched.
+    """
+    _run_in_subprocess(
+        """
+        import sys
+
+        import dynamo.common.multimodal as mm
+
+        assert "torch" not in sys.modules, "package import loaded torch eagerly"
+
+        from dynamo.common.multimodal import AsyncEncoderCache, TransferRequest
+
+        assert AsyncEncoderCache is not None
+        assert TransferRequest is not None
+        assert "torch" in sys.modules, "torch should load once a heavy member is used"
+
+        missing = [name for name in mm.__all__ if not hasattr(mm, name)]
+        assert not missing, f"names in __all__ failed to resolve: {missing}"
+        """
+    )
+
+
+def test_embedding_factories_cover_every_transfer_mode_with_stable_identity() -> None:
+    """The factory dicts build on demand, stay stable, and cover every mode.
+
+    The sglang multimodal worker handlers index these dicts by
+    ``EmbeddingTransferMode``, and callers may hold a reference across
+    accesses, so both total coverage and object identity matter.
+    """
+    _run_in_subprocess(
+        """
+        import dynamo.common.multimodal as mm
+        from dynamo.common.constants import EmbeddingTransferMode
+
+        senders = mm.EMBEDDING_SENDER_FACTORIES
+        receivers = mm.EMBEDDING_RECEIVER_FACTORIES
+
+        modes = set(EmbeddingTransferMode)
+        assert set(senders) == modes, f"sender factories missing {modes - set(senders)}"
+        assert set(receivers) == modes, (
+            f"receiver factories missing {modes - set(receivers)}"
+        )
+        assert all(callable(f) for f in senders.values())
+        assert all(callable(f) for f in receivers.values())
+
+        # Cached into globals(): repeat access must return the same objects.
+        assert mm.EMBEDDING_SENDER_FACTORIES is senders
+        assert mm.EMBEDDING_RECEIVER_FACTORIES is receivers
+        """
+    )
+
+
+def test_unknown_attribute_still_raises_attribute_error() -> None:
+    """``__getattr__`` must not swallow typos into silence."""
+    import dynamo.common.multimodal as mm
+
+    with pytest.raises(AttributeError, match="no attribute 'NotARealSymbol'"):
+        mm.NotARealSymbol


### PR DESCRIPTION
## Overview:

`from dynamo.common.multimodal import ImageLoader` pulls in the entire torch/vLLM stack
before returning, which makes the media loaders unusable in lightweight processes that only
need image, audio, or video decoding. This defers every torch-bound import in
`dynamo.common.multimodal` so the media loaders import with no ML stack loaded.

After this change, importing a media loader in a fresh interpreter leaves `torch`, `vllm`,
and `safetensors` all absent from `sys.modules`.

## Details:

There are three independent eager paths from `dynamo/common/multimodal/__init__.py` to
`import torch`, and closing only the first leaves the reported symptom fully in place:

1. `__init__.py` → `async_encoder_cache.py` → `memory/multimodal_embedding_cache_manager.py` → `import torch`
2. `__init__.py` → `embedding_transfer.py` → `import torch` and `from safetensors import torch as safetensors_torch`
3. `__init__.py` → `audio_loader.py` → module-level `from vllm.multimodal.media import MediaConnector` → torch

All three are closed:

- **`multimodal/__init__.py`** — the three media loaders (`ImageLoader`, `AudioLoader`,
  `VideoLoader`) stay eagerly imported, since PIL/numpy plus local HTTP helpers are their
  whole footprint and they are the point of the issue. `AsyncEncoderCache`, the nine
  `embedding_transfer` re-exports, and the two `EMBEDDING_*_FACTORIES` dicts now resolve
  through a PEP 562 module-level `__getattr__` that caches each result into `globals()`.
  The factory dicts needed their *construction* deferred, not just their lookup, so a
  private `_build_embedding_factories()` assembles both on first access to either name and
  installs them — which also keeps their object identity stable across repeat access.
  `__all__` is byte-for-byte unchanged (all thirteen names), and a blocked-`torch` probe
  confirms the deferred members still raise the true `ModuleNotFoundError` rather than a
  misleading `AttributeError`. This mirrors four existing lazy `__init__` modules in the
  repo (`common/__init__.py`, `configuration/__init__.py`,
  `sglang/request_handlers/__init__.py`, `planner/plugins/transport/__init__.py`).

- **`multimodal/audio_loader.py`** — the module-level `MediaConnector` / `AudioMediaIO`
  import block moves into the existing `_require_vllm_audio_media()` helper, now raising
  `RuntimeError(...) from exc` on `ImportError`. The error message is preserved verbatim.
  This makes the module match the pattern `video_loader.py` already uses; `audio_loader.py`
  was the odd one out.

- **`common/tests/multimodal/test_lazy_imports.py`** (new) — four unit tests. Each
  torch-absence assertion runs in a subprocess, since the ambient pytest session has already
  imported torch. They cover: the media loaders load neither torch nor vLLM; the deferred
  members still resolve (and every `__all__` name resolves) with torch appearing only once
  one is touched; both factory dicts cover every `EmbeddingTransferMode` member and keep
  stable identity; an unknown attribute still raises `AttributeError`.

**Known limitation, stated plainly:** this makes the package importable without *torch*, not
without the compiled extension. `dynamo.common.multimodal` still reaches `dynamo._core` via
`dynamo.common.http` → `configuration.groups.runtime_args`. That satisfies this issue, which
is a torch/ML-stack complaint, but decoupling from `dynamo._core` is separate, larger work.

**Overlap with #11179 — please read before merging.** [#11179](https://github.com/ai-dynamo/dynamo/pull/11179)
("fix(common): make multimodal media loaders importable without torch") is open, changes the
same three files, and implements the same approach including the `audio_loader` fix. This
branch deliberately converges on that design rather than inventing a third, so reconciliation
is cheap either way — but if #11179 is still live, maintainers should likely prefer it and
close this one.

## Where should the reviewer start?

Start with `components/src/dynamo/common/multimodal/__init__.py` — specifically
`_EMBEDDING_TRANSFER_NAMES`, `_build_embedding_factories()`, and `__getattr__`. The two
things worth checking closely are that `__all__` is unchanged and that the deferred factory
dicts are built together on first access to either name.

Then `components/src/dynamo/common/multimodal/audio_loader.py`, which is a small move of an
existing import block into the existing helper, and finally the new
`components/src/dynamo/common/tests/multimodal/test_lazy_imports.py`.

## Validation

| Check | Command | Result |
|---|---|---|
| Editable install / import | `from dynamo.common.multimodal import ImageLoader` in a fresh interpreter | `torch: False, vllm: False, safetensors: False` |
| Lint | `pre-commit run --files <3 files>` | pass (isort, black, flake8, ruff, codespell, …) |
| New tests | `pytest components/src/dynamo/common/tests/multimodal/test_lazy_imports.py -m "unit and not gpu"` | 4 passed |
| Multimodal suite | `pytest components/src/dynamo/common/tests/multimodal/ -m "unit and not gpu"` | 71 passed, 24 deselected |
| Wider `common` suite | `pytest components/src/dynamo/common/tests/ -m "unit and not gpu"` | 307 passed, 7 failed |

The 7 failures are all in `components/src/dynamo/common/tests/test_video_utils.py` with
`ModuleNotFoundError: No module named 'imageio'`. They reproduce identically on `main` with
this branch's changes absent, and that file contains no reference to `multimodal` — a missing
test dependency in the environment, not a regression from this change.

Reverting the two production files while keeping the new test file causes tests 1 and 2 to
fail with `AssertionError: package import loaded torch eagerly`, so the tests genuinely pin
the behavior. All six in-repo call sites of `dynamo.common.multimodal` were exercised as
literal import statements, along with `from dynamo.common.multimodal import *`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #11172

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved multimodal component startup by deferring heavy dependencies until they are needed.
  * Audio support dependencies are now loaded only when audio decoding is requested.

* **Compatibility**
  * Existing multimodal exports and embedding transfer functionality remain available.
  * Invalid or unknown attributes continue to report clear errors.

* **Reliability**
  * Added coverage to verify lazy loading, embedding transfer behavior, and dependency isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->