### PR TITLE
docs(skill): clarify KV replay parity protocol [DYN-3850]

### DIFF
--- a/.agents/skills/dynamo-kv-replay-parity/SKILL.md
+++ b/.agents/skills/dynamo-kv-replay-parity/SKILL.md
@@ -150,6 +150,20 @@ or concurrency minimally and identically for baseline and candidate within the r
 family, and back off rather than accepting a preemption flood. Never tune the revisions
 separately.
 
+### Start from qualified internal-polynomial seeds
+
+For the canonical 5,000-row Mooncake window with the internal polynomial mocker, read
+[internal-polynomial golden points](references/internal-polynomial-golden-points.md)
+before searching for capacity edges. Treat those configurations and observed counters as
+suggested starting points, not universal constants or substitutes for qualification on the
+pinned baseline. Requalify one frozen configuration identically on both revisions.
+
+Use the reference's expected preemption, retraction, queue, reuse, worker, and handoff
+signals as drift detectors. For KVBM rows, also require deterministic nonzero G1-to-G2 and
+G2-to-G1 activity. Matching lifecycle counts do not waive an unstable canonical digest;
+stop correctness and performance work for that row until both internal determinism and
+cross-revision parity are established.
+
 ## Stage 4: Run byte parity
 
 Run the 5,000-request corpus for this authoritative matrix:

--- a/.agents/skills/dynamo-kv-replay-parity/SKILL.md
+++ b/.agents/skills/dynamo-kv-replay-parity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dynamo-kv-replay-parity
-description: Runs deterministic byte-parity and paired performance campaigns for Dynamo offline KV-aware replay across aggregated and disaggregated vLLM and SGLang configurations, including forced preemption and KVBM offload lifecycles. It is used when validating replay refactors, routing changes, scheduler-event changes, or performance-sensitive offline simulation changes against a baseline revision.
+description: Runs deterministic byte-parity and paired performance campaigns for Dynamo offline KV-aware replay across native vLLM and SGLang configurations plus supported vLLM KVBM offload paths, including forced preemption and offload lifecycles. It is used when validating replay refactors, routing changes, scheduler-event changes, or performance-sensitive offline simulation changes against a baseline revision.
 license: Apache-2.0
 metadata:
   author: NVIDIA
@@ -29,10 +29,11 @@ Resolve and record before running anything:
 
 - immutable baseline and candidate commit SHAs;
 - Rust toolchain, build profile, flags, and host characteristics;
-- exact Cargo features from the relevant manifests;
+- each artifact's exact Cargo features from the relevant manifests;
 - Mooncake trace path, SHA-256 checksum, and deterministic slice rule;
 - engine, topology, concurrency, worker counts, block sizes, and KVBM capacities;
-- the report fields excluded from canonical comparison.
+- the canonical-report exclusion allowlist; and
+- the performance run-order seed, CPU placement, timing scope, and invalidation rules.
 
 Use the project root `.venv/bin/python` for Python analysis and `uv pip` for any approved
 installation. Do not compare against moving branches or reuse a binary after changing its
@@ -46,11 +47,54 @@ can differ between `dynamo-mocker` and `dynamo-bench`.
 2. Create isolated checkouts for both revisions using the same host and toolchain.
 3. Apply any temporary determinism correction identically to both revisions. Keep it out
    of the measured semantic delta and record its patch checksum.
-4. Build separate release binaries, copy them to a temporary campaign directory, and
-   record binary plus `.text` sizes.
-5. Return each checkout to its original branch after extracting the binary.
+4. For the current `dynamo-bench` harness on Linux, build one feature-superset release
+   artifact per revision with exactly `replay-bench,mocker-kvbm-offload` and no default
+   features. `--canonical-reports-jsonl` requires `replay-bench`, which also selects the
+   seeded router. Compiled KVBM support attaches an offload engine only when runtime
+   arguments provide a positive `--num-g2-blocks` and `--kv-bytes-per-token`; omit
+   `--num-g2-blocks` for native rows.
+5. Reuse that artifact across native and KVBM correctness and performance rows. Do not
+   build separate native, KVBM, or production-routing artifacts. If the named manifest
+   features or runtime opt-in contract no longer exist, stop and report that this protocol
+   needs updating rather than guessing a replacement matrix.
+6. Copy the artifacts to a temporary campaign directory. Record exact features, binary
+   SHA-256, binary size, and `.text` size.
+7. Return each checkout to its original branch after extracting the binaries.
 
 Never build while collecting performance samples.
