### PR TITLE
chore(sglang): use 2026-07-29 nightly base image

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -99,7 +99,7 @@ sglang:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.5.15-cu130-runtime
+    runtime_image_tag: nightly-dev-cu13-20260729-16a52bff
     # Baseline is the TRUE base of the third-party lmsysorg/sglang image,
     # nvidia/cuda:13.0.1-cudnn-devel-ubuntu24.04 (Docker Hub; CUDA_VERSION=13.0.1,
     # cuDNN 9.13.0.50, ubuntu24.04), NOT a self-baseline of lmsysorg/sglang.


### PR DESCRIPTION
## Summary

- update the CUDA 13 SGLang runtime image to `lmsysorg/sglang:nightly-dev-cu13-20260729-16a52bff`
- leave all other SGLang and container dependency pins unchanged

## Validation

- `docker manifest inspect lmsysorg/sglang:nightly-dev-cu13-20260729-16a52bff`
- `python3 container/compliance/resolve_base_image.py --framework sglang --cuda-version 13.0`
- commit-time pre-commit hooks, including YAML validation

Linear: [DIS-2543](https://linear.app/nvidia/issue/DIS-2543/update-dynamo-sglang-base-image-to-2026-07-29-nightly)