### PR TITLE
perf(mocker): optimize offline replay hot paths

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -278,7 +278,7 @@ impl RadixCache {
             .filter(|(id, node)| *id != self.root && node.lock_ref == 0 && node.children.is_empty())
             .map(|(id, node)| (node.last_access_time, id))
             .collect::<BTreeSet<_>>();
-        debug_assert_eq!(
+        assert_eq!(
             self.evictable_leaves, expected,
             "SGLang evictable-leaf index drifted from radix nodes"
         );
@@ -642,6 +642,8 @@ impl RadixCache {
     }
 
     fn split_node(&mut self, child_id: NodeId, split_pos: usize) -> NodeId {
+        // Keep child_id as the suffix node so its last-access timestamp and
+        // evictable-index key remain valid across the split.
         let (child_parent, original_ck, prefix_key, prefix_value, suffix_ck, lock_ref, accessed) = {
             let child = &mut self.nodes[child_id];
             let child_parent = child.parent;

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -242,19 +242,21 @@ impl RadixCache {
         (self.nodes[id].last_access_time, id)
     }
 
+    fn is_evictable_leaf(&self, id: NodeId) -> bool {
+        id != self.root && self.nodes[id].lock_ref == 0 && self.is_leaf(id)
+    }
+
     fn insert_evictable_leaf(&mut self, id: NodeId) {
-        debug_assert_ne!(id, self.root, "root must not enter the eviction index");
-        debug_assert!(self.is_leaf(id), "only leaves are directly evictable");
-        debug_assert_eq!(
-            self.nodes[id].lock_ref, 0,
-            "locked leaf must not enter the eviction index"
+        debug_assert!(
+            self.is_evictable_leaf(id),
+            "only unlocked non-root leaves are directly evictable"
         );
         let inserted = self.evictable_leaves.insert(self.evictable_key(id));
         debug_assert!(inserted, "evictable leaf was already indexed");
     }
 
     fn remove_evictable_leaf(&mut self, id: NodeId) -> bool {
-        if id == self.root {
+        if !self.is_evictable_leaf(id) {
             return false;
         }
         self.evictable_leaves.remove(&self.evictable_key(id))

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -6,8 +6,9 @@
 //! Reference: sglang/python/sglang/srt/mem_cache/radix_cache.py
 
 use dynamo_kv_router::protocols::{BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq};
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 use slotmap::{SlotMap, new_key_type};
+use std::collections::BTreeSet;
 use std::time::Instant;
 
 new_key_type! {
@@ -192,8 +193,10 @@ pub struct RadixCache {
     root: NodeId,
     pub page_pool: PagePool,
     page_size: usize,
+    /// Unlocked leaves ordered by their last access time for O(log n) updates
+    /// and O(1) oldest-victim lookup.
+    evictable_leaves: BTreeSet<(Instant, NodeId)>,
     /// Total token count in evictable nodes.
-    pub evictable_leaves: FxHashSet<NodeId>,
     pub evictable_size: usize,
     /// Total token count in protected (locked) nodes.
     pub protected_size: usize,
@@ -216,7 +219,7 @@ impl RadixCache {
             root,
             page_pool: PagePool::new(total_tokens, page_size),
             page_size,
-            evictable_leaves: FxHashSet::default(),
+            evictable_leaves: BTreeSet::new(),
             evictable_size: 0,
             protected_size: 0,
         }
@@ -233,6 +236,55 @@ impl RadixCache {
     }
     pub fn num_nodes(&self) -> usize {
         self.nodes.len()
+    }
+
+    fn evictable_key(&self, id: NodeId) -> (Instant, NodeId) {
+        (self.nodes[id].last_access_time, id)
+    }
+
+    fn insert_evictable_leaf(&mut self, id: NodeId) {
+        debug_assert_ne!(id, self.root, "root must not enter the eviction index");
+        debug_assert!(self.is_leaf(id), "only leaves are directly evictable");
+        debug_assert_eq!(
+            self.nodes[id].lock_ref, 0,
+            "locked leaf must not enter the eviction index"
+        );
+        let inserted = self.evictable_leaves.insert(self.evictable_key(id));
+        debug_assert!(inserted, "evictable leaf was already indexed");
+    }
+
+    fn remove_evictable_leaf(&mut self, id: NodeId) -> bool {
+        if id == self.root {
+            return false;
+        }
+        self.evictable_leaves.remove(&self.evictable_key(id))
+    }
+
+    fn touch_node(&mut self, id: NodeId, now: Instant) {
+        let was_indexed = self.remove_evictable_leaf(id);
+        self.nodes[id].last_access_time = now;
+        if was_indexed {
+            self.insert_evictable_leaf(id);
+        }
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_evictable_index(&self) {
+        let expected = self
+            .nodes
+            .iter()
+            .filter(|(id, node)| *id != self.root && node.lock_ref == 0 && node.children.is_empty())
+            .map(|(id, node)| (node.last_access_time, id))
+            .collect::<BTreeSet<_>>();
+        debug_assert_eq!(
+            self.evictable_leaves, expected,
+            "SGLang evictable-leaf index drifted from radix nodes"
+        );
+    }
+
+    #[cfg(test)]
+    fn evictable_leaf_is_indexed(&self, id: NodeId) -> bool {
+        self.evictable_leaves.contains(&self.evictable_key(id))
     }
 
     pub(crate) fn page_hashes(&self, tokens: &[u32]) -> Vec<LocalBlockHash> {
@@ -306,9 +358,11 @@ impl RadixCache {
 
             matched_pages += common_len;
             current = child_id;
-            self.nodes[current].last_access_time = now;
+            self.touch_node(current, now);
         }
 
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
         (matched_pages * self.page_size, current)
     }
 
@@ -359,7 +413,10 @@ impl RadixCache {
             value.len()
         );
         let page_ids = self.page_ids(&value[..aligned_len], aligned_len / self.page_size);
-        self.insert_page_suffix(self.root, 0, key, &page_ids, false)
+        let inserted = self.insert_page_suffix(self.root, 0, key, &page_ids, false);
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
+        inserted
     }
 
     /// Insert only the suffix after a retained, page-aligned prefix.
@@ -394,7 +451,10 @@ impl RadixCache {
             &value[prefix_len..aligned_len],
             (aligned_len - prefix_len) / self.page_size,
         );
-        self.insert_page_suffix(prefix_node, prefix_len, key, &page_ids, true)
+        let inserted = self.insert_page_suffix(prefix_node, prefix_len, key, &page_ids, true);
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
+        inserted
     }
 
     /// Insert page identities already materialized by the request lease.
@@ -422,12 +482,15 @@ impl RadixCache {
             "prefix pages {prefix_pages} exceed hashed pages {}",
             page_keys.len()
         );
-        self.insert_page_hash_suffix(
+        let inserted = self.insert_page_hash_suffix(
             prefix_node,
             &page_keys[prefix_pages..],
             &pages[prefix_pages..page_keys.len()],
             true,
-        )
+        );
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
+        inserted
     }
 
     #[cfg(test)]
@@ -525,7 +588,7 @@ impl RadixCache {
             if common_len == child_len {
                 key_offset += common_len;
                 current = child_id;
-                self.nodes[current].last_access_time = now;
+                self.touch_node(current, now);
             } else {
                 if common_len > 0 {
                     let intermediate = self.split_node(child_id, common_len);
@@ -549,8 +612,9 @@ impl RadixCache {
     fn touch_path(&mut self, node_id: NodeId, now: Instant) {
         let mut current = Some(node_id);
         while let Some(id) = current {
-            self.nodes[id].last_access_time = now;
-            current = self.nodes[id].parent;
+            let parent = self.nodes[id].parent;
+            self.touch_node(id, now);
+            current = parent;
         }
     }
 
@@ -561,12 +625,12 @@ impl RadixCache {
         value: &[KvPageId],
         now: Instant,
     ) -> NodeId {
+        self.touch_node(node_id, now);
         let node = &mut self.nodes[node_id];
         debug_assert!(node.children.is_empty());
         debug_assert!(node.lock_ref <= 1);
         node.key.extend_from_slice(key);
         node.value.extend_from_slice(value);
-        node.last_access_time = now;
         if node.lock_ref == 0 {
             self.evictable_size += key.len() * self.page_size;
         } else {
@@ -639,11 +703,11 @@ impl RadixCache {
         let ck = key[0];
         let new_id = self.nodes.insert(new_node);
 
-        self.evictable_leaves.remove(&parent_id);
+        self.remove_evictable_leaf(parent_id);
 
         self.nodes[parent_id].children.insert(ck, new_id);
 
-        self.evictable_leaves.insert(new_id);
+        self.insert_evictable_leaf(new_id);
         self.evictable_size += key.len() * self.page_size;
 
         new_id
@@ -659,16 +723,21 @@ impl RadixCache {
             if id == self.root {
                 break;
             }
+            let was_unlocked = self.nodes[id].lock_ref == 0;
+            if was_unlocked {
+                self.remove_evictable_leaf(id);
+            }
             let node = &mut self.nodes[id];
             let tokens = node.key.len() * self.page_size;
             node.lock_ref += 1;
-            if node.lock_ref == 1 {
-                self.evictable_leaves.remove(&id);
+            if was_unlocked {
                 self.evictable_size -= tokens;
                 self.protected_size += tokens;
             }
             current = self.nodes[id].parent;
         }
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
     }
 
     pub fn dec_lock_ref(&mut self, node_id: NodeId) {
@@ -688,11 +757,13 @@ impl RadixCache {
                 self.protected_size -= tokens;
                 self.evictable_size += tokens;
                 if self.is_leaf(id) {
-                    self.evictable_leaves.insert(id);
+                    self.insert_evictable_leaf(id);
                 }
             }
             current = self.nodes[id].parent;
         }
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
     }
 
     /// Evict tokens from the cache by LRU order, rounding partial leaves to full pages.
@@ -702,15 +773,13 @@ impl RadixCache {
         let mut evicted_indices =
             Vec::with_capacity(num_tokens.min(self.evictable_size).div_ceil(self.page_size));
         while evicted < num_tokens {
-            let victim = self
-                .evictable_leaves
-                .iter()
-                .min_by_key(|&&id| self.nodes[id].last_access_time)
-                .copied();
-
-            let Some(victim_id) = victim else {
+            let Some((last_access_time, victim_id)) = self.evictable_leaves.pop_first() else {
                 break;
             };
+            debug_assert_eq!(
+                last_access_time, self.nodes[victim_id].last_access_time,
+                "eviction index timestamp drifted from radix node"
+            );
 
             let victim_pages = self.nodes[victim_id].key.len();
             let victim_tokens = victim_pages * self.page_size;
@@ -732,6 +801,7 @@ impl RadixCache {
 
                 self.evictable_size -= eviction_len;
                 evicted += eviction_len;
+                self.insert_evictable_leaf(victim_id);
                 continue;
             }
 
@@ -742,7 +812,6 @@ impl RadixCache {
             let tokens = victim_node.key.len() * self.page_size;
             let parent_id = victim_node.parent;
 
-            self.evictable_leaves.remove(&victim_id);
             self.evictable_size -= tokens;
             evicted += tokens;
 
@@ -756,10 +825,12 @@ impl RadixCache {
                     && self.nodes[pid].children.is_empty()
                     && self.nodes[pid].lock_ref == 0
                 {
-                    self.evictable_leaves.insert(pid);
+                    self.insert_evictable_leaf(pid);
                 }
             }
         }
+        #[cfg(debug_assertions)]
+        self.debug_assert_evictable_index();
         (evicted, evicted_indices)
     }
 
@@ -978,7 +1049,7 @@ mod tests {
         assert_eq!(cache.protected_size, 7); // 2+2+3
 
         cache.dec_lock_ref(node_a);
-        assert!(cache.evictable_leaves.contains(&node_a));
+        assert!(cache.evictable_leaf_is_indexed(node_a));
         cache.dec_lock_ref(node_b);
         assert_eq!(cache.protected_size, 0);
     }
@@ -1031,6 +1102,64 @@ mod tests {
             "should evict unlocked [4,5,6] indices"
         );
         assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+    }
+
+    #[test]
+    fn touching_an_evictable_leaf_updates_order() {
+        let mut cache = RadixCache::new(100, 1);
+        cache.insert(&[1, 2, 3], &[0, 1, 2]);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        cache.insert(&[4, 5, 6], &[3, 4, 5]);
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+
+        assert_eq!(cache.evict(3).0, 3);
+        assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+        assert_eq!(cache.match_prefix(&[4, 5, 6]).0, 0);
+    }
+
+    #[test]
+    fn unlocking_preserves_last_access_order() {
+        let mut cache = RadixCache::new(100, 1);
+        cache.insert(&[1, 2, 3], &[0, 1, 2]);
+        let (_, older) = cache.match_prefix(&[1, 2, 3]);
+        cache.inc_lock_ref(older);
+
+        std::thread::sleep(std::time::Duration::from_millis(1));
+        cache.insert(&[4, 5, 6], &[3, 4, 5]);
+        let (_, newer) = cache.match_prefix(&[4, 5, 6]);
+        cache.inc_lock_ref(newer);
+        cache.dec_lock_ref(newer);
+        cache.dec_lock_ref(older);
+
+        assert_eq!(cache.evict(3).0, 3);
+        assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 0);
+        assert_eq!(cache.match_prefix(&[4, 5, 6]).0, 3);
+    }
+
+    #[test]
+    fn partial_eviction_and_parent_promotion_keep_index_consistent() {
+        let mut cache = RadixCache::new(100, 1);
+        cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
+        let (_, leaf) = cache.match_prefix(&[1, 2, 3, 4]);
+
+        assert_eq!(cache.evict(2).0, 2);
+        assert_eq!(cache.node(leaf).key.len(), 2);
+        assert!(cache.evictable_leaf_is_indexed(leaf));
+
+        let mut branched = RadixCache::new(100, 1);
+        branched.insert(&[10, 11, 12], &[0, 1, 2]);
+        branched.insert(&[10, 11, 13], &[0, 1, 3]);
+        let parent = *branched.nodes[branched.root]
+            .children
+            .values()
+            .next()
+            .unwrap();
+        assert!(!branched.is_leaf(parent));
+
+        assert_eq!(branched.evict(2).0, 2);
+        assert!(branched.is_leaf(parent));
+        assert!(branched.evictable_leaf_is_indexed(parent));
     }
 
     #[test]

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -193,6 +193,8 @@ pub struct RadixCache {
     root: NodeId,
     pub page_pool: PagePool,
     page_size: usize,
+    #[cfg(test)]
+    test_now: Option<Instant>,
     /// Unlocked leaves ordered by their last access time for O(log n) updates
     /// and O(1) oldest-victim lookup.
     evictable_leaves: BTreeSet<(Instant, NodeId)>,
@@ -219,6 +221,8 @@ impl RadixCache {
             root,
             page_pool: PagePool::new(total_tokens, page_size),
             page_size,
+            #[cfg(test)]
+            test_now: None,
             evictable_leaves: BTreeSet::new(),
             evictable_size: 0,
             protected_size: 0,
@@ -236,6 +240,19 @@ impl RadixCache {
     }
     pub fn num_nodes(&self) -> usize {
         self.nodes.len()
+    }
+
+    fn now(&self) -> Instant {
+        #[cfg(test)]
+        if let Some(now) = self.test_now {
+            return now;
+        }
+        Instant::now()
+    }
+
+    #[cfg(test)]
+    fn set_test_now(&mut self, now: Instant) {
+        self.test_now = Some(now);
     }
 
     fn evictable_key(&self, id: NodeId) -> (Instant, NodeId) {
@@ -325,11 +342,31 @@ impl RadixCache {
 
     /// Match a prefix using page hashes already owned by the request.
     pub(crate) fn match_prefix_hashes(&mut self, page_keys: &[LocalBlockHash]) -> (usize, NodeId) {
-        let now = Instant::now();
+        self.match_prefix_hashes_impl(page_keys, false)
+    }
+
+    /// Match and protect a prefix using page hashes already owned by the request.
+    pub(crate) fn match_prefix_hashes_and_lock(
+        &mut self,
+        page_keys: &[LocalBlockHash],
+    ) -> (usize, NodeId) {
+        self.match_prefix_hashes_impl(page_keys, true)
+    }
+
+    fn match_prefix_hashes_impl(
+        &mut self,
+        page_keys: &[LocalBlockHash],
+        lock_match: bool,
+    ) -> (usize, NodeId) {
+        let now = self.now();
         self.nodes[self.root].last_access_time = now;
 
         let mut current = self.root;
         let mut matched_pages: usize = 0;
+        // Delay the most recently matched node's touch until we know whether it
+        // is the terminal match. The match-and-lock path can then remove an
+        // unlocked terminal leaf once without reinserting it before locking.
+        let mut pending_touch = None;
 
         while matched_pages < page_keys.len() {
             let child_id = match self.nodes[current]
@@ -340,6 +377,10 @@ impl RadixCache {
                 Some(id) => id,
                 None => break,
             };
+
+            if let Some(id) = pending_touch.take() {
+                self.touch_node(id, now);
+            }
 
             let (common_len, child_len) = {
                 let child_key = &self.nodes[child_id].key;
@@ -360,7 +401,18 @@ impl RadixCache {
 
             matched_pages += common_len;
             current = child_id;
-            self.touch_node(current, now);
+            pending_touch = Some(current);
+        }
+
+        if let Some(id) = pending_touch {
+            if lock_match {
+                self.touch_and_inc_lock_ref(id, now);
+            } else {
+                self.touch_node(id, now);
+            }
+        } else if lock_match {
+            // A partial edge match keeps the split node's inherited timestamp.
+            self.inc_lock_ref(current);
         }
 
         #[cfg(test)]
@@ -542,7 +594,7 @@ impl RadixCache {
         if page_keys.is_empty() {
             return start_node;
         }
-        let now = Instant::now();
+        let now = self.now();
         self.touch_path(start_node, now);
 
         let mut current = start_node;
@@ -696,13 +748,14 @@ impl RadixCache {
         key: &[LocalBlockHash],
         value: &[KvPageId],
     ) -> NodeId {
+        let now = self.now();
         let new_node = TreeNode {
             children: FxHashMap::default(),
             parent: Some(parent_id),
             key: key.to_vec(),
             value: value.to_vec(),
             lock_ref: 0,
-            last_access_time: Instant::now(),
+            last_access_time: now,
         };
         let ck = key[0];
         let new_id = self.nodes.insert(new_node);
@@ -721,14 +774,25 @@ impl RadixCache {
         self.nodes[id].children.is_empty()
     }
 
+    fn touch_and_inc_lock_ref(&mut self, node_id: NodeId, now: Instant) {
+        let terminal_unindexed = self.remove_evictable_leaf(node_id);
+        self.nodes[node_id].last_access_time = now;
+        self.inc_lock_ref_impl(node_id, terminal_unindexed);
+    }
+
     pub fn inc_lock_ref(&mut self, node_id: NodeId) {
+        self.inc_lock_ref_impl(node_id, false);
+    }
+
+    fn inc_lock_ref_impl(&mut self, node_id: NodeId, terminal_unindexed: bool) {
         let mut current = Some(node_id);
+        let mut is_terminal = true;
         while let Some(id) = current {
             if id == self.root {
                 break;
             }
             let was_unlocked = self.nodes[id].lock_ref == 0;
-            if was_unlocked {
+            if was_unlocked && !(is_terminal && terminal_unindexed) {
                 self.remove_evictable_leaf(id);
             }
             let node = &mut self.nodes[id];
@@ -739,6 +803,7 @@ impl RadixCache {
                 self.protected_size += tokens;
             }
             current = self.nodes[id].parent;
+            is_terminal = false;
         }
         #[cfg(test)]
         self.debug_assert_evictable_index();
@@ -1062,12 +1127,14 @@ mod tests {
     fn test_evict() {
         // LRU order: oldest evicted first
         let mut cache = RadixCache::new(100, 1);
+        let base = Instant::now();
+        cache.set_test_now(base);
         cache.insert(&[1, 2, 3], &[0, 1, 2]);
         let (_, n1) = cache.match_prefix(&[1, 2, 3]);
         cache.inc_lock_ref(n1);
         cache.dec_lock_ref(n1);
 
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        cache.set_test_now(base + std::time::Duration::from_secs(1));
         cache.insert(&[4, 5, 6], &[3, 4, 5]);
         let (_, n2) = cache.match_prefix(&[4, 5, 6]);
         cache.inc_lock_ref(n2);
@@ -1111,28 +1178,33 @@ mod tests {
     #[test]
     fn touching_an_evictable_leaf_updates_order() {
         let mut cache = RadixCache::new(100, 1);
+        let base = Instant::now();
+        cache.set_test_now(base);
         cache.insert(&[1, 2, 3], &[0, 1, 2]);
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        cache.set_test_now(base + std::time::Duration::from_secs(1));
         cache.insert(&[4, 5, 6], &[3, 4, 5]);
-        std::thread::sleep(std::time::Duration::from_millis(1));
-        assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+        cache.set_test_now(base + std::time::Duration::from_secs(2));
+        let (_, extended) = cache.match_prefix(&[1, 2, 3]);
+        cache.insert_from_node(extended, 3, &[1, 2, 3, 7], &[0, 1, 2, 6]);
 
         assert_eq!(cache.evict(3).0, 3);
-        assert_eq!(cache.match_prefix(&[1, 2, 3]).0, 3);
+        assert_eq!(cache.match_prefix(&[1, 2, 3, 7]).0, 4);
         assert_eq!(cache.match_prefix(&[4, 5, 6]).0, 0);
     }
 
     #[test]
     fn unlocking_preserves_last_access_order() {
         let mut cache = RadixCache::new(100, 1);
+        let base = Instant::now();
+        cache.set_test_now(base);
         cache.insert(&[1, 2, 3], &[0, 1, 2]);
-        let (_, older) = cache.match_prefix(&[1, 2, 3]);
-        cache.inc_lock_ref(older);
+        let older_hashes = cache.page_hashes(&[1, 2, 3]);
+        let (_, older) = cache.match_prefix_hashes_and_lock(&older_hashes);
 
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        cache.set_test_now(base + std::time::Duration::from_secs(1));
         cache.insert(&[4, 5, 6], &[3, 4, 5]);
-        let (_, newer) = cache.match_prefix(&[4, 5, 6]);
-        cache.inc_lock_ref(newer);
+        let newer_hashes = cache.page_hashes(&[4, 5, 6]);
+        let (_, newer) = cache.match_prefix_hashes_and_lock(&newer_hashes);
         cache.dec_lock_ref(newer);
         cache.dec_lock_ref(older);
 
@@ -1144,26 +1216,40 @@ mod tests {
     #[test]
     fn partial_eviction_and_parent_promotion_keep_index_consistent() {
         let mut cache = RadixCache::new(100, 1);
+        let base = Instant::now();
+        cache.set_test_now(base);
         cache.insert(&[1, 2, 3, 4], &[0, 1, 2, 3]);
         let (_, leaf) = cache.match_prefix(&[1, 2, 3, 4]);
+        cache.set_test_now(base + std::time::Duration::from_secs(1));
+        cache.insert(&[5, 6, 7], &[4, 5, 6]);
 
         assert_eq!(cache.evict(2).0, 2);
         assert_eq!(cache.node(leaf).key.len(), 2);
         assert!(cache.evictable_leaf_is_indexed(leaf));
+        assert_eq!(cache.evict(2).0, 2);
+        assert_eq!(cache.match_prefix(&[1, 2, 3, 4]).0, 0);
+        assert_eq!(cache.match_prefix(&[5, 6, 7]).0, 3);
 
         let mut branched = RadixCache::new(100, 1);
+        branched.set_test_now(base);
         branched.insert(&[10, 11, 12], &[0, 1, 2]);
+        branched.set_test_now(base + std::time::Duration::from_secs(1));
         branched.insert(&[10, 11, 13], &[0, 1, 3]);
+        branched.set_test_now(base + std::time::Duration::from_secs(2));
+        branched.insert(&[20, 21], &[4, 5]);
+        let parent_hash = branched.page_hashes(&[10])[0];
         let parent = *branched.nodes[branched.root]
             .children
-            .values()
-            .next()
+            .get(&parent_hash)
             .unwrap();
         assert!(!branched.is_leaf(parent));
 
         assert_eq!(branched.evict(2).0, 2);
         assert!(branched.is_leaf(parent));
         assert!(branched.evictable_leaf_is_indexed(parent));
+        assert_eq!(branched.evict(2).0, 2);
+        assert_eq!(branched.match_prefix(&[10, 11, 12]).0, 0);
+        assert_eq!(branched.match_prefix(&[20, 21]).0, 2);
     }
 
     #[test]

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -270,7 +270,7 @@ impl RadixCache {
         }
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(test)]
     fn debug_assert_evictable_index(&self) {
         let expected = self
             .nodes
@@ -363,7 +363,7 @@ impl RadixCache {
             self.touch_node(current, now);
         }
 
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
         (matched_pages * self.page_size, current)
     }
@@ -416,7 +416,7 @@ impl RadixCache {
         );
         let page_ids = self.page_ids(&value[..aligned_len], aligned_len / self.page_size);
         let inserted = self.insert_page_suffix(self.root, 0, key, &page_ids, false);
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
         inserted
     }
@@ -454,7 +454,7 @@ impl RadixCache {
             (aligned_len - prefix_len) / self.page_size,
         );
         let inserted = self.insert_page_suffix(prefix_node, prefix_len, key, &page_ids, true);
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
         inserted
     }
@@ -490,7 +490,7 @@ impl RadixCache {
             &pages[prefix_pages..page_keys.len()],
             true,
         );
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
         inserted
     }
@@ -738,7 +738,7 @@ impl RadixCache {
             }
             current = self.nodes[id].parent;
         }
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
     }
 
@@ -764,7 +764,7 @@ impl RadixCache {
             }
             current = self.nodes[id].parent;
         }
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
     }
 
@@ -831,7 +831,7 @@ impl RadixCache {
                 }
             }
         }
-        #[cfg(debug_assertions)]
+        #[cfg(test)]
         self.debug_assert_evictable_index();
         (evicted, evicted_indices)
     }

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -10,7 +10,7 @@
 use dynamo_tokens::SequenceHash;
 use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
-use std::collections::VecDeque;
+use std::collections::{VecDeque, hash_map::Entry};
 
 new_key_type! {
     pub(crate) struct BlockCopyId;
@@ -44,6 +44,12 @@ struct HashCopies {
     duplicates: Option<Box<VecDeque<BlockCopyId>>>,
 }
 
+enum CopyRemoval {
+    Last,
+    Remaining,
+    Missing,
+}
+
 impl HashCopies {
     fn new(primary: BlockCopyId) -> Self {
         Self {
@@ -58,11 +64,10 @@ impl HashCopies {
             .push_back(id);
     }
 
-    /// Remove `id`, returning whether the hash no longer has any copies.
-    fn remove(&mut self, id: BlockCopyId) -> Option<bool> {
+    fn remove(&mut self, id: BlockCopyId) -> CopyRemoval {
         if self.primary == id {
             let Some(duplicates) = self.duplicates.as_mut() else {
-                return Some(true);
+                return CopyRemoval::Last;
             };
             self.primary = duplicates
                 .pop_front()
@@ -70,16 +75,20 @@ impl HashCopies {
             if duplicates.is_empty() {
                 self.duplicates = None;
             }
-            return Some(false);
+            return CopyRemoval::Remaining;
         }
 
-        let duplicates = self.duplicates.as_mut()?;
-        let position = duplicates.iter().position(|candidate| *candidate == id)?;
+        let Some(duplicates) = self.duplicates.as_mut() else {
+            return CopyRemoval::Missing;
+        };
+        let Some(position) = duplicates.iter().position(|candidate| *candidate == id) else {
+            return CopyRemoval::Missing;
+        };
         duplicates.remove(position);
         if duplicates.is_empty() {
             self.duplicates = None;
         }
-        Some(false)
+        CopyRemoval::Remaining
     }
 
     #[cfg(test)]
@@ -354,12 +363,15 @@ impl VllmBlockPool {
             inactive_prev: None,
             inactive_next: None,
         };
-        if let Some(copies) = self.by_hash.get_mut(&hash) {
-            copies.push(id);
-            false
-        } else {
-            self.by_hash.insert(hash, HashCopies::new(id));
-            true
+        match self.by_hash.entry(hash) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().push(id);
+                false
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(HashCopies::new(id));
+                true
+            }
         }
     }
 
@@ -728,10 +740,13 @@ impl VllmBlockPool {
             let Some(copies) = self.by_hash.get_mut(&hash) else {
                 panic!("evicted cached hash is missing from its index")
             };
-            let Some(remove_hash) = copies.remove(id) else {
-                panic!("evicted copy is missing from its hash index")
-            };
-            remove_hash
+            match copies.remove(id) {
+                CopyRemoval::Last => true,
+                CopyRemoval::Remaining => false,
+                CopyRemoval::Missing => {
+                    panic!("evicted copy is missing from its hash index")
+                }
+            }
         };
         if remove_hash {
             self.by_hash.remove(&hash);

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -878,20 +878,26 @@ mod tests {
     }
 
     #[test]
-    fn evicting_non_primary_duplicate_preserves_primary_lookup() {
-        let mut pool = VllmBlockPool::new(2);
+    fn evicting_middle_duplicate_preserves_primary_lookup() {
+        let mut pool = VllmBlockPool::new(4);
         let mut first = reserve(&mut pool, &[], 1).reservation;
         let first_id = pool.allocate_private(&mut first);
         assert!(pool.cache_private(first_id, 3));
 
-        let mut second = reserve(&mut pool, &[], 1).reservation;
-        let second_id = pool.allocate_private(&mut second);
-        assert!(!pool.cache_private(second_id, 3));
-        pool.release(second_id);
+        let mut duplicate_ids = Vec::new();
+        for _ in 0..3 {
+            let mut duplicate = reserve(&mut pool, &[], 1).reservation;
+            let duplicate_id = pool.allocate_private(&mut duplicate);
+            assert!(!pool.cache_private(duplicate_id, 3));
+            duplicate_ids.push(duplicate_id);
+        }
+        let middle_id = duplicate_ids[1];
+        pool.release(middle_id);
 
         let pressure = reserve(&mut pool, &[], 1);
         assert!(pressure.removed.is_empty());
         pool.cancel(pressure.reservation);
+        assert!(pool.copies.get(middle_id).is_none());
 
         let primary = pool
             .reserve_exact_prefix([3], 1)
@@ -899,6 +905,8 @@ mod tests {
         assert_eq!(primary.reservation.prefix, vec![(3, first_id)]);
         pool.cancel(primary.reservation);
         pool.release(first_id);
+        pool.release(duplicate_ids[0]);
+        pool.release(duplicate_ids[2]);
         pool.assert_lru_consistent();
     }
 

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -851,15 +851,22 @@ mod tests {
 
     #[test]
     fn removal_is_reported_only_for_the_last_physical_copy() {
-        let mut pool = VllmBlockPool::new(2);
+        let mut pool = VllmBlockPool::new(4);
         let mut first = reserve(&mut pool, &[], 1).reservation;
         let first_id = pool.allocate_private(&mut first);
         assert!(pool.cache_private(first_id, 3));
-        let mut second = reserve(&mut pool, &[], 1).reservation;
-        let second_id = pool.allocate_private(&mut second);
-        assert!(!pool.cache_private(second_id, 3));
+
+        let mut duplicate_ids = Vec::new();
+        for _ in 0..3 {
+            let mut duplicate = reserve(&mut pool, &[], 1).reservation;
+            let duplicate_id = pool.allocate_private(&mut duplicate);
+            assert!(!pool.cache_private(duplicate_id, 3));
+            duplicate_ids.push(duplicate_id);
+        }
         pool.release(first_id);
-        pool.release(second_id);
+        for &duplicate_id in &duplicate_ids {
+            pool.release(duplicate_id);
+        }
 
         let first_eviction = reserve(&mut pool, &[], 1);
         assert!(first_eviction.removed.is_empty());
@@ -868,12 +875,18 @@ mod tests {
         let promoted = pool
             .reserve_exact_prefix([3], 1)
             .expect("promoted duplicate should remain reservable");
-        assert_eq!(promoted.reservation.prefix, vec![(3, second_id)]);
+        assert_eq!(promoted.reservation.prefix, vec![(3, duplicate_ids[0])]);
         pool.cancel(promoted.reservation);
 
-        let second_eviction = reserve(&mut pool, &[], 2);
-        assert_eq!(second_eviction.removed, vec![3]);
-        pool.cancel(second_eviction.reservation);
+        for fresh in [2, 3] {
+            let duplicate_eviction = reserve(&mut pool, &[], fresh);
+            assert!(duplicate_eviction.removed.is_empty());
+            pool.cancel(duplicate_eviction.reservation);
+        }
+
+        let final_eviction = reserve(&mut pool, &[], 4);
+        assert_eq!(final_eviction.removed, vec![3]);
+        pool.cancel(final_eviction.reservation);
         pool.assert_lru_consistent();
     }
 

--- a/lib/mocker/src/cache/vllm_block_pool.rs
+++ b/lib/mocker/src/cache/vllm_block_pool.rs
@@ -10,7 +10,7 @@
 use dynamo_tokens::SequenceHash;
 use rustc_hash::{FxHashMap, FxHashSet};
 use slotmap::{SlotMap, new_key_type};
-use smallvec::SmallVec;
+use std::collections::VecDeque;
 
 new_key_type! {
     pub(crate) struct BlockCopyId;
@@ -34,6 +34,62 @@ enum CopyState {
 #[derive(Debug)]
 struct BlockCopy {
     state: CopyState,
+}
+
+struct HashCopies {
+    primary: BlockCopyId,
+    // Keep the common one-copy value to two machine words; duplicate hashes
+    // pay the extra allocation only on the uncommon overflow path.
+    #[allow(clippy::box_collection)]
+    duplicates: Option<Box<VecDeque<BlockCopyId>>>,
+}
+
+impl HashCopies {
+    fn new(primary: BlockCopyId) -> Self {
+        Self {
+            primary,
+            duplicates: None,
+        }
+    }
+
+    fn push(&mut self, id: BlockCopyId) {
+        self.duplicates
+            .get_or_insert_with(|| Box::new(VecDeque::new()))
+            .push_back(id);
+    }
+
+    /// Remove `id`, returning whether the hash no longer has any copies.
+    fn remove(&mut self, id: BlockCopyId) -> Option<bool> {
+        if self.primary == id {
+            let Some(duplicates) = self.duplicates.as_mut() else {
+                return Some(true);
+            };
+            self.primary = duplicates
+                .pop_front()
+                .expect("duplicate-copy queue must not be empty");
+            if duplicates.is_empty() {
+                self.duplicates = None;
+            }
+            return Some(false);
+        }
+
+        let duplicates = self.duplicates.as_mut()?;
+        let position = duplicates.iter().position(|candidate| *candidate == id)?;
+        duplicates.remove(position);
+        if duplicates.is_empty() {
+            self.duplicates = None;
+        }
+        Some(false)
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = BlockCopyId> + '_ {
+        std::iter::once(self.primary).chain(
+            self.duplicates
+                .iter()
+                .flat_map(|duplicates| duplicates.iter().copied()),
+        )
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -67,7 +123,7 @@ pub(crate) struct ReserveOutcome {
 pub(crate) struct VllmBlockPool {
     capacity: usize,
     copies: SlotMap<BlockCopyId, BlockCopy>,
-    by_hash: FxHashMap<SequenceHash, SmallVec<[BlockCopyId; 1]>>,
+    by_hash: FxHashMap<SequenceHash, HashCopies>,
     /// Intrusive ordinary LRU: head is evicted first, tail was released last.
     inactive_head: Option<BlockCopyId>,
     inactive_tail: Option<BlockCopyId>,
@@ -284,7 +340,6 @@ impl VllmBlockPool {
     /// Make a request-private computed full block available for prefix reuse.
     /// Returns whether this is the first resident physical copy of `hash`.
     pub(crate) fn cache_private(&mut self, id: BlockCopyId, hash: SequenceHash) -> bool {
-        let became_visible = !self.by_hash.contains_key(&hash);
         let Some(copy) = self.copies.get_mut(id) else {
             panic!("attempted to cache an unknown block copy")
         };
@@ -299,8 +354,13 @@ impl VllmBlockPool {
             inactive_prev: None,
             inactive_next: None,
         };
-        self.by_hash.entry(hash).or_default().push(id);
-        became_visible
+        if let Some(copies) = self.by_hash.get_mut(&hash) {
+            copies.push(id);
+            false
+        } else {
+            self.by_hash.insert(hash, HashCopies::new(id));
+            true
+        }
     }
 
     /// Release one request-owned reference. Private copies return capacity
@@ -372,10 +432,7 @@ impl VllmBlockPool {
     }
 
     fn first_copy(&self, hash: SequenceHash) -> Option<BlockCopyId> {
-        self.by_hash
-            .get(&hash)
-            .and_then(|copies| copies.first())
-            .copied()
+        self.by_hash.get(&hash).map(|copies| copies.primary)
     }
 
     fn is_inactive(&self, id: BlockCopyId) -> bool {
@@ -538,6 +595,8 @@ impl VllmBlockPool {
 
     #[cfg(test)]
     fn assert_lru_consistent(&self) {
+        self.assert_hash_index_consistent();
+
         let mut linked = FxHashSet::default();
         let mut previous = None;
         let mut cursor = self.inactive_head;
@@ -612,6 +671,34 @@ impl VllmBlockPool {
         }
     }
 
+    #[cfg(test)]
+    fn assert_hash_index_consistent(&self) {
+        let mut indexed = FxHashSet::default();
+        for (&expected_hash, copies) in &self.by_hash {
+            for id in copies.iter() {
+                assert!(indexed.insert(id), "copy is indexed by multiple hashes");
+                let Some(copy) = self.copies.get(id) else {
+                    panic!("hash index points to a missing copy")
+                };
+                let CopyState::Cached { hash, .. } = &copy.state else {
+                    panic!("hash index points to a private copy")
+                };
+                assert_eq!(*hash, expected_hash, "copy is indexed under the wrong hash");
+            }
+        }
+
+        for (id, copy) in self.copies.iter() {
+            match &copy.state {
+                CopyState::Private => {
+                    assert!(!indexed.contains(&id), "private copy is hash-indexed");
+                }
+                CopyState::Cached { .. } => {
+                    assert!(indexed.contains(&id), "cached copy is not hash-indexed");
+                }
+            }
+        }
+    }
+
     /// Evict one physical copy. A hash is returned only on its final copy.
     fn evict_one(&mut self) -> Option<SequenceHash> {
         let Some(id) = self.inactive_head else {
@@ -641,11 +728,10 @@ impl VllmBlockPool {
             let Some(copies) = self.by_hash.get_mut(&hash) else {
                 panic!("evicted cached hash is missing from its index")
             };
-            let Some(position) = copies.iter().position(|candidate| *candidate == id) else {
+            let Some(remove_hash) = copies.remove(id) else {
                 panic!("evicted copy is missing from its hash index")
             };
-            copies.remove(position);
-            copies.is_empty()
+            remove_hash
         };
         if remove_hash {
             self.by_hash.remove(&hash);
@@ -764,9 +850,40 @@ mod tests {
         assert!(first_eviction.removed.is_empty());
         pool.cancel(first_eviction.reservation);
 
+        let promoted = pool
+            .reserve_exact_prefix([3], 1)
+            .expect("promoted duplicate should remain reservable");
+        assert_eq!(promoted.reservation.prefix, vec![(3, second_id)]);
+        pool.cancel(promoted.reservation);
+
         let second_eviction = reserve(&mut pool, &[], 2);
         assert_eq!(second_eviction.removed, vec![3]);
         pool.cancel(second_eviction.reservation);
+        pool.assert_lru_consistent();
+    }
+
+    #[test]
+    fn evicting_non_primary_duplicate_preserves_primary_lookup() {
+        let mut pool = VllmBlockPool::new(2);
+        let mut first = reserve(&mut pool, &[], 1).reservation;
+        let first_id = pool.allocate_private(&mut first);
+        assert!(pool.cache_private(first_id, 3));
+
+        let mut second = reserve(&mut pool, &[], 1).reservation;
+        let second_id = pool.allocate_private(&mut second);
+        assert!(!pool.cache_private(second_id, 3));
+        pool.release(second_id);
+
+        let pressure = reserve(&mut pool, &[], 1);
+        assert!(pressure.removed.is_empty());
+        pool.cancel(pressure.reservation);
+
+        let primary = pool
+            .reserve_exact_prefix([3], 1)
+            .expect("primary copy should remain reservable");
+        assert_eq!(primary.reservation.prefix, vec![(3, first_id)]);
+        pool.cancel(primary.reservation);
+        pool.release(first_id);
         pool.assert_lru_consistent();
     }
 

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -210,14 +210,13 @@ impl SglangKvManager {
         let page_size = self.cache.page_size();
         lease.ensure_page_hashes(token_ids, page_size);
         let materialized_hashes = lease.page_hashes_through(token_ids.len(), page_size);
-        let (prefix_len, last_node) = self.cache.match_prefix_hashes(materialized_hashes);
+        let (prefix_len, last_node) = self.cache.match_prefix_hashes_and_lock(materialized_hashes);
         let required_pages = token_ids.len().div_ceil(page_size) - prefix_len / page_size;
         let required_tokens = required_pages * page_size;
 
         // Protect the matched path before making room. Otherwise an LRU
         // eviction can remove the prefix used to size this allocation, and a
         // second match would require more pages than were freed.
-        self.cache.inc_lock_ref(last_node);
         let reservable = self.cache.available_tokens() + self.cache.evictable_size;
         if required_tokens > reservable {
             self.cache.dec_lock_ref(last_node);
@@ -460,9 +459,8 @@ impl SglangKvManager {
         page_hashes: &[LocalBlockHash],
         token_count: usize,
     ) -> Option<SglangDestinationReservation> {
-        let (prefix_len, last_node) = self.cache.match_prefix_hashes(page_hashes);
+        let (prefix_len, last_node) = self.cache.match_prefix_hashes_and_lock(page_hashes);
         let prefix_pages = self.collect_path_pages_through(last_node, prefix_len);
-        self.cache.inc_lock_ref(last_node);
 
         let allocated_tokens = if token_count == 0 {
             0

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -36,11 +36,11 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 - `lib/mocker/src/replay/offline/state.rs`
   Per-worker wrapper around `EngineCore`, including optional KV event capture.
 - `lib/mocker/src/replay/offline/events.rs`
-  `SimulationEvent` + `SimulationEventKind` priority-queue types used by the multi-worker harness.
+  `SimulationEvent`, `SimulationEventKind`, and worker-completion payload types used by the multi-worker harness.
 - `lib/mocker/src/replay/offline/core.rs`
   Small `ReplayWorkerCore` wrapper used by the single-worker path.
 - `lib/mocker/src/replay/offline/runtime_utils.rs`
-  Shared helpers used by `agg.rs` and `disagg.rs`: `WorkerCompletionPayload`, event scheduling, `next_timestamp`.
+  Shared helpers used by `agg.rs` and `disagg.rs`: event scheduling and `next_timestamp`.
 - `lib/mocker/src/replay/offline/progress.rs`
   `ReplayProgress`, the indicatif-based progress bar used by the harnesses.
 - `lib/mocker/src/replay/offline/components/`
@@ -48,7 +48,7 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
   - `router.rs` — `OfflineReplayRouter` (synchronous in-process router, KV + round-robin modes) and `OfflineRouterSnapshot`.
   - `engine.rs` — `EngineComponent`, `EngineEffects`, `EnginePassMode` wrappers around `EngineCore`.
   - `admission.rs` — admission queue and trace/workload request gating.
-  - `types.rs` — `WorkerAdmission`, `RouterEffects`, `ScheduledWorkerCompletion`, `TrafficAccumulator`, `TrafficStats`, `ReplayMode`.
+  - `types.rs` — `WorkerAdmission`, `RouterEffects`, `ScheduledWorkerCompletions`, `TrafficAccumulator`, `TrafficStats`, `ReplayMode`.
   - `mod.rs` — re-exports.
 
 ## Single-Worker Fast Path
@@ -150,12 +150,14 @@ pub(crate) struct SimulationEvent {
 
 pub(crate) enum SimulationEventKind {
     WorkerCompletion { stage, worker_idx, completed_requests, output_signals, kv_events },
+    WorkerCompletionBatch { payloads },
     DecodeHandoff { uuid },
     WorkerReady { stage, worker_id },
 }
 ```
 
 - `WorkerCompletion` is emitted after a worker pass is executed and applied when the harness clock reaches `pass.end_ms`. It carries the `stage` (`Aggregated`, `Prefill`, or `Decode`), `worker_idx`, `completed_requests`, `output_signals`, and router-visible `kv_events`.
+- `WorkerCompletionBatch` stores the ordered rank payloads for one positive-duration attention-DP epoch in a single heap event. Each payload is still applied independently in rank order.
 - `DecodeHandoff` is used by the disaggregated harness to move a request from prefill to decode at the same logical timestamp (see below).
 - `WorkerReady` marks the point at which a worker returns to the admission pool after a pass completes.
 

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -40,7 +40,8 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 - `lib/mocker/src/replay/offline/core.rs`
   Small `ReplayWorkerCore` wrapper used by the single-worker path.
 - `lib/mocker/src/replay/offline/runtime_utils.rs`
-  Shared helpers used by `agg.rs` and `disagg.rs`: event scheduling and `next_timestamp`.
+  Shared helpers used by `agg.rs` and `disagg.rs`: event scheduling,
+  `ReadyWorkerCompletions`, and `next_timestamp`.
 - `lib/mocker/src/replay/offline/progress.rs`
   `ReplayProgress`, the indicatif-based progress bar used by the harnesses.
 - `lib/mocker/src/replay/offline/components/`
@@ -142,13 +143,13 @@ So offline replay is not a toy simulator. It reuses the real per-pass mocker sch
 The multi-worker and disagg harnesses use `SimulationEvent` from `lib/mocker/src/replay/offline/events.rs` as a min-time priority queue implemented with `BinaryHeap`. The event itself is a small struct carrying the scheduled timestamp, a sequence number for tie-breaking, and a typed payload:
 
 ```rust
-pub(crate) struct SimulationEvent {
-    pub(crate) at_ms: f64,
-    pub(crate) seq_no: u64,
-    pub(crate) kind: SimulationEventKind,
+pub(in crate::replay::offline) struct SimulationEvent {
+    pub(in crate::replay::offline) at_ms: f64,
+    pub(in crate::replay::offline) seq_no: u64,
+    pub(in crate::replay::offline) kind: SimulationEventKind,
 }
 
-pub(crate) enum SimulationEventKind {
+pub(in crate::replay::offline) enum SimulationEventKind {
     WorkerCompletion { stage, worker_idx, completed_requests, output_signals, kv_events },
     WorkerCompletionBatch { payloads },
     DecodeHandoff { uuid },

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -11,13 +11,14 @@ use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::extensions::kv_router::AggRuntime;
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_scaling_tick, pop_ready_worker_completion,
-    pop_ready_worker_ready, push_scaling_tick, push_worker_completion, push_worker_ready,
+    ReadyWorkerCompletions, next_timestamp as choose_next_timestamp, pop_ready_scaling_tick,
+    pop_ready_worker_completions, pop_ready_worker_ready, push_scaling_tick,
+    push_worker_completions, push_worker_ready,
 };
 #[cfg(test)]
 use super::scaling::ReplayScalingDecision;
@@ -29,8 +30,7 @@ use super::state::OfflineWorkerSnapshot;
 use super::{
     components::{
         AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, NoReplayMetadata,
-        ReplayAdmissionMetadata, ReplayEngineObservation, ScheduledWorkerCompletion,
-        TrafficAccumulator,
+        ReplayAdmissionMetadata, ReplayEngineObservation, TrafficAccumulator,
     },
     state::AggRequestState,
 };
@@ -632,26 +632,42 @@ where
         // each pass may drain router-pending work before its sibling ranks are applied.
         // Preserve this lower-rank-first tie-break for now. Atomic settlement requires
         // splitting router state mutation from pending-admission draining.
-        while let Some(payload) = pop_ready_worker_completion(&mut self.events, self.now_ms) {
-            debug_assert_eq!(payload.stage, SimulationWorkerStage::Aggregated);
-            let payload = self.engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.record_fpm(payload.worker_idx, fpm)?;
+        while let Some(completions) = pop_ready_worker_completions(&mut self.events, self.now_ms) {
+            match completions {
+                ReadyWorkerCompletions::Single(payload) => {
+                    self.apply_worker_completion(payload)?;
+                }
+                ReadyWorkerCompletions::Batch(payloads) => {
+                    for payload in payloads {
+                        self.apply_worker_completion(payload)?;
+                    }
+                }
             }
-            self.process_completed_pass(
-                payload.worker_idx,
-                payload.completed_requests,
-                payload.output_signals,
-                payload.engine_events,
-                payload.accept_length_output_tokens,
-                payload.accept_length_decode_forwards,
-            )?;
             changed = true;
         }
 
         Ok(changed)
+    }
+
+    fn apply_worker_completion(
+        &mut self,
+        payload: WorkerCompletionPayload<Observation::Batch>,
+    ) -> anyhow::Result<()> {
+        debug_assert_eq!(payload.stage, SimulationWorkerStage::Aggregated);
+        let payload = self.engine.on_scheduled_completion(payload)?;
+        if self.collect_fpm
+            && let Some(fpm) = payload.fpm
+        {
+            self.record_fpm(payload.worker_idx, fpm)?;
+        }
+        self.process_completed_pass(
+            payload.worker_idx,
+            payload.completed_requests,
+            payload.output_signals,
+            payload.engine_events,
+            payload.accept_length_output_tokens,
+            payload.accept_length_decode_forwards,
+        )
     }
 
     /// Release every admission made ready by the shared admission queue.
@@ -701,23 +717,10 @@ where
     ) -> anyhow::Result<()> {
         self.apply_engine_observations(effects.pass_start_events)?;
         for payload in effects.immediate_completions {
-            let payload = self.engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.record_fpm(payload.worker_idx, fpm)?;
-            }
-            self.process_completed_pass(
-                payload.worker_idx,
-                payload.completed_requests,
-                payload.output_signals,
-                payload.engine_events,
-                payload.accept_length_output_tokens,
-                payload.accept_length_decode_forwards,
-            )?;
+            self.apply_worker_completion(payload)?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -45,6 +45,8 @@ where
     worker_groups: Vec<Option<Vec<usize>>>,
     /// Number of non-tombstoned worker groups.
     live_group_count: usize,
+    /// Aggregate request ownership across all live DP-rank schedulers.
+    total_in_flight: usize,
     /// Logical workers that can start a pass, ordered by stable worker ID.
     ready_groups: BTreeSet<usize>,
     /// Ready groups that made no observable progress during the prior drive.
@@ -70,6 +72,7 @@ where
         workers: Vec<OfflineWorkerState>,
     ) -> Self {
         let count = workers.len();
+        let total_in_flight = workers.iter().map(OfflineWorkerState::in_flight).sum();
         debug_assert!(
             workers
                 .iter()
@@ -85,6 +88,7 @@ where
             workers,
             worker_groups,
             live_group_count: count,
+            total_in_flight,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
             pending_removal: BTreeSet::new(),
@@ -131,6 +135,7 @@ where
             workers,
             worker_groups,
             live_group_count: num_workers,
+            total_in_flight: 0,
             ready_groups: BTreeSet::new(),
             deferred_ready_groups: BTreeSet::new(),
             pending_removal: BTreeSet::new(),
@@ -221,6 +226,36 @@ where
         }
     }
 
+    fn record_in_flight_change(&mut self, before: usize, after: usize) {
+        if after >= before {
+            self.total_in_flight = self
+                .total_in_flight
+                .checked_add(after - before)
+                .expect("offline engine in-flight request count overflow");
+        } else {
+            self.total_in_flight = self
+                .total_in_flight
+                .checked_sub(before - after)
+                .expect("offline engine in-flight request count underflow");
+        }
+        #[cfg(debug_assertions)]
+        self.debug_assert_total_in_flight();
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_total_in_flight(&self) {
+        let expected: usize = self
+            .workers
+            .iter()
+            .filter_map(Option::as_ref)
+            .map(OfflineWorkerState::in_flight)
+            .sum();
+        debug_assert_eq!(
+            self.total_in_flight, expected,
+            "aggregate offline engine in-flight count drifted from workers"
+        );
+    }
+
     #[cfg(debug_assertions)]
     fn debug_assert_ready_frontier(&self) {
         let expected = (0..self.worker_groups.len())
@@ -253,6 +288,8 @@ where
         debug_assert_eq!(worker_id, self.worker_groups.len());
         self.worker_groups.push(Some(rank_ids));
         self.live_group_count += 1;
+        #[cfg(debug_assertions)]
+        self.debug_assert_total_in_flight();
         worker_id
     }
 
@@ -263,10 +300,15 @@ where
             return false;
         };
         for rank_id in rank_ids {
-            self.workers
+            let worker = self
+                .workers
                 .get_mut(rank_id)
                 .and_then(Option::take)
                 .expect("live worker group referenced a missing rank");
+            self.total_in_flight = self
+                .total_in_flight
+                .checked_sub(worker.in_flight())
+                .expect("tombstoned worker exceeded aggregate in-flight count");
         }
         self.live_group_count = self
             .live_group_count
@@ -277,6 +319,8 @@ where
             self.worker_groups.iter().flatten().count(),
             "live worker group count drifted from storage"
         );
+        #[cfg(debug_assertions)]
+        self.debug_assert_total_in_flight();
         true
     }
 
@@ -475,9 +519,15 @@ where
         rank_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        self.worker_mut(rank_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?
-            .receive_request(request);
+        let (before, after) = {
+            let worker = self
+                .worker_mut(rank_id)
+                .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
+            let before = worker.in_flight();
+            worker.receive_request(request);
+            (before, worker.in_flight())
+        };
+        self.record_in_flight_change(before, after);
         self.refresh_rank(rank_id);
         Ok(())
     }
@@ -487,10 +537,15 @@ where
         rank_id: usize,
         command: SchedulerCommand,
     ) -> anyhow::Result<ObservedCommandEffects<Observation::Batch>> {
-        let mut effects = self
-            .worker_mut(rank_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?
-            .apply_command(command)?;
+        let (mut effects, before, after) = {
+            let worker = self
+                .worker_mut(rank_id)
+                .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
+            let before = worker.in_flight();
+            let effects = worker.apply_command(command)?;
+            (effects, before, worker.in_flight())
+        };
+        self.record_in_flight_change(before, after);
         let engine_events = Observation::take_command_events(&mut effects);
         let observed = ObservedCommandEffects {
             result: effects.result,
@@ -710,16 +765,21 @@ where
             );
         }
         let rank_id = payload.worker_idx;
-        let worker = self.worker_mut(rank_id).ok_or_else(|| {
-            anyhow::anyhow!("offline replay completion for unknown worker {}", rank_id)
-        })?;
-        worker.mark_idle();
-        worker.mark_completed(payload.completed_requests);
         let mut payload = payload;
-        payload
-            .lifecycle_events
-            .extend(worker.retry_pending_destinations());
-        let observed = Observation::drain_worker_events(worker);
+        let (observed, before, after) = {
+            let worker = self.worker_mut(rank_id).ok_or_else(|| {
+                anyhow::anyhow!("offline replay completion for unknown worker {}", rank_id)
+            })?;
+            let before = worker.in_flight();
+            worker.mark_idle();
+            worker.mark_completed(payload.completed_requests);
+            payload
+                .lifecycle_events
+                .extend(worker.retry_pending_destinations());
+            let observed = Observation::drain_worker_events(worker);
+            (observed, before, worker.in_flight())
+        };
+        self.record_in_flight_change(before, after);
         payload.progress.had_raw_observations |= observed.had_raw_observations;
         payload.progress.made_progress |= observed.had_raw_observations;
         payload.engine_events.append(observed.events);
@@ -728,11 +788,9 @@ where
     }
 
     pub(in crate::replay::offline) fn in_flight(&self) -> usize {
-        self.workers
-            .iter()
-            .filter_map(Option::as_ref)
-            .map(OfflineWorkerState::in_flight)
-            .sum()
+        #[cfg(debug_assertions)]
+        self.debug_assert_total_in_flight();
+        self.total_in_flight
     }
 
     pub(in crate::replay::offline) fn is_drained(&self) -> bool {
@@ -1002,6 +1060,61 @@ mod tests {
         assert_eq!(effects.scheduled_completions.len(), 1);
         assert_eq!(effects.scheduled_completions[0].at_ms, 5.0);
         assert_eq!(collector.request_latencies(uuid).unwrap().0, 5.0);
+    }
+
+    #[test]
+    fn sglang_aggregate_in_flight_tracks_worker_ownership() {
+        let args = MockEngineArgs::builder()
+            .engine_type(EngineType::Sglang)
+            .block_size(4)
+            .num_gpu_blocks(16)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(1))
+            .speedup_ratio(0.0)
+            .sglang(Some(SglangArgs {
+                page_size: Some(4),
+                chunked_prefill_size: Some(16),
+                ..Default::default()
+            }))
+            .build()
+            .unwrap();
+        let worker = OfflineWorkerState::new(0, args.clone(), false);
+        let mut engine = EngineComponent::<NoEngineEvents>::new(
+            SimulationWorkerStage::Aggregated,
+            EnginePassMode::Visible,
+            vec![worker],
+        );
+        engine.set_scaling_args(args, false);
+        assert_eq!(engine.in_flight(), 0);
+
+        let cancelled = Uuid::from_u128(501);
+        engine.dispatch(0, timed_request(cancelled, 4)).unwrap();
+        assert_eq!(engine.in_flight(), 1);
+        let effects = engine
+            .apply_command(
+                0,
+                SchedulerCommand::CancelRequest {
+                    request_id: cancelled,
+                },
+            )
+            .unwrap();
+        assert_eq!(effects.result, SchedulerCommandResult::Applied);
+        assert_eq!(engine.in_flight(), 0);
+
+        let completed = Uuid::from_u128(502);
+        engine.dispatch(0, timed_request(completed, 4)).unwrap();
+        assert_eq!(engine.in_flight(), 1);
+        let effects = engine
+            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .unwrap();
+        let completion = take_only_completion(effects);
+        assert_eq!(engine.in_flight(), 1);
+        engine.on_scheduled_completion(completion).unwrap();
+        assert_eq!(engine.in_flight(), 0);
+
+        engine.mark_for_removal(0);
+        assert_eq!(engine.try_remove_drained(), vec![0]);
+        assert_eq!(engine.in_flight(), 0);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -174,8 +174,19 @@ where
         self.workers.get(rank_id)?.as_ref()
     }
 
-    fn worker_mut(&mut self, rank_id: usize) -> Option<&mut OfflineWorkerState> {
-        self.workers.get_mut(rank_id)?.as_mut()
+    fn update_worker<T>(
+        &mut self,
+        rank_id: usize,
+        update: impl FnOnce(&mut OfflineWorkerState) -> T,
+    ) -> Option<T> {
+        let (result, before, after) = {
+            let worker = self.workers.get_mut(rank_id)?.as_mut()?;
+            let before = worker.in_flight();
+            let result = update(worker);
+            (result, before, worker.in_flight())
+        };
+        self.record_in_flight_change(before, after);
+        Some(result)
     }
 
     fn required_worker(
@@ -531,15 +542,8 @@ where
         rank_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        let (before, after) = {
-            let worker = self
-                .worker_mut(rank_id)
-                .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
-            let before = worker.in_flight();
-            worker.receive_request(request);
-            (before, worker.in_flight())
-        };
-        self.record_in_flight_change(before, after);
+        self.update_worker(rank_id, |worker| worker.receive_request(request))
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
         self.refresh_rank(rank_id);
         Ok(())
     }
@@ -549,15 +553,9 @@ where
         rank_id: usize,
         command: SchedulerCommand,
     ) -> anyhow::Result<ObservedCommandEffects<Observation::Batch>> {
-        let (mut effects, before, after) = {
-            let worker = self
-                .worker_mut(rank_id)
-                .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
-            let before = worker.in_flight();
-            let effects = worker.apply_command(command)?;
-            (effects, before, worker.in_flight())
-        };
-        self.record_in_flight_change(before, after);
+        let mut effects = self
+            .update_worker(rank_id, |worker| worker.apply_command(command))
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))??;
         let engine_events = Observation::take_command_events(&mut effects);
         let observed = ObservedCommandEffects {
             result: effects.result,
@@ -578,7 +576,7 @@ where
         Ok(worker.is_busy())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "profile", inline(never))]
     fn lower_executed_pass(
         workers: &mut [Option<OfflineWorkerState>],
         stage: SimulationWorkerStage,
@@ -711,7 +709,16 @@ where
                     EnginePassMode::Hidden => Self::required_worker_mut(&mut self.workers, rank_id)
                         .try_execute_hidden_pass(now_ms),
                 }?;
-                let group_end_ms = executed.end_ms;
+                let group_end_ms = executed.end_ms.max(now_ms);
+                let align_collector = if self.pass_mode == EnginePassMode::Visible {
+                    Some(
+                        collector
+                            .as_deref_mut()
+                            .expect("visible pass collector checked before execution"),
+                    )
+                } else {
+                    None
+                };
                 Self::lower_executed_pass(
                     &mut self.workers,
                     self.stage,
@@ -721,7 +728,7 @@ where
                         end_ms: group_end_ms,
                     },
                     executed,
-                    None,
+                    align_collector,
                     &mut effects,
                 );
 
@@ -849,20 +856,18 @@ where
         }
         let rank_id = payload.worker_idx;
         let mut payload = payload;
-        let (observed, before, after) = {
-            let worker = self.worker_mut(rank_id).ok_or_else(|| {
+        let observed = self
+            .update_worker(rank_id, |worker| {
+                worker.mark_idle();
+                worker.mark_completed(payload.completed_requests);
+                payload
+                    .lifecycle_events
+                    .extend(worker.retry_pending_destinations());
+                Observation::drain_worker_events(worker)
+            })
+            .ok_or_else(|| {
                 anyhow::anyhow!("offline replay completion for unknown worker {}", rank_id)
             })?;
-            let before = worker.in_flight();
-            worker.mark_idle();
-            worker.mark_completed(payload.completed_requests);
-            payload
-                .lifecycle_events
-                .extend(worker.retry_pending_destinations());
-            let observed = Observation::drain_worker_events(worker);
-            (observed, before, worker.in_flight())
-        };
-        self.record_in_flight_change(before, after);
         payload.progress.had_raw_observations |= observed.had_raw_observations;
         payload.progress.made_progress |= observed.had_raw_observations;
         payload.engine_events.append(observed.events);
@@ -1131,18 +1136,38 @@ mod tests {
     }
 
     #[test]
-    fn single_rank_group_keeps_local_completion_time() {
-        let mut engine = ranked_timing_engine(1);
-        let uuid = Uuid::from_u128(50);
-        engine.dispatch(0, timed_request(uuid, 4)).unwrap();
-        let mut collector = TraceCollector::default();
-        collector.on_arrival(uuid, 0.0, 4, 1);
+    fn single_rank_visible_timeline_matches_grouped_path() {
+        fn run(dp_size: u32, uuid: Uuid) -> (f64, f64) {
+            let mut engine = ranked_timing_engine(dp_size);
+            let mut request = timed_request(uuid, 4);
+            request.max_output_tokens = 3;
+            engine.dispatch(0, request).unwrap();
+            let mut collector = TraceCollector::default();
+            collector.on_arrival(uuid, 0.0, 4, 3);
 
-        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+            let mut now_ms = 0.0;
+            while engine.in_flight() > 0 {
+                let effects = engine.drive_ready(now_ms, Some(&mut collector)).unwrap();
+                assert!(effects.immediate_completions.is_empty());
+                assert_eq!(effects.scheduled_completions.len(), dp_size as usize);
+                now_ms = effects.scheduled_completions[0].at_ms;
+                assert!(
+                    effects
+                        .scheduled_completions
+                        .iter()
+                        .all(|completion| completion.at_ms == now_ms)
+                );
+                for completion in effects.scheduled_completions {
+                    engine.on_scheduled_completion(completion.payload).unwrap();
+                }
+            }
+            collector.request_latencies(uuid).unwrap()
+        }
 
-        assert_eq!(effects.scheduled_completions.len(), 1);
-        assert_eq!(effects.scheduled_completions[0].at_ms, 5.0);
-        assert_eq!(collector.request_latencies(uuid).unwrap().0, 5.0);
+        let singleton = run(1, Uuid::from_u128(50));
+        let grouped = run(2, Uuid::from_u128(51));
+        assert_eq!(singleton, grouped);
+        assert_eq!(singleton, (5.0, 1.0));
     }
 
     #[test]
@@ -1394,9 +1419,11 @@ mod tests {
 
         assert_eq!(engine.active_worker_ids().len(), 1);
         engine
-            .worker_mut(new_id)
-            .unwrap()
-            .receive_request(timed_request(Uuid::from_u128(60), 4));
+            .update_worker(new_id, |worker| {
+                worker.receive_request(timed_request(Uuid::from_u128(60), 4))
+            })
+            .unwrap();
+        assert_eq!(engine.in_flight(), 1);
         assert!(!engine.ready_groups.contains(&new_id));
         assert!(engine.mark_worker_ready(new_id));
         assert_eq!(engine.active_worker_ids().len(), 2);
@@ -1653,7 +1680,9 @@ mod tests {
         });
         // Model a reservation attempt at the t=0 boundary, before the GPU
         // compute interval becomes externally busy.
-        engine.worker_mut(0).unwrap().mark_idle();
+        engine
+            .update_worker(0, OfflineWorkerState::mark_idle)
+            .unwrap();
 
         let handoff_id = HandoffId::from(Uuid::from_u128(102));
         let reserve = engine
@@ -1676,7 +1705,9 @@ mod tests {
             .expect("reservation eviction should start G1 to G2 DMA");
         assert!((deadline - 20.0).abs() < 0.01);
 
-        engine.worker_mut(0).unwrap().mark_busy();
+        engine
+            .update_worker(0, OfflineWorkerState::mark_busy)
+            .unwrap();
         assert_eq!(engine.earliest_offload_deadline(), Some(deadline));
         let transport = engine.tick_offload_engines(deadline);
         assert!(transport.lifecycle_events.is_empty());

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -27,6 +27,18 @@ fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
     snapshot.num_prefill_requests > 0 || snapshot.num_decode_requests > 0
 }
 
+#[derive(Clone, Copy)]
+struct PassBoundary {
+    start_ms: f64,
+    end_ms: f64,
+}
+
+impl PassBoundary {
+    fn wall_time_secs(self) -> f64 {
+        (self.end_ms - self.start_ms).max(0.0) / 1000.0
+    }
+}
+
 pub(in crate::replay::offline) struct EngineComponent<Observation = NoEngineEvents>
 where
     Observation: ReplayEngineObservation,
@@ -566,6 +578,87 @@ where
         Ok(worker.is_busy())
     }
 
+    #[inline(always)]
+    fn lower_executed_pass(
+        workers: &mut [Option<OfflineWorkerState>],
+        stage: SimulationWorkerStage,
+        rank_id: usize,
+        boundary: PassBoundary,
+        mut executed: EnginePassResult,
+        align_collector: Option<&mut TraceCollector>,
+        effects: &mut EngineEffects<Observation::Batch>,
+    ) {
+        if let Some(fpm) = executed.fpm.as_mut() {
+            fpm.wall_time_secs = boundary.wall_time_secs();
+        }
+        if let Some(collector) = align_collector {
+            collector.align_pass_token_times(&executed.output_signals, boundary.end_ms);
+        }
+
+        let admitted_requests = !executed.admissions.is_empty();
+        let had_raw_observations = !executed.kv_events.is_empty();
+        let published_pass_start_kv = executed.router_event_visibility
+            == RouterEventVisibility::PassStart
+            && had_raw_observations;
+        let made_progress = admitted_requests
+            || published_pass_start_kv
+            || executed.completed_requests > 0
+            || !executed.output_signals.is_empty()
+            || !executed.lifecycle_events.is_empty()
+            || had_raw_observations
+            || executed.fpm.as_ref().is_some_and(fpm_has_scheduled_work);
+        let observed_events = Observation::take_pass_events(&mut executed);
+        effects.admissions.extend(executed.admissions);
+        let completion_events =
+            if executed.router_event_visibility == RouterEventVisibility::PassStart {
+                effects.pass_start_events.append(observed_events);
+                Observation::Batch::default()
+            } else {
+                observed_events
+            };
+        let payload = WorkerCompletionPayload {
+            stage,
+            worker_idx: rank_id,
+            completed_requests: executed.completed_requests,
+            output_signals: executed.output_signals,
+            lifecycle_events: executed.lifecycle_events,
+            engine_events: completion_events,
+            progress: EngineProgress {
+                made_progress,
+                had_raw_observations,
+            },
+            fpm: executed.fpm,
+            accept_length_output_tokens: executed.accept_length_output_tokens,
+            accept_length_decode_forwards: executed.accept_length_decode_forwards,
+        };
+
+        if boundary.end_ms > boundary.start_ms {
+            Self::required_worker_mut(workers, rank_id).mark_busy();
+            effects
+                .scheduled_completions
+                .push(ScheduledWorkerCompletion {
+                    at_ms: boundary.end_ms,
+                    payload,
+                });
+            return;
+        }
+
+        // NOTE: Keep both lifecycle extremes in view when changing this gate.
+        // Tight-spin/livelock occurs when an effect-free, queued-only,
+        // zero-duration pass is repeatedly treated as progress at the same
+        // virtual timestamp. Dead-end/lost-wakeup occurs when replay declares
+        // quiescence while workers still own unfinished requests but have no
+        // concrete future event, deadline, or dependency notification. Stop
+        // same-time iteration when no observable state changed, but only after
+        // the owning subsystem can account for every unfinished request's
+        // future wakeup; an empty event queue alone is not quiescence.
+        if made_progress {
+            effects.progress.made_progress = true;
+            effects.progress.had_raw_observations |= had_raw_observations;
+            effects.immediate_completions.push(payload);
+        }
+    }
+
     pub(in crate::replay::offline) fn drive_ready(
         &mut self,
         now_ms: f64,
@@ -604,6 +697,48 @@ where
                 continue;
             }
 
+            let mut effects = EngineEffects::default();
+            if rank_ids.len() == 1 {
+                let rank_id = rank_ids[0];
+                let executed = match self.pass_mode {
+                    EnginePassMode::Visible => {
+                        let Some(collector) = collector.as_deref_mut() else {
+                            bail!("offline replay visible engine pass requires a collector");
+                        };
+                        Self::required_worker_mut(&mut self.workers, rank_id)
+                            .try_execute_pass(collector, now_ms)
+                    }
+                    EnginePassMode::Hidden => Self::required_worker_mut(&mut self.workers, rank_id)
+                        .try_execute_hidden_pass(now_ms),
+                }?;
+                let group_end_ms = executed.end_ms;
+                Self::lower_executed_pass(
+                    &mut self.workers,
+                    self.stage,
+                    rank_id,
+                    PassBoundary {
+                        start_ms: now_ms,
+                        end_ms: group_end_ms,
+                    },
+                    executed,
+                    None,
+                    &mut effects,
+                );
+
+                if !effects.is_empty() {
+                    if group_end_ms <= now_ms {
+                        // A zero-duration pass can remain ready. Re-arm it here
+                        // without depending on caller completion processing.
+                        self.refresh_group(worker_id);
+                    }
+                    return Ok(effects);
+                }
+                if self.group_is_ready(worker_id) {
+                    self.deferred_ready_groups.insert(worker_id);
+                }
+                continue;
+            }
+
             let mut executed_by_rank: SmallVec<[Option<EnginePassResult>; 1]> =
                 SmallVec::with_capacity(rank_ids.len());
             for &rank_id in rank_ids {
@@ -630,11 +765,13 @@ where
                 .filter_map(Option::as_ref)
                 .map(|executed| executed.end_ms)
                 .fold(now_ms, f64::max);
-            let group_wall_time_secs = (group_end_ms - now_ms).max(0.0) / 1000.0;
-            let mut effects = EngineEffects::default();
+            let boundary = PassBoundary {
+                start_ms: now_ms,
+                end_ms: group_end_ms,
+            };
 
             for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
-                let Some(mut executed) = executed else {
+                let Some(executed) = executed else {
                     if group_end_ms > now_ms {
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
@@ -652,7 +789,7 @@ where
                                     engine_events: Observation::Batch::default(),
                                     progress: EngineProgress::default(),
                                     fpm: Some(ForwardPassSnapshot {
-                                        wall_time_secs: group_wall_time_secs,
+                                        wall_time_secs: boundary.wall_time_secs(),
                                         ..Default::default()
                                     }),
                                     accept_length_output_tokens: 0,
@@ -663,78 +800,24 @@ where
                     continue;
                 };
 
-                if let Some(fpm) = executed.fpm.as_mut() {
-                    fpm.wall_time_secs = group_wall_time_secs;
-                }
-                if self.pass_mode == EnginePassMode::Visible {
-                    collector
-                        .as_deref_mut()
-                        .expect("visible pass collector checked before execution")
-                        .align_pass_token_times(&executed.output_signals, group_end_ms);
-                }
-
-                let admitted_requests = !executed.admissions.is_empty();
-                let had_raw_observations = !executed.kv_events.is_empty();
-                let published_pass_start_kv = executed.router_event_visibility
-                    == RouterEventVisibility::PassStart
-                    && had_raw_observations;
-                let made_progress = admitted_requests
-                    || published_pass_start_kv
-                    || executed.completed_requests > 0
-                    || !executed.output_signals.is_empty()
-                    || !executed.lifecycle_events.is_empty()
-                    || had_raw_observations
-                    || executed.fpm.as_ref().is_some_and(fpm_has_scheduled_work);
-                let observed_events = Observation::take_pass_events(&mut executed);
-                effects.admissions.extend(executed.admissions);
-                let completion_events =
-                    if executed.router_event_visibility == RouterEventVisibility::PassStart {
-                        effects.pass_start_events.append(observed_events);
-                        Observation::Batch::default()
-                    } else {
-                        observed_events
-                    };
-                let payload = WorkerCompletionPayload {
-                    stage: self.stage,
-                    worker_idx: rank_id,
-                    completed_requests: executed.completed_requests,
-                    output_signals: executed.output_signals,
-                    lifecycle_events: executed.lifecycle_events,
-                    engine_events: completion_events,
-                    progress: EngineProgress {
-                        made_progress,
-                        had_raw_observations,
-                    },
-                    fpm: executed.fpm,
-                    accept_length_output_tokens: executed.accept_length_output_tokens,
-                    accept_length_decode_forwards: executed.accept_length_decode_forwards,
+                let align_collector = if self.pass_mode == EnginePassMode::Visible {
+                    Some(
+                        collector
+                            .as_deref_mut()
+                            .expect("visible pass collector checked before execution"),
+                    )
+                } else {
+                    None
                 };
-
-                if group_end_ms > now_ms {
-                    Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
-                    effects
-                        .scheduled_completions
-                        .push(ScheduledWorkerCompletion {
-                            at_ms: group_end_ms,
-                            payload,
-                        });
-                    continue;
-                }
-
-                // NOTE: Keep both lifecycle extremes in view when changing this gate.
-                // Tight-spin/livelock occurs when an effect-free, queued-only,
-                // zero-duration pass is repeatedly treated as progress at the same
-                // virtual timestamp. Dead-end/lost-wakeup occurs when replay declares
-                // quiescence while workers still own unfinished requests but have no
-                // concrete future event, deadline, or dependency notification. Stop
-                // same-time iteration when no observable state changed, but only after
-                // the owning subsystem can account for every unfinished request's
-                // future wakeup; an empty event queue alone is not quiescence.
-                if made_progress {
-                    effects.progress.made_progress = true;
-                    effects.progress.had_raw_observations |= had_raw_observations;
-                    effects.immediate_completions.push(payload);
-                }
+                Self::lower_executed_pass(
+                    &mut self.workers,
+                    self.stage,
+                    rank_id,
+                    boundary,
+                    executed,
+                    align_collector,
+                    &mut effects,
+                );
             }
 
             if !effects.is_empty() {

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -27,6 +27,7 @@ fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
 struct PassBoundary {
     start_ms: f64,
     end_ms: f64,
+    completion_capacity: usize,
 }
 
 impl PassBoundary {
@@ -628,7 +629,7 @@ where
 
         if boundary.end_ms > boundary.start_ms {
             Self::required_worker_mut(workers, rank_id).mark_busy();
-            effects.schedule_completion(boundary.end_ms, payload);
+            effects.schedule_completion(boundary.end_ms, payload, boundary.completion_capacity);
             return;
         }
 
@@ -687,7 +688,7 @@ where
             }
 
             let mut effects = EngineEffects::default();
-            if rank_ids.len() == 1 {
+            let group_end_ms = if rank_ids.len() == 1 {
                 let rank_id = rank_ids[0];
                 let executed = match self.pass_mode {
                     EnginePassMode::Visible => {
@@ -717,107 +718,99 @@ where
                     PassBoundary {
                         start_ms: now_ms,
                         end_ms: group_end_ms,
+                        completion_capacity: 1,
                     },
                     executed,
                     align_collector,
                     &mut effects,
                 );
-
-                if !effects.is_empty() {
-                    if group_end_ms <= now_ms {
-                        // A zero-duration pass can remain ready. Re-arm it here
-                        // without depending on caller completion processing.
-                        self.refresh_group(worker_id);
+                group_end_ms
+            } else {
+                let completion_capacity = rank_ids.len();
+                let mut executed_by_rank: SmallVec<[Option<EnginePassResult>; 1]> =
+                    SmallVec::with_capacity(completion_capacity);
+                for &rank_id in rank_ids {
+                    if !Self::required_worker(&self.workers, rank_id).is_ready() {
+                        executed_by_rank.push(None);
+                        continue;
                     }
-                    return Ok(effects);
+                    let executed = match self.pass_mode {
+                        EnginePassMode::Visible => {
+                            let Some(collector) = collector.as_deref_mut() else {
+                                bail!("offline replay visible engine pass requires a collector");
+                            };
+                            Self::required_worker_mut(&mut self.workers, rank_id)
+                                .try_execute_pass(collector, now_ms)
+                        }
+                        EnginePassMode::Hidden => {
+                            Self::required_worker_mut(&mut self.workers, rank_id)
+                                .try_execute_hidden_pass(now_ms)
+                        }
+                    }?;
+                    executed_by_rank.push(Some(executed));
                 }
-                if self.group_is_ready(worker_id) {
-                    self.deferred_ready_groups.insert(worker_id);
-                }
-                continue;
-            }
 
-            let mut executed_by_rank: SmallVec<[Option<EnginePassResult>; 1]> =
-                SmallVec::with_capacity(rank_ids.len());
-            for &rank_id in rank_ids {
-                if !Self::required_worker(&self.workers, rank_id).is_ready() {
-                    executed_by_rank.push(None);
-                    continue;
-                }
-                let executed = match self.pass_mode {
-                    EnginePassMode::Visible => {
-                        let Some(collector) = collector.as_deref_mut() else {
-                            bail!("offline replay visible engine pass requires a collector");
-                        };
-                        Self::required_worker_mut(&mut self.workers, rank_id)
-                            .try_execute_pass(collector, now_ms)
-                    }
-                    EnginePassMode::Hidden => Self::required_worker_mut(&mut self.workers, rank_id)
-                        .try_execute_hidden_pass(now_ms),
-                }?;
-                executed_by_rank.push(Some(executed));
-            }
+                let group_end_ms = executed_by_rank
+                    .iter()
+                    .filter_map(Option::as_ref)
+                    .map(|executed| executed.end_ms)
+                    .fold(now_ms, f64::max);
+                let boundary = PassBoundary {
+                    start_ms: now_ms,
+                    end_ms: group_end_ms,
+                    completion_capacity,
+                };
 
-            let group_end_ms = executed_by_rank
-                .iter()
-                .filter_map(Option::as_ref)
-                .map(|executed| executed.end_ms)
-                .fold(now_ms, f64::max);
-            let boundary = PassBoundary {
-                start_ms: now_ms,
-                end_ms: group_end_ms,
+                for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
+                    let Some(executed) = executed else {
+                        if group_end_ms > now_ms {
+                            // Empty ranks still participate in the barrier so work
+                            // arriving mid-epoch cannot start ahead of a sibling.
+                            Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
+                            effects.schedule_completion(
+                                group_end_ms,
+                                WorkerCompletionPayload {
+                                    stage: self.stage,
+                                    worker_idx: rank_id,
+                                    completed_requests: 0,
+                                    output_signals: Vec::new(),
+                                    lifecycle_events: Vec::new(),
+                                    engine_events: Observation::Batch::default(),
+                                    progress: EngineProgress::default(),
+                                    fpm: Some(ForwardPassSnapshot {
+                                        wall_time_secs: boundary.wall_time_secs(),
+                                        ..Default::default()
+                                    }),
+                                    accept_length_output_tokens: 0,
+                                    accept_length_decode_forwards: 0,
+                                },
+                                boundary.completion_capacity,
+                            );
+                        }
+                        continue;
+                    };
+
+                    let align_collector = if self.pass_mode == EnginePassMode::Visible {
+                        Some(
+                            collector
+                                .as_deref_mut()
+                                .expect("visible pass collector checked before execution"),
+                        )
+                    } else {
+                        None
+                    };
+                    Self::lower_executed_pass(
+                        &mut self.workers,
+                        self.stage,
+                        rank_id,
+                        boundary,
+                        executed,
+                        align_collector,
+                        &mut effects,
+                    );
+                }
+                group_end_ms
             };
-            if group_end_ms > now_ms {
-                effects.prepare_scheduled_completion(group_end_ms, rank_ids.len());
-            }
-
-            for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
-                let Some(executed) = executed else {
-                    if group_end_ms > now_ms {
-                        // Empty ranks still participate in the barrier so work
-                        // arriving mid-epoch cannot start ahead of a sibling.
-                        Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
-                        effects.schedule_completion(
-                            group_end_ms,
-                            WorkerCompletionPayload {
-                                stage: self.stage,
-                                worker_idx: rank_id,
-                                completed_requests: 0,
-                                output_signals: Vec::new(),
-                                lifecycle_events: Vec::new(),
-                                engine_events: Observation::Batch::default(),
-                                progress: EngineProgress::default(),
-                                fpm: Some(ForwardPassSnapshot {
-                                    wall_time_secs: boundary.wall_time_secs(),
-                                    ..Default::default()
-                                }),
-                                accept_length_output_tokens: 0,
-                                accept_length_decode_forwards: 0,
-                            },
-                        );
-                    }
-                    continue;
-                };
-
-                let align_collector = if self.pass_mode == EnginePassMode::Visible {
-                    Some(
-                        collector
-                            .as_deref_mut()
-                            .expect("visible pass collector checked before execution"),
-                    )
-                } else {
-                    None
-                };
-                Self::lower_executed_pass(
-                    &mut self.workers,
-                    self.stage,
-                    rank_id,
-                    boundary,
-                    executed,
-                    align_collector,
-                    &mut effects,
-                );
-            }
 
             if !effects.is_empty() {
                 if group_end_ms <= now_ms {
@@ -868,8 +861,6 @@ where
     }
 
     pub(in crate::replay::offline) fn in_flight(&self) -> usize {
-        #[cfg(debug_assertions)]
-        self.debug_assert_total_in_flight();
         self.total_in_flight
     }
 

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -8,17 +8,13 @@ use anyhow::bail;
 use smallvec::SmallVec;
 
 use super::super::core::{EngineEventBatch, EngineProgress, NoEngineEvents, WorkerTopology};
-use super::super::events::SimulationWorkerStage;
-use super::super::runtime_utils::WorkerCompletionPayload;
+use super::super::events::{SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::super::state::OfflineWorkerSnapshot;
 use super::super::state::OfflineWorkerState;
 #[cfg(feature = "kvbm-offload")]
 use super::ObservedOffloadEffects;
-use super::{
-    EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineObservation,
-    ScheduledWorkerCompletion,
-};
+use super::{EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineObservation};
 use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
 use crate::scheduler::{EnginePassResult, RouterEventVisibility, SchedulerCommand};
@@ -632,12 +628,7 @@ where
 
         if boundary.end_ms > boundary.start_ms {
             Self::required_worker_mut(workers, rank_id).mark_busy();
-            effects
-                .scheduled_completions
-                .push(ScheduledWorkerCompletion {
-                    at_ms: boundary.end_ms,
-                    payload,
-                });
+            effects.schedule_completion(boundary.end_ms, payload);
             return;
         }
 
@@ -776,6 +767,9 @@ where
                 start_ms: now_ms,
                 end_ms: group_end_ms,
             };
+            if group_end_ms > now_ms {
+                effects.prepare_scheduled_completion(group_end_ms, rank_ids.len());
+            }
 
             for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
                 let Some(executed) = executed else {
@@ -783,26 +777,24 @@ where
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
                         Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
-                        effects
-                            .scheduled_completions
-                            .push(ScheduledWorkerCompletion {
-                                at_ms: group_end_ms,
-                                payload: WorkerCompletionPayload {
-                                    stage: self.stage,
-                                    worker_idx: rank_id,
-                                    completed_requests: 0,
-                                    output_signals: Vec::new(),
-                                    lifecycle_events: Vec::new(),
-                                    engine_events: Observation::Batch::default(),
-                                    progress: EngineProgress::default(),
-                                    fpm: Some(ForwardPassSnapshot {
-                                        wall_time_secs: boundary.wall_time_secs(),
-                                        ..Default::default()
-                                    }),
-                                    accept_length_output_tokens: 0,
-                                    accept_length_decode_forwards: 0,
-                                },
-                            });
+                        effects.schedule_completion(
+                            group_end_ms,
+                            WorkerCompletionPayload {
+                                stage: self.stage,
+                                worker_idx: rank_id,
+                                completed_requests: 0,
+                                output_signals: Vec::new(),
+                                lifecycle_events: Vec::new(),
+                                engine_events: Observation::Batch::default(),
+                                progress: EngineProgress::default(),
+                                fpm: Some(ForwardPassSnapshot {
+                                    wall_time_secs: boundary.wall_time_secs(),
+                                    ..Default::default()
+                                }),
+                                accept_length_output_tokens: 0,
+                                accept_length_decode_forwards: 0,
+                            },
+                        );
                     }
                     continue;
                 };
@@ -982,11 +974,15 @@ mod tests {
         mut effects: EngineEffects<Events>,
     ) -> WorkerCompletionPayload<Events> {
         if let Some(payload) = effects.immediate_completions.pop() {
-            assert!(effects.scheduled_completions.is_empty());
+            assert!(effects.scheduled_completion.is_none());
             return payload;
         }
-        assert_eq!(effects.scheduled_completions.len(), 1);
-        effects.scheduled_completions.pop().unwrap().payload
+        let mut scheduled = effects
+            .scheduled_completion
+            .take()
+            .expect("one scheduled completion must be present");
+        assert_eq!(scheduled.payloads.len(), 1);
+        scheduled.payloads.pop().unwrap()
     }
 
     fn decode_engine_with_chunking(enable_chunked_prefill: bool) -> EngineComponent {
@@ -1072,15 +1068,22 @@ mod tests {
 
         let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
 
-        assert_eq!(effects.scheduled_completions.len(), 2);
+        let scheduled = effects.scheduled_completion.as_ref().unwrap();
+        assert_eq!(scheduled.payloads.len(), 2);
         assert!(
-            effects
-                .scheduled_completions
-                .iter()
-                .all(|completion| (completion.at_ms - 9.0).abs() < f64::EPSILON)
+            (scheduled.at_ms - 9.0).abs() < f64::EPSILON,
+            "batch must fire at the slowest-rank boundary"
         );
-        assert!(effects.scheduled_completions.iter().all(|completion| {
-            (completion.payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
+        assert_eq!(
+            scheduled
+                .payloads
+                .iter()
+                .map(|payload| payload.worker_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert!(scheduled.payloads.iter().all(|payload| {
+            (payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
         }));
         assert_eq!(collector.request_latencies(fast).unwrap().0, 9.0);
         assert_eq!(collector.request_latencies(slow).unwrap().0, 9.0);
@@ -1094,15 +1097,15 @@ mod tests {
         let mut collector = TraceCollector::default();
         collector.on_arrival(slow, 0.0, 8, 1);
 
-        let first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert_eq!(first_epoch.scheduled_completions.len(), 2);
+        let mut first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let first_scheduled = first_epoch.scheduled_completion.as_ref().unwrap();
+        assert_eq!(first_scheduled.payloads.len(), 2);
         assert!(engine.debug_snapshots().iter().all(|rank| rank.busy));
-        let idle_fpm = first_epoch
-            .scheduled_completions
+        let idle_fpm = first_scheduled
+            .payloads
             .iter()
-            .find(|completion| completion.payload.worker_idx == 1)
+            .find(|payload| payload.worker_idx == 1)
             .unwrap()
-            .payload
             .fpm
             .as_ref()
             .expect("idle DP rank must emit an empty FPM");
@@ -1121,17 +1124,13 @@ mod tests {
                 .is_empty()
         );
 
-        for completion in first_epoch.scheduled_completions {
-            engine.on_scheduled_completion(completion.payload).unwrap();
+        for payload in first_epoch.scheduled_completion.take().unwrap().payloads {
+            engine.on_scheduled_completion(payload).unwrap();
         }
         let second_epoch = engine.drive_ready(9.0, Some(&mut collector)).unwrap();
-        assert_eq!(second_epoch.scheduled_completions.len(), 2);
-        assert!(
-            second_epoch
-                .scheduled_completions
-                .iter()
-                .all(|completion| (completion.at_ms - 14.0).abs() < f64::EPSILON)
-        );
+        let second_scheduled = second_epoch.scheduled_completion.as_ref().unwrap();
+        assert_eq!(second_scheduled.payloads.len(), 2);
+        assert!((second_scheduled.at_ms - 14.0).abs() < f64::EPSILON);
         assert_eq!(collector.request_latencies(mid_epoch).unwrap().0, 10.0);
     }
 
@@ -1149,16 +1148,11 @@ mod tests {
             while engine.in_flight() > 0 {
                 let effects = engine.drive_ready(now_ms, Some(&mut collector)).unwrap();
                 assert!(effects.immediate_completions.is_empty());
-                assert_eq!(effects.scheduled_completions.len(), dp_size as usize);
-                now_ms = effects.scheduled_completions[0].at_ms;
-                assert!(
-                    effects
-                        .scheduled_completions
-                        .iter()
-                        .all(|completion| completion.at_ms == now_ms)
-                );
-                for completion in effects.scheduled_completions {
-                    engine.on_scheduled_completion(completion.payload).unwrap();
+                let scheduled = effects.scheduled_completion.unwrap();
+                assert_eq!(scheduled.payloads.len(), dp_size as usize);
+                now_ms = scheduled.at_ms;
+                for payload in scheduled.payloads {
+                    engine.on_scheduled_completion(payload).unwrap();
                 }
             }
             collector.request_latencies(uuid).unwrap()
@@ -1396,7 +1390,13 @@ mod tests {
             )
             .unwrap();
         let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert_eq!(effects.scheduled_completions.len(), 1);
+        assert_eq!(
+            effects
+                .scheduled_completion
+                .as_ref()
+                .map(|scheduled| scheduled.payloads.len()),
+            Some(1)
+        );
 
         let (_, newly_marked, _) = engine.apply_target_count(1);
         assert_eq!(newly_marked, vec![1]);
@@ -1456,7 +1456,7 @@ mod tests {
         let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(second.admissions.is_empty());
         assert_eq!(second.immediate_completions.len(), 1);
-        assert!(second.scheduled_completions.is_empty());
+        assert!(second.scheduled_completion.is_none());
         let second = take_only_completion(second);
         assert_eq!(second.fpm.as_ref().unwrap().num_prefill_requests, 1);
         assert_eq!(second.completed_requests, 0);
@@ -1570,7 +1570,10 @@ mod tests {
             .unwrap();
         let mut collector = TraceCollector::default();
         let mut pass = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert_eq!(pass.scheduled_completions.len(), 1);
+        assert_eq!(
+            pass.scheduled_completion.as_ref().unwrap().payloads.len(),
+            1
+        );
 
         let handoff_id = HandoffId::from(Uuid::from_u128(2));
         let effects = engine
@@ -1600,8 +1603,14 @@ mod tests {
         assert!(engine.active_worker_ids().is_empty());
         assert_eq!(engine.worker_count(), 1);
 
-        let completion = pass.scheduled_completions.pop().unwrap();
-        let payload = engine.on_scheduled_completion(completion.payload).unwrap();
+        let payload = pass
+            .scheduled_completion
+            .take()
+            .unwrap()
+            .payloads
+            .pop()
+            .unwrap();
+        let payload = engine.on_scheduled_completion(payload).unwrap();
         assert!(payload.lifecycle_events.iter().any(|event| matches!(
             event,
             SchedulerLifecycleEvent::DestinationReserved {
@@ -1668,15 +1677,17 @@ mod tests {
                 .any(|event| { event.storage_tier == StorageTier::Device })
         );
         assert_eq!(
-            seed.immediate_completions.len() + seed.scheduled_completions.len(),
+            seed.immediate_completions.len() + usize::from(seed.scheduled_completion.is_some()),
             1,
             "seed request should produce exactly one completion boundary"
         );
         let completion = seed.immediate_completions.pop().unwrap_or_else(|| {
-            seed.scheduled_completions
-                .pop()
+            seed.scheduled_completion
+                .take()
                 .expect("seed request completion must be present")
-                .payload
+                .payloads
+                .pop()
+                .expect("singleton completion batch must contain one payload")
         });
         // Model a reservation attempt at the t=0 boundary, before the GPU
         // compute interval becomes externally busy.

--- a/lib/mocker/src/replay/offline/components/mod.rs
+++ b/lib/mocker/src/replay/offline/components/mod.rs
@@ -18,6 +18,6 @@ pub(in crate::replay) use types::ReplayMode;
 pub use types::TrafficStats;
 pub(in crate::replay::offline) use types::{
     EngineEffects, EnginePassMode, ObservedCommandEffects, ObservedWorkerEvents,
-    ReplayEngineObservation, ScheduledWorkerCompletion, TrafficAccumulator,
+    ReplayEngineObservation, ScheduledWorkerCompletions, TrafficAccumulator,
 };
 pub(crate) use worker_core::ReplayWorkerCore;

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -126,31 +126,21 @@ pub(in crate::replay::offline) struct EngineEffects<Events: EngineEventBatch = (
 }
 
 impl<Events: EngineEventBatch> EngineEffects<Events> {
-    pub(in crate::replay::offline) fn prepare_scheduled_completion(
-        &mut self,
-        at_ms: f64,
-        capacity: usize,
-    ) {
-        assert!(
-            self.scheduled_completion.is_none(),
-            "offline replay engine effects already contain a scheduled completion"
-        );
-        self.scheduled_completion = Some(ScheduledWorkerCompletions {
-            at_ms,
-            payloads: Vec::with_capacity(capacity),
-        });
-    }
-
     pub(in crate::replay::offline) fn schedule_completion(
         &mut self,
         at_ms: f64,
         payload: WorkerCompletionPayload<Events>,
+        capacity_hint: usize,
     ) {
+        assert!(
+            capacity_hint > 0,
+            "scheduled completion capacity hint must be non-zero"
+        );
         let scheduled =
             self.scheduled_completion
                 .get_or_insert_with(|| ScheduledWorkerCompletions {
                     at_ms,
-                    payloads: Vec::with_capacity(1),
+                    payloads: Vec::with_capacity(capacity_hint),
                 });
         assert_eq!(
             scheduled.at_ms.to_bits(),

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -4,7 +4,7 @@
 use uuid::Uuid;
 
 use super::super::core::{EngineEventBatch, EngineProgress, NoEngineEvents};
-use super::super::runtime_utils::WorkerCompletionPayload;
+use super::super::events::WorkerCompletionPayload;
 use super::super::state::OfflineWorkerState;
 use crate::common::protocols::DirectRequest;
 use crate::loadgen::ReplayRequestPayload;
@@ -111,9 +111,9 @@ pub(in crate::replay) struct ObservedOffloadEffects<Events: EngineEventBatch> {
 }
 
 #[derive(Debug)]
-pub(in crate::replay::offline) struct ScheduledWorkerCompletion<Events: EngineEventBatch = ()> {
+pub(in crate::replay::offline) struct ScheduledWorkerCompletions<Events: EngineEventBatch = ()> {
     pub(in crate::replay::offline) at_ms: f64,
-    pub(in crate::replay::offline) payload: WorkerCompletionPayload<Events>,
+    pub(in crate::replay::offline) payloads: Vec<WorkerCompletionPayload<Events>>,
 }
 
 #[derive(Debug, Default)]
@@ -121,16 +121,50 @@ pub(in crate::replay::offline) struct EngineEffects<Events: EngineEventBatch = (
     pub(in crate::replay::offline) admissions: Vec<AdmissionEvent>,
     pub(in crate::replay::offline) pass_start_events: Events,
     pub(in crate::replay::offline) immediate_completions: Vec<WorkerCompletionPayload<Events>>,
-    pub(in crate::replay::offline) scheduled_completions: Vec<ScheduledWorkerCompletion<Events>>,
+    pub(in crate::replay::offline) scheduled_completion: Option<ScheduledWorkerCompletions<Events>>,
     pub(in crate::replay::offline) progress: EngineProgress,
 }
 
 impl<Events: EngineEventBatch> EngineEffects<Events> {
+    pub(in crate::replay::offline) fn prepare_scheduled_completion(
+        &mut self,
+        at_ms: f64,
+        capacity: usize,
+    ) {
+        assert!(
+            self.scheduled_completion.is_none(),
+            "offline replay engine effects already contain a scheduled completion"
+        );
+        self.scheduled_completion = Some(ScheduledWorkerCompletions {
+            at_ms,
+            payloads: Vec::with_capacity(capacity),
+        });
+    }
+
+    pub(in crate::replay::offline) fn schedule_completion(
+        &mut self,
+        at_ms: f64,
+        payload: WorkerCompletionPayload<Events>,
+    ) {
+        let scheduled =
+            self.scheduled_completion
+                .get_or_insert_with(|| ScheduledWorkerCompletions {
+                    at_ms,
+                    payloads: Vec::with_capacity(1),
+                });
+        assert_eq!(
+            scheduled.at_ms.to_bits(),
+            at_ms.to_bits(),
+            "offline replay engine effects contain mismatched completion timestamps"
+        );
+        scheduled.payloads.push(payload);
+    }
+
     pub(in crate::replay::offline) fn is_empty(&self) -> bool {
         self.admissions.is_empty()
             && self.pass_start_events.is_empty()
             && self.immediate_completions.is_empty()
-            && self.scheduled_completions.is_empty()
+            && self.scheduled_completion.is_none()
             && !self.progress.made_progress
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -11,24 +11,23 @@ pub(super) use super::components::ReplayMode;
 use super::components::TrafficStats;
 use super::components::{
     AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, NoReplayMetadata,
-    ReplayAdmissionMetadata, ReplayEngineObservation, ScheduledWorkerCompletion,
-    TrafficAccumulator,
+    ReplayAdmissionMetadata, ReplayEngineObservation, TrafficAccumulator,
 };
 use super::core::round_robin::PoolRoundRobinPlacement;
 use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::extensions::kv_router::{
     DisaggRuntime, ReplayKvRouterConfig, derive_decode_router_config, derive_prefill_router_config,
 };
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_scaling_tick, pop_ready_transfer_complete,
-    pop_ready_worker_completion, pop_ready_worker_ready, push_scaling_tick, push_transfer_complete,
-    push_worker_completion, push_worker_ready,
+    ReadyWorkerCompletions, next_timestamp as choose_next_timestamp, pop_ready_scaling_tick,
+    pop_ready_transfer_complete, pop_ready_worker_completions, pop_ready_worker_ready,
+    push_scaling_tick, push_transfer_complete, push_worker_completions, push_worker_ready,
 };
 use super::scaling::{LatestFpmBuffer, ReplayScalingPolicy, ReplayScalingSnapshot};
 #[cfg(test)]
@@ -1828,49 +1827,65 @@ where
     /// Drain all worker-completion events scheduled for the current logical timestamp.
     fn apply_worker_completions(&mut self) -> Result<bool> {
         let mut changed = false;
-        while let Some(payload) = pop_ready_worker_completion(&mut self.events, self.now_ms) {
-            match payload.stage {
-                SimulationWorkerStage::Prefill => {
-                    let payload = self.prefill_engine.on_scheduled_completion(payload)?;
-                    self.wake_deferred_actions(SimulationWorkerStage::Prefill, payload.worker_idx);
-                    if self.collect_fpm
-                        && let Some(fpm) = payload.fpm
-                    {
-                        self.prefill_fpm_buffer
-                            .insert(payload.worker_idx, fpm, self.now_ms);
-                    }
-                    self.process_prefill_pass(
-                        payload.worker_idx,
-                        payload.completed_requests,
-                        payload.output_signals,
-                        payload.lifecycle_events,
-                        payload.engine_events,
-                    )?;
+        while let Some(completions) = pop_ready_worker_completions(&mut self.events, self.now_ms) {
+            match completions {
+                ReadyWorkerCompletions::Single(payload) => {
+                    self.apply_worker_completion(payload)?;
                 }
-                SimulationWorkerStage::Decode => {
-                    let payload = self.decode_engine.on_scheduled_completion(payload)?;
-                    self.wake_deferred_actions(SimulationWorkerStage::Decode, payload.worker_idx);
-                    if self.collect_fpm
-                        && let Some(fpm) = payload.fpm
-                    {
-                        self.decode_fpm_buffer
-                            .insert(payload.worker_idx, fpm, self.now_ms);
+                ReadyWorkerCompletions::Batch(payloads) => {
+                    for payload in payloads {
+                        self.apply_worker_completion(payload)?;
                     }
-                    self.process_decode_pass(
-                        payload.output_signals,
-                        payload.lifecycle_events,
-                        payload.engine_events,
-                        payload.accept_length_output_tokens,
-                        payload.accept_length_decode_forwards,
-                    )?;
-                }
-                SimulationWorkerStage::Aggregated => {
-                    bail!("offline disagg replay received an aggregated completion event")
                 }
             }
             changed = true;
         }
         Ok(changed)
+    }
+
+    fn apply_worker_completion(
+        &mut self,
+        payload: WorkerCompletionPayload<Observation::Batch>,
+    ) -> Result<()> {
+        match payload.stage {
+            SimulationWorkerStage::Prefill => {
+                let payload = self.prefill_engine.on_scheduled_completion(payload)?;
+                self.wake_deferred_actions(SimulationWorkerStage::Prefill, payload.worker_idx);
+                if self.collect_fpm
+                    && let Some(fpm) = payload.fpm
+                {
+                    self.prefill_fpm_buffer
+                        .insert(payload.worker_idx, fpm, self.now_ms);
+                }
+                self.process_prefill_pass(
+                    payload.worker_idx,
+                    payload.completed_requests,
+                    payload.output_signals,
+                    payload.lifecycle_events,
+                    payload.engine_events,
+                )
+            }
+            SimulationWorkerStage::Decode => {
+                let payload = self.decode_engine.on_scheduled_completion(payload)?;
+                self.wake_deferred_actions(SimulationWorkerStage::Decode, payload.worker_idx);
+                if self.collect_fpm
+                    && let Some(fpm) = payload.fpm
+                {
+                    self.decode_fpm_buffer
+                        .insert(payload.worker_idx, fpm, self.now_ms);
+                }
+                self.process_decode_pass(
+                    payload.output_signals,
+                    payload.lifecycle_events,
+                    payload.engine_events,
+                    payload.accept_length_output_tokens,
+                    payload.accept_length_decode_forwards,
+                )
+            }
+            SimulationWorkerStage::Aggregated => {
+                bail!("offline disagg replay received an aggregated completion event")
+            }
+        }
     }
 
     /// Drain transfer completions scheduled for the current logical timestamp.
@@ -1970,8 +1985,8 @@ where
                 payload.engine_events,
             )?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }
@@ -2034,8 +2049,8 @@ where
                 payload.accept_length_decode_forwards,
             )?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -1970,20 +1970,7 @@ where
         self.record_prefill_admissions(effects.admissions);
         self.apply_prefill_observations(effects.pass_start_events)?;
         for payload in effects.immediate_completions {
-            let payload = self.prefill_engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.prefill_fpm_buffer
-                    .insert(payload.worker_idx, fpm, self.now_ms);
-            }
-            self.process_prefill_pass(
-                payload.worker_idx,
-                payload.completed_requests,
-                payload.output_signals,
-                payload.lifecycle_events,
-                payload.engine_events,
-            )?;
+            self.apply_worker_completion(payload)?;
         }
         if let Some(scheduled) = effects.scheduled_completion {
             push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
@@ -2034,20 +2021,7 @@ where
     ) -> Result<()> {
         self.record_decode_admissions(effects.admissions)?;
         for payload in effects.immediate_completions {
-            let payload = self.decode_engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.decode_fpm_buffer
-                    .insert(payload.worker_idx, fpm, self.now_ms);
-            }
-            self.process_decode_pass(
-                payload.output_signals,
-                payload.lifecycle_events,
-                payload.engine_events,
-                payload.accept_length_output_tokens,
-                payload.accept_length_decode_forwards,
-            )?;
+            self.apply_worker_completion(payload)?;
         }
         if let Some(scheduled) = effects.scheduled_completion {
             push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -3,9 +3,9 @@
 
 use std::cmp::Ordering;
 
-use super::core::EngineEventBatch;
+use super::core::{EngineEventBatch, EngineProgress};
 use crate::common::handoff::HandoffId;
-use crate::common::protocols::OutputSignal;
+use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
 use crate::scheduler::SchedulerLifecycleEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,6 +13,20 @@ pub(crate) enum SimulationWorkerStage {
     Aggregated,
     Prefill,
     Decode,
+}
+
+#[derive(Debug)]
+pub(crate) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
+    pub stage: SimulationWorkerStage,
+    pub worker_idx: usize,
+    pub completed_requests: usize,
+    pub output_signals: Vec<OutputSignal>,
+    pub lifecycle_events: Vec<SchedulerLifecycleEvent>,
+    pub engine_events: Events,
+    pub progress: EngineProgress,
+    pub fpm: Option<ForwardPassSnapshot>,
+    pub accept_length_output_tokens: usize,
+    pub accept_length_decode_forwards: usize,
 }
 
 #[derive(Debug)]
@@ -29,6 +43,9 @@ pub(crate) enum SimulationEventKind<Events: EngineEventBatch = ()> {
         fpm: Option<Box<crate::common::protocols::ForwardPassSnapshot>>,
         accept_length_output_tokens: usize,
         accept_length_decode_forwards: usize,
+    },
+    WorkerCompletionBatch {
+        payloads: Box<[WorkerCompletionPayload<Events>]>,
     },
     TransferComplete {
         handoff_id: HandoffId,

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -9,28 +9,28 @@ use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
 use crate::scheduler::SchedulerLifecycleEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum SimulationWorkerStage {
+pub(in crate::replay::offline) enum SimulationWorkerStage {
     Aggregated,
     Prefill,
     Decode,
 }
 
 #[derive(Debug)]
-pub(crate) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
-    pub stage: SimulationWorkerStage,
-    pub worker_idx: usize,
-    pub completed_requests: usize,
-    pub output_signals: Vec<OutputSignal>,
-    pub lifecycle_events: Vec<SchedulerLifecycleEvent>,
-    pub engine_events: Events,
-    pub progress: EngineProgress,
-    pub fpm: Option<ForwardPassSnapshot>,
-    pub accept_length_output_tokens: usize,
-    pub accept_length_decode_forwards: usize,
+pub(in crate::replay::offline) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
+    pub(in crate::replay::offline) stage: SimulationWorkerStage,
+    pub(in crate::replay::offline) worker_idx: usize,
+    pub(in crate::replay::offline) completed_requests: usize,
+    pub(in crate::replay::offline) output_signals: Vec<OutputSignal>,
+    pub(in crate::replay::offline) lifecycle_events: Vec<SchedulerLifecycleEvent>,
+    pub(in crate::replay::offline) engine_events: Events,
+    pub(in crate::replay::offline) progress: EngineProgress,
+    pub(in crate::replay::offline) fpm: Option<ForwardPassSnapshot>,
+    pub(in crate::replay::offline) accept_length_output_tokens: usize,
+    pub(in crate::replay::offline) accept_length_decode_forwards: usize,
 }
 
 #[derive(Debug)]
-pub(crate) enum SimulationEventKind<Events: EngineEventBatch = ()> {
+pub(in crate::replay::offline) enum SimulationEventKind<Events: EngineEventBatch = ()> {
     WorkerCompletion {
         stage: SimulationWorkerStage,
         worker_idx: usize,
@@ -75,10 +75,10 @@ impl<Events: EngineEventBatch> SimulationEventKind<Events> {
 }
 
 #[derive(Debug)]
-pub(crate) struct SimulationEvent<Events: EngineEventBatch = ()> {
-    pub(crate) at_ms: f64,
-    pub(crate) seq_no: u64,
-    pub(crate) kind: SimulationEventKind<Events>,
+pub(in crate::replay::offline) struct SimulationEvent<Events: EngineEventBatch = ()> {
+    pub(in crate::replay::offline) at_ms: f64,
+    pub(in crate::replay::offline) seq_no: u64,
+    pub(in crate::replay::offline) kind: SimulationEventKind<Events>,
 }
 
 impl<Events: EngineEventBatch> PartialEq for SimulationEvent<Events> {

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -107,6 +107,8 @@ pub(super) fn push_worker_completions<Events: EngineEventBatch>(
         seq_no: *next_event_seq,
         kind,
     });
+    // Preserve the sequence numbers that later events would have received
+    // before these payloads were represented by one heap entry.
     *next_event_seq = next_event_seq
         .checked_add(payload_count)
         .expect("offline replay event sequence overflow");

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -5,26 +5,23 @@ use std::collections::BinaryHeap;
 #[cfg(test)]
 use std::collections::VecDeque;
 
+use super::components::ScheduledWorkerCompletions;
 use super::core::{EngineEventBatch, EngineProgress};
-use super::events::{SimulationEvent, SimulationEventKind, SimulationWorkerStage};
+use super::events::{
+    SimulationEvent, SimulationEventKind, SimulationWorkerStage, WorkerCompletionPayload,
+};
 use crate::common::handoff::HandoffId;
 #[cfg(test)]
 use crate::common::protocols::DirectRequest;
-use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
-use crate::scheduler::SchedulerLifecycleEvent;
+#[cfg(test)]
+use crate::common::protocols::OutputSignal;
 
-#[derive(Debug)]
-pub(super) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
-    pub stage: SimulationWorkerStage,
-    pub worker_idx: usize,
-    pub completed_requests: usize,
-    pub output_signals: Vec<OutputSignal>,
-    pub lifecycle_events: Vec<SchedulerLifecycleEvent>,
-    pub engine_events: Events,
-    pub progress: EngineProgress,
-    pub fpm: Option<ForwardPassSnapshot>,
-    pub accept_length_output_tokens: usize,
-    pub accept_length_decode_forwards: usize,
+// Keep the large singleton inline: boxing it would add an allocation to every
+// DP1 and disaggregated completion solely to shrink this transient pop result.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum ReadyWorkerCompletions<Events: EngineEventBatch = ()> {
+    Single(WorkerCompletionPayload<Events>),
+    Batch(Box<[WorkerCompletionPayload<Events>]>),
 }
 
 pub(super) fn next_timestamp(
@@ -68,16 +65,26 @@ pub(super) fn pop_next_concurrency_ready(
     Some((request, now_ms))
 }
 
-pub(super) fn push_worker_completion<Events: EngineEventBatch>(
+pub(super) fn push_worker_completions<Events: EngineEventBatch>(
     events: &mut BinaryHeap<SimulationEvent<Events>>,
     next_event_seq: &mut u64,
-    at_ms: f64,
-    payload: WorkerCompletionPayload<Events>,
+    scheduled: ScheduledWorkerCompletions<Events>,
 ) {
-    events.push(SimulationEvent {
+    let ScheduledWorkerCompletions {
         at_ms,
-        seq_no: *next_event_seq,
-        kind: SimulationEventKind::WorkerCompletion {
+        mut payloads,
+    } = scheduled;
+    let payload_count =
+        u64::try_from(payloads.len()).expect("completion payload count must fit in u64");
+    assert!(
+        payload_count > 0,
+        "scheduled completion batch must not be empty"
+    );
+    let kind = if payloads.len() == 1 {
+        let payload = payloads
+            .pop()
+            .expect("singleton scheduled completion must contain one payload");
+        SimulationEventKind::WorkerCompletion {
             stage: payload.stage,
             worker_idx: payload.worker_idx,
             completed_requests: payload.completed_requests,
@@ -89,36 +96,39 @@ pub(super) fn push_worker_completion<Events: EngineEventBatch>(
             fpm: payload.fpm.map(Box::new),
             accept_length_output_tokens: payload.accept_length_output_tokens,
             accept_length_decode_forwards: payload.accept_length_decode_forwards,
-        },
+        }
+    } else {
+        SimulationEventKind::WorkerCompletionBatch {
+            payloads: payloads.into_boxed_slice(),
+        }
+    };
+    events.push(SimulationEvent {
+        at_ms,
+        seq_no: *next_event_seq,
+        kind,
     });
-    *next_event_seq += 1;
+    *next_event_seq = next_event_seq
+        .checked_add(payload_count)
+        .expect("offline replay event sequence overflow");
 }
 
-pub(super) fn pop_ready_worker_completion<Events: EngineEventBatch>(
+pub(super) fn pop_ready_worker_completions<Events: EngineEventBatch>(
     events: &mut BinaryHeap<SimulationEvent<Events>>,
     now_ms: f64,
-) -> Option<WorkerCompletionPayload<Events>> {
+) -> Option<ReadyWorkerCompletions<Events>> {
     let event = events.peek()?;
     if event.at_ms != now_ms {
         return None;
     }
-    let SimulationEventKind::WorkerCompletion { .. } = &event.kind else {
+    if !matches!(
+        event.kind,
+        SimulationEventKind::WorkerCompletion { .. }
+            | SimulationEventKind::WorkerCompletionBatch { .. }
+    ) {
         return None;
-    };
+    }
     let event = events.pop().expect("event must exist after peek");
-    let (
-        stage,
-        worker_idx,
-        completed_requests,
-        output_signals,
-        lifecycle_events,
-        engine_events,
-        made_progress,
-        had_raw_observations,
-        fpm,
-        accept_length_output_tokens,
-        accept_length_decode_forwards,
-    ) = match event.kind {
+    match event.kind {
         SimulationEventKind::WorkerCompletion {
             stage,
             worker_idx,
@@ -131,40 +141,30 @@ pub(super) fn pop_ready_worker_completion<Events: EngineEventBatch>(
             fpm,
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        } => (
+        } => Some(ReadyWorkerCompletions::Single(WorkerCompletionPayload {
             stage,
             worker_idx,
             completed_requests,
             output_signals,
             lifecycle_events,
             engine_events,
-            made_progress,
-            had_raw_observations,
-            fpm.map(|fpm| *fpm),
+            progress: EngineProgress {
+                made_progress,
+                had_raw_observations,
+            },
+            fpm: fpm.map(|fpm| *fpm),
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        ),
+        })),
+        SimulationEventKind::WorkerCompletionBatch { payloads } => {
+            Some(ReadyWorkerCompletions::Batch(payloads))
+        }
         SimulationEventKind::TransferComplete { .. }
         | SimulationEventKind::WorkerReady { .. }
         | SimulationEventKind::ScalingTick => {
             unreachable!("peeked worker completion event must match popped event")
         }
-    };
-    Some(WorkerCompletionPayload {
-        stage,
-        worker_idx,
-        completed_requests,
-        output_signals,
-        lifecycle_events,
-        engine_events,
-        progress: EngineProgress {
-            made_progress,
-            had_raw_observations,
-        },
-        fpm,
-        accept_length_output_tokens,
-        accept_length_decode_forwards,
-    })
+    }
 }
 
 pub(super) fn push_transfer_complete<Events: EngineEventBatch>(
@@ -282,6 +282,27 @@ mod tests {
         }
     }
 
+    fn completion_payload(worker_idx: usize, completed_requests: usize) -> WorkerCompletionPayload {
+        WorkerCompletionPayload {
+            stage: SimulationWorkerStage::Aggregated,
+            worker_idx,
+            completed_requests,
+            output_signals: vec![OutputSignal {
+                uuid: Uuid::from_u128(worker_idx as u128),
+                token_id: None,
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            }],
+            lifecycle_events: Vec::new(),
+            engine_events: (),
+            progress: EngineProgress::default(),
+            fpm: None,
+            accept_length_output_tokens: 1,
+            accept_length_decode_forwards: 1,
+        }
+    }
+
     #[test]
     fn test_next_timestamp_matches_current_choice_logic() {
         assert_eq!(next_timestamp(Some(1.0), Some(2.0)), Some(1.0));
@@ -324,67 +345,50 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_completion_helpers_preserve_same_time_sequence_ordering() {
+    fn test_worker_completion_batch_preserves_payload_and_event_ordering() {
         let mut events = BinaryHeap::new();
         let mut next_event_seq = 0;
 
-        push_worker_completion(
+        push_worker_completions(
+            &mut events,
+            &mut next_event_seq,
+            ScheduledWorkerCompletions {
+                at_ms: 10.0,
+                payloads: vec![completion_payload(7, 1), completion_payload(8, 2)],
+            },
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(next_event_seq, 2);
+
+        push_worker_ready(
             &mut events,
             &mut next_event_seq,
             10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 7,
-                completed_requests: 1,
-                output_signals: vec![OutputSignal {
-                    uuid: Uuid::from_u128(7),
-                    token_id: None,
-                    completed: true,
-                    rejected: false,
-                    handoff_delay_ms: None,
-                }],
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 1,
-                accept_length_decode_forwards: 1,
-            },
+            SimulationWorkerStage::Aggregated,
+            5,
         );
-        push_worker_completion(
-            &mut events,
-            &mut next_event_seq,
-            10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 8,
-                completed_requests: 2,
-                output_signals: vec![OutputSignal {
-                    uuid: Uuid::from_u128(8),
-                    token_id: None,
-                    completed: false,
-                    rejected: false,
-                    handoff_delay_ms: None,
-                }],
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 1,
-                accept_length_decode_forwards: 1,
-            },
+        assert_eq!(next_event_seq, 3);
+        push_scaling_tick(&mut events, &mut next_event_seq, 10.0);
+        assert_eq!(next_event_seq, 4);
+
+        assert!(pop_ready_worker_completions(&mut events, 9.0).is_none());
+        let ReadyWorkerCompletions::Batch(payloads) =
+            pop_ready_worker_completions(&mut events, 10.0).unwrap()
+        else {
+            panic!("DP2 completions must use one batched heap event");
+        };
+        assert_eq!(
+            payloads
+                .iter()
+                .map(|payload| (payload.worker_idx, payload.completed_requests))
+                .collect::<Vec<_>>(),
+            vec![(7, 1), (8, 2)]
         );
-
-        assert!(pop_ready_worker_completion(&mut events, 9.0).is_none());
-
-        let first = pop_ready_worker_completion(&mut events, 10.0).unwrap();
-        let second = pop_ready_worker_completion(&mut events, 10.0).unwrap();
-        assert_eq!(first.stage, SimulationWorkerStage::Aggregated);
-        assert_eq!(first.worker_idx, 7);
-        assert_eq!(first.completed_requests, 1);
-        assert_eq!(second.stage, SimulationWorkerStage::Aggregated);
-        assert_eq!(second.worker_idx, 8);
-        assert_eq!(second.completed_requests, 2);
+        assert_eq!(
+            pop_ready_worker_ready(&mut events, 10.0),
+            Some((SimulationWorkerStage::Aggregated, 5))
+        );
+        assert!(pop_ready_scaling_tick(&mut events, 10.0));
         assert!(events.is_empty());
     }
 
@@ -423,8 +427,8 @@ mod tests {
             1,
         );
 
-        // pop_ready_worker_completion must return None (wrong event kind).
-        assert!(pop_ready_worker_completion(&mut events, 10.0).is_none());
+        // pop_ready_worker_completions must return None (wrong event kind).
+        assert!(pop_ready_worker_completions(&mut events, 10.0).is_none());
         // The event should still be in the heap.
         assert_eq!(events.len(), 1);
         // pop_ready_worker_ready should succeed.
@@ -436,21 +440,12 @@ mod tests {
         let mut events = BinaryHeap::new();
         let mut next_event_seq = 0;
 
-        push_worker_completion(
+        push_worker_completions(
             &mut events,
             &mut next_event_seq,
-            10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 0,
-                completed_requests: 1,
-                output_signals: Vec::new(),
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 0,
-                accept_length_decode_forwards: 0,
+            ScheduledWorkerCompletions {
+                at_ms: 10.0,
+                payloads: vec![completion_payload(0, 1)],
             },
         );
         push_worker_ready(
@@ -462,11 +457,15 @@ mod tests {
         );
 
         // The completion was pushed first (lower seq_no) so it pops first.
-        let completion = pop_ready_worker_completion(&mut events, 10.0).unwrap();
+        let ReadyWorkerCompletions::Single(completion) =
+            pop_ready_worker_completions(&mut events, 10.0).unwrap()
+        else {
+            panic!("singleton completion must retain its existing representation");
+        };
         assert_eq!(completion.worker_idx, 0);
 
         // Now the ready event is at the front.
-        assert!(pop_ready_worker_completion(&mut events, 10.0).is_none());
+        assert!(pop_ready_worker_completions(&mut events, 10.0).is_none());
         let (stage, worker_id) = pop_ready_worker_ready(&mut events, 10.0).unwrap();
         assert_eq!(stage, SimulationWorkerStage::Aggregated);
         assert_eq!(worker_id, 5);


### PR DESCRIPTION
## Overview

This PR reduces offline-replay coordinator, cache-index, and completion-event
overhead without changing public APIs, configuration, replay formats, admission,
scaling, or KV-event formats.

#12329 has merged; this branch is based on `main`.

## Summary

- maintain aggregate offline worker in-flight ownership so coordinator checks are
  O(1), with debug recomputation only at mutation boundaries
- replace SGLang's hash-set-wide oldest-leaf scan with an ordered
  `(last_access_time, NodeId)` evictable-leaf index
- skip ordered-index searches for SGLang nodes that cannot be unlocked leaves
- execute and lower singleton offline worker groups without attention-DP staging
  while preserving token-time alignment
- store native vLLM's primary cached-copy ID directly, with duplicate copies in a
  rare overflow queue
- batch each positive-duration attention-DP epoch into one ordered completion
  heap event while preserving rank-level processing

LRU behavior is preserved except that equal SGLang eviction timestamps now use
`NodeId` as a deterministic tie-breaker instead of hash-set iteration order.

## Details

- `EngineComponent::in_flight()` returns the tracked aggregate directly; mutation
  wrappers retain debug validation against the full worker sum.
- SGLang leaf insertion, removal, touch, split, promotion, and partial eviction
  update one ordered evictable-leaf index. `split_node` keeps the original child
  as the suffix node, including its timestamp/index identity.
- Singleton execution avoids grouped staging but shares the grouped effects and
  refresh/defer tail.
- Scheduled completion batches allocate lazily on the first payload using a
  caller-provided capacity hint. Sequence allocation still advances by payload
  count so later events retain their pre-batching sequence identities.
- Disaggregated immediate completions use the same worker-accounting, FPM,
  lifecycle, and deferred-action path as scheduled completions.
- Native vLLM lookup keeps the common primary copy inline and uses the duplicate
  queue only when a hash has multiple physical copies.

## Where should the reviewer start?

Start with:

1. `lib/mocker/src/replay/offline/components/engine.rs` for aggregate ownership
   and singleton/grouped execution.
2. `lib/mocker/src/cache/radix_cache.rs` for the ordered SGLang eviction index.
3. `lib/mocker/src/cache/vllm_block_pool.rs` for the compact native vLLM copy
   index.
4. `lib/mocker/src/replay/offline/events.rs` and
   `lib/mocker/src/replay/offline/runtime_utils.rs` for attention-DP completion
   batching.

## Related Issues

No related issue.

## Exact-head 128/128 Results

Frozen ordinary-release binaries were built with
`RUSTFLAGS="-C target-cpu=x86-64-v3"` from:

- P0 `97f38efdfc`: rebased state before the later singleton, cache-index, review,
  and attention-DP commits
- pre-fix `61b7fb4034`: prior PR head before the latest SGLang review fix
- final `f4c80b5986`: current PR head including all review fixes

AgentX 128 sessions; 128 workers; KV routing/events; native G1; 16-token engine
blocks/pages; 64-token trace blocks; engine speedup 20; seed 42; CPU 0. Runs were
sequential in final-vLLM, final-SGLang, pre-fix-SGLang, P0-vLLM, P0-SGLang
order, with no warm-ups. These are one-point measurements, not statistical
estimates.

| Backend | P0 processed tok/s | Final processed tok/s | Gain | P0 wall ms | Final wall ms | Wall reduction |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| vLLM | 128,714,377 | 134,904,746 | +4.81% | 36,453.293 | 34,780.562 | 4.59% |
| SGLang | 161,273,456 | 176,451,658 | +9.41% | 29,093.833 | 26,591.209 | 8.60% |

Normalized reports are exactly equal after removing only `wall_time_ms`,
`processed_tokens_per_s`, and `processed_output_tokens_per_s`. Every run
completed all 38,114 requests and processed 4,692,062,939 tokens. Prefix-cache
reuse was identical within each backend: 97.369893% for vLLM and 97.354061% for
SGLang. CPU-0 preflight was clean for every cell (98.02-100% idle).

The isolated SGLang review fix improved processed-token throughput from
176,236,918 to 176,451,658 tok/s (+0.12%) and reduced wall time from
26,623.610 to 26,591.209 ms (0.12%). The normalized reports were exactly equal.

The two optimizations already present in P0 retain their earlier isolated
SGLang measurements: +4.98% for aggregate in-flight accounting and +2.82% for
ordered leaves. Those historical one-point deltas are not compounded with the
P0-to-final results above.

The untracked harness preserves commit, binary/config/trace hashes, build IDs,
CPU preflight, environment capture, run order, and raw reports.

## Attention-DP Speedup

Exact `99e975ee98` baseline versus the attention-DP completion batching commit,
using ordinary release builds and the AgentX setup with 32 logical workers,
DP4, 128 ranks and sessions, native G1, KV routing/events, block size 16,
trace block size 64, speedup 20, seed 42, and CPU 0.

One matched pair was collected per backend with no warm-ups:
vLLM baseline then candidate, followed by SGLang candidate then baseline.
Every CPU-0 preflight reported 100% idle.

| Backend | Baseline processed tok/s | Candidate processed tok/s | Gain |
| --- | ---: | ---: | ---: |
| vLLM | 97,292,732 | 115,701,733 | +18.92% |
| SGLang | 112,896,058 | 144,153,017 | +27.69% |

Normalized reports are byte-identical after removing wall-clock time and its
derived throughput fields. Each run completed 38,114 requests and processed
4,692,062,939 tokens.

One no-warm-up candidate profile per backend recorded zero lost samples.
Against the existing pre-change DP4 structural profiles, completion push/pop
helper samples fell 82-96%, heap push samples fell 72-78%, and aggregate heap
pop samples fell 60-70%. `on_scheduled_completion`, token-time alignment, and
KV-event capture remain visible as expected.

## Validation

### Full correctness parity

**PASS.** The full correctness-parity skill compared the exact PR merge-base
`677f92cc38` with head `f4c80b5986` using identical temporary lifecycle
instrumentation and two independent processes per revision across SGLang and
vLLM aggregate/disaggregated rows (16 canonical reports total).

Every report completed all 5,000 requests. Results were deterministic within
each revision and byte-identical across revisions after excluding only wall
time and derived throughput. Coverage included KV-overlap-sensitive requests,
immediate and queued admission, 5,000 handoffs in each disaggregated row,
vLLM preemptions, and balanced G1→G2/G2→G1 reservation/completion lifecycles.
The Mooncake corpus SHA-256 was
`3892ae19ae480b643155f0c6b9d798591cbe2e73bec6a0fa5ae3d3bc0332fb8a`.

- `cargo test -p dynamo-mocker cache::radix_cache` (15 passed)
- `cargo test -p dynamo-mocker cache::vllm_block_pool` (12 passed)
- `cargo test -p dynamo-mocker replay::offline` (180 passed)
- `cargo test -p dynamo-mocker` (693 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline`
  (183 passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact normalized 128/128 report parity for both backends
- every commit retains a DCO signoff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added batched worker-completion events for offline replay.
  * Preserved completion ordering and metadata across multi-worker simulations.
  * Improved cache eviction behavior with consistent least-recently-used ordering.
  * Improved handling of duplicate physical cache copies during lookup, reservation, and eviction.

* **Bug Fixes**
  * Fixed cache index consistency after partial eviction, node promotion, and unlock operations.

* **Documentation**
  * Updated offline replay documentation for batched completion events and current module responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
