### PR TITLE
fix(vllm): measure FPM self-benchmark decode points on a steady-state

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -2492,6 +2492,22 @@ class InstrumentedScheduler(AsyncScheduler):
             minimum_units=1,
         )
 
+    @classmethod
+    def _bench_decode_steady_kv_tokens(
+        cls, batch_size: int, total_kv_read_tokens: int
+    ) -> int:
+        """Coordinate the steady step actually measures for this point.
+
+        Mirrors the admission clamp in ``_bench_step_decode``: every request
+        is admitted at ``max(1, ctx - 1)`` tokens, so ctx=1 entries run one
+        token deeper than their nominal coordinate. Idempotent: coordinates
+        at or above ``2 * batch_size`` map to themselves.
+        """
+        context_lengths = cls._bench_decode_context_lengths(
+            total_kv_read_tokens, batch_size
+        )
+        return sum(max(1, ctx - 1) for ctx in context_lengths) + batch_size
+
     def _bench_decode_point_feasible(
         self, batch_size: int, total_kv_read_tokens: int
     ) -> bool:
@@ -2546,7 +2562,23 @@ class InstrumentedScheduler(AsyncScheduler):
             if value >= batch_size
         )
         presets.append(max_kv_read_tokens)
-        return sorted(set(presets))
+        # Normalize every preset to the coordinate its steady step actually
+        # measures before IDs and the grid digest are assigned. All presets
+        # below 2 * batch_size land on 2 * batch_size (their partitions only
+        # contain ctx 1 and 2 entries, which the admission clamp makes
+        # indistinguishable), so without deduplication the grid would carry
+        # duplicate rows at that coordinate and overweight it in the fit.
+        # Normalization never exceeds max_kv_read_tokens: a non-empty ladder
+        # always has max_kv_read_tokens >= 2 * batch_size because
+        # _bench_decode_point_feasible prices ctx=1 and ctx=2 identically
+        # (the max(ctx, 2) floor), so feasibility at batch_size implies
+        # feasibility at 2 * batch_size.
+        return sorted(
+            {
+                self._bench_decode_steady_kv_tokens(batch_size, value)
+                for value in presets
+            }
+        )
 
     # -- Request injection / cleanup ------------------------------------
 

--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -89,7 +89,7 @@ import time
 import uuid
 from collections import deque
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from itertools import count
 from typing import TYPE_CHECKING, cast
@@ -1407,11 +1407,20 @@ class InstrumentedScheduler(AsyncScheduler):
             is_benchmark_point = self._bench_active and (
                 self._bench_should_record_scheduled(scheduled)
             )
-            wall_time = self._iteration_wall_time(
-                model_output_arrival,
-                t_sched,
-                is_benchmark_point=is_benchmark_point,
-            )
+            if is_benchmark_point and self._bench_steady_fpm_expected():
+                # Steady-state sample of a two-step decode point. Under async
+                # scheduling its schedule() ran while the admission step was
+                # still on the GPU, so the narrow schedule->output span would
+                # also count that wait; the inter-update period is the true
+                # iteration time (and is what the non-benchmark path reports
+                # for production steps).
+                wall_time = model_output_arrival - self._last_update_time
+            else:
+                wall_time = self._iteration_wall_time(
+                    model_output_arrival,
+                    t_sched,
+                    is_benchmark_point=is_benchmark_point,
+                )
             self._last_update_time = model_output_arrival
 
             metrics = self._extract_metrics(
@@ -1532,6 +1541,29 @@ class InstrumentedScheduler(AsyncScheduler):
     def _bench_should_record_fpm(self, metrics: ForwardPassMetrics) -> bool:
         """Keep only the forward-pass type represented by the current point."""
         return self._bench_should_record_scheduled(metrics.scheduled_requests)
+
+    def _bench_steady_fpm_expected(self) -> bool:
+        """True when the FPM about to be recorded is a steady-state sample.
+
+        The admission FPM of a two-step decode point is already in
+        ``_bench_current_fpms``, so the update being processed belongs to
+        the steady step. ``_last_update_time`` is the admission step's
+        arrival: the steady step is dispatched by the first ``schedule()``
+        call after the admission step, so the two updates are adjacent in
+        the engine's FIFO and the empty-step zeroing of
+        ``_last_update_time`` (empty outputs DO flow through
+        ``update_from_output``) can only happen after the steady update.
+        Should that adjacency ever break, the ``> 0`` guard fails closed
+        to the narrow window instead of recording a garbage timestamp.
+        """
+        point = getattr(self, "_bench_current_point", None)
+        return (
+            point is not None
+            and point.point_type == "decode"
+            and getattr(self, "_bench_expected_fpms", 1) > 1
+            and len(getattr(self, "_bench_current_fpms", [])) >= 1
+            and self._last_update_time > 0
+        )
 
     def _bench_should_record_scheduled(
         self, scheduled: ScheduledRequestMetrics
@@ -1691,6 +1723,17 @@ class InstrumentedScheduler(AsyncScheduler):
                 "decode query length"
             )
 
+        if (
+            self._bench_config.mode in {"decode", "agg"}
+            and getattr(vllm_config.parallel_config, "pipeline_parallel_size", 1) > 1
+        ):
+            raise ValueError(
+                "decode self-benchmarking does not yet support pipeline "
+                "parallelism: the steady-state step neither returns sampled "
+                "tokens through new_token_ids (required by non-last PP "
+                "stages) nor honors the pp_size decode cadence"
+            )
+
         compilation_config = getattr(vllm_config, "compilation_config", None)
         cudagraph_mode = getattr(compilation_config, "cudagraph_mode", None)
         self._bench_cudagraph_mode = getattr(cudagraph_mode, "name", None) or "NONE"
@@ -1778,6 +1821,13 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_stop_requested = False
         self._bench_stop_reason: str | None = None
         self._bench_point_deadline = 0.0
+        # Steady-state decode measurement (see _bench_make_steady_step):
+        # how many extra production-shaped steps remain to dispatch for the
+        # current point, and how many FPMs the point must collect before it
+        # is saved (decode: admission + steady = 2; prefill: 1).
+        self._bench_extra_steps_left = 0
+        self._bench_expected_fpms = 1
+        self._bench_admission_kv_tokens = 0
         self._bench_point_result_timeout_seconds = (
             float(_BenchmarkSynchronizer.MAX_SYNC_TIMEOUT_SECONDS) * 0.8
         )
@@ -2453,13 +2503,19 @@ class InstrumentedScheduler(AsyncScheduler):
             )
         except ValueError:
             return False
