### PR TITLE
fix: pin uv to one version across all container stages

### DIFF
--- a/container/Dockerfile.docs
+++ b/container/Dockerfile.docs
@@ -22,8 +22,8 @@ ENV DYNAMO_COMMIT_SHA=$DYNAMO_COMMIT_SHA
 ARG DYNAMO_DOCS_VERSION=dev
 ENV DYNAMO_DOCS_VERSION=$DYNAMO_DOCS_VERSION
 
-# TODO: Pin uv image to a specific version tag for reproducibility (e.g. ghcr.io/astral-sh/uv:0.10.7)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Keep in sync with container/context.yaml `uv_version`.
+COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /usr/local/bin/
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/container/Dockerfile.docs
+++ b/container/Dockerfile.docs
@@ -23,7 +23,8 @@ ARG DYNAMO_DOCS_VERSION=dev
 ENV DYNAMO_DOCS_VERSION=$DYNAMO_DOCS_VERSION
 
 # Keep in sync with container/context.yaml `uv_version`.
-COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.12.0 /uv /uvx /opt/uv/bin/
+ENV PATH=/opt/uv/bin:${PATH}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/container/Dockerfile.test
+++ b/container/Dockerfile.test
@@ -9,12 +9,16 @@ ARG BASE_IMAGE
 
 FROM ${BASE_IMAGE} AS test_image
 
-# Install test dependencies on top of runtime image
+# Install test dependencies on top of runtime image.
+# No uv cache: this image is built from a SHA-tagged base, so the layer is
+# rebuilt every time and a shared cache mount would be the one place a build
+# could still meet uv cache entries written by a different uv version. The
+# download is a few seconds against a ~660MB cache, so UV_NO_CACHE keeps it out
+# of the layer rather than trading that for the version hazard.
 USER root
 RUN --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
-    --mount=type=cache,target=/root/.cache/uv,sharing=shared \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
-    export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    export UV_NO_CACHE=1 UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     if [ -n "$VIRTUAL_ENV" ]; then \
         uv pip install \

--- a/container/README.md
+++ b/container/README.md
@@ -27,7 +27,7 @@ Below is a summary of the general file structure for the framework Dockerfile st
 | Stage/Filepath | Target |
 | --- | --- |
 | **STAGE dynamo_base** | **FROM ${BASE_IMAGE}** |
-| /bin/uv, /bin/uvx | COPY from ghcr.io/astral-sh/uv:latest (→ framework, runtime) |
+| /usr/local/bin/uv, /usr/local/bin/uvx | COPY from ghcr.io/astral-sh/uv:${uv_version} (→ framework, runtime) |
 |  /usr/bin/nats-server | Downloaded from GitHub (→ runtime) |
 |  /usr/local/bin/etcd/ | Downloaded from GitHub (→ runtime) |
 |  /usr/local/rustup/ | Installed via rustup-init (→ wheel_builder, dev) |

--- a/container/README.md
+++ b/container/README.md
@@ -27,7 +27,7 @@ Below is a summary of the general file structure for the framework Dockerfile st
 | Stage/Filepath | Target |
 | --- | --- |
 | **STAGE dynamo_base** | **FROM ${BASE_IMAGE}** |
-| /usr/local/bin/uv, /usr/local/bin/uvx | COPY from ghcr.io/astral-sh/uv:${uv_version} (→ framework, runtime) |
+| /opt/uv/bin/uv, /opt/uv/bin/uvx | COPY from ghcr.io/astral-sh/uv:${uv_version}, prepended to PATH (→ framework, runtime) |
 |  /usr/bin/nats-server | Downloaded from GitHub (→ runtime) |
 |  /usr/local/bin/etcd/ | Downloaded from GitHub (→ runtime) |
 |  /usr/local/rustup/ | Installed via rustup-init (→ wheel_builder, dev) |

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -34,6 +34,9 @@ dynamo:
   # it so planner NOTICES attribute only what the builder adds on top.
   planner_baseline_sbom: python@043085f9
   python_version: "3.12"
