### PR TITLE
fix(mocker): order replay G2 publication

### DIFF
--- a/lib/mocker/src/kvbm_offload/engine.rs
+++ b/lib/mocker/src/kvbm_offload/engine.rs
@@ -60,7 +60,7 @@ use super::coordinator::{
 };
 use super::shared_g3::SharedG3Pool;
 use super::shared_g4::SharedG4Store;
-use super::worker::MockWorker;
+use super::worker::{MockWorker, TransferDirection};
 
 // Successful offline barriers wake via watch channels. The timeout is only a
 // hang guard for pipeline bugs.
@@ -1052,7 +1052,28 @@ impl MockOffloadEngine {
         self.worker.set_now_ms(now_ms);
         let g2_registrations_before = Self::tier_registrations(&self.g2_manager);
         let local_token = self.engine.settlement_token();
-        let drained = self.worker.drain_completions_summary(now_ms);
+        let mut ordered_offload_completions = 0u64;
+        let drained = self.worker.drain_completions_summary_with_local(
+            now_ms,
+            |completion| {
+                // Settle destination registration before publishing the next
+                // deterministic model completion.
+                if !cfg!(feature = "replay-bench")
+                    || completion.direction != TransferDirection::G1ToG2
+                {
+                    return;
+                }
+
+                ordered_offload_completions = ordered_offload_completions
+                    .checked_add(1)
+                    .expect("G1→G2 completion count overflow");
+                let mut target = SettlementTarget::new();
+                target
+                    .add_completed_batches(PipelineLane::G1ToG2, ordered_offload_completions)
+                    .expect("G1→G2 settlement target overflow");
+                self.settle_or_panic(local_token.clone(), target);
+            },
+        );
         let offload_drained = drained.local.offload_transfers;
         let offload_drained_blocks = drained.local.offload_blocks;
         let shared_g3 = drained.shared_g3.counts;

--- a/lib/mocker/src/kvbm_offload/worker.rs
+++ b/lib/mocker/src/kvbm_offload/worker.rs
@@ -260,6 +260,15 @@ impl TransferState {
     /// Advance both models to `now_ms` under PS and notify any completion
     /// sinks registered for drained `TransferId`s.
     pub(crate) fn drain_completions(&mut self, now_ms: f64, scope: &'static str) -> DrainResult {
+        self.drain_completions_with(now_ms, scope, |_| {})
+    }
+
+    pub(crate) fn drain_completions_with(
+        &mut self,
+        now_ms: f64,
+        scope: &'static str,
+        mut after_pipeline_completion: impl FnMut(CompletedTransfer),
+    ) -> DrainResult {
         let offload_before = self.offload_bw.active_count();
         let onboard_before = self.onboard_bw.active_count();
         let offload_drained = self.offload_bw.advance_to(now_ms);
@@ -311,13 +320,15 @@ impl TransferState {
                     .entry(awaiter.owner_id)
                     .or_default()
                     .add_transfer(awaiter.direction, awaiter.num_blocks);
-                result.completed.push(CompletedTransfer {
+                let completed = CompletedTransfer {
                     id,
                     direction: awaiter.direction,
-                });
+                };
+                result.completed.push(completed);
                 // Ignore trigger errors — the velo event system may be
                 // shut down during cleanup.
                 let _ = awaiter.event.trigger();
+                after_pipeline_completion(completed);
                 awaiter_fired += 1;
             }
             if let Some(status) = self.swap_in_status.remove(&id) {
@@ -482,8 +493,18 @@ impl MockWorker {
     }
 
     pub(crate) fn drain_completions_summary(&self, now_ms: f64) -> DrainSummary {
+        self.drain_completions_summary_with_local(now_ms, |_| {})
+    }
+
+    pub(crate) fn drain_completions_summary_with_local(
+        &self,
+        now_ms: f64,
+        after_local_pipeline_completion: impl FnMut(CompletedTransfer),
+    ) -> DrainSummary {
         let mut state = self.state.lock().expect("TransferState mutex poisoned");
-        let local = state.drain_completions(now_ms, "worker").total;
+        let local = state
+            .drain_completions_with(now_ms, "worker", after_local_pipeline_completion)
+            .total;
         drop(state);
         let shared_g3 = self
             .shared_g3
@@ -1385,6 +1406,25 @@ mod tests {
             awaiter_id, swap_id,
             "offload and swap-in must draw distinct TransferIds"
         );
+    }
+
+    #[tokio::test]
+    async fn local_completion_hook_follows_processor_sharing_completion_order() {
+        let worker = make_worker();
+        let (long_id, _long) = worker
+            .reserve_transfer_with(TransferDirection::G1ToG2, 0.0, 2, |_| {})
+            .unwrap();
+        let (short_id, _short) = worker
+            .reserve_transfer_with(TransferDirection::G1ToG2, 0.0, 1, |_| {})
+            .unwrap();
+        let mut observed = Vec::new();
+
+        let drained = worker.drain_completions_summary_with_local(3.0, |completed| {
+            observed.push(completed.id);
+        });
+
+        assert_eq!(drained.local.offload_transfers, 2);
+        assert_eq!(observed, vec![short_id, long_id]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #12347 by preserving the mock bandwidth model's deterministic completion
order through G2 destination registration.

The bandwidth model already returns G1→G2 completions deterministically, but
offline replay previously fired every drained completion awaiter before one
aggregate pipeline-settlement wait. The awakened Tokio tasks could register
their destination blocks in a different order, changing G2 router publication,
worker selection, cache reuse, and replay metrics.

This change exposes each local pipeline completion to `MockOffloadEngine` and,
for replay-bench G1→G2 traffic, waits for that completion's destination
registration before firing the next completion. It does not serialize transfer
reservation or modeled transfer execution, and normal non-replay builds retain
the existing behavior.

## Validation

- 5,000-row Mooncake trace, vLLM disaggregated serving with 2 prefill and 2
  decode workers, KV routing, and KVBM G1↔G2:
  - Baseline: two canonical report digests across 8 fresh processes (5/8 and
    3/8).
  - Candidate: one canonical report digest across 20/20 fresh processes.
- All 28 reports completed 5,000/5,000 requests and passed disaggregated
  handoff-causality checks.
- A representative candidate run retained the issue's lifecycle coverage:
  one vLLM preemption, 236 G2→G1 swap-in hits, and 26,340 G1→G2 drain
  publications.
- Focused regression test passed:
  `local_completion_hook_follows_processor_sharing_completion_order`
  (1 passed, 772 filtered out).
- Baseline and candidate release builds passed with
  `--no-default-features --features replay-bench,mocker-kvbm-offload`.
  Candidate binary growth was 0.085% overall and 0.115% in `.text`.
- Commit hooks and `git diff --check` passed.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12348" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved completion handling for simulated data transfers.
  - Local transfer settlements now occur in the correct completion order, including processor-sharing scenarios.
  - Completion processing is more consistent when multiple transfers finish at different times.

- **Tests**
  - Added coverage verifying that shorter transfers are reported before longer transfers when both complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->