### PR TITLE
feat(vllm): add custom encoder response data

### DIFF
--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -105,7 +105,8 @@ class GenerateChunk(TypedDict, total=False):
     # JSON object. Carries `prompt_logprobs` on the final chunk.
     engine_data: dict[str, Any]
     # Internal custom-encoder metadata handoff from Python backends to the LLM
-    # frontend transport. Kept separate from the opt-in `engine_data` channel.
+    # frontend transport. Emitted only when requested through
+    # `nvext.extra_fields=["custom_encoder"]`.
     custom_encoder_data: dict[str, Any]
 
 

--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -104,6 +104,9 @@ class GenerateChunk(TypedDict, total=False):
     # Forwarded verbatim to Rust `LLMEngineOutput.engine_data` as a
     # JSON object. Carries `prompt_logprobs` on the final chunk.
     engine_data: dict[str, Any]
+    # Internal custom-encoder metadata handoff from Python backends to the LLM
+    # frontend transport. Kept separate from the opt-in `engine_data` channel.
+    custom_encoder_data: dict[str, Any]
 
 
 @dataclass

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -613,9 +613,9 @@ class DynamoVllmConfig(ConfigBase):
         """Validate the aggregated CustomEncoder configuration.
 
         The encoder runs in-process in a single aggregated worker on the
-        token-in/token-out path and produces image embeds for the mixed
-        EmbedsPrompt, so it is a multimodal, aggregated-only, token-mode
-        component. Enforce those here (fail fast) instead of silently bypassing
+        token-in/token-out path and produces decoder-adapted image artifacts, so
+        it is a multimodal, aggregated-only, token-mode component. Enforce those
+        here (fail fast) instead of silently bypassing
         the multimodal gate at request time, no-op'ing in a decode worker that
         never reaches the custom-encoder branch, or loading the encoder in
         --use-vllm-tokenizer text mode where it is never invoked.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3097,10 +3097,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
-            encodings = await self._custom_encoder.encode(image_urls)
+            artifacts = await self._custom_encoder.encode(image_urls)
             prepared = self._custom_encoder_adapter.prepare_prompt(
                 token_ids,
-                encodings,
+                artifacts,
             )
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
@@ -3110,7 +3110,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         logger.debug(
             "Request %s: CustomEncoder prepared prompt for %d image(s)",
             request_id,
-            len(encodings),
+            len(artifacts),
         )
         return prepared, None
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -119,8 +119,6 @@ _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
 _RL_INIT_WEIGHTS_TIMEOUT_ENV = "DYN_RL_INIT_WEIGHTS_TIMEOUT_S"
 _RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
 _CUSTOM_ENCODER_RESPONSE_MAX_BYTES = 64 * 1024
-_JSON_INTEGER_MIN = -(1 << 63)
-_JSON_INTEGER_MAX = (1 << 64) - 1
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -675,11 +673,13 @@ def _prepare_custom_encoder_results(
         artifacts.append(result.artifact)
         response_items.append(response_data)
 
-    if not any(item is not None for item in response_items):
+    if all(item is None for item in response_items):
         return artifacts, None
 
     payload = {"items": response_items}
-    _validate_custom_encoder_json_integers(payload)
+    # For simplicity and performance, we deliberately do not validate Python's
+    # arbitrary-size integers against serde_json's i64/u64 range here; that niche
+    # edge case may still fail later at the Python-to-Rust response boundary.
     try:
         serialized = json.dumps(
             payload,
@@ -699,36 +699,16 @@ def _prepare_custom_encoder_results(
     return artifacts, json.loads(serialized)
 
 
-def _validate_custom_encoder_json_integers(value: Any) -> None:
-    """Reject integers that serde_json cannot represent across Pythonize."""
-
-    if isinstance(value, bool):
-        return
-    if isinstance(value, int):
-        if not _JSON_INTEGER_MIN <= value <= _JSON_INTEGER_MAX:
-            raise ValueError(
-                "CustomEncoder response_data integers must fit serde_json's "
-                "i64/u64 range"
-            )
-        return
-    if isinstance(value, dict):
-        for item in value.values():
-            _validate_custom_encoder_json_integers(item)
-        return
-    if isinstance(value, (list, tuple)):
-        for item in value:
-            _validate_custom_encoder_json_integers(item)
-
-
 def _attach_custom_encoder_data(
     chunk: Dict[str, Any],
     response_data: dict[str, Any] | None,
     *,
+    requested: bool,
     already_sent: bool,
 ) -> bool:
-    """Attach metadata once, to the first non-error generation chunk."""
+    """Attach requested metadata once, to the first non-error generation chunk."""
 
-    if already_sent or response_data is None:
+    if not requested or already_sent or response_data is None:
         return already_sent
     finish_reason = chunk.get("finish_reason")
     if isinstance(finish_reason, str) and finish_reason.startswith("error"):
@@ -3374,6 +3354,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # `NvExtResponseFieldSelection.engine_data` so this payload
                 # only reaches clients that asked for it.
                 want_engine_data = _nvext_extra_field_requested(request, "engine_data")
+                want_custom_encoder_data = _nvext_extra_field_requested(
+                    request, "custom_encoder"
+                )
                 # Prompt token IDs the engine actually saw. Either the
                 # pre-tokenized `nvext.token_data` (TITO) or whatever the
                 # preprocessor produced from messages (MITO). We echo them
@@ -3416,6 +3399,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         custom_encoder_data_sent = _attach_custom_encoder_data(
                             tok,
                             custom_encoder_data,
+                            requested=want_custom_encoder_data,
                             already_sent=custom_encoder_data_sent,
                         )
                         yield tok

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -6,6 +6,7 @@ import base64
 import functools
 import importlib
 import inspect
+import json
 import logging
 import math
 import os
@@ -93,6 +94,7 @@ from .lora_state import LoRAState
 from .multimodal_utils.custom_encoder import (
     AsyncVisionEncoder,
     CustomEncoderAdapter,
+    EncoderResult,
     VisionEncoderBackend,
     create_custom_encoder_adapter,
 )
@@ -116,6 +118,9 @@ _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
 _RL_INIT_WEIGHTS_TIMEOUT_ENV = "DYN_RL_INIT_WEIGHTS_TIMEOUT_S"
 _RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
+_CUSTOM_ENCODER_RESPONSE_MAX_BYTES = 64 * 1024
+_JSON_INTEGER_MIN = -(1 << 63)
+_JSON_INTEGER_MAX = (1 << 64) - 1
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -646,6 +651,90 @@ def _accumulate_engine_data(
     if request_prompt_token_ids:
         engine_data["prompt_token_ids"] = list(request_prompt_token_ids)
     tok["engine_data"] = engine_data
+
+
+def _prepare_custom_encoder_results(
+    results: list[Any],
+) -> tuple[list[Any], dict[str, Any] | None]:
+    """Split decoder artifacts from bounded, JSON-safe response metadata."""
+
+    artifacts: list[Any] = []
+    response_items: list[dict[str, Any] | None] = []
+    for index, result in enumerate(results):
+        if not isinstance(result, EncoderResult):
+            raise TypeError(
+                "CustomEncoder forward_batch must return EncoderResult values; "
+                f"result {index} is {type(result).__name__}"
+            )
+        response_data = result.response_data
+        if response_data is not None and not isinstance(response_data, dict):
+            raise TypeError(
+                "CustomEncoder response_data must be a JSON object or None; "
+                f"result {index} is {type(response_data).__name__}"
+            )
+        artifacts.append(result.artifact)
+        response_items.append(response_data)
+
+    if not any(item is not None for item in response_items):
+        return artifacts, None
+
+    payload = {"items": response_items}
+    _validate_custom_encoder_json_integers(payload)
+    try:
+        serialized = json.dumps(
+            payload,
+            allow_nan=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "CustomEncoder response_data must contain JSON-serializable values"
+        ) from exc
+    if len(serialized) > _CUSTOM_ENCODER_RESPONSE_MAX_BYTES:
+        raise ValueError(
+            "CustomEncoder response_data exceeds the 64 KiB response limit"
+        )
+    # Deserialize the exact validated bytes so later backend mutations cannot
+    # change the payload after validation or bypass the size limit.
+    return artifacts, json.loads(serialized)
+
+
+def _validate_custom_encoder_json_integers(value: Any) -> None:
+    """Reject integers that serde_json cannot represent across Pythonize."""
+
+    if isinstance(value, bool):
+        return
+    if isinstance(value, int):
+        if not _JSON_INTEGER_MIN <= value <= _JSON_INTEGER_MAX:
+            raise ValueError(
+                "CustomEncoder response_data integers must fit serde_json's "
+                "i64/u64 range"
+            )
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            _validate_custom_encoder_json_integers(item)
+        return
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            _validate_custom_encoder_json_integers(item)
+
+
+def _attach_custom_encoder_data(
+    chunk: Dict[str, Any],
+    response_data: dict[str, Any] | None,
+    *,
+    already_sent: bool,
+) -> bool:
+    """Attach metadata once, to the first non-error generation chunk."""
+
+    if already_sent or response_data is None:
+        return already_sent
+    finish_reason = chunk.get("finish_reason")
+    if isinstance(finish_reason, str) and finish_reason.startswith("error"):
+        return False
+    chunk["custom_encoder_data"] = response_data
+    return True
 
 
 def _serialize_routed_experts(
@@ -3034,15 +3123,19 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         self,
         request: Dict[str, Any],
         request_id: str,
-    ) -> tuple[EmbedsPrompt | TokensPrompt | None, Dict[str, Any] | None]:
+    ) -> tuple[
+        EmbedsPrompt | TokensPrompt | None,
+        dict[str, Any] | None,
+        Dict[str, Any] | None,
+    ]:
         """Run the in-process CustomEncoder and prepare its engine prompt.
 