+
+## Campaign concurrency
+
+Treat one engine/topology/frozen-configuration comparison row as the unit of node
+placement. When scheduler capacity permits, allocate multiple nodes and assign independent
+rows to them. The nodes do not need to be homogeneous because no individual comparison
+crosses nodes. Keep the baseline, candidate, all determinism repetitions, and lifecycle
+evidence for one row on the same node. Use the same prebuilt revision artifacts and inputs
+throughout the campaign, and record the node characteristics and CPU placement for every
+row.
+
+Native replay is normally single-core: pin each native process to one physical core after
+confirming that assumption during preflight. KVBM replay also owns a one-worker Tokio
+runtime for background pipeline and session tasks. Pin each KVBM process to a fixed,
+disjoint CPU set containing at least two physical cores for the main replay thread and the
+background worker. Expand that set if thread inspection shows additional runnable workers.
+Keep the CPU-set size, NUMA placement, and affinity identical between baseline and candidate
+for a row.
+
+For correctness, run the baseline and candidate repetitions for a row concurrently when
+its node has sufficient resources. Pin concurrent processes to disjoint CPU sets, give each
+process separate output paths, and ensure they do not share mutable state. Keep every
+repetition in a separate process even when several repetitions run at the same time.
+
+For performance, keep the entire row's warmups and 60-pair measurement series on
+its assigned node. Execute only one performance invocation at a time on that node with a
+fixed CPU placement, and keep each randomized baseline/candidate pair adjacent. Different
+performance rows may run concurrently on different nodes, but do not pool one row's pairs
+across heterogeneous nodes. Do not run another replay, build, profiler, or unrelated
+workload concurrently on a node collecting performance samples.
+
+Multi-node and within-node correctness parallelism are campaign throughput optimizations;
+they must not change workload concurrency or weaken performance isolation.
 
 ## Stage 2: Establish deterministic reports
 
@@ -63,7 +107,13 @@ Require the harness to control every known entropy source:
 - recursively sort JSON object keys;
 - sort only explicitly unordered collections such as per-request records;
 - preserve semantically ordered event and lifecycle arrays;
-- exclude only approved real-time fields such as wall time and derived throughput.
+- exclude exactly `/summary/wall_time_ms`, `/summary/processed_tokens_per_s`, and
+  `/summary/processed_output_tokens_per_s`.
+
+This exclusion list is closed: include every other field, and stop for review before adding
+another exclusion. Make semantic fields such as request UUIDs deterministic rather than
+dropping them. Require parity output metadata to report `replay_bench: true`; otherwise the
+seeded routing contract was not active.
 
 Run baseline twice and candidate twice in separate processes. Each revision must produce
 one unique canonical digest. This is an entropy-leak check, not a statistical trial. If a
@@ -80,37 +130,43 @@ checksum. Do not randomly sample rows, duplicate a shorter trace, or silently cl
 The committed `lib/bench/testdata/mooncake_trace_1000.jsonl` fixture is suitable for a
 quick harness preflight, not the authoritative long-corpus campaign.
 
-Tune one shared configuration until the campaign can prove that it exercised:
+Qualify and freeze one configuration per comparison row, or per explicitly named
+configuration family when rows genuinely share every relevant parameter. For each frozen
+configuration, prove that it exercised every applicable path:
 
 - KV-overlap-sensitive routing;
 - immediate and queued placement;
 - a small, bounded number of preemptions at the block-capacity edge;
 - disaggregated prefill/decode handoff;
 - terminal cleanup;
-- G1 to G2 eviction; and
-- G2 to G1 restoration.
+- G1 to G2 eviction on KVBM rows; and
+- G2 to G1 restoration on KVBM rows.
 
 Use coverage counters, lifecycle traces, or report evidence rather than inferring these
 paths from successful completion. Target one to three preemptions per configuration. Zero
 means the edge was not exercised; repeated preempt/re-admit cycling, a rapidly growing
 preemption count, or failure to advance virtual time invalidates the fixture. Tune capacity
