### PR TITLE
fix(mocker): compare optional G1 backends correctly

### DIFF
--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -888,7 +888,7 @@ impl VllmCore {
         // unchanged here. The waiting-admission policy owns terminal rejection
         // because that path can emit the lifecycle signal.
         let output_capacity_hint = self.output_capacity_hint(prompt_len, max_output_tokens);
-        let sequence = if self.args.g1_backend == G1Backend::Native {
+        let sequence = if self.args.g1_backend == Some(G1Backend::Native) {
             ActiveSequence::new_flat_with_planned_output_ids(
                 request.tokens,
                 max_output_tokens,
@@ -1206,7 +1206,7 @@ impl VllmCore {
     fn complete_swap_in(&mut self, aws: AwaitingSwapIn) {
         debug_assert_eq!(
             self.args.g1_backend,
-            G1Backend::Kvbm,
+            Some(G1Backend::Kvbm),
             "KVBM swap-in completion requires legacy sequence storage"
         );
         let count = aws.handle.block_count();


### PR DESCRIPTION
## Summary

- Compare the optional G1 backend against `Some(G1Backend::Native)` when selecting native flat sequence storage.
- Apply the same type-correct comparison to the feature-gated KVBM swap-in assertion.

## Root cause

The native G1 sequence optimization in #12248 compared `Option<G1Backend>` fields against bare `G1Backend` values. The first mismatch fails the `lib/bindings/kvbm` Clippy matrix with `E0308`; the second would fail the subsequent feature-gated KVBM check.

## Validation

- `cargo fmt --all -- --check`
- `(cd lib/bindings/kvbm && cargo clippy --locked --no-deps --all-targets -- -D warnings)`
- `cargo clippy --locked --no-deps -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload -- -D warnings`
- `cargo test --locked -p dynamo-mocker flat_ -- --nocapture` — 10 passed

## Related Issues

- Closes [DIS-2542](https://linear.app/nvidia/issue/DIS-2542/fix-g1-backend-type-mismatches-in-mocker)
