### PR TITLE
perf(mocker): move request KV ownership into backend leases

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -20,10 +20,12 @@ new_key_type! {
 pub struct KvPageId(usize);
 
 impl KvPageId {
+    #[cfg(test)]
     pub(crate) fn from_token_index(index: usize, page_size: usize) -> Self {
         Self(index / page_size)
     }
 
+    #[cfg(test)]
     pub(crate) fn first_token_index(self, page_size: usize) -> usize {
         self.0 * page_size
     }
@@ -31,8 +33,7 @@ impl KvPageId {
 
 /// Manages free / allocated pages for the simulated SGLang KV cache.
 ///
-/// SGLang's paged allocator owns and frees whole pages. Compatibility helpers
-/// can still flatten page IDs into token indices for existing callers.
+/// SGLang's paged allocator owns and frees whole pages in production.
 pub struct PagePool {
     next_fresh: usize,
     free: Vec<KvPageId>,
@@ -74,6 +75,7 @@ impl PagePool {
 
     /// Append flattened indices for `new_tokens`, allocating whole pages only
     /// when the request's current final page has no remaining slots.
+    #[cfg(test)]
     pub fn allocate_indices_into(&mut self, new_tokens: usize, indices: &mut Vec<usize>) -> bool {
         if new_tokens == 0 {
             return true;
@@ -109,6 +111,7 @@ impl PagePool {
         true
     }
 
+    #[cfg(test)]
     pub fn expand_pages(&self, pages: &[KvPageId], token_count: usize) -> Vec<usize> {
         assert!(
             token_count <= pages.len() * self.page_size,
@@ -132,6 +135,7 @@ impl PagePool {
     }
 
     /// Free every distinct page represented by a contiguous request-index list.
+    #[cfg(test)]
     pub fn free_indices(&mut self, indices: &[usize]) -> Vec<KvPageId> {
         let mut pages = Vec::with_capacity(indices.len().div_ceil(self.page_size));
         for &index in indices {
@@ -235,6 +239,7 @@ impl RadixCache {
         compute_block_hash_for_seq(tokens, self.page_size as u32, BlockHashOptions::default())
     }
 
+    #[cfg(test)]
     fn page_ids(&self, indices: &[usize], page_count: usize) -> Vec<KvPageId> {
         assert!(
             indices.len() >= page_count * self.page_size,
@@ -345,6 +350,7 @@ impl RadixCache {
     }
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
+    #[cfg(test)]
     pub fn insert(&mut self, key: &[u32], value: &[usize]) -> NodeId {
         let aligned_len = key.len() / self.page_size * self.page_size;
         assert!(
@@ -361,6 +367,7 @@ impl RadixCache {
     /// `prefix_node` must be the locked terminal node for `prefix_len`. Keeping
     /// that handle lets decode growth avoid walking the full sequence from the
     /// root on every completed page.
+    #[cfg(test)]
     pub fn insert_from_node(
         &mut self,
         prefix_node: NodeId,
@@ -423,6 +430,7 @@ impl RadixCache {
         )
     }
 
+    #[cfg(test)]
     fn insert_page_suffix(
         &mut self,
         start_node: NodeId,
@@ -444,14 +452,7 @@ impl RadixCache {
         if aligned_len == prefix_len {
             return start_node;
         }
-        let expected_pages = (aligned_len - prefix_len) / self.page_size;
-        assert!(
-            page_ids.len() >= expected_pages,
-            "not enough KV pages: need {expected_pages}, got {}",
-            page_ids.len()
-        );
         let page_keys = self.page_hashes(&key[prefix_len..aligned_len]);
-        let page_ids = &page_ids[..page_keys.len()];
         self.insert_page_hash_suffix(
             start_node,
             &page_keys,

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -27,17 +27,12 @@ impl KvPageId {
     pub(crate) fn first_token_index(self, page_size: usize) -> usize {
         self.0 * page_size
     }
-
-    pub(crate) fn terminal_token_index(self, page_size: usize) -> usize {
-        self.first_token_index(page_size) + page_size - 1
-    }
 }
 
 /// Manages free / allocated pages for the simulated SGLang KV cache.
 ///
-/// SGLang's paged allocator owns and frees whole pages even though its public
-/// interface returns flattened token indices. This pool preserves that
-/// ownership model and only expands page IDs while a request is active.
+/// SGLang's paged allocator owns and frees whole pages. Compatibility helpers
+/// can still flatten page IDs into token indices for existing callers.
 pub struct PagePool {
     next_fresh: usize,
     free: Vec<KvPageId>,
@@ -236,7 +231,7 @@ impl RadixCache {
         self.nodes.len()
     }
 
-    fn page_hashes(&self, tokens: &[u32]) -> Vec<LocalBlockHash> {
+    pub(crate) fn page_hashes(&self, tokens: &[u32]) -> Vec<LocalBlockHash> {
         compute_block_hash_for_seq(tokens, self.page_size as u32, BlockHashOptions::default())
     }
 
@@ -266,6 +261,11 @@ impl RadixCache {
 
     pub fn match_prefix(&mut self, key: &[u32]) -> (usize, NodeId) {
         let page_keys = self.page_hashes(key);
+        self.match_prefix_hashes(&page_keys)
+    }
+
+    /// Match a prefix using page hashes already owned by the request.
+    pub(crate) fn match_prefix_hashes(&mut self, page_keys: &[LocalBlockHash]) -> (usize, NodeId) {
         let now = Instant::now();
         self.nodes[self.root].last_access_time = now;
 
@@ -311,6 +311,11 @@ impl RadixCache {
     /// Used for LPM scheduling scoring.
     pub fn prefix_match_len(&self, key: &[u32]) -> usize {
         let page_keys = self.page_hashes(key);
+        self.prefix_match_hashes_len(&page_keys)
+    }
+
+    /// Read-only prefix match using page hashes already owned by the request.
+    pub(crate) fn prefix_match_hashes_len(&self, page_keys: &[LocalBlockHash]) -> usize {
         let mut current = self.root;
         let mut matched_pages: usize = 0;
 
@@ -341,7 +346,14 @@ impl RadixCache {
 
     /// Insert a token sequence into the tree. Key is page-aligned before insertion.
     pub fn insert(&mut self, key: &[u32], value: &[usize]) -> NodeId {
-        self.insert_from(self.root, 0, key, value, false)
+        let aligned_len = key.len() / self.page_size * self.page_size;
+        assert!(
+            value.len() >= aligned_len,
+            "not enough token indices: need {aligned_len}, got {}",
+            value.len()
+        );
+        let page_ids = self.page_ids(&value[..aligned_len], aligned_len / self.page_size);
+        self.insert_page_suffix(self.root, 0, key, &page_ids, false)
     }
 
     /// Insert only the suffix after a retained, page-aligned prefix.
@@ -356,15 +368,67 @@ impl RadixCache {
         key: &[u32],
         value: &[usize],
     ) -> NodeId {
-        self.insert_from(prefix_node, prefix_len, key, value, true)
+        let aligned_len = key.len() / self.page_size * self.page_size;
+        assert_eq!(
+            prefix_len % self.page_size,
+            0,
+            "prefix length must be page-aligned"
+        );
+        assert!(
+            prefix_len <= aligned_len,
+            "prefix length {prefix_len} exceeds aligned key length {aligned_len}"
+        );
+        assert!(
+            value.len() >= aligned_len,
+            "not enough token indices: need {aligned_len}, got {}",
+            value.len()
+        );
+        let page_ids = self.page_ids(
+            &value[prefix_len..aligned_len],
+            (aligned_len - prefix_len) / self.page_size,
+        );
+        self.insert_page_suffix(prefix_node, prefix_len, key, &page_ids, true)
     }
 
-    fn insert_from(
+    /// Insert page identities already materialized by the request lease.
+    pub(crate) fn insert_page_hashes_from_node(
+        &mut self,
+        prefix_node: NodeId,
+        prefix_len: usize,
+        page_keys: &[LocalBlockHash],
+        pages: &[KvPageId],
+    ) -> NodeId {
+        assert_eq!(
+            prefix_len % self.page_size,
+            0,
+            "prefix length must be page-aligned"
+        );
+        assert!(
+            pages.len() >= page_keys.len(),
+            "not enough KV pages: need {}, got {}",
+            page_keys.len(),
+            pages.len()
+        );
+        let prefix_pages = prefix_len / self.page_size;
+        assert!(
+            prefix_pages <= page_keys.len(),
+            "prefix pages {prefix_pages} exceed hashed pages {}",
+            page_keys.len()
+        );
+        self.insert_page_hash_suffix(
+            prefix_node,
+            &page_keys[prefix_pages..],
+            &pages[prefix_pages..page_keys.len()],
+            true,
+        )
+    }
+
+    fn insert_page_suffix(
         &mut self,
         start_node: NodeId,
         prefix_len: usize,
         key: &[u32],
-        value: &[usize],
+        page_ids: &[KvPageId],
         allow_locked_tail_extension: bool,
     ) -> NodeId {
         let aligned_len = key.len() / self.page_size * self.page_size;
@@ -380,18 +444,38 @@ impl RadixCache {
         if aligned_len == prefix_len {
             return start_node;
         }
+        let expected_pages = (aligned_len - prefix_len) / self.page_size;
         assert!(
-            value.len() >= aligned_len,
-            "not enough token indices: need {aligned_len}, got {}",
-            value.len()
+            page_ids.len() >= expected_pages,
+            "not enough KV pages: need {expected_pages}, got {}",
+            page_ids.len()
         );
-        // `start_node` already represents the retained prefix. Hashing and
-        // validating it again on every decode-page completion makes growth
-        // quadratic in sequence length; only the newly completed suffix is
-        // needed for insertion.
         let page_keys = self.page_hashes(&key[prefix_len..aligned_len]);
-        let page_ids = self.page_ids(&value[prefix_len..aligned_len], page_keys.len());
+        let page_ids = &page_ids[..page_keys.len()];
+        self.insert_page_hash_suffix(
+            start_node,
+            &page_keys,
+            page_ids,
+            allow_locked_tail_extension,
+        )
+    }
 
+    fn insert_page_hash_suffix(
+        &mut self,
+        start_node: NodeId,
+        page_keys: &[LocalBlockHash],
+        page_ids: &[KvPageId],
+        allow_locked_tail_extension: bool,
+    ) -> NodeId {
+        assert!(
+            page_ids.len() >= page_keys.len(),
+            "not enough KV pages: need {}, got {}",
+            page_keys.len(),
+            page_ids.len()
+        );
+        if page_keys.is_empty() {
+            return start_node;
+        }
         let now = Instant::now();
         self.touch_path(start_node, now);
 

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -114,17 +114,7 @@ impl VllmBlockPool {
             return self.reserve_fresh(fresh);
         }
 
-        let hits = prefix
-            .iter()
-            .map(|hash| {
-                let Some(id) = self.first_copy(*hash) else {
-                    panic!("authorized prefix hash {hash} is no longer resident")
-                };
-                (*hash, id)
-            })
-            .collect::<Vec<_>>();
-
-        self.reserve_hits(hits, fresh)
+        self.reserve_exact_prefix(prefix.iter().copied(), prefix.len() + fresh)
     }
 
     /// Resolve and pin the longest resident prefix from `candidates`, then
@@ -134,7 +124,16 @@ impl VllmBlockPool {
         candidates: impl IntoIterator<Item = SequenceHash>,
         total: usize,
     ) -> Option<ReserveOutcome> {
-        let mut hits = Vec::with_capacity(total);
+        let mut candidates = candidates.into_iter();
+        let Some(first_hash) = candidates.next() else {
+            return self.reserve_fresh(total);
+        };
+        assert!(total > 0, "prefix candidates exceed layout");
+        let Some(first_id) = self.first_copy(first_hash) else {
+            return self.reserve_fresh(total);
+        };
+
+        let mut hits = vec![(first_hash, first_id)];
         for hash in candidates {
             assert!(hits.len() < total, "prefix candidates exceed layout");
             let Some(id) = self.first_copy(hash) else {
@@ -151,12 +150,27 @@ impl VllmBlockPool {
     /// Unlike [`Self::reserve_resident_prefix`], every candidate must still be
     /// resident. A missing hash means the caller's synchronous prefix
     /// authorization changed before allocation committed.
-    pub(crate) fn reserve_exact_prefix(
+    pub(crate) fn reserve_exact_prefix<I>(
         &mut self,
-        candidates: impl IntoIterator<Item = SequenceHash>,
+        candidates: I,
         total: usize,
-    ) -> Option<ReserveOutcome> {
-        let mut hits = Vec::with_capacity(total);
+    ) -> Option<ReserveOutcome>
+    where
+        I: IntoIterator<Item = SequenceHash>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut candidates = candidates.into_iter();
+        let candidate_count = candidates.len();
+        let Some(first_hash) = candidates.next() else {
+            return self.reserve_fresh(total);
+        };
+        assert!(candidate_count <= total, "prefix candidates exceed layout");
+        let Some(first_id) = self.first_copy(first_hash) else {
+            panic!("authorized prefix hash {first_hash} is no longer resident")
+        };
+        let mut hits = Vec::with_capacity(candidate_count);
+        hits.push((first_hash, first_id));
+
         for hash in candidates {
             assert!(hits.len() < total, "prefix candidates exceed layout");
             let Some(id) = self.first_copy(hash) else {
@@ -659,6 +673,30 @@ mod tests {
     }
 
     #[test]
+    fn empty_exact_prefix_reserves_fresh_without_prefix_storage() {
+        let mut pool = VllmBlockPool::new(3);
+        let outcome = pool
+            .reserve_exact_prefix(std::iter::empty(), 3)
+            .expect("fresh capacity should fit");
+
+        assert_eq!(outcome.reservation.prefix.capacity(), 0);
+        assert_eq!(outcome.reservation.fresh_len(), 3);
+        pool.cancel(outcome.reservation);
+    }
+
+    #[test]
+    fn cold_resident_prefix_reserves_fresh_without_prefix_storage() {
+        let mut pool = VllmBlockPool::new(3);
+        let outcome = pool
+            .reserve_resident_prefix([7, 8, 9], 3)
+            .expect("fresh capacity should fit");
+
+        assert_eq!(outcome.reservation.prefix.capacity(), 0);
+        assert_eq!(outcome.reservation.fresh_len(), 3);
+        pool.cancel(outcome.reservation);
+    }
+
+    #[test]
     fn duplicate_hashes_consume_distinct_capacity_but_share_visibility() {
         let mut pool = VllmBlockPool::new(2);
         let mut first = reserve(&mut pool, &[], 1).reservation;
@@ -704,6 +742,7 @@ mod tests {
         assert!(outcome.removed.is_empty());
         assert_eq!(outcome.reservation.len(), 2);
         assert_eq!(outcome.reservation.fresh_len(), 1);
+        assert_eq!(outcome.reservation.prefix.capacity(), 1);
         pool.cancel(outcome.reservation);
         assert_eq!(pool.num_inactive(), 1);
         pool.assert_lru_consistent();

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -691,6 +691,25 @@ mod tests {
     }
 
     #[test]
+    fn resident_prefix_stops_at_first_miss_and_reserves_fresh_suffix() {
+        let mut pool = VllmBlockPool::new(2);
+        let mut seed = reserve(&mut pool, &[], 1).reservation;
+        let id = pool.allocate_private(&mut seed);
+        assert!(pool.cache_private(id, 7));
+        pool.release(id);
+
+        let outcome = pool
+            .reserve_resident_prefix([7, 9], 2)
+            .expect("one resident prefix plus one fresh block should fit");
+        assert!(outcome.removed.is_empty());
+        assert_eq!(outcome.reservation.len(), 2);
+        assert_eq!(outcome.reservation.fresh_len(), 1);
+        pool.cancel(outcome.reservation);
+        assert_eq!(pool.num_inactive(), 1);
+        pool.assert_lru_consistent();
+    }
+
+    #[test]
     fn removal_is_reported_only_for_the_last_physical_copy() {
         let mut pool = VllmBlockPool::new(2);
         let mut first = reserve(&mut pool, &[], 1).reservation;

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -146,6 +146,28 @@ impl VllmBlockPool {
         self.reserve_hits(hits, fresh)
     }
 
+    /// Pin an already-authorized prefix and reserve the remaining entries.
+    ///
+    /// Unlike [`Self::reserve_resident_prefix`], every candidate must still be
+    /// resident. A missing hash means the caller's synchronous prefix
+    /// authorization changed before allocation committed.
+    pub(crate) fn reserve_exact_prefix(
+        &mut self,
+        candidates: impl IntoIterator<Item = SequenceHash>,
+        total: usize,
+    ) -> Option<ReserveOutcome> {
+        let mut hits = Vec::with_capacity(total);
+        for hash in candidates {
+            assert!(hits.len() < total, "prefix candidates exceed layout");
+            let Some(id) = self.first_copy(hash) else {
+                panic!("authorized prefix hash {hash} is no longer resident")
+            };
+            hits.push((hash, id));
+        }
+        let fresh = total - hits.len();
+        self.reserve_hits(hits, fresh)
+    }
+
     fn reserve_hits(
         &mut self,
         hits: Vec<(SequenceHash, BlockCopyId)>,
@@ -627,6 +649,13 @@ mod tests {
     fn reserve(pool: &mut VllmBlockPool, prefix: &[u64], fresh: usize) -> ReserveOutcome {
         pool.reserve(prefix, fresh)
             .unwrap_or_else(|| panic!("unexpected capacity exhaustion"))
+    }
+
+    #[test]
+    #[should_panic(expected = "authorized prefix hash 9 is no longer resident")]
+    fn exact_prefix_reports_missing_hash() {
+        let mut pool = VllmBlockPool::new(1);
+        let _ = pool.reserve_exact_prefix([9], 1);
     }
 
     #[test]

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -134,7 +134,7 @@ impl VllmBlockPool {
         candidates: impl IntoIterator<Item = SequenceHash>,
         total: usize,
     ) -> Option<ReserveOutcome> {
-        let mut hits = Vec::new();
+        let mut hits = Vec::with_capacity(total);
         for hash in candidates {
             assert!(hits.len() < total, "prefix candidates exceed layout");
             let Some(id) = self.first_copy(hash) else {
@@ -746,7 +746,10 @@ mod tests {
         pool.release(id);
 
         let mut activation = reserve(&mut pool, &[7], 0).reservation;
-        assert_eq!(pool.activate_prefix(&mut activation), vec![id]);
+        assert_eq!(
+            pool.activate_prefix(&mut activation).collect::<Vec<_>>(),
+            vec![(7, id)]
+        );
         pool.cancel(activation);
         assert_eq!(pool.num_inactive(), 0);
         pool.assert_lru_consistent();

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -124,6 +124,33 @@ impl VllmBlockPool {
             })
             .collect::<Vec<_>>();
 
+        self.reserve_hits(hits, fresh)
+    }
+
+    /// Resolve and pin the longest resident prefix from `candidates`, then
+    /// reserve the remaining entries as fresh capacity in one traversal.
+    pub(crate) fn reserve_resident_prefix(
+        &mut self,
+        candidates: impl IntoIterator<Item = SequenceHash>,
+        total: usize,
+    ) -> Option<ReserveOutcome> {
+        let mut hits = Vec::new();
+        for hash in candidates {
+            assert!(hits.len() < total, "prefix candidates exceed layout");
+            let Some(id) = self.first_copy(hash) else {
+                break;
+            };
+            hits.push((hash, id));
+        }
+        let fresh = total - hits.len();
+        self.reserve_hits(hits, fresh)
+    }
+
+    fn reserve_hits(
+        &mut self,
+        hits: Vec<(SequenceHash, BlockCopyId)>,
+        fresh: usize,
+    ) -> Option<ReserveOutcome> {
         let free = self.free_capacity();
         let needed_evictions = fresh.saturating_sub(free);
         if needed_evictions > 0 {
@@ -187,14 +214,12 @@ impl VllmBlockPool {
     pub(crate) fn activate_prefix(
         &mut self,
         reservation: &mut BlockReservation,
-    ) -> Vec<BlockCopyId> {
+    ) -> std::vec::IntoIter<(SequenceHash, BlockCopyId)> {
         let prefix = std::mem::take(&mut reservation.prefix);
-        let mut ids = Vec::with_capacity(prefix.len());
-        for (hash, id) in prefix {
+        for &(hash, id) in &prefix {
             self.activate_pin(id, hash);
-            ids.push(id);
         }
-        ids
+        prefix.into_iter()
     }
 
     pub(crate) fn allocate_private(&mut self, reservation: &mut BlockReservation) -> BlockCopyId {

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1014,8 +1014,8 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
         return Err(mock_engine_args_validation_error(
             "native_g1_block_size_too_small",
             format!(
-                "native G1 requires block_size to be at least 2 for engine_type={:?}, got block_size={}",
-                args.engine_type, args.block_size
+                "native G1 requires block_size to be at least 2 for engine_type={:?}, got block_size={}; set g1_backend=kvbm to keep block_size=1",
+                args.engine_type, args.block_size,
             ),
         ));
     }
@@ -2181,21 +2181,27 @@ mod tests {
     #[test]
     fn test_normalized_native_g1_rejects_block_size_one() {
         for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
-            let error = MockEngineArgs::builder()
+            let explicit = MockEngineArgs::builder()
                 .engine_type(engine_type)
                 .g1_backend(G1Backend::Native)
                 .block_size(1)
                 .build()
-                .unwrap()
-                .normalized()
-                .unwrap_err();
+                .unwrap();
+            let mut unset = explicit.clone();
+            unset.g1_backend = None;
 
-            assert!(
-                error
-                    .to_string()
-                    .contains("native G1 requires block_size to be at least 2"),
-                "engine_type={engine_type:?}, error={error:#}"
-            );
+            for args in [explicit, unset] {
+                let error = args.normalized().unwrap_err();
+                let message = error.to_string();
+                assert!(
+                    message.contains("native G1 requires block_size to be at least 2"),
+                    "engine_type={engine_type:?}, error={error:#}"
+                );
+                assert!(
+                    message.contains("set g1_backend=kvbm to keep block_size=1"),
+                    "engine_type={engine_type:?}, error={error:#}"
+                );
+            }
         }
     }
 

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1007,6 +1007,19 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
         ));
     }
 
+    if matches!(args.engine_type, EngineType::Vllm | EngineType::Trtllm)
+        && args.resolved_g1_backend() == G1Backend::Native
+        && args.block_size < 2
+    {
+        return Err(mock_engine_args_validation_error(
+            "native_g1_block_size_too_small",
+            format!(
+                "native G1 requires block_size to be at least 2 for engine_type={:?}, got block_size={}",
+                args.engine_type, args.block_size
+            ),
+        ));
+    }
+
     if args.g1_backend == Some(G1Backend::Native) && args.requires_kvbm_g1() {
         return Err(mock_engine_args_validation_error(
             "native_g1_legacy_offload_conflict",
@@ -2163,6 +2176,44 @@ mod tests {
             .unwrap();
 
         assert_eq!(args.block_size, 1);
+    }
+
+    #[test]
+    fn test_normalized_native_g1_rejects_block_size_one() {
+        for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
+            let error = MockEngineArgs::builder()
+                .engine_type(engine_type)
+                .g1_backend(G1Backend::Native)
+                .block_size(1)
+                .build()
+                .unwrap()
+                .normalized()
+                .unwrap_err();
+
+            assert!(
+                error
+                    .to_string()
+                    .contains("native G1 requires block_size to be at least 2"),
+                "engine_type={engine_type:?}, error={error:#}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalized_kvbm_accepts_block_size_one() {
+        for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
+            let args = MockEngineArgs::builder()
+                .engine_type(engine_type)
+                .g1_backend(G1Backend::Kvbm)
+                .block_size(1)
+                .build()
+                .unwrap()
+                .normalized()
+                .unwrap();
+
+            assert_eq!(args.block_size, 1, "engine_type={engine_type:?}");
+            assert_eq!(args.resolved_g1_backend(), G1Backend::Kvbm);
+        }
     }
 
     #[test]

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -1007,14 +1007,11 @@ fn validate_mock_engine_args(args: &MockEngineArgs) -> Result<(), ValidationErro
         ));
     }
 
-    if matches!(args.engine_type, EngineType::Vllm | EngineType::Trtllm)
-        && args.resolved_g1_backend() == G1Backend::Native
-        && args.block_size < 2
-    {
+    if matches!(args.engine_type, EngineType::Vllm | EngineType::Trtllm) && args.block_size < 2 {
         return Err(mock_engine_args_validation_error(
-            "native_g1_block_size_too_small",
+            "shared_scheduler_block_size_too_small",
             format!(
-                "native G1 requires block_size to be at least 2 for engine_type={:?}, got block_size={}; set g1_backend=kvbm to keep block_size=1",
+                "the vLLM/TRT-LLM scheduler requires block_size to be at least 2 for engine_type={:?}, got block_size={}",
                 args.engine_type, args.block_size,
             ),
         ));
@@ -2179,26 +2176,30 @@ mod tests {
     }
 
     #[test]
-    fn test_normalized_native_g1_rejects_block_size_one() {
+    fn test_normalized_shared_scheduler_rejects_block_size_one_for_every_backend() {
         for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
-            let explicit = MockEngineArgs::builder()
-                .engine_type(engine_type)
-                .g1_backend(G1Backend::Native)
-                .block_size(1)
-                .build()
-                .unwrap();
-            let mut unset = explicit.clone();
+            let args_for = |g1_backend| {
+                MockEngineArgs::builder()
+                    .engine_type(engine_type)
+                    .g1_backend(g1_backend)
+                    .block_size(1)
+                    .build()
+                    .unwrap()
+            };
+            let explicit_native = args_for(G1Backend::Native);
+            let explicit_kvbm = args_for(G1Backend::Kvbm);
+            let mut unset = explicit_native.clone();
             unset.g1_backend = None;
+            let mut automatic_kvbm = unset.clone();
+            automatic_kvbm.num_g2_blocks = Some(1);
 
-            for args in [explicit, unset] {
+            for args in [explicit_native, explicit_kvbm, unset, automatic_kvbm] {
                 let error = args.normalized().unwrap_err();
                 let message = error.to_string();
                 assert!(
-                    message.contains("native G1 requires block_size to be at least 2"),
-                    "engine_type={engine_type:?}, error={error:#}"
-                );
-                assert!(
-                    message.contains("set g1_backend=kvbm to keep block_size=1"),
+                    message.contains(
+                        "the vLLM/TRT-LLM scheduler requires block_size to be at least 2"
+                    ),
                     "engine_type={engine_type:?}, error={error:#}"
                 );
             }
@@ -2206,20 +2207,16 @@ mod tests {
     }
 
     #[test]
-    fn test_normalized_kvbm_accepts_block_size_one() {
-        for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
-            let args = MockEngineArgs::builder()
-                .engine_type(engine_type)
-                .g1_backend(G1Backend::Kvbm)
-                .block_size(1)
-                .build()
-                .unwrap()
-                .normalized()
-                .unwrap();
+    fn test_normalized_sglang_accepts_block_size_one() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .block_size(1)
+            .build()
+            .unwrap()
+            .normalized()
+            .unwrap();
 
-            assert_eq!(args.block_size, 1, "engine_type={engine_type:?}");
-            assert_eq!(args.resolved_g1_backend(), G1Backend::Kvbm);
-        }
+        assert_eq!(args.block_size, 1);
     }
 
     #[test]

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -100,7 +100,7 @@ pub(crate) struct NativeBlockIdentity {
 }
 
 impl NativeBlockIdentity {
-    fn partial() -> Self {
+    pub(crate) fn partial() -> Self {
         Self {
             sequence_hash: None,
             local_hash: None,
@@ -276,6 +276,11 @@ impl RequestSequence {
         }
     }
 
+    /// Materialize one complete block's token IDs when event emission requires it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if token-ID event mode did not retain the full request history.
     pub(crate) fn block_token_ids(&self, position: usize) -> Option<Vec<u32>> {
         if !self.emit_token_ids {
             return None;
@@ -593,12 +598,6 @@ impl ActiveSequence {
     }
 
     /// Materialize every complete block's token IDs.
-    ///
-    /// # Panics
-    ///
-    /// Panics for native flat sequences that were created without token-ID
-    /// event emission, because those sequences intentionally discard completed
-    /// prompt and decode blocks.
     pub fn block_token_ids(&self) -> Vec<Vec<u32>> {
         self.block_token_ids_in(0, self.len() / self.block_size)
     }
@@ -765,8 +764,7 @@ impl ActiveSequence {
     /// boundary. Using this to unwind arbitrary prompt history would be incorrect.
     ///
     /// If this contract is violated in release builds, legacy token storage
-    /// preserves its historical no-op on an empty buffer, while flat storage
-    /// panics to surface the invalid rollback.
+    /// preserves its historical no-op on an empty buffer.
     pub fn pop(&mut self) {
         debug_assert!(
             self.generated_tokens > 0,

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -5,7 +5,7 @@ use crate::common::protocols::MoveBlock;
 use derive_getters::Getters;
 use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{
-    BlockHash, PositionalLineageHash, SaltHash, TokenBlockSequence, Tokens,
+    BlockHash, PositionalLineageHash, SaltHash, SequenceHash, TokenBlockSequence, Tokens,
     compute_block_hash_for_tokens, compute_next_sequence_hash,
 };
 use rand::random;
@@ -88,10 +88,252 @@ impl FlatTokens {
     }
 }
 
+/// Logical identity for one native-G1 request block.
+///
+/// A missing sequence hash denotes the request's mutable partial tail. Native
+/// G1 never needs a positional-lineage hash; KVBM continues to use
+/// [`ActiveSequence`] and its legacy metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NativeBlockIdentity {
+    pub(crate) sequence_hash: Option<SequenceHash>,
+    pub(crate) local_hash: Option<BlockHash>,
+}
+
+impl NativeBlockIdentity {
+    fn partial() -> Self {
+        Self {
+            sequence_hash: None,
+            local_hash: None,
+        }
+    }
+}
+
+/// Lightweight request-owned token and generation progress for native G1.
+///
+/// Physical block ownership and cache visibility live in the attached
+/// `BlockRequestLease`; this type deliberately contains no physical IDs,
+/// positional lineage, or allocation bookkeeping.
 #[derive(Debug)]
-enum SequenceTokens {
-    Legacy(TokenBlockSequence),
-    Flat(FlatTokens),
+pub(crate) struct RequestSequence {
+    tokens: FlatTokens,
+    block_size: usize,
+    max_output_tokens: usize,
+    generated_tokens: usize,
+    planned_output_ids: Option<Vec<u32>>,
+    num_input_tokens: usize,
+    enable_prefix_caching: bool,
+    emit_token_ids: bool,
+    retain_local_hashes: bool,
+}
+
+impl RequestSequence {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        tokens: Vec<u32>,
+        max_output_tokens: usize,
+        output_capacity_hint: usize,
+        block_size: usize,
+        enable_prefix_caching: bool,
+        retain_local_hashes: bool,
+        emit_token_ids: bool,
+        planned_output_ids: Option<Vec<u32>>,
+    ) -> (Self, Vec<NativeBlockIdentity>) {
+        assert!(block_size >= 2, "block_size must be at least two");
+        let num_input_tokens = tokens.len();
+        let output_capacity_hint = output_capacity_hint.min(max_output_tokens);
+        let completion_blocks = num_input_tokens
+            .checked_add(output_capacity_hint)
+            .expect("native request completion length overflow")
+            .div_ceil(block_size);
+        let emit_token_ids = emit_token_ids && enable_prefix_caching;
+        let retain_local_hashes = retain_local_hashes && enable_prefix_caching;
+
+        let mut identities = Vec::with_capacity(completion_blocks);
+        let mut parent_hash = None;
+        for block in tokens.chunks_exact(block_size) {
+            let (sequence_hash, local_hash) = if enable_prefix_caching {
+                let local_hash = compute_block_hash_for_tokens(block, MOCKER_SALT_HASH);
+                let sequence_hash = parent_hash
+                    .map(|parent| compute_next_sequence_hash(parent, local_hash))
+                    .unwrap_or(local_hash);
+                (sequence_hash, retain_local_hashes.then_some(local_hash))
+            } else {
+                (random::<u64>(), None)
+            };
+            identities.push(NativeBlockIdentity {
+                sequence_hash: Some(sequence_hash),
+                local_hash,
+            });
+            parent_hash = Some(sequence_hash);
+        }
+        if !tokens.len().is_multiple_of(block_size) {
+            identities.push(NativeBlockIdentity::partial());
+        }
+
+        let sequence = Self {
+            tokens: FlatTokens::new(tokens, output_capacity_hint, block_size, emit_token_ids),
+            block_size,
+            max_output_tokens,
+            generated_tokens: 0,
+            planned_output_ids,
+            num_input_tokens,
+            enable_prefix_caching,
+            emit_token_ids,
+            retain_local_hashes,
+        };
+        sequence.debug_assert_invariants(identities.iter().copied());
+        (sequence, identities)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.tokens.len()
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(crate) fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    pub(crate) fn max_output_tokens(&self) -> usize {
+        self.max_output_tokens
+    }
+
+    pub(crate) fn generated_tokens(&self) -> usize {
+        self.generated_tokens
+    }
+
+    pub(crate) fn num_input_tokens(&self) -> usize {
+        self.num_input_tokens
+    }
+
+    pub(crate) fn enable_prefix_caching(&self) -> bool {
+        self.enable_prefix_caching
+    }
+
+    pub(crate) fn current_known_blocks(&self) -> usize {
+        self.len().div_ceil(self.block_size)
+    }
+
+    pub(crate) fn to_completion_blocks(&self) -> usize {
+        (self.num_input_tokens + self.max_output_tokens).div_ceil(self.block_size)
+    }
+
+    /// Append the next planned or synthetic token.
+    ///
+    /// Returns the token and whether this append opened a new partial block.
+    pub(crate) fn generate_token(&mut self) -> (u32, bool) {
+        assert!(
+            self.generated_tokens < self.max_output_tokens,
+            "Cannot generate more tokens: reached max_output_tokens limit"
+        );
+        let token = self
+            .planned_output_ids
+            .as_ref()
+            .and_then(|ids| ids.get(self.generated_tokens).copied())
+            .unwrap_or_else(random::<u32>);
+        let opened_partial = self.len().is_multiple_of(self.block_size);
+        self.tokens.push(token);
+        self.generated_tokens += 1;
+        (token, opened_partial)
+    }
+
+    pub(crate) fn pop_generated_token(&mut self) -> bool {
+        assert!(
+            self.generated_tokens > 0,
+            "sequence rollback requires a freshly generated token"
+        );
+        self.tokens
+            .pop()
+            .expect("native sequence rollback requires a retained token");
+        self.generated_tokens -= 1;
+        self.len().is_multiple_of(self.block_size)
+    }
+
+    pub(crate) fn complete_block_identity(
+        &self,
+        position: usize,
+        parent_hash: Option<SequenceHash>,
+    ) -> NativeBlockIdentity {
+        let tokens = self
+            .tokens
+            .complete_block(position, self.block_size)
+            .unwrap_or_else(|| {
+                panic!("native partial tail cannot be promoted without a complete token block")
+            });
+        if !self.enable_prefix_caching {
+            return NativeBlockIdentity {
+                sequence_hash: Some(random::<u64>()),
+                local_hash: None,
+            };
+        }
+        let local_hash = compute_block_hash_for_tokens(tokens, MOCKER_SALT_HASH);
+        let sequence_hash = parent_hash
+            .map(|parent| compute_next_sequence_hash(parent, local_hash))
+            .unwrap_or(local_hash);
+        NativeBlockIdentity {
+            sequence_hash: Some(sequence_hash),
+            local_hash: self.retain_local_hashes.then_some(local_hash),
+        }
+    }
+
+    pub(crate) fn block_token_ids(&self, position: usize) -> Option<Vec<u32>> {
+        if !self.emit_token_ids {
+            return None;
+        }
+        assert_eq!(
+            self.tokens.retained_start, 0,
+            "token-ID event mode must retain full request history"
+        );
+        self.tokens
+            .complete_block(position, self.block_size)
+            .map(<[u32]>::to_vec)
+    }
+
+    /// Compact the bounded native tail after its completed block is published.
+    pub(crate) fn discard_completed_block(&mut self, position: usize) {
+        if self.emit_token_ids {
+            return;
+        }
+        let promoted_end = position
+            .checked_add(1)
+            .and_then(|blocks| blocks.checked_mul(self.block_size))
+            .expect("native promoted-block boundary overflow");
+        if promoted_end <= self.tokens.retained_start {
+            return;
+        }
+        self.tokens.discard_through(promoted_end);
+    }
+
+    pub(crate) fn debug_assert_invariants(
+        &self,
+        identities: impl ExactSizeIterator<Item = NativeBlockIdentity>,
+    ) {
+        #[cfg(debug_assertions)]
+        {
+            let identity_count = identities.len();
+            let aligned = self.len().is_multiple_of(self.block_size);
+            debug_assert_eq!(identity_count, self.current_known_blocks());
+            debug_assert!(
+                identities
+                    .enumerate()
+                    .all(
+                        |(position, identity)| position + 1 == identity_count && !aligned
+                            || identity.sequence_hash.is_some()
+                    ),
+                "only the final native block may be partial"
+            );
+            if self.emit_token_ids {
+                debug_assert_eq!(self.tokens.retained_start, 0);
+            } else {
+                debug_assert!(self.tokens.retained.len() <= self.block_size + 1);
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn token_capacity(&self) -> usize {
+        self.tokens.retained.capacity()
+    }
 }
 
 /// Create unique blocks, block hashes, and positional-lineage hashes from a
@@ -130,53 +372,6 @@ fn create_sequence_cache(
     (unique_blocks, block_hashes, plhs)
 }
 
-/// Build the native-G1 block metadata directly over a flat token vector.
-fn create_flat_sequence_cache(
-    tokens: &[u32],
-    block_size: usize,
-    enable_prefix_caching: bool,
-    completion_blocks: usize,
-) -> (Vec<UniqueBlock>, Vec<BlockHash>, Vec<PositionalLineageHash>) {
-    let mut unique_blocks = Vec::with_capacity(completion_blocks);
-    let mut block_hashes = if enable_prefix_caching {
-        Vec::with_capacity(completion_blocks)
-    } else {
-        Vec::new()
-    };
-    let mut plhs = Vec::with_capacity(completion_blocks);
-    let mut parent_hash = None;
-
-    for (position, block) in tokens.chunks_exact(block_size).enumerate() {
-        if enable_prefix_caching {
-            let block_hash = compute_block_hash_for_tokens(block, MOCKER_SALT_HASH);
-            let sequence_hash = parent_hash
-                .map(|parent| compute_next_sequence_hash(parent, block_hash))
-                .unwrap_or(block_hash);
-            block_hashes.push(block_hash);
-            unique_blocks.push(UniqueBlock::FullBlock(sequence_hash));
-            plhs.push(PositionalLineageHash::new(
-                sequence_hash,
-                parent_hash,
-                position as u64,
-            ));
-            parent_hash = Some(sequence_hash);
-        } else {
-            unique_blocks.push(UniqueBlock::FullBlock(random::<u64>()));
-            plhs.push(PositionalLineageHash::new(
-                random::<u64>(),
-                None,
-                position as u64,
-            ));
-        }
-    }
-
-    if !tokens.len().is_multiple_of(block_size) {
-        unique_blocks.push(UniqueBlock::default());
-    }
-
-    (unique_blocks, block_hashes, plhs)
-}
-
 /// A sequence that is actively being built, with the ability to add tokens and commit to hashes
 /// TODO: reuse tokens
 #[derive(Debug, Getters, Validate)]
@@ -186,7 +381,7 @@ pub struct ActiveSequence {
     plhs: Vec<PositionalLineageHash>,
 
     #[getter(skip)]
-    tokens: SequenceTokens,
+    tokens: TokenBlockSequence,
 
     #[getter(copy)]
     #[validate(range(min = 2))]
@@ -214,28 +409,6 @@ pub struct ActiveSequence {
 }
 
 impl ActiveSequence {
-    /// Promote the mutable tail after its last token has actually been
-    /// computed.
-    ///
-    /// A generated block is represented as partial until the scheduler has
-    /// computed every token in it.  The historical path promotes that block
-    /// when the first token of the following block is appended.  Native vLLM
-    /// prefix caching needs the earlier boundary: `allocate_slots()` caches a
-    /// just-completed block before considering the next waiting request in the
-    /// same scheduling pass.
-    pub(crate) fn promote_computed_tail(
-        &mut self,
-        cumulative_computed_tokens: usize,
-    ) -> Option<MoveBlock> {
-        if cumulative_computed_tokens == 0
-            || cumulative_computed_tokens != self.len()
-            || !cumulative_computed_tokens.is_multiple_of(self.block_size)
-        {
-            return None;
-        }
-        self.promote_last_partial()
-    }
-
     fn promote_last_partial(&mut self) -> Option<MoveBlock> {
         let UniqueBlock::PartialBlock(uuid) = self.unique_blocks.last().cloned()? else {
             return None;
@@ -249,61 +422,26 @@ impl ActiveSequence {
             });
         let position = self.plhs.len();
         debug_assert_eq!(position + 1, self.len() / self.block_size);
-        let (last_seq_hash, last_block_hash, last_plh, promote_token_ids) = match &self.tokens {
-            SequenceTokens::Legacy(tokens) => {
-                let last_complete = tokens.last_complete_block().unwrap_or_else(|| {
-                    panic!(
-                        "partial sequence tail cannot be promoted without a complete token block"
-                    )
-                });
-                let last_seq_hash = if self.enable_prefix_caching {
-                    last_complete.sequence_hash()
-                } else {
-                    random::<u64>()
-                };
-                let last_block_hash = self
-                    .enable_prefix_caching
-                    .then(|| last_complete.block_hash());
-                // With prefix caching off, the sequence hash and PLH must both remain
-                // request-unique so another identical prompt cannot reuse this slot.
-                let last_plh = if self.enable_prefix_caching {
-                    last_complete.positional_lineage_hash()
-                } else {
-                    PositionalLineageHash::new(random::<u64>(), None, position as u64)
-                };
-                let promote_token_ids = if self.emit_token_ids {
-                    Some(last_complete.tokens().to_vec())
-                } else {
-                    None
-                };
-                (last_seq_hash, last_block_hash, last_plh, promote_token_ids)
-            }
-            SequenceTokens::Flat(tokens) => {
-                let complete = tokens
-                    .complete_block(position, self.block_size)
-                    .unwrap_or_else(|| {
-                    panic!(
-                        "partial flat sequence tail cannot be promoted without a complete token block"
-                    )
-                });
-                let last_block_hash = self
-                    .enable_prefix_caching
-                    .then(|| compute_block_hash_for_tokens(complete, MOCKER_SALT_HASH));
-                let last_seq_hash = last_block_hash
-                    .map(|block_hash| {
-                        parent_hash
-                            .map(|parent| compute_next_sequence_hash(parent, block_hash))
-                            .unwrap_or(block_hash)
-                    })
-                    .unwrap_or_else(random::<u64>);
-                let last_plh = if self.enable_prefix_caching {
-                    PositionalLineageHash::new(last_seq_hash, parent_hash, position as u64)
-                } else {
-                    PositionalLineageHash::new(random::<u64>(), None, position as u64)
-                };
-                let promote_token_ids = self.emit_token_ids.then(|| complete.to_vec());
-                (last_seq_hash, last_block_hash, last_plh, promote_token_ids)
-            }
+        let last_complete = self.tokens.last_complete_block().unwrap_or_else(|| {
+            panic!("partial sequence tail cannot be promoted without a complete token block")
+        });
+        let last_seq_hash = if self.enable_prefix_caching {
+            last_complete.sequence_hash()
+        } else {
+            random::<u64>()
+        };
+        let last_block_hash = self
+            .enable_prefix_caching
+            .then(|| last_complete.block_hash());
+        let last_plh = if self.enable_prefix_caching {
+            last_complete.positional_lineage_hash()
+        } else {
+            PositionalLineageHash::new(random::<u64>(), None, position as u64)
+        };
+        let promote_token_ids = if self.emit_token_ids {
+            Some(last_complete.tokens().to_vec())
+        } else {
+            None
         };
         if let Some(last_block_hash) = last_block_hash {
             self.block_hashes.push(last_block_hash);
@@ -313,17 +451,6 @@ impl ActiveSequence {
 
         self.unique_blocks
             .push(UniqueBlock::FullBlock(last_seq_hash));
-
-        if !self.emit_token_ids {
-            let promoted_end = position
-                .checked_add(1)
-                .and_then(|blocks| blocks.checked_mul(self.block_size))
-                .expect("promoted flat-token boundary overflow");
-            if let SequenceTokens::Flat(tokens) = &mut self.tokens {
-                tokens.discard_through(promoted_end);
-            }
-        }
-        self.debug_assert_flat_token_invariants();
 
         Some(MoveBlock::Promote(
             uuid,
@@ -372,7 +499,7 @@ impl ActiveSequence {
             unique_blocks,
             block_hashes,
             plhs,
-            tokens: SequenceTokens::Legacy(tokens),
+            tokens,
             block_size,
             max_output_tokens,
             generated_tokens: 0,
@@ -386,63 +513,12 @@ impl ActiveSequence {
         seq
     }
 
-    /// Build a native-G1 sequence directly over the request's flat token vector.
-    ///
-    /// `output_capacity_hint` controls eager allocation only. The logical
-    /// generation limit remains `max_output_tokens`, and the vectors can grow
-    /// if the scheduler realizes more output than the hint.
-    pub(crate) fn new_flat_with_planned_output_ids(
-        tokens: Vec<u32>,
-        max_output_tokens: usize,
-        output_capacity_hint: usize,
-        block_size: usize,
-        enable_prefix_caching: bool,
-        emit_token_ids: bool,
-        planned_output_ids: Option<Vec<u32>>,
-    ) -> Self {
-        let num_input_tokens = tokens.len();
-        let emit_token_ids = emit_token_ids && enable_prefix_caching;
-        let output_capacity_hint = output_capacity_hint.min(max_output_tokens);
-        let completion_blocks = num_input_tokens
-            .checked_add(output_capacity_hint)
-            .expect("native sequence completion length overflow")
-            .div_ceil(block_size);
-        let (unique_blocks, block_hashes, plhs) = create_flat_sequence_cache(
-            &tokens,
-            block_size,
-            enable_prefix_caching,
-            completion_blocks,
-        );
-        let tokens = FlatTokens::new(tokens, output_capacity_hint, block_size, emit_token_ids);
-
-        let seq = Self {
-            unique_blocks,
-            block_hashes,
-            plhs,
-            tokens: SequenceTokens::Flat(tokens),
-            block_size,
-            max_output_tokens,
-            generated_tokens: 0,
-            planned_output_ids,
-            num_input_tokens,
-            num_allocated_tokens: 0,
-            enable_prefix_caching,
-            emit_token_ids,
-        };
-        seq.validate().expect("invalid flat ActiveSequence");
-        seq.debug_assert_flat_token_invariants();
-        seq
-    }
-
     pub fn extra_tokens(&self) -> u32 {
         (self.len() % self.block_size) as u32
     }
 
     pub fn len(&self) -> usize {
-        match &self.tokens {
-            SequenceTokens::Legacy(tokens) => tokens.total_tokens(),
-            SequenceTokens::Flat(tokens) => tokens.len(),
-        }
+        self.tokens.total_tokens()
     }
 
     pub fn is_empty(&self) -> bool {
@@ -510,25 +586,10 @@ impl ActiveSequence {
     }
 
     fn block_token_ids_in(&self, start: usize, end: usize) -> Vec<Vec<u32>> {
-        match &self.tokens {
-            SequenceTokens::Legacy(tokens) => tokens.blocks()[start..end]
-                .iter()
-                .map(|block| block.tokens().to_vec())
-                .collect(),
-            SequenceTokens::Flat(tokens) => {
-                assert!(
-                    self.emit_token_ids && tokens.retained_start == 0,
-                    "flat sequences retain full token history only when token-ID events are enabled"
-                );
-                tokens
-                    .retained
-                    .chunks_exact(self.block_size)
-                    .skip(start)
-                    .take(end - start)
-                    .map(<[u32]>::to_vec)
-                    .collect()
-            }
-        }
+        self.tokens.blocks()[start..end]
+            .iter()
+            .map(|block| block.tokens().to_vec())
+            .collect()
     }
 
     /// Materialize every complete block's token IDs.
@@ -580,14 +641,8 @@ impl ActiveSequence {
     /// Push a token to the sequence
     #[cfg_attr(feature = "profile", inline(never))]
     pub fn push(&mut self, token: u32) -> Option<Vec<MoveBlock>> {
-        match &mut self.tokens {
-            SequenceTokens::Legacy(tokens) => {
-                tokens.append(token).expect("Token push failed.");
-            }
-            SequenceTokens::Flat(tokens) => tokens.push(token),
-        }
+        self.tokens.append(token).expect("Token push failed.");
         self.generated_tokens += 1;
-        self.debug_assert_flat_token_invariants();
 
         if self.len() % self.block_size != 1 {
             return None;
@@ -612,7 +667,6 @@ impl ActiveSequence {
             None,
             None,
         ));
-        self.debug_assert_flat_token_invariants();
         Some(signals)
     }
 
@@ -718,81 +772,26 @@ impl ActiveSequence {
             self.generated_tokens > 0,
             "sequence rollback requires a freshly generated token"
         );
-        match &mut self.tokens {
-            SequenceTokens::Legacy(tokens) => {
-                tokens.pop();
-            }
-            SequenceTokens::Flat(tokens) => {
-                debug_assert!(
-                    !tokens.retained.is_empty(),
-                    "flat rollback token must be retained"
-                );
-                tokens.pop().expect("flat rollback token must be retained");
-            }
-        }
+        self.tokens.pop();
         self.generated_tokens = self.generated_tokens.saturating_sub(1);
 
         // Reverts to the last full block
         if self.len().is_multiple_of(self.block_size) {
             self.unique_blocks.pop();
         }
-        self.debug_assert_flat_token_invariants();
-    }
-
-    fn debug_assert_flat_token_invariants(&self) {
-        if let SequenceTokens::Flat(tokens) = &self.tokens {
-            debug_assert_eq!(
-                tokens.len(),
-                self.num_input_tokens + self.generated_tokens,
-                "flat retained-token window must cover the logical sequence suffix"
-            );
-            if self.emit_token_ids {
-                debug_assert_eq!(
-                    tokens.retained_start, 0,
-                    "token-ID events require complete flat-token history"
-                );
-            } else {
-                debug_assert!(
-                    tokens.retained.len() <= self.block_size + 1,
-                    "non-emitting flat sequences retain at most one block plus the next token"
-                );
-            }
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn uses_flat_tokens(&self) -> bool {
-        matches!(self.tokens, SequenceTokens::Flat(_))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn flat_storage_capacities(&self) -> Option<(usize, usize, usize, usize)> {
-        let SequenceTokens::Flat(tokens) = &self.tokens else {
-            return None;
-        };
-        Some((
-            tokens.retained.capacity(),
-            self.unique_blocks.capacity(),
-            self.block_hashes.capacity(),
-            self.plhs.capacity(),
-        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dynamo_tokens::SequenceHash;
 
     fn block_hashes_from_tokens(seq: &ActiveSequence) -> Vec<BlockHash> {
-        match &seq.tokens {
-            SequenceTokens::Legacy(tokens) => tokens
-                .blocks()
-                .iter()
-                .map(|block| block.block_hash())
-                .collect(),
-            SequenceTokens::Flat(_) => seq.block_hashes().clone(),
-        }
+        seq.tokens
+            .blocks()
+            .iter()
+            .map(|block| block.block_hash())
+            .collect()
     }
 
     fn assert_cached_hashes_match_promoted_blocks(seq: &ActiveSequence) {
@@ -1096,484 +1095,5 @@ mod tests {
         // current partial block; this is the replay/preemption path we rely on.
         seq.pop();
         assert_cached_hashes_match_promoted_blocks(&seq);
-    }
-
-    #[derive(Debug, PartialEq)]
-    enum SignalShape {
-        Use {
-            blocks: Vec<Option<u64>>,
-            hashes: Vec<BlockHash>,
-            plhs: Vec<PositionalLineageHash>,
-            token_ids: Option<Vec<Vec<u32>>>,
-            parent: Option<Option<u64>>,
-        },
-        Deref(Vec<Option<u64>>),
-        Promote {
-            sequence_hash: SequenceHash,
-            parent_hash: Option<u64>,
-            block_hash: Option<BlockHash>,
-            plh: PositionalLineageHash,
-            token_ids: Option<Vec<u32>>,
-        },
-    }
-
-    fn block_shape(block: &UniqueBlock) -> Option<u64> {
-        match block {
-            UniqueBlock::FullBlock(hash) => Some(*hash),
-            UniqueBlock::PartialBlock(_) => None,
-        }
-    }
-
-    fn signal_shape(signal: MoveBlock) -> SignalShape {
-        match signal {
-            MoveBlock::Use(blocks, hashes, plhs, token_ids, parent) => SignalShape::Use {
-                blocks: blocks.iter().map(block_shape).collect(),
-                hashes,
-                plhs,
-                token_ids,
-                parent: parent.as_ref().map(block_shape),
-            },
-            MoveBlock::Deref(blocks) => {
-                SignalShape::Deref(blocks.iter().map(block_shape).collect())
-            }
-            MoveBlock::Promote(_, sequence_hash, parent_hash, block_hash, plh, token_ids) => {
-                SignalShape::Promote {
-                    sequence_hash,
-                    parent_hash,
-                    block_hash,
-                    plh,
-                    token_ids,
-                }
-            }
-        }
-    }
-
-    fn signal_shapes(signals: impl IntoIterator<Item = MoveBlock>) -> Vec<SignalShape> {
-        signals.into_iter().map(signal_shape).collect()
-    }
-
-    fn sequence_pair(
-        prompt: Vec<u32>,
-        output_ids: Vec<u32>,
-        block_size: usize,
-        emit_token_ids: bool,
-    ) -> (ActiveSequence, ActiveSequence) {
-        let legacy = ActiveSequence::new_with_planned_output_ids(
-            prompt.clone(),
-            output_ids.len(),
-            Some(block_size),
-            true,
-            emit_token_ids,
-            Some(output_ids.clone()),
-        );
-        let flat = ActiveSequence::new_flat_with_planned_output_ids(
-            prompt,
-            output_ids.len(),
-            output_ids.len(),
-            block_size,
-            true,
-            emit_token_ids,
-            Some(output_ids),
-        );
-        assert!(!legacy.uses_flat_tokens());
-        assert!(flat.uses_flat_tokens());
-        (legacy, flat)
-    }
-
-    fn assert_sequence_parity(legacy: &ActiveSequence, flat: &ActiveSequence) {
-        assert_eq!(legacy.len(), flat.len());
-        assert_eq!(legacy.extra_tokens(), flat.extra_tokens());
-        assert_eq!(legacy.emit_token_ids(), flat.emit_token_ids());
-        assert_eq!(legacy.block_hashes(), flat.block_hashes());
-        assert_eq!(
-            legacy.positional_lineage_hashes(),
-            flat.positional_lineage_hashes()
-        );
-        assert_eq!(
-            legacy
-                .unique_blocks()
-                .iter()
-                .map(block_shape)
-                .collect::<Vec<_>>(),
-            flat.unique_blocks()
-                .iter()
-                .map(block_shape)
-                .collect::<Vec<_>>()
-        );
-        assert_eq!(legacy.generated_tokens(), flat.generated_tokens());
-        assert_eq!(legacy.num_input_tokens(), flat.num_input_tokens());
-        assert_eq!(legacy.num_allocated_tokens(), flat.num_allocated_tokens());
-        if flat.emit_token_ids() {
-            assert_eq!(legacy.block_token_ids(), flat.block_token_ids());
-        } else {
-            let SequenceTokens::Flat(tokens) = &flat.tokens else {
-                panic!("expected flat token storage");
-            };
-            assert!(
-                tokens.retained.len() <= flat.block_size() + 1,
-                "non-emitting flat storage exceeded one block plus one token"
-            );
-        }
-    }
-
-    #[test]
-    fn flat_sequence_matches_legacy_across_prompt_and_output_boundaries() {
-        const BLOCK_SIZE: usize = 16;
-        for promote_eagerly in [true, false] {
-            for emit_token_ids in [false, true] {
-                for prompt_len in [0, 1, BLOCK_SIZE - 1, BLOCK_SIZE, BLOCK_SIZE + 1, 53] {
-                    let prompt: Vec<u32> = (0..prompt_len as u32).collect();
-                    let outputs: Vec<u32> =
-                        (10_000..10_000 + (BLOCK_SIZE * 2 + 3) as u32).collect();
-                    let (mut legacy, mut flat) =
-                        sequence_pair(prompt, outputs.clone(), BLOCK_SIZE, emit_token_ids);
-                    let SequenceTokens::Flat(tokens) = &flat.tokens else {
-                        panic!("expected flat token storage");
-                    };
-                    let token_capacity = tokens.retained.capacity();
-                    let mut push_promotions = 0;
-
-                    assert_sequence_parity(&legacy, &flat);
-                    assert_eq!(
-                        legacy.take_creation_signal().map(signal_shape),
-                        flat.take_creation_signal().map(signal_shape)
-                    );
-
-                    for expected_token in outputs {
-                        let (legacy_token, legacy_signals) = legacy.generate_token();
-                        let (flat_token, flat_signals) = flat.generate_token();
-                        assert_eq!(legacy_token, expected_token);
-                        assert_eq!(flat_token, expected_token);
-
-                        let legacy_push_promoted = legacy_signals
-                            .iter()
-                            .any(|signal| matches!(signal, MoveBlock::Promote(..)));
-                        let flat_push_promoted = flat_signals
-                            .iter()
-                            .any(|signal| matches!(signal, MoveBlock::Promote(..)));
-                        assert_eq!(legacy_push_promoted, flat_push_promoted);
-                        if flat_push_promoted {
-                            push_promotions += 1;
-                        }
-                        assert_eq!(signal_shapes(legacy_signals), signal_shapes(flat_signals));
-                        assert_sequence_parity(&legacy, &flat);
-
-                        let SequenceTokens::Flat(tokens) = &flat.tokens else {
-                            panic!("expected flat token storage");
-                        };
-                        assert_eq!(tokens.retained.capacity(), token_capacity);
-                        if flat_push_promoted && !emit_token_ids {
-                            assert_eq!(tokens.retained.len(), 1);
-                            assert_eq!(tokens.retained_start + 1, flat.len());
-                        }
-
-                        if promote_eagerly
-                            && legacy.generated_tokens() < legacy.max_output_tokens()
-                            && legacy.len().is_multiple_of(BLOCK_SIZE)
-                        {
-                            assert_eq!(
-                                legacy.promote_computed_tail(legacy.len()).map(signal_shape),
-                                flat.promote_computed_tail(flat.len()).map(signal_shape)
-                            );
-                            assert_sequence_parity(&legacy, &flat);
-                        }
-                    }
-
-                    if promote_eagerly {
-                        assert_eq!(push_promotions, 0);
-                    } else {
-                        assert!(push_promotions > 0);
-                    }
-                    assert_eq!(
-                        signal_shapes(legacy.terminal_signals()),
-                        signal_shapes(flat.terminal_signals())
-                    );
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn flat_sequence_matches_chunked_token_id_allocations() {
-        const BLOCK_SIZE: usize = 4;
-        let prompt: Vec<u32> = (0..12).collect();
-        let (mut legacy, mut flat) = sequence_pair(prompt.clone(), Vec::new(), BLOCK_SIZE, true);
-
-        for cumulative_tokens in [4, 8, 12] {
-            let legacy_signal = legacy
-                .prepare_allocation(cumulative_tokens)
-                .expect("legacy chunk should allocate");
-            let flat_signal = flat
-                .prepare_allocation(cumulative_tokens)
-                .expect("flat chunk should allocate");
-            assert_eq!(
-                signal_shape(legacy_signal),
-                signal_shape(flat_signal.clone())
-            );
-            let MoveBlock::Use(_, _, _, Some(token_ids), _) = flat_signal else {
-                panic!("chunked native allocation must include token IDs");
-            };
-            let start = cumulative_tokens - BLOCK_SIZE;
-            assert_eq!(token_ids, vec![prompt[start..cumulative_tokens].to_vec()]);
-            legacy.commit_allocation(cumulative_tokens);
-            flat.commit_allocation(cumulative_tokens);
-        }
-    }
-
-    #[test]
-    fn flat_sequence_capacities_do_not_grow_during_decode() {
-        const BLOCK_SIZE: usize = 16;
-        let prompt: Vec<u32> = (0..17).collect();
-        let outputs: Vec<u32> = (1_000..1_037).collect();
-
-        for emit_token_ids in [false, true] {
-            let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
-                prompt.clone(),
-                outputs.len(),
-                outputs.len(),
-                BLOCK_SIZE,
-                true,
-                emit_token_ids,
-                Some(outputs.clone()),
-            );
-            let metadata_capacities = (
-                flat.unique_blocks.capacity(),
-                flat.block_hashes.capacity(),
-                flat.plhs.capacity(),
-            );
-            let SequenceTokens::Flat(tokens) = &flat.tokens else {
-                panic!("expected flat token storage");
-            };
-            let token_capacity = tokens.retained.capacity();
-            if emit_token_ids {
-                assert!(token_capacity >= prompt.len() + outputs.len());
-            } else {
-                assert!(token_capacity > BLOCK_SIZE);
-                assert_eq!(tokens.retained_start, BLOCK_SIZE);
-                assert_eq!(tokens.retained, prompt[BLOCK_SIZE..]);
-            }
-
-            for _ in &outputs {
-                flat.generate_token();
-                if flat.generated_tokens() < flat.max_output_tokens()
-                    && flat.len().is_multiple_of(BLOCK_SIZE)
-                {
-                    flat.promote_computed_tail(flat.len());
-                }
-
-                assert_eq!(
-                    metadata_capacities,
-                    (
-                        flat.unique_blocks.capacity(),
-                        flat.block_hashes.capacity(),
-                        flat.plhs.capacity(),
-                    )
-                );
-                let SequenceTokens::Flat(tokens) = &flat.tokens else {
-                    panic!("expected flat token storage");
-                };
-                assert_eq!(tokens.retained.capacity(), token_capacity);
-                if emit_token_ids {
-                    assert_eq!(tokens.retained_start, 0);
-                } else {
-                    assert!(tokens.retained.len() <= BLOCK_SIZE + 1);
-                }
-            }
-        }
-    }
-
-    fn assert_uncached_signal_parity(left: Vec<MoveBlock>, right: Vec<MoveBlock>) {
-        assert_eq!(left.len(), right.len());
-        for (left, right) in left.into_iter().zip(right) {
-            match (left, right) {
-                (
-                    MoveBlock::Use(lb, lh, lp, lt, lparent),
-                    MoveBlock::Use(rb, rh, rp, rt, rparent),
-                ) => {
-                    assert_eq!(
-                        lb.iter()
-                            .map(block_shape)
-                            .map(|hash| hash.is_some())
-                            .collect::<Vec<_>>(),
-                        rb.iter()
-                            .map(block_shape)
-                            .map(|hash| hash.is_some())
-                            .collect::<Vec<_>>()
-                    );
-                    assert_eq!(lh.len(), rh.len());
-                    assert_eq!(lp.len(), rp.len());
-                    assert_eq!(lt.is_some(), rt.is_some());
-                    assert_eq!(lparent.is_some(), rparent.is_some());
-                }
-                (
-                    MoveBlock::Promote(_, _, lp, lbh, lplh, lt),
-                    MoveBlock::Promote(_, _, rp, rbh, rplh, rt),
-                ) => {
-                    assert_eq!(lp.is_some(), rp.is_some());
-                    assert_eq!(lbh.is_some(), rbh.is_some());
-                    assert_eq!(lplh.position(), rplh.position());
-                    assert_eq!(lt.is_some(), rt.is_some());
-                }
-                (MoveBlock::Deref(lb), MoveBlock::Deref(rb)) => {
-                    assert_eq!(lb.len(), rb.len());
-                    assert_eq!(
-                        lb.iter()
-                            .map(block_shape)
-                            .map(|hash| hash.is_some())
-                            .collect::<Vec<_>>(),
-                        rb.iter()
-                            .map(block_shape)
-                            .map(|hash| hash.is_some())
-                            .collect::<Vec<_>>()
-                    );
-                }
-                (left, right) => panic!("signal variants differ: {left:?} != {right:?}"),
-            }
-        }
-    }
-
-    #[test]
-    fn flat_sequence_matches_uncached_legacy_structure() {
-        const BLOCK_SIZE: usize = 4;
-        let prompt: Vec<u32> = (0..9).collect();
-        let outputs: Vec<u32> = (100..108).collect();
-        let mut legacy = ActiveSequence::new_with_planned_output_ids(
-            prompt.clone(),
-            outputs.len(),
-            Some(BLOCK_SIZE),
-            false,
-            true,
-            Some(outputs.clone()),
-        );
-        let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
-            prompt,
-            outputs.len(),
-            outputs.len(),
-            BLOCK_SIZE,
-            false,
-            true,
-            Some(outputs),
-        );
-
-        assert!(!legacy.emit_token_ids());
-        assert!(!flat.emit_token_ids());
-        assert!(legacy.block_hashes().is_empty());
-        assert!(flat.block_hashes().is_empty());
-        assert_eq!(legacy.unique_blocks().len(), flat.unique_blocks().len());
-        assert_eq!(
-            legacy
-                .positional_lineage_hashes()
-                .iter()
-                .map(PositionalLineageHash::position)
-                .collect::<Vec<_>>(),
-            flat.positional_lineage_hashes()
-                .iter()
-                .map(PositionalLineageHash::position)
-                .collect::<Vec<_>>()
-        );
-        assert_uncached_signal_parity(
-            legacy.take_creation_signal().into_iter().collect(),
-            flat.take_creation_signal().into_iter().collect(),
-        );
-
-        while legacy.generated_tokens() < legacy.max_output_tokens() {
-            let (_, legacy_signals) = legacy.generate_token();
-            let (_, flat_signals) = flat.generate_token();
-            assert_uncached_signal_parity(legacy_signals, flat_signals);
-        }
-        assert_uncached_signal_parity(legacy.terminal_signals(), flat.terminal_signals());
-    }
-
-    #[test]
-    #[should_panic(expected = "partial block cannot be a parent")]
-    fn flat_promotion_rejects_partial_parent() {
-        let mut flat = ActiveSequence::new_flat_with_planned_output_ids(
-            (0..15).collect(),
-            1,
-            1,
-            16,
-            true,
-            false,
-            Some(vec![99]),
-        );
-        flat.push(99);
-        flat.unique_blocks.insert(0, UniqueBlock::default());
-        flat.promote_computed_tail(flat.len());
-    }
-
-    #[test]
-    #[should_panic(expected = "flat sequences retain full token history")]
-    fn non_emitting_flat_sequence_rejects_token_materialization() {
-        let flat = ActiveSequence::new_flat_with_planned_output_ids(
-            (0..16).collect(),
-            1,
-            1,
-            16,
-            true,
-            false,
-            None,
-        );
-        flat.block_token_ids();
-    }
-
-    #[test]
-    fn flat_sequence_matches_legacy_reset_and_one_token_rollback() {
-        const BLOCK_SIZE: usize = 16;
-        let prompt: Vec<u32> = (0..BLOCK_SIZE as u32).collect();
-        let (mut legacy, mut flat) = sequence_pair(prompt, vec![1_001, 1_002], BLOCK_SIZE, false);
-
-        legacy.take_creation_signal();
-        flat.take_creation_signal();
-        assert_eq!(
-            signal_shapes(legacy.push(1_001).unwrap()),
-            signal_shapes(flat.push(1_001).unwrap())
-        );
-        legacy.pop();
-        flat.pop();
-        assert_sequence_parity(&legacy, &flat);
-
-        legacy.commit_allocation(legacy.len());
-        flat.commit_allocation(flat.len());
-        assert_eq!(
-            signal_shapes(legacy.reset_with_signal()),
-            signal_shapes(flat.reset_with_signal())
-        );
-    }
-
-    #[test]
-    fn flat_sequence_preserves_uncached_random_identity_behavior() {
-        let make = || {
-            ActiveSequence::new_flat_with_planned_output_ids(
-                (0..17).collect(),
-                16,
-                16,
-                16,
-                false,
-                true,
-                None,
-            )
-        };
-        let mut first = make();
-        let second = make();
-
-        assert!(first.block_hashes().is_empty());
-        assert_ne!(first.unique_blocks()[0], second.unique_blocks()[0]);
-        assert_ne!(
-            first.positional_lineage_hashes()[0],
-            second.positional_lineage_hashes()[0]
-        );
-
-        for token in 0..15 {
-            first.push(token);
-        }
-        let promote = first
-            .promote_computed_tail(first.len())
-            .expect("completed uncached block should promote");
-        let MoveBlock::Promote(_, _, _, block_hash, plh, token_ids) = promote else {
-            panic!("expected promote signal");
-        };
-        assert!(block_hash.is_none());
-        assert_eq!(plh.parent_hash_fragment(), 0);
-        assert!(token_ids.is_none());
     }
 }

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -59,10 +59,6 @@ impl FlatTokens {
         self.retained.push(token);
     }
 
-    fn pop(&mut self) -> Option<u32> {
-        self.retained.pop()
-    }
-
     fn complete_block(&self, position: usize, block_size: usize) -> Option<&[u32]> {
         let start = position.checked_mul(block_size)?;
         debug_assert!(
@@ -237,23 +233,15 @@ impl RequestSequence {
         (token, opened_partial)
     }
 
-    pub(crate) fn pop_generated_token(&mut self) -> bool {
-        assert!(
-            self.generated_tokens > 0,
-            "sequence rollback requires a freshly generated token"
-        );
-        self.tokens
-            .pop()
-            .expect("native sequence rollback requires a retained token");
-        self.generated_tokens -= 1;
-        self.len().is_multiple_of(self.block_size)
-    }
-
     pub(crate) fn complete_block_identity(
         &self,
         position: usize,
         parent_hash: Option<SequenceHash>,
     ) -> NativeBlockIdentity {
+        // Validate that the retained tail still contains the complete block
+        // even when prefix caching is disabled. Finalization discards that
+        // tail immediately afterward, so skipping this lookup would hide
+        // request/lease progress drift.
         let tokens = self
             .tokens
             .complete_block(position, self.block_size)
@@ -313,6 +301,8 @@ impl RequestSequence {
         &self,
         _identities: impl ExactSizeIterator<Item = NativeBlockIdentity>,
     ) {
+        // The underscore keeps release builds warning-free; debug builds use
+        // the iterator for the full logical-identity consistency check.
         #[cfg(debug_assertions)]
         {
             let identity_count = _identities.len();

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -306,15 +306,15 @@ impl RequestSequence {
 
     pub(crate) fn debug_assert_invariants(
         &self,
-        identities: impl ExactSizeIterator<Item = NativeBlockIdentity>,
+        _identities: impl ExactSizeIterator<Item = NativeBlockIdentity>,
     ) {
         #[cfg(debug_assertions)]
         {
-            let identity_count = identities.len();
+            let identity_count = _identities.len();
             let aligned = self.len().is_multiple_of(self.block_size);
             debug_assert_eq!(identity_count, self.current_known_blocks());
             debug_assert!(
-                identities
+                _identities
                     .enumerate()
                     .all(
                         |(position, identity)| position + 1 == identity_count && !aligned

--- a/lib/mocker/src/common/sequence.rs
+++ b/lib/mocker/src/common/sequence.rs
@@ -309,19 +309,44 @@ impl RequestSequence {
             let aligned = self.len().is_multiple_of(self.block_size);
             debug_assert_eq!(identity_count, self.current_known_blocks());
             debug_assert!(
-                _identities
-                    .enumerate()
-                    .all(
-                        |(position, identity)| position + 1 == identity_count && !aligned
-                            || identity.sequence_hash.is_some()
-                    ),
+                _identities.enumerate().all(|(position, identity)| {
+                    identity.sequence_hash.is_some() || (position + 1 == identity_count && !aligned)
+                }),
                 "only the final native block may be partial"
             );
-            if self.emit_token_ids {
-                debug_assert_eq!(self.tokens.retained_start, 0);
-            } else {
-                debug_assert!(self.tokens.retained.len() <= self.block_size + 1);
-            }
+            self.debug_assert_storage_invariants();
+        }
+    }
+
+    /// Check only identities changed by one finalization plus the final tail.
+    #[cfg(debug_assertions)]
+    pub(crate) fn debug_assert_finalized_range(
+        &self,
+        identity_count: usize,
+        finalized: impl IntoIterator<Item = NativeBlockIdentity>,
+        final_identity: Option<NativeBlockIdentity>,
+    ) {
+        debug_assert_eq!(identity_count, self.current_known_blocks());
+        debug_assert!(
+            finalized
+                .into_iter()
+                .all(|identity| identity.sequence_hash.is_some()),
+            "finalized native blocks must have sequence hashes"
+        );
+        let aligned = self.len().is_multiple_of(self.block_size);
+        debug_assert!(
+            final_identity.is_none_or(|identity| identity.sequence_hash.is_some() || !aligned),
+            "only an unaligned final native block may be partial"
+        );
+        self.debug_assert_storage_invariants();
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_storage_invariants(&self) {
+        if self.emit_token_ids {
+            debug_assert_eq!(self.tokens.retained_start, 0);
+        } else {
+            debug_assert!(self.tokens.retained.len() <= self.block_size + 1);
         }
     }
 

--- a/lib/mocker/src/kv_manager/g1_manager.rs
+++ b/lib/mocker/src/kv_manager/g1_manager.rs
@@ -12,7 +12,6 @@ use std::sync::{Arc, Mutex};
 
 #[cfg(feature = "kvbm-offload")]
 use dynamo_tokens::PositionalLineageHash;
-use dynamo_tokens::blocks::UniqueBlock;
 #[cfg(feature = "kvbm-offload")]
 use kvbm_logical::ImmutableBlock;
 use uuid::Uuid;
@@ -22,7 +21,7 @@ use crate::common::protocols::G1;
 use crate::common::protocols::{
     G1Backend, KvEventPublishers, MockerEvictionBackend, MoveBlock, PrefillCost,
 };
-use crate::common::sequence::ActiveSequence;
+use crate::common::sequence::{ActiveSequence, RequestSequence};
 #[cfg(feature = "kvbm-offload")]
 use crate::kvbm_offload::{MockOffloadEngine, OffloadId};
 
@@ -31,7 +30,7 @@ use super::kvbm_backend;
 #[cfg(feature = "kvbm-offload")]
 use super::kvbm_backend::{BatchSwapInOutcome, SwapInRegistrationBlock, SwapInRegistrationOutcome};
 use super::vllm_backend::{
-    NativeDecodeBlockReservation, NativeDestinationReservation, VllmAcquire, VllmBlockLayout,
+    BlockRequestLease, NativeDecodeBlockReservation, NativeDestinationReservation, VllmAcquire,
     VllmKvManager,
 };
 
@@ -40,56 +39,10 @@ enum G1ManagerBackend {
     Native(VllmKvManager),
 }
 
-fn validate_plh_alignment(blocks: &[UniqueBlock], plh_count: usize) {
-    let full_blocks = blocks
-        .iter()
-        .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
-        .count();
-    assert_eq!(plh_count, full_blocks, "PLHs must align with full blocks");
-}
-
 fn into_g1_acquire<T>(outcome: VllmAcquire<T>) -> G1Acquire<T> {
     match outcome {
         VllmAcquire::Ready(value) => G1Acquire::Ready(value),
         VllmAcquire::CapacityExhausted => G1Acquire::CapacityExhausted,
-    }
-}
-
-fn process_vllm_event(
-    manager: &mut VllmKvManager,
-    owner: Uuid,
-    event: &MoveBlock,
-    reusable_prefix_blocks: usize,
-) -> VllmAcquire<usize> {
-    match event {
-        MoveBlock::Use(blocks, local_hashes, plhs, token_ids, parent) => {
-            validate_plh_alignment(blocks, plhs.len());
-            manager.use_for_request(
-                owner,
-                blocks,
-                local_hashes,
-                token_ids.as_deref(),
-                parent.as_ref(),
-                reusable_prefix_blocks,
-            )
-        }
-        MoveBlock::Deref(blocks) => {
-            assert_eq!(reusable_prefix_blocks, 0);
-            manager.deref_for_request(owner, blocks);
-            VllmAcquire::Ready(1)
-        }
-        MoveBlock::Promote(uuid, hash, parent_hash, local_hash, _plh, token_ids) => {
-            assert_eq!(reusable_prefix_blocks, 0);
-            manager.promote_for_request(
-                owner,
-                *uuid,
-                *hash,
-                *parent_hash,
-                *local_hash,
-                token_ids.clone(),
-            );
-            VllmAcquire::Ready(1)
-        }
     }
 }
 
@@ -211,32 +164,133 @@ impl G1Manager {
         Self { backend }
     }
 
+    pub(crate) fn allocate_native(
+        &mut self,
+        owner: Uuid,
+        lease: &mut BlockRequestLease,
+        cumulative_tokens: usize,
+        reusable_prefix_blocks: usize,
+    ) -> G1Acquire<usize> {
+        let G1ManagerBackend::Native(manager) = &mut self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        into_g1_acquire(manager.allocate_lease(
+            owner,
+            lease,
+            cumulative_tokens,
+            reusable_prefix_blocks,
+        ))
+    }
+
+    pub(crate) fn finalize_native_computed_prefix(
+        &mut self,
+        owner: Uuid,
+        computed_before: usize,
+        computed_after: usize,
+        sequence: &mut RequestSequence,
+        lease: &mut BlockRequestLease,
+    ) {
+        let G1ManagerBackend::Native(manager) = &mut self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        manager.finalize_lease_computed_prefix(
+            owner,
+            sequence,
+            lease,
+            computed_before,
+            computed_after,
+        );
+    }
+
+    pub(crate) fn preempt_native(&mut self, owner: Uuid, lease: &mut BlockRequestLease) {
+        let G1ManagerBackend::Native(manager) = &mut self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        manager.preempt_lease(owner, lease);
+    }
+
+    pub(crate) fn finish_native(&mut self, owner: Uuid, lease: BlockRequestLease) {
+        let G1ManagerBackend::Native(manager) = &mut self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        manager.finish_lease(owner, lease);
+    }
+
+    pub(crate) fn get_native_prefill_cost(
+        &self,
+        sequence: &RequestSequence,
+        lease: &BlockRequestLease,
+    ) -> PrefillCost {
+        let G1ManagerBackend::Native(manager) = &self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        manager.get_lease_prefill_cost(sequence, lease)
+    }
+
+    pub(crate) fn reserve_native_destination_at(
+        &mut self,
+        owner: Uuid,
+        sequence: &RequestSequence,
+        lease: &BlockRequestLease,
+        eviction_now_ms: Option<f64>,
+    ) -> G1Acquire<DestinationReservation> {
+        let G1ManagerBackend::Native(manager) = &mut self.backend else {
+            panic!("native request lease used with legacy KVBM")
+        };
+        into_g1_acquire(manager.reserve_destination_lease(owner, sequence, lease, eviction_now_ms))
+            .map(|inner| DestinationReservation {
+                inner: DestinationReservationBackend::Native(inner),
+            })
+    }
+
+    pub(crate) fn activate_native_destination(
+        &mut self,
+        owner: Uuid,
+        sequence: &RequestSequence,
+        lease: &mut BlockRequestLease,
+        reservation: DestinationReservation,
+    ) {
+        let (G1ManagerBackend::Native(manager), DestinationReservationBackend::Native(reservation)) =
+            (&mut self.backend, reservation.inner)
+        else {
+            panic!("destination reservation belongs to a different G1 backend")
+        };
+        manager.activate_destination_lease(owner, sequence, lease, reservation);
+    }
+
+    pub(crate) fn use_native_decode_reservation(
+        &mut self,
+        owner: Uuid,
+        lease: &mut BlockRequestLease,
+        cumulative_tokens: usize,
+        reservation: &mut DecodeBlockReservation,
+    ) {
+        let (G1ManagerBackend::Native(manager), DecodeBlockReservationBackend::Native(reservation)) =
+            (&mut self.backend, &mut reservation.inner)
+        else {
+            panic!("decode reservation belongs to a different G1 backend")
+        };
+        manager.allocate_lease_from_decode_reservation(
+            owner,
+            lease,
+            cumulative_tokens,
+            reservation,
+        );
+    }
+
     /// Make newly allocated full blocks prefix-cache-visible once the current
     /// scheduling decision reaches their complete token range. KVBM retains
     /// its historical eager lifecycle; the native backend mirrors vLLM's
     /// per-request `allocate_slots()` / `cache_blocks()` boundary.
     pub(crate) fn finalize_computed_prefix(
         &mut self,
-        owner: Uuid,
-        computed_before: usize,
-        computed_after: usize,
-        sequence: &mut ActiveSequence,
+        _owner: Uuid,
+        _computed_before: usize,
+        _computed_after: usize,
+        _sequence: &mut ActiveSequence,
     ) {
-        if let G1ManagerBackend::Native(manager) = &mut self.backend {
-            // A single scheduling decision can complete several prompt blocks
-            // and the mutable tail together. Publish/cache the earlier full
-            // blocks first so the promoted tail never references a parent that
-            // is not cache-visible yet.
-            manager.finalize_computed_prefix(owner, computed_before, computed_after);
-            if let Some(promote) = sequence.promote_computed_tail(computed_after) {
-                assert!(
-                    matches!(
-                        process_vllm_event(manager, owner, &promote, 0),
-                        VllmAcquire::Ready(_)
-                    ),
-                    "computed-tail promotion must be infallible"
-                );
-            }
+        if matches!(self.backend, G1ManagerBackend::Native(_)) {
+            panic!("native requests must finalize their attached block lease")
         }
     }
 
@@ -262,18 +316,15 @@ impl G1Manager {
     /// native G1 uses it to address the exact physical request block table.
     pub(crate) fn process_for_request(
         &mut self,
-        owner: Uuid,
+        _owner: Uuid,
         event: &MoveBlock,
-        reusable_prefix_blocks: usize,
+        _reusable_prefix_blocks: usize,
     ) -> G1Acquire<usize> {
         match &mut self.backend {
             G1ManagerBackend::Kvbm(manager) => manager.process(event),
-            G1ManagerBackend::Native(manager) => into_g1_acquire(process_vllm_event(
-                manager,
-                owner,
-                event,
-                reusable_prefix_blocks,
-            )),
+            G1ManagerBackend::Native(_) => {
+                panic!("native requests must use direct block-lease operations")
+            }
         }
     }
 
@@ -313,7 +364,7 @@ impl G1Manager {
 
     pub(crate) fn process_decode_signal_for_request(
         &mut self,
-        owner: Uuid,
+        _owner: Uuid,
         event: &MoveBlock,
         reservation: &mut DecodeBlockReservation,
     ) {
@@ -321,27 +372,8 @@ impl G1Manager {
             (G1ManagerBackend::Kvbm(manager), DecodeBlockReservationBackend::Kvbm(inner)) => {
                 manager.process_decode_signal(event, inner);
             }
-            (G1ManagerBackend::Native(manager), DecodeBlockReservationBackend::Native(inner)) => {
-                match event {
-                    MoveBlock::Use(blocks, local_hashes, plhs, token_ids, parent) => {
-                        validate_plh_alignment(blocks, plhs.len());
-                        manager.use_decode_reservation_for_request(
-                            owner,
-                            blocks,
-                            local_hashes,
-                            token_ids.as_deref(),
-                            parent.as_ref(),
-                            inner,
-                        );
-                    }
-                    _ => assert!(
-                        matches!(
-                            process_vllm_event(manager, owner, event, 0),
-                            VllmAcquire::Ready(_)
-                        ),
-                        "non-Use decode signal must be infallible"
-                    ),
-                }
+            (G1ManagerBackend::Native(_), DecodeBlockReservationBackend::Native(_)) => {
+                panic!("native decode must mutate its attached block lease")
             }
             _ => panic!("decode reservation belongs to a different G1 backend"),
         }
@@ -359,7 +391,7 @@ impl G1Manager {
 
     pub(crate) fn reserve_destination_at(
         &mut self,
-        owner: Uuid,
+        _owner: Uuid,
         sequence: &ActiveSequence,
         eviction_now_ms: Option<f64>,
     ) -> G1Acquire<DestinationReservation> {
@@ -369,25 +401,8 @@ impl G1Manager {
                 .map(|inner| DestinationReservation {
                     inner: DestinationReservationBackend::Kvbm(inner),
                 }),
-            G1ManagerBackend::Native(manager) => {
-                let layout = match sequence.prepare_allocation(sequence.num_input_tokens()) {
-                    None => None,
-                    Some(MoveBlock::Use(blocks, local_hashes, plhs, token_ids, parent)) => {
-                        validate_plh_alignment(&blocks, plhs.len());
-                        Some(VllmBlockLayout::new(
-                            blocks,
-                            local_hashes,
-                            token_ids,
-                            parent,
-                        ))
-                    }
-                    Some(_) => panic!("destination allocation must be a Use signal"),
-                };
-                into_g1_acquire(manager.reserve_destination_at(owner, layout, eviction_now_ms)).map(
-                    |inner| DestinationReservation {
-                        inner: DestinationReservationBackend::Native(inner),
-                    },
-                )
+            G1ManagerBackend::Native(_) => {
+                panic!("native destination must reserve its attached block lease")
             }
         }
     }
@@ -397,8 +412,8 @@ impl G1Manager {
             (G1ManagerBackend::Kvbm(manager), DestinationReservationBackend::Kvbm(inner)) => {
                 manager.activate_destination(inner);
             }
-            (G1ManagerBackend::Native(manager), DestinationReservationBackend::Native(inner)) => {
-                manager.activate_destination(inner);
+            (G1ManagerBackend::Native(_), DestinationReservationBackend::Native(_)) => {
+                panic!("native destination must activate into its attached block lease")
             }
             _ => panic!("destination reservation belongs to a different G1 backend"),
         }
@@ -464,17 +479,21 @@ impl G1Manager {
     }
 
     #[cfg(test)]
-    pub(crate) fn request_block_count(&self, owner: Uuid, sequence: &ActiveSequence) -> usize {
+    pub(crate) fn request_block_count(&self, _owner: Uuid, sequence: &ActiveSequence) -> usize {
         match &self.backend {
             G1ManagerBackend::Kvbm(manager) => manager.active_block_ids(sequence).len(),
-            G1ManagerBackend::Native(manager) => manager.request_block_count(owner),
+            G1ManagerBackend::Native(_) => {
+                panic!("native block counts come from the attached request lease")
+            }
         }
     }
 
     pub fn get_prefill_cost(&self, sequence: &ActiveSequence) -> PrefillCost {
         match &self.backend {
             G1ManagerBackend::Kvbm(manager) => manager.get_prefill_cost(sequence),
-            G1ManagerBackend::Native(manager) => manager.get_prefill_cost(sequence),
+            G1ManagerBackend::Native(_) => {
+                panic!("native prefill cost requires an attached block lease")
+            }
         }
     }
 
@@ -585,24 +604,6 @@ impl G1Manager {
 #[cfg(test)]
 mod tests {
     use dynamo_kv_router::protocols::KvCacheEventData;
-
-    use super::*;
-
-    #[test]
-    #[should_panic(expected = "PLHs must align with full blocks")]
-    fn vllm_boundary_rejects_misaligned_lineage_metadata() {
-        let mut manager =
-            G1Manager::new_with_backend(2, 4, KvEventPublishers::default(), 0, G1Backend::Native);
-        let event = MoveBlock::Use(
-            vec![UniqueBlock::FullBlock(7)],
-            vec![107],
-            Vec::new(),
-            None,
-            None,
-        );
-
-        let _ = manager.process_for_request(Uuid::from_u128(1), &event, 0);
-    }
 
     #[test]
     fn native_finalization_publishes_parent_before_promoted_tail() {

--- a/lib/mocker/src/kv_manager/g1_manager.rs
+++ b/lib/mocker/src/kv_manager/g1_manager.rs
@@ -6,6 +6,10 @@
 //! This module is not a third KV manager. It forwards each operation to either
 //! KVBM G1 or vLLM G1, selected when the manager is constructed. Remove this
 //! facade when the KVBM G1 implementation is removed.
+//!
+//! Tracking issue: <https://github.com/ai-dynamo/dynamo/issues/12340> splits
+//! the native lease API from the legacy KVBM signal/offload API so backend
+//! mismatches become unrepresentable instead of panicking at runtime.
 
 #[cfg(feature = "kvbm-offload")]
 use std::sync::{Arc, Mutex};

--- a/lib/mocker/src/kv_manager/mod.rs
+++ b/lib/mocker/src/kv_manager/mod.rs
@@ -65,3 +65,4 @@ pub(crate) use g1_manager::DestinationReservation;
 pub use g1_manager::G1Manager;
 pub use kvbm_backend::KvManager;
 pub use sglang_backend::SglangKvManager;
+pub(crate) use vllm_backend::BlockRequestLease;

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -125,6 +125,7 @@ pub struct SglangKvManager {
 pub struct DecodeTokenReservation {
     pages: Vec<KvPageId>,
     next: usize,
+    #[cfg(test)]
     page_size: usize,
 }
 
@@ -163,6 +164,7 @@ impl DecodeTokenReservation {
         page
     }
 
+    #[cfg(test)]
     fn take(&mut self, last_idx: Option<usize>) -> usize {
         if let Some(last_idx) = last_idx
             && (last_idx + 1) % self.page_size != 0
@@ -233,8 +235,7 @@ impl SglangKvManager {
         if required_tokens > available {
             self.evict(required_tokens - available);
         }
-        let mut pages = self.collect_path_pages(last_node);
-        debug_assert_eq!(pages.len(), prefix_len / page_size);
+        let mut pages = self.collect_path_pages_through(last_node, prefix_len);
 
         let available_before = self.cache.available_tokens();
         let Some(mut new_pages) = self.cache.page_pool.allocate_pages(required_pages) else {
@@ -456,6 +457,7 @@ impl SglangKvManager {
 
     /// Allocate a decode token, consuming a new page only at a page boundary.
     /// Router-visible BlockStored events are published once a full block exists.
+    #[cfg(test)]
     pub fn allocate_decode_token(&mut self, last_idx: Option<usize>) -> Option<usize> {
         let mut reservation = self.reserve_decode_pages(usize::from(
             last_idx.is_none_or(|idx| (idx + 1) % self.cache.page_size() == 0),
@@ -472,6 +474,7 @@ impl SglangKvManager {
         Some(DecodeTokenReservation {
             pages,
             next: 0,
+            #[cfg(test)]
             page_size: self.cache.page_size(),
         })
     }
@@ -482,8 +485,7 @@ impl SglangKvManager {
         token_count: usize,
     ) -> Option<SglangDestinationReservation> {
         let (prefix_len, last_node) = self.cache.match_prefix_hashes(page_hashes);
-        let mut prefix_pages = self.collect_path_pages(last_node);
-        prefix_pages.truncate(prefix_len / self.cache.page_size());
+        let prefix_pages = self.collect_path_pages_through(last_node, prefix_len);
         self.cache.inc_lock_ref(last_node);
 
         let allocated_tokens = if token_count == 0 {
@@ -544,7 +546,7 @@ impl SglangKvManager {
         } = reservation;
         prefix_pages.append(&mut unpublished_pages);
         let new_last_node = self.cache_unfinished_hashes(
-            lease.page_hashes(),
+            lease.page_hashes_through(token_count, self.cache.page_size()),
             &mut prefix_pages,
             last_node,
             prefix_len,
@@ -631,6 +633,23 @@ impl SglangKvManager {
         for node_id in path {
             pages.extend_from_slice(&self.cache.node(node_id).value);
         }
+        pages
+    }
+
+    fn collect_path_pages_through(&self, last_node: NodeId, prefix_len: usize) -> Vec<KvPageId> {
+        assert_eq!(
+            prefix_len % self.cache.page_size(),
+            0,
+            "matched SGLang prefix must be page-aligned"
+        );
+        let expected_pages = prefix_len / self.cache.page_size();
+        let mut pages = self.collect_path_pages(last_node);
+        assert!(
+            pages.len() >= expected_pages,
+            "SGLang radix path returned {} pages for a {expected_pages}-page prefix",
+            pages.len()
+        );
+        pages.truncate(expected_pages);
         pages
     }
 
@@ -1186,6 +1205,52 @@ mod tests {
         assert_eq!(mgr.cache().protected_size, 0);
         assert_eq!(mgr.cache().evictable_size, 4);
         assert_eq!(mgr.cache().prefix_match_len(&[1, 2, 3, 4]), 4);
+    }
+
+    #[test]
+    fn destination_activation_bounds_hashes_to_materialized_tokens() {
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut lease = RadixRequestLease::default();
+        lease.ensure_page_hashes(&tokens, 4);
+
+        let reservation = mgr
+            .reserve_destination_lease(lease.page_hashes(), 4)
+            .unwrap();
+        assert_eq!(
+            mgr.activate_destination_lease(reservation, 4, &mut lease),
+            0
+        );
+
+        assert_eq!(lease.page_count(), 1);
+        assert_eq!(lease.cached_tokens(), 4);
+        assert_eq!(mgr.cache().prefix_match_len(&tokens[..4]), 4);
+        assert_eq!(mgr.cache().prefix_match_len(&tokens), 4);
+        mgr.abort(lease);
+    }
+
+    #[test]
+    fn retract_and_readmit_reuses_cached_page_hashes() {
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut lease = RadixRequestLease::default();
+        assert_eq!(mgr.allocate_for_request_lease(&tokens, &mut lease), Some(0));
+        mgr.extend_cached_prefix(&tokens, &mut lease);
+
+        let hashes = lease.page_hashes().to_vec();
+        let hash_storage = lease.page_hashes().as_ptr();
+        let hash_capacity = lease.page_hashes.capacity();
+        assert!(mgr.retract_in_place(&mut lease));
+        assert_eq!(lease.page_hashes(), hashes);
+
+        assert_eq!(
+            mgr.allocate_for_request_lease(&tokens, &mut lease),
+            Some(tokens.len())
+        );
+        assert_eq!(lease.page_hashes(), hashes);
+        assert_eq!(lease.page_hashes().as_ptr(), hash_storage);
+        assert_eq!(lease.page_hashes.capacity(), hash_capacity);
+        mgr.abort(lease);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -14,31 +14,59 @@ use dynamo_kv_router::protocols::{
 };
 use rustc_hash::FxHashMap;
 
-/// Move-only ownership of an active request's KV slots and protected radix path.
+/// Move-only ownership of a request's SGLang KV state.
+///
+/// Logical page hashes survive retraction so re-admission never rescans the
+/// prompt. Physical pages and the radix lock exist only while the lease is
+/// active.
 #[derive(Debug, Default)]
 #[must_use = "an active KV lease must be finished, aborted, or retracted"]
-pub(crate) struct ActiveKvLease {
-    kv_indices: Vec<usize>,
+pub(crate) struct RadixRequestLease {
+    pages: Vec<KvPageId>,
+    materialized_tokens: usize,
     cached_tokens: usize,
+    page_hashes: Vec<LocalBlockHash>,
     last_node: Option<NodeId>,
 }
 
-impl ActiveKvLease {
+impl RadixRequestLease {
     #[cfg(test)]
-    pub(crate) fn indices(&self) -> &[usize] {
-        &self.kv_indices
+    pub(crate) fn pages(&self) -> &[KvPageId] {
+        &self.pages
     }
 
     pub(crate) fn len(&self) -> usize {
-        self.kv_indices.len()
+        self.materialized_tokens
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(crate) fn page_count(&self) -> usize {
+        self.pages.len()
     }
 
     pub(crate) fn cached_tokens(&self) -> usize {
         self.cached_tokens
     }
 
-    pub(crate) fn last_index(&self) -> Option<usize> {
-        self.kv_indices.last().copied()
+    pub(crate) fn page_hashes(&self) -> &[LocalBlockHash] {
+        &self.page_hashes
+    }
+
+    pub(crate) fn ensure_page_hashes(&mut self, token_ids: &[u32], page_size: usize) {
+        let complete_pages = token_ids.len() / page_size;
+        if self.page_hashes.len() >= complete_pages {
+            return;
+        }
+        let first_new_token = self.page_hashes.len() * page_size;
+        self.page_hashes.extend(compute_block_hash_for_seq(
+            &token_ids[first_new_token..complete_pages * page_size],
+            page_size as u32,
+            BlockHashOptions::default(),
+        ));
+    }
+
+    fn page_hashes_through(&self, token_count: usize, page_size: usize) -> &[LocalBlockHash] {
+        &self.page_hashes[..token_count / page_size]
     }
 
     pub(crate) fn is_active(&self) -> bool {
@@ -52,23 +80,27 @@ impl ActiveKvLease {
 
     #[cfg(test)]
     pub(crate) fn from_parts(
-        kv_indices: Vec<usize>,
+        pages: Vec<KvPageId>,
+        materialized_tokens: usize,
         cached_tokens: usize,
         last_node: NodeId,
     ) -> Self {
         Self {
-            kv_indices,
+            pages,
+            materialized_tokens,
             cached_tokens,
+            page_hashes: Vec::new(),
             last_node: Some(last_node),
         }
     }
 }
 
 /// Result of `allocate_for_request`.
+#[cfg(test)]
 pub(crate) struct AllocResult {
     /// Number of tokens matched from the prefix cache.
     pub(crate) prefix_len: usize,
-    pub(crate) lease: ActiveKvLease,
+    pub(crate) lease: RadixRequestLease,
 }
 
 pub struct SglangKvManager {
@@ -76,9 +108,9 @@ pub struct SglangKvManager {
     kv_event_publishers: KvEventPublishers,
     dp_rank: u32,
     next_event_id: u64,
-    /// Maps each complete block's terminal pool_idx → block_hash assigned
-    /// during Stored events, so Removed events can use the same block_hash.
-    idx_to_block_hash: FxHashMap<usize, ExternalSequenceBlockHash>,
+    /// Maps each physical page to the block hash assigned during Stored
+    /// events, so Removed events can use the same block hash.
+    page_to_block_hash: FxHashMap<KvPageId, ExternalSequenceBlockHash>,
     /// Tracks how many live pool slots currently advertise the same logical
     /// block hash so router events reflect logical block visibility, not
     /// transient slot ownership.
@@ -93,7 +125,7 @@ pub struct DecodeTokenReservation {
 
 pub struct SglangDestinationReservation {
     pub(crate) prefix_len: usize,
-    prefix_indices: Vec<usize>,
+    prefix_pages: Vec<KvPageId>,
     last_node: NodeId,
     unpublished_pages: Vec<KvPageId>,
     page_size: usize,
@@ -107,35 +139,32 @@ impl SglangDestinationReservation {
     }
 
     #[cfg(test)]
-    pub(crate) fn indices(&self) -> Vec<usize> {
-        self.prefix_indices
+    pub(crate) fn pages(&self) -> Vec<KvPageId> {
+        self.prefix_pages
             .iter()
+            .chain(&self.unpublished_pages)
             .copied()
-            .chain(
-                self.unpublished_pages
-                    .iter()
-                    .flat_map(|page| {
-                        let start = page.first_token_index(self.page_size);
-                        start..start + self.page_size
-                    })
-                    .take(self.missing_tokens),
-            )
             .collect()
     }
 }
 
 impl DecodeTokenReservation {
+    fn take_page(&mut self) -> KvPageId {
+        let page = *self
+            .pages
+            .get(self.next)
+            .expect("reserved decode page allocation must be infallible");
+        self.next += 1;
+        page
+    }
+
     fn take(&mut self, last_idx: Option<usize>) -> usize {
         if let Some(last_idx) = last_idx
             && (last_idx + 1) % self.page_size != 0
         {
             return last_idx + 1;
         }
-        let page = *self
-            .pages
-            .get(self.next)
-            .expect("reserved decode page allocation must be infallible");
-        self.next += 1;
+        let page = self.take_page();
         page.first_token_index(self.page_size)
     }
 
@@ -156,7 +185,7 @@ impl SglangKvManager {
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
-            idx_to_block_hash: FxHashMap::default(),
+            page_to_block_hash: FxHashMap::default(),
             block_hash_refcounts: FxHashMap::default(),
         }
     }
@@ -173,10 +202,18 @@ impl SglangKvManager {
     /// then allocate KV pages for a new request.
     ///
     /// Returns `None` if protected and free capacity cannot satisfy the request.
-    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u32]) -> Option<AllocResult> {
-        let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
-        let new_tokens = token_ids.len() - prefix_len;
-        let required_tokens = new_tokens.div_ceil(self.cache.page_size()) * self.cache.page_size();
+    pub(crate) fn allocate_for_request_lease(
+        &mut self,
+        token_ids: &[u32],
+        lease: &mut RadixRequestLease,
+    ) -> Option<usize> {
+        assert!(!lease.is_active(), "request KV lease is already active");
+        let page_size = self.cache.page_size();
+        lease.ensure_page_hashes(token_ids, page_size);
+        let materialized_hashes = lease.page_hashes_through(token_ids.len(), page_size);
+        let (prefix_len, last_node) = self.cache.match_prefix_hashes(materialized_hashes);
+        let required_pages = token_ids.len().div_ceil(page_size) - prefix_len / page_size;
+        let required_tokens = required_pages * page_size;
 
         // Protect the matched path before making room. Otherwise an LRU
         // eviction can remove the prefix used to size this allocation, and a
@@ -191,33 +228,34 @@ impl SglangKvManager {
         if required_tokens > available {
             self.evict(required_tokens - available);
         }
-        let prefix_indices = self.collect_path_indices(last_node);
+        let mut pages = self.collect_path_pages(last_node);
+        debug_assert_eq!(pages.len(), prefix_len / page_size);
 
-        let mut kv_indices = prefix_indices;
         let available_before = self.cache.available_tokens();
-        if !self
-            .cache
-            .page_pool
-            .allocate_indices_into(new_tokens, &mut kv_indices)
-        {
+        let Some(mut new_pages) = self.cache.page_pool.allocate_pages(required_pages) else {
             self.cache.dec_lock_ref(last_node);
             return None;
-        }
+        };
+        pages.append(&mut new_pages);
         let allocated_tokens = available_before - self.cache.available_tokens();
 
         // Router-visible KV events are complete-block only.
-        self.publish_stored_event(token_ids, &kv_indices, prefix_len);
+        self.publish_stored_hashes(materialized_hashes, &pages, token_ids.len(), prefix_len);
 
         self.log_trace("allocation", allocated_tokens);
 
-        Some(AllocResult {
-            prefix_len,
-            lease: ActiveKvLease {
-                kv_indices,
-                cached_tokens: prefix_len,
-                last_node: Some(last_node),
-            },
-        })
+        lease.pages = pages;
+        lease.materialized_tokens = token_ids.len();
+        lease.cached_tokens = prefix_len;
+        lease.last_node = Some(last_node);
+        Some(prefix_len)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allocate_for_request(&mut self, token_ids: &[u32]) -> Option<AllocResult> {
+        let mut lease = RadixRequestLease::default();
+        let prefix_len = self.allocate_for_request_lease(token_ids, &mut lease)?;
+        Some(AllocResult { prefix_len, lease })
     }
 
     /// Continue an in-flight request from an already materialized prefix.
@@ -228,32 +266,43 @@ impl SglangKvManager {
     pub(crate) fn extend_allocation(
         &mut self,
         token_ids: &[u32],
-        lease: &mut ActiveKvLease,
+        lease: &mut RadixRequestLease,
     ) -> bool {
-        let prefix_len = lease.kv_indices.len();
+        let prefix_len = lease.materialized_tokens;
         assert!(
             lease.is_active() && prefix_len <= token_ids.len(),
             "invalid SGLang KV lease extension: active={}, owned_tokens={prefix_len}, target_tokens={}",
             lease.is_active(),
             token_ids.len()
         );
-        let new_tokens = token_ids.len() - prefix_len;
+        let page_size = self.cache.page_size();
+        let target_pages = token_ids.len().div_ceil(page_size);
+        let new_pages = target_pages.saturating_sub(lease.pages.len());
         let available_before = self.cache.available_tokens();
-        if !self
-            .cache
-            .page_pool
-            .allocate_indices_into(new_tokens, &mut lease.kv_indices)
-        {
+        let Some(mut allocated_pages) = self.cache.page_pool.allocate_pages(new_pages) else {
             return false;
-        }
+        };
+        lease.pages.append(&mut allocated_pages);
+        lease.materialized_tokens = token_ids.len();
+        lease.ensure_page_hashes(token_ids, page_size);
         let allocated_tokens = available_before - self.cache.available_tokens();
 
-        self.publish_stored_event(token_ids, &lease.kv_indices, prefix_len);
+        self.publish_stored_hashes(
+            lease.page_hashes_through(token_ids.len(), page_size),
+            &lease.pages,
+            lease.materialized_tokens,
+            prefix_len,
+        );
         self.log_trace("allocation", allocated_tokens);
         true
     }
 
-    pub(crate) fn extend_cached_prefix(&mut self, token_ids: &[u32], lease: &mut ActiveKvLease) {
+    pub(crate) fn extend_cached_prefix(
+        &mut self,
+        token_ids: &[u32],
+        lease: &mut RadixRequestLease,
+    ) {
+        lease.ensure_page_hashes(token_ids, self.cache.page_size());
         let complete_len = token_ids.len() / self.cache.page_size() * self.cache.page_size();
         if complete_len <= lease.cached_tokens {
             return;
@@ -266,29 +315,34 @@ impl SglangKvManager {
             lease.len()
         );
         let last_node = lease.last_node();
-        let new_last_node = self.cache_unfinished_req(
-            token_ids,
-            &mut lease.kv_indices[..complete_len],
-            last_node,
-            lease.cached_tokens,
-        );
+        let complete_pages = complete_len / self.cache.page_size();
+        let page_hashes = &lease.page_hashes[..complete_pages];
+        let pages = &mut lease.pages[..complete_pages];
+        let new_last_node =
+            self.cache_unfinished_hashes(page_hashes, pages, last_node, lease.cached_tokens);
         lease.last_node = Some(new_last_node);
         lease.cached_tokens = complete_len;
     }
 
     pub(crate) fn extend_decode(
         &mut self,
-        lease: &mut ActiveKvLease,
+        lease: &mut RadixRequestLease,
         reservation: &mut DecodeTokenReservation,
     ) {
         debug_assert!(lease.is_active());
-        let new_idx = reservation.take(lease.last_index());
-        lease.kv_indices.push(new_idx);
+        if lease
+            .materialized_tokens
+            .is_multiple_of(self.cache.page_size())
+        {
+            lease.pages.push(reservation.take_page());
+        }
+        lease.materialized_tokens += 1;
     }
 
-    pub(crate) fn finish(&mut self, token_ids: &[u32], mut lease: ActiveKvLease) {
+    pub(crate) fn finish(&mut self, token_ids: &[u32], mut lease: RadixRequestLease) {
         let Some(last_node) = lease.last_node.take() else {
-            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert!(lease.pages.is_empty());
+            debug_assert_eq!(lease.materialized_tokens, 0);
             debug_assert_eq!(lease.cached_tokens, 0);
             return;
         };
@@ -300,52 +354,53 @@ impl SglangKvManager {
             lease.cached_tokens,
             lease.len()
         );
-        self.free_indices(&lease.kv_indices[complete_len..]);
-        lease.kv_indices.truncate(complete_len);
+        let complete_pages = complete_len / self.cache.page_size();
+        self.free_pages(&lease.pages[complete_pages..]);
+        lease.pages.truncate(complete_pages);
+        lease.materialized_tokens = complete_len;
 
         if complete_len == 0 {
             self.cache.dec_lock_ref(last_node);
             return;
         }
-        self.cache_finished_req(
-            &token_ids[..complete_len],
-            &lease.kv_indices,
+        self.cache_finished_hashes(
+            lease.page_hashes_through(complete_len, self.cache.page_size()),
+            &lease.pages,
             last_node,
             lease.cached_tokens,
         );
     }
 
-    pub(crate) fn abort(&mut self, lease: ActiveKvLease) -> bool {
+    pub(crate) fn abort(&mut self, mut lease: RadixRequestLease) -> bool {
+        self.release_active_lease(&mut lease)
+    }
+
+    pub(crate) fn retract_in_place(&mut self, lease: &mut RadixRequestLease) -> bool {
         self.release_active_lease(lease)
     }
 
-    pub(crate) fn retract(&mut self, lease: ActiveKvLease) -> bool {
-        self.release_active_lease(lease)
+    #[cfg(test)]
+    pub(crate) fn retract(&mut self, mut lease: RadixRequestLease) -> bool {
+        self.release_active_lease(&mut lease)
     }
 
     /// Cache a completed request's full sequence into the radix tree.
     ///
     /// Inserts the full token sequence so future requests can reuse it,
     /// then unlocks the path.
-    fn cache_finished_req(
+    fn cache_finished_hashes(
         &mut self,
-        token_ids: &[u32],
-        kv_indices: &[usize],
+        page_hashes: &[LocalBlockHash],
+        pages: &[KvPageId],
         last_node: NodeId,
         first_new_token: usize,
     ) {
-        self.publish_stored_event(token_ids, kv_indices, first_new_token);
+        let complete_len = page_hashes.len() * self.cache.page_size();
+        self.publish_stored_hashes(page_hashes, pages, complete_len, first_new_token);
         let new_last_node =
             self.cache
-                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
-        let complete_len =
-            token_ids.len().min(kv_indices.len()) / self.cache.page_size() * self.cache.page_size();
-        self.release_unretained_finished_indices(
-            kv_indices,
-            new_last_node,
-            first_new_token,
-            complete_len,
-        );
+                .insert_page_hashes_from_node(last_node, first_new_token, page_hashes, pages);
+        self.release_unretained_finished_pages(pages, new_last_node, first_new_token, complete_len);
         self.cache.dec_lock_ref(last_node);
     }
 
@@ -357,27 +412,27 @@ impl SglangKvManager {
     ///
     /// Returns the new `last_node` that the caller should use for
     /// subsequent calls.
-    fn cache_unfinished_req(
+    fn cache_unfinished_hashes(
         &mut self,
-        token_ids: &[u32],
-        kv_indices: &mut [usize],
+        page_hashes: &[LocalBlockHash],
+        pages: &mut [KvPageId],
         last_node: NodeId,
         first_new_token: usize,
     ) -> NodeId {
         let block_size = self.cache.page_size();
-        let complete_len = token_ids.len() / block_size * block_size;
+        let complete_len = page_hashes.len() * block_size;
         assert!(
             first_new_token.is_multiple_of(block_size)
                 && first_new_token <= complete_len
-                && complete_len <= kv_indices.len(),
-            "invalid SGLang canonicalization range: first_new_token={first_new_token}, complete_len={complete_len}, kv_indices={}",
-            kv_indices.len()
+                && complete_len / block_size <= pages.len(),
+            "invalid SGLang canonicalization range: first_new_token={first_new_token}, complete_len={complete_len}, pages={}",
+            pages.len()
         );
 
-        self.publish_stored_event(token_ids, kv_indices, first_new_token);
+        self.publish_stored_hashes(page_hashes, pages, complete_len, first_new_token);
         let new_last_node =
             self.cache
-                .insert_from_node(last_node, first_new_token, token_ids, kv_indices);
+                .insert_page_hashes_from_node(last_node, first_new_token, page_hashes, pages);
 
         // An interleaved insert can retain different physical pages for the same prefix.
         // Move the active request to canonical pages before releasing its duplicates.
@@ -386,12 +441,7 @@ impl SglangKvManager {
         if new_last_node != last_node {
             self.cache.inc_lock_ref(new_last_node);
         }
-        self.canonicalize_unfinished_indices(
-            kv_indices,
-            new_last_node,
-            first_new_token,
-            complete_len,
-        );
+        self.canonicalize_unfinished_pages(pages, new_last_node, first_new_token, complete_len);
         if new_last_node != last_node {
             self.cache.dec_lock_ref(last_node);
         }
@@ -421,19 +471,20 @@ impl SglangKvManager {
         })
     }
 
-    pub(crate) fn reserve_destination(
+    pub(crate) fn reserve_destination_lease(
         &mut self,
-        token_ids: &[u32],
+        page_hashes: &[LocalBlockHash],
+        token_count: usize,
     ) -> Option<SglangDestinationReservation> {
-        let (prefix_len, last_node) = self.cache.match_prefix(token_ids);
-        let mut prefix_indices = self.collect_path_indices(last_node);
-        prefix_indices.truncate(prefix_len);
+        let (prefix_len, last_node) = self.cache.match_prefix_hashes(page_hashes);
+        let mut prefix_pages = self.collect_path_pages(last_node);
+        prefix_pages.truncate(prefix_len / self.cache.page_size());
         self.cache.inc_lock_ref(last_node);
 
-        let allocated_tokens = if token_ids.is_empty() {
+        let allocated_tokens = if token_count == 0 {
             0
         } else {
-            token_ids.len().div_ceil(self.cache.page_size()) * self.cache.page_size()
+            token_count.div_ceil(self.cache.page_size()) * self.cache.page_size()
         };
         let fresh_tokens = allocated_tokens.saturating_sub(prefix_len);
         let fresh_pages = fresh_tokens / self.cache.page_size();
@@ -453,45 +504,52 @@ impl SglangKvManager {
         self.log_trace("reserve_destination", fresh_tokens);
         Some(SglangDestinationReservation {
             prefix_len,
-            prefix_indices,
+            prefix_pages,
             last_node,
             unpublished_pages,
             page_size: self.cache.page_size(),
-            missing_tokens: token_ids.len().saturating_sub(prefix_len),
+            missing_tokens: token_count.saturating_sub(prefix_len),
             allocated_tokens,
         })
     }
 
-    pub(crate) fn activate_destination(
+    #[cfg(test)]
+    pub(crate) fn reserve_destination(
+        &mut self,
+        token_ids: &[u32],
+    ) -> Option<SglangDestinationReservation> {
+        let hashes = self.cache.page_hashes(token_ids);
+        self.reserve_destination_lease(&hashes, token_ids.len())
+    }
+
+    pub(crate) fn activate_destination_lease(
         &mut self,
         reservation: SglangDestinationReservation,
-        token_ids: &[u32],
-    ) -> AllocResult {
+        token_count: usize,
+        lease: &mut RadixRequestLease,
+    ) -> usize {
         let SglangDestinationReservation {
             prefix_len,
-            mut prefix_indices,
+            mut prefix_pages,
             last_node,
-            unpublished_pages,
+            mut unpublished_pages,
             page_size: _,
             missing_tokens,
             allocated_tokens: _,
         } = reservation;
-        let mut unpublished_indices = self
-            .cache
-            .page_pool
-            .expand_pages(&unpublished_pages, missing_tokens);
-        prefix_indices.append(&mut unpublished_indices);
-        let new_last_node =
-            self.cache_unfinished_req(token_ids, &mut prefix_indices, last_node, prefix_len);
-        self.log_trace("activate_destination", missing_tokens);
-        AllocResult {
+        prefix_pages.append(&mut unpublished_pages);
+        let new_last_node = self.cache_unfinished_hashes(
+            lease.page_hashes(),
+            &mut prefix_pages,
+            last_node,
             prefix_len,
-            lease: ActiveKvLease {
-                kv_indices: prefix_indices,
-                cached_tokens: token_ids.len() / self.cache.page_size() * self.cache.page_size(),
-                last_node: Some(new_last_node),
-            },
-        }
+        );
+        self.log_trace("activate_destination", missing_tokens);
+        lease.pages = prefix_pages;
+        lease.materialized_tokens = token_count;
+        lease.cached_tokens = token_count / self.cache.page_size() * self.cache.page_size();
+        lease.last_node = Some(new_last_node);
+        prefix_len
     }
 
     pub(crate) fn cancel_destination(&mut self, reservation: SglangDestinationReservation) {
@@ -521,21 +579,10 @@ impl SglangKvManager {
         self.cache.dec_lock_ref(last_node);
     }
 
-    /// Return request-owned token slots to the free pool and publish matching
-    /// removal events for any slots that were previously advertised to the router.
-    fn free_indices(&mut self, indices: &[usize]) {
-        if indices.is_empty() {
-            return;
-        }
-
-        let pages = self.cache.page_pool.free_indices(indices);
-        self.publish_removed_pages(&pages);
-        self.log_trace("free", pages.len() * self.cache.page_size());
-    }
-
-    fn release_active_lease(&mut self, mut lease: ActiveKvLease) -> bool {
+    fn release_active_lease(&mut self, lease: &mut RadixRequestLease) -> bool {
         let Some(last_node) = lease.last_node.take() else {
-            debug_assert!(lease.kv_indices.is_empty());
+            debug_assert!(lease.pages.is_empty());
+            debug_assert_eq!(lease.materialized_tokens, 0);
             debug_assert_eq!(lease.cached_tokens, 0);
             return false;
         };
@@ -545,15 +592,19 @@ impl SglangKvManager {
             lease.cached_tokens,
             lease.len()
         );
-        let owned_suffix = &lease.kv_indices[lease.cached_tokens..];
+        let first_owned_page = lease.cached_tokens / self.cache.page_size();
+        let owned_suffix = &lease.pages[first_owned_page..];
         let capacity_improved = !owned_suffix.is_empty() || last_node != self.cache.root();
-        self.free_indices(owned_suffix);
+        self.free_pages(owned_suffix);
         self.cache.dec_lock_ref(last_node);
+        lease.pages.clear();
+        lease.materialized_tokens = 0;
+        lease.cached_tokens = 0;
         capacity_improved
     }
 
-    /// Collect token indices from the matched prefix path by walking root→last_node.
-    fn collect_path_indices(&self, last_node: NodeId) -> Vec<usize> {
+    /// Collect physical pages from the matched prefix path by walking root→last_node.
+    fn collect_path_pages(&self, last_node: NodeId) -> Vec<KvPageId> {
         if last_node == self.cache.root() {
             return Vec::new();
         }
@@ -571,22 +622,16 @@ impl SglangKvManager {
         }
         path.reverse();
 
-        // Expand cached page IDs only for the bounded active request.
-        let mut indices = Vec::new();
+        let mut pages = Vec::new();
         for node_id in path {
-            let node = self.cache.node(node_id);
-            indices.extend(
-                self.cache
-                    .page_pool
-                    .expand_pages(&node.value, node.value.len() * self.cache.page_size()),
-            );
+            pages.extend_from_slice(&self.cache.node(node_id).value);
         }
-        indices
+        pages
     }
 
-    fn release_unretained_finished_indices(
+    fn release_unretained_finished_pages(
         &mut self,
-        kv_indices: &[usize],
+        pages: &[KvPageId],
         last_node: NodeId,
         first_new_token: usize,
         complete_len: usize,
@@ -628,9 +673,12 @@ impl SglangKvManager {
             let path_start = path_end - node_len;
             let reconcile_start = path_start.max(first_new_page);
 
-            for page_idx in reconcile_start..path_end {
-                let token_start = page_idx * block_size;
-                let incoming_page = KvPageId::from_token_index(kv_indices[token_start], block_size);
+            for (page_idx, &incoming_page) in pages
+                .iter()
+                .enumerate()
+                .take(path_end)
+                .skip(reconcile_start)
+            {
                 let canonical_page = node.value[page_idx - path_start];
                 if incoming_page != canonical_page {
                     unretained_pages.push(incoming_page);
@@ -644,9 +692,9 @@ impl SglangKvManager {
         self.free_pages(&unretained_pages);
     }
 
-    fn canonicalize_unfinished_indices(
+    fn canonicalize_unfinished_pages(
         &mut self,
-        kv_indices: &mut [usize],
+        pages: &mut [KvPageId],
         last_node: NodeId,
         first_new_token: usize,
         complete_len: usize,
@@ -654,17 +702,17 @@ impl SglangKvManager {
         let block_size = self.cache.page_size();
         debug_assert_eq!(complete_len % block_size, 0);
         debug_assert_eq!(first_new_token % block_size, 0);
-        debug_assert!(complete_len <= kv_indices.len());
+        debug_assert!(complete_len / block_size <= pages.len());
         debug_assert!(first_new_token <= complete_len);
 
         assert!(
             first_new_token.is_multiple_of(block_size)
                 && complete_len.is_multiple_of(block_size)
-                && complete_len <= kv_indices.len()
+                && complete_len / block_size <= pages.len()
                 && first_new_token <= complete_len
                 && self.radix_path_covers(last_node, first_new_token, complete_len),
-            "invalid SGLang canonicalization range or radix path: first_new_token={first_new_token}, complete_len={complete_len}, kv_indices={}",
-            kv_indices.len()
+            "invalid SGLang canonicalization range or radix path: first_new_token={first_new_token}, complete_len={complete_len}, pages={}",
+            pages.len()
         );
 
         let mut unretained_pages = Vec::new();
@@ -678,18 +726,16 @@ impl SglangKvManager {
             let path_start = path_end - node_len;
             let reconcile_start = path_start.max(first_new_page);
 
-            for page_idx in reconcile_start..path_end {
-                let token_start = page_idx * block_size;
-                let token_end = token_start + block_size;
-                let incoming_page = KvPageId::from_token_index(kv_indices[token_start], block_size);
+            for (page_idx, incoming_page) in pages
+                .iter_mut()
+                .enumerate()
+                .take(path_end)
+                .skip(reconcile_start)
+            {
                 let canonical_page = node.value[page_idx - path_start];
-                if incoming_page != canonical_page {
-                    unretained_pages.push(incoming_page);
-                    let canonical = self
-                        .cache
-                        .page_pool
-                        .expand_pages(&[canonical_page], block_size);
-                    kv_indices[token_start..token_end].copy_from_slice(&canonical);
+                if *incoming_page != canonical_page {
+                    unretained_pages.push(*incoming_page);
+                    *incoming_page = canonical_page;
                 }
             }
 
@@ -754,10 +800,11 @@ impl SglangKvManager {
         });
     }
 
-    fn publish_stored_event(
+    fn publish_stored_hashes(
         &mut self,
-        token_ids: &[u32],
-        indices: &[usize],
+        page_hashes: &[LocalBlockHash],
+        pages: &[KvPageId],
+        num_tokens: usize,
         first_new_token: usize,
     ) -> usize {
         if self.kv_event_publishers.is_empty() {
@@ -765,40 +812,45 @@ impl SglangKvManager {
         }
 
         let block_size = self.cache.page_size();
-        let complete_len = token_ids.len().min(indices.len()) / block_size * block_size;
+        let complete_len =
+            (page_hashes.len() * block_size).min(num_tokens) / block_size * block_size;
         if complete_len == 0 || first_new_token >= complete_len {
             return 0;
         }
+        let complete_pages = complete_len / block_size;
+        assert!(
+            pages.len() >= complete_pages,
+            "not enough KV pages for Stored event: need {complete_pages}, got {}",
+            pages.len()
+        );
 
         let first_block_start = first_new_token / block_size * block_size;
         let Some(first_unpublished_block) = (first_block_start..complete_len)
             .step_by(block_size)
             .find(|&block_start| {
-                let representative_idx = indices[block_start + block_size - 1];
-                !self.idx_to_block_hash.contains_key(&representative_idx)
+                let page = pages[block_start / block_size];
+                !self.page_to_block_hash.contains_key(&page)
             })
         else {
             return 0;
         };
 
         let mut computed_blocks = Vec::new();
-        let local_hashes =
-            self.local_hashes_for_range(&token_ids[first_unpublished_block..complete_len]);
+        let first_unpublished_page = first_unpublished_block / block_size;
+        let local_hashes = &page_hashes[first_unpublished_page..complete_pages];
 
         for (block_idx, tokens_hash) in local_hashes.iter().copied().enumerate() {
             let block_start = first_unpublished_block + block_idx * block_size;
-            let block_end = block_start + block_size;
-            let representative_idx = indices[block_end - 1];
-            if self.idx_to_block_hash.contains_key(&representative_idx) {
+            let page_idx = block_start / block_size;
+            let page = pages[page_idx];
+            if self.page_to_block_hash.contains_key(&page) {
                 continue;
             }
 
             let parent_hash = if block_start == 0 {
                 None
             } else {
-                self.idx_to_block_hash
-                    .get(&indices[block_start - 1])
-                    .copied()
+                self.page_to_block_hash.get(&pages[page_idx - 1]).copied()
             };
             let block_hash = match parent_hash {
                 Some(parent_hash) => {
@@ -807,8 +859,7 @@ impl SglangKvManager {
                 None => ExternalSequenceBlockHash(tokens_hash.0),
             };
 
-            self.idx_to_block_hash
-                .insert(representative_idx, block_hash);
+            self.page_to_block_hash.insert(page, block_hash);
             let refcount = self.block_hash_refcounts.entry(block_hash).or_default();
             *refcount += 1;
             computed_blocks.push((
@@ -856,12 +907,40 @@ impl SglangKvManager {
         hashed_blocks
     }
 
-    fn local_hashes_for_range(&self, token_ids: &[u32]) -> Vec<LocalBlockHash> {
-        compute_block_hash_for_seq(
-            token_ids,
-            self.cache.page_size() as u32,
-            BlockHashOptions::default(),
-        )
+    #[cfg(test)]
+    fn publish_stored_event(
+        &mut self,
+        token_ids: &[u32],
+        pages: &[KvPageId],
+        num_tokens: usize,
+        first_new_token: usize,
+    ) -> usize {
+        let page_hashes = self.cache.page_hashes(token_ids);
+        self.publish_stored_hashes(&page_hashes, pages, num_tokens, first_new_token)
+    }
+
+    #[cfg(test)]
+    fn cache_finished_req(
+        &mut self,
+        token_ids: &[u32],
+        pages: &[KvPageId],
+        last_node: NodeId,
+        first_new_token: usize,
+    ) {
+        let page_hashes = self.cache.page_hashes(token_ids);
+        self.cache_finished_hashes(&page_hashes, pages, last_node, first_new_token);
+    }
+
+    #[cfg(test)]
+    fn cache_unfinished_req(
+        &mut self,
+        token_ids: &[u32],
+        pages: &mut [KvPageId],
+        last_node: NodeId,
+        first_new_token: usize,
+    ) -> NodeId {
+        let page_hashes = self.cache.page_hashes(token_ids);
+        self.cache_unfinished_hashes(&page_hashes, pages, last_node, first_new_token)
     }
 
     fn publish_removed_pages(&mut self, evicted_pages: &[KvPageId]) {
@@ -871,8 +950,7 @@ impl SglangKvManager {
 
         let mut block_hashes = Vec::new();
         for &page in evicted_pages {
-            let idx = page.terminal_token_index(self.cache.page_size());
-            let Some(block_hash) = self.idx_to_block_hash.remove(&idx) else {
+            let Some(block_hash) = self.page_to_block_hash.remove(&page) else {
                 continue;
             };
             let Some(refcount) = self.block_hash_refcounts.get_mut(&block_hash) else {
@@ -969,12 +1047,24 @@ mod tests {
     }
 
     #[test]
-    fn active_kv_lease_has_no_space_overhead() {
-        let previous_fields = std::mem::size_of::<Vec<usize>>()
-            + std::mem::size_of::<usize>()
-            + std::mem::size_of::<Option<NodeId>>();
+    fn active_kv_lease_retains_one_id_per_physical_page() {
+        let mut mgr = SglangKvManager::new(64, 16, KvEventPublishers::default(), 0);
+        let mut tokens = vec![1; 33];
+        let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
 
-        assert_eq!(std::mem::size_of::<ActiveKvLease>(), previous_fields);
+        assert_eq!(alloc.lease.len(), 33);
+        assert_eq!(alloc.lease.page_count(), 3);
+        assert_eq!(mgr.cache().available_tokens(), 16);
+
+        tokens.resize(48, 2);
+        assert!(mgr.extend_allocation(&tokens, &mut alloc.lease));
+        assert_eq!(alloc.lease.page_count(), 3);
+        assert_eq!(mgr.cache().available_tokens(), 16);
+
+        tokens.push(3);
+        assert!(mgr.extend_allocation(&tokens, &mut alloc.lease));
+        assert_eq!(alloc.lease.page_count(), 4);
+        assert_eq!(mgr.cache().available_tokens(), 0);
     }
 
     #[test]
@@ -994,6 +1084,22 @@ mod tests {
         assert_eq!(mgr.cache().available_tokens(), 4);
         assert!(mgr.retract(alloc.lease));
         assert_eq!(mgr.cache().available_tokens(), 12);
+    }
+
+    #[test]
+    fn page_native_extension_oom_is_atomic() {
+        let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
+        let mut alloc = mgr.allocate_for_request(&[1]).unwrap();
+        let blocker = mgr.allocate_for_request(&[9]).unwrap();
+        let pages_before = alloc.lease.pages().to_vec();
+
+        assert!(!mgr.extend_allocation(&[1, 2, 3, 4, 5], &mut alloc.lease));
+        assert_eq!(alloc.lease.pages(), pages_before);
+        assert_eq!(alloc.lease.len(), 1);
+        assert_eq!(mgr.cache().available_tokens(), 0);
+
+        mgr.abort(alloc.lease);
+        mgr.abort(blocker.lease);
     }
 
     #[test]
@@ -1128,7 +1234,7 @@ mod tests {
 
         let result = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(result.prefix_len, 0);
-        assert_eq!(result.lease.kv_indices.len(), 5);
+        assert_eq!(result.lease.pages.len(), 5);
         assert_eq!(mgr.cache().page_pool.available(), 95);
     }
 
@@ -1138,18 +1244,13 @@ mod tests {
 
         // First request: allocate and cache
         let r1 = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
-        assert_eq!(r1.lease.kv_indices.len(), 5); // 5 pages (page_size=1)
-        mgr.cache_finished_req(
-            &[1, 2, 3, 4, 5],
-            &r1.lease.kv_indices,
-            r1.lease.last_node(),
-            0,
-        );
+        assert_eq!(r1.lease.pages.len(), 5);
+        mgr.cache_finished_req(&[1, 2, 3, 4, 5], &r1.lease.pages, r1.lease.last_node(), 0);
 
         // Second request with shared prefix
         let r2 = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
         assert_eq!(r2.prefix_len, 5);
-        assert_eq!(r2.lease.kv_indices.len(), 7); // 5 reused + 2 new pages
+        assert_eq!(r2.lease.pages.len(), 7);
         assert_eq!(mgr.cache().page_pool.available(), 93); // 100 - 5 - 2
     }
 
@@ -1170,7 +1271,7 @@ mod tests {
             .expect("prefix allocation should fit");
         mgr.cache_finished_req(
             prefix_tokens,
-            &prefix.lease.kv_indices,
+            &prefix.lease.pages,
             prefix.lease.last_node(),
             prefix.prefix_len,
         );
@@ -1186,7 +1287,7 @@ mod tests {
             .expect("aligned prompt allocation should fit");
         mgr.cache_finished_req(
             &aligned_tokens,
-            &aligned.lease.kv_indices,
+            &aligned.lease.pages,
             aligned.lease.last_node(),
             aligned.prefix_len,
         );
@@ -1216,7 +1317,7 @@ mod tests {
         let r = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
         assert_eq!(sink.event_count(), 1); // BlockStored for 3 new pages
 
-        mgr.cache_finished_req(&[1, 2, 3], &r.lease.kv_indices, r.lease.last_node(), 0);
+        mgr.cache_finished_req(&[1, 2, 3], &r.lease.pages, r.lease.last_node(), 0);
 
         // Second request with full cache hit → no new events
         let r2 = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
@@ -1231,12 +1332,7 @@ mod tests {
             SglangKvManager::new(100, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
 
         let r = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6]).unwrap();
-        mgr.cache_finished_req(
-            &[1, 2, 3, 4, 5, 6],
-            &r.lease.kv_indices,
-            r.lease.last_node(),
-            0,
-        );
+        mgr.cache_finished_req(&[1, 2, 3, 4, 5, 6], &r.lease.pages, r.lease.last_node(), 0);
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
@@ -1261,11 +1357,11 @@ mod tests {
         let mut mgr =
             SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
-        let indices = mgr.cache_mut().page_pool.allocate(tokens.len()).unwrap();
+        let pages = mgr.cache_mut().page_pool.allocate_pages(2).unwrap();
 
-        assert_eq!(mgr.publish_stored_event(&tokens[..4], &indices[..4], 0), 1);
-        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 1);
-        assert_eq!(mgr.publish_stored_event(&tokens, &indices, 0), 0);
+        assert_eq!(mgr.publish_stored_event(&tokens[..4], &pages[..1], 4, 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &pages, 8, 0), 1);
+        assert_eq!(mgr.publish_stored_event(&tokens, &pages, 8, 0), 0);
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
@@ -1288,19 +1384,15 @@ mod tests {
 
         let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
         let alloc_last_node = alloc.lease.last_node();
-        let first_last_node = mgr.cache_unfinished_req(
-            &tokens[..2],
-            &mut alloc.lease.kv_indices,
-            alloc_last_node,
-            0,
-        );
+        let first_last_node =
+            mgr.cache_unfinished_req(&tokens[..2], &mut alloc.lease.pages, alloc_last_node, 0);
 
-        let mut kv_indices = alloc.lease.kv_indices;
-        kv_indices.extend_from_slice(&mgr.cache_mut().page_pool.allocate(4).unwrap());
+        let mut pages = alloc.lease.pages;
+        pages.extend_from_slice(&mgr.cache_mut().page_pool.allocate_pages(2).unwrap());
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
         let last_after_first_cache =
-            mgr.cache_unfinished_req(&tokens[..4], &mut kv_indices[..4], first_last_node, 2);
+            mgr.cache_unfinished_req(&tokens[..4], &mut pages[..2], first_last_node, 2);
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
         let KvCacheEventData::Stored(first_store) = &events[0].data else {
@@ -1312,7 +1404,7 @@ mod tests {
             "first unfinished cache should store only the newly completed block"
         );
 
-        mgr.cache_finished_req(&tokens, &kv_indices, last_after_first_cache, 4);
+        mgr.cache_finished_req(&tokens, &pages, last_after_first_cache, 4);
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
         let KvCacheEventData::Stored(final_store) = &events[1].data else {
@@ -1341,10 +1433,10 @@ mod tests {
         };
         assert_eq!(store.blocks.len(), 3);
 
-        mgr.free_indices(&req1.lease.kv_indices);
+        mgr.free_pages(&req1.lease.pages);
         assert_eq!(sink.event_count(), 1);
 
-        mgr.free_indices(&req2.lease.kv_indices);
+        mgr.free_pages(&req2.lease.pages);
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
         let KvCacheEventData::Removed(remove) = &events[1].data else {
@@ -1354,7 +1446,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_duplicate_completion_releases_unretained_indices_and_removes_on_eviction() {
+    async fn test_duplicate_completion_releases_unretained_pages_and_removes_on_eviction() {
         let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
         let harness = RouterIndexerHarness::new(1, ROUTER_TEST_WORKER_ID);
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::new(Some(sink), None), 0);
@@ -1378,7 +1470,7 @@ mod tests {
         assert_eq!(query_hashes.len(), tokens.len());
         harness.apply_events(allocation_events).await;
 
-        mgr.cache_finished_req(&tokens, &req1.lease.kv_indices, req1.lease.last_node(), 0);
+        mgr.cache_finished_req(&tokens, &req1.lease.pages, req1.lease.last_node(), 0);
         let req1_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req1_completion_events),
@@ -1396,7 +1488,7 @@ mod tests {
             "canonical completion should retain the first request's slots"
         );
 
-        mgr.cache_finished_req(&tokens, &req2.lease.kv_indices, req2.lease.last_node(), 0);
+        mgr.cache_finished_req(&tokens, &req2.lease.pages, req2.lease.last_node(), 0);
         let req2_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req2_completion_events),
@@ -1486,10 +1578,11 @@ mod tests {
         let shared_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut first = mgr.allocate_for_request(&shared_tokens).unwrap();
         let mut duplicate = mgr.allocate_for_request(&shared_tokens).unwrap();
-        let duplicate_suffix = duplicate.lease.indices()[seed_tokens.len()..].to_vec();
+        let first_suffix_page = seed_tokens.len() / mgr.cache().page_size();
+        let duplicate_suffix = duplicate.lease.pages()[first_suffix_page..].to_vec();
         assert_ne!(
-            first.lease.indices()[seed_tokens.len()..],
-            duplicate.lease.indices()[seed_tokens.len()..]
+            first.lease.pages()[first_suffix_page..],
+            duplicate.lease.pages()[first_suffix_page..]
         );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
@@ -1498,8 +1591,8 @@ mod tests {
         mgr.extend_cached_prefix(&shared_tokens, &mut first.lease);
         mgr.extend_cached_prefix(&shared_tokens, &mut duplicate.lease);
         assert_eq!(
-            duplicate.lease.indices(),
-            first.lease.indices(),
+            duplicate.lease.pages(),
+            first.lease.pages(),
             "the active duplicate must switch to radix-owned canonical pages"
         );
         assert_eq!(
@@ -1510,8 +1603,8 @@ mod tests {
         assert!(
             duplicate_suffix
                 .iter()
-                .all(|idx| !duplicate.lease.indices().contains(idx)),
-            "no duplicate physical slot may remain attached to the active request"
+                .all(|page| !duplicate.lease.pages().contains(page)),
+            "no duplicate physical page may remain attached to the active request"
         );
         for event in buffer.drain() {
             indexer.apply_event(event).unwrap();
@@ -1564,10 +1657,10 @@ mod tests {
     #[should_panic(expected = "invalid SGLang canonicalization range or radix path")]
     fn invalid_canonical_path_is_fatal() {
         let mut mgr = SglangKvManager::new(8, 4, KvEventPublishers::default(), 0);
-        let mut indices = mgr.cache_mut().page_pool.allocate(4).unwrap();
+        let mut pages = mgr.cache_mut().page_pool.allocate_pages(1).unwrap();
         let root = mgr.cache().root();
 
-        mgr.canonicalize_unfinished_indices(&mut indices, root, 0, 4);
+        mgr.canonicalize_unfinished_pages(&mut pages, root, 0, 4);
     }
 
     #[test]
@@ -1581,7 +1674,7 @@ mod tests {
         let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 2)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.pages, last_node, 2)
         }));
 
         assert!(result.is_err());
@@ -1589,18 +1682,18 @@ mod tests {
     }
 
     #[test]
-    fn cache_unfinished_rejects_short_indices_before_publishing() {
+    fn cache_unfinished_rejects_short_page_list_before_publishing() {
         let sink = Arc::new(MockSink::new());
         let mut mgr =
             SglangKvManager::new(8, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
-        alloc.lease.kv_indices.truncate(4);
+        alloc.lease.pages.truncate(1);
         let events_before = sink.event_count();
         let last_node = alloc.lease.last_node();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.kv_indices, last_node, 0)
+            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.pages, last_node, 0)
         }));
 
         assert!(result.is_err());
@@ -1630,7 +1723,7 @@ mod tests {
         let previous_last = alloc1.lease.last_node();
         let new_last = mgr.cache_unfinished_req(
             &tokens[..chunk1_len],
-            &mut alloc1.lease.kv_indices,
+            &mut alloc1.lease.pages,
             previous_last,
             0,
         );

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -57,6 +57,11 @@ impl RadixRequestLease {
             .reserve_exact(complete_pages.saturating_sub(self.page_hashes.len()));
     }
 
+    #[cfg(test)]
+    pub(crate) fn page_hash_capacity(&self) -> usize {
+        self.page_hashes.capacity()
+    }
+
     pub(crate) fn ensure_page_hashes(&mut self, token_ids: &[u32], page_size: usize) {
         let complete_pages = token_ids.len() / page_size;
         if self.page_hashes.len() >= complete_pages {
@@ -125,8 +130,6 @@ pub struct SglangKvManager {
 pub struct DecodeTokenReservation {
     pages: Vec<KvPageId>,
     next: usize,
-    #[cfg(test)]
-    page_size: usize,
 }
 
 pub struct SglangDestinationReservation {
@@ -162,17 +165,6 @@ impl DecodeTokenReservation {
             .expect("reserved decode page allocation must be infallible");
         self.next += 1;
         page
-    }
-
-    #[cfg(test)]
-    fn take(&mut self, last_idx: Option<usize>) -> usize {
-        if let Some(last_idx) = last_idx
-            && (last_idx + 1) % self.page_size != 0
-        {
-            return last_idx + 1;
-        }
-        let page = self.take_page();
-        page.first_token_index(self.page_size)
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -455,28 +447,12 @@ impl SglangKvManager {
         new_last_node
     }
 
-    /// Allocate a decode token, consuming a new page only at a page boundary.
-    /// Router-visible BlockStored events are published once a full block exists.
-    #[cfg(test)]
-    pub fn allocate_decode_token(&mut self, last_idx: Option<usize>) -> Option<usize> {
-        let mut reservation = self.reserve_decode_pages(usize::from(
-            last_idx.is_none_or(|idx| (idx + 1) % self.cache.page_size() == 0),
-        ))?;
-        let idx = reservation.take(last_idx);
-        Some(idx)
-    }
-
     pub fn reserve_decode_pages(&mut self, count: usize) -> Option<DecodeTokenReservation> {
         let pages = self.cache.page_pool.allocate_pages(count)?;
         if !pages.is_empty() {
             self.log_trace("allocation", pages.len() * self.cache.page_size());
         }
-        Some(DecodeTokenReservation {
-            pages,
-            next: 0,
-            #[cfg(test)]
-            page_size: self.cache.page_size(),
-        })
+        Some(DecodeTokenReservation { pages, next: 0 })
     }
 
     pub(crate) fn reserve_destination_lease(
@@ -518,15 +494,6 @@ impl SglangKvManager {
             missing_tokens: token_count.saturating_sub(prefix_len),
             allocated_tokens,
         })
-    }
-
-    #[cfg(test)]
-    pub(crate) fn reserve_destination(
-        &mut self,
-        token_ids: &[u32],
-    ) -> Option<SglangDestinationReservation> {
-        let hashes = self.cache.page_hashes(token_ids);
-        self.reserve_destination_lease(&hashes, token_ids.len())
     }
 
     pub(crate) fn activate_destination_lease(
@@ -579,11 +546,6 @@ impl SglangKvManager {
         }
         self.cache.page_pool.free_pages(&pages);
         self.log_trace("release_unpublished", pages.len() * self.cache.page_size());
-    }
-
-    #[cfg(test)]
-    fn free_request(&mut self, last_node: NodeId) {
-        self.cache.dec_lock_ref(last_node);
     }
 
     fn release_active_lease(&mut self, lease: &mut RadixRequestLease) -> bool {
@@ -931,42 +893,6 @@ impl SglangKvManager {
         hashed_blocks
     }
 
-    #[cfg(test)]
-    fn publish_stored_event(
-        &mut self,
-        token_ids: &[u32],
-        pages: &[KvPageId],
-        num_tokens: usize,
-        first_new_token: usize,
-    ) -> usize {
-        let page_hashes = self.cache.page_hashes(token_ids);
-        self.publish_stored_hashes(&page_hashes, pages, num_tokens, first_new_token)
-    }
-
-    #[cfg(test)]
-    fn cache_finished_req(
-        &mut self,
-        token_ids: &[u32],
-        pages: &[KvPageId],
-        last_node: NodeId,
-        first_new_token: usize,
-    ) {
-        let page_hashes = self.cache.page_hashes(token_ids);
-        self.cache_finished_hashes(&page_hashes, pages, last_node, first_new_token);
-    }
-
-    #[cfg(test)]
-    fn cache_unfinished_req(
-        &mut self,
-        token_ids: &[u32],
-        pages: &mut [KvPageId],
-        last_node: NodeId,
-        first_new_token: usize,
-    ) -> NodeId {
-        let page_hashes = self.cache.page_hashes(token_ids);
-        self.cache_unfinished_hashes(&page_hashes, pages, last_node, first_new_token)
-    }
-
     fn publish_removed_pages(&mut self, evicted_pages: &[KvPageId]) {
         if self.kv_event_publishers.is_empty() {
             return;
@@ -1018,6 +944,12 @@ mod tests {
     use dynamo_kv_router::protocols::{RouterEvent, WorkerId, compute_seq_hash_for_block};
 
     const ROUTER_TEST_WORKER_ID: WorkerId = 31;
+
+    fn lease_with_hashes(tokens: &[u32], page_size: usize) -> RadixRequestLease {
+        let mut lease = RadixRequestLease::default();
+        lease.ensure_page_hashes(tokens, page_size);
+        lease
+    }
 
     struct MockSink {
         events: Mutex<Vec<KvCacheEvent>>,
@@ -1171,7 +1103,7 @@ mod tests {
     fn partially_consumed_decode_reservation_releases_only_unused_slots() {
         let mut mgr = SglangKvManager::new(4, 1, KvEventPublishers::default(), 0);
         let mut reservation = mgr.reserve_decode_pages(3).unwrap();
-        let consumed = reservation.take(None);
+        let consumed = reservation.take_page();
         assert_eq!(reservation.len(), 2);
         let mut expected_unused = reservation.pages[reservation.next..].to_vec();
 
@@ -1187,7 +1119,7 @@ mod tests {
         reallocated.sort_unstable();
         assert_eq!(reallocated, expected_unused);
         assert!(reallocated.windows(2).all(|pair| pair[0] != pair[1]));
-        assert!(!reallocated.contains(&KvPageId::from_token_index(consumed, 1)));
+        assert!(!reallocated.contains(&consumed));
     }
 
     #[test]
@@ -1315,7 +1247,7 @@ mod tests {
         // First request: allocate and cache
         let r1 = mgr.allocate_for_request(&[1, 2, 3, 4, 5]).unwrap();
         assert_eq!(r1.lease.pages.len(), 5);
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5], &r1.lease.pages, r1.lease.last_node(), 0);
+        mgr.finish(&[1, 2, 3, 4, 5], r1.lease);
 
         // Second request with shared prefix
         let r2 = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6, 7]).unwrap();
@@ -1329,8 +1261,9 @@ mod tests {
         let mut mgr = SglangKvManager::new(64, 4, KvEventPublishers::default(), 0);
         let prompt = (0..10).collect::<Vec<_>>();
 
+        let cold_lease = lease_with_hashes(&prompt, 4);
         let cold = mgr
-            .reserve_destination(&prompt)
+            .reserve_destination_lease(cold_lease.page_hashes(), prompt.len())
             .expect("cold destination reservation should fit");
         assert_eq!(cold.transferable_prompt_tokens(), 12);
         mgr.cancel_destination(cold);
@@ -1339,14 +1272,10 @@ mod tests {
         let prefix = mgr
             .allocate_for_request(prefix_tokens)
             .expect("prefix allocation should fit");
-        mgr.cache_finished_req(
-            prefix_tokens,
-            &prefix.lease.pages,
-            prefix.lease.last_node(),
-            prefix.prefix_len,
-        );
+        mgr.finish(prefix_tokens, prefix.lease);
+        let partial_lease = lease_with_hashes(&prompt, 4);
         let partial = mgr
-            .reserve_destination(&prompt)
+            .reserve_destination_lease(partial_lease.page_hashes(), prompt.len())
             .expect("partially cached destination reservation should fit");
         assert_eq!(partial.transferable_prompt_tokens(), 8);
         mgr.cancel_destination(partial);
@@ -1355,14 +1284,10 @@ mod tests {
         let aligned = mgr
             .allocate_for_request(&aligned_tokens)
             .expect("aligned prompt allocation should fit");
-        mgr.cache_finished_req(
-            &aligned_tokens,
-            &aligned.lease.pages,
-            aligned.lease.last_node(),
-            aligned.prefix_len,
-        );
+        mgr.finish(&aligned_tokens, aligned.lease);
+        let full_hit_lease = lease_with_hashes(&aligned_tokens, 4);
         let full_hit = mgr
-            .reserve_destination(&aligned_tokens)
+            .reserve_destination_lease(full_hit_lease.page_hashes(), aligned_tokens.len())
             .expect("fully cached destination reservation should fit");
         assert_eq!(full_hit.transferable_prompt_tokens(), 0);
     }
@@ -1372,9 +1297,9 @@ mod tests {
         let mut mgr = SglangKvManager::new(100, 1, KvEventPublishers::default(), 0);
 
         let result = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
-        mgr.free_request(result.lease.last_node());
+        assert!(mgr.abort(result.lease));
 
-        // Path is unlocked, tokens still allocated in pool
+        // The request path is unlocked and its private pages are returned.
         assert_eq!(mgr.cache().protected_size, 0);
     }
 
@@ -1387,7 +1312,7 @@ mod tests {
         let r = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
         assert_eq!(sink.event_count(), 1); // BlockStored for 3 new pages
 
-        mgr.cache_finished_req(&[1, 2, 3], &r.lease.pages, r.lease.last_node(), 0);
+        mgr.finish(&[1, 2, 3], r.lease);
 
         // Second request with full cache hit → no new events
         let r2 = mgr.allocate_for_request(&[1, 2, 3]).unwrap();
@@ -1402,7 +1327,7 @@ mod tests {
             SglangKvManager::new(100, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
 
         let r = mgr.allocate_for_request(&[1, 2, 3, 4, 5, 6]).unwrap();
-        mgr.cache_finished_req(&[1, 2, 3, 4, 5, 6], &r.lease.pages, r.lease.last_node(), 0);
+        mgr.finish(&[1, 2, 3, 4, 5, 6], r.lease);
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
@@ -1428,10 +1353,20 @@ mod tests {
             SglangKvManager::new(16, 4, KvEventPublishers::new(Some(sink.clone()), None), 0);
         let tokens = [1, 2, 3, 4, 5, 6, 7, 8];
         let pages = mgr.cache_mut().page_pool.allocate_pages(2).unwrap();
+        let lease = lease_with_hashes(&tokens, 4);
 
-        assert_eq!(mgr.publish_stored_event(&tokens[..4], &pages[..1], 4, 0), 1);
-        assert_eq!(mgr.publish_stored_event(&tokens, &pages, 8, 0), 1);
-        assert_eq!(mgr.publish_stored_event(&tokens, &pages, 8, 0), 0);
+        assert_eq!(
+            mgr.publish_stored_hashes(lease.page_hashes_through(4, 4), &pages[..1], 4, 0),
+            1
+        );
+        assert_eq!(
+            mgr.publish_stored_hashes(lease.page_hashes_through(8, 4), &pages, 8, 0),
+            1
+        );
+        assert_eq!(
+            mgr.publish_stored_hashes(lease.page_hashes_through(8, 4), &pages, 8, 0),
+            0
+        );
 
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
@@ -1453,16 +1388,11 @@ mod tests {
         let tokens = [1, 2, 3, 4, 5, 6];
 
         let mut alloc = mgr.allocate_for_request(&tokens[..2]).unwrap();
-        let alloc_last_node = alloc.lease.last_node();
-        let first_last_node =
-            mgr.cache_unfinished_req(&tokens[..2], &mut alloc.lease.pages, alloc_last_node, 0);
-
-        let mut pages = alloc.lease.pages;
-        pages.extend_from_slice(&mgr.cache_mut().page_pool.allocate_pages(2).unwrap());
+        mgr.extend_cached_prefix(&tokens[..2], &mut alloc.lease);
         mgr.kv_event_publishers = KvEventPublishers::new(Some(sink.clone()), None);
 
-        let last_after_first_cache =
-            mgr.cache_unfinished_req(&tokens[..4], &mut pages[..2], first_last_node, 2);
+        assert!(mgr.extend_allocation(&tokens[..4], &mut alloc.lease));
+        mgr.extend_cached_prefix(&tokens[..4], &mut alloc.lease);
         let events = sink.clone_events();
         assert_eq!(events.len(), 1);
         let KvCacheEventData::Stored(first_store) = &events[0].data else {
@@ -1474,7 +1404,8 @@ mod tests {
             "first unfinished cache should store only the newly completed block"
         );
 
-        mgr.cache_finished_req(&tokens, &pages, last_after_first_cache, 4);
+        assert!(mgr.extend_allocation(&tokens, &mut alloc.lease));
+        mgr.finish(&tokens, alloc.lease);
         let events = sink.clone_events();
         assert_eq!(events.len(), 2);
         let KvCacheEventData::Stored(final_store) = &events[1].data else {
@@ -1540,7 +1471,7 @@ mod tests {
         assert_eq!(query_hashes.len(), tokens.len());
         harness.apply_events(allocation_events).await;
 
-        mgr.cache_finished_req(&tokens, &req1.lease.pages, req1.lease.last_node(), 0);
+        mgr.finish(&tokens, req1.lease);
         let req1_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req1_completion_events),
@@ -1558,7 +1489,7 @@ mod tests {
             "canonical completion should retain the first request's slots"
         );
 
-        mgr.cache_finished_req(&tokens, &req2.lease.pages, req2.lease.last_node(), 0);
+        mgr.finish(&tokens, req2.lease);
         let req2_completion_events = buffer.drain();
         assert_eq!(
             stored_event_count(&req2_completion_events),
@@ -1742,9 +1673,10 @@ mod tests {
         let mut alloc = mgr.allocate_for_request(&tokens).unwrap();
         let events_before = sink.event_count();
         let last_node = alloc.lease.last_node();
+        let page_hashes = alloc.lease.page_hashes().to_vec();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.pages, last_node, 2)
+            mgr.cache_unfinished_hashes(&page_hashes, &mut alloc.lease.pages, last_node, 2)
         }));
 
         assert!(result.is_err());
@@ -1761,9 +1693,10 @@ mod tests {
         alloc.lease.pages.truncate(1);
         let events_before = sink.event_count();
         let last_node = alloc.lease.last_node();
+        let page_hashes = alloc.lease.page_hashes().to_vec();
 
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            mgr.cache_unfinished_req(&tokens, &mut alloc.lease.pages, last_node, 0)
+            mgr.cache_unfinished_hashes(&page_hashes, &mut alloc.lease.pages, last_node, 0)
         }));
 
         assert!(result.is_err());
@@ -1790,16 +1723,10 @@ mod tests {
         let chunk2_len = 6;
 
         let mut alloc1 = mgr.allocate_for_request(&tokens[..chunk1_len]).unwrap();
-        let previous_last = alloc1.lease.last_node();
-        let new_last = mgr.cache_unfinished_req(
-            &tokens[..chunk1_len],
-            &mut alloc1.lease.pages,
-            previous_last,
-            0,
-        );
+        mgr.extend_cached_prefix(&tokens[..chunk1_len], &mut alloc1.lease);
 
         let alloc2 = mgr.allocate_for_request(&tokens[..chunk2_len]).unwrap();
-        mgr.free_request(new_last);
+        assert!(mgr.abort(alloc1.lease));
 
         let events = sink.events.lock().unwrap();
         assert_eq!(events.len(), 2, "expected two stored events");

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -52,6 +52,11 @@ impl RadixRequestLease {
         &self.page_hashes
     }
 
+    pub(crate) fn reserve_page_hashes(&mut self, complete_pages: usize) {
+        self.page_hashes
+            .reserve_exact(complete_pages.saturating_sub(self.page_hashes.len()));
+    }
+
     pub(crate) fn ensure_page_hashes(&mut self, token_ids: &[u32], page_size: usize) {
         let complete_pages = token_ids.len() / page_size;
         if self.page_hashes.len() >= complete_pages {

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -85,10 +85,7 @@ impl BlockRequestLease {
             "native lease already has a partial tail"
         );
         self.entries.push(BlockLeaseEntry {
-            identity: NativeBlockIdentity {
-                sequence_hash: None,
-                local_hash: None,
-            },
+            identity: NativeBlockIdentity::partial(),
             copy: None,
             pending_cache: false,
         });
@@ -257,14 +254,14 @@ impl VllmKvManager {
         let Some(ReserveOutcome {
             mut reservation,
             removed,
-        }) = self.pool.reserve_resident_prefix(prefix, count)
+        }) = self.pool.reserve_exact_prefix(prefix, count)
         else {
             return VllmAcquire::CapacityExhausted;
         };
         assert_eq!(
             reservation.len() - reservation.fresh_len(),
             reusable_prefix_blocks,
-            "authorized native prefix changed during atomic allocation"
+            "exact native prefix reservation returned the wrong hit count"
         );
         self.publish_removed(removed);
         self.commit_lease_range(
@@ -424,6 +421,11 @@ impl VllmKvManager {
         mut reservation: NativeDestinationReservation,
     ) {
         lease.debug_assert_owner(owner);
+        debug_assert_eq!(
+            lease.resident_block_count(),
+            0,
+            "destination request already owns physical blocks"
+        );
         assert_eq!(reservation.request_id, owner, "destination owner mismatch");
         let prompt_blocks = sequence
             .num_input_tokens()
@@ -434,7 +436,7 @@ impl VllmKvManager {
             0,
             prompt_blocks,
             &mut reservation.pool,
-            true,
+            self.enable_prefix_caching,
             Some(sequence),
         );
         lease.allocated_tokens = sequence.num_input_tokens();

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -91,17 +91,6 @@ impl BlockRequestLease {
         });
     }
 
-    pub(crate) fn rollback_partial(&mut self) {
-        let entry = self
-            .entries
-            .pop()
-            .expect("native rollback requires a partial tail");
-        assert!(
-            entry.identity.sequence_hash.is_none() && entry.copy.is_none(),
-            "native rollback may remove only an unallocated partial tail"
-        );
-    }
-
     fn debug_assert_owner(&self, owner: Uuid) {
         debug_assert_eq!(self.owner, owner, "native lease owner mismatch");
     }
@@ -239,7 +228,10 @@ impl VllmKvManager {
             reusable_prefix_blocks == 0 || previous_blocks == 0,
             "only a request's first allocation may reuse a prefix"
         );
-        assert!(reusable_prefix_blocks <= target_blocks - previous_blocks);
+        assert!(
+            reusable_prefix_blocks <= target_blocks - previous_blocks,
+            "reusable prefix exceeds the newly allocated block range"
+        );
         assert!(self.enable_prefix_caching || reusable_prefix_blocks == 0);
 
         let count = target_blocks - previous_blocks;
@@ -332,7 +324,8 @@ impl VllmKvManager {
             return;
         }
 
-        let materialize_store_events = self.materialize_store_events();
+        let materialize_store_events =
+            self.enable_prefix_caching && self.materialize_store_events();
         let mut stores = materialize_store_events
             .then(|| Vec::with_capacity(completed_blocks - first_new_block));
         for position in first_new_block..completed_blocks {
@@ -835,6 +828,29 @@ mod tests {
         ready(manager.allocate_lease(second, &mut second_lease, 4, 1));
         assert_eq!(manager.num_active_blocks(), 1);
         assert_eq!(manager.num_inactive_blocks(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "only a request's first allocation may reuse a prefix")]
+    fn later_native_allocation_rejects_prefix_reuse() {
+        let mut manager =
+            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let owner = Uuid::from_u128(3);
+        let (_, mut lease) = request(owner, &[7, 8], false);
+        ready(manager.allocate_lease(owner, &mut lease, 4, 0));
+
+        let _ = manager.allocate_lease(owner, &mut lease, 8, 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "reusable prefix exceeds the newly allocated block range")]
+    fn native_allocation_rejects_excessive_reusable_prefix() {
+        let mut manager =
+            VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let owner = Uuid::from_u128(4);
+        let (_, mut lease) = request(owner, &[7, 8], false);
+
+        let _ = manager.allocate_lease(owner, &mut lease, 4, 2);
     }
 
     #[test]

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -3,22 +3,21 @@
 
 //! vLLM G1 manager over a minimal physical block-pool model.
 //!
-//! The manager owns request block tables and KV-event metadata. The pool owns
-//! physical occupancy, duplicate copies, prefix pins, and LRU eviction.
+//! Each request lease owns its physical-copy IDs and visibility state. The
+//! manager owns KV-event metadata, while the pool owns occupancy, duplicate
+//! copies, prefix pins, and LRU eviction.
 
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
     KvCacheStoredBlockData, LocalBlockHash,
 };
-use dynamo_tokens::blocks::UniqueBlock;
 use dynamo_tokens::{BlockHash, SequenceHash};
-use rustc_hash::{FxHashMap, FxHashSet};
 use uuid::Uuid;
 
 use crate::cache::vllm_block_pool::{BlockCopyId, BlockReservation, ReserveOutcome, VllmBlockPool};
 use crate::common::kv_cache_trace;
 use crate::common::protocols::{KvEventPublishers, PrefillCost};
-use crate::common::sequence::ActiveSequence;
+use crate::common::sequence::{NativeBlockIdentity, RequestSequence};
 
 struct PendingStore {
     parent_hash: Option<SequenceHash>,
@@ -26,18 +25,90 @@ struct PendingStore {
     token_ids: Option<Vec<u32>>,
 }
 
-struct FullBlock {
-    copy: BlockCopyId,
-    hash: SequenceHash,
+#[derive(Debug)]
+struct BlockLeaseEntry {
+    identity: NativeBlockIdentity,
+    copy: Option<BlockCopyId>,
     /// Whether a freshly allocated full block still needs to become cache-visible.
     pending_cache: bool,
-    /// Event metadata retained until `pending_cache` is finalized.
-    pending_store: Option<PendingStore>,
 }
 
-enum OwnedBlock {
-    Partial { copy: BlockCopyId, uuid: Uuid },
-    Full(FullBlock),
+/// Move-only native-G1 ownership token attached to one scheduler request.
+#[derive(Debug)]
+#[must_use = "a native block lease must be finished, aborted, retracted, or moved into a hold"]
+pub(crate) struct BlockRequestLease {
+    owner: Uuid,
+    entries: Vec<BlockLeaseEntry>,
+    allocated_tokens: usize,
+}
+
+impl BlockRequestLease {
+    pub(crate) fn new(owner: Uuid, identities: Vec<NativeBlockIdentity>) -> Self {
+        Self {
+            owner,
+            entries: identities
+                .into_iter()
+                .map(|identity| BlockLeaseEntry {
+                    identity,
+                    copy: None,
+                    pending_cache: false,
+                })
+                .collect(),
+            allocated_tokens: 0,
+        }
+    }
+
+    pub(crate) fn owner(&self) -> Uuid {
+        self.owner
+    }
+
+    pub(crate) fn allocated_tokens(&self) -> usize {
+        self.allocated_tokens
+    }
+
+    pub(crate) fn resident_block_count(&self) -> usize {
+        self.entries
+            .iter()
+            .filter(|entry| entry.copy.is_some())
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn entry_capacity(&self) -> usize {
+        self.entries.capacity()
+    }
+
+    pub(crate) fn append_partial(&mut self) {
+        assert!(
+            self.entries
+                .last()
+                .is_none_or(|entry| entry.identity.sequence_hash.is_some()),
+            "native lease already has a partial tail"
+        );
+        self.entries.push(BlockLeaseEntry {
+            identity: NativeBlockIdentity {
+                sequence_hash: None,
+                local_hash: None,
+            },
+            copy: None,
+            pending_cache: false,
+        });
+    }
+
+    pub(crate) fn rollback_partial(&mut self) {
+        let entry = self
+            .entries
+            .pop()
+            .expect("native rollback requires a partial tail");
+        assert!(
+            entry.identity.sequence_hash.is_none() && entry.copy.is_none(),
+            "native rollback may remove only an unallocated partial tail"
+        );
+    }
+
+    fn debug_assert_owner(&self, owner: Uuid) {
+        debug_assert_eq!(self.owner, owner, "native lease owner mismatch");
+    }
 }
 
 struct StoredBlock {
@@ -96,7 +167,6 @@ impl NativeDecodeBlockReservation {
 pub(crate) struct NativeDestinationReservation {
     request_id: Uuid,
     pool: BlockReservation,
-    layout: Option<VllmBlockLayout>,
 }
 
 impl NativeDestinationReservation {
@@ -115,33 +185,8 @@ pub(super) enum VllmAcquire<T> {
     CapacityExhausted,
 }
 
-pub(super) struct VllmBlockLayout {
-    blocks: Vec<UniqueBlock>,
-    local_hashes: Vec<BlockHash>,
-    token_ids: Option<Vec<Vec<u32>>>,
-    parent: Option<UniqueBlock>,
-}
-
-impl VllmBlockLayout {
-    pub(super) fn new(
-        blocks: Vec<UniqueBlock>,
-        local_hashes: Vec<BlockHash>,
-        token_ids: Option<Vec<Vec<u32>>>,
-        parent: Option<UniqueBlock>,
-    ) -> Self {
-        Self {
-            blocks,
-            local_hashes,
-            token_ids,
-            parent,
-        }
-    }
-}
-
 pub(crate) struct VllmKvManager {
     pool: VllmBlockPool,
-    request_blocks: FxHashMap<Uuid, Vec<OwnedBlock>>,
-    partial_uuids: FxHashSet<Uuid>,
     block_size: usize,
     enable_prefix_caching: bool,
     kv_event_publishers: KvEventPublishers,
@@ -163,8 +208,6 @@ impl VllmKvManager {
         }
         Self {
             pool: VllmBlockPool::new(max_capacity),
-            request_blocks: FxHashMap::default(),
-            partial_uuids: FxHashSet::default(),
             block_size,
             enable_prefix_caching,
             kv_event_publishers,
@@ -173,110 +216,368 @@ impl VllmKvManager {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn use_for_request(
+    /// Atomically allocate the native lease through `cumulative_tokens`.
+    ///
+    /// Capacity is reserved before either physical residency or the allocation
+    /// watermark changes, so exhaustion leaves the lease unchanged.
+    pub(crate) fn allocate_lease(
         &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
+        owner: Uuid,
+        lease: &mut BlockRequestLease,
+        cumulative_tokens: usize,
         reusable_prefix_blocks: usize,
     ) -> VllmAcquire<usize> {
-        self.process_use(
-            request_id,
-            blocks,
-            local_hashes,
-            token_ids,
-            parent,
+        lease.debug_assert_owner(owner);
+        let previous_blocks = lease
+            .allocated_tokens
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        let target_blocks = cumulative_tokens
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        if target_blocks <= previous_blocks {
+            lease.allocated_tokens = cumulative_tokens;
+            return VllmAcquire::Ready(0);
+        }
+        assert!(
+            reusable_prefix_blocks == 0 || previous_blocks == 0,
+            "only a request's first allocation may reuse a prefix"
+        );
+        assert!(reusable_prefix_blocks <= target_blocks - previous_blocks);
+        assert!(self.enable_prefix_caching || reusable_prefix_blocks == 0);
+
+        let count = target_blocks - previous_blocks;
+        let prefix = lease.entries[previous_blocks..previous_blocks + reusable_prefix_blocks]
+            .iter()
+            .map(|entry| {
+                entry
+                    .identity
+                    .sequence_hash
+                    .expect("reusable prefix must contain only complete blocks")
+            });
+        let Some(ReserveOutcome {
+            mut reservation,
+            removed,
+        }) = self.pool.reserve_resident_prefix(prefix, count)
+        else {
+            return VllmAcquire::CapacityExhausted;
+        };
+        assert_eq!(
+            reservation.len() - reservation.fresh_len(),
             reusable_prefix_blocks,
+            "authorized native prefix changed during atomic allocation"
+        );
+        self.publish_removed(removed);
+        self.commit_lease_range(
+            lease,
+            previous_blocks,
+            target_blocks,
+            &mut reservation,
+            false,
             None,
-        )
+        );
+        assert_eq!(reservation.len(), 0, "native reservation was not consumed");
+        self.pool.cancel(reservation);
+        lease.allocated_tokens = cumulative_tokens;
+        VllmAcquire::Ready(count)
     }
 
-    pub(super) fn deref_for_request(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        self.process_deref(request_id, blocks);
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn promote_for_request(
+    pub(crate) fn allocate_lease_from_decode_reservation(
         &mut self,
-        request_id: Uuid,
-        uuid: Uuid,
-        hash: SequenceHash,
-        parent_hash: Option<SequenceHash>,
-        local_hash: Option<BlockHash>,
-        token_ids: Option<Vec<u32>>,
+        owner: Uuid,
+        lease: &mut BlockRequestLease,
+        cumulative_tokens: usize,
+        reservation: &mut NativeDecodeBlockReservation,
     ) {
-        self.process_promote(request_id, uuid, hash, parent_hash, local_hash, token_ids);
+        lease.debug_assert_owner(owner);
+        let previous_blocks = lease
+            .allocated_tokens
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        let target_blocks = cumulative_tokens
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        if target_blocks <= previous_blocks {
+            lease.allocated_tokens = cumulative_tokens;
+            return;
+        }
+        let count = target_blocks - previous_blocks;
+        assert!(
+            reservation.pool.fresh_len() >= count,
+            "decode reservation does not cover the native lease growth"
+        );
+        self.commit_lease_range(
+            lease,
+            previous_blocks,
+            target_blocks,
+            &mut reservation.pool,
+            false,
+            None,
+        );
+        lease.allocated_tokens = cumulative_tokens;
     }
 
-    /// Publish full blocks completed by this scheduling decision.
-    ///
-    /// `computed_before` is a finalization watermark: every earlier complete
-    /// block was either finalized by a prior decision or arrived as an already
-    /// cache-visible prefix/destination block. Restricting the scan to this
-    /// delta avoids revisiting the full request block table on every decode
-    /// step.
-    pub(crate) fn finalize_computed_prefix(
+    pub(crate) fn finalize_lease_computed_prefix(
         &mut self,
-        request_id: Uuid,
+        owner: Uuid,
+        sequence: &mut RequestSequence,
+        lease: &mut BlockRequestLease,
         computed_before: usize,
         computed_after: usize,
     ) {
-        if !self.enable_prefix_caching {
-            return;
-        }
+        lease.debug_assert_owner(owner);
         assert!(
             computed_before <= computed_after,
             "computed token count cannot move backwards during one scheduling decision"
         );
         let first_new_block = computed_before / self.block_size;
-        let completed_blocks = computed_after / self.block_size;
-        if first_new_block == completed_blocks {
+        let completed_blocks = (computed_after / self.block_size).min(lease.entries.len());
+        if first_new_block >= completed_blocks {
             return;
         }
 
         let materialize_store_events = self.materialize_store_events();
-        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
-            panic!("request {request_id} owns no block table")
-        };
-        let completed_blocks = completed_blocks.min(blocks.len());
-        if first_new_block >= completed_blocks {
-            return;
-        }
         let mut stores = materialize_store_events
             .then(|| Vec::with_capacity(completed_blocks - first_new_block));
-        for block in &mut blocks[first_new_block..completed_blocks] {
-            match block {
-                OwnedBlock::Full(full) => {
-                    if !full.pending_cache {
-                        if let Some(stores) = &mut stores {
-                            stores.push(None);
-                        }
-                        continue;
-                    }
-                    full.pending_cache = false;
-                    let metadata = full.pending_store.take();
-                    let became_visible = self.pool.cache_private(full.copy, full.hash);
-                    if let Some(stores) = &mut stores {
-                        stores.push(became_visible.then(|| {
-                            StoredBlock {
-                                hash: full.hash,
-                                metadata: metadata.expect(
-                                    "materialized pending store must retain event metadata",
-                                ),
-                            }
-                        }));
-                    } else {
-                        debug_assert!(metadata.is_none());
-                    }
-                }
-                OwnedBlock::Partial { .. } => break,
+        for position in first_new_block..completed_blocks {
+            let parent_hash = position
+                .checked_sub(1)
+                .and_then(|parent| lease.entries[parent].identity.sequence_hash);
+            if lease.entries[position].identity.sequence_hash.is_none() {
+                lease.entries[position].identity =
+                    sequence.complete_block_identity(position, parent_hash);
+                lease.entries[position].pending_cache = self.enable_prefix_caching;
             }
+
+            let entry = &mut lease.entries[position];
+            if !entry.pending_cache {
+                if let Some(stores) = &mut stores {
+                    stores.push(None);
+                }
+                sequence.discard_completed_block(position);
+                continue;
+            }
+            entry.pending_cache = false;
+            let copy = entry
+                .copy
+                .expect("computed native block must retain physical residency");
+            let hash = entry
+                .identity
+                .sequence_hash
+                .expect("computed native block must have a sequence hash");
+            let became_visible = self.pool.cache_private(copy, hash);
+            if let Some(stores) = &mut stores {
+                stores.push(became_visible.then(|| StoredBlock {
+                    hash,
+                    metadata: PendingStore {
+                        parent_hash,
+                        local_hash: entry.identity.local_hash,
+                        token_ids: sequence.block_token_ids(position),
+                    },
+                }));
+            }
+            sequence.discard_completed_block(position);
         }
         if let Some(stores) = stores {
             self.publish_store_sequence(stores);
+        }
+        sequence.debug_assert_invariants(lease.entries.iter().map(|entry| entry.identity));
+    }
+
+    pub(crate) fn reserve_destination_lease(
+        &mut self,
+        owner: Uuid,
+        sequence: &RequestSequence,
+        lease: &BlockRequestLease,
+        _eviction_now_ms: Option<f64>,
+    ) -> VllmAcquire<NativeDestinationReservation> {
+        lease.debug_assert_owner(owner);
+        assert_eq!(
+            lease.resident_block_count(),
+            0,
+            "destination request already owns physical blocks"
+        );
+        let prompt_blocks = sequence
+            .num_input_tokens()
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        let prefix_candidates = lease.entries[..prompt_blocks]
+            .iter()
+            .map_while(|entry| entry.identity.sequence_hash);
+        let Some(outcome) = self
+            .pool
+            .reserve_resident_prefix(prefix_candidates, prompt_blocks)
+        else {
+            return VllmAcquire::CapacityExhausted;
+        };
+        self.publish_removed(outcome.removed);
+        VllmAcquire::Ready(NativeDestinationReservation {
+            request_id: owner,
+            pool: outcome.reservation,
+        })
+    }
+
+    pub(crate) fn activate_destination_lease(
+        &mut self,
+        owner: Uuid,
+        sequence: &RequestSequence,
+        lease: &mut BlockRequestLease,
+        mut reservation: NativeDestinationReservation,
+    ) {
+        lease.debug_assert_owner(owner);
+        assert_eq!(reservation.request_id, owner, "destination owner mismatch");
+        let prompt_blocks = sequence
+            .num_input_tokens()
+            .div_ceil(self.block_size)
+            .min(lease.entries.len());
+        self.commit_lease_range(
+            lease,
+            0,
+            prompt_blocks,
+            &mut reservation.pool,
+            true,
+            Some(sequence),
+        );
+        lease.allocated_tokens = sequence.num_input_tokens();
+        assert_eq!(
+            reservation.pool.len(),
+            0,
+            "destination reservation was not consumed"
+        );
+        self.pool.cancel(reservation.pool);
+    }
+
+    pub(crate) fn preempt_lease(&mut self, owner: Uuid, lease: &mut BlockRequestLease) {
+        lease.debug_assert_owner(owner);
+        self.release_lease_entries(lease);
+        lease.allocated_tokens = 0;
+    }
+
+    pub(crate) fn finish_lease(&mut self, owner: Uuid, mut lease: BlockRequestLease) {
+        lease.debug_assert_owner(owner);
+        self.release_lease_entries(&mut lease);
+        lease.allocated_tokens = 0;
+    }
+
+    fn release_lease_entries(&mut self, lease: &mut BlockRequestLease) {
+        for entry in lease.entries.iter_mut().rev() {
+            if let Some(copy) = entry.copy.take() {
+                self.pool.release(copy);
+            }
+            entry.pending_cache = false;
+        }
+    }
+
+    fn commit_lease_range(
+        &mut self,
+        lease: &mut BlockRequestLease,
+        start: usize,
+        end: usize,
+        reservation: &mut BlockReservation,
+        cache_fresh: bool,
+        sequence: Option<&RequestSequence>,
+    ) {
+        assert!(start <= end && end <= lease.entries.len());
+        let prefix_len = reservation.len() - reservation.fresh_len();
+        let mut prefix_copies = self.pool.activate_prefix(reservation);
+        assert_eq!(prefix_copies.len(), prefix_len);
+        let materialize_store_events = self.materialize_store_events();
+        let mut stores =
+            (cache_fresh && materialize_store_events).then(|| Vec::with_capacity(end - start));
+
+        for (offset, position) in (start..end).enumerate() {
+            let parent_hash = position
+                .checked_sub(1)
+                .and_then(|parent| lease.entries[parent].identity.sequence_hash);
+            let entry = &mut lease.entries[position];
+            assert!(
+                entry.copy.is_none(),
+                "native lease entry is already resident"
+            );
+            if offset < prefix_len {
+                let (hash, copy) = prefix_copies
+                    .next()
+                    .expect("prefix reservation returned too few copies");
+                assert_eq!(
+                    entry.identity.sequence_hash,
+                    Some(hash),
+                    "reserved prefix hash changed before activation"
+                );
+                entry.copy = Some(copy);
+                entry.pending_cache = false;
+                if let Some(stores) = &mut stores {
+                    stores.push(None);
+                }
+                continue;
+            }
+
+            let Some(hash) = entry.identity.sequence_hash else {
+                entry.copy = Some(self.pool.allocate_private(reservation));
+                entry.pending_cache = false;
+                if let Some(stores) = &mut stores {
+                    stores.push(None);
+                }
+                continue;
+            };
+            if cache_fresh && self.enable_prefix_caching {
+                let (copy, became_visible) = self.pool.allocate_cached(reservation, hash);
+                entry.copy = Some(copy);
+                entry.pending_cache = false;
+                if let Some(stores) = &mut stores {
+                    stores.push(became_visible.then(|| StoredBlock {
+                        hash,
+                        metadata: PendingStore {
+                            parent_hash,
+                            local_hash: entry.identity.local_hash,
+                            token_ids: sequence.and_then(|seq| seq.block_token_ids(position)),
+                        },
+                    }));
+                }
+            } else {
+                entry.copy = Some(self.pool.allocate_private(reservation));
+                entry.pending_cache = self.enable_prefix_caching;
+                if let Some(stores) = &mut stores {
+                    stores.push(None);
+                }
+            }
+        }
+        assert!(prefix_copies.next().is_none());
+        if let Some(stores) = stores {
+            self.publish_store_sequence(stores);
+        }
+    }
+
+    pub(crate) fn get_lease_prefill_cost(
+        &self,
+        sequence: &RequestSequence,
+        lease: &BlockRequestLease,
+    ) -> PrefillCost {
+        let (overlap_blocks, active_overlap_blocks) =
+            if self.enable_prefix_caching && sequence.enable_prefix_caching() {
+                let mut overlap = 0;
+                let mut active = 0;
+                for entry in &lease.entries {
+                    let Some(hash) = entry.identity.sequence_hash else {
+                        break;
+                    };
+                    let Some(hit) = self.pool.prefix_hit(hash) else {
+                        break;
+                    };
+                    overlap += 1;
+                    active += usize::from(hit.is_active);
+                }
+                (overlap, active)
+            } else {
+                (0, 0)
+            };
+        let new_blocks = lease.entries.len() - overlap_blocks;
+        let cached_tokens = (overlap_blocks * self.block_size).min(sequence.len());
+        let active_cached_tokens = (active_overlap_blocks * self.block_size).min(sequence.len());
+        PrefillCost {
+            new_blocks,
+            new_tokens: sequence.len() - cached_tokens,
+            cached_tokens,
+            active_cached_tokens,
         }
     }
 
@@ -297,445 +598,8 @@ impl VllmKvManager {
         self.pool.cancel(reservation.pool);
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub(super) fn use_decode_reservation_for_request(
-        &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-        reservation: &mut NativeDecodeBlockReservation,
-    ) {
-        let outcome = self.process_use(
-            request_id,
-            blocks,
-            local_hashes,
-            token_ids,
-            parent,
-            0,
-            Some(&mut reservation.pool),
-        );
-        assert!(
-            matches!(outcome, VllmAcquire::Ready(allocated) if allocated == blocks.len()),
-            "reserved decode allocation must be infallible"
-        );
-    }
-
-    pub(crate) fn reserve_destination_at(
-        &mut self,
-        request_id: Uuid,
-        layout: Option<VllmBlockLayout>,
-        _eviction_now_ms: Option<f64>,
-    ) -> VllmAcquire<NativeDestinationReservation> {
-        assert!(
-            !self.request_blocks.contains_key(&request_id),
-            "destination request already owns a block table"
-        );
-        let (prefix, fresh) = match layout.as_ref() {
-            Some(VllmBlockLayout {
-                blocks,
-                local_hashes,
-                token_ids,
-                parent,
-            }) => {
-                Self::validate_use_metadata(
-                    blocks,
-                    local_hashes,
-                    token_ids.as_deref(),
-                    parent.as_ref(),
-                );
-                self.validate_fresh_partials(blocks);
-                let prefix = self.resident_prefix(blocks);
-                let fresh = blocks.len() - prefix.len();
-                (prefix, fresh)
-            }
-            None => (Vec::new(), 0),
-        };
-        let Some(outcome) = self.pool.reserve(&prefix, fresh) else {
-            return VllmAcquire::CapacityExhausted;
-        };
-        self.publish_removed(outcome.removed);
-        VllmAcquire::Ready(NativeDestinationReservation {
-            request_id,
-            pool: outcome.reservation,
-            layout,
-        })
-    }
-
-    pub(crate) fn activate_destination(&mut self, reservation: NativeDestinationReservation) {
-        let NativeDestinationReservation {
-            request_id,
-            mut pool,
-            layout,
-        } = reservation;
-        assert!(
-            !self.request_blocks.contains_key(&request_id),
-            "destination request already owns a block table"
-        );
-        let Some(VllmBlockLayout {
-            blocks,
-            local_hashes,
-            token_ids,
-            parent,
-        }) = layout
-        else {
-            self.pool.cancel(pool);
-            return;
-        };
-        Self::validate_use_metadata(
-            &blocks,
-            &local_hashes,
-            token_ids.as_deref(),
-            parent.as_ref(),
-        );
-        self.validate_fresh_partials(&blocks);
-        self.commit_layout(
-            request_id,
-            &blocks,
-            &local_hashes,
-            token_ids.as_deref(),
-            parent.as_ref(),
-            &mut pool,
-            self.enable_prefix_caching,
-        );
-        assert_eq!(pool.len(), 0, "destination reservation was not consumed");
-        self.pool.cancel(pool);
-    }
-
     pub(crate) fn cancel_destination(&mut self, reservation: NativeDestinationReservation) {
         self.pool.cancel(reservation.pool);
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn process_use(
-        &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-        reusable_prefix_blocks: usize,
-        reservation: Option<&mut BlockReservation>,
-    ) -> VllmAcquire<usize> {
-        Self::validate_use_metadata(blocks, local_hashes, token_ids, parent);
-        self.validate_fresh_partials(blocks);
-        assert!(reusable_prefix_blocks <= blocks.len());
-        assert!(self.enable_prefix_caching || reusable_prefix_blocks == 0);
-        assert!(
-            reusable_prefix_blocks == 0
-                || self
-                    .request_blocks
-                    .get(&request_id)
-                    .is_none_or(Vec::is_empty),
-            "only a request's first allocation may reuse a prefix"
-        );
-
-        let prefix = if reusable_prefix_blocks == 0 {
-            Vec::new()
-        } else {
-            blocks[..reusable_prefix_blocks]
-                .iter()
-                .map(|block| match block {
-                    UniqueBlock::FullBlock(hash) => *hash,
-                    UniqueBlock::PartialBlock(_) => {
-                        panic!("a reusable prefix can contain only full blocks")
-                    }
-                })
-                .collect::<Vec<_>>()
-        };
-        let fresh = blocks.len() - reusable_prefix_blocks;
-
-        match reservation {
-            Some(reservation) => {
-                assert!(prefix.is_empty(), "decode cannot reuse a new prefix");
-                if reservation.fresh_len() < fresh {
-                    return VllmAcquire::CapacityExhausted;
-                }
-                self.commit_layout(
-                    request_id,
-                    blocks,
-                    local_hashes,
-                    token_ids,
-                    parent,
-                    reservation,
-                    false,
-                );
-            }
-            None => {
-                let Some(ReserveOutcome {
-                    mut reservation,
-                    removed,
-                }) = self.pool.reserve(&prefix, fresh)
-                else {
-                    return VllmAcquire::CapacityExhausted;
-                };
-                self.publish_removed(removed);
-                self.commit_layout(
-                    request_id,
-                    blocks,
-                    local_hashes,
-                    token_ids,
-                    parent,
-                    &mut reservation,
-                    false,
-                );
-                assert_eq!(reservation.len(), 0, "Use reservation was not consumed");
-                self.pool.cancel(reservation);
-            }
-        }
-        VllmAcquire::Ready(blocks.len())
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn commit_layout(
-        &mut self,
-        request_id: Uuid,
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-        reservation: &mut BlockReservation,
-        cache_fresh: bool,
-    ) {
-        let prefix_len = reservation.len() - reservation.fresh_len();
-        let prefix_copies = self.pool.activate_prefix(reservation);
-        assert_eq!(prefix_copies.len(), prefix_len);
-        let mut prefix_copies = prefix_copies.into_iter();
-        let mut cursor = match parent {
-            None => None,
-            Some(UniqueBlock::FullBlock(hash)) => Some(*hash),
-            Some(UniqueBlock::PartialBlock(_)) => unreachable!("validated above"),
-        };
-        let mut full_idx = 0;
-        let materialize_store_events = self.materialize_store_events();
-        let owned = self.request_blocks.entry(request_id).or_default();
-        owned.reserve(blocks.len());
-        let mut stores =
-            (cache_fresh && materialize_store_events).then(|| Vec::with_capacity(blocks.len()));
-
-        for (block_idx, block) in blocks.iter().enumerate() {
-            match block {
-                UniqueBlock::FullBlock(hash) => {
-                    let local_hash = local_hashes.get(full_idx).copied();
-                    full_idx += 1;
-
-                    if block_idx < prefix_len {
-                        let Some(copy) = prefix_copies.next() else {
-                            panic!("prefix reservation returned too few copies")
-                        };
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache: false,
-                            pending_store: None,
-                        }));
-                        cursor = Some(*hash);
-                        continue;
-                    }
-
-                    if cache_fresh {
-                        let (copy, became_visible) = self.pool.allocate_cached(reservation, *hash);
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache: false,
-                            pending_store: None,
-                        }));
-                        if let Some(stores) = &mut stores {
-                            let metadata = PendingStore {
-                                parent_hash: cursor,
-                                local_hash,
-                                token_ids: token_ids.and_then(|ids| ids.get(full_idx - 1).cloned()),
-                            };
-                            stores.push(became_visible.then_some(StoredBlock {
-                                hash: *hash,
-                                metadata,
-                            }));
-                        }
-                    } else {
-                        let copy = self.pool.allocate_private(reservation);
-                        let pending_cache = self.enable_prefix_caching;
-                        let pending_store =
-                            (pending_cache && materialize_store_events).then(|| PendingStore {
-                                parent_hash: cursor,
-                                local_hash,
-                                token_ids: token_ids.and_then(|ids| ids.get(full_idx - 1).cloned()),
-                            });
-                        owned.push(OwnedBlock::Full(FullBlock {
-                            copy,
-                            hash: *hash,
-                            pending_cache,
-                            pending_store,
-                        }));
-                    }
-                    cursor = Some(*hash);
-                }
-                UniqueBlock::PartialBlock(uuid) => {
-                    let copy = self.pool.allocate_private(reservation);
-                    assert!(
-                        self.partial_uuids.insert(*uuid),
-                        "partial block {uuid} is already allocated"
-                    );
-                    owned.push(OwnedBlock::Partial { copy, uuid: *uuid });
-                    if let Some(stores) = &mut stores {
-                        stores.push(None);
-                    }
-                }
-            }
-        }
-        assert!(prefix_copies.next().is_none());
-        if let Some(stores) = stores {
-            self.publish_store_sequence(stores);
-        }
-    }
-
-    fn validate_use_metadata(
-        blocks: &[UniqueBlock],
-        local_hashes: &[BlockHash],
-        token_ids: Option<&[Vec<u32>]>,
-        parent: Option<&UniqueBlock>,
-    ) {
-        let full_blocks = blocks
-            .iter()
-            .filter(|block| matches!(block, UniqueBlock::FullBlock(_)))
-            .count();
-        assert!(
-            local_hashes.is_empty() || local_hashes.len() == full_blocks,
-            "local hashes must be empty or align with full blocks"
-        );
-        assert!(
-            token_ids.is_none_or(|ids| ids.len() == full_blocks),
-            "token IDs must align with full blocks"
-        );
-        assert!(!matches!(parent, Some(UniqueBlock::PartialBlock(_))));
-    }
-
-    fn validate_fresh_partials(&self, blocks: &[UniqueBlock]) {
-        let mut first_partial = None;
-        for (index, uuid) in blocks
-            .iter()
-            .enumerate()
-            .filter_map(|(index, block)| match block {
-                UniqueBlock::PartialBlock(uuid) => Some((index, uuid)),
-                UniqueBlock::FullBlock(_) => None,
-            })
-        {
-            let repeated_in_layout = first_partial.is_some_and(|first| {
-                first == *uuid
-                    || blocks[..index].iter().any(
-                        |block| matches!(block, UniqueBlock::PartialBlock(seen) if seen == uuid),
-                    )
-            });
-            assert!(
-                !self.partial_uuids.contains(uuid) && !repeated_in_layout,
-                "partial block {uuid} is already allocated"
-            );
-            first_partial.get_or_insert(*uuid);
-        }
-    }
-
-    fn resident_prefix(&self, blocks: &[UniqueBlock]) -> Vec<SequenceHash> {
-        if !self.enable_prefix_caching {
-            return Vec::new();
-        }
-        blocks
-            .iter()
-            .map_while(|block| match block {
-                UniqueBlock::FullBlock(hash) if self.pool.prefix_hit(*hash).is_some() => {
-                    Some(*hash)
-                }
-                _ => None,
-            })
-            .collect()
-    }
-
-    /// Release request blocks in caller-provided eviction-priority order.
-    ///
-    /// Like vLLM's `BlockPool::free_blocks`, the physical pool is lineage-agnostic:
-    /// reversing the request-owned table here makes suffix/leaf blocks older LRU
-    /// candidates than their parents, so capacity pressure evicts the leaf first.
-    fn process_deref(&mut self, request_id: Uuid, blocks: &[UniqueBlock]) {
-        let released = {
-            let Some(owned) = self.request_blocks.get_mut(&request_id) else {
-                panic!("request {request_id} owns no block table")
-            };
-            assert!(
-                blocks.len() <= owned.len(),
-                "request releases too many blocks"
-            );
-            let start = owned.len() - blocks.len();
-            for (expected, actual) in blocks.iter().zip(owned[start..].iter().rev()) {
-                match (expected, actual) {
-                    (UniqueBlock::FullBlock(expected), OwnedBlock::Full(full)) => {
-                        assert_eq!(*expected, full.hash, "full-block Deref mismatch");
-                    }
-                    (UniqueBlock::PartialBlock(expected), OwnedBlock::Partial { uuid, .. }) => {
-                        assert_eq!(expected, uuid, "partial Deref mismatch")
-                    }
-                    _ => panic!("Deref block kind disagrees with request table"),
-                }
-            }
-            owned.split_off(start)
-        };
-        if self.request_blocks[&request_id].is_empty() {
-            self.request_blocks.remove(&request_id);
-        }
-
-        for block in released.into_iter().rev() {
-            match block {
-                OwnedBlock::Partial { copy, uuid } => {
-                    assert!(self.partial_uuids.remove(&uuid));
-                    self.pool.release(copy);
-                }
-                OwnedBlock::Full(full) => self.pool.release(full.copy),
-            }
-        }
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn process_promote(
-        &mut self,
-        request_id: Uuid,
-        uuid: Uuid,
-        hash: SequenceHash,
-        parent_hash: Option<SequenceHash>,
-        local_hash: Option<BlockHash>,
-        token_ids: Option<Vec<u32>>,
-    ) {
-        let materialize_store_events = self.materialize_store_events();
-        let Some(blocks) = self.request_blocks.get_mut(&request_id) else {
-            panic!("request {request_id} owns no block table")
-        };
-        let Some(last) = blocks.last_mut() else {
-            panic!("Promote requires a request-owned partial tail")
-        };
-        let copy = match last {
-            OwnedBlock::Partial { copy, uuid: actual } => {
-                assert_eq!(*actual, uuid, "Promote partial UUID mismatch");
-                *copy
-            }
-            OwnedBlock::Full(_) => panic!("Promote requires a partial tail"),
-        };
-        assert!(self.partial_uuids.remove(&uuid));
-
-        let became_visible = self.enable_prefix_caching && self.pool.cache_private(copy, hash);
-        *last = OwnedBlock::Full(FullBlock {
-            copy,
-            hash,
-            pending_cache: false,
-            pending_store: None,
-        });
-        if became_visible && materialize_store_events {
-            self.publish_store_sequence(vec![Some(StoredBlock {
-                hash,
-                metadata: PendingStore {
-                    parent_hash,
-                    local_hash,
-                    token_ids,
-                },
-            })]);
-        }
     }
 
     fn materialize_store_events(&self) -> bool {
@@ -881,41 +745,6 @@ impl VllmKvManager {
     pub(crate) fn dp_rank(&self) -> u32 {
         self.dp_rank
     }
-
-    #[cfg(test)]
-    pub(crate) fn request_block_count(&self, request_id: Uuid) -> usize {
-        self.request_blocks.get(&request_id).map_or(0, Vec::len)
-    }
-
-    pub(crate) fn get_prefill_cost(&self, sequence: &ActiveSequence) -> PrefillCost {
-        let (overlap_blocks, active_overlap_blocks) =
-            if self.enable_prefix_caching && sequence.enable_prefix_caching() {
-                let mut overlap = 0;
-                let mut active = 0;
-                for block in sequence.unique_blocks() {
-                    let UniqueBlock::FullBlock(hash) = block else {
-                        break;
-                    };
-                    let Some(hit) = self.pool.prefix_hit(*hash) else {
-                        break;
-                    };
-                    overlap += 1;
-                    active += usize::from(hit.is_active);
-                }
-                (overlap, active)
-            } else {
-                (0, 0)
-            };
-        let new_blocks = sequence.unique_blocks().len() - overlap_blocks;
-        let cached_tokens = (overlap_blocks * self.block_size).min(sequence.len());
-        let active_cached_tokens = (active_overlap_blocks * self.block_size).min(sequence.len());
-        PrefillCost {
-            new_blocks,
-            new_tokens: sequence.len() - cached_tokens,
-            cached_tokens,
-            active_cached_tokens,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -943,26 +772,22 @@ mod tests {
         }
     }
 
-    fn use_full(
-        manager: &mut VllmKvManager,
+    fn request(
         owner: Uuid,
         hashes: &[u64],
-        reusable_prefix_blocks: usize,
-    ) -> VllmAcquire<usize> {
-        let blocks = hashes
+        emit_token_ids: bool,
+    ) -> (RequestSequence, BlockRequestLease) {
+        let tokens = (0..hashes.len() * 4).map(|token| token as u32).collect();
+        let (sequence, _) = RequestSequence::new(tokens, 0, 0, 4, true, true, emit_token_ids, None);
+        let identities = hashes
             .iter()
             .copied()
-            .map(UniqueBlock::FullBlock)
-            .collect::<Vec<_>>();
-        let local_hashes = hashes.iter().map(|hash| hash + 100).collect::<Vec<_>>();
-        manager.use_for_request(
-            owner,
-            &blocks,
-            &local_hashes,
-            None,
-            None,
-            reusable_prefix_blocks,
-        )
+            .map(|hash| NativeBlockIdentity {
+                sequence_hash: Some(hash),
+                local_hash: Some(hash + 100),
+            })
+            .collect();
+        (sequence, BlockRequestLease::new(owner, identities))
     }
 
     fn ready<T>(outcome: VllmAcquire<T>) -> T {
@@ -976,15 +801,22 @@ mod tests {
     fn duplicate_full_hashes_consume_physical_capacity() {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
+        let mut leases = Vec::new();
         for owner in [Uuid::from_u128(1), Uuid::from_u128(2)] {
-            ready(use_full(&mut manager, owner, &[7], 0));
-            manager.finalize_computed_prefix(owner, 0, 4);
+            let (mut sequence, mut lease) = request(owner, &[7], false);
+            ready(manager.allocate_lease(owner, &mut lease, 4, 0));
+            manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 0, 4);
+            leases.push(lease);
         }
         assert_eq!(manager.num_active_blocks(), 2);
+        let third = Uuid::from_u128(3);
+        let (_, mut third_lease) = request(third, &[8], false);
         assert!(matches!(
-            use_full(&mut manager, Uuid::from_u128(3), &[8], 0),
+            manager.allocate_lease(third, &mut third_lease, 4, 0),
             VllmAcquire::CapacityExhausted
         ));
+        assert_eq!(third_lease.allocated_tokens(), 0);
+        assert_eq!(third_lease.resident_block_count(), 0);
     }
 
     #[test]
@@ -992,11 +824,14 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
         let first = Uuid::from_u128(1);
-        ready(use_full(&mut manager, first, &[7], 0));
-        manager.finalize_computed_prefix(first, 0, 4);
-        manager.deref_for_request(first, &[UniqueBlock::FullBlock(7)]);
+        let (mut first_sequence, mut first_lease) = request(first, &[7], false);
+        ready(manager.allocate_lease(first, &mut first_lease, 4, 0));
+        manager.finalize_lease_computed_prefix(first, &mut first_sequence, &mut first_lease, 0, 4);
+        manager.finish_lease(first, first_lease);
 
-        ready(use_full(&mut manager, Uuid::from_u128(2), &[7], 1));
+        let second = Uuid::from_u128(2);
+        let (_, mut second_lease) = request(second, &[7], false);
+        ready(manager.allocate_lease(second, &mut second_lease, 4, 1));
         assert_eq!(manager.num_active_blocks(), 1);
         assert_eq!(manager.num_inactive_blocks(), 0);
     }
@@ -1006,9 +841,10 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
         let owner = Uuid::from_u128(1);
-        ready(use_full(&mut manager, owner, &[7], 0));
+        let (mut sequence, mut lease) = request(owner, &[7], false);
+        ready(manager.allocate_lease(owner, &mut lease, 4, 0));
         assert!(manager.pool.prefix_hit(7).is_none());
-        manager.finalize_computed_prefix(owner, 0, 4);
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 0, 4);
         assert!(manager.pool.prefix_hit(7).is_some());
     }
 
@@ -1017,13 +853,14 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
         let owner = Uuid::from_u128(1);
-        ready(use_full(&mut manager, owner, &[7, 8], 0));
+        let (mut sequence, mut lease) = request(owner, &[7, 8], false);
+        ready(manager.allocate_lease(owner, &mut lease, 8, 0));
 
-        manager.finalize_computed_prefix(owner, 0, 4);
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 0, 4);
         assert!(manager.pool.prefix_hit(7).is_some());
         assert!(manager.pool.prefix_hit(8).is_none());
 
-        manager.finalize_computed_prefix(owner, 4, 8);
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 4, 8);
         assert!(manager.pool.prefix_hit(8).is_some());
     }
 
@@ -1032,9 +869,10 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(3, 4, true, KvEventPublishers::default(), 0);
         let owner = Uuid::from_u128(1);
-        ready(use_full(&mut manager, owner, &[7, 8, 9], 0));
+        let (mut sequence, mut lease) = request(owner, &[7, 8, 9], false);
+        ready(manager.allocate_lease(owner, &mut lease, 12, 0));
 
-        manager.finalize_computed_prefix(owner, 3, 9);
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 3, 9);
         assert!(manager.pool.prefix_hit(7).is_some());
         assert!(manager.pool.prefix_hit(8).is_some());
         assert!(manager.pool.prefix_hit(9).is_none());
@@ -1045,13 +883,15 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
         let seed = Uuid::from_u128(1);
-        ready(use_full(&mut manager, seed, &[7], 0));
-        manager.finalize_computed_prefix(seed, 0, 4);
-        manager.deref_for_request(seed, &[UniqueBlock::FullBlock(7)]);
+        let (mut seed_sequence, mut seed_lease) = request(seed, &[7], false);
+        ready(manager.allocate_lease(seed, &mut seed_lease, 4, 0));
+        manager.finalize_lease_computed_prefix(seed, &mut seed_sequence, &mut seed_lease, 0, 4);
+        manager.finish_lease(seed, seed_lease);
 
         let owner = Uuid::from_u128(2);
-        ready(use_full(&mut manager, owner, &[7, 8], 1));
-        manager.finalize_computed_prefix(owner, 4, 8);
+        let (mut sequence, mut lease) = request(owner, &[7, 8], false);
+        ready(manager.allocate_lease(owner, &mut lease, 8, 1));
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 4, 8);
         assert!(manager.pool.prefix_hit(7).is_some());
         assert!(manager.pool.prefix_hit(8).is_some());
     }
@@ -1061,15 +901,14 @@ mod tests {
         let mut manager =
             VllmKvManager::new_with_event_sink(2, 4, true, KvEventPublishers::default(), 0);
         let owner = Uuid::from_u128(1);
-        ready(use_full(&mut manager, owner, &[7, 8], 0));
-        manager.finalize_computed_prefix(owner, 0, 8);
+        let (mut sequence, mut lease) = request(owner, &[7, 8], false);
+        ready(manager.allocate_lease(owner, &mut lease, 8, 0));
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 0, 8);
+        manager.finish_lease(owner, lease);
 
-        // Deref signals describe the request tail first.
-        manager.deref_for_request(
-            owner,
-            &[UniqueBlock::FullBlock(8), UniqueBlock::FullBlock(7)],
-        );
-        ready(use_full(&mut manager, Uuid::from_u128(2), &[9], 0));
+        let next = Uuid::from_u128(2);
+        let (_, mut next_lease) = request(next, &[9], false);
+        ready(manager.allocate_lease(next, &mut next_lease, 4, 0));
 
         assert!(
             manager.pool.prefix_hit(7).is_some(),
@@ -1087,18 +926,10 @@ mod tests {
         let publishers = KvEventPublishers::new(None, Some(sink.clone()));
         let mut manager = VllmKvManager::new_with_event_sink(2, 4, true, publishers, 3);
         let owner = Uuid::from_u128(1);
-        let token_ids = vec![vec![1, 2, 3, 4]];
-        let parent = UniqueBlock::FullBlock(6);
-
-        ready(manager.use_for_request(
-            owner,
-            &[UniqueBlock::FullBlock(7)],
-            &[107],
-            Some(&token_ids),
-            Some(&parent),
-            0,
-        ));
-        manager.finalize_computed_prefix(owner, 0, 4);
+        let token_ids = vec![vec![4, 5, 6, 7]];
+        let (mut sequence, mut lease) = request(owner, &[6, 7], true);
+        ready(manager.allocate_lease(owner, &mut lease, 8, 0));
+        manager.finalize_lease_computed_prefix(owner, &mut sequence, &mut lease, 4, 8);
 
         let mut events = sink.take();
         assert_eq!(events.len(), 1);

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -370,7 +370,14 @@ impl VllmKvManager {
         if let Some(stores) = stores {
             self.publish_store_sequence(stores);
         }
-        sequence.debug_assert_invariants(lease.entries.iter().map(|entry| entry.identity));
+        #[cfg(debug_assertions)]
+        sequence.debug_assert_finalized_range(
+            lease.entries.len(),
+            lease.entries[first_new_block..completed_blocks]
+                .iter()
+                .map(|entry| entry.identity),
+            lease.entries.last().map(|entry| entry.identity),
+        );
     }
 
     pub(crate) fn reserve_destination_lease(

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -44,16 +44,15 @@ pub(crate) struct BlockRequestLease {
 
 impl BlockRequestLease {
     pub(crate) fn new(owner: Uuid, identities: Vec<NativeBlockIdentity>) -> Self {
+        let mut entries = Vec::with_capacity(identities.capacity());
+        entries.extend(identities.into_iter().map(|identity| BlockLeaseEntry {
+            identity,
+            copy: None,
+            pending_cache: false,
+        }));
         Self {
             owner,
-            entries: identities
-                .into_iter()
-                .map(|identity| BlockLeaseEntry {
-                    identity,
-                    copy: None,
-                    pending_cache: false,
-                })
-                .collect(),
+            entries,
             allocated_tokens: 0,
         }
     }

--- a/lib/mocker/src/replay/artifacts.rs
+++ b/lib/mocker/src/replay/artifacts.rs
@@ -16,8 +16,8 @@ use crate::loadgen::ReplayRequestHashes;
 #[doc(hidden)]
 pub fn native_g1_parent_chain_artifact(block_size: usize) -> ReplayWorkerArtifacts {
     use crate::common::protocols::{G1Backend, KvEventPublishers};
-    use crate::common::sequence::ActiveSequence;
-    use crate::kv_manager::{G1Acquire, G1Manager};
+    use crate::common::sequence::RequestSequence;
+    use crate::kv_manager::{BlockRequestLease, G1Acquire, G1Manager};
     use crate::scheduler::capture_router_event_sink;
 
     assert!(block_size >= 2, "block size must be at least 2");
@@ -28,25 +28,41 @@ pub fn native_g1_parent_chain_artifact(block_size: usize) -> ReplayWorkerArtifac
     let prompt_len_u32 =
         u32::try_from(prompt_len).expect("ordering regression prompt length must fit in u32");
     let mut tokens = (0..prompt_len_u32).collect::<Vec<_>>();
-    let mut sequence = ActiveSequence::new(tokens.clone(), 2, Some(block_size), true, false);
+    let (mut sequence, identities) = RequestSequence::new(
+        tokens.clone(),
+        2,
+        2,
+        block_size,
+        true,
+        true,
+        false,
+        Some(vec![prompt_len_u32, prompt_len_u32 + 1]),
+    );
     let owner = Uuid::from_u128(1);
+    let mut lease = BlockRequestLease::new(owner, identities);
     let (events, sink) = capture_router_event_sink(1);
     let publishers = KvEventPublishers::new(Some(sink), None);
     let mut manager = G1Manager::new_with_backend(3, block_size, publishers, 0, G1Backend::Native);
-
-    let creation = sequence
-        .take_creation_signal()
-        .expect("three-block sequence must allocate G1 blocks");
     assert!(matches!(
-        manager.process_for_request(owner, &creation, 0),
+        manager.allocate_native(owner, &mut lease, prompt_len, 0),
         G1Acquire::Ready(3)
     ));
+    let prompt_complete = prompt_len / block_size * block_size;
+    manager.finalize_native_computed_prefix(owner, 0, prompt_complete, &mut sequence, &mut lease);
 
     for token in [prompt_len_u32, prompt_len_u32 + 1] {
-        assert!(sequence.push(token).is_none());
+        let (generated, opened_partial) = sequence.generate_token();
+        assert_eq!(generated, token);
+        assert!(!opened_partial);
         tokens.push(token);
     }
-    manager.finalize_computed_prefix(owner, 0, computed_after, &mut sequence);
+    manager.finalize_native_computed_prefix(
+        owner,
+        prompt_complete,
+        computed_after,
+        &mut sequence,
+        &mut lease,
+    );
 
     let kv_events = events
         .drain()

--- a/lib/mocker/src/scheduler/sglang/config.rs
+++ b/lib/mocker/src/scheduler/sglang/config.rs
@@ -95,6 +95,27 @@ impl SglangConfig {
             speculative_max_tokens: args.aic_nextn.map(|nextn| nextn + 1),
         }
     }
+
+    /// Storage reservation hint for output tokens that this worker can realize.
+    ///
+    /// Planned replay outputs keep their known length for allocation-free
+    /// appends. Online requests use SGLang's existing decode-reservation clip
+    /// so a large caller-declared limit does not eagerly size every queued
+    /// request to the whole KV pool.
+    pub(super) fn output_storage_hint(
+        &self,
+        prompt_len: usize,
+        max_output_tokens: usize,
+        has_planned_output: bool,
+    ) -> usize {
+        let realizable = self.total_kv_tokens.saturating_sub(prompt_len);
+        let requested = if has_planned_output {
+            max_output_tokens
+        } else {
+            max_output_tokens.min(self.clip_max_new_tokens)
+        };
+        requested.min(realizable)
+    }
 }
 
 pub(super) fn ceil_to_block(tokens: usize, block_size: usize) -> usize {

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -243,7 +243,7 @@ impl SglangCore {
                 {
                     anyhow::bail!("destination handoff {handoff_id:?} is already active");
                 }
-                let request = SglangRequest::new(request, self.config.block_size);
+                let request = self.build_request(request);
                 let prompt_footprint = request
                     .prompt_len()
                     .div_ceil(self.config.block_size)
@@ -366,7 +366,7 @@ impl SglangCore {
     }
 
     fn submit(&mut self, request: DirectRequest) -> anyhow::Result<Uuid> {
-        let request = SglangRequest::new(request, self.config.block_size);
+        let request = self.build_request(request);
         if self.request_is_active(request.uuid) {
             anyhow::bail!("request {} is already active", request.uuid);
         }
@@ -374,6 +374,19 @@ impl SglangCore {
         let uuid = request.uuid;
         self.waiting.push_back(request);
         Ok(uuid)
+    }
+
+    fn build_request(&self, request: DirectRequest) -> SglangRequest {
+        let max_output_tokens = request
+            .output_token_ids
+            .as_ref()
+            .map_or(request.max_output_tokens, Vec::len);
+        let output_storage_hint = self.config.output_storage_hint(
+            request.tokens.len(),
+            max_output_tokens,
+            request.output_token_ids.is_some(),
+        );
+        SglangRequest::new(request, self.config.block_size, output_storage_hint)
     }
 
     fn complete_source(&mut self, request: SglangRequest) {
@@ -546,6 +559,27 @@ impl SglangCore {
         self.prebuilt_ready
             .iter()
             .find(|request| request.uuid == uuid)
+    }
+
+    #[cfg(test)]
+    pub(super) fn request_storage_capacities(&self, uuid: Uuid) -> Option<(usize, usize)> {
+        self.waiting
+            .iter()
+            .chain(&self.prebuilt_ready)
+            .chain(&self.running)
+            .find(|request| request.uuid == uuid)
+            .or_else(|| {
+                self.pending_destinations
+                    .payloads()
+                    .find(|request| request.uuid == uuid)
+            })
+            .or_else(|| {
+                self.destination_holds
+                    .payloads()
+                    .map(|reservation| &reservation.request)
+                    .find(|request| request.uuid == uuid)
+            })
+            .map(SglangRequest::storage_capacities)
     }
 
     fn bump_capacity_generation(&mut self) {

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -243,8 +243,7 @@ impl SglangCore {
                 {
                     anyhow::bail!("destination handoff {handoff_id:?} is already active");
                 }
-                let mut request = SglangRequest::from(request);
-                request.prepare(self.config.block_size);
+                let request = SglangRequest::new(request, self.config.block_size);
                 let prompt_footprint = request
                     .prompt_len()
                     .div_ceil(self.config.block_size)
@@ -367,8 +366,7 @@ impl SglangCore {
     }
 
     fn submit(&mut self, request: DirectRequest) -> anyhow::Result<Uuid> {
-        let mut request = SglangRequest::from(request);
-        request.prepare(self.config.block_size);
+        let request = SglangRequest::new(request, self.config.block_size);
         if self.request_is_active(request.uuid) {
             anyhow::bail!("request {} is already active", request.uuid);
         }

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use dynamo_kv_router::protocols::WorkerId;
 use uuid::Uuid;
 
+#[cfg(test)]
+use crate::cache::radix_cache::KvPageId;
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::{DirectRequest, KvEventPublishers, MockEngineArgs, WorkerType};
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
@@ -63,8 +65,7 @@ impl ReservedSglangDecode {
     fn activate(self, kv_manager: &mut SglangKvManager, block_size: usize) -> SglangRequest {
         let Self { mut request, kv } = self;
         let allocated_tokens = kv.allocated_tokens;
-        let alloc = kv_manager.activate_destination(kv, request.prompt_tokens());
-        request.kv_lease = alloc.lease;
+        kv_manager.activate_destination_lease(kv, request.prompt_len(), &mut request.kv_lease);
         request.materialized_tokens = request.prompt_len();
         request.allocated_tokens = allocated_tokens;
         request.debug_assert_invariants(block_size);
@@ -242,7 +243,8 @@ impl SglangCore {
                 {
                     anyhow::bail!("destination handoff {handoff_id:?} is already active");
                 }
-                let request = SglangRequest::from(request);
+                let mut request = SglangRequest::from(request);
+                request.prepare(self.config.block_size);
                 let prompt_footprint = request
                     .prompt_len()
                     .div_ceil(self.config.block_size)
@@ -322,7 +324,9 @@ impl SglangCore {
         {
             self.destination_reservation_attempts += 1;
         }
-        let reservation = self.kv_manager.reserve_destination(request.prompt_tokens());
+        let reservation = self
+            .kv_manager
+            .reserve_destination_lease(request.kv_lease.page_hashes(), request.prompt_len());
         self.pending_destinations.mark_front_attempted(generation);
         let Some(kv) = reservation else {
             return Vec::new();
@@ -363,7 +367,8 @@ impl SglangCore {
     }
 
     fn submit(&mut self, request: DirectRequest) -> anyhow::Result<Uuid> {
-        let request = SglangRequest::from(request);
+        let mut request = SglangRequest::from(request);
+        request.prepare(self.config.block_size);
         if self.request_is_active(request.uuid) {
             anyhow::bail!("request {} is already active", request.uuid);
         }
@@ -531,10 +536,10 @@ impl SglangCore {
     }
 
     #[cfg(test)]
-    pub(crate) fn destination_indices(&self, handoff_id: HandoffId) -> Vec<usize> {
+    pub(crate) fn destination_pages(&self, handoff_id: HandoffId) -> Vec<KvPageId> {
         self.destination_holds
             .get(handoff_id)
-            .map(|reservation| reservation.kv.indices())
+            .map(|reservation| reservation.kv.pages())
             .unwrap_or_default()
     }
 

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -110,7 +110,7 @@ fn check_decode_mem_for_burst(
         };
 
         let mut req = running.remove(idx);
-        kv_manager.retract(std::mem::take(&mut req.kv_lease));
+        kv_manager.retract_in_place(&mut req.kv_lease);
         req.reset_for_retract();
         req.debug_assert_invariants(config.block_size);
         retracted.push(req);
@@ -296,7 +296,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 req.allocated_tokens += config.block_size;
             }
             let token_id = req.next_output_token();
-            req.append_output_token(token_id);
+            req.append_output_token(token_id, config.block_size);
             req.debug_assert_invariants(config.block_size);
 
             let is_complete = req.output_len() >= req.max_output_tokens;

--- a/lib/mocker/src/scheduler/sglang/policy.rs
+++ b/lib/mocker/src/scheduler/sglang/policy.rs
@@ -43,17 +43,12 @@ pub(super) fn apply_schedule_policy(
                     && {
                         let duplicate_prefix =
                             &req.kv_lease.page_hashes()[..duplicate_prefix_len / page_size];
-                        !waiting_prefixes.insert(
-                            duplicate_prefix
-                                .iter()
-                                .copied()
-                                .reduce(|parent, local| {
-                                    dynamo_kv_router::protocols::LocalBlockHash(
-                                        compute_next_seq_hash(parent.0, local),
-                                    )
-                                })
-                                .expect("duplicate-prefix threshold must cover at least one page"),
-                        )
+                        let mut local_hashes = duplicate_prefix.iter().copied();
+                        let first = local_hashes
+                            .next()
+                            .expect("duplicate-prefix threshold must cover at least one page");
+                        let sequence_hash = local_hashes.fold(first.0, compute_next_seq_hash);
+                        !waiting_prefixes.insert(sequence_hash)
                     };
 
                 scored.push((prefix_len, deprioritized, req));

--- a/lib/mocker/src/scheduler/sglang/policy.rs
+++ b/lib/mocker/src/scheduler/sglang/policy.rs
@@ -3,6 +3,8 @@
 
 use std::collections::VecDeque;
 
+use dynamo_kv_router::protocols::compute_next_seq_hash;
+
 use crate::kv_manager::SglangKvManager;
 use rustc_hash::FxHashSet;
 
@@ -30,12 +32,29 @@ pub(super) fn apply_schedule_policy(
             let mut waiting_prefixes = FxHashSet::default();
             let mut scored = Vec::with_capacity(waiting.len());
 
-            for req in waiting.drain(..) {
-                let sequence = req.sequence_tokens();
-                let prefix_len = kv_manager.cache().prefix_match_len(sequence);
+            for mut req in waiting.drain(..) {
+                let sequence_tokens = &req.sequence_tokens;
+                req.kv_lease.ensure_page_hashes(sequence_tokens, page_size);
+                let prefix_len = kv_manager
+                    .cache()
+                    .prefix_match_hashes_len(req.kv_lease.page_hashes());
                 let deprioritized = prefix_len <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD
-                    && sequence.len() >= duplicate_prefix_len
-                    && !waiting_prefixes.insert(sequence[..duplicate_prefix_len].to_vec());
+                    && req.sequence_tokens().len() >= duplicate_prefix_len
+                    && {
+                        let duplicate_prefix =
+                            &req.kv_lease.page_hashes()[..duplicate_prefix_len / page_size];
+                        !waiting_prefixes.insert(
+                            duplicate_prefix
+                                .iter()
+                                .copied()
+                                .reduce(|parent, local| {
+                                    dynamo_kv_router::protocols::LocalBlockHash(
+                                        compute_next_seq_hash(parent.0, local),
+                                    )
+                                })
+                                .expect("duplicate-prefix threshold must cover at least one page"),
+                        )
+                    };
 
                 scored.push((prefix_len, deprioritized, req));
             }

--- a/lib/mocker/src/scheduler/sglang/prefill.rs
+++ b/lib/mocker/src/scheduler/sglang/prefill.rs
@@ -120,10 +120,7 @@ pub(super) fn get_new_batch_prefill(
                 .extend_allocation(alloc_tokens, &mut lease)
                 .then_some(req.materialized_tokens)
         } else {
-            kv_manager.allocate_for_request(alloc_tokens).map(|alloc| {
-                lease = alloc.lease;
-                alloc.prefix_len
-            })
+            kv_manager.allocate_for_request_lease(alloc_tokens, &mut lease)
         };
 
         let Some(prefix_len) = prefix_len else {

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -110,6 +110,13 @@ impl SglangRequest {
                 .map_or(self.max_output_tokens, Vec::len),
         );
         self.sequence_tokens.reserve_exact(output_capacity);
+        let completion_pages = self
+            .sequence_tokens
+            .len()
+            .checked_add(output_capacity)
+            .expect("SGLang request completion length overflow")
+            / block_size;
+        self.kv_lease.reserve_page_hashes(completion_pages);
         self.kv_lease
             .ensure_page_hashes(&self.sequence_tokens, block_size);
     }

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -24,13 +24,13 @@ pub(super) struct SglangRequest {
 }
 
 impl SglangRequest {
-    pub(super) fn new(req: DirectRequest, block_size: usize) -> Self {
+    pub(super) fn new(req: DirectRequest, block_size: usize, output_storage_hint: usize) -> Self {
         let prompt_len = req.tokens.len();
         let max_output_tokens = req
             .output_token_ids
             .as_ref()
             .map_or(req.max_output_tokens, Vec::len);
-        let output_capacity = max_output_tokens;
+        let output_capacity = output_storage_hint.min(max_output_tokens);
         let mut sequence_tokens = req.tokens;
         sequence_tokens.reserve_exact(output_capacity);
         let completion_pages = sequence_tokens
@@ -109,6 +109,14 @@ impl SglangRequest {
     #[cfg(test)]
     pub(super) fn output_tokens(&self) -> &[u32] {
         &self.sequence_tokens[self.prompt_len..]
+    }
+
+    #[cfg(test)]
+    pub(super) fn storage_capacities(&self) -> (usize, usize) {
+        (
+            self.sequence_tokens.capacity(),
+            self.kv_lease.page_hash_capacity(),
+        )
     }
 
     pub(super) fn next_output_token(&self) -> u32 {

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -6,8 +6,10 @@ use std::hash::{Hash, Hasher};
 
 use uuid::Uuid;
 
+#[cfg(test)]
+use crate::cache::radix_cache::KvPageId;
 use crate::common::protocols::DirectRequest;
-use crate::kv_manager::sglang_backend::ActiveKvLease;
+use crate::kv_manager::sglang_backend::RadixRequestLease;
 
 #[derive(Debug)]
 pub(super) struct SglangRequest {
@@ -16,7 +18,7 @@ pub(super) struct SglangRequest {
     pub(super) prompt_len: usize,
     pub(super) max_output_tokens: usize,
     pub(super) planned_output_ids: Option<Vec<u32>>,
-    pub(super) kv_lease: ActiveKvLease,
+    pub(super) kv_lease: RadixRequestLease,
     pub(super) materialized_tokens: usize,
     pub(super) allocated_tokens: usize,
 }
@@ -49,8 +51,8 @@ impl SglangRequest {
     }
 
     #[cfg(test)]
-    pub(super) fn kv_indices(&self) -> &[usize] {
-        self.kv_lease.indices()
+    pub(super) fn kv_pages(&self) -> &[KvPageId] {
+        self.kv_lease.pages()
     }
 
     #[cfg(debug_assertions)]
@@ -64,10 +66,6 @@ impl SglangRequest {
 
     pub(super) fn page_aligned_materialized_tokens(&self, block_size: usize) -> usize {
         self.materialized_tokens / block_size * block_size
-    }
-
-    pub(super) fn prompt_tokens(&self) -> &[u32] {
-        &self.sequence_tokens[..self.prompt_len]
     }
 
     pub(super) fn sequence_tokens(&self) -> &[u32] {
@@ -98,9 +96,22 @@ impl SglangRequest {
         hasher.finish() as u32
     }
 
-    pub(super) fn append_output_token(&mut self, token: u32) {
+    pub(super) fn append_output_token(&mut self, token: u32, block_size: usize) {
         self.sequence_tokens.push(token);
+        self.kv_lease
+            .ensure_page_hashes(&self.sequence_tokens, block_size);
         self.materialized_tokens += 1;
+    }
+
+    pub(super) fn prepare(&mut self, block_size: usize) {
+        let output_capacity = self.max_output_tokens.min(
+            self.planned_output_ids
+                .as_ref()
+                .map_or(self.max_output_tokens, Vec::len),
+        );
+        self.sequence_tokens.reserve_exact(output_capacity);
+        self.kv_lease
+            .ensure_page_hashes(&self.sequence_tokens, block_size);
     }
 
     pub(super) fn debug_assert_invariants(&self, _block_size: usize) {
@@ -130,10 +141,18 @@ impl SglangRequest {
             debug_assert_eq!(
                 self.kv_len(),
                 self.materialized_tokens,
-                "request {} has {} kv indices but {} materialized tokens",
+                "request {} owns KV for {} tokens but has {} materialized tokens",
                 self.uuid,
                 self.kv_len(),
                 self.materialized_tokens
+            );
+            debug_assert_eq!(
+                self.kv_lease.page_count() * block_size,
+                self.allocated_tokens,
+                "request {} owns {} KV pages but tracks {} allocated tokens",
+                self.uuid,
+                self.kv_lease.page_count(),
+                self.allocated_tokens
             );
             debug_assert!(
                 self.allocated_tokens >= self.materialized_tokens,
@@ -193,7 +212,7 @@ impl From<DirectRequest> for SglangRequest {
             prompt_len,
             max_output_tokens,
             planned_output_ids: req.output_token_ids,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             materialized_tokens: 0,
             allocated_tokens: 0,
         }

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -24,6 +24,36 @@ pub(super) struct SglangRequest {
 }
 
 impl SglangRequest {
+    pub(super) fn new(req: DirectRequest, block_size: usize) -> Self {
+        let prompt_len = req.tokens.len();
+        let max_output_tokens = req
+            .output_token_ids
+            .as_ref()
+            .map_or(req.max_output_tokens, Vec::len);
+        let output_capacity = max_output_tokens;
+        let mut sequence_tokens = req.tokens;
+        sequence_tokens.reserve_exact(output_capacity);
+        let completion_pages = sequence_tokens
+            .len()
+            .checked_add(output_capacity)
+            .expect("SGLang request completion length overflow")
+            / block_size;
+        let mut kv_lease = RadixRequestLease::default();
+        kv_lease.reserve_page_hashes(completion_pages);
+        kv_lease.ensure_page_hashes(&sequence_tokens, block_size);
+
+        Self {
+            uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
+            sequence_tokens,
+            prompt_len,
+            max_output_tokens,
+            planned_output_ids: req.output_token_ids,
+            kv_lease,
+            materialized_tokens: 0,
+            allocated_tokens: 0,
+        }
+    }
+
     pub(super) fn prompt_len(&self) -> usize {
         self.prompt_len
     }
@@ -101,24 +131,6 @@ impl SglangRequest {
         self.kv_lease
             .ensure_page_hashes(&self.sequence_tokens, block_size);
         self.materialized_tokens += 1;
-    }
-
-    pub(super) fn prepare(&mut self, block_size: usize) {
-        let output_capacity = self.max_output_tokens.min(
-            self.planned_output_ids
-                .as_ref()
-                .map_or(self.max_output_tokens, Vec::len),
-        );
-        self.sequence_tokens.reserve_exact(output_capacity);
-        let completion_pages = self
-            .sequence_tokens
-            .len()
-            .checked_add(output_capacity)
-            .expect("SGLang request completion length overflow")
-            / block_size;
-        self.kv_lease.reserve_page_hashes(completion_pages);
-        self.kv_lease
-            .ensure_page_hashes(&self.sequence_tokens, block_size);
     }
 
     pub(super) fn debug_assert_invariants(&self, _block_size: usize) {
@@ -202,26 +214,5 @@ impl SglangRequest {
         debug_assert!(!self.kv_lease.is_active());
         self.materialized_tokens = 0;
         self.allocated_tokens = 0;
-    }
-}
-
-impl From<DirectRequest> for SglangRequest {
-    fn from(req: DirectRequest) -> Self {
-        let prompt_len = req.tokens.len();
-        let max_output_tokens = req
-            .output_token_ids
-            .as_ref()
-            .map_or(req.max_output_tokens, Vec::len);
-        let sequence_tokens = req.tokens;
-        Self {
-            uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
-            sequence_tokens,
-            prompt_len,
-            max_output_tokens,
-            planned_output_ids: req.output_token_ids,
-            kv_lease: RadixRequestLease::default(),
-            materialized_tokens: 0,
-            allocated_tokens: 0,
-        }
     }
 }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -25,7 +25,7 @@ use crate::common::protocols::{
     SglangArgs,
 };
 use crate::kv_manager::SglangKvManager;
-use crate::kv_manager::sglang_backend::ActiveKvLease;
+use crate::kv_manager::sglang_backend::RadixRequestLease;
 use crate::scheduler::test_utils::{
     CapturingFpmSink, RouterIndexerHarness, nth_stored_hashes, removed_event_count, stored_hashes,
 };
@@ -171,7 +171,7 @@ fn zero_output_completion_survives_decode_reservation_failure() {
 }
 
 #[test]
-fn fresh_prefill_tracks_cache_owned_prefix_indices() {
+fn fresh_prefill_tracks_cache_owned_prefix_pages() {
     let args = test_args(8, 4, 16);
     let config = SglangConfig::from_args(&args);
     let (buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
@@ -179,7 +179,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
     let prompt = vec![1, 2, 3, 4];
 
     let cached = kv_manager.allocate_for_request(&prompt).unwrap();
-    let cached_indices = cached.lease.indices().to_vec();
+    let cached_pages = cached.lease.pages().to_vec();
     kv_manager.finish(&prompt, cached.lease);
     let mut waiting = VecDeque::from([SglangRequest {
         uuid: Uuid::from_u128(90_002),
@@ -188,7 +188,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         max_output_tokens: 1,
         planned_output_ids: None,
         materialized_tokens: 0,
-        kv_lease: ActiveKvLease::default(),
+        kv_lease: RadixRequestLease::default(),
         allocated_tokens: 0,
     }]);
     let req = get_new_batch_prefill(&mut waiting, &mut kv_manager, &config, 0.7, &[])
@@ -197,7 +197,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_indices() {
         .unwrap();
 
     assert_eq!(req.cached_tokens(), prompt.len());
-    assert_eq!(req.kv_indices(), cached_indices);
+    assert_eq!(req.kv_pages(), cached_pages);
 
     // The three-token blocker owns a complete physical page. With two pages
     // total there is no free capacity, so the cache-hit request is retracted
@@ -728,9 +728,9 @@ mod destination_lifecycle {
         assert!(occupied_tokens(&destination) > usage_before_reservation);
         assert!(stored_hashes(&destination.drain_kv_events()).is_empty());
 
-        let reserved_indices = destination.destination_indices(handoff_id);
+        let reserved_pages = destination.destination_pages(handoff_id);
         let protected_before_activation = destination.kv_manager.cache().protected_size;
-        assert!(!reserved_indices.is_empty());
+        assert!(!reserved_pages.is_empty());
         assert_eq!(
             destination
                 .apply_command(SchedulerCommand::ActivateDestination { handoff_id })
@@ -740,7 +740,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("activated request must be prebuilt-ready");
-        assert_eq!(ready.kv_indices(), reserved_indices);
+        assert_eq!(ready.kv_pages(), reserved_pages);
         assert_eq!(destination.running.len(), 1);
         assert!(destination.kv_manager.cache().protected_size >= protected_before_activation);
         let activation_stores = stored_hashes(&destination.drain_kv_events());
@@ -765,7 +765,7 @@ mod destination_lifecycle {
         let ready = destination
             .prebuilt_request(logical_uuid)
             .expect("full running batch must keep request ready");
-        assert_eq!(ready.kv_indices(), reserved_indices);
+        assert_eq!(ready.kv_pages(), reserved_pages);
         assert_no_republished_stores(&activation_stores, &stored_hashes(&blocked.kv_events));
 
         let blocker_terminal = execute(&mut destination, blocked.end_ms);
@@ -796,7 +796,7 @@ mod destination_lifecycle {
             .iter()
             .find(|request| request.uuid == logical_uuid)
             .expect("prebuilt request must enter the running batch");
-        assert!(running.kv_indices().starts_with(&reserved_indices));
+        assert!(running.kv_pages().starts_with(&reserved_pages));
         assert_no_republished_stores(&activation_stores, &stored_hashes(&admitted.kv_events));
 
         let terminal = execute(&mut destination, admitted.end_ms);
@@ -1016,7 +1016,7 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 materialized_tokens: 0,
-                kv_lease: ActiveKvLease::default(),
+                kv_lease: RadixRequestLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1026,7 +1026,7 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 materialized_tokens: 0,
-                kv_lease: ActiveKvLease::default(),
+                kv_lease: RadixRequestLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1059,7 +1059,7 @@ mod scheduling {
                 max_output_tokens: 1,
                 planned_output_ids: None,
                 materialized_tokens: 0,
-                kv_lease: ActiveKvLease::default(),
+                kv_lease: RadixRequestLease::default(),
                 allocated_tokens: 0,
             });
         }
@@ -1071,7 +1071,7 @@ mod scheduling {
             max_output_tokens: 1,
             planned_output_ids: None,
             materialized_tokens: 0,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             allocated_tokens: 0,
         });
 
@@ -1137,7 +1137,7 @@ mod core_behavior {
             max_output_tokens: 3,
             planned_output_ids: None,
             materialized_tokens: 0,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1167,7 +1167,7 @@ mod core_behavior {
             max_output_tokens: 2,
             planned_output_ids: None,
             materialized_tokens: 0,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             allocated_tokens: 0,
         }]);
 
@@ -1200,7 +1200,7 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 materialized_tokens: 0,
-                kv_lease: ActiveKvLease::default(),
+                kv_lease: RadixRequestLease::default(),
                 allocated_tokens: 0,
             },
             SglangRequest {
@@ -1210,7 +1210,7 @@ mod core_behavior {
                 max_output_tokens: 3,
                 planned_output_ids: None,
                 materialized_tokens: 0,
-                kv_lease: ActiveKvLease::default(),
+                kv_lease: RadixRequestLease::default(),
                 allocated_tokens: 0,
             },
         ]);
@@ -1339,8 +1339,8 @@ mod core_behavior {
                 .unwrap(),
         );
         let mut kv_manager = SglangKvManager::new(16, 4, KvEventPublishers::default(), 0);
-        let first = kv_manager.cache_mut().page_pool.allocate(8).unwrap();
-        let second = kv_manager.cache_mut().page_pool.allocate(5).unwrap();
+        let first = kv_manager.cache_mut().page_pool.allocate_pages(2).unwrap();
+        let second = kv_manager.cache_mut().page_pool.allocate_pages(2).unwrap();
 
         let mut running = vec![
             SglangRequest {
@@ -1349,7 +1349,7 @@ mod core_behavior {
                 prompt_len: 4,
                 max_output_tokens: 10,
                 planned_output_ids: None,
-                kv_lease: ActiveKvLease::from_parts(first, 4, kv_manager.cache().root()),
+                kv_lease: RadixRequestLease::from_parts(first, 8, 4, kv_manager.cache().root()),
                 materialized_tokens: 8,
                 allocated_tokens: 8,
             },
@@ -1359,7 +1359,7 @@ mod core_behavior {
                 prompt_len: 4,
                 max_output_tokens: 10,
                 planned_output_ids: None,
-                kv_lease: ActiveKvLease::from_parts(second, 4, kv_manager.cache().root()),
+                kv_lease: RadixRequestLease::from_parts(second, 5, 4, kv_manager.cache().root()),
                 materialized_tokens: 5,
                 allocated_tokens: 8,
             },
@@ -1369,7 +1369,7 @@ mod core_behavior {
         assert_eq!(retracted.len(), 1);
         assert_eq!(retracted[0].output_tokens(), &[21]);
         assert_eq!(retracted[0].materialized_tokens, 0);
-        assert!(retracted[0].kv_indices().is_empty());
+        assert!(retracted[0].kv_pages().is_empty());
     }
 
     #[test]
@@ -1687,11 +1687,11 @@ mod router_events {
             max_output_tokens: 2,
             planned_output_ids: None,
             materialized_tokens: 0,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             allocated_tokens: 0,
         };
         let first_output = expected_request.next_output_token();
-        expected_request.append_output_token(first_output);
+        expected_request.append_output_token(first_output, 4);
         let second_output = expected_request.next_output_token();
 
         let mut expected_tokens = prompt_tokens;
@@ -1799,7 +1799,7 @@ mod router_events {
             max_output_tokens: 3,
             planned_output_ids: None,
             materialized_tokens: 0,
-            kv_lease: ActiveKvLease::default(),
+            kv_lease: RadixRequestLease::default(),
             allocated_tokens: 0,
         }]);
 

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -66,6 +66,81 @@ fn direct_request(tokens: Vec<u32>, max_output_tokens: usize) -> DirectRequest {
     }
 }
 
+#[test]
+fn request_storage_reservation_is_bounded_for_submit_and_destination() {
+    const BLOCK_SIZE: usize = 4;
+    const MAX_OUTPUT_TOKENS: usize = 1_000_000;
+    const CLIP_MAX_NEW_TOKENS: usize = 7;
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Sglang)
+        .num_gpu_blocks(4)
+        .block_size(BLOCK_SIZE)
+        .speedup_ratio(0.0)
+        .sglang(Some(SglangArgs {
+            page_size: Some(BLOCK_SIZE),
+            chunked_prefill_size: Some(16),
+            clip_max_new_tokens: Some(CLIP_MAX_NEW_TOKENS),
+            ..Default::default()
+        }))
+        .build()
+        .unwrap();
+    let mut core = SglangCore::new(args);
+    let prompt = (0..8).collect::<Vec<_>>();
+    let bounded_tokens = prompt.len() + CLIP_MAX_NEW_TOKENS;
+    let bounded_pages = bounded_tokens / BLOCK_SIZE;
+
+    let submitted = Uuid::from_u128(80_001);
+    core.receive(DirectRequest {
+        tokens: prompt.clone(),
+        max_output_tokens: MAX_OUTPUT_TOKENS,
+        uuid: Some(submitted),
+        ..Default::default()
+    });
+    let (token_capacity, hash_capacity) = core.request_storage_capacities(submitted).unwrap();
+    assert!(token_capacity >= bounded_tokens);
+    assert!(token_capacity < prompt.len() + MAX_OUTPUT_TOKENS);
+    assert!(hash_capacity >= bounded_pages);
+    assert!(hash_capacity < (prompt.len() + MAX_OUTPUT_TOKENS) / BLOCK_SIZE);
+
+    let destination = Uuid::from_u128(80_002);
+    core.apply_command_effects(
+        SchedulerCommand::ReserveDestination {
+            handoff_id: HandoffId::from(Uuid::from_u128(80_003)),
+            request: DirectRequest {
+                tokens: prompt.clone(),
+                max_output_tokens: MAX_OUTPUT_TOKENS,
+                uuid: Some(destination),
+                ..Default::default()
+            },
+        },
+        false,
+    )
+    .unwrap();
+    let (token_capacity, hash_capacity) = core.request_storage_capacities(destination).unwrap();
+    assert!(token_capacity >= bounded_tokens);
+    assert!(token_capacity < prompt.len() + MAX_OUTPUT_TOKENS);
+    assert!(hash_capacity >= bounded_pages);
+    assert!(hash_capacity < (prompt.len() + MAX_OUTPUT_TOKENS) / BLOCK_SIZE);
+
+    let planned = Uuid::from_u128(80_004);
+    let planned_output = (100..109).collect::<Vec<_>>();
+    core.receive(DirectRequest {
+        tokens: prompt.clone(),
+        max_output_tokens: MAX_OUTPUT_TOKENS,
+        output_token_ids: Some(planned_output.clone()),
+        uuid: Some(planned),
+        ..Default::default()
+    });
+    let (token_capacity, hash_capacity) = core.request_storage_capacities(planned).unwrap();
+    let realizable_planned = 8;
+    assert!(token_capacity >= prompt.len() + realizable_planned);
+    assert!(hash_capacity >= (prompt.len() + realizable_planned) / BLOCK_SIZE);
+    assert!(
+        planned_output.len() > CLIP_MAX_NEW_TOKENS,
+        "planned-output coverage must exceed the online storage clip"
+    );
+}
+
 fn make_decoded_request(
     kv_manager: &mut SglangKvManager,
     config: &SglangConfig,
@@ -874,7 +949,7 @@ mod destination_lifecycle {
             .build()
             .unwrap();
         let mut core = SglangCore::new(args);
-        let blocker = core.kv_manager.allocate_decode_token(None).unwrap();
+        let blocker = core.kv_manager.reserve_decode_pages(1).unwrap();
         let owner_handoff = HandoffId::from(Uuid::from_u128(20_201));
         let follower_handoff = HandoffId::from(Uuid::from_u128(20_202));
         let follower_request = Uuid::from_u128(20_203);
@@ -928,7 +1003,7 @@ mod destination_lifecycle {
             .unwrap(),
             SchedulerCommandResult::Applied
         );
-        core.kv_manager.cache_mut().page_pool.free(&[blocker]);
+        core.kv_manager.release_decode_reservation(blocker);
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -15,7 +15,6 @@ use crate::common::protocols::{
     DirectRequest, G1Backend, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal,
     PreemptionMode, PrefillCost, SchedulingPolicy, WorkerType,
 };
-use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
 use crate::common::utils::{compute_prefill_handoff_delay_ms, prefill_handoff_transfer_timing};
 use crate::kv_manager::G1Manager;
@@ -25,7 +24,8 @@ use crate::kv_manager::{DestinationReservation, G1Acquire, OffloadDependency};
 #[cfg(feature = "kvbm-offload")]
 use crate::kvbm_offload::coordinator::SwapInTerminal;
 use crate::replay::TraceCollector;
-use crate::scheduler::vllm::policy::{self, AdmissionDecision};
+use crate::scheduler::vllm::policy::{self, AdmissionDecision, PolicySequence};
+use crate::scheduler::vllm::request::RequestKvState;
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
     CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, ForwardPassSnapshot,
@@ -43,7 +43,7 @@ pub(crate) enum RequestStatus {
 }
 
 pub(crate) struct VllmRequestState {
-    pub(crate) sequence: ActiveSequence,
+    pub(crate) sequence: RequestKvState,
     pub(crate) status: RequestStatus,
     pub(crate) num_computed_tokens: usize,
     pub(crate) num_preemptions: usize,
@@ -228,17 +228,13 @@ impl SchedulerState {
         }
     }
 
-    pub(crate) fn complete(&mut self, uuid: &Uuid) {
-        self.take_completed(uuid);
-    }
-
     pub(crate) fn take_completed(&mut self, uuid: &Uuid) -> Option<VllmRequestState> {
         self.waiting_members.remove(uuid);
         self.running_members.remove(uuid);
         self.requests.remove(uuid)
     }
 
-    pub(crate) fn running_sequence_mut(&mut self, uuid: Uuid) -> Option<&mut ActiveSequence> {
+    pub(crate) fn running_sequence_mut(&mut self, uuid: Uuid) -> Option<&mut RequestKvState> {
         if !self.running_members.contains(&uuid) {
             return None;
         }
@@ -268,10 +264,10 @@ impl SchedulerState {
         request.num_computed_tokens = 0;
         request.num_preemptions += 1;
         self.preemptions_total += 1;
-        let signals = request.sequence.reset_with_signal();
+        let signals = request.sequence.reset_legacy_with_signal();
         request.debug_assert_invariants(uuid);
         #[cfg(debug_assertions)]
-        {
+        if matches!(request.sequence, RequestKvState::Kvbm(_)) {
             debug_assert_eq!(
                 request.sequence.num_allocated_tokens(),
                 0,
@@ -395,6 +391,8 @@ pub(crate) struct VllmCore {
     #[cfg(test)]
     destination_reservation_attempts: usize,
     lifecycle_events: Vec<SchedulerLifecycleEvent>,
+    retain_local_hashes: bool,
+    emit_token_ids: bool,
 
     /// Requests parked on pending G2→G1 swap-ins. Populated by the
     /// admission path when a request's remaining prefix matches G2 only
@@ -422,9 +420,16 @@ struct ReservedVllmDecode {
 impl ReservedVllmDecode {
     fn activate(self, kv_manager: &mut G1Manager) -> VllmRequestState {
         let Self { mut request, kv } = self;
-        kv_manager.activate_destination(kv);
         let prompt_len = request.sequence.num_input_tokens();
-        request.sequence.commit_allocation(prompt_len);
+        match &mut request.sequence {
+            RequestKvState::Native { sequence, lease } => {
+                kv_manager.activate_native_destination(lease.owner(), sequence, lease, kv);
+            }
+            RequestKvState::Kvbm(sequence) => {
+                kv_manager.activate_destination(kv);
+                sequence.commit_allocation(prompt_len);
+            }
+        }
         request.num_computed_tokens = prompt_len;
         request.status = RequestStatus::Waiting;
         request
@@ -487,6 +492,9 @@ impl VllmCore {
         } else {
             KvEventPublishers::default()
         };
+        let retain_local_hashes =
+            !kv_event_publishers.is_empty() || args.zmq_kv_events_port.is_some();
+        let emit_token_ids = kv_event_publishers.raw_enabled() || args.zmq_kv_events_port.is_some();
         let speculative_sampler = args.aic_nextn.map(|nextn| {
             let rates =
                 normalize_conditional_accept_rates(nextn, args.aic_nextn_accept_rates.as_deref())
@@ -515,6 +523,8 @@ impl VllmCore {
             #[cfg(test)]
             destination_reservation_attempts: 0,
             lifecycle_events: Vec::new(),
+            retain_local_hashes,
+            emit_token_ids,
             #[cfg(feature = "kvbm-offload")]
             requests_awaiting_swap_in: Vec::new(),
         }
@@ -753,11 +763,15 @@ impl VllmCore {
         {
             self.destination_reservation_attempts += 1;
         }
-        let reservation = self.kv_manager.reserve_destination_at(
-            request_id,
-            &request.sequence,
-            reservation_now_ms,
-        );
+        let reservation = match &request.sequence {
+            RequestKvState::Native { sequence, lease } => self
+                .kv_manager
+                .reserve_native_destination_at(request_id, sequence, lease, reservation_now_ms),
+            RequestKvState::Kvbm(sequence) => {
+                self.kv_manager
+                    .reserve_destination_at(request_id, sequence, reservation_now_ms)
+            }
+        };
         let kv = match reservation {
             G1Acquire::Ready(kv) => kv,
             G1Acquire::BlockedOnOffload {
@@ -889,23 +903,27 @@ impl VllmCore {
         // because that path can emit the lifecycle signal.
         let output_capacity_hint = self.output_capacity_hint(prompt_len, max_output_tokens);
         let sequence = if self.args.resolved_g1_backend() == G1Backend::Native {
-            ActiveSequence::new_flat_with_planned_output_ids(
+            RequestKvState::native(
+                uuid,
                 request.tokens,
                 max_output_tokens,
                 output_capacity_hint,
                 self.args.block_size,
                 self.args.enable_prefix_caching,
-                self.args.zmq_kv_events_port.is_some(),
+                self.retain_local_hashes,
+                self.emit_token_ids,
                 planned_output_ids,
             )
         } else {
-            ActiveSequence::new_with_planned_output_ids(
-                request.tokens,
-                max_output_tokens,
-                Some(self.args.block_size),
-                self.args.enable_prefix_caching,
-                self.args.zmq_kv_events_port.is_some(),
-                planned_output_ids,
+            RequestKvState::kvbm(
+                crate::common::sequence::ActiveSequence::new_with_planned_output_ids(
+                    request.tokens,
+                    max_output_tokens,
+                    Some(self.args.block_size),
+                    self.args.enable_prefix_caching,
+                    self.args.zmq_kv_events_port.is_some(),
+                    planned_output_ids,
+                ),
             )
         };
         VllmRequestState {
@@ -988,16 +1006,23 @@ impl VllmCore {
             request,
             deferred_deref,
         } = payload;
-        for signal in deferred_deref {
-            assert!(
-                matches!(
-                    self.kv_manager.process_for_request(request_id, &signal, 0),
-                    G1Acquire::Ready(_)
-                ),
-                "terminal prefill cleanup must be infallible"
-            );
+        match request.sequence {
+            RequestKvState::Native { lease, .. } => {
+                debug_assert!(deferred_deref.is_empty());
+                self.kv_manager.finish_native(request_id, lease);
+            }
+            RequestKvState::Kvbm(_) => {
+                for signal in deferred_deref {
+                    assert!(
+                        matches!(
+                            self.kv_manager.process_for_request(request_id, &signal, 0),
+                            G1Acquire::Ready(_)
+                        ),
+                        "terminal prefill cleanup must be infallible"
+                    );
+                }
+            }
         }
-        drop(request);
     }
 
     #[cfg(test)]
@@ -1059,7 +1084,12 @@ impl VllmCore {
         self.state
             .requests
             .get(&uuid)
-            .map(|request| self.kv_manager.request_block_count(uuid, &request.sequence))
+            .map(|request| match &request.sequence {
+                RequestKvState::Native { lease, .. } => lease.resident_block_count(),
+                RequestKvState::Kvbm(sequence) => {
+                    self.kv_manager.request_block_count(uuid, sequence)
+                }
+            })
             .unwrap_or(0)
     }
 
@@ -1661,18 +1691,28 @@ impl VllmCore {
         let capacity_improved = request.sequence.num_allocated_tokens() > 0
             || self.state.running_members.contains(&uuid)
             || self.kv_manager.num_active_blocks() < active_blocks_before;
-        for signal in request.sequence.free_signal() {
-            assert!(
-                matches!(
-                    self.kv_manager.process_for_request(uuid, &signal, 0),
-                    G1Acquire::Ready(_)
-                ),
-                "request drop cleanup must be infallible"
-            );
-        }
         self.source_holds.remove_request(uuid);
         self.active_destination_handoffs.remove_request(uuid);
-        self.state.complete(&uuid);
+        let request = self
+            .state
+            .take_completed(&uuid)
+            .expect("request drop must remove the scheduler-owned request");
+        match request.sequence {
+            RequestKvState::Native { lease, .. } => {
+                self.kv_manager.finish_native(uuid, lease);
+            }
+            RequestKvState::Kvbm(sequence) => {
+                for signal in sequence.free_signal() {
+                    assert!(
+                        matches!(
+                            self.kv_manager.process_for_request(uuid, &signal, 0),
+                            G1Acquire::Ready(_)
+                        ),
+                        "request drop cleanup must be infallible"
+                    );
+                }
+            }
+        }
         if capacity_improved {
             self.bump_capacity_generation();
         }
@@ -1712,6 +1752,12 @@ impl VllmCore {
             break;
         }
         let preempted = selected.and_then(|uuid| self.state.preempt_uuid(uuid));
+        if let Some(preempted) = preempted.as_ref()
+            && let Some(request) = self.state.requests.get_mut(&preempted.uuid)
+            && let RequestKvState::Native { lease, .. } = &mut request.sequence
+        {
+            self.kv_manager.preempt_native(preempted.uuid, lease);
+        }
         if let Some(preempted) = preempted.as_ref() {
             self.bump_capacity_generation();
             tracing::debug!(
@@ -1829,7 +1875,7 @@ impl VllmCore {
                         self.args.block_size,
                         self.args.aic_nextn.is_some(),
                         !policy::generation_complete(&request.sequence, self.args.max_model_len),
-                        self.kv_manager.get_prefill_cost(&request.sequence),
+                        request.sequence.prefill_cost(&self.kv_manager),
                     )
                     .cached_tokens
                 })
@@ -1864,62 +1910,78 @@ impl VllmCore {
         }
 
         loop {
-            let allocation = {
+            let allocation_outcome = {
+                let kv_manager = &mut self.kv_manager;
                 let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
-                    panic!("schedule_request: {uuid} removed mid-pass (alloc prep)")
+                    panic!("schedule_request: {uuid} removed mid-pass (allocation)")
                 });
                 let allocation_target = desired_computed_after;
                 let prev_allocated_tokens = request.sequence.num_allocated_tokens();
                 if allocation_target <= prev_allocated_tokens {
                     request.num_computed_tokens = actual_computed_after;
-                    None
+                    G1Acquire::Ready(0)
                 } else {
-                    let maybe_signal = request.sequence.prepare_allocation(allocation_target);
-                    Some((allocation_target, maybe_signal))
+                    let outcome = match &mut request.sequence {
+                        RequestKvState::Native { lease, .. } => kv_manager.allocate_native(
+                            uuid,
+                            lease,
+                            allocation_target,
+                            cached_prefix_tokens / self.args.block_size,
+                        ),
+                        RequestKvState::Kvbm(sequence) => {
+                            match sequence.prepare_allocation(allocation_target) {
+                                None => {
+                                    sequence.commit_allocation(allocation_target);
+                                    G1Acquire::Ready(0)
+                                }
+                                Some(signal) => {
+                                    let outcome = kv_manager.process_for_request(
+                                        uuid,
+                                        &signal,
+                                        cached_prefix_tokens / self.args.block_size,
+                                    );
+                                    if let G1Acquire::Ready(allocated) = outcome {
+                                        let expected = match &signal {
+                                            MoveBlock::Use(blocks, ..) => blocks.len(),
+                                            _ => unreachable!(),
+                                        };
+                                        assert_eq!(
+                                            allocated, expected,
+                                            "Use commit must be all-or-nothing"
+                                        );
+                                        sequence.commit_allocation(allocation_target);
+                                    }
+                                    outcome
+                                }
+                            }
+                        }
+                    };
+                    match outcome {
+                        G1Acquire::Ready(_) => {
+                            request.num_computed_tokens = actual_computed_after;
+                            request.offload_dependency = None;
+                        }
+                        G1Acquire::BlockedOnOffload {
+                            offload_id,
+                            deadline_ms,
+                        } => {
+                            request.offload_dependency = Some(OffloadDependency {
+                                offload_id,
+                                deadline_ms,
+                            });
+                        }
+                        G1Acquire::RetryNow { .. } | G1Acquire::CapacityExhausted => {}
+                    }
+                    outcome
                 }
-            };
-            let Some((allocation_target, maybe_signal)) = allocation else {
-                break;
-            };
-            let Some(signal) = maybe_signal else {
-                let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
-                    panic!("schedule_request: {uuid} removed mid-pass (commit no-signal)")
-                });
-                request.sequence.commit_allocation(allocation_target);
-                request.num_computed_tokens = actual_computed_after;
-                break;
             };
 
-            match self.kv_manager.process_for_request(
-                uuid,
-                &signal,
-                cached_prefix_tokens / self.args.block_size,
-            ) {
-                G1Acquire::Ready(allocated) => {
-                    let expected = match &signal {
-                        MoveBlock::Use(blocks, ..) => blocks.len(),
-                        _ => unreachable!(),
-                    };
-                    assert_eq!(allocated, expected, "Use commit must be all-or-nothing");
-                    let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
-                        panic!("schedule_request: {uuid} removed mid-pass (post-process commit)")
-                    });
-                    request.sequence.commit_allocation(allocation_target);
-                    request.num_computed_tokens = actual_computed_after;
-                    request.offload_dependency = None;
-                    break;
-                }
+            match allocation_outcome {
+                G1Acquire::Ready(_) => break,
                 G1Acquire::BlockedOnOffload {
-                    offload_id,
-                    deadline_ms,
+                    offload_id: _,
+                    deadline_ms: _,
                 } => {
-                    let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
-                        panic!("schedule_request: {uuid} removed while attaching dependency")
-                    });
-                    request.offload_dependency = Some(OffloadDependency {
-                        offload_id,
-                        deadline_ms,
-                    });
                     return ScheduleOutcome::DependencyBlocked;
                 }
                 G1Acquire::RetryNow { .. } => {
@@ -1974,12 +2036,25 @@ impl VllmCore {
             let request = self.state.requests.get_mut(&uuid).unwrap_or_else(|| {
                 panic!("schedule_request: {uuid} removed before prefix finalization")
             });
-            self.kv_manager.finalize_computed_prefix(
-                uuid,
-                effective_computed_before,
-                actual_computed_after,
-                &mut request.sequence,
-            );
+            match &mut request.sequence {
+                RequestKvState::Native { sequence, lease } => {
+                    self.kv_manager.finalize_native_computed_prefix(
+                        uuid,
+                        effective_computed_before,
+                        actual_computed_after,
+                        sequence,
+                        lease,
+                    );
+                }
+                RequestKvState::Kvbm(sequence) => {
+                    self.kv_manager.finalize_computed_prefix(
+                        uuid,
+                        effective_computed_before,
+                        actual_computed_after,
+                        sequence,
+                    );
+                }
+            }
         }
 
         let prompt_after = actual_computed_after.min(prompt_len);
@@ -2404,11 +2479,22 @@ impl VllmCore {
             let mut deferred_deref = Vec::new();
             for _ in 0..burst {
                 let (token_id, signals, is_complete) = {
+                    let kv_manager = &mut self.kv_manager;
                     let request = self
                         .state
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
+                    if let RequestKvState::Native { sequence, lease } = &mut request.sequence {
+                        let len = sequence.len();
+                        kv_manager.finalize_native_computed_prefix(
+                            uuid,
+                            len.saturating_sub(1),
+                            len,
+                            sequence,
+                            lease,
+                        );
+                    }
                     let (token_id, mut signals) = request.sequence.generate_token();
                     let is_complete =
                         policy::generation_complete(&request.sequence, self.args.max_model_len);
@@ -2435,6 +2521,17 @@ impl VllmCore {
                         &mut reservation,
                     );
                 }
+                if let Some(request) = self.state.requests.get_mut(&uuid)
+                    && let RequestKvState::Native { sequence, lease } = &mut request.sequence
+                    && lease.allocated_tokens() < sequence.len()
+                {
+                    self.kv_manager.use_native_decode_reservation(
+                        uuid,
+                        lease,
+                        sequence.len(),
+                        &mut reservation,
+                    );
+                }
 
                 let prompt_tokens = {
                     let request = self
@@ -2442,8 +2539,8 @@ impl VllmCore {
                         .requests
                         .get_mut(&uuid)
                         .expect("sampled request must remain active");
-                    if !is_complete {
-                        request.sequence.commit_allocation(request.sequence.len());
+                    if !is_complete && let RequestKvState::Kvbm(sequence) = &mut request.sequence {
+                        sequence.commit_allocation(sequence.len());
                     }
                     request.sequence.num_input_tokens()
                 };

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -266,14 +266,6 @@ impl SchedulerState {
         self.preemptions_total += 1;
         let signals = request.sequence.reset_legacy_with_signal();
         request.debug_assert_invariants(uuid);
-        #[cfg(debug_assertions)]
-        if matches!(request.sequence, RequestKvState::Kvbm(_)) {
-            debug_assert_eq!(
-                request.sequence.num_allocated_tokens(),
-                0,
-                "preempted request {uuid} should release all allocated KV"
-            );
-        }
         self.prepend_waiting(uuid);
         Some(PreemptedRequest { uuid, signals })
     }
@@ -921,7 +913,7 @@ impl VllmCore {
                     max_output_tokens,
                     Some(self.args.block_size),
                     self.args.enable_prefix_caching,
-                    self.args.zmq_kv_events_port.is_some(),
+                    self.emit_token_ids,
                     planned_output_ids,
                 ),
             )
@@ -1759,6 +1751,14 @@ impl VllmCore {
             self.kv_manager.preempt_native(preempted.uuid, lease);
         }
         if let Some(preempted) = preempted.as_ref() {
+            debug_assert_eq!(
+                self.state.requests[&preempted.uuid]
+                    .sequence
+                    .num_allocated_tokens(),
+                0,
+                "preempted request {} should release all allocated KV",
+                preempted.uuid
+            );
             self.bump_capacity_generation();
             tracing::debug!(
                 worker_id = self.dp_rank,
@@ -1768,6 +1768,26 @@ impl VllmCore {
             );
         }
         preempted
+    }
+
+    fn process_preemption_cleanup(&mut self, preempted: &PreemptedRequest) {
+        debug_assert!(
+            matches!(
+                &self.state.requests[&preempted.uuid].sequence,
+                RequestKvState::Kvbm(_)
+            ) || preempted.signals.is_empty(),
+            "native preemption must release its lease directly without legacy signals"
+        );
+        for signal in &preempted.signals {
+            assert!(
+                matches!(
+                    self.kv_manager
+                        .process_for_request(preempted.uuid, signal, 0),
+                    G1Acquire::Ready(_)
+                ),
+                "preemption cleanup must be infallible"
+            );
+        }
     }
 
     fn refresh_request_offload_dependency(&mut self, uuid: Uuid) -> Option<OffloadDependency> {
@@ -1994,16 +2014,7 @@ impl VllmCore {
                 actual_computed_after = effective_computed_before;
                 break;
             };
-            for signal in preempted.signals {
-                assert!(
-                    matches!(
-                        self.kv_manager
-                            .process_for_request(preempted.uuid, &signal, 0),
-                        G1Acquire::Ready(_)
-                    ),
-                    "preemption cleanup must be infallible"
-                );
-            }
+            self.process_preemption_cleanup(&preempted);
             *preempted_any = true;
             if let Some(undone) = scheduled.remove(&preempted.uuid) {
                 *token_budget += undone.total_tokens;
@@ -2264,16 +2275,7 @@ impl VllmCore {
                     break;
                 };
                 running_changed = true;
-                for signal in preempted.signals {
-                    assert!(
-                        matches!(
-                            self.kv_manager
-                                .process_for_request(preempted.uuid, &signal, 0),
-                            G1Acquire::Ready(_)
-                        ),
-                        "decode preemption cleanup must be infallible"
-                    );
-                }
+                self.process_preemption_cleanup(&preempted);
                 if preempted.uuid == uuid {
                     break;
                 }
@@ -2392,16 +2394,7 @@ impl VllmCore {
                 return (Duration::ZERO, Vec::new());
             };
             running_changed = true;
-            for signal in preempted.signals {
-                assert!(
-                    matches!(
-                        self.kv_manager
-                            .process_for_request(preempted.uuid, &signal, 0),
-                        G1Acquire::Ready(_)
-                    ),
-                    "speculative preemption cleanup must be infallible"
-                );
-            }
+            self.process_preemption_cleanup(&preempted);
 
             ready.clear();
             for uuid in self.state.running.iter().copied() {

--- a/lib/mocker/src/scheduler/vllm/mod.rs
+++ b/lib/mocker/src/scheduler/vllm/mod.rs
@@ -9,6 +9,7 @@
 mod core;
 mod live;
 mod policy;
+mod request;
 
 pub(crate) use core::VllmCore;
 pub use live::{MockerMetrics, Scheduler};

--- a/lib/mocker/src/scheduler/vllm/policy.rs
+++ b/lib/mocker/src/scheduler/vllm/policy.rs
@@ -6,6 +6,91 @@
 use crate::common::protocols::{PrefillCost, SchedulingPolicy};
 use crate::common::sequence::ActiveSequence;
 use crate::kv_manager::G1Manager;
+use crate::scheduler::vllm::request::RequestKvState;
+
+pub(super) trait PolicySequence {
+    fn len(&self) -> usize;
+    fn max_output_tokens(&self) -> usize;
+    fn generated_tokens(&self) -> usize;
+    fn num_input_tokens(&self) -> usize;
+    fn num_allocated_tokens(&self) -> usize;
+    fn current_known_blocks(&self) -> usize;
+    fn to_completion_blocks(&self) -> usize;
+    fn prefill_cost(&self, kv_manager: &G1Manager) -> PrefillCost;
+}
+
+impl PolicySequence for ActiveSequence {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn max_output_tokens(&self) -> usize {
+        self.max_output_tokens()
+    }
+
+    fn generated_tokens(&self) -> usize {
+        self.generated_tokens()
+    }
+
+    fn num_input_tokens(&self) -> usize {
+        self.num_input_tokens()
+    }
+
+    fn num_allocated_tokens(&self) -> usize {
+        self.num_allocated_tokens()
+    }
+
+    fn current_known_blocks(&self) -> usize {
+        self.current_known_blocks()
+    }
+
+    fn to_completion_blocks(&self) -> usize {
+        self.to_completion_blocks()
+    }
+
+    fn prefill_cost(&self, kv_manager: &G1Manager) -> PrefillCost {
+        kv_manager.get_prefill_cost(self)
+    }
+}
+
+impl PolicySequence for RequestKvState {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn max_output_tokens(&self) -> usize {
+        self.max_output_tokens()
+    }
+
+    fn generated_tokens(&self) -> usize {
+        self.generated_tokens()
+    }
+
+    fn num_input_tokens(&self) -> usize {
+        self.num_input_tokens()
+    }
+
+    fn num_allocated_tokens(&self) -> usize {
+        self.num_allocated_tokens()
+    }
+
+    fn current_known_blocks(&self) -> usize {
+        self.current_known_blocks()
+    }
+
+    fn to_completion_blocks(&self) -> usize {
+        self.to_completion_blocks()
+    }
+
+    fn prefill_cost(&self, kv_manager: &G1Manager) -> PrefillCost {
+        match self {
+            RequestKvState::Native { sequence, lease } => {
+                kv_manager.get_native_prefill_cost(sequence, lease)
+            }
+            RequestKvState::Kvbm(sequence) => kv_manager.get_prefill_cost(sequence),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(super) enum AdmissionDecision {
@@ -25,9 +110,9 @@ pub(super) struct WaitingAdmissionConfig {
     pub(super) mtp_enabled: bool,
 }
 
-pub(super) fn should_reject_for_model_len(
+pub(super) fn should_reject_for_model_len<S: PolicySequence>(
     policy: SchedulingPolicy,
-    sequence: &ActiveSequence,
+    sequence: &S,
     max_model_len: Option<usize>,
 ) -> bool {
     policy == SchedulingPolicy::Vllm
@@ -36,8 +121,8 @@ pub(super) fn should_reject_for_model_len(
 
 /// Number of additional tokens the request may generate before reaching
 /// either its requested output length or the model sequence-length limit.
-pub(super) fn remaining_generation_tokens(
-    sequence: &ActiveSequence,
+pub(super) fn remaining_generation_tokens<S: PolicySequence>(
+    sequence: &S,
     max_model_len: Option<usize>,
 ) -> usize {
     let requested_remaining = sequence
@@ -49,7 +134,10 @@ pub(super) fn remaining_generation_tokens(
     requested_remaining.min(context_remaining)
 }
 
-pub(super) fn generation_complete(sequence: &ActiveSequence, max_model_len: Option<usize>) -> bool {
+pub(super) fn generation_complete<S: PolicySequence>(
+    sequence: &S,
+    max_model_len: Option<usize>,
+) -> bool {
     remaining_generation_tokens(sequence, max_model_len) == 0
 }
 
@@ -128,11 +216,11 @@ pub(super) fn apply_prefix_recompute(
 /// vLLM reserves only the current known sequence. TRT-LLM
 /// `GUARANTEED_NO_EVICT` reserves the request through its maximum completion
 /// and accounts for the completion reservations of running requests.
-pub(super) fn decide_waiting_admission<'a>(
+pub(super) fn decide_waiting_admission<'a, S: PolicySequence + 'a>(
     config: WaitingAdmissionConfig,
-    sequence: &ActiveSequence,
+    sequence: &S,
     is_fresh: bool,
-    running: impl Iterator<Item = &'a ActiveSequence>,
+    running: impl Iterator<Item = &'a S>,
     kv_manager: &G1Manager,
 ) -> AdmissionDecision {
     let WaitingAdmissionConfig {
@@ -159,7 +247,7 @@ pub(super) fn decide_waiting_admission<'a>(
         }
     }
 
-    let raw_prefill_cost = kv_manager.get_prefill_cost(sequence);
+    let raw_prefill_cost = sequence.prefill_cost(kv_manager);
     let g1_cached_tokens = raw_prefill_cost.cached_tokens;
     let prefill_cost = apply_prefix_recompute(
         policy,
@@ -207,8 +295,8 @@ pub(super) fn decide_waiting_admission<'a>(
 /// the KV manager's active blocks), so only the remaining footprint is reserved.
 /// For a waiting candidate, only the active cached prefix is discounted
 /// (`active_cached_tokens`).
-fn blocks_needed_to_finish(
-    sequence: &ActiveSequence,
+fn blocks_needed_to_finish<S: PolicySequence>(
+    sequence: &S,
     block_size: usize,
     kv_manager: &G1Manager,
     prefill_cost: Option<&PrefillCost>,
@@ -217,7 +305,7 @@ fn blocks_needed_to_finish(
     if sequence.num_allocated_tokens() == 0 {
         let reusable_blocks = prefill_cost
             .map(|cost| cost.active_cached_tokens)
-            .unwrap_or_else(|| kv_manager.get_prefill_cost(sequence).active_cached_tokens)
+            .unwrap_or_else(|| sequence.prefill_cost(kv_manager).active_cached_tokens)
             / block_size;
         full_blocks.saturating_sub(reusable_blocks)
     } else {
@@ -233,8 +321,8 @@ fn blocks_needed_to_finish(
 /// `running` yields the active sequence of each currently-running request;
 /// `num_gpu_blocks` is the KV pool size and `kv_manager` supplies the count of
 /// physically allocated blocks.
-fn available_blocks<'a>(
-    running: impl Iterator<Item = &'a ActiveSequence>,
+fn available_blocks<'a, S: PolicySequence + 'a>(
+    running: impl Iterator<Item = &'a S>,
     num_gpu_blocks: usize,
     block_size: usize,
     kv_manager: &G1Manager,

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -120,6 +120,16 @@ mod vllm {
 
     #[test]
     fn preempted_non_aligned_prompt_uses_complete_known_context() {
+        let assert_cost = |raw: PrefillCost| {
+            assert_eq!(raw.cached_tokens, 8);
+            assert_eq!(raw.new_tokens, 1);
+            assert_eq!(raw.active_cached_tokens, 0);
+
+            let adjusted = apply_prefix_recompute(SchedulingPolicy::Vllm, 9, 4, false, true, raw);
+            assert_eq!(adjusted.cached_tokens, 8);
+            assert_eq!(adjusted.new_tokens, 1);
+        };
+
         let owner = Uuid::from_u128(700);
         let mut manager =
             G1Manager::new_with_backend(8, 4, KvEventPublishers::default(), 0, G1Backend::Native);
@@ -151,14 +161,48 @@ mod vllm {
         manager.preempt_native(owner, lease);
 
         let raw = manager.get_native_prefill_cost(sequence, lease);
-        assert_eq!(raw.cached_tokens, 8);
-        assert_eq!(raw.new_tokens, 1);
-        assert_eq!(raw.active_cached_tokens, 0);
+        assert_cost(raw);
 
-        let adjusted =
-            apply_prefix_recompute(SchedulingPolicy::Vllm, sequence.len(), 4, false, true, raw);
-        assert_eq!(adjusted.cached_tokens, 8);
-        assert_eq!(adjusted.new_tokens, 1);
+        let owner = Uuid::from_u128(701);
+        let mut manager =
+            G1Manager::new_with_backend(8, 4, KvEventPublishers::default(), 0, G1Backend::Kvbm);
+        let mut request = RequestKvState::kvbm(ActiveSequence::new(
+            (0..6).collect(),
+            8,
+            Some(4),
+            true,
+            false,
+        ));
+        let RequestKvState::Kvbm(sequence) = &mut request else {
+            unreachable!()
+        };
+        let creation = sequence.take_creation_signal().unwrap();
+        assert!(matches!(
+            manager.process_for_request(owner, &creation, 0),
+            G1Acquire::Ready(_)
+        ));
+        for _ in 0..3 {
+            let (_, signals) = request.generate_token();
+            for signal in signals {
+                assert!(matches!(
+                    manager.process_for_request(owner, &signal, 0),
+                    G1Acquire::Ready(_)
+                ));
+            }
+        }
+        let RequestKvState::Kvbm(sequence) = &mut request else {
+            unreachable!()
+        };
+        let sequence_len = sequence.len();
+        sequence.commit_allocation(sequence_len);
+        manager.finalize_computed_prefix(owner, 0, sequence_len, sequence);
+        for signal in sequence.reset_with_signal() {
+            assert!(matches!(
+                manager.process_for_request(owner, &signal, 0),
+                G1Acquire::Ready(_)
+            ));
+        }
+        assert_cost(manager.get_prefill_cost(sequence));
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -17,6 +17,7 @@ use crate::common::protocols::{
 use crate::common::sequence::ActiveSequence;
 use crate::kv_manager::G1Acquire;
 use crate::kv_manager::G1Manager;
+use crate::scheduler::vllm::request::RequestKvState;
 use crate::scheduler::vllm::{RequestStatus, VllmCore};
 
 use super::{
@@ -119,47 +120,45 @@ mod vllm {
 
     #[test]
     fn preempted_non_aligned_prompt_uses_complete_known_context() {
-        for backend in [G1Backend::Kvbm, G1Backend::Native] {
-            let owner = Uuid::from_u128(700 + backend as u128);
-            let mut manager =
-                G1Manager::new_with_backend(8, 4, KvEventPublishers::default(), 0, backend);
-            // The six-token prompt is not block aligned. Retained generation
-            // extends the known context to nine tokens: two reusable full
-            // blocks plus one partial block.
-            let mut sequence = ActiveSequence::new((0..6).collect(), 8, Some(4), true, false);
-            let creation = sequence.take_creation_signal().unwrap();
-            assert!(matches!(
-                manager.process_for_request(owner, &creation, 0),
-                G1Acquire::Ready(_)
-            ));
-            assert!(sequence.push(6).is_none());
-            assert!(sequence.push(7).is_none());
-            for signal in sequence.push(8).unwrap() {
-                assert!(matches!(
-                    manager.process_for_request(owner, &signal, 0),
-                    G1Acquire::Ready(_)
-                ));
-            }
-            sequence.commit_allocation(sequence.len());
-            manager.finalize_computed_prefix(owner, 0, sequence.len(), &mut sequence);
-
-            for signal in sequence.reset_with_signal() {
-                assert!(matches!(
-                    manager.process_for_request(owner, &signal, 0),
-                    G1Acquire::Ready(_)
-                ));
-            }
-
-            let raw = manager.get_prefill_cost(&sequence);
-            assert_eq!(raw.cached_tokens, 8, "backend={backend:?}");
-            assert_eq!(raw.new_tokens, 1, "backend={backend:?}");
-            assert_eq!(raw.active_cached_tokens, 0, "backend={backend:?}");
-
-            let adjusted =
-                apply_prefix_recompute(SchedulingPolicy::Vllm, sequence.len(), 4, false, true, raw);
-            assert_eq!(adjusted.cached_tokens, 8, "backend={backend:?}");
-            assert_eq!(adjusted.new_tokens, 1, "backend={backend:?}");
+        let owner = Uuid::from_u128(700);
+        let mut manager =
+            G1Manager::new_with_backend(8, 4, KvEventPublishers::default(), 0, G1Backend::Native);
+        let mut request =
+            RequestKvState::native(owner, (0..6).collect(), 8, 8, 4, true, false, false, None);
+        let RequestKvState::Native { sequence: _, lease } = &mut request else {
+            unreachable!()
+        };
+        assert!(matches!(
+            manager.allocate_native(owner, lease, 6, 0),
+            G1Acquire::Ready(_)
+        ));
+        for _ in 0..2 {
+            request.generate_token();
         }
+        let RequestKvState::Native { sequence, lease } = &mut request else {
+            unreachable!()
+        };
+        manager.finalize_native_computed_prefix(owner, 0, 8, sequence, lease);
+        request.generate_token();
+        let RequestKvState::Native { sequence, lease } = &mut request else {
+            unreachable!()
+        };
+        assert!(matches!(
+            manager.allocate_native(owner, lease, 9, 0),
+            G1Acquire::Ready(_)
+        ));
+        manager.finalize_native_computed_prefix(owner, 8, 9, sequence, lease);
+        manager.preempt_native(owner, lease);
+
+        let raw = manager.get_native_prefill_cost(sequence, lease);
+        assert_eq!(raw.cached_tokens, 8);
+        assert_eq!(raw.new_tokens, 1);
+        assert_eq!(raw.active_cached_tokens, 0);
+
+        let adjusted =
+            apply_prefix_recompute(SchedulingPolicy::Vllm, sequence.len(), 4, false, true, raw);
+        assert_eq!(adjusted.cached_tokens, 8);
+        assert_eq!(adjusted.new_tokens, 1);
     }
 
     #[test]
@@ -343,12 +342,28 @@ mod vllm {
             ..Default::default()
         });
 
-        let probe = ActiveSequence::new((0..8).collect(), 1, Some(4), true, false);
+        let probe = RequestKvState::native(
+            Uuid::from_u128(104),
+            (0..8).collect(),
+            1,
+            1,
+            4,
+            true,
+            false,
+            false,
+            None,
+        );
         let mut collector = crate::replay::TraceCollector::default();
 
         let first = core.execute_pass(&mut collector, 0.0);
         assert_eq!(core.state().requests[&uuid].num_computed_tokens, 2);
-        assert_eq!(core.kv_manager.get_prefill_cost(&probe).cached_tokens, 0);
+        let (probe_sequence, probe_lease) = probe.native_parts().unwrap();
+        assert_eq!(
+            core.kv_manager
+                .get_native_prefill_cost(probe_sequence, probe_lease)
+                .cached_tokens,
+            0
+        );
         assert!(
             first
                 .kv_events
@@ -359,7 +374,12 @@ mod vllm {
 
         let second = core.execute_pass(&mut collector, first.end_ms);
         assert_eq!(core.state().requests[&uuid].num_computed_tokens, 4);
-        assert_eq!(core.kv_manager.get_prefill_cost(&probe).cached_tokens, 4);
+        assert_eq!(
+            core.kv_manager
+                .get_native_prefill_cost(probe_sequence, probe_lease)
+                .cached_tokens,
+            4
+        );
         let stored = second
             .kv_events
             .iter()

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -502,6 +502,68 @@ mod vllm {
     }
 
     #[test]
+    fn same_pass_admission_recomputes_prefix_after_earlier_eviction() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Vllm)
+            .g1_backend(G1Backend::Native)
+            .block_size(4)
+            .num_gpu_blocks(3)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(2))
+            .enable_chunked_prefill(true)
+            .enable_prefix_caching(true)
+            .speedup_ratio(0.0)
+            .build()
+            .unwrap();
+        let mut core = VllmCore::new(args);
+        let seed = Uuid::from_u128(105_001);
+        core.receive(DirectRequest {
+            tokens: (100..104).collect(),
+            max_output_tokens: 0,
+            uuid: Some(seed),
+            ..Default::default()
+        });
+        let mut collector = crate::replay::TraceCollector::default();
+        let seed_pass = core.execute_pass(&mut collector, 0.0);
+        assert_eq!(seed_pass.completed_requests, 1);
+        assert!(!core.state().requests.contains_key(&seed));
+
+        let evictor = Uuid::from_u128(105_002);
+        let former_hit = Uuid::from_u128(105_003);
+        core.receive(DirectRequest {
+            tokens: (0..12).collect(),
+            max_output_tokens: 0,
+            uuid: Some(evictor),
+            ..Default::default()
+        });
+        core.receive(DirectRequest {
+            tokens: (100..104).collect(),
+            max_output_tokens: 0,
+            uuid: Some(former_hit),
+            ..Default::default()
+        });
+
+        let pass = core.execute_pass(&mut collector, seed_pass.end_ms);
+        assert_eq!(pass.admissions.len(), 1);
+        assert_eq!(pass.admissions[0].uuid, evictor);
+        assert_eq!(
+            core.state().requests[&former_hit].status,
+            RequestStatus::Waiting
+        );
+        let (sequence, lease) = core.state().requests[&former_hit]
+            .sequence
+            .native_parts()
+            .unwrap();
+        assert_eq!(
+            core.kv_manager
+                .get_native_prefill_cost(sequence, lease)
+                .cached_tokens,
+            0,
+            "the later waiting decision must observe the earlier allocation's eviction"
+        );
+    }
+
+    #[test]
     fn native_g1_exposes_generated_block_at_computed_boundary_in_same_pass() {
         let args = MockEngineArgs::builder()
             .engine_type(EngineType::Vllm)

--- a/lib/mocker/src/scheduler/vllm/request.rs
+++ b/lib/mocker/src/scheduler/vllm/request.rs
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(feature = "kvbm-offload")]
+use dynamo_tokens::blocks::UniqueBlock;
+#[cfg(feature = "kvbm-offload")]
+use dynamo_tokens::{BlockHash, PositionalLineageHash};
+use uuid::Uuid;
+
+use crate::common::protocols::MoveBlock;
+use crate::common::sequence::{ActiveSequence, RequestSequence};
+use crate::kv_manager::BlockRequestLease;
+
+/// Backend-specific request KV state selected once when the request enters the
+/// shared vLLM/TRT scheduler.
+pub(crate) enum RequestKvState {
+    Native {
+        sequence: RequestSequence,
+        lease: BlockRequestLease,
+    },
+    Kvbm(ActiveSequence),
+}
+
+impl RequestKvState {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn native(
+        owner: Uuid,
+        tokens: Vec<u32>,
+        max_output_tokens: usize,
+        output_capacity_hint: usize,
+        block_size: usize,
+        enable_prefix_caching: bool,
+        retain_local_hashes: bool,
+        emit_token_ids: bool,
+        planned_output_ids: Option<Vec<u32>>,
+    ) -> Self {
+        let (sequence, identities) = RequestSequence::new(
+            tokens,
+            max_output_tokens,
+            output_capacity_hint,
+            block_size,
+            enable_prefix_caching,
+            retain_local_hashes,
+            emit_token_ids,
+            planned_output_ids,
+        );
+        Self::Native {
+            sequence,
+            lease: BlockRequestLease::new(owner, identities),
+        }
+    }
+
+    pub(super) fn kvbm(sequence: ActiveSequence) -> Self {
+        Self::Kvbm(sequence)
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn legacy(&self) -> Option<&ActiveSequence> {
+        match self {
+            Self::Native { .. } => None,
+            Self::Kvbm(sequence) => Some(sequence),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn native_parts(&self) -> Option<(&RequestSequence, &BlockRequestLease)> {
+        match self {
+            Self::Native { sequence, lease } => Some((sequence, lease)),
+            Self::Kvbm(_) => None,
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.len(),
+            Self::Kvbm(sequence) => sequence.len(),
+        }
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn block_size(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.block_size(),
+            Self::Kvbm(sequence) => sequence.block_size(),
+        }
+    }
+
+    pub(super) fn max_output_tokens(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.max_output_tokens(),
+            Self::Kvbm(sequence) => sequence.max_output_tokens(),
+        }
+    }
+
+    pub(super) fn generated_tokens(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.generated_tokens(),
+            Self::Kvbm(sequence) => sequence.generated_tokens(),
+        }
+    }
+
+    pub(super) fn num_input_tokens(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.num_input_tokens(),
+            Self::Kvbm(sequence) => sequence.num_input_tokens(),
+        }
+    }
+
+    pub(super) fn num_allocated_tokens(&self) -> usize {
+        match self {
+            Self::Native { lease, .. } => lease.allocated_tokens(),
+            Self::Kvbm(sequence) => sequence.num_allocated_tokens(),
+        }
+    }
+
+    pub(super) fn current_known_blocks(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.current_known_blocks(),
+            Self::Kvbm(sequence) => sequence.current_known_blocks(),
+        }
+    }
+
+    pub(super) fn to_completion_blocks(&self) -> usize {
+        match self {
+            Self::Native { sequence, .. } => sequence.to_completion_blocks(),
+            Self::Kvbm(sequence) => sequence.to_completion_blocks(),
+        }
+    }
+
+    pub(super) fn generate_token(&mut self) -> (u32, Vec<MoveBlock>) {
+        match self {
+            Self::Native { sequence, lease } => {
+                let (token, opened_partial) = sequence.generate_token();
+                if opened_partial {
+                    lease.append_partial();
+                }
+                (token, Vec::new())
+            }
+            Self::Kvbm(sequence) => sequence.generate_token(),
+        }
+    }
+
+    pub(super) fn pop(&mut self) {
+        match self {
+            Self::Native { sequence, lease } => {
+                if sequence.pop_generated_token() {
+                    lease.rollback_partial();
+                }
+            }
+            Self::Kvbm(sequence) => sequence.pop(),
+        }
+    }
+
+    pub(super) fn terminal_signals(&self) -> Vec<MoveBlock> {
+        match self {
+            Self::Native { .. } => Vec::new(),
+            Self::Kvbm(sequence) => sequence.terminal_signals(),
+        }
+    }
+
+    pub(super) fn free_signal(&self) -> Vec<MoveBlock> {
+        match self {
+            Self::Native { .. } => Vec::new(),
+            Self::Kvbm(sequence) => sequence.free_signal(),
+        }
+    }
+
+    pub(super) fn reset_legacy_with_signal(&mut self) -> Vec<MoveBlock> {
+        match self {
+            Self::Native { .. } => Vec::new(),
+            Self::Kvbm(sequence) => sequence.reset_with_signal(),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn uses_flat_tokens(&self) -> bool {
+        match self {
+            Self::Native { .. } => true,
+            Self::Kvbm(_) => false,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn native_storage_capacities(&self) -> Option<(usize, usize)> {
+        match self {
+            Self::Native { sequence, lease } => {
+                Some((sequence.token_capacity(), lease.entry_capacity()))
+            }
+            Self::Kvbm(_) => None,
+        }
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn unique_blocks(&self) -> &[UniqueBlock] {
+        self.legacy()
+            .expect("KVBM metadata requested from a native request")
+            .unique_blocks()
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn positional_lineage_hashes(&self) -> &[PositionalLineageHash] {
+        self.legacy()
+            .expect("KVBM metadata requested from a native request")
+            .positional_lineage_hashes()
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn block_hashes(&self) -> &[BlockHash] {
+        self.legacy()
+            .expect("KVBM metadata requested from a native request")
+            .block_hashes()
+    }
+
+    #[cfg(feature = "kvbm-offload")]
+    pub(super) fn block_token_ids(&self) -> Vec<Vec<u32>> {
+        self.legacy()
+            .expect("KVBM metadata requested from a native request")
+            .block_token_ids()
+    }
+}

--- a/lib/mocker/src/scheduler/vllm/request.rs
+++ b/lib/mocker/src/scheduler/vllm/request.rs
@@ -142,10 +142,8 @@ impl RequestKvState {
 
     pub(super) fn pop(&mut self) {
         match self {
-            Self::Native { sequence, lease } => {
-                if sequence.pop_generated_token() {
-                    lease.rollback_partial();
-                }
+            Self::Native { .. } => {
+                unreachable!("native decode never rolls back a sampled token")
             }
             Self::Kvbm(sequence) => sequence.pop(),
         }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -151,6 +151,43 @@ fn unset_g1_backend_constructs_native_request_state() {
 }
 
 #[test]
+fn minimum_shared_scheduler_block_size_constructs_requests_for_both_backends() {
+    let mut next_uuid = 80_200_u128;
+    for engine_type in [EngineType::Vllm, EngineType::Trtllm] {
+        for backend in [G1Backend::Native, G1Backend::Kvbm] {
+            let args = MockEngineArgs::builder()
+                .engine_type(engine_type)
+                .g1_backend(backend)
+                .block_size(2)
+                .num_gpu_blocks(4)
+                .max_num_batched_tokens(Some(4))
+                .max_num_seqs(Some(1))
+                .enable_chunked_prefill(true)
+                .enable_prefix_caching(true)
+                .speedup_ratio(0.0)
+                .build()
+                .unwrap();
+            let mut core = VllmCore::new(args);
+            let uuid = Uuid::from_u128(next_uuid);
+            next_uuid += 1;
+            core.receive(DirectRequest {
+                tokens: vec![0],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![1]),
+                uuid: Some(uuid),
+                ..Default::default()
+            });
+
+            assert_eq!(
+                core.request_uses_flat_tokens(uuid),
+                backend == G1Backend::Native,
+                "engine_type={engine_type:?}, backend={backend:?}"
+            );
+        }
+    }
+}
+
+#[test]
 #[should_panic(expected = "native decode never rolls back a sampled token")]
 fn native_request_state_rejects_decode_rollback() {
     let mut request = RequestKvState::native(
@@ -511,6 +548,12 @@ mod destination_lifecycle {
             .unwrap()
     }
 
+    fn args_for_backend(worker_type: WorkerType, backend: G1Backend) -> MockEngineArgs {
+        let mut args = args(worker_type);
+        args.g1_backend = Some(backend);
+        args
+    }
+
     fn request(uuid: Uuid, tokens: Vec<u32>, max_output_tokens: usize) -> DirectRequest {
         DirectRequest {
             tokens,
@@ -745,14 +788,20 @@ mod destination_lifecycle {
         assert_eq!(footprint(128), 12);
     }
 
-    #[test]
-    fn handoff_prefill_to_reserved_decode_owns_kv_until_normal_admission() {
+    #[rstest]
+    #[case::kvbm(G1Backend::Kvbm)]
+    #[case::native(G1Backend::Native)]
+    fn handoff_prefill_to_reserved_decode_owns_kv_until_normal_admission(
+        #[case] backend: G1Backend,
+    ) {
         let logical_uuid = Uuid::from_u128(10_001);
         let handoff_id = HandoffId::from(Uuid::from_u128(10_002));
         let logical_tokens = (0..8).collect::<Vec<_>>();
 
-        let mut source = VllmCore::new_with_kv_capture(args(WorkerType::Prefill), 31);
-        let mut destination = VllmCore::new_with_kv_capture(args(WorkerType::Decode), 32);
+        let mut source =
+            VllmCore::new_with_kv_capture(args_for_backend(WorkerType::Prefill, backend), 31);
+        let mut destination =
+            VllmCore::new_with_kv_capture(args_for_backend(WorkerType::Decode, backend), 32);
 
         destination.receive(request(Uuid::from_u128(10_003), (0..4).collect(), 1));
         execute(&mut destination, 0.0);
@@ -1944,10 +1993,14 @@ mod router_events {
         harness.shutdown();
     }
 
+    #[rstest]
+    #[case::kvbm(G1Backend::Kvbm)]
+    #[case::native(G1Backend::Native)]
     #[tokio::test]
-    async fn test_preemption_recompute_events_apply_cleanly() {
+    async fn test_preemption_recompute_events_apply_cleanly(#[case] backend: G1Backend) {
         let harness = RouterIndexerHarness::new(4, ROUTER_TEST_WORKER_ID);
         let args = MockEngineArgs::builder()
+            .g1_backend(backend)
             .block_size(4)
             .num_gpu_blocks(6)
             .max_num_batched_tokens(Some(16))
@@ -1991,11 +2044,12 @@ mod router_events {
             }
         }
 
-        assert!(saw_preemption);
+        assert!(saw_preemption, "backend={backend:?}");
         let request = core.state.requests.get(&r2).unwrap();
         assert_eq!(request.status, RequestStatus::Preempted);
         assert_eq!(request.num_computed_tokens, 0);
         assert_eq!(request.num_preemptions, 1);
+        assert_eq!(request.sequence.num_allocated_tokens(), 0);
         assert_eq!(core.state.waiting.front().copied(), Some(r2));
 
         let mut readmitted = false;
@@ -2011,7 +2065,7 @@ mod router_events {
 
         assert!(
             readmitted,
-            "preempted request should be admitted for recompute"
+            "preempted request should be admitted for recompute: backend={backend:?}"
         );
         harness.assert_no_event_warnings();
         harness.shutdown();
@@ -2428,7 +2482,9 @@ mod live_scheduler {
     #[case::kvbm(G1Backend::Kvbm)]
     #[case::native(G1Backend::Native)]
     #[tokio::test]
-    async fn raw_sink_emits_token_ids_for_both_g1_backends(#[case] backend: G1Backend) {
+    async fn raw_sink_emits_completed_unaligned_prompt_block_for_both_g1_backends(
+        #[case] backend: G1Backend,
+    ) {
         let sink = Arc::new(CapturingKvSink::default());
         let (output_tx, mut output_rx) = mpsc::unbounded_channel::<Vec<OutputSignal>>();
         let args = MockEngineArgs::builder()
@@ -2452,24 +2508,28 @@ mod live_scheduler {
         );
 
         scheduler.receive(DirectRequest {
-            tokens: (0..8).collect(),
-            max_output_tokens: 1,
-            output_token_ids: None,
+            tokens: vec![0, 1, 2],
+            max_output_tokens: 2,
+            output_token_ids: Some(vec![3, 4]),
             uuid: Some(Uuid::from_u128(72)),
             dp_rank: 0,
             arrival_timestamp_ms: None,
             ..Default::default()
         });
 
-        let output_batch = tokio::time::timeout(Duration::from_secs(2), output_rx.recv())
-            .await
-            .expect("scheduler should emit output")
-            .expect("output channel should stay open");
-        let signal = output_batch
-            .into_iter()
-            .next()
-            .expect("live scheduler should emit one output signal");
-        assert!(signal.completed);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let output_batch = output_rx
+                    .recv()
+                    .await
+                    .expect("output channel should stay open");
+                if output_batch.iter().any(|signal| signal.completed) {
+                    break;
+                }
+            }
+        })
+        .await
+        .expect("scheduler should complete the request");
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         let events = sink.take();
@@ -2480,7 +2540,7 @@ mod live_scheduler {
                 _ => None,
             })
             .expect("live scheduler should forward stored KV event token ids");
-        assert_eq!(stored, vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7]]);
+        assert_eq!(stored, vec![vec![0, 1, 2, 3]]);
     }
 
     #[tokio::test]

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -2380,11 +2380,15 @@ mod live_scheduler {
         assert_scheduler_idle(&metrics);
     }
 
+    #[rstest]
+    #[case::kvbm(G1Backend::Kvbm)]
+    #[case::native(G1Backend::Native)]
     #[tokio::test]
-    async fn test_live_scheduler_forwards_buffered_kv_token_ids() {
+    async fn raw_sink_emits_token_ids_for_both_g1_backends(#[case] backend: G1Backend) {
         let sink = Arc::new(CapturingKvSink::default());
         let (output_tx, mut output_rx) = mpsc::unbounded_channel::<Vec<OutputSignal>>();
         let args = MockEngineArgs::builder()
+            .g1_backend(backend)
             .block_size(4)
             .num_gpu_blocks(12)
             .max_num_batched_tokens(Some(8))
@@ -2392,7 +2396,6 @@ mod live_scheduler {
             .enable_chunked_prefill(true)
             .enable_prefix_caching(true)
             .speedup_ratio(1000.0)
-            .zmq_kv_events_port(Some(12345))
             .build()
             .unwrap();
         let scheduler = Scheduler::new(
@@ -2433,8 +2436,7 @@ mod live_scheduler {
                 _ => None,
             })
             .expect("live scheduler should forward stored KV event token ids");
-        assert!(!stored.is_empty());
-        assert!(stored.iter().all(|block| !block.is_empty()));
+        assert_eq!(stored, vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7]]);
     }
 
     #[tokio::test]

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -139,7 +139,7 @@ fn flat_storage_capacity_is_bounded_by_realizable_output() {
     const BLOCK_SIZE: usize = 4;
     const MAX_OUTPUT_TOKENS: usize = 1_000_000;
 
-    for (prompt_len, expected_output_capacity) in [(10_usize, 2_usize), (17, 0)] {
+    for (prompt_len, expected_output_capacity) in [(8_usize, 4_usize), (10, 2), (17, 0)] {
         let args = MockEngineArgs::builder()
             .engine_type(EngineType::Vllm)
             .g1_backend(G1Backend::Native)

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -135,6 +135,50 @@ fn flat_tokens_cover_every_native_g1_configuration() {
 }
 
 #[test]
+fn unset_g1_backend_constructs_native_request_state() {
+    let mut args = router_args();
+    args.g1_backend = None;
+    let mut core = VllmCore::new(args);
+    let uuid = Uuid::from_u128(80_100);
+    core.receive(DirectRequest {
+        tokens: (0..8).collect(),
+        max_output_tokens: 2,
+        uuid: Some(uuid),
+        ..Default::default()
+    });
+
+    assert!(core.request_uses_flat_tokens(uuid));
+}
+
+#[test]
+#[should_panic(expected = "native decode never rolls back a sampled token")]
+fn native_request_state_rejects_decode_rollback() {
+    let mut request = RequestKvState::native(
+        Uuid::from_u128(80_101),
+        vec![1, 2],
+        1,
+        1,
+        4,
+        true,
+        false,
+        false,
+        None,
+    );
+    request.pop();
+}
+
+#[test]
+fn kvbm_request_state_preserves_decode_rollback() {
+    let mut request =
+        RequestKvState::kvbm(ActiveSequence::new(vec![1, 2], 1, Some(4), true, false));
+    let original_len = request.len();
+    request.generate_token();
+    request.pop();
+
+    assert_eq!(request.len(), original_len);
+}
+
+#[test]
 fn flat_storage_capacity_is_bounded_by_realizable_output() {
     const BLOCK_SIZE: usize = 4;
     const MAX_OUTPUT_TOKENS: usize = 1_000_000;

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -26,6 +26,7 @@ use crate::scheduler::{
 
 use super::core::{RequestStatus, VllmCore, VllmRequestState};
 use super::live::{MockerMetrics, Scheduler};
+use super::request::RequestKvState;
 
 const ROUTER_TEST_WORKER_ID: WorkerId = 23;
 
@@ -164,18 +165,16 @@ fn flat_storage_capacity_is_bounded_by_realizable_output() {
 
         let sequence = &core.state().requests[&uuid].sequence;
         assert_eq!(sequence.max_output_tokens(), MAX_OUTPUT_TOKENS);
-        let (token_capacity, unique_capacity, hash_capacity, lineage_capacity) = sequence
-            .flat_storage_capacities()
-            .expect("native G1 must use flat storage");
+        let (token_capacity, lease_capacity) = sequence
+            .native_storage_capacities()
+            .expect("native G1 must use request-sequence storage");
         let bounded_blocks = (prompt_len + expected_output_capacity).div_ceil(BLOCK_SIZE);
         let unbounded_blocks = (prompt_len + MAX_OUTPUT_TOKENS).div_ceil(BLOCK_SIZE);
 
         assert!(token_capacity >= prompt_len + expected_output_capacity);
         assert!(token_capacity < prompt_len + MAX_OUTPUT_TOKENS);
-        for capacity in [unique_capacity, hash_capacity, lineage_capacity] {
-            assert!(capacity >= bounded_blocks);
-            assert!(capacity < unbounded_blocks);
-        }
+        assert!(lease_capacity >= bounded_blocks);
+        assert!(lease_capacity < unbounded_blocks);
     }
 }
 
@@ -1523,7 +1522,7 @@ mod core_behavior {
         core.state.requests.insert(
             uuid,
             VllmRequestState {
-                sequence,
+                sequence: RequestKvState::kvbm(sequence),
                 status: RequestStatus::Running,
                 num_computed_tokens: 9,
                 num_preemptions: 1,
@@ -2987,6 +2986,7 @@ mod offload {
     };
 
     use super::super::core::{RequestStatus, VllmCore, VllmRequestState};
+    use super::super::request::RequestKvState;
 
     /// Seed `g2` with each PLH by allocating a fresh slot, staging,
     /// registering, and dropping — so the block lands in the inactive
@@ -3035,7 +3035,7 @@ mod offload {
         core.state.requests.insert(
             uuid,
             VllmRequestState {
-                sequence,
+                sequence: RequestKvState::kvbm(sequence),
                 status: RequestStatus::Running,
                 num_computed_tokens,
                 num_preemptions: 0,
@@ -3702,6 +3702,8 @@ mod offload {
             (
                 request
                     .sequence
+                    .legacy()
+                    .expect("KVBM test request must use legacy storage")
                     .prepare_allocation(block_size * 2)
                     .expect("prefix allocation signal"),
                 request.sequence.positional_lineage_hashes().to_vec(),
@@ -3780,6 +3782,8 @@ mod offload {
             (
                 request
                     .sequence
+                    .legacy()
+                    .expect("KVBM test request must use legacy storage")
                     .prepare_allocation(block_size * 2)
                     .expect("prefix allocation signal"),
                 request.sequence.positional_lineage_hashes().to_vec(),


### PR DESCRIPTION
## Summary

- introduce move-only, backend-specific request leases: native vLLM/TRT owns logical and physical block state in `BlockRequestLease`, while SGLang owns page-native state and incremental page hashes in `RadixRequestLease`
- remove native `MoveBlock`, manager UUID block-table lookups, native PLH construction, partial-block UUID tracking, and SGLang page-to-token expansion from the new hot paths
- keep request token/progress state lightweight, preserve bounded vector capacity across lease construction, and reserve vLLM prefix-hit/SGLang page-hash storage up front
- make raw-sink token-ID behavior consistent across native G1 and KVBM, retain SGLang page hashes across retract/re-admit, and harden request lifecycle invariants
- bound SGLang eager token/hash storage by remaining physical KV capacity and, for unplanned outputs, `clip_max_new_tokens`; planned DynoSim outputs retain their known-size reservation within the physical limit
- remove token-rescanning SGLang test adapters, forbid native rollback, avoid disabled-prefix-caching finalization work, and add focused prefix-reuse/admission regressions
- remove cold-prefix reservation over-allocation, make native finalization checks incremental in debug builds, and cover Native/KVBM preemption and disaggregated ownership lifecycles symmetrically
- keep legacy KVBM behavior isolated and preserve aggregate/disaggregated request lifecycle semantics

This PR is directly based on refreshed `main`. The five pre-existing PR commits were rebased onto `d2e3f2f6a4`; `git range-diff` verified that all five remained patch-identical before the PeaBrane review-fix commit was added.

The larger `G1Manager` dispatcher split remains intentionally deferred to #12340.

### Compatibility

The shared vLLM/TRT-LLM scheduler now requires `block_size >= 2` for Native, explicit KVBM, and automatically resolved KVBM. SGLang continues to accept block size one. Supporting KVBM block size one is intentionally deferred rather than expanding legacy `ActiveSequence` in this PR.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker --lib` — 683 passed
- `cargo test -p dynamo-mocker --all-features --lib` — 812 passed
- `cargo clippy -p dynamo-mocker --lib --all-targets -- -D warnings`
- `git diff --check`
- focused regressions cover block-size-two Native/KVBM request construction for vLLM and TRT-LLM, block-size-one normalization rejection for every shared-scheduler backend configuration, zero-capacity cold/empty prefix reservations, partial/full prefix reuse, Native/KVBM preemption and re-admission, the full source-hold/destination reserve→activate→admit→release lifecycle, and exact raw-sink payload `[[0, 1, 2, 3]]` from an unaligned prompt

### DynoSim correctness parity against refreshed main

Correctness-only parity compared baseline `d2e3f2f6a405657adec175e5dc63610abe233033` with candidate `0baf13eaa8cf69d3f51547162e7db79bfe4c748d` on the fixed contiguous 5,000-request Mooncake corpus. Every row ran two independent processes per revision. Both runs within each revision were byte-stable, baseline and candidate canonical digests matched exactly, all requests completed, and lifecycle evidence matched.

| Backend / topology | Canonical SHA-256 | Handoffs | Preemptions | G1→G2 reserved/completed | G2→G1 reserved/completed |
|---|---|---:|---:|---:|---:|
| SGLang aggregate | `e522f4835ac9df7f982def3c05a1a79b3e4e94dd3a727b6ed08e36688ff4d87a` | 0 | 0 | 0 / 0 | 0 / 0 |
| SGLang disaggregated | `40f414ca264abb065b33ed51b10370e5786eb37ff1aa4a4a77b27aca3e506b0f` | 5,000 | 0 | 0 / 0 | 0 / 0 |
| vLLM aggregate, KVBM stress | `dd7af53c6fa32fab6ba44510c0a7587175de1cd20715f526c33585e3e06d309a` | 0 | 3 | 6,479 / 6,479 | 135 / 135 |
| vLLM disaggregated, KVBM stress | `9e89fa875e0689ecc24a9b0dd6894bda989e67799588d42dd0f76a165a71051d` | 5,000 | 2 | 16,459 / 16,459 | 307 / 307 |

No performance benchmark or profile was rerun for this review pass. The production hot-path change removes unnecessary cold-prefix allocation, while the invariant optimization affects debug/test builds only. The existing isolated ownership-refactor A/B below remains the relevant performance measurement.

### DynoSim aggregate benchmark

AgentX replay, 16 workers / 16 sessions, block size 16, CPU 0 affinity. Baseline and candidate were freshly built from the same runner, lockfile, configs, toolchain, and release flags (`x86-64-v3`, frame pointers, DWARF enabled).

The 16/16 A/B parity gate compared the complete DynoSim reports, not only replay time and memory. Both arms processed exactly 3,211 requests, 479,843,008 input tokens, 3,552,472 output tokens, and 483,395,480 total tokens, and every simulated/non-wall-clock report field was identical.

The benchmark was collected before the history-only rebase: baseline `9e0a8cc6d6` was rebased #12248 plus the native resolved-backend fix, and measured candidate `897efbec73` contains the same three request-lease commits ending at `db98b92fdf`. Those ownership-refactor patches remain unchanged in the current history, as verified by `git range-diff`; the subsequent review-fix commits were not part of the measured candidate.

| Backend | Baseline replay | Candidate replay | Replay delta | Baseline peak RSS | Candidate peak RSS | RSS delta |
|---|---:|---:|---:|---:|---:|---:|
| vLLM | 3.971660 s | 3.029880 s | -23.71% | 215.961 MiB | 205.500 MiB | -4.84% |
| SGLang | 3.039690 s | 2.370373 s | -22.02% | 173.023 MiB | 164.773 MiB | -4.77% |

Candidate `.text` size is 2,647,557 bytes versus 2,652,773 bytes for baseline (-0.20%).

These are deliberately one-shot results per arm; no CPU profiles were collected.