-or concurrency minimally and identically for baseline and candidate, and back off rather
-than accepting a preemption flood. Freeze the qualified configuration before the comparison;
-never tune each revision separately.
+or concurrency minimally and identically for baseline and candidate within the row or
+family, and back off rather than accepting a preemption flood. Never tune the revisions
+separately.
 
 ## Stage 4: Run byte parity
 
 Run the 5,000-request corpus for this authoritative matrix:
 
-| Engine semantics | Topology | Routing |
-| --- | --- | --- |
-| vLLM pass-start | Aggregated | KV-aware |
-| vLLM pass-start | Disaggregated | KV-aware |
-| SGLang pass-end | Aggregated | KV-aware |
-| SGLang pass-end | Disaggregated | KV-aware |
+| Engine semantics | Topology | Memory path | Routing |
+| --- | --- | --- | --- |
+| vLLM pass-start | Aggregated | Native G1 | KV-aware |
+| vLLM pass-start | Disaggregated | Native G1 | KV-aware |
+| SGLang pass-end | Aggregated | Native G1 | KV-aware |
+| SGLang pass-end | Disaggregated | Native G1 | KV-aware |
+| vLLM pass-start | Aggregated | KVBM G1 to G2 and G2 to G1 | KV-aware |
+| vLLM pass-start | Disaggregated | KVBM G1 to G2 and G2 to G1 | KV-aware |
 
-Enable KVBM offload on supported Linux hosts and require the lifecycle evidence from
-Stage 3 for every applicable row. For each row:
+The current harness supports KVBM offload only for vLLM. Record SGLang plus KVBM as
+`UNSUPPORTED`; do not require an impossible lifecycle and do not count that unsupported
+combination as an authoritative row. Run the two KVBM rows only on supported Linux hosts
+and require the Stage 3 eviction and restoration evidence. For each row:
 
 1. Produce canonical baseline and candidate outputs with the frozen configuration.
 2. Compare their bytes or SHA-256 digests exactly.
@@ -158,22 +214,55 @@ occurred.
 
 ## Stage 7: Measure performance
 
-Measure the same four engine/topology rows with the frozen KVBM-enabled configuration and
-authoritative production routing behavior. Run seeded matched-routing variants separately
-as diagnostics; do not substitute them for production results.
+Measure every supported row from Stage 4 with its frozen configuration. The authoritative
+gate reuses the `replay-bench` artifacts from byte parity, so routing selection is seeded
+and matched between revisions. Require timing metadata to report `replay_bench: true`.
+Describe the result as seeded matched-routing replay-loop parity, not production-routing
+performance. Production-routing timing is outside the default campaign because it requires
+a separate build without `replay-bench`; add that campaign only when the user explicitly
+requests it.
+
+The primary metric is replay execution time. Start its timer after trace normalization,
+workload construction, and engine/runtime preparation, immediately before
+`prepared.run(...)`; stop it immediately after that call returns and before collector
+finalization or report aggregation. Emit this value as `replay_execution_ms`. Record setup
+and end-to-end time separately as diagnostics. In particular, do not let KVBM messenger
+initialization or its fixed readiness delay dilute a replay-loop regression. If the harness
+does not expose this exact timing boundary, extend it before running the campaign; do not
+substitute the existing broader `wall_time_ms`.
+
+Stage binaries and trace inputs on node-local storage and verify their checksums before
+warmups. File transfer is campaign setup, not a sample. For each measured invocation, pass
+`--iterations 1` and a unique node-local `--timings-jsonl` path. Do not pass
+`--canonical-reports-jsonl`, `--report-json`, or another full-report output option in a
+gated performance invocation. Run one fresh process per sample so lazy per-request capture,
+report serialization, and in-process iteration state cannot contaminate the metric.
 
 For each row:
 
-1. Run five warmups.
-2. Collect 30 measured baseline/candidate pairs.
-3. Randomize which arm runs first within each pair while keeping the pair adjacent.
-4. Capture one machine-readable internal elapsed sample per process invocation.
-5. With `.venv/bin/python` and SciPy, compute fixed-seed, one-sided 95% bootstrap upper
-   and lower confidence bounds for the median candidate/baseline ratio.
-6. Pass when the upper bound is at most `1.05`.
-7. Fail when the lower bound is greater than `1.05`.
-8. If the interval crosses `1.05`, collect 60 total pairs. A still-inconclusive result
-   blocks a performance-parity claim.
+1. Run five warmups per arm, alternating arms for ten warmups total.
+2. Generate and persist a fixed-seed, balanced 60-pair schedule with 30 baseline-first and
+   30 candidate-first pairs in randomized order.
+3. Collect all 60 measured pairs. Keep the two invocations in each pair adjacent and
+   compute `r_i = candidate_replay_execution_ms / baseline_replay_execution_ms` regardless
+   of run order.
+4. Sort the 60 ratios. Use the 24th order statistic as the exact distribution-free
+   one-sided 95% lower confidence bound for the population median ratio and the 37th order
+   statistic as the corresponding upper bound. Do not use a Wald interval.
+5. Pass when the upper bound is at most `1.05`.
+6. Fail when the lower bound is greater than `1.05`.
+7. Otherwise report `INCONCLUSIVE`; do not add samples adaptively and claim the original
+   confidence level.
+
+Never remove an observation because its value looks like an outlier. Retain every attempted
+sample and its process status. A replay error, assertion failure, malformed timing record,
+or other product failure fails or blocks the row; it is not a discardable sample. Only a
+predeclared environmental condition, such as scheduler eviction, node-health failure,
+affinity violation, or independently detected competing load, may invalidate a sample.
+Invalidate both members of that pair, record the evidence and reason, and rerun the complete
+pair with the same arm order. Never retry or replace a sample silently. A paired bootstrap
+of log ratios may be reported as a secondary effect-size diagnostic, but it does not decide
+the gate.
 
 Also fail release binary or `.text` growth above 5% until the added footprint is explained
 and narrowed.
@@ -213,10 +302,13 @@ The final report must include:
 
 - revision SHAs and determinism-patch checksum, if any;
 - trace checksum and 5,000-request slice specification;
-- full frozen configuration and feature manifest;
-- one row per engine/topology with digests and lifecycle evidence;
+- every artifact's exact feature manifest, binary checksum, and routing-mode assertion;
+- each row's frozen configuration, node characteristics, CPU set, and NUMA placement;
+- one row per engine/topology/memory path with digests and lifecycle evidence;
+- the exact canonical exclusion allowlist;
 - every semantic exception record;
-- paired performance ratios and confidence intervals;
+- performance timing scopes, persisted arm-order schedule, all attempted samples and
+  invalidations, paired ratios, and exact order-statistic confidence bounds;
 - binary and `.text` sizes;
 - profiler findings for any investigated regression; and
 - skipped or unsupported coverage without overstating the result.

--- a/.agents/skills/dynamo-kv-replay-parity/SKILL.md
+++ b/.agents/skills/dynamo-kv-replay-parity/SKILL.md
@@ -246,12 +246,21 @@ For each row:
 3. Collect all 60 measured pairs. Keep the two invocations in each pair adjacent and
    compute `r_i = candidate_replay_execution_ms / baseline_replay_execution_ms` regardless
    of run order.
-4. Sort the 60 ratios. Use the 24th order statistic as the exact distribution-free
-   one-sided 95% lower confidence bound for the population median ratio and the 37th order
-   statistic as the corresponding upper bound. Do not use a Wald interval.
-5. Pass when the upper bound is at most `1.05`.
-6. Fail when the lower bound is greater than `1.05`.
-7. Otherwise report `INCONCLUSIVE`; do not add samples adaptively and claim the original
+4. Treat the ratios as independent and identically distributed, or otherwise exchangeable,
+   only when the campaign can justify that sampling assumption; pair adjacency does not
+   establish it. Predeclare thresholds for serial-dependence diagnostics, including lag
+   autocorrelation and pair-order trends against elapsed time and available temperature or
+   frequency telemetry, and record their results.
+5. If the diagnostics breach their thresholds or exchangeability cannot be justified,
+   report `INCONCLUSIVE` or use a predeclared dependence-aware method. Do not apply the
+   order-statistic gate.
+6. Otherwise sort the 60 ratios. Conditional on the sampling assumption, use the 24th order
+   statistic as the exact distribution-free one-sided 95% lower confidence bound for the
+   population median ratio and the 37th order statistic as the corresponding upper bound.
+   Do not use a Wald interval.
+7. Pass when the upper bound is at most `1.05`.
+8. Fail when the lower bound is greater than `1.05`.
+9. Otherwise report `INCONCLUSIVE`; do not add samples adaptively and claim the original
    confidence level.
 
 Never remove an observation because its value looks like an outlier. Retain every attempted