+  # Every stage must use the same uv: stages share one BuildKit uv cache mount,
+  # and uv rejects cache entries written by a newer version.
+  uv_version: "0.12.0"
 
   nats_version: v2.10.28
   etcd_version: v3.5.30

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -359,13 +359,13 @@ COPY --from=wheel_builder --chown=dynamo:0 --chmod=775 /workspace/.venv/bin/matu
 # SGLang XPU: conda env from framework stage; install uv and maturin.
 # uv doesn't natively recognize conda envs (no pyvenv.cfg), so we use
 # --python to target the conda interpreter explicitly.
-COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /tmp/uv-binary
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /tmp/uv-binary
 RUN cp /tmp/uv-binary ${VIRTUAL_ENV}/bin/uv && \
     chmod +x ${VIRTUAL_ENV}/bin/uv && \
     pip install maturin[patchelf]
 {% else %}
 # SGLang CUDA: Create venv with --system-site-packages to inherit runtime packages
-COPY --from=ghcr.io/astral-sh/uv:0.10.7 /uv /tmp/uv-binary
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /tmp/uv-binary
 RUN mkdir -p /opt/dynamo/venv && \
     python3 -m venv --system-site-packages /opt/dynamo/venv && \
     cp -r /usr/local/lib/python${PYTHON_VERSION}/dist-packages/* \
@@ -414,7 +414,7 @@ ARG FRAMEWORK
 RUN --mount=type=bind,source=./container/deps/requirements.dev.txt,target=/tmp/requirements.dev.txt \
     --mount=type=bind,source=./container/deps/requirements.test.txt,target=/tmp/requirements.test.txt \
     # Cache uv downloads; uv handles its own locking for this cache.
-    --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv \
     export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     # Git LFS init (needed for requirements with lfs=true); folded in to save a layer.
     git lfs install && \

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -382,7 +382,7 @@ RUN mkdir -p /opt/dynamo/venv && \
 # CUDA: Runtime uses system Python, so --system-site-packages correctly inherits packages.
 RUN mkdir -p /opt/dynamo/venv && \
     python3 -m venv --system-site-packages /opt/dynamo/venv && \
-    ln -sf /usr/local/bin/uv /opt/dynamo/venv/bin/uv
+    ln -sf /opt/uv/bin/uv /opt/dynamo/venv/bin/uv
 {% else %}
 # CPU/XPU: Runtime uses /opt/venv from upstream vLLM-CPU image. Reuse it directly
 # instead of creating /opt/dynamo/venv, since --system-site-packages points to UV Python
@@ -392,7 +392,7 @@ RUN mkdir -p /opt/dynamo/venv && \
 # Point /usr/local/bin/python to /opt/venv so scripts using 'python' work correctly
 # Use a wrapper script instead of symlink to ensure Python recognizes the venv context
 RUN chown -R dynamo:0 /opt/venv && \
-    ln -sf /usr/local/bin/uv /opt/venv/bin/uv && \
+    ln -sf /opt/uv/bin/uv /opt/venv/bin/uv && \
     rm -f /usr/local/bin/python && \
     echo '#!/bin/bash' > /usr/local/bin/python && \
     echo 'exec /opt/venv/bin/python "$@"' >> /usr/local/bin/python && \

--- a/container/templates/dynamo_base.Dockerfile
+++ b/container/templates/dynamo_base.Dockerfile
@@ -30,9 +30,10 @@ RUN ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64")
     mv "sccache-${SCCACHE_VERSION}-${ARCH_ALT}-unknown-linux-musl/sccache" /usr/local/bin/ && \
     rm -rf sccache*
 
-# Install uv package manager
-# TODO: Pin uv image to a specific version tag for reproducibility (e.g. ghcr.io/astral-sh/uv:0.10.7)
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Install uv package manager. Targets /usr/local/bin so it takes precedence over
+# any uv a downstream base image bundles: every stage shares one uv cache mount,
+# and uv rejects cache entries written by a newer version.
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
 
 # Install NATS server
 ARG NATS_VERSION

--- a/container/templates/dynamo_base.Dockerfile
+++ b/container/templates/dynamo_base.Dockerfile
@@ -30,10 +30,14 @@ RUN ARCH_ALT=$([ "${TARGETARCH}" = "amd64" ] && echo "x86_64" || echo "aarch64")
     mv "sccache-${SCCACHE_VERSION}-${ARCH_ALT}-unknown-linux-musl/sccache" /usr/local/bin/ && \
     rm -rf sccache*
 
-# Install uv package manager. Targets /usr/local/bin so it takes precedence over
-# any uv a downstream base image bundles: every stage shares one uv cache mount,
-# and uv rejects cache entries written by a newer version.
-COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
+# Install uv package manager. It lives in a directory of its own, prepended to
+# PATH, because some bases ship a uv earlier on PATH than /usr/local/bin
+# (/root/.local/bin, /opt/venv/bin). All stages share one uv cache mount and uv
+# rejects cache entries written by a newer version, so the pinned copy has to be
+# the one that runs. Holding only uv/uvx keeps the prepend from shadowing
+# anything else, notably a framework venv's python.
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /opt/uv/bin/
+ENV PATH=/opt/uv/bin:${PATH}
 
 # Install NATS server
 ARG NATS_VERSION

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -96,7 +96,7 @@ ENV HOME=/home/dynamo
 # Use login shell to pick up umask 002 from /etc/profile.d/00-umask.sh for group-writable files
 SHELL ["/bin/bash", "-l", "-o", "pipefail", "-c"]
 # Cache uv downloads; uv handles its own locking for the cache.
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     uv venv /opt/dynamo/venv --python ${PYTHON_VERSION}
 
@@ -107,7 +107,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 # Install dynamo wheels (runtime packages only, no test dependencies)
 # uv handles its own locking for the cache, no need to add sharing=locked
 ARG ENABLE_KVBM
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
@@ -124,14 +124,14 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 {% else %}
 # Dev/local-dev: skip dynamo wheel install (users build from source via cargo build + maturin develop).
 # Install NIXL wheel only (pre-built C++ binary, not buildable from source).
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     uv pip install /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
 
 # Install gpu_memory_service wheel if enabled (all targets)
 ARG ENABLE_GPU_MEMORY_SERVICE
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     if [ "${ENABLE_GPU_MEMORY_SERVICE}" = "true" ]; then \
         export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
         GMS_WHEEL=$(ls /opt/dynamo/wheelhouse/gpu_memory_service*.whl 2>/dev/null | head -1); \
@@ -148,7 +148,7 @@ RUN git lfs install
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
     --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
-    --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --index-strategy unsafe-best-match \

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -102,7 +102,8 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="/opt/dynamo/venv/bin:$PATH"
 
 # Copy uv from base stage and wheels from wheel_builder (no runtime stage dependency)
-COPY --chown=dynamo: --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --chown=dynamo: --from=dynamo_base /opt/uv/bin/uv /opt/uv/bin/uvx /opt/uv/bin/
+ENV PATH=/opt/uv/bin:${PATH}
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -102,7 +102,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv
 ENV PATH="/opt/dynamo/venv/bin:$PATH"
 
 # Copy uv from base stage and wheels from wheel_builder (no runtime stage dependency)
-COPY --chown=dynamo: --from=dynamo_base /bin/uv /bin/uvx /bin/
+COPY --chown=dynamo: --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 COPY --chown=dynamo: --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
@@ -110,7 +110,7 @@ COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/pyt
 COPY --chown=dynamo: --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
 # Create virtual environment
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     mkdir -p /opt/dynamo/venv && \
     uv venv /opt/dynamo/venv --python $PYTHON_VERSION
@@ -120,7 +120,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 # Test and dev dependencies are NOT installed here — they go in the test and dev images.
 RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
     --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
-    --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --requirement /tmp/requirements.common.txt \
@@ -131,7 +131,7 @@ ARG ENABLE_GPU_MEMORY_SERVICE
 # In an ideal world, we'd use a mirror of PyPI for much more reliable downloads.
 # UV_FIND_LINKS points at the crick wheel pre-built in the crick_builder stage;
 # uv prefers it over the sdist on arm64 where no manylinux aarch64 wheel exists.
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
     uv pip install \
     /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -56,14 +56,14 @@ ENV HOME=/home/dynamo \
 
 WORKDIR /workspace
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
 COPY --from=dynamo_base /usr/local/bin/nats-server /usr/local/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd /usr/local/bin/etcd
 COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
 USER dynamo
 
-RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
     uv venv ${VIRTUAL_ENV} --python ${PYTHON_VERSION}
 
@@ -72,7 +72,7 @@ RUN --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sh
 # aiperf is required by the thorough profiler path (profiler/utils/aiperf.py).
 RUN --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
-    --mount=type=cache,target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
     export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --requirement /tmp/requirements.planner.txt \
@@ -102,7 +102,7 @@ FROM ${PLANNER_RUNTIME_IMAGE}:${PLANNER_RUNTIME_IMAGE_TAG} AS planner
 
 COPY --from=planner_builder /etc/group /etc/passwd /etc/
 COPY --from=planner_builder /bin/dash /bin/sh
-COPY --from=planner_builder /bin/uv /bin/uvx /usr/local/bin/
+COPY --from=planner_builder /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 COPY --chown=1000:0 --from=planner_builder /home/dynamo /home/dynamo
 COPY --chown=1000:0 --from=planner_builder /opt/dynamo/venv /opt/dynamo/venv
 COPY --from=planner_builder /usr/lib/*-linux-gnu/libgomp.so.1* /opt/dynamo/lib/

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -51,12 +51,12 @@ RUN useradd -m -s /bin/bash -g 0 dynamo \
 
 ENV HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \
-    PATH="/opt/dynamo/venv/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
+    PATH="/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
     PYTHONPATH="/workspace"
 
 WORKDIR /workspace
 
-COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /opt/uv/bin/
 COPY --from=dynamo_base /usr/local/bin/nats-server /usr/local/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd /usr/local/bin/etcd
 COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
@@ -102,7 +102,7 @@ FROM ${PLANNER_RUNTIME_IMAGE}:${PLANNER_RUNTIME_IMAGE_TAG} AS planner
 
 COPY --from=planner_builder /etc/group /etc/passwd /etc/
 COPY --from=planner_builder /bin/dash /bin/sh
-COPY --from=planner_builder /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=planner_builder /opt/uv/bin/uv /opt/uv/bin/uvx /opt/uv/bin/
 COPY --chown=1000:0 --from=planner_builder /home/dynamo /home/dynamo
 COPY --chown=1000:0 --from=planner_builder /opt/dynamo/venv /opt/dynamo/venv
 COPY --from=planner_builder /usr/lib/*-linux-gnu/libgomp.so.1* /opt/dynamo/lib/
@@ -116,7 +116,7 @@ ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA} \
     HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \
     LD_LIBRARY_PATH="/opt/dynamo/lib" \
-    PATH="/opt/dynamo/venv/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
+    PATH="/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
     PYTHONPATH="/workspace/components/src:/workspace"
 
 WORKDIR /workspace

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -20,8 +20,8 @@ COPY --chmod=775 components/src/dynamo/mocker /workspace_src/components/src/dyna
 COPY --chmod=775 lib /workspace_src/lib
 COPY --chmod=664 LICENSE /workspace_src/
 
-# Transport stage for dynamo_base artifacts. uv/uvx go to /usr/bin (not /bin)
-# because upstream is usrmerged and cross-stage COPY chokes on the symlink.
+# Transport stage for dynamo_base artifacts. nats-server goes to /usr/bin (not
+# /bin) because upstream is usrmerged and cross-stage COPY chokes on the symlink.
 FROM scratch AS dynamo_base_export
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -25,8 +25,8 @@ COPY --chmod=664 LICENSE /workspace_src/
 FROM scratch AS dynamo_base_export
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
-COPY --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uv
-COPY --from=dynamo_base /usr/local/bin/uvx /usr/local/bin/uvx
+COPY --from=dynamo_base /opt/uv/bin/uv /opt/uv/bin/uv
+COPY --from=dynamo_base /opt/uv/bin/uvx /opt/uv/bin/uvx
 
 {% if target in ("runtime", "dev", "local-dev") %}
 # Renamed `runtime` → `runtime_full` so the final stage can re-FROM upstream
@@ -86,6 +86,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 # One COPY pulls nats-server, etcd/, uv, uvx into their final paths.
 COPY --from=dynamo_base_export / /
+ENV PATH=/opt/uv/bin:${PATH}
 
 # dynamo user (group 0 for OpenShift), clear upstream /workspace baggage
 # (otherwise pytest collects broken tutorial test files), and create the
@@ -101,7 +102,7 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && mkdir -p /etc/profile.d \
     && echo 'umask 002' > /etc/profile.d/00-umask.sh{% if target not in ("dev", "local-dev") %} \
     && python3 -m venv --system-site-packages /opt/dynamo/venv \
-    && ln -sf /usr/local/bin/uv /opt/dynamo/venv/bin/uv{% endif %}
+    && ln -sf /opt/uv/bin/uv /opt/dynamo/venv/bin/uv{% endif %}
 
 {% if target not in ("dev", "local-dev") %}
 ENV VIRTUAL_ENV=/opt/dynamo/venv \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -206,7 +206,7 @@ COPY --from=runtime_full / /
 {% if target in ("dev", "local-dev") %}
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
-    PATH=/usr/local/bin/etcd:${PATH} \
+    PATH=/opt/uv/bin:/usr/local/bin/etcd:${PATH} \
     IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
     NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \
@@ -215,7 +215,7 @@ ENV DYNAMO_HOME=/workspace \
 ENV DYNAMO_HOME=/workspace \
     HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \
-    PATH=/opt/dynamo/venv/bin:/usr/local/bin/etcd:${PATH} \
+    PATH=/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/bin/etcd:${PATH} \
     IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg \
     LD_PRELOAD=/opt/dynamo/libstdc++.so.6:/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/libnixl.so \
     NIXL_PLUGIN_DIR=/usr/local/lib/python3.12/dist-packages/tensorrt_llm/libs/nixl/plugins \

--- a/container/templates/trtllm_runtime.Dockerfile
+++ b/container/templates/trtllm_runtime.Dockerfile
@@ -25,8 +25,8 @@ COPY --chmod=664 LICENSE /workspace_src/
 FROM scratch AS dynamo_base_export
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
-COPY --from=dynamo_base /bin/uv /usr/bin/uv
-COPY --from=dynamo_base /bin/uvx /usr/bin/uvx
+COPY --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=dynamo_base /usr/local/bin/uvx /usr/local/bin/uvx
 
 {% if target in ("runtime", "dev", "local-dev") %}
 # Renamed `runtime` → `runtime_full` so the final stage can re-FROM upstream
@@ -101,7 +101,7 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
     && mkdir -p /etc/profile.d \
     && echo 'umask 002' > /etc/profile.d/00-umask.sh{% if target not in ("dev", "local-dev") %} \
     && python3 -m venv --system-site-packages /opt/dynamo/venv \
-    && ln -sf /usr/bin/uv /opt/dynamo/venv/bin/uv{% endif %}
+    && ln -sf /usr/local/bin/uv /opt/dynamo/venv/bin/uv{% endif %}
 
 {% if target not in ("dev", "local-dev") %}
 ENV VIRTUAL_ENV=/opt/dynamo/venv \
@@ -115,7 +115,7 @@ ENV VIRTUAL_ENV=/opt/dynamo/venv \
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
 {% if target not in ("dev", "local-dev") %}
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     --mount=type=bind,source=./container/deps/requirements.trtllm.txt,target=/tmp/requirements.trtllm.txt \
     export UV_CACHE_DIR=/root/.cache/uv && \
     \

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -70,7 +70,8 @@ ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:${LD_LIBRARY_PATH:-}
 # Install NATS and ETCD
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
-COPY --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+COPY --from=dynamo_base /opt/uv/bin/uv /opt/uv/bin/uvx /opt/uv/bin/
+ENV PATH=/opt/uv/bin:${PATH}
 
 # Create dynamo user with group 0 for OpenShift compatibility.
 # Pin -u 1000 explicitly: the vllm/vllm-openai >=0.22 image ships a `vllm` user at

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -70,7 +70,7 @@ ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:${LD_LIBRARY_PATH:-}
 # Install NATS and ETCD
 COPY --from=dynamo_base /usr/bin/nats-server /usr/bin/nats-server
 COPY --from=dynamo_base /usr/local/bin/etcd/ /usr/local/bin/etcd/
-COPY --from=dynamo_base /bin/uv /bin/uvx /bin/
+COPY --from=dynamo_base /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 
 # Create dynamo user with group 0 for OpenShift compatibility.
 # Pin -u 1000 explicitly: the vllm/vllm-openai >=0.22 image ships a `vllm` user at
@@ -124,7 +124,7 @@ COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /o
 # v1.1.0 nixl-cu13 has in-built RPATH point to conflicting built-in libs with symbols unsupported in non-cuda builds.
 # we therefore avoid installing nixl-cu13
 
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     set -eu; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     NIXL_VERSION="${NIXL_REF#v}"; \
@@ -137,7 +137,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 # Install device-specific NIXL wheels for non-CUDA devices.
 # These are custom-built in wheel_builder and required for dev builds to link against NIXL libraries.
 {% if device != "cuda" %}
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
@@ -149,7 +149,7 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 
 # Install Dynamo runtime wheels and optional KVBM/GMS wheels.
 # Use --no-deps to prevent dependency conflicts (e.g., KVBM downgrading nixl).
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl && \
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/ai_dynamo*any.whl && \
@@ -180,7 +180,7 @@ RUN set -eux; \
 # constraining packages already solved in the upstream vLLM image.
 RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target=/tmp/vllm_omni_protected_packages.txt \
     --mount=type=bind,source=./container/deps/vllm/install_vllm_omni.sh,target=/tmp/install_vllm_omni.sh \
-    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
@@ -197,7 +197,7 @@ RUN uv pip uninstall triton && \
 {% if context.vllm.enable_modelexpress == "true" %}
 # Install only the ModelExpress client package. --no-deps preserves the upstream
 # vLLM runtime dependency stack.
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     uv pip install {{ pip_target }} --no-deps \
@@ -265,7 +265,7 @@ ENV IMAGEIO_FFMPEG_EXE=/usr/local/bin/ffmpeg
 # (set above) points imageio at the LGPL CLI copied from wheel_builder. The
 # --no-binary directive lives in the requirements file itself.
 RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/requirements.vllm.txt \
-    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --reinstall-package imageio-ffmpeg --no-deps \
         --requirement /tmp/requirements.vllm.txt

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -204,9 +204,12 @@ RUN set -eux; \
 # Point build tools explicitly at the modern protoc
 ENV PROTOC=/usr/local/bin/protoc
 
+# Install uv package manager. Targets /usr/local/bin so it takes precedence over
+# the copy manylinux bundles: every stage shares one uv cache mount, and uv
+# rejects cache entries written by a newer version.
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
+
 {% if device == "xpu" or device == "cpu" %}
-# Install uv package manager
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}
 {% else %}
 ENV CUDA_PATH=/usr/local/cuda \
@@ -221,7 +224,7 @@ ENV VIRTUAL_ENV=/workspace/.venv
 # Cache uv downloads; uv handles its own locking for this cache.
 # pyyaml: needed by the compliance NOTICES-bundling steps below (overrides.py
 # imports yaml at module scope); the system python3 doesn't ship it.
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv venv ${VIRTUAL_ENV} --python $PYTHON_VERSION && \
     uv pip install --upgrade meson pybind11 patchelf maturin[patchelf] tomlkit pyyaml
@@ -508,7 +511,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
     --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
     --mount=type=cache,target=/root/.cargo/git,sharing=shared \
-    --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export AWS_WEB_IDENTITY_TOKEN_FILE=/run/secrets/aws-token && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \
@@ -532,7 +535,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
 # image, after the Dynamo wheels so Python-only changes do not invalidate the
 # expensive Rust build layers above.
 COPY aisimulate/ /opt/dynamo/aisimulate/
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv && \
     source ${VIRTUAL_ENV}/bin/activate && \
     uv build --wheel --out-dir /opt/dynamo/dist /opt/dynamo/aisimulate
@@ -616,7 +619,7 @@ COPY lib/gpu_memory_service/ /opt/dynamo/lib/gpu_memory_service/
 {% if device == "cuda" %}
 # Build gpu_memory_service wheel (C++ extension only needs Python headers, no CUDA/torch)
 ARG ENABLE_GPU_MEMORY_SERVICE
-RUN --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     if [ "$ENABLE_GPU_MEMORY_SERVICE" = "true" ]; then \
         export UV_CACHE_DIR=/root/.cache/uv && \
         source ${VIRTUAL_ENV}/bin/activate && \
@@ -708,7 +711,7 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
-    --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export AWS_WEB_IDENTITY_TOKEN_FILE=/run/secrets/aws-token && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX="${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}}" && \
@@ -732,7 +735,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     --mount=type=secret,id=aws-role-arn,env=AWS_ROLE_ARN \
     --mount=type=cache,target=/root/.cargo/registry,sharing=shared \
     --mount=type=cache,target=/root/.cargo/git,sharing=shared \
-    --mount=type=cache,target=/root/.cache/uv,sharing=shared \
+    --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export AWS_WEB_IDENTITY_TOKEN_FILE=/run/secrets/aws-token && \
     export UV_CACHE_DIR=/root/.cache/uv && \
     export SCCACHE_S3_KEY_PREFIX=${SCCACHE_S3_KEY_PREFIX:-${TARGETARCH}} && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -204,10 +204,10 @@ RUN set -eux; \
 # Point build tools explicitly at the modern protoc
 ENV PROTOC=/usr/local/bin/protoc
 
-# Install uv package manager. Targets /usr/local/bin so it takes precedence over
-# the copy manylinux bundles: every stage shares one uv cache mount, and uv
-# rejects cache entries written by a newer version.
-COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /usr/local/bin/
+# Install uv package manager, ahead of the copy manylinux bundles in
+# /usr/local/bin. See dynamo_base.Dockerfile for why it gets its own directory.
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /opt/uv/bin/
+ENV PATH=/opt/uv/bin:${PATH}
 
 {% if device == "xpu" or device == "cpu" %}
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}


### PR DESCRIPTION
`vllm-runtime` builds began failing on 2026-07-29 with:

```
× Failed to read `ai-dynamo-runtime @ file:///opt/dynamo/wheelhouse/ai_dynamo_runtime-1.4.0-cp310-abi3-manylinux_2_28_x86_64.whl`
├─▶ Failed to deserialize cache entry
╰─▶ array had incorrect length, expected 4
```

uv 0.12.0 (published 2026-07-28 18:58 UTC) added a `size` field to its cached `Archive` and
`Revision` entries without bumping the cache bucket version. A newer uv still reads older
entries, but an **older uv fails on newer ones** — the message is `rmp_serde` finding a
5-element array where the older struct expects 4.

Every stage shares one BuildKit uv cache mount. The mounts carried no `id=`, so BuildKit keyed
them by target path alone: one `/root/.cache/uv` shared across every stage and every image built
on that builder. Meanwhile the stages ran *different* uv versions:

| uv source | version |
|---|---|
| `dynamo_base`, `wheel_builder` via `ghcr.io/astral-sh/uv:latest` | 0.12.0 (as of 2026-07-28) |
| `manylinux_2_28` bundled, at `/usr/local/bin` | 0.11.32 |
| `vllm/vllm-openai` bundled, at `/usr/local/bin` | 0.11.32 |
| `vllm-ci-test-repo` (XPU) and `vllm-openai-cpu` bundled, at `/root/.local/bin` | 0.11.x |

As soon as any 0.12.0 stage wrote to the shared cache, every older reader failed. It looked
intermittent because it depended on which image last rebuilt its uv layer on a given builder.

Note the CUDA `pre_runtime` never ran our uv at all: it copied uv into `/bin`, which the vLLM
image's `/usr/local/bin/uv` shadows on PATH. Pinning alone would not have fixed this.

## Details:

1. **Single pinned version.** `uv_version` in `container/context.yaml`, consumed by every
   template. Replaces four `ghcr.io/astral-sh/uv:latest` references and two stragglers pinned
   to `0.10.7`.

2. **Dedicated install directory ahead of base-image copies.** uv installs to `/opt/uv/bin`
   with `ENV PATH=/opt/uv/bin:${PATH}`. Prepending `/usr/local/bin` instead would reorder every
   binary in it; `/opt/uv/bin` holds only `uv` and `uvx`, so nothing else changes resolution.
   Two stages (`planner_builder`, distroless `planner`) set an absolute PATH with no `${PATH}`,
   so the directory is spliced in explicitly there.

3. **Version-keyed cache mount IDs.** `id=uv-root-${uv_version}` and `id=uv-dynamo-${uv_version}`,
   so a future uv bump rotates to a fresh cache instead of mixing formats. This also means no
   builder cache purge is needed to land the fix — the poisoned default-ID cache is abandoned.

closes: OPS-7955

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized Docker builds on a pinned `uv` version for more predictable tooling behavior.
  * Isolated build caches by `uv` version to prevent incompatible cached entries from being reused.
  * Updated `uv` and `uvx` locations across container stages for consistent runtime availability.
* **Documentation**
  * Updated container documentation to reflect the revised `uv` versioning, paths, and caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->