### PR TITLE
 fix(snapshot): Disable Service-Mesh Sidecars for One-Shot Checkpoint Cleanup Jobs

### DIFF
--- a/deploy/operator/internal/controller/checkpoint_cleanup_job.go
+++ b/deploy/operator/internal/controller/checkpoint_cleanup_job.go
@@ -68,6 +68,7 @@ func buildCheckpointCleanupJob(
 					Labels: map[string]string{
 						snapshotprotocol.CheckpointIDLabel: checkpointID,
 					},
+					Annotations: snapshotprotocol.DisableCheckpointJobSidecarInjection(nil),
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -731,6 +731,7 @@ func TestCheckpointReconciler_FinalizeResourceCleansRetainedAutoCheckpointOnCRDe
 	}
 
 	t.Run("creates cleanup job and keeps finalizer pending", func(t *testing.T) {
+		t.Log("creates cleanup job with service mesh injection disabled")
 		ckpt := makeTestCheckpoint(nvidiacomv1alpha1.DynamoCheckpointPhaseReady)
 		ckpt.Labels = map[string]string{snapshotprotocol.CheckpointIDLabel: testHash}
 		ckpt.Annotations = map[string]string{
@@ -749,6 +750,8 @@ func TestCheckpointReconciler_FinalizeResourceCleansRetainedAutoCheckpointOnCRDe
 			Namespace: testNamespace,
 		}, current))
 		assert.Equal(t, testHash, current.Labels[snapshotprotocol.CheckpointIDLabel])
+		assert.Equal(t, "disabled", current.Spec.Template.Annotations["linkerd.io/inject"])
+		assert.Equal(t, "false", current.Spec.Template.Annotations["sidecar.istio.io/inject"])
 	})
 
 	t.Run("running cleanup job keeps finalizer pending", func(t *testing.T) {


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Disable Service-Mesh Sidecars for One-Shot Checkpoint Cleanup Jobs

## Details:

<!-- Describe the changes made in this PR. -->

A one-shot Checkpoint cleanup Job Pod should exit immediately after it completes the cleanup task.

Without disabling sidecar injection, Linkerd or Istio injects a sidecar in namespaces where injection is enabled. 

After the cleanup container exits, the sidecar remains running, preventing the Pod from terminating. Kubernetes therefore does not mark the Job as complete. 

Add these annotations to the cleanup Job Pod template:

```
annotations:
  linkerd.io/inject: disabled
  sidecar.istio.io/inject: "false"
```

This prevents Linkerd and Istio from injecting sidecars, allowing the Job to complete after the cleanup container exits

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12364" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint cleanup jobs now disable service mesh sidecar injection, helping ensure cleanup completes reliably without unintended sidecar dependencies.

* **Tests**
  * Added validation confirming cleanup jobs include the required settings for supported service meshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->