### PR TITLE
fix(frontend): derive reasoning default from SGLang instead of a local table

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -116,6 +116,63 @@ def _normalize_sglang_parser_name(parser_name: str | None) -> str | None:
     return _SGLANG_PARSER_NAME_ALIASES.get(parser_name, parser_name)
 
 
+@lru_cache(maxsize=64)
+def _sglang_reasoning_default(parser_name: str) -> str | None:
+    """Return SGLang's own ``reasoning_default`` for ``parser_name``.
+
+    ``_THINKING_BY_DEFAULT`` / ``_THINKING_OPT_IN`` below duplicate a table that
+    SGLang already publishes: every reasoning detector declares a
+    ``reasoning_default`` and ``serving_chat._get_reasoning_from_request`` reads
+    it. Duplicating it means each new SGLang model silently gets the wrong
+    answer here until someone remembers to update the sets -- and the failure is
+    quiet, because an unlisted parser falls through to ``template_default``,
+    which is ``False`` for any model that ships no Jinja chat template.
+
+    Kimi-K3 hit exactly that: ``reasoning_default='thinking'`` (thinking on
+    unless ``chat_template_kwargs.thinking is False``), but it was in neither
+    set and has no chat template, so reasoning was never enabled -- the parser
+    stayed off, ``reasoning_content`` came back null, and the raw
+    ``<|close|>think<|sep|>`` marker leaked into ``content``.
+
+    Ask SGLang instead. Returns None when the parser is unknown to this SGLang
+    build, in which case the caller falls back to the static tables.
+    """
+    try:
+        detector = ReasoningParser(model_type=parser_name).detector
+    except Exception:
+        # Unknown to this SGLang build: ReasoningParser raises on an
+        # unrecognised model_type. Fall back to the static tables rather than
+        # failing the request.
+        return None
+    return getattr(detector, "reasoning_default", None)
+
+
+def _force_reasoning_from_sglang_default(
+    mode: str | None, kwargs: dict[str, Any], request: dict[str, Any]
+) -> bool | None:
+    """Apply SGLang's ``reasoning_default`` semantics; None if not applicable.
+
+    Mirrors the mode dispatch in
+    ``serving_chat._get_reasoning_from_request``.
+    """
+    if mode is None:
+        return None
+    if mode == "always":
+        return True
+    if mode == "mistral":
+        reasoning_effort = request.get("reasoning_effort")
+        if reasoning_effort is None:
+            reasoning_effort = kwargs.get("reasoning_effort")
+        return reasoning_effort is not None and reasoning_effort != "none"
+    if mode in ("thinking", "enable_thinking"):
+        # on by default; the matching kwarg set to False opts out
+        return kwargs.get(mode) is not False
+    if mode in ("explicit_thinking", "explicit_enable_thinking"):
+        toggle = mode.replace("explicit_", "")
+        return kwargs.get(toggle) is True
+    return None
+
+
 def resolve_request_force_reasoning(
     request: dict[str, Any],
     reasoning_parser_name: str | None,
@@ -137,6 +194,13 @@ def resolve_request_force_reasoning(
       * opt-in families (``deepseek-v3``/``gemma4``): off by default,
         enabled by ``chat_template_kwargs.{thinking,enable_thinking}=True``.
       * anything else: follow the statically-detected template default.
+
+    The opt-out/opt-in families are resolved from SGLang's own
+    ``reasoning_default`` where this SGLang build exposes the parser, so a model
+    SGLang knows about does not need to be added to the tables below. The tables
+    remain as the fallback for parsers this build does not expose. ``minimax-m3``
+    and ``mistral`` keep their explicit handling above, so their behaviour is
+    unaffected.
     """
     reasoning_parser_name = _normalize_sglang_parser_name(reasoning_parser_name)
     if not reasoning_parser_name:
@@ -154,6 +218,12 @@ def resolve_request_force_reasoning(
         if reasoning_effort is None:
             reasoning_effort = kwargs.get("reasoning_effort")
         return reasoning_effort is not None and reasoning_effort != "none"
+
+    resolved = _force_reasoning_from_sglang_default(
+        _sglang_reasoning_default(reasoning_parser_name), kwargs, request
+    )
+    if resolved is not None:
+        return resolved
 
     if reasoning_parser_name in _THINKING_BY_DEFAULT:
         flag_key = (

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -116,6 +116,21 @@ def _normalize_sglang_parser_name(parser_name: str | None) -> str | None:
     return _SGLANG_PARSER_NAME_ALIASES.get(parser_name, parser_name)
 
 
+# SGLang ``reasoning_default`` modes this frontend implements, mirroring the
+# dispatch in ``serving_chat._get_reasoning_from_request``. A mode outside this
+# set is reported rather than silently ignored -- see _sglang_reasoning_default.
+_SGLANG_REASONING_MODES = frozenset(
+    {
+        "always",
+        "mistral",
+        "thinking",
+        "enable_thinking",
+        "explicit_thinking",
+        "explicit_enable_thinking",
+    }
+)
+
+
 @lru_cache(maxsize=64)
 def _sglang_reasoning_default(parser_name: str) -> str | None:
     """Return SGLang's own ``reasoning_default`` for ``parser_name``.
@@ -135,16 +150,38 @@ def _sglang_reasoning_default(parser_name: str) -> str | None:
     ``<|close|>think<|sep|>`` marker leaked into ``content``.
 
     Ask SGLang instead. Returns None when the parser is unknown to this SGLang
-    build, in which case the caller falls back to the static tables.
+    build, or declares a mode this dispatch does not implement, in which case
+    the caller falls back to the static tables.
     """
     try:
         detector = ReasoningParser(model_type=parser_name).detector
-    except Exception:
-        # Unknown to this SGLang build: ReasoningParser raises on an
-        # unrecognised model_type. Fall back to the static tables rather than
-        # failing the request.
+    except ValueError:
+        # The parser is unknown to this SGLang build: ReasoningParser raises
+        # ValueError("Unsupported model type: ...") for a name outside its
+        # DetectorMap. That is the expected fallback path, so it is not logged.
+        # Any other exception is a genuine SGLang failure and must propagate.
         return None
-    return getattr(detector, "reasoning_default", None)
+
+    # Deliberately a direct attribute access, not getattr(..., None): every
+    # detector inherits reasoning_default from BaseReasoningFormatDetector, so
+    # its absence means the detector contract has changed and we want the
+    # AttributeError rather than a silent fallback.
+    mode = detector.reasoning_default
+
+    if mode not in _SGLANG_REASONING_MODES:
+        # SGLang knows this parser but declares a mode we do not implement --
+        # a new mode added upstream. Falling back to the static tables here
+        # would silently reintroduce exactly the miss this function exists to
+        # prevent, so say so. lru_cache keeps this to once per parser.
+        logger.warning(
+            "sglang reasoning parser %r declares reasoning_default=%r, which "
+            "this frontend does not implement; falling back to the static "
+            "thinking tables. Reasoning enablement may be wrong for this model.",
+            parser_name,
+            mode,
+        )
+        return None
+    return mode
 
 
 def _force_reasoning_from_sglang_default(
@@ -153,7 +190,9 @@ def _force_reasoning_from_sglang_default(
     """Apply SGLang's ``reasoning_default`` semantics; None if not applicable.
 
     Mirrors the mode dispatch in
-    ``serving_chat._get_reasoning_from_request``.
+    ``serving_chat._get_reasoning_from_request``. ``mode`` is None when the
+    parser is unknown to this SGLang build or declares an unimplemented mode;
+    both mean "fall back to the static tables".
     """
     if mode is None:
         return None
@@ -170,7 +209,10 @@ def _force_reasoning_from_sglang_default(
     if mode in ("explicit_thinking", "explicit_enable_thinking"):
         toggle = mode.replace("explicit_", "")
         return kwargs.get(toggle) is True
-    return None
+    # Unreachable: _sglang_reasoning_default only returns a mode in
+    # _SGLANG_REASONING_MODES, and every member is handled above. Kept so the
+    # two stay honest if a mode is ever added to the set without a branch here.
+    raise AssertionError(f"unhandled sglang reasoning_default mode: {mode!r}")
 
 
 def resolve_request_force_reasoning(

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -184,6 +184,21 @@ def _sglang_reasoning_default(parser_name: str) -> str | None:
     return mode
 
 
+def _request_reasoning_effort(
+    request: dict[str, Any], kwargs: dict[str, Any]
+) -> str | None:
+    """``reasoning_effort`` for this request, top-level winning over kwargs.
+
+    SGLang reads only the top-level field; the ``chat_template_kwargs`` fallback
+    is pre-existing frontend behaviour, kept so the ``mistral`` and ``hunyuan``
+    gates agree on where the value comes from.
+    """
+    reasoning_effort = request.get("reasoning_effort")
+    if reasoning_effort is None:
+        reasoning_effort = kwargs.get("reasoning_effort")
+    return reasoning_effort
+
+
 def _force_reasoning_from_sglang_default(
     mode: str | None, kwargs: dict[str, Any], request: dict[str, Any]
 ) -> bool | None:
@@ -199,9 +214,7 @@ def _force_reasoning_from_sglang_default(
     if mode == "always":
         return True
     if mode == "mistral":
-        reasoning_effort = request.get("reasoning_effort")
-        if reasoning_effort is None:
-            reasoning_effort = kwargs.get("reasoning_effort")
+        reasoning_effort = _request_reasoning_effort(request, kwargs)
         return reasoning_effort is not None and reasoning_effort != "none"
     if mode in ("thinking", "enable_thinking"):
         # on by default; the matching kwarg set to False opts out
@@ -256,10 +269,17 @@ def resolve_request_force_reasoning(
         return kwargs.get("thinking_mode") != "disabled"
 
     if reasoning_parser_name == "mistral":
-        reasoning_effort = request.get("reasoning_effort")
-        if reasoning_effort is None:
-            reasoning_effort = kwargs.get("reasoning_effort")
+        reasoning_effort = _request_reasoning_effort(request, kwargs)
         return reasoning_effort is not None and reasoning_effort != "none"
+
+    if reasoning_parser_name == "hunyuan":
+        # SGLang special-cases hunyuan ahead of its own reasoning_default
+        # dispatch, and must be mirrored here for the same reason: the detector
+        # declares reasoning_default="always", but the Hy3-preview template
+        # emits no <think> unless reasoning_effort asks for it, so honouring
+        # "always" would route the entire response into reasoning_content.
+        reasoning_effort = _request_reasoning_effort(request, kwargs)
+        return reasoning_effort not in (None, "none", "no_think")
 
     resolved = _force_reasoning_from_sglang_default(
         _sglang_reasoning_default(reasoning_parser_name), kwargs, request

--- a/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
@@ -21,6 +21,7 @@ from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 from dynamo.frontend.sglang_prepost import (
     _SGLANG_REASONING_MODES,
+    _force_reasoning_from_sglang_default,
     _sglang_reasoning_default,
     resolve_request_force_reasoning,
 )
@@ -111,6 +112,87 @@ class TestExistingBehaviourUnchanged:
     )
     def test_mistral_keeps_explicit_handling(self, request_body, expected):
         assert _resolve("mistral", request=request_body) is expected
+
+    @pytest.mark.parametrize(
+        "effort, expected",
+        [
+            (None, False),
+            ("none", False),
+            ("no_think", False),
+            ("low", True),
+            ("high", True),
+        ],
+    )
+    def test_hunyuan_gates_on_reasoning_effort(self, effort, expected):
+        """hunyuan declares reasoning_default='always' but must not honour it.
+
+        The Hy3-preview template emits no <think> unless reasoning_effort asks
+        for it, so taking 'always' at face value would route the whole response
+        into reasoning_content. SGLang special-cases this ahead of its own
+        reasoning_default dispatch; we mirror that.
+        """
+        body = {} if effort is None else {"reasoning_effort": effort}
+        assert _resolve("hunyuan", request=body) is expected
+
+    def test_hunyuan_reasoning_default_is_always(self):
+        """Documents why the branch above is needed, not redundant."""
+        _skip_if_parser_absent("hunyuan")
+        assert _sglang_reasoning_default("hunyuan") == "always"
+
+
+class TestDispatchHelper:
+    """Direct coverage of every mode branch, independent of any real parser."""
+
+    @pytest.mark.parametrize(
+        "mode, kwargs, request_body, expected",
+        [
+            # always: unconditional
+            ("always", {}, {}, True),
+            ("always", {"enable_thinking": False}, {}, True),
+            # mistral: gated on reasoning_effort, top-level or nested
+            ("mistral", {}, {}, False),
+            ("mistral", {}, {"reasoning_effort": "none"}, False),
+            ("mistral", {}, {"reasoning_effort": "low"}, True),
+            ("mistral", {"reasoning_effort": "low"}, {}, True),
+            # top-level wins over the nested value
+            (
+                "mistral",
+                {"reasoning_effort": "low"},
+                {"reasoning_effort": "none"},
+                False,
+            ),
+            (
+                "mistral",
+                {"reasoning_effort": "none"},
+                {"reasoning_effort": "low"},
+                True,
+            ),
+            # opt-out modes: on unless the matching kwarg is exactly False
+            ("thinking", {}, {}, True),
+            ("thinking", {"thinking": False}, {}, False),
+            ("thinking", {"thinking": True}, {}, True),
+            ("enable_thinking", {}, {}, True),
+            ("enable_thinking", {"enable_thinking": False}, {}, False),
+            # opt-in modes: off unless the toggle is exactly True
+            ("explicit_thinking", {}, {}, False),
+            ("explicit_thinking", {"thinking": True}, {}, True),
+            ("explicit_thinking", {"thinking": "yes"}, {}, False),
+            ("explicit_enable_thinking", {}, {}, False),
+            ("explicit_enable_thinking", {"enable_thinking": True}, {}, True),
+            # no mode: not applicable, caller falls back
+            (None, {}, {}, None),
+        ],
+    )
+    def test_mode_dispatch(self, mode, kwargs, request_body, expected):
+        assert _force_reasoning_from_sglang_default(mode, kwargs, request_body) is (
+            expected
+        )
+
+    def test_every_implemented_mode_has_a_branch(self):
+        """No member of the set may fall through to the AssertionError."""
+        for mode in _SGLANG_REASONING_MODES:
+            result = _force_reasoning_from_sglang_default(mode, {}, {})
+            assert isinstance(result, bool), f"mode {mode!r} returned {result!r}"
 
 
 class TestFallback:

--- a/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
@@ -14,9 +14,13 @@ template, so ``reasoning_content`` came back null and the raw
 ``<|close|>think<|sep|>`` marker leaked into ``content``.
 """
 
+import logging
+
 import pytest
+from sglang.srt.parser.reasoning_parser import ReasoningParser
 
 from dynamo.frontend.sglang_prepost import (
+    _SGLANG_REASONING_MODES,
     _sglang_reasoning_default,
     resolve_request_force_reasoning,
 )
@@ -121,3 +125,67 @@ class TestFallback:
 
     def test_no_parser_disables_reasoning(self):
         assert _resolve(None, {}, template_default=True) is False
+
+
+class TestModeCoverage:
+    """Guard the assumption that the dispatch covers what SGLang declares.
+
+    Without this, SGLang adding a new ``reasoning_default`` value would silently
+    route every affected model back to the static tables -- reintroducing the
+    exact silent miss this change exists to remove. This test fails loudly
+    instead.
+    """
+
+    def test_every_registered_detector_mode_is_implemented(self):
+        detector_map = getattr(ReasoningParser, "DetectorMap", None)
+        if not detector_map:
+            pytest.skip("this sglang build exposes no DetectorMap")
+
+        unimplemented = {}
+        for name in sorted(detector_map):
+            try:
+                mode = ReasoningParser(model_type=name).detector.reasoning_default
+            except Exception:  # pragma: no cover - detector needs extra deps
+                continue
+            if mode not in _SGLANG_REASONING_MODES:
+                unimplemented[name] = mode
+
+        assert not unimplemented, (
+            "sglang declares reasoning_default values this frontend does not "
+            f"implement: {unimplemented}. Add them to _SGLANG_REASONING_MODES "
+            "and give each a branch in _force_reasoning_from_sglang_default."
+        )
+
+    def test_unimplemented_mode_warns_and_falls_back(self, monkeypatch, caplog):
+        """A mode outside the implemented set must be reported, not swallowed."""
+
+        class _Detector:
+            reasoning_default = "some_future_mode"
+
+        class _Parser:
+            def __init__(self, *args, **kwargs):
+                self.detector = _Detector()
+
+        monkeypatch.setattr("dynamo.frontend.sglang_prepost.ReasoningParser", _Parser)
+        _sglang_reasoning_default.cache_clear()
+        try:
+            with caplog.at_level(logging.WARNING):
+                assert _sglang_reasoning_default("pretend-parser") is None
+            assert "some_future_mode" in caplog.text
+        finally:
+            _sglang_reasoning_default.cache_clear()
+
+    def test_non_valueerror_propagates(self, monkeypatch):
+        """Only ValueError means 'unknown parser'; other failures must surface."""
+
+        class _Parser:
+            def __init__(self, *args, **kwargs):
+                raise RuntimeError("sglang is broken")
+
+        monkeypatch.setattr("dynamo.frontend.sglang_prepost.ReasoningParser", _Parser)
+        _sglang_reasoning_default.cache_clear()
+        try:
+            with pytest.raises(RuntimeError, match="sglang is broken"):
+                _sglang_reasoning_default("pretend-parser-2")
+        finally:
+            _sglang_reasoning_default.cache_clear()

--- a/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reasoning enablement on the sglang chat-processor path.
+
+Regression coverage for the bug where ``resolve_request_force_reasoning``
+decided enablement from two local sets duplicating a table SGLang already
+publishes as each detector's ``reasoning_default``. A parser in neither set
+fell through to ``template_default``, which is ``False`` for any model shipping
+no Jinja chat template -- so reasoning silently never ran.
+
+Kimi-K3 is exactly that case: ``reasoning_default='thinking'`` and no chat
+template, so ``reasoning_content`` came back null and the raw
+``<|close|>think<|sep|>`` marker leaked into ``content``.
+"""
+
+import pytest
+
+from dynamo.frontend.sglang_prepost import (
+    _sglang_reasoning_default,
+    resolve_request_force_reasoning,
+)
+
+# Needs sglang packages (gpu_1 container) but allocates no GPU VRAM.
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+    pytest.mark.profiled_vram_gib(0),
+]
+
+
+def _resolve(parser, kwargs=None, template_default=False, request=None):
+    req = dict(request or {})
+    if kwargs is not None:
+        req["chat_template_kwargs"] = kwargs
+    return resolve_request_force_reasoning(req, parser, template_default)
+
+
+def _skip_if_parser_absent(parser):
+    """Skip when this SGLang build does not expose the parser.
+
+    The fallback tables still cover the older names, but asserting SGLang-derived
+    behaviour is only meaningful when SGLang actually knows the parser.
+    """
+    if _sglang_reasoning_default(parser) is None:
+        pytest.skip(f"sglang build does not expose reasoning parser {parser!r}")
+
+
+class TestSglangDerivedDefault:
+    """The regression: a parser SGLang knows but the local tables do not."""
+
+    def test_kimi_k3_reasons_by_default_with_no_chat_template(self):
+        # The exact failing case. template_default=False stands in for "model
+        # ships no Jinja template"; before the fix this returned False.
+        _skip_if_parser_absent("kimi_k3")
+        assert _resolve("kimi_k3", {}, template_default=False) is True
+
+    def test_kimi_k3_opts_out_via_thinking_false(self):
+        _skip_if_parser_absent("kimi_k3")
+        assert _resolve("kimi_k3", {"thinking": False}, template_default=False) is False
+
+    def test_kimi_k3_ignores_template_default(self):
+        # SGLang's answer must win over the statically detected template default.
+        _skip_if_parser_absent("kimi_k3")
+        assert _resolve("kimi_k3", {}, template_default=True) is True
+
+
+class TestExistingBehaviourUnchanged:
+    """Parsers already covered by the static tables must not shift."""
+
+    @pytest.mark.parametrize(
+        "parser, flag",
+        [
+            ("kimi_k2", "thinking"),
+            ("qwen3", "enable_thinking"),
+        ],
+    )
+    def test_opt_out_families(self, parser, flag):
+        assert _resolve(parser, {}) is True
+        assert _resolve(parser, {flag: False}) is False
+
+    @pytest.mark.parametrize(
+        "parser, flag",
+        [
+            ("deepseek-v3", "thinking"),
+            ("gemma4", "enable_thinking"),
+        ],
+    )
+    def test_opt_in_families(self, parser, flag):
+        assert _resolve(parser, {}) is False
+        assert _resolve(parser, {flag: True}) is True
+
+    def test_minimax_m3_keeps_explicit_handling(self):
+        # Handled before the SGLang lookup, so it must be unaffected by it.
+        assert _resolve("minimax-m3", {}) is True
+        assert _resolve("minimax-m3", {"thinking_mode": "disabled"}) is False
+
+    @pytest.mark.parametrize(
+        "request_body, expected",
+        [
+            ({}, False),
+            ({"reasoning_effort": "none"}, False),
+            ({"reasoning_effort": "low"}, True),
+        ],
+    )
+    def test_mistral_keeps_explicit_handling(self, request_body, expected):
+        assert _resolve("mistral", request=request_body) is expected
+
+
+class TestFallback:
+    """Parsers SGLang does not expose fall back to the static tables."""
+
+    def test_unknown_parser_follows_template_default(self):
+        assert _resolve("not-a-real-parser", {}, template_default=True) is True
+        assert _resolve("not-a-real-parser", {}, template_default=False) is False
+
+    def test_unknown_parser_lookup_returns_none(self):
+        assert _sglang_reasoning_default("not-a-real-parser") is None
+
+    def test_no_parser_disables_reasoning(self):
+        assert _resolve(None, {}, template_default=True) is False


### PR DESCRIPTION
## Overview:

`resolve_request_force_reasoning` decides whether to enable the reasoning parser from two hardcoded sets in `sglang_prepost.py`, `_THINKING_BY_DEFAULT` and `_THINKING_OPT_IN`. SGLang already publishes this information — every reasoning detector declares a `reasoning_default`, and `serving_chat._get_reasoning_from_request` reads it.

Maintaining a copy means each new SGLang model is wrong here until someone remembers to update the sets, and **the failure is silent**: a parser in neither set falls through to `template_default`, which is `False` for any model shipping no Jinja chat template. There is no warning and no error — reasoning simply never runs.

## Summary

Ask SGLang for the mode instead of duplicating its table, and apply the same dispatch it does (`always` / `mistral` / `thinking` / `enable_thinking` / `explicit_*`).

Kimi-K3 is exactly the failing case: its detector declares `reasoning_default='thinking'` with markers `<|open|>think<|sep|>` / `<|close|>think<|sep|>`, but it is in neither set and ships no chat template. The parser never ran, `reasoning_content` came back `null`, and the raw `<|close|>think<|sep|>` marker leaked into `content`.

This is deliberately not a "add kimi_k3 to the list" fix — that would leave the next model equally broken.

## Details:

- New `_sglang_reasoning_default(parser_name)` reads the detector's `reasoning_default`. `lru_cache`d, because detector construction is not free and this runs per request.
- New `_force_reasoning_from_sglang_default(...)` mirrors the mode dispatch in `serving_chat._get_reasoning_from_request`.
- The lookup sits **after** the existing `minimax-m3` and `mistral` special cases, so those keep their explicit handling, and **before** the static tables, which remain as the fallback for parsers a given SGLang build does not expose. Behaviour is therefore unchanged for everything already listed, and for unknown parsers (still `template_default`).

## Validation

Table-tested against sglang `0.0.0.dev0` (v0.5.16), before = current `main`:

| parser | `chat_template_kwargs` | before | after |
|---|---|---|---|
| `kimi_k3` | `{}` | **False** | **True** |
| `kimi_k3` | `{thinking: False}` | False | False |
| `kimi_k2` | `{}` / `{thinking: False}` | True / False | unchanged |
| `qwen3` | `{}` / `{enable_thinking: False}` | True / False | unchanged |
| `deepseek-v3` | `{}` / `{thinking: True}` | False / True | unchanged |
| `gemma4` | `{}` / `{enable_thinking: True}` | False / True | unchanged |
| `minimax-m3` | `{}` / `{thinking_mode: "disabled"}` | True / False | unchanged |
| unknown parser | any | `template_default` | unchanged |

Also verified end to end on a live Kimi-K3 deployment (Dynamo + SGLang, disaggregated, GB300 NVL72): `reasoning_content` populated, no marker leak in `content`, tool calling unaffected.

Adds `components/src/dynamo/frontend/tests/test_sglang_reasoning_default.py` — 14 cases covering the regression, the unchanged families, and the unknown-parser fallback. The SGLang-derived assertions skip when the build does not expose the parser, so the file stays valid across SGLang versions.

`isort` / `black` / `flake8` clean on both changed files (flake8 W503 count is identical to `main`, all pre-existing and outside this diff).

## Where should the reviewer start?

`components/src/dynamo/frontend/sglang_prepost.py` — the ordering inside `resolve_request_force_reasoning` is the part worth scrutinising: SGLang's answer must take precedence over the static tables, but not over the `minimax-m3` / `mistral` branches above it.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #12349

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reasoning behavior now follows each model’s SGLang defaults when available.
  * Supports explicit opt-in and opt-out controls, including model-specific reasoning settings.

* **Bug Fixes**
  * Preserves existing reasoning behavior for known model families.
  * Provides consistent fallback behavior for unknown or unspecified models.

* **Tests**
  * Added coverage for model defaults, explicit overrides, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->