-        # Fake decode requests carry one prompt-padding token at ``context_len``
-        # so async input-slot reuse never reads its -1 placeholder, then sample
-        # one output token in the measured iteration. Both tokens must fit.
-        if any(context_len + 2 > self.max_model_len for context_len in context_lengths):
+        # A decode point admits at max(1, ctx-1) and measures its steady step
+        # one position later, so a request occupies max(ctx, 2) + 1 slots and
+        # the runner's post-step bookkeeping writes through slot
+        # max(ctx, 2) + 2, which must stay within max_model_len (ctx + 2 for
+        # the ordinary ctx >= 2 case; one extra slot for clamped ctx = 1
+        # entries, which run one token deeper than their nominal coordinate).
+        if any(
+            max(context_len, 2) + 2 > self.max_model_len
+            for context_len in context_lengths
+        ):
             return False
         required_blocks = sum(
-            self._bench_blocks_per_req(context_len + 1)
+            self._bench_blocks_per_req(max(context_len, 2) + 1)
             for context_len in context_lengths
         )
         return required_blocks <= self._bench_usable_blocks(
@@ -2635,6 +2691,16 @@ class InstrumentedScheduler(AsyncScheduler):
         Also allocate ``ctx_len + 1`` KV slots so block-table indexing for
         position ``ctx_len`` (block ``ctx_len // block_size`` -- which is
         a NEW block when ``ctx_len % block_size == 0``) stays in range.
+
+        Under the two-step measurement the STEADY step reads the input slot
+        at ``ctx_len + 1`` -- exactly where the async placeholder lands. That
+        read is safe through production mechanisms, not through padding:
+        under async scheduling ``_prepare_input_ids`` takes the
+        common-request fast path and scatters the admission step's sampled
+        token from ``prev_sampled_token_ids`` on the GPU (the CPU ``-1`` is
+        never uploaded); under synchronous scheduling the runner writes the
+        real sampled token into that slot. The padding above remains
+        load-bearing only for the admission read at ``ctx_len``.
         """
         new_reqs_data: list[NewRequestData] = []
         num_scheduled_tokens: dict[str, int] = {}
@@ -2744,6 +2810,7 @@ class InstrumentedScheduler(AsyncScheduler):
         ]
         self._bench_active_req_ids.clear()
         self._schedule_times.clear()
+        self._bench_extra_steps_left = 0
 
     def _bench_clear_prefix_cache(self) -> None:
         """Remove all synthetic prefix entries before normal serving starts."""
@@ -2787,9 +2854,8 @@ class InstrumentedScheduler(AsyncScheduler):
             time.monotonic() + self._bench_point_result_timeout_seconds
         )
 
-    @staticmethod
     def _bench_output_validation_error(
-        point: BenchmarkPoint, summary: dict
+        self, point: BenchmarkPoint, summary: dict
     ) -> str | None:
         if point.point_type == "prefill":
             expected = {
@@ -2801,13 +2867,16 @@ class InstrumentedScheduler(AsyncScheduler):
                 "sum_decode_kv_tokens": 0,
             }
         else:
+            # The synchronized output is the ADMISSION step, which runs one
+            # token short of the point's coordinate (the steady step measured
+            # afterwards reads the full context).
             expected = {
                 "total_num_scheduled_tokens": point.batch_size,
                 "num_prefill_requests": 0,
                 "sum_prefill_tokens": 0,
                 "sum_prefill_kv_tokens": 0,
                 "num_decode_requests": point.batch_size,
-                "sum_decode_kv_tokens": point.total_kv_read_tokens,
+                "sum_decode_kv_tokens": self._bench_admission_kv_tokens,
             }
         if summary == expected:
             return None
@@ -2823,6 +2892,8 @@ class InstrumentedScheduler(AsyncScheduler):
         self._bench_active = False
         self._bench_phase = _BenchPhase.IDLE
         self._bench_sync_pending = False
+        self._bench_extra_steps_left = 0
+        self._bench_expected_fpms = 1
         self._schedule_times.clear()
         self._last_update_time = 0.0
         if resume_publisher:
@@ -3068,6 +3139,8 @@ class InstrumentedScheduler(AsyncScheduler):
             self.kv_cache_manager.new_step_starts()
 
             self._bench_current_point = point
+            self._bench_expected_fpms = 1
+            self._bench_extra_steps_left = 0
             injected = self._bench_inject_prefill(
                 prompt_lens=[
                     new_tokens + kv_read_tokens
@@ -3098,6 +3171,8 @@ class InstrumentedScheduler(AsyncScheduler):
             return None
 
         self._bench_current_point = point
+        self._bench_expected_fpms = 1
+        self._bench_extra_steps_left = 0
         injected = self._bench_inject_prefill(
             prompt_lens=new_token_lengths,
             max_tokens=1,
@@ -3114,12 +3189,107 @@ class InstrumentedScheduler(AsyncScheduler):
         )
         return None
 
+    def _bench_make_steady_step(self) -> SchedulerOutput | None:
+        """One production-shaped decode step for the injected requests.
+
+        A decode point's first step admits its requests as brand-new
+        (``scheduled_new_reqs``: full prompt arrays, first-touch bookkeeping)
+        -- a shape that production decode traffic never has after its prefill.
+        The step built here goes out through ``scheduled_cached_reqs`` exactly
+        like a real decode iteration: a per-request delta instead of the full
+        token arrays. Only this step's FPM is recorded.
+
+        Mirrors the parent scheduler's running-request branch
+        (vllm/v1/core/sched/scheduler.py); ``delay_cache_blocks=True`` matches
+        the admission injection and skips the allocation-time prefix-cache
+        commit (the async scheduler still caches blocks on output updates --
+        isolation is guaranteed by the per-request cache salts and the
+        post-benchmark ``reset_prefix_cache``).
+        """
+        reqs = [
+            request
+            for request in self.running
+            if request.request_id in self._bench_active_req_ids
+            and not request.is_finished()
+        ]
+        if not reqs:
+            return None
+        new_blocks = {}
+        for request in reqs:
+            blocks = self.kv_cache_manager.allocate_slots(
+                request,
+                1,
+                num_lookahead_tokens=getattr(self, "num_lookahead_tokens", 0),
+                delay_cache_blocks=True,
+            )
+            if blocks is None:
+                return None
+            new_blocks[request.request_id] = blocks
+        cached = CachedRequestData(
+            req_ids=[request.request_id for request in reqs],
+            resumed_req_ids=set(),
+            new_token_ids=[],
+            all_token_ids={},
+            new_block_ids=[
+                new_blocks[request.request_id].get_block_ids(allow_none=True)
+                for request in reqs
+            ],
+            num_computed_tokens=[request.num_computed_tokens for request in reqs],
+            num_output_tokens=[
+                max(1, request.num_output_tokens + request.num_output_placeholders)
+                for request in reqs
+            ],
+        )
+        output = SchedulerOutput(
+            scheduled_new_reqs=[],
+            scheduled_cached_reqs=cached,
+            num_scheduled_tokens={request.request_id: 1 for request in reqs},
+            total_num_scheduled_tokens=len(reqs),
+            scheduled_spec_decode_tokens={},
+            scheduled_encoder_inputs={},
+            num_common_prefix_blocks=([0] * self.kv_cache_manager.num_kv_cache_groups),
+            finished_req_ids=self.finished_req_ids,
+            free_encoder_mm_hashes=[],
+            new_block_ids_to_zero=(
+                (self.kv_cache_manager.take_new_block_ids() or None)
+                if getattr(self, "needs_kv_cache_zeroing", False)
+                else None
+            ),
+        )
+        if self.connector is not None:
+            output.kv_connector_metadata = self.connector.build_connector_meta(output)
+        if self.ec_connector is not None:
+            output.ec_connector_metadata = self.ec_connector.build_connector_meta(
+                output
+            )
+        return output
+
     def _bench_step_decode(self) -> SchedulerOutput | None:
         if self._bench_drain_if_pending():
             pass  # fall through to inject next point
 
         elif self._bench_active_req_ids:
-            if not self._bench_current_fpms:
+            if (
+                getattr(self, "_bench_extra_steps_left", 0) > 0
+                and not self._bench_point_result_timed_out()
+            ):
+                # The steady step deliberately does NOT re-arm the READY/GO
+                # barrier: production decode steps have no per-step barrier
+                # either (ranks stay aligned through the collectives), and a
+                # ZMQ round between the admission and steady updates would be
+                # counted into the steady step's inter-update wall_time under
+                # synchronous scheduling. Group agreement on the point is
+                # still enforced at collect_result.
+                steady = self._bench_make_steady_step()
+                if steady is not None:
+                    self._bench_extra_steps_left -= 1
+                    return steady
+                # Defensive: feasibility reserved ctx+1 slots per request, so
+                # this should be unreachable. Wait out the point deadline; the
+                # admission-only FPM then fails shape validation and the point
+                # is skipped through the normal group-synchronized save path.
+                return None
+            if len(self._bench_current_fpms) < getattr(self, "_bench_expected_fpms", 1):
                 if not self._bench_point_result_timed_out():
                     return None
             self._bench_save_current_point()
@@ -3137,17 +3307,33 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_phase = _BenchPhase.DONE
             return None
 
-        self._bench_current_point = point
-        self._bench_current_fpms = []
         context_lengths = self._bench_decode_context_lengths(
             point.total_kv_read_tokens, point.batch_size
         )
+        # Steady-state measurement: admit the requests one token short so the
+        # SECOND step -- a production-shaped decode step -- reads the point's
+        # context. A request must keep at least one computed token, so ctx=1
+        # entries are clamped; the point is then recorded at the coordinate
+        # the steady step actually measures.
+        injected_lengths = [max(1, ctx - 1) for ctx in context_lengths]
+        self._bench_admission_kv_tokens = sum(injected_lengths)
+        steady_kv_tokens = self._bench_admission_kv_tokens + point.batch_size
+        if steady_kv_tokens != point.total_kv_read_tokens:
+            point = replace(
+                point,
+                total_kv_read_tokens=steady_kv_tokens,
+                sample_reasons=[*point.sample_reasons, "context_clamped"],
+            )
+        self._bench_current_point = point
+        self._bench_current_fpms = []
+        self._bench_extra_steps_left = 1
+        self._bench_expected_fpms = 2
         logger.info(
             "Benchmark decode: total_kv_reads=%d batch_size=%d",
             point.total_kv_read_tokens,
             point.batch_size,
         )
-        output = self._bench_inject_fake_decode(context_lengths)
+        output = self._bench_inject_fake_decode(injected_lengths)
         if output.total_num_scheduled_tokens != point.batch_size:
             logger.warning(
                 "Skipping benchmark decode point after request injection produced "
@@ -3159,6 +3345,7 @@ class InstrumentedScheduler(AsyncScheduler):
             self._bench_cleanup_requests()
             self._bench_skip_point(point, "decode_injection_failed")
             self._bench_current_point = None
+            self._bench_extra_steps_left = 0
             return None
         self._bench_sync_pending = True
         return output
@@ -3181,6 +3368,15 @@ class InstrumentedScheduler(AsyncScheduler):
         if self._bench_current_point is not None:
             point = self._bench_current_point
             local_fpms = list(self._bench_current_fpms)
+            expected_fpms = getattr(self, "_bench_expected_fpms", 1)
+            if expected_fpms > 1 and len(local_fpms) >= expected_fpms:
+                # Keep only the steady-state sample; the admission step is
+                # scaffolding. A rank that reached the deadline with the
+                # admission FPM alone sends it through collect_result
+                # unchanged: the shape validator rejects it
+                # (sum_decode_kv_tokens mismatch) and every rank skips the
+                # point together -- no rank ever bypasses the barrier.
+                local_fpms = local_fpms[-1:]
             if self._bench_synchronizer is not None:
                 group_result = self._bench_synchronizer.collect_result(
                     point,
@@ -3389,6 +3585,10 @@ class InstrumentedScheduler(AsyncScheduler):
                 "feasible_max_batch_size": getattr(
                     self, "_bench_feasible_max_decode_batch_size", 0
                 ),
+            },
+            "measurement_policy": {
+                "decode": "steady_state_second_step",
+                "prefill": "single_step",
             },
             "cudagraph": {
                 "mode": getattr(self, "_bench_cudagraph_mode", "NONE"),

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -903,20 +903,35 @@ def test_benchmark_output_summary_must_match_point_before_go():
         total_kv_read_tokens=128,
         batch_size=2,
     )
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    # The synchronized output is the admission step, which runs one token
+    # short per request (the steady step reads the full 128 afterwards).
+    stub._bench_admission_kv_tokens = 126
     matching = {
         "total_num_scheduled_tokens": 2,
         "num_prefill_requests": 0,
         "sum_prefill_tokens": 0,
         "sum_prefill_kv_tokens": 0,
         "num_decode_requests": 2,
-        "sum_decode_kv_tokens": 128,
+        "sum_decode_kv_tokens": 126,
     }
 
-    assert InstrumentedScheduler._bench_output_validation_error(point, matching) is None
+    assert (
+        InstrumentedScheduler._bench_output_validation_error(stub, point, matching)
+        is None
+    )
 
     mismatched = dict(matching, num_decode_requests=1)
-    error = InstrumentedScheduler._bench_output_validation_error(point, mismatched)
+    error = InstrumentedScheduler._bench_output_validation_error(
+        stub, point, mismatched
+    )
     assert "benchmark_id=3 SchedulerOutput does not match" in error
+
+    full_context = dict(matching, sum_decode_kv_tokens=128)
+    error = InstrumentedScheduler._bench_output_validation_error(
+        stub, point, full_context
+    )
+    assert error is not None, "the admission step must run one token short"
 
 
 def test_dp_rank_falls_back_to_rank_when_index_absent():
@@ -2657,6 +2672,7 @@ def _benchmark_save_stub(point: BenchmarkPoint, fpms: list[dict]):
     stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
     stub._bench_current_point = point
     stub._bench_current_fpms = fpms
+    stub._bench_expected_fpms = 1
     stub._bench_results = []
     stub._bench_iteration_groups = []
     stub._bench_skipped_points = []
@@ -2885,5 +2901,308 @@ def test_zero_request_decode_injection_is_skipped_immediately():
     assert stub._bench_skipped_points == [
         SkippedBenchmarkPoint(point=point, reason="decode_injection_failed")
     ]
-    stub._bench_inject_fake_decode.assert_called_once_with([16, 16, 16])
+    # The admission step is injected one token short of the coordinate.
+    stub._bench_inject_fake_decode.assert_called_once_with([15, 15, 15])
     stub._bench_cleanup_requests.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Steady-state decode measurement (two-step points)
+# ---------------------------------------------------------------------------
+
+
+def _steady_injection_stub(point: BenchmarkPoint):
+    """Populate only what the injection branch of ``_bench_step_decode``
+    reads; the injection itself is captured."""
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_pending = False
+    stub._bench_active_req_ids = set()
+    stub._bench_grid = deque([point])
+    stub._bench_current_point = None
+    stub._bench_current_fpms = []
+    stub._bench_stop_at_timeout_boundary = MagicMock(return_value=False)
+    stub._bench_inject_fake_decode = MagicMock(
+        return_value=SimpleNamespace(total_num_scheduled_tokens=point.batch_size)
+    )
+    return stub
+
+
+def test_decode_injection_admits_one_token_short():
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=5, total_kv_read_tokens=128, batch_size=2
+    )
+    stub = _steady_injection_stub(point)
+
+    output = InstrumentedScheduler._bench_step_decode(stub)
+
+    assert output is not None
+    stub._bench_inject_fake_decode.assert_called_once_with([63, 63])
+    assert stub._bench_admission_kv_tokens == 126
+    assert stub._bench_extra_steps_left == 1
+    assert stub._bench_expected_fpms == 2
+    # No clamping: the point keeps its grid coordinate.
+    assert stub._bench_current_point.total_kv_read_tokens == 128
+    assert "context_clamped" not in stub._bench_current_point.sample_reasons
+    assert stub._bench_sync_pending is True
+
+
+def test_decode_ctx1_point_is_clamped_and_recorded_at_measured_coordinate():
+    # total_kv == batch_size means every request targets a 1-token context,
+    # which cannot give up a token for the admission step.
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=6, total_kv_read_tokens=4, batch_size=4
+    )
+    stub = _steady_injection_stub(point)
+
+    output = InstrumentedScheduler._bench_step_decode(stub)
+
+    assert output is not None
+    stub._bench_inject_fake_decode.assert_called_once_with([1, 1, 1, 1])
+    assert stub._bench_admission_kv_tokens == 4
+    # The steady step reads ctx=2 per request; the point is recorded at the
+    # coordinate it actually measures.
+    assert stub._bench_current_point.total_kv_read_tokens == 8
+    assert "context_clamped" in stub._bench_current_point.sample_reasons
+    assert stub._bench_current_point.benchmark_id == 6
+
+
+def test_steady_step_dispatch_then_wait_then_save():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_pending = False
+    stub._bench_active_req_ids = {"__bench_0"}
+    stub._bench_current_fpms = []
+    stub._bench_extra_steps_left = 1
+    stub._bench_expected_fpms = 2
+    stub._bench_point_deadline = 0.0
+    steady_output = object()
+    stub._bench_make_steady_step = MagicMock(return_value=steady_output)
+
+    assert InstrumentedScheduler._bench_step_decode(stub) is steady_output
+    assert stub._bench_extra_steps_left == 0
+
+    # Only the admission FPM has arrived: keep waiting, no save.
+    stub._bench_save_current_point = MagicMock()
+    stub._bench_current_fpms = [{"admission": True}]
+    assert InstrumentedScheduler._bench_step_decode(stub) is None
+    stub._bench_save_current_point.assert_not_called()
+
+    # Second (steady) FPM arrived: save and enter drain.
+    stub._bench_current_fpms = [{"admission": True}, {"steady": True}]
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
+    assert InstrumentedScheduler._bench_step_decode(stub) is None
+    stub._bench_save_current_point.assert_called_once_with()
+    assert stub._bench_drain_pending is True
+
+
+def test_steady_step_unavailable_waits_out_the_deadline():
+    import time
+
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._bench_drain_pending = False
+    stub._bench_active_req_ids = {"__bench_0"}
+    stub._bench_current_fpms = [{"admission": True}]
+    stub._bench_extra_steps_left = 1
+    stub._bench_expected_fpms = 2
+    stub._bench_point_deadline = 0.0  # no deadline yet -> not timed out
+    stub._bench_make_steady_step = MagicMock(return_value=None)
+    stub._bench_save_current_point = MagicMock()
+
+    # Builder failed: no dispatch, no save, state intact for a retry.
+    assert InstrumentedScheduler._bench_step_decode(stub) is None
+    stub._bench_save_current_point.assert_not_called()
+    assert stub._bench_extra_steps_left == 1
+
+    # Once the deadline passes, the point flows into the normal save path
+    # (where the admission-only FPM fails shape validation and the group
+    # skips together).
+    stub._bench_point_deadline = time.monotonic() - 1.0
+    stub._bench_cleanup_requests = MagicMock()
+    stub._bench_transition_to_timeout_done = MagicMock(return_value=False)
+    assert InstrumentedScheduler._bench_step_decode(stub) is None
+    stub._bench_save_current_point.assert_called_once_with()
+
+
+def test_make_steady_step_builds_production_shaped_output():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    requests = [
+        SimpleNamespace(
+            request_id=f"__bench_{index}",
+            num_computed_tokens=63 + index,
+            num_output_tokens=0,
+            num_output_placeholders=1,
+            is_finished=lambda: False,
+        )
+        for index in range(2)
+    ]
+    stub.running = requests
+    stub._bench_active_req_ids = {r.request_id for r in requests}
+    blocks = MagicMock()
+    blocks.get_block_ids.return_value = None
+    kv = MagicMock()
+    kv.allocate_slots.return_value = blocks
+    kv.num_kv_cache_groups = 1
+    stub.kv_cache_manager = kv
+    stub.num_lookahead_tokens = 0
+    stub.needs_kv_cache_zeroing = False
+    stub.finished_req_ids = set()
+    stub.connector = None
+    stub.ec_connector = None
+
+    output = InstrumentedScheduler._bench_make_steady_step(stub)
+
+    assert output.scheduled_new_reqs == []
+    cached = output.scheduled_cached_reqs
+    assert cached.req_ids == ["__bench_0", "__bench_1"]
+    assert cached.resumed_req_ids == set()
+    assert cached.new_token_ids == []
+    assert cached.num_computed_tokens == [63, 64]
+    assert cached.num_output_tokens == [1, 1]
+    assert output.total_num_scheduled_tokens == 2
+    assert output.num_scheduled_tokens == {"__bench_0": 1, "__bench_1": 1}
+    kv.allocate_slots.assert_any_call(
+        requests[0], 1, num_lookahead_tokens=0, delay_cache_blocks=True
+    )
+    blocks.get_block_ids.assert_called_with(allow_none=True)
+
+
+def test_make_steady_step_returns_none_when_kv_exhausted():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    request = SimpleNamespace(
+        request_id="__bench_0",
+        num_computed_tokens=63,
+        num_output_tokens=0,
+        num_output_placeholders=1,
+        is_finished=lambda: False,
+    )
+    stub.running = [request]
+    stub._bench_active_req_ids = {"__bench_0"}
+    kv = MagicMock()
+    kv.allocate_slots.return_value = None
+    stub.kv_cache_manager = kv
+    stub.num_lookahead_tokens = 0
+
+    assert InstrumentedScheduler._bench_make_steady_step(stub) is None
+
+
+def _steady_fpm(sum_kv: int, batch: int, bench_id: int = 1, rank: int = 0) -> dict:
+    return {
+        "counter_id": bench_id,
+        "dp_rank": rank,
+        "wall_time": 1.0,
+        "scheduled_requests": {
+            "num_decode_requests": batch,
+            "sum_decode_kv_tokens": sum_kv,
+        },
+    }
+
+
+def test_save_records_only_the_steady_fpm():
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
+    )
+    admission = _steady_fpm(126, 2)
+    steady = _steady_fpm(128, 2)
+    stub = _benchmark_save_stub(point, [admission, steady])
+    stub._bench_expected_fpms = 2
+
+    InstrumentedScheduler._bench_save_current_point(stub)
+
+    assert len(stub._bench_results) == 1
+    assert stub._bench_results[0].fpms == [steady]
+    assert stub._bench_skipped_points == []
+
+
+def test_save_admission_only_fpm_becomes_validation_skip():
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
+    )
+    stub = _benchmark_save_stub(point, [_steady_fpm(126, 2)])
+    stub._bench_expected_fpms = 2  # steady FPM never arrived
+
+    InstrumentedScheduler._bench_save_current_point(stub)
+
+    assert stub._bench_results == []
+    assert stub._bench_skipped_points == [
+        SkippedBenchmarkPoint(point=point, reason="measured_decode_context_mismatch")
+    ]
+
+
+def test_two_step_group_skip_traverses_barrier_without_deadlock():
+    """One rank misses its steady FPM while the other has both: the short
+    rank must still enter collect_result so the whole group leaves the
+    barrier together and skips the point consistently."""
+    import time
+
+    endpoint = f"inproc://benchmark-sync-{uuid.uuid4().hex}"
+    rank0 = instrumented_scheduler_module._BenchmarkSynchronizer(
+        dp_rank=0, dp_size=2, master_ip="unused", port=0, timeout=5, endpoint=endpoint
+    )
+    rank1 = instrumented_scheduler_module._BenchmarkSynchronizer(
+        dp_rank=1, dp_size=2, master_ip="unused", port=0, timeout=5, endpoint=endpoint
+    )
+    point = BenchmarkPoint(
+        point_type="decode", benchmark_id=1, total_kv_read_tokens=128, batch_size=2
+    )
+
+    def build(rank, synchronizer, fpms):
+        stub = _benchmark_save_stub(point, fpms)
+        stub._bench_expected_fpms = 2
+        stub._bench_synchronizer = synchronizer
+        stub._bench_dp_size = 2
+        stub._fpm_dp_rank = rank
+        stub._bench_deadline_monotonic = time.monotonic() + 30.0
+        return stub
+
+    # rank0 timed out with only the admission FPM; rank1 got both.
+    stub0 = build(0, rank0, [_steady_fpm(126, 2, rank=0)])
+    stub1 = build(1, rank1, [_steady_fpm(126, 2, rank=1), _steady_fpm(128, 2, rank=1)])
+
+    errors: dict[int, Exception] = {}
+
+    def save(rank, stub):
+        try:
+            InstrumentedScheduler._bench_save_current_point(stub)
+        except Exception as error:  # pragma: no cover - failure diagnostics
+            errors[rank] = error
+
+    follower = threading.Thread(target=save, args=(1, stub1))
+    follower.start()
+    try:
+        save(0, stub0)
+        follower.join(timeout=10)
+        assert not follower.is_alive(), "rank1 deadlocked in collect_result"
+    finally:
+        rank1.close()
+        rank0.close()
+
+    assert errors == {}
+    for stub in (stub0, stub1):
+        assert stub._bench_results == []
+        assert [s.reason for s in stub._bench_skipped_points] == [
+            "measured_decode_context_mismatch"
+        ]
+
+
+def test_steady_fpm_gate_only_fires_for_two_step_decode_points():
+    stub = InstrumentedScheduler.__new__(InstrumentedScheduler)
+    stub._last_update_time = 100.0
+    stub._bench_current_point = BenchmarkPoint(point_type="decode")
+    stub._bench_expected_fpms = 2
+    stub._bench_current_fpms = [{"admission": True}]
+    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is True
+
+    stub._bench_current_fpms = []  # admission FPM not recorded yet
+    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+
+    stub._bench_current_fpms = [{"admission": True}]
+    stub._bench_expected_fpms = 1  # single-step point
+    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+
+    stub._bench_expected_fpms = 2
+    stub._bench_current_point = BenchmarkPoint(point_type="prefill")
+    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False
+
+    stub._bench_current_point = BenchmarkPoint(point_type="decode")
+    stub._last_update_time = 0.0  # previous update was an empty step
+    assert InstrumentedScheduler._bench_steady_fpm_expected(stub) is False

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -3128,6 +3128,7 @@ def test_save_admission_only_fpm_becomes_validation_skip():
     ]
 
 
+@pytest.mark.timeout(60)
 def test_two_step_group_skip_traverses_barrier_without_deadlock():
     """One rank misses its steady FPM while the other has both: the short
     rank must still enter collect_result so the whole group leaves the

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1950,9 +1950,11 @@ def test_prefill_kv_read_ladder_is_uniformly_limited_with_endpoints():
 def test_decode_kv_read_ladder_keeps_every_power_of_two_and_exact_maximum():
     stub = _grid_stub_with_kv_capacity(num_gpu_blocks=64, block_size=16)
 
+    # Presets 9 (all ctx=1) and 16 (mixed ctx 1/2) both measure at 18 after
+    # the admission clamp, so they normalize into a single steady coordinate;
+    # every preset at or above 2 * batch_size keeps its exact value.
     assert InstrumentedScheduler._bench_decode_kv_read_points(stub, 9) == [
-        9,
-        16,
+        18,
         32,
         64,
         128,
@@ -1960,6 +1962,52 @@ def test_decode_kv_read_ladder_keeps_every_power_of_two_and_exact_maximum():
         512,
         999,
     ]
+
+
+def test_decode_kv_read_points_are_normalized_steady_coordinates():
+    stub = _grid_stub_with_kv_capacity(num_gpu_blocks=64, block_size=16)
+
+    for batch_size in (1, 8, 24):
+        points = InstrumentedScheduler._bench_decode_kv_read_points(stub, batch_size)
+        assert points, f"batch_size={batch_size} produced an empty ladder"
+        assert len(points) == len(set(points))
+        assert points[0] == 2 * batch_size
+        assert all(
+            InstrumentedScheduler._bench_decode_steady_kv_tokens(batch_size, value)
+            == value
+            for value in points
+        ), "normalization must be idempotent: labels equal measured coordinates"
+
+
+def test_decode_kv_read_points_merge_colliding_sub_2b_presets():
+    # Non-power-of-two batch: presets 24 (all ctx=1) and 32 (8 ctx=2 +
+    # 16 ctx=1) both measure at 48, a coordinate absent from the raw preset
+    # ladder. They must collapse into one point instead of duplicating it.
+    stub = _grid_stub_with_kv_capacity(num_gpu_blocks=64, block_size=16)
+
+    assert InstrumentedScheduler._bench_decode_steady_kv_tokens(24, 24) == 48
+    assert InstrumentedScheduler._bench_decode_steady_kv_tokens(24, 32) == 48
+
+    points = InstrumentedScheduler._bench_decode_kv_read_points(stub, 24)
+    assert 48 in points
+    assert 24 not in points
+    assert 32 not in points
+    assert points.count(48) == 1
+
+
+def test_decode_kv_read_ladder_boundaries_at_model_len_floor():
+    stub = _grid_stub_with_kv_capacity(num_gpu_blocks=64, block_size=16)
+
+    # max_model_len=4 bounds every request to ctx=2, so max_kv is exactly
+    # 2 * batch_size and the ladder collapses to that single steady point.
+    stub.max_model_len = 4
+    assert InstrumentedScheduler._bench_decode_kv_read_points(stub, 4) == [8]
+
+    # Below the two-step floor (ctx=2 needs max(ctx, 2) + 2 slots) no point
+    # is feasible: the ladder must be empty rather than emit a normalized
+    # coordinate above the validated maximum.
+    stub.max_model_len = 3
+    assert InstrumentedScheduler._bench_decode_kv_read_points(stub, 4) == []
 
 
 def test_decode_grid_uniformly_limits_batch_and_kv_axes():


### PR DESCRIPTION
## Overview:

Every FPM self-benchmark decode point admits its requests as brand-new, so the
measured step ships full token arrays through `scheduled_new_reqs` — **8.5 MB
vs 6.8 KB** per step at B=513, plus first-step bookkeeping that production
decode traffic never pays after its prefill. The recorded rows are
systematically inflated (up to **6.4x**: 171.62 ms recorded vs 25.36 ms
measured end-to-end at B=256 on MiniMax-M2.7-NVFP4, 4xB200), and the perf
model downstream is fitted to the bias. This is the mechanism behind the
"more self-benchmark points somehow degrade real-traffic prediction"
observation in the AIC forward-pass evaluation: the contaminated y-values,
not the point distribution.

This PR measures each decode point on the request's **second** step — a
production-shaped steady-state decode iteration.

## Details:

- **Two-step measurement**: the batch is admitted one token short
  (`max(1, ctx-1)` per request) and one extra step is dispatched through
  `scheduled_cached_reqs` (`_bench_make_steady_step`, mirroring the reference
  scheduler's running-request branch: per-request delta payload,
  `delay_cache_blocks` like the admission injection, kv/ec connector metadata
  like every sibling path). Only the steady FPM is recorded; the admission
  FPM is scaffolding and is dropped at save time.
- **Timing**: the steady sample uses the inter-update period. Under async
  scheduling its `schedule()` runs while the admission step is still on the
  GPU, so the narrow schedule->output span would also count that wait
  (measured: B=1 read 11.29 ms ≈ 6.74 + 4.83 with the narrow window, 4.71 ms
  with the inter-update period vs 4.83 ms real). The gate fails closed to
  the narrow window if the two updates are ever not adjacent.
- **Coordinate-honest validation**: the admission output is validated against
  the actually injected lengths; the steady FPM against the coordinate the
  steady step actually reads. `ctx=1` entries cannot give up a token, so
  clamped points are recorded at their measured coordinate with a
  `context_clamped` sample reason (this is also what makes the safety net
  work — an admission-only FPM can never masquerade as a valid measurement).
- **No new skip paths / DP-safe by construction**: a rank whose steady FPM
  never arrives sends its admission FPM through the existing
  `collect_result` barrier, where shape validation rejects it and every
  attention-DP rank skips the point together. Regression-tested with a
  two-rank inproc synchronizer pair (one rank short, no deadlock, identical
  group decision).
- **Deliberately no per-step READY/GO round** for the steady step: production
  decode steps have no per-step barrier either, and a ZMQ round between the
  two updates would be counted into the steady step's inter-update wall_time
  under synchronous scheduling. Group agreement is enforced at
  `collect_result`.
- **Guards**: decode/agg self-benchmarking now rejects pipeline parallelism
  (the steady step neither returns `new_token_ids` for non-last PP stages nor
  honors the pp_size decode cadence), and the feasibility bound is
  clamp-aware (`max(ctx,2)+2 <= max_model_len`), fixing an engine-killing
  assert at the degenerate `max_model_len==3` configuration.
- Artifacts carry a `measurement_policy` block
  (`decode: steady_state_second_step`) so database provenance is explicit.

### Validation

- **Prototype A/B** (MiniMax-M2.7-NVFP4, 4xB200, vLLM 0.25.1):

| point | before | after | real (end-to-end) |
|---|---|---|---|
| B=256 | 171.62 ms | **26.71 ms** | 25.36 ms |
| B=1 | 6.74 ms | **4.71 ms** | 4.83 ms |

- Full scheduler unit suite — **133 tests, incl. 10 new steady-state tests
  and the DP-barrier regression test — executed in-container against
  vLLM 0.25.1**; vLLM 0.26.0 API compatibility (CachedRequestData fields,
  `allocate_slots` kwargs, `num_output_placeholders`) verified against the
  0.26.0 sources.
- Adversarial multi-agent review over the final diff (6 dimensions, each
  finding independently re-verified): all confirmed findings fixed in this
  commit; 9 of 14 initial claims were refuted with code evidence.

### Composition note for #12176 (eager-warmup)

The two PRs are textually independent (verified: this diff applies to main
with zero overlap against #12176's hunks). Whichever merges second should
handle two semantic touch points: warmup replicas will also run two-step
(desired — identical execution keeps DP grids rank-identical), and a warmup
replica that fails steady validation must be **discarded, not recorded** in
`skipped_points` (evaluate `EAGER_WARMUP_REASON` before converting a
validation failure into a skip).

## Where should the reviewer start?

- `components/src/dynamo/vllm/instrumented_scheduler.py`:
  - `_bench_make_steady_step` — the production-shaped step (docstring carries
    the payload rationale)
  - `_bench_step_decode` — ctx-1 injection, coordinate rewrite, steady
    dispatch, deadline flow
  - `_bench_steady_fpm_expected` + the timing branch in `_update_from_output`
  - `_bench_output_validation_error` / `_bench_save_current_point` — the
    admission-vs-steady expectations and the save-time trim
- `components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py` —
  the "Steady-state decode measurement" block, especially
  `test_two_step_group_skip_traverses_barrier_without_deadlock`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12358" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Decode benchmarks now measure steady-state performance using a production-shaped second step.
  - Benchmark results identify the measurement policy used for decode and prefill.

- **Bug Fixes**
  - Improved decode timing and token accounting for multi-step measurements.
  - Added safer handling for timeouts, exhausted KV capacity, and incomplete benchmark results.
  - Decode self-benchmarking now rejects unsupported pipeline-parallel configurations.

- **Tests**
  - Expanded coverage for steady-state decode scheduling, validation, fallbacks, and result saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->