### PR TITLE
fix(mocker): resolve G1 backend before comparison

### DIFF
--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -888,7 +888,7 @@ impl VllmCore {
         // unchanged here. The waiting-admission policy owns terminal rejection
         // because that path can emit the lifecycle signal.
         let output_capacity_hint = self.output_capacity_hint(prompt_len, max_output_tokens);
-        let sequence = if self.args.g1_backend == G1Backend::Native {
+        let sequence = if self.args.resolved_g1_backend() == G1Backend::Native {
             ActiveSequence::new_flat_with_planned_output_ids(
                 request.tokens,
                 max_output_tokens,
@@ -1205,7 +1205,7 @@ impl VllmCore {
     #[cfg(feature = "kvbm-offload")]
     fn complete_swap_in(&mut self, aws: AwaitingSwapIn) {
         debug_assert_eq!(
-            self.args.g1_backend,
+            self.args.resolved_g1_backend(),
             G1Backend::Kvbm,
             "KVBM swap-in completion requires legacy sequence storage"
         );


### PR DESCRIPTION
## Summary

- fix the latest-main Rust build failure in `dynamo-mocker`
- compare the selected G1 backend through `resolved_g1_backend()` instead of comparing `Option<G1Backend>` with `G1Backend`
- apply the same resolved-backend check to the feature-gated KVBM swap-in assertion

The regression was introduced when native G1 flat-sequence selection began reading the raw optional configuration field directly. This restores compilation while preserving the normalized backend-selection semantics.

## Validation

- `cargo build --workspace`
- `cargo test -p dynamo-mocker --all-features --lib` (801 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

A strict local `cargo clippy -p dynamo-mocker --all-targets --all-features -- -D warnings` also reached the crate successfully, then reported existing unrelated Rust 1.96 warnings outside this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend selection and validation for G1 sequence handling during request setup and swap-in completion.
  * Ensures behavior consistently reflects the resolved backend configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->