@@ -308,7 +317,8 @@ The final report must include:
 - the exact canonical exclusion allowlist;
 - every semantic exception record;
 - performance timing scopes, persisted arm-order schedule, all attempted samples and
-  invalidations, paired ratios, and exact order-statistic confidence bounds;
+  invalidations, paired ratios, sampling assumption, dependence diagnostics, and conditional
+  order-statistic confidence bounds;
 - binary and `.text` sizes;
 - profiler findings for any investigated regression; and
 - skipped or unsupported coverage without overstating the result.

--- a/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
+++ b/.agents/skills/dynamo-kv-replay-parity/references/internal-polynomial-golden-points.md
@@ -1,0 +1,153 @@
+# Internal-polynomial replay golden-point seeds
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+Use these configurations as starting seeds for offline replay qualification, not as
+universal capacities, parity results, or performance results. They were qualified against
+the contiguous first 5,000 rows of the canonical Mooncake trace:
+
+- slice rule: rows 0 through 4,999 in source arrival order;
+- slice SHA-256:
+  `3892ae19ae480b643155f0c6b9d798591cbe2e73bec6a0fa5ae3d3bc0332fb8a`;
+- model: internal polynomial mocker, without AIC profile arguments;
+- routing: KV-aware;
+- arrival speedup: 4;
+- trace block size: 512; and
+- model and decode speedups: 1.
+
+Requalify on the pinned baseline, then run the candidate with exactly the same
+configuration. Never tune the revisions separately.
+
+## Native G1 seeds
+
+| Engine and topology | Starting configuration | Expected pressure and nearest boundaries |
+| --- | --- | --- |
+| vLLM aggregated | 4 workers; engine block 64; G1 blocks 6,144; max sequences 16; batch tokens 8,192 | 1 preemption; 4,096 produced 21 and 8,192 produced 0 |
+| vLLM disaggregated | 2 prefill + 2 decode; engine block 64; G1 blocks 40,964; max sequences 16; batch tokens 8,192; KV bytes/token 1; 100 GB/s full-prompt transfer | 4 preemptions; exact next integer capacity 40,965 produced 0. This is a documented nearest-feasible exception to the 1–3 target: max sequences 15 produced 9–13 near the edge and max sequences 17 produced 0 |
+| SGLang aggregated | 4 workers; engine/page block 512; G1 blocks 1,536; max sequences 256; batch tokens 32,768 | 1 retraction; 1,024 produced 8 and 2,048 produced 0 |
+| SGLang disaggregated | 2 prefill + 2 decode; engine/page block 512; G1 blocks 17,408; max sequences 256; batch tokens 32,768; KV bytes/token 262,144; 100 GB/s full-prompt transfer | 2 retractions; 16,384 produced 12 and 18,432 produced 0 |
+
+The vLLM configurations rely on native/default G1 selection. An experiment-only
+`--g1-backend` switch is not required to reproduce the native seeds.
+
+### CLI templates
+
+Set the artifact and trace paths, then reuse the common load-generation arguments:
+
+```bash
+BIN=/path/to/offline_replay_bench
+TRACE_5000=/path/to/mooncake_trace_rows_000000_004999.jsonl
+COMMON_ARGS=(
+  --router-mode kv-router
+  --arrival-speedup-ratio 4
+  --trace-block-size 512
+  --speedup-ratio 1
+  --decode-speedup-ratio 1
+  --iterations 1
+)
+```
+
+vLLM aggregated:
+
+```bash
+"$BIN" "$TRACE_5000" \
+  --serving-mode aggregated \
+  --num-workers 4 \
+  --engine-type vllm \
+  --block-size 64 \
+  --num-gpu-blocks 6144 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 8192 \
+  "${COMMON_ARGS[@]}"
+```
+
+vLLM disaggregated:
+
+```bash
+"$BIN" "$TRACE_5000" \
+  --serving-mode disagg \
+  --num-prefill-workers 2 \
+  --num-decode-workers 2 \
+  --engine-type vllm \
+  --block-size 64 \
+  --num-gpu-blocks 40964 \
+  --max-num-seqs 16 \
+  --max-num-batched-tokens 8192 \
+  --kv-bytes-per-token 1 \
+  --kv-transfer-bandwidth 100 \
+  --kv-transfer-timing-mode full-prompt \
+  "${COMMON_ARGS[@]}"
+```
+
+SGLang aggregated:
+
+```bash
+"$BIN" "$TRACE_5000" \
+  --serving-mode aggregated \
+  --num-workers 4 \
+  --engine-type sglang \
+  --block-size 512 \
+  --num-gpu-blocks 1536 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 32768 \
+  "${COMMON_ARGS[@]}"
+```
+
+SGLang disaggregated:
+
+```bash
+"$BIN" "$TRACE_5000" \
+  --serving-mode disagg \
+  --num-prefill-workers 2 \
+  --num-decode-workers 2 \
+  --engine-type sglang \
+  --block-size 512 \
+  --num-gpu-blocks 17408 \
+  --max-num-seqs 256 \
+  --max-num-batched-tokens 32768 \
+  --kv-bytes-per-token 262144 \
+  --kv-transfer-bandwidth 100 \
+  --kv-transfer-timing-mode full-prompt \
+  "${COMMON_ARGS[@]}"
+```
+
+## Expected behavior
+
+With the exact corpus and internal model above, use these observed values as drift
+detectors:
+
+| Engine and topology | Immediate / queued | Requests with reuse | Worker and handoff evidence |
+| --- | --- | --- | --- |
+| vLLM aggregated | 8 / 4,992 | 4,918 | decode workers 0–3 |
+| vLLM disaggregated | 4 / 4,996 | 4,991 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+| SGLang aggregated | 5 / 4,995 | 4,840 | decode workers 0–3 |
+| SGLang disaggregated | 2 / 4,998 | 4,992 | prefill and decode workers 0–1; 5,000 complete, backend-valid handoffs |
+
+Every row must complete all 5,000 requests with no rejected, canceled, failed, or stranded
+requests. A changed counter is not automatically a product failure, but it means the seed
+must be requalified and the cause recorded before freezing the row.
+
+## Derive and sanity-check KVBM rows
+
+Derive each vLLM KVBM row from its corresponding native seed by enabling G2 and modestly
+reducing or limiting G1. Keep the topology fixed; start disaggregated qualification at
+exactly 2 prefill + 2 decode workers. Tune capacity or concurrency identically for both
+revisions.
+
+Require all of the following before freezing a KVBM row:
+
+- all 5,000 requests complete;
+- one to three bounded preemptions, without repeated preempt/re-admit cycling;
+- nonzero G1-to-G2 eviction completion;
+- nonzero G2-to-G1 restoration hits;
+- identical lifecycle counts across repeated baseline and candidate runs;
+- 5,000 complete, backend-valid handoffs for disaggregated replay; and
+- one canonical digest per revision, with baseline and candidate digests matching.
+
+Do not infer offload coverage from successful completion. Do not proceed to performance
+when lifecycle counters match but a revision's canonical repetitions differ; that is an
+internal determinism failure. SGLang KVBM offload is unsupported by the current harness
+and must be reported as `UNSUPPORTED`, not simulated by toggling an ignored G1 option.


### PR DESCRIPTION
## Summary

- define one statically verified feature-superset replay artifact per revision and reuse it across native and KVBM rows
- make the supported vLLM/SGLang and native/KVBM capability matrix explicit
- specify canonical byte exclusions, multi-node row placement, CPU affinity, execution-only timing, and performance-output rules
- replace the underspecified sequential bootstrap gate with a balanced 60-pair schedule and exact distribution-free median-ratio bounds
- define warmups, environmental invalidation, outlier, configuration-freezing, and reporting requirements

## Validation

- `.venv/bin/python scripts/validate_skills.py`
- `git diff --check`
- commit-time pre-commit hooks, including codespell and `validate-skills`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12343" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Dynamo KV replay parity guidance with stricter reproducibility and artifact-recording requirements.
  - Clarified supported aggregated, disaggregated, and KVBM validation scenarios, including unsupported combinations.
  - Added detailed lifecycle, preemption, placement, eviction, and restoration coverage expectations.
  - Standardized byte-parity reporting, configuration evidence, timing boundaries, performance sampling, invalidation rules, and final report contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->