-        The CustomEncoder consumes image URLs directly and emits artifacts. Returns
-        ``(prepared_prompt, error)``:
-        - images present: ``(prepared_prompt, None)``,
-        - no image content: ``(None, None)`` — text-only request, nothing
+        The CustomEncoder consumes image URLs directly and emits results. Returns
+        ``(prepared_prompt, response_data, error)``:
+        - images present: ``(prepared_prompt, response_data, None)``,
+        - no image content: ``(None, None, None)`` — text-only request, nothing
           to assemble or extract (non-image modalities are rejected above),
-        - failure: ``(None, error_dict)`` for the caller to yield.
+        - failure: ``(None, None, error_dict)`` for the caller to yield.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
         # before reaching here. Use an explicit raise (not assert, which is
@@ -3065,7 +3158,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 f"unsupported multimodal data: {unsupported}"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         image_items = mm_map.get(IMAGE_URL_KEY) or []
         image_urls = [
@@ -3083,12 +3176,12 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 "'Url'; each item must be a dict with a 'Url' key"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         if not image_urls:
             # No image items at all — and non-image modalities were already
             # rejected above — so there is nothing to assemble → text-only.
-            return None, None
+            return None, None, None
 
         token_ids: list[int] = request.get("token_ids") or []
         # Both encode() and adapter preparation run user/model-specific code, so
@@ -3097,7 +3190,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
-            artifacts = await self._custom_encoder.encode(image_urls)
+            results = await self._custom_encoder.encode(image_urls)
+            artifacts, response_data = await asyncio.to_thread(
+                _prepare_custom_encoder_results,
+                results,
+            )
             prepared = self._custom_encoder_adapter.prepare_prompt(
                 token_ids,
                 artifacts,
@@ -3105,14 +3202,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
             logger.exception("Request %s: %s", request_id, msg)
-            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         logger.debug(
             "Request %s: CustomEncoder prepared prompt for %d image(s)",
             request_id,
-            len(artifacts),
+            len(results),
         )
-        return prepared, None
+        return prepared, response_data, None
 
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
@@ -3141,6 +3238,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             mode = DisaggregationMode.AGGREGATED
         has_mm_data = request.get("multi_modal_data") is not None
         custom_prompt: EmbedsPrompt | TokensPrompt | None = None
+        custom_encoder_data: dict[str, Any] | None = None
 
         if (
             mode == DisaggregationMode.AGGREGATED
@@ -3150,10 +3248,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             # A configured CustomEncoder owns the aggregated image path. Bypass
             # raw-media loading and let its decoder-selected adapter prepare the
             # final engine prompt.
-            custom_prompt, assemble_error = await self._assemble_custom_encoder_prompt(
-                request,
-                request_id,
-            )
+            (
+                custom_prompt,
+                custom_encoder_data,
+                assemble_error,
+            ) = await self._assemble_custom_encoder_prompt(request, request_id)
             if assemble_error is not None:
                 yield assemble_error
                 return
@@ -3287,6 +3386,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 )
                 accumulated_token_ids: dict[int, list[int]] = {}
                 accumulated_log_probs: dict[int, list[float]] = {}
+                custom_encoder_data_sent = False
                 try:
                     async for tok in self.generate_tokens(
                         prompt,
@@ -3313,6 +3413,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                                 accumulated_token_ids,
                                 accumulated_log_probs,
                             )
+                        custom_encoder_data_sent = _attach_custom_encoder_data(
+                            tok,
+                            custom_encoder_data,
+                            already_sent=custom_encoder_data_sent,
+                        )
                         yield tok
                 except EngineDeadError as e:
                     logger.error(f"vLLM EngineDeadError: {e}")

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -4,6 +4,7 @@
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.vllm.multimodal_utils.chat_message_utils import extract_user_text
 from dynamo.vllm.multimodal_utils.custom_encoder import (
+    ArtifactT,
     CustomEncoderAdapter,
     Preprocessed,
     VisionEncoderBackend,
@@ -38,6 +39,7 @@ __all__ = [
     "encode_image_embeddings",
     "extract_user_text",
     "get_encoder_components",
+    "ArtifactT",
     "Preprocessed",
     "VisionEncoderBackend",
     "ImageLoader",

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -6,6 +6,7 @@ from dynamo.vllm.multimodal_utils.chat_message_utils import extract_user_text
 from dynamo.vllm.multimodal_utils.custom_encoder import (
     ArtifactT,
     CustomEncoderAdapter,
+    EncoderResult,
     Preprocessed,
     VisionEncoderBackend,
     build_mixed_embeds,
@@ -40,6 +41,7 @@ __all__ = [
     "extract_user_text",
     "get_encoder_components",
     "ArtifactT",
+    "EncoderResult",
     "Preprocessed",
     "VisionEncoderBackend",
     "ImageLoader",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
@@ -10,6 +10,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.adapter import (
 )
 from dynamo.vllm.multimodal_utils.custom_encoder.async_encoder import AsyncVisionEncoder
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -18,6 +19,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
 
 __all__ = [
     "AsyncVisionEncoder",
+    "ArtifactT",
     "build_mixed_embeds",
     "CustomEncoderAdapter",
     "create_custom_encoder_adapter",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
@@ -11,6 +11,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.adapter import (
 from dynamo.vllm.multimodal_utils.custom_encoder.async_encoder import AsyncVisionEncoder
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
     ArtifactT,
+    EncoderResult,
     ItemT,
     Preprocessed,
     RawT,
@@ -23,6 +24,7 @@ __all__ = [
     "build_mixed_embeds",
     "CustomEncoderAdapter",
     "create_custom_encoder_adapter",
+    "EncoderResult",
     "ItemT",
     "Preprocessed",
     "RawT",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
@@ -6,19 +6,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Generic, Sequence
 
-import torch
 from vllm.inputs import EmbedsPrompt, TokensPrompt
 
+from dynamo.vllm.multimodal_utils.custom_encoder.backend import ArtifactT
 
-class CustomEncoderAdapter(ABC):
+
+class CustomEncoderAdapter(ABC, Generic[ArtifactT]):
     """Translate encoder artifacts for one resolved downstream decoder."""
 
     @abstractmethod
     def prepare_prompt(
         self,
         token_ids: list[int],
-        encodings: Sequence[torch.Tensor],
+        artifacts: Sequence[ArtifactT],
     ) -> EmbedsPrompt | TokensPrompt:
         """Validate encoder artifacts and build the final vLLM prompt."""

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
@@ -17,10 +17,10 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
 
 
 def create_custom_encoder_adapter(
-    backend: VisionEncoderBackend,
+    backend: VisionEncoderBackend[Any, Any, Any],
     model_config: Any,
     engine_args: Any,
-) -> CustomEncoderAdapter:
+) -> CustomEncoderAdapter[Any]:
     """Create the adapter selected by the resolved downstream decoder."""
 
     return LinearEmbedsAdapter(backend, model_config, engine_args)

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
@@ -165,12 +165,12 @@ def build_mixed_embeds(
     return prompt_embeds, out_token_ids, is_token_ids
 
 
-class LinearEmbedsAdapter(CustomEncoderAdapter):
+class LinearEmbedsAdapter(CustomEncoderAdapter[torch.Tensor]):
     """Build mixed ``EmbedsPrompt`` inputs for a text-only decoder."""
 
     def __init__(
         self,
-        backend: VisionEncoderBackend,
+        backend: VisionEncoderBackend[Any, Any, torch.Tensor],
         model_config: Any,
         engine_args: Any,
     ) -> None:
@@ -199,9 +199,9 @@ class LinearEmbedsAdapter(CustomEncoderAdapter):
     def prepare_prompt(
         self,
         token_ids: list[int],
-        encodings: Sequence[torch.Tensor],
+        artifacts: Sequence[torch.Tensor],
     ) -> EmbedsPrompt | TokensPrompt:
-        rows = list(encodings)
+        rows = list(artifacts)
         for index, tensor in enumerate(rows):
             if not isinstance(tensor, torch.Tensor):
                 raise TypeError(

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
@@ -5,7 +5,7 @@
 
 ``AsyncVisionEncoder`` is the **Dynamo-owned** layer the worker talks to. It
 turns the author's synchronous, thread-affine backend into an awaitable
-``encode(raws) -> list[tensor]`` by:
+``encode(raws) -> list[artifact]`` by:
 
 - running ``backend.preprocess`` **off the event loop** on a bounded
   ``ThreadPoolExecutor`` (CPU-heavy fetch / resize / patchify must not serialize
@@ -21,9 +21,8 @@ turns the author's synchronous, thread-affine backend into an awaitable
 
 The backend's ``build`` runs on the batcher's actor thread (so a CUDA graph it
 captures is replayed on the same thread) and its ``close`` runs there at
-teardown. ``load`` fails fast: it re-raises a build error and resolves the image
-placeholder id once, so a misconfigured encoder errors at startup, not on the
-first request.
+teardown. ``load`` re-raises build errors so a misconfigured encoder fails at
+startup, not on the first request.
 """
 
 from __future__ import annotations
@@ -32,9 +31,8 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Generic, List
 
-import torch
-
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -43,7 +41,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
 from dynamo.vllm.multimodal_utils.custom_encoder.batcher import ThreadedMicroBatcher
 
 
-class AsyncVisionEncoder(Generic[RawT, ItemT]):
+class AsyncVisionEncoder(Generic[RawT, ItemT, ArtifactT]):
     """Drive a ``VisionEncoderBackend`` from the worker's async request path.
 
     The worker calls ``load`` once at startup and ``await``s ``encode`` per
@@ -66,7 +64,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
 
     def __init__(
         self,
-        backend: VisionEncoderBackend[RawT, ItemT],
+        backend: VisionEncoderBackend[RawT, ItemT, ArtifactT],
         *,
         preprocess_concurrency: int | None = None,
         name: str = "vision-encoder",
@@ -98,7 +96,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         self._backend = backend
         self._preprocess_concurrency = conc
         self._name = name
-        self._batcher: ThreadedMicroBatcher | None = None
+        self._batcher: ThreadedMicroBatcher[ItemT, ArtifactT] | None = None
         self._pool: ThreadPoolExecutor | None = None
 
     # ---- lifecycle ---------------------------------------------------------
@@ -106,10 +104,8 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     def load(self, model_id: str) -> None:
         """Start the actor thread (running ``backend.build`` on it) and fail fast.
 
-        Re-raises any build error, then ``validate``s the placeholder id so a
-        misconfigured encoder errors at startup instead of on the first request.
-        Single-shot: a second ``load()`` raises rather than orphaning the first
-        batcher's (non-daemon) worker thread and model.
+        Re-raises any build error. Single-shot: a second ``load()`` raises rather
+        than orphaning the first batcher's (non-daemon) worker thread and model.
         """
         if self._batcher is not None:
             raise RuntimeError("AsyncVisionEncoder.load() called twice")
@@ -136,36 +132,21 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 else None
             )
             self._batcher.start()  # runs backend.build() on the actor thread
-            self.validate()
         except BaseException:
             self.shutdown()
             raise
 
-    def validate(self) -> None:
-        """Fail-fast check run by ``load`` after ``build``: the author hardcoded a
-        usable ``image_token_id``."""
-        tid = getattr(self._backend, "image_token_id", None)
-        if not isinstance(tid, int) or isinstance(tid, bool):
-            raise ValueError(
-                "VisionEncoderBackend.image_token_id must be a hardcoded int (the "
-                f"image placeholder token id); got {tid!r}"
-            )
-
-    def get_image_placeholder_token_id(self) -> int:
-        """The token id marking image positions (the backend's hardcoded value)."""
-        return self._backend.image_token_id
-
     # ---- request path ------------------------------------------------------
 
-    async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
+    async def encode(self, raws: List[RawT]) -> List[ArtifactT]:
         """Optionally preprocess (off-loop, with a request-atomicity barrier) then
         batched-encode.
 
         With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
         to the batcher (the backend folds any prep into ``forward_batch``). Returns
-        one ``(n_visual_tokens, lm_hidden_dim)`` tensor per raw input, in order.
-        Raises if any image's preprocess fails (submitting nothing) or if the
-        batched forward fails.
+        one backend-defined artifact per raw input, in order. Raises if any
+        image's preprocess fails (submitting nothing) or if the batched forward
+        fails.
         """
         if self._batcher is None:
             raise RuntimeError("AsyncVisionEncoder.encode() called before load()")
@@ -192,7 +173,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 raise result
         # No exception above ⇒ every settled entry is a Preprocessed. Alias the
         # list gather() already returned rather than copying it.
-        preprocessed: List[Preprocessed] = settled  # type: ignore[assignment]
+        preprocessed: List[Preprocessed[ItemT]] = settled  # type: ignore[assignment]
         items = [p.item for p in preprocessed]
         costs = [p.cost for p in preprocessed]
         return await self._batcher.submit(items, costs)

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
@@ -5,7 +5,7 @@
 
 ``AsyncVisionEncoder`` is the **Dynamo-owned** layer the worker talks to. It
 turns the author's synchronous, thread-affine backend into an awaitable
-``encode(raws) -> list[artifact]`` by:
+``encode(raws) -> list[EncoderResult[artifact]]`` by:
 
 - running ``backend.preprocess`` **off the event loop** on a bounded
   ``ThreadPoolExecutor`` (CPU-heavy fetch / resize / patchify must not serialize
@@ -33,6 +33,7 @@ from typing import Generic, List
 
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
     ArtifactT,
+    EncoderResult,
     ItemT,
     Preprocessed,
     RawT,
@@ -96,7 +97,9 @@ class AsyncVisionEncoder(Generic[RawT, ItemT, ArtifactT]):
         self._backend = backend
         self._preprocess_concurrency = conc
         self._name = name
-        self._batcher: ThreadedMicroBatcher[ItemT, ArtifactT] | None = None
+        self._batcher: ThreadedMicroBatcher[
+            ItemT, EncoderResult[ArtifactT]
+        ] | None = None
         self._pool: ThreadPoolExecutor | None = None
 
     # ---- lifecycle ---------------------------------------------------------
@@ -138,13 +141,13 @@ class AsyncVisionEncoder(Generic[RawT, ItemT, ArtifactT]):
 
     # ---- request path ------------------------------------------------------
 
-    async def encode(self, raws: List[RawT]) -> List[ArtifactT]:
+    async def encode(self, raws: List[RawT]) -> List[EncoderResult[ArtifactT]]:
         """Optionally preprocess (off-loop, with a request-atomicity barrier) then
         batched-encode.
 
         With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
         to the batcher (the backend folds any prep into ``forward_batch``). Returns
-        one backend-defined artifact per raw input, in order. Raises if any
+        one backend-defined result per raw input, in order. Raises if any
         image's preprocess fails (submitting nothing) or if the batched forward
         fails.
         """

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
@@ -4,6 +4,7 @@
 """Author-facing custom encoder backend contract."""
 
 from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -11,6 +12,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
 )
 
 __all__ = [
+    "ArtifactT",
     "ItemT",
     "Preprocessed",
     "RawT",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
@@ -5,6 +5,7 @@
 
 from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
     ArtifactT,
+    EncoderResult,
     ItemT,
     Preprocessed,
     RawT,
@@ -13,6 +14,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
 
 __all__ = [
     "ArtifactT",
+    "EncoderResult",
     "ItemT",
     "Preprocessed",
     "RawT",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -94,8 +94,9 @@ class EncoderResult(Generic[ArtifactT]):
     """One decoder artifact plus optional JSON metadata for the response.
 
     ``artifact`` is interpreted only by the decoder-selected adapter.
-    ``response_data`` must be a JSON-serializable object when present. Dynamo
-    preserves input order in the internal ``items`` payload, including ``null``
+    ``response_data`` must be a JSON-serializable object when present. When the
+    request selects ``custom_encoder`` through ``nvext.extra_fields``, Dynamo
+    preserves input order in the response ``items`` payload, including ``null``
     entries, and omits the payload when every entry is ``None``. The combined
     per-request payload is limited to 64 KiB.
     """

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -31,11 +31,13 @@ Division of labour (author vs. Dynamo):
   there is no preprocess phase — ``preprocess`` is never called and raws go
   straight to ``forward_batch``. A mismatch (overridden ``preprocess`` with
   ``preprocess_concurrency`` left at ``0``) fails fast at startup.
-- ``forward_batch(items, target_bucket=None) -> list[ArtifactT]`` — **actor
+- ``forward_batch(items, target_bucket=None) -> list[EncoderResult[ArtifactT]]`` —
+  **actor
   thread, serialized.** ``items`` are a cost-bounded batch (summed ``cost`` within
   the budget). Fence (stream event + sync) and **copy outputs to CPU** before
   returning, so results are safe to consume from another thread. Returns one
-  artifact per item, in input order. ``target_bucket`` is reserved for CUDA-graph
+  result per item, in input order. The result carries the adapter artifact plus
+  optional JSON response metadata. ``target_bucket`` is reserved for CUDA-graph
   batching, once supported (the ladder rung to pad to); it is ``None`` until then.
 - ``close()`` — actor thread, on teardown. Release any thread-affine resources.
 
@@ -60,7 +62,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, List, Optional, Sequence, TypeVar
+from typing import Any, Generic, List, Optional, Sequence, TypeVar
 
 RawT = TypeVar("RawT")  # raw input the author preprocesses (e.g. an image URL)
 ItemT = TypeVar("ItemT")  # opaque payload preprocess() hands to forward_batch()
@@ -85,6 +87,21 @@ class Preprocessed(Generic[ItemT]):
 
     item: ItemT
     cost: int = 1
+
+
+@dataclass(frozen=True)
+class EncoderResult(Generic[ArtifactT]):
+    """One decoder artifact plus optional JSON metadata for the response.
+
+    ``artifact`` is interpreted only by the decoder-selected adapter.
+    ``response_data`` must be a JSON-serializable object when present. Dynamo
+    preserves input order in the internal ``items`` payload, including ``null``
+    entries, and omits the payload when every entry is ``None``. The combined
+    per-request payload is limited to 64 KiB.
+    """
+
+    artifact: ArtifactT
+    response_data: dict[str, Any] | None = None
 
 
 class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
@@ -146,13 +163,15 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
     @abstractmethod
     def forward_batch(
         self, items: List[ItemT], target_bucket: Optional[int] = None
-    ) -> List[ArtifactT]:
-        """Encode one cost-bounded batch; one artifact per item, in input order.
+    ) -> List[EncoderResult[ArtifactT]]:
+        """Encode a batch; return one result per item, in input order.
 
         Fence (stream event + sync) and **copy outputs to CPU** before returning,
         so results are safe to consume from another thread. ``target_bucket`` is
         reserved for CUDA-graph batching, once supported (the ladder rung to pad
-        to), and is ``None`` until then.
+        to), and is ``None`` until then. Dynamo passes each result's ``artifact``
+        to the selected adapter and carries optional ``response_data`` across
+        the internal Python engine-chunk boundary without interpreting it.
         """
         ...
 

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -6,15 +6,14 @@
 ``VisionEncoderBackend`` is the **single surface an encoder author implements**.
 It is a pure policy + compute backend: no threads, no futures, no event loop.
 Dynamo owns all the *driving* — the dedicated actor thread, cross-request
-coalescing, the embeds splice, and the lifecycle — via ``ThreadedMicroBatcher``
+coalescing, engine adaptation, and the lifecycle — via ``ThreadedMicroBatcher``
 (the generic cross-request batcher) and ``AsyncVisionEncoder`` (the async
 request-API glue). This module defines only the contract those drivers call.
 
 The encoder runs in the **same process** as the aggregated vLLM worker (no
-separate encode worker, no NIXL transfer): it turns image inputs into the
-visual-token embeddings for each image, and Dynamo splices those embeds into a
-mixed ``EmbedsPrompt`` at the placeholder positions (see
-``adapter.linear.build_mixed_embeds``) for a text-only LM.
+separate encode worker, no NIXL transfer): it turns image inputs into ordered,
+producer-defined artifacts. The resolved downstream decoder selects an adapter
+that validates those artifacts and constructs the final engine prompt.
 
 Division of labour (author vs. Dynamo):
 
@@ -32,20 +31,16 @@ Division of labour (author vs. Dynamo):
   there is no preprocess phase — ``preprocess`` is never called and raws go
   straight to ``forward_batch``. A mismatch (overridden ``preprocess`` with
   ``preprocess_concurrency`` left at ``0``) fails fast at startup.
-- ``forward_batch(items, target_bucket=None) -> list[torch.Tensor]`` — **actor
+- ``forward_batch(items, target_bucket=None) -> list[ArtifactT]`` — **actor
   thread, serialized.** ``items`` are a cost-bounded batch (summed ``cost`` within
   the budget). Fence (stream event + sync) and **copy outputs to CPU** before
-  returning, so results are safe to consume from another thread and splice
-  directly. Returns one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per
-  item, in input order. ``target_bucket`` is reserved for CUDA-graph batching,
-  once supported (the ladder rung to pad to); it is ``None`` until then.
+  returning, so results are safe to consume from another thread. Returns one
+  artifact per item, in input order. ``target_bucket`` is reserved for CUDA-graph
+  batching, once supported (the ladder rung to pad to); it is ``None`` until then.
 - ``close()`` — actor thread, on teardown. Release any thread-affine resources.
 
 Attributes read **once at setup** (never per-request):
 
-- ``image_token_id`` — the token id marking image positions in the prompt;
-  **hardcode it for your model** (e.g. ``151655`` for Qwen3-VL's ``<|image_pad|>``).
-  Dynamo uses it to locate each image span for the splice.
 - ``max_batch_cost`` — the scalar dispatch ceiling the batcher packs up to; a
   *chosen* budget (a token budget when ``cost`` is a token count). ``None`` (the
   default) ⇒ **pass-through**: no cap (the author owns sizing).
@@ -67,10 +62,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Sequence, TypeVar
 
-import torch
-
 RawT = TypeVar("RawT")  # raw input the author preprocesses (e.g. an image URL)
 ItemT = TypeVar("ItemT")  # opaque payload preprocess() hands to forward_batch()
+ArtifactT = TypeVar("ArtifactT")  # opaque result consumed by a decoder adapter
 
 
 @dataclass(frozen=True)
@@ -93,22 +87,16 @@ class Preprocessed(Generic[ItemT]):
     cost: int = 1
 
 
-class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
+class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
     """Author-written, in-process vision encoder contract.
 
     A pure policy + compute backend — no threads, no futures. Dynamo drives it
     on a dedicated actor thread (``ThreadedMicroBatcher``) and exposes the async
     request API (``AsyncVisionEncoder``). Subclasses implement ``build`` and
-    ``forward_batch`` and set ``image_token_id``; ``preprocess`` (default identity
-    passthrough), ``max_batch_cost``, ``buckets``, and ``preprocess_concurrency``
-    are overridden only as needed.
+    ``forward_batch``; ``preprocess`` (default identity passthrough),
+    ``max_batch_cost``, ``buckets``, and ``preprocess_concurrency`` are overridden
+    only as needed. Artifact interpretation belongs to the selected adapter.
     """
-
-    #: Image placeholder token id — **hardcode it for your model** (e.g. ``151655``
-    #: for Qwen3-VL's ``<|image_pad|>``; resolve it from your tokenizer offline if
-    #: unsure). Dynamo uses it to locate each image span for the splice. Declared
-    #: without a default so a backend that forgets to set it fails fast at startup.
-    image_token_id: int
 
     #: Scalar dispatch ceiling: the batcher packs items up to this summed ``cost``
     #: per ``forward_batch`` call. ``None`` (the default) ⇒ **pass-through**: no cap
@@ -158,14 +146,13 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     @abstractmethod
     def forward_batch(
         self, items: List[ItemT], target_bucket: Optional[int] = None
-    ) -> List[torch.Tensor]:
-        """Encode one cost-bounded batch (actor thread); one tensor per item, in order.
+    ) -> List[ArtifactT]:
+        """Encode one cost-bounded batch; one artifact per item, in input order.
 
         Fence (stream event + sync) and **copy outputs to CPU** before returning,
-        so results are safe to consume from another thread and splice directly.
-        Return one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per item, in
-        input order. ``target_bucket`` is reserved for CUDA-graph batching, once
-        supported (the ladder rung to pad to), and is ``None`` until then.
+        so results are safe to consume from another thread. ``target_bucket`` is
+        reserved for CUDA-graph batching, once supported (the ladder rung to pad
+        to), and is ``None`` until then.
         """
         ...
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
@@ -166,6 +166,14 @@ def test_linear_adapter_requires_prompt_embeds_flag():
         )
 
 
+def test_linear_adapter_requires_image_token_id():
+    backend = _Backend()
+    backend.image_token_id = None
+
+    with pytest.raises(ValueError, match="image_token_id"):
+        create_custom_encoder_adapter(backend, _model_config(), _engine_args())
+
+
 def test_linear_adapter_rejects_multimodal_decoder():
     with pytest.raises(ValueError, match="multimodal decoder"):
         create_custom_encoder_adapter(

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
@@ -4,9 +4,8 @@
 """Unit tests for the custom encoder backend contract.
 
 Pin the author-facing contract surface: the ``Preprocessed`` carrier (item +
-scalar cost, no bucket_key), the hardcoded ``image_token_id`` attribute, the
-no-device ``build`` signature, and that the ABC cannot be instantiated without
-the required methods.
+scalar cost, no bucket_key), generic forward artifacts, the no-device ``build``
+signature, and that the ABC cannot be instantiated without the required methods.
 """
 
 import pytest
@@ -27,7 +26,7 @@ pytestmark = [
 
 
 class _MinimalBackend(VisionEncoderBackend):
-    """Smallest concrete backend — hardcodes the image token id."""
+    """Smallest concrete backend with an explicit preprocess phase."""
 
     image_token_id = 151655
 
@@ -97,5 +96,4 @@ def test_default_attrs_and_close_noop():
     assert e.buckets is None
     assert e.max_batch_cost is None
     assert e.preprocess_concurrency == 0
-    assert e.image_token_id == 151655
     assert e.close() is None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
@@ -8,10 +8,13 @@ scalar cost, no bucket_key), generic forward artifacts, the no-device ``build``
 signature, and that the ABC cannot be instantiated without the required methods.
 """
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 import torch
 
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
+    EncoderResult,
     Preprocessed,
     VisionEncoderBackend,
 )
@@ -37,7 +40,7 @@ class _MinimalBackend(VisionEncoderBackend):
         return Preprocessed(item=raw, cost=1)
 
     def forward_batch(self, items, target_bucket=None):
-        return [torch.zeros(1, 1) for _ in items]
+        return [EncoderResult(torch.zeros(1, 1)) for _ in items]
 
 
 class _PassthroughBackend(VisionEncoderBackend):
@@ -50,7 +53,7 @@ class _PassthroughBackend(VisionEncoderBackend):
         ...
 
     def forward_batch(self, items, target_bucket=None):
-        return [torch.zeros(1, 1) for _ in items]
+        return [EncoderResult(torch.zeros(1, 1)) for _ in items]
 
 
 def test_preprocessed_is_frozen():
@@ -68,6 +71,14 @@ def test_preprocessed_cost_defaults_to_1():
 def test_preprocessed_has_no_bucket_key():
     # Batching is one-dimensional (scalar cost only) — there is no bucket_key.
     assert not hasattr(Preprocessed(item="x"), "bucket_key")
+
+
+def test_encoder_result_is_frozen_and_defaults_response_data_to_none():
+    result = EncoderResult(artifact="embedding")
+    assert result.artifact == "embedding"
+    assert result.response_data is None
+    with pytest.raises(FrozenInstanceError):
+        result.response_data = {"score": 1}  # type: ignore[misc]
 
 
 def test_abc_cannot_be_instantiated():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
@@ -4,9 +4,9 @@
 """Unit tests for the custom encoder async driver.
 
 Pin the glue contract: build / forward / close run on one actor thread; encode
-returns one tensor per raw; the preprocess barrier fails a request atomically
-(no GPU work) if any image's preprocess fails; load fails fast on a build error or
-a missing/invalid hardcoded image_token_id and reaps its thread.
+returns one opaque artifact per raw; the preprocess barrier fails a request
+atomically (no GPU work) if any image's preprocess fails; load fails fast on a
+build error and reaps its thread.
 """
 
 import threading
@@ -102,12 +102,11 @@ async def test_build_and_forward_share_one_non_main_thread():
         enc.shutdown()
 
 
-async def test_load_resolves_placeholder_and_passes_model_id():
+async def test_load_passes_model_id():
     be = _FakeBackend()
     enc = AsyncVisionEncoder(be)
     enc.load("my-model")
     try:
-        assert enc.get_image_placeholder_token_id() == 151655
         assert be.model_id == "my-model"
     finally:
         enc.shutdown()
@@ -170,15 +169,23 @@ def test_load_fails_fast_on_build_error_and_reaps_threads():
     assert enc._pool is None
 
 
-def test_load_fails_fast_on_missing_image_token_id():
-    class _NoTokenId(_FakeBackend):
-        image_token_id = None  # author forgot to hardcode it
+async def test_encode_preserves_opaque_artifacts():
+    class _ArtifactBackend(VisionEncoderBackend):
+        def build(self, model_id):
+            pass
 
-    enc = AsyncVisionEncoder(_NoTokenId())
-    with pytest.raises(ValueError, match="image_token_id"):
-        enc.load("m")
-    assert enc._batcher is None
-    assert enc._pool is None
+        def forward_batch(self, items, target_bucket=None):
+            return [{"source": item} for item in items]
+
+    enc = AsyncVisionEncoder(_ArtifactBackend())
+    enc.load("m")
+    try:
+        assert await enc.encode(["first", "second"]) == [
+            {"source": "first"},
+            {"source": "second"},
+        ]
+    finally:
+        enc.shutdown()
 
 
 def test_shutdown_before_load_is_safe():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
@@ -4,9 +4,9 @@
 """Unit tests for the custom encoder async driver.
 
 Pin the glue contract: build / forward / close run on one actor thread; encode
-returns one opaque artifact per raw; the preprocess barrier fails a request
-atomically (no GPU work) if any image's preprocess fails; load fails fast on a
-build error and reaps its thread.
+returns one result per raw; the preprocess barrier fails a request atomically
+(no GPU work) if any image's preprocess fails; load fails fast on a build error
+and reaps its thread.
 """
 
 import threading
@@ -16,6 +16,7 @@ import torch
 
 from dynamo.vllm.multimodal_utils.custom_encoder import (
     AsyncVisionEncoder,
+    EncoderResult,
     Preprocessed,
     VisionEncoderBackend,
 )
@@ -58,7 +59,7 @@ class _FakeBackend(VisionEncoderBackend):
 
     def forward_batch(self, items, target_bucket=None):
         self.forward_threads.append(threading.get_ident())
-        return [torch.full((2, 4), float(len(str(it)))) for it in items]
+        return [EncoderResult(torch.full((2, 4), float(len(str(it))))) for it in items]
 
     def close(self):
         self.close_thread = threading.get_ident()
@@ -72,7 +73,7 @@ async def test_encode_returns_one_tensor_per_raw():
     try:
         out = await enc.encode(["a", "bb", "ccc"])
         assert len(out) == 3
-        assert all(t.shape == (2, 4) for t in out)
+        assert all(result.artifact.shape == (2, 4) for result in out)
     finally:
         enc.shutdown()
 
@@ -175,14 +176,26 @@ async def test_encode_preserves_opaque_artifacts():
             pass
 
         def forward_batch(self, items, target_bucket=None):
-            return [{"source": item} for item in items]
+            return [
+                EncoderResult(
+                    artifact={"source": item},
+                    response_data={"position": index},
+                )
+                for index, item in enumerate(items)
+            ]
 
     enc = AsyncVisionEncoder(_ArtifactBackend())
     enc.load("m")
     try:
         assert await enc.encode(["first", "second"]) == [
-            {"source": "first"},
-            {"source": "second"},
+            EncoderResult(
+                artifact={"source": "first"},
+                response_data={"position": 0},
+            ),
+            EncoderResult(
+                artifact={"source": "second"},
+                response_data={"position": 1},
+            ),
         ]
     finally:
         enc.shutdown()
@@ -206,7 +219,7 @@ class _PassthroughBackend(VisionEncoderBackend):
 
     def forward_batch(self, items, target_bucket=None):
         self.forward_calls.append(list(items))
-        return [torch.zeros(2, 4) for _ in items]
+        return [EncoderResult(torch.zeros(2, 4)) for _ in items]
 
 
 async def test_passthrough_skips_preprocess_when_no_pool():
@@ -224,7 +237,7 @@ async def test_passthrough_skips_preprocess_when_no_pool():
         assert enc._pool is None  # no pool created
         out = await enc.encode(["a", "bb"])
         assert len(out) == 2
-        assert all(t.shape == (2, 4) for t in out)
+        assert all(result.artifact.shape == (2, 4) for result in out)
         # Passthrough must hand the raws themselves to forward_batch, unchanged
         # and in order. A single request may span multiple micro-batches, so
         # flatten the recorded calls rather than requiring one forward call.

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_flow.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_flow.py
@@ -7,15 +7,16 @@ The unit tests cover each side with the other mocked out — the backend test ne
 touches the assembler, and the assembler test hand-builds tensors instead of a
 backend — so neither pins the seam. This walks the whole contract for one request
 (build -> preprocess -> forward_batch -> build_mixed_embeds) and doubles as a
-worked example of how the APIs fit: forward_batch emits one CPU
-(n_tokens, hidden) tensor per image, and build_mixed_embeds splices them at the
-one-placeholder-token-per-image positions.
+worked example of how the APIs fit: forward_batch emits one result containing a
+CPU (n_tokens, hidden) tensor per image, and build_mixed_embeds splices the
+artifacts at the one-placeholder-token-per-image positions.
 """
 
 import pytest
 import torch
 
 from dynamo.vllm.multimodal_utils.custom_encoder import (
+    EncoderResult,
     Preprocessed,
     VisionEncoderBackend,
     build_mixed_embeds,
@@ -49,7 +50,8 @@ class _ToyEncoder(VisionEncoderBackend):
         # Distinct non-zero fill per image (1.0, 2.0, ...) so the splice is
         # unambiguous against the zero-filled text rows. CPU, per the contract.
         return [
-            torch.full((n, _HIDDEN), float(i + 1)) for i, (_, n) in enumerate(items)
+            EncoderResult(torch.full((n, _HIDDEN), float(i + 1)))
+            for i, (_, n) in enumerate(items)
         ]
 
 
@@ -61,7 +63,8 @@ def test_backend_and_assembler_work_together():
     # Caller flow: preprocess each raw off-thread, then one batched forward.
     pre = [enc.preprocess(r) for r in ("ab", "cde")]
     assert [p.cost for p in pre] == [2, 3]
-    img_tensors = enc.forward_batch([p.item for p in pre])
+    results = enc.forward_batch([p.item for p in pre])
+    img_tensors = [result.artifact for result in results]
     assert [tuple(t.shape) for t in img_tensors] == [(2, _HIDDEN), (3, _HIDDEN)]
 
     # Prompt: 10 <img> 11 12 <img> — one placeholder token per image.

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -7,8 +7,13 @@ from unittest.mock import AsyncMock
 import pytest
 import torch
 
-from dynamo.vllm.handlers import DecodeWorkerHandler
+from dynamo.vllm.handlers import (
+    DecodeWorkerHandler,
+    _attach_custom_encoder_data,
+    _prepare_custom_encoder_results,
+)
 from dynamo.vllm.multimodal_utils.custom_encoder import (
+    EncoderResult,
     VisionEncoderBackend,
     create_custom_encoder_adapter,
 )
@@ -48,10 +53,17 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
     handler = object.__new__(DecodeWorkerHandler)
     handler._custom_encoder_adapter = _adapter()
     handler._custom_encoder = SimpleNamespace(
-        encode=AsyncMock(return_value=[torch.ones((2, 4), dtype=torch.bfloat16)])
+        encode=AsyncMock(
+            return_value=[
+                EncoderResult(
+                    artifact=torch.ones((2, 4), dtype=torch.bfloat16),
+                    response_data={"score": 0.75},
+                )
+            ]
+        )
     )
 
-    prompt, error = await handler._assemble_custom_encoder_prompt(
+    prompt, response_data, error = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [1, 99, 2],
             "multi_modal_data": {
@@ -62,6 +74,7 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
     )
 
     assert error is None
+    assert response_data == {"items": [{"score": 0.75}]}
     assert prompt is not None
     assert tuple(prompt["prompt_embeds"].shape) == (4, 4)
     assert prompt["prompt_token_ids"] == [1, 99, 99, 2]
@@ -74,7 +87,7 @@ async def test_custom_encoder_handler_preserves_string_error_contract():
         encode=AsyncMock(side_effect=RuntimeError("encoder failed"))
     )
 
-    prompt, error = await handler._assemble_custom_encoder_prompt(
+    prompt, response_data, error = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [99],
             "multi_modal_data": {
@@ -85,5 +98,116 @@ async def test_custom_encoder_handler_preserves_string_error_contract():
     )
 
     assert prompt is None
+    assert response_data is None
     assert error is not None
     assert error["finish_reason"] == "error: CustomEncoder failed: encoder failed"
+
+
+def test_prepare_custom_encoder_results_preserves_null_positions():
+    artifact = torch.ones((1, 4))
+    response_item = {"score": 0.5}
+
+    artifacts, response_data = _prepare_custom_encoder_results(
+        [
+            EncoderResult(artifact=artifact, response_data=response_item),
+            EncoderResult(artifact=artifact),
+        ]
+    )
+    response_item["score"] = 1.0
+
+    assert artifacts == [artifact, artifact]
+    assert response_data == {"items": [{"score": 0.5}, None]}
+
+
+def test_prepare_custom_encoder_results_omits_empty_response_payload():
+    artifact = torch.ones((1, 4))
+
+    artifacts, response_data = _prepare_custom_encoder_results(
+        [EncoderResult(artifact=artifact)]
+    )
+
+    assert artifacts == [artifact]
+    assert response_data is None
+
+
+@pytest.mark.parametrize(
+    "result, message",
+    [
+        (torch.ones((1, 4)), "must return EncoderResult"),
+        (
+            EncoderResult(artifact=torch.ones((1, 4)), response_data={"bad": {1}}),
+            "JSON-serializable",
+        ),
+        (
+            EncoderResult(
+                artifact=torch.ones((1, 4)),
+                response_data={"score": float("nan")},
+            ),
+            "JSON-serializable",
+        ),
+        (
+            EncoderResult(
+                artifact=torch.ones((1, 4)),
+                response_data={"value": -(1 << 63) - 1},
+            ),
+            "i64/u64 range",
+        ),
+        (
+            EncoderResult(
+                artifact=torch.ones((1, 4)),
+                response_data={"value": 1 << 64},
+            ),
+            "i64/u64 range",
+        ),
+    ],
+)
+def test_prepare_custom_encoder_results_rejects_invalid_results(result, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        _prepare_custom_encoder_results([result])
+
+
+@pytest.mark.parametrize("value", [-(1 << 63), (1 << 64) - 1])
+def test_prepare_custom_encoder_results_accepts_serde_json_integer_limits(value):
+    artifact = torch.ones((1, 4))
+
+    _, response_data = _prepare_custom_encoder_results(
+        [EncoderResult(artifact=artifact, response_data={"value": value})]
+    )
+
+    assert response_data == {"items": [{"value": value}]}
+
+
+def test_prepare_custom_encoder_results_enforces_response_limit():
+    result = EncoderResult(
+        artifact=torch.ones((1, 4)),
+        response_data={"value": "x" * (64 * 1024)},
+    )
+
+    with pytest.raises(ValueError, match="64 KiB"):
+        _prepare_custom_encoder_results([result])
+
+
+def test_custom_encoder_data_attaches_only_to_first_success_chunk():
+    response_data = {"items": [{"score": 0.75}]}
+    first = {"token_ids": [1], "index": 0}
+    second = {"token_ids": [2], "index": 0}
+
+    sent = _attach_custom_encoder_data(first, response_data, already_sent=False)
+    sent = _attach_custom_encoder_data(second, response_data, already_sent=sent)
+
+    assert sent is True
+    assert first["custom_encoder_data"] == response_data
+    assert "custom_encoder_data" not in second
+
+
+def test_custom_encoder_data_is_not_attached_to_error_chunk():
+    error = {"finish_reason": "error: generation failed", "token_ids": []}
+
+    sent = _attach_custom_encoder_data(
+        error,
+        {"items": [{"score": 0.75}]},
+        already_sent=False,
+    )
+
+    assert sent is False
+    assert "custom_encoder_data" not in error

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -145,36 +145,11 @@ def test_prepare_custom_encoder_results_omits_empty_response_payload():
             ),
             "JSON-serializable",
         ),
-        (
-            EncoderResult(
-                artifact=torch.ones((1, 4)),
-                response_data={"value": -(1 << 63) - 1},
-            ),
-            "i64/u64 range",
-        ),
-        (
-            EncoderResult(
-                artifact=torch.ones((1, 4)),
-                response_data={"value": 1 << 64},
-            ),
-            "i64/u64 range",
-        ),
     ],
 )
 def test_prepare_custom_encoder_results_rejects_invalid_results(result, message):
     with pytest.raises((TypeError, ValueError), match=message):
         _prepare_custom_encoder_results([result])
-
-
-@pytest.mark.parametrize("value", [-(1 << 63), (1 << 64) - 1])
-def test_prepare_custom_encoder_results_accepts_serde_json_integer_limits(value):
-    artifact = torch.ones((1, 4))
-
-    _, response_data = _prepare_custom_encoder_results(
-        [EncoderResult(artifact=artifact, response_data={"value": value})]
-    )
-
-    assert response_data == {"items": [{"value": value}]}
 
 
 def test_prepare_custom_encoder_results_enforces_response_limit():
@@ -192,8 +167,18 @@ def test_custom_encoder_data_attaches_only_to_first_success_chunk():
     first = {"token_ids": [1], "index": 0}
     second = {"token_ids": [2], "index": 0}
 
-    sent = _attach_custom_encoder_data(first, response_data, already_sent=False)
-    sent = _attach_custom_encoder_data(second, response_data, already_sent=sent)
+    sent = _attach_custom_encoder_data(
+        first,
+        response_data,
+        requested=True,
+        already_sent=False,
+    )
+    sent = _attach_custom_encoder_data(
+        second,
+        response_data,
+        requested=True,
+        already_sent=sent,
+    )
 
     assert sent is True
     assert first["custom_encoder_data"] == response_data
@@ -206,8 +191,23 @@ def test_custom_encoder_data_is_not_attached_to_error_chunk():
     sent = _attach_custom_encoder_data(
         error,
         {"items": [{"score": 0.75}]},
+        requested=True,
         already_sent=False,
     )
 
     assert sent is False
     assert "custom_encoder_data" not in error
+
+
+def test_custom_encoder_data_is_not_attached_without_opt_in() -> None:
+    chunk = {"token_ids": [1], "index": 0}
+
+    sent = _attach_custom_encoder_data(
+        chunk,
+        {"items": [{"score": 0.75}]},
+        requested=False,
+        already_sent=False,
+    )
+
+    assert sent is False
+    assert "custom_encoder_data" not in chunk

--- a/examples/custom_encoder/hitchhikers_vision_encoder.py
+++ b/examples/custom_encoder/hitchhikers_vision_encoder.py
@@ -3,8 +3,8 @@
 
 """Example ``VisionEncoderBackend`` that fakes an image as a known text phrase.
 
-Instead of a real vision encoder, ``forward_batch()`` returns the LM's
-``embed_tokens`` embeddings of a fixed phrase (default: *"the Ultimate Question
+Instead of a real vision encoder, ``forward_batch()`` returns results containing
+the LM's ``embed_tokens`` embeddings of a fixed phrase (default: *"the Ultimate Question
 of Life, the Universe, and Everything"*). Splicing those embeddings in at the
 image placeholder makes the assembled prompt read as one coherent sentence, so
 the mixed-embeds path can be checked for **semantic** correctness, not just
@@ -44,6 +44,7 @@ import torch
 from safetensors import safe_open
 from transformers.utils import cached_file
 
+from dynamo.vllm.multimodal_utils.custom_encoder import EncoderResult
 from examples.custom_encoder.qwen_vision_encoder import QwenVisionEncoderBackend
 
 logger = logging.getLogger(__name__)
@@ -115,7 +116,7 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
 
     def forward_batch(
         self, items: List[str], target_bucket: Optional[int] = None
-    ) -> List[torch.Tensor]:
+    ) -> List[EncoderResult[torch.Tensor]]:
         """Return the ``embed_tokens`` embeddings of the phrase for each item.
 
         Synchronous batched forward — the AsyncVisionEncoder runs it on the
@@ -138,4 +139,4 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
             len(ids),
             tuple(phrase_embeds.shape),
         )
-        return [phrase_embeds.clone() for _ in items]
+        return [EncoderResult(artifact=phrase_embeds.clone()) for _ in items]

--- a/examples/custom_encoder/hitchhikers_vision_encoder.py
+++ b/examples/custom_encoder/hitchhikers_vision_encoder.py
@@ -94,7 +94,8 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
 
     A test/example backend, not a production vision encoder: it loads the LM's
     ``embed_tokens`` weight and returns the embeddings of ``DYN_CUSTOM_PHRASE``
-    so the spliced prompt reads as a coherent sentence.
+    so the spliced prompt reads as a coherent sentence. Its optional response
+    metadata reports the number of phrase tokens embedded for each image.
     """
 
     # Eager: no graph ladder. Count-based budget (cost == 1 per image). The URL is
@@ -139,4 +140,10 @@ class HitchhikersVisionEncoder(QwenVisionEncoderBackend):
             len(ids),
             tuple(phrase_embeds.shape),
         )
-        return [EncoderResult(artifact=phrase_embeds.clone()) for _ in items]
+        return [
+            EncoderResult(
+                artifact=phrase_embeds.clone(),
+                response_data={"phrase_token_count": len(ids)},
+            )
+            for _ in items
+        ]

--- a/examples/custom_encoder/qwen_vision_encoder.py
+++ b/examples/custom_encoder/qwen_vision_encoder.py
@@ -5,8 +5,9 @@
 
 Hardcodes the Qwen ``<|image_pad|>`` placeholder id and loads the model tokenizer
 (handy for subclasses that tokenize text). A concrete Qwen-family encoder
-subclasses this and implements ``forward_batch`` — plus ``preprocess`` (and
-``preprocess_concurrency > 0``) only when it needs off-loop fetch/resize.
+subclasses this and implements ``forward_batch`` with one ``EncoderResult`` per
+input — plus ``preprocess`` (and ``preprocess_concurrency > 0``) only when it
+needs off-loop fetch/resize.
 
     class MyQwenEncoder(QwenVisionEncoderBackend):
         preprocess_concurrency = 4              # enable the off-loop pool
@@ -16,7 +17,7 @@ subclasses this and implements ``forward_batch`` — plus ``preprocess`` (and
         def preprocess(self, raw):
             ...                                 # off-thread, returns Preprocessed
         def forward_batch(self, items, target_bucket=None):
-            ...                                 # actor thread, batched forward (CPU out)
+            ...                                 # actor thread, EncoderResult (CPU artifact)
 """
 
 from __future__ import annotations


### PR DESCRIPTION
_Based on #11849._

## Why

Custom encoders can produce small per-image JSON metadata alongside decoder artifacts. Dynamo needs a typed, bounded handoff that preserves item order without coupling encoder implementations to a public response schema. Because this is non-standard response data, collection should occur only when the client explicitly requests `custom_encoder` through `nvext.extra_fields`.

## Effect

```json
{"nvext":{"extra_fields":["custom_encoder"]}}
```

enables the stacked response field `nvext.custom_encoder`; requests without the selector do not collect or return it.

## What Change

- Return ordered `EncoderResult` values with artifacts and optional metadata.
- Validate, detach, and cap metadata before the internal engine handoff.
- Attach metadata once to the first successful generation chunk, only when requested.
- Extend the example encoder with observable response metadata.

## Test Plan

- Focused custom-encoder pytest suite: 83 passed.
- Repository pre-commit hooks passed.
- Stacked HTTP E2E verified default omission and explicit opt-in.
