### PR TITLE
feat(kv-router): stamp request identity on selector scoring rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you're running a single model on a single GPU, your inference engine alone is
 
 | | [SGLang](https://docs.nvidia.com/dynamo/backends/sg-lang) | [TensorRT-LLM](https://docs.nvidia.com/dynamo/backends/tensor-rt-llm) | [vLLM](https://docs.nvidia.com/dynamo/backends/v-llm) |
 |---|:----:|:----------:|:--:|
-| [**Disaggregated Serving**](https://docs.nvidia.com/dynamo/design-docs/disaggregated-serving) | ✅ | ✅ | ✅ |
+| [**Disaggregated Serving**](https://docs.nvidia.com/dynamo/dev/knowledge-base/concepts/system-architecture/disaggregated-serving) | ✅ | ✅ | ✅ |
 | [**KV-Aware Routing**](https://docs.nvidia.com/dynamo/components/router) | ✅ | ✅ | ✅ |
 | [**SLA-Based Planner**](https://docs.nvidia.com/dynamo/components/planner/planner-guide) | ✅ | ✅ | ✅ |
 | [**KVBM**](https://docs.nvidia.com/dynamo/components/kvbm) | 🚧 | ✅ | ✅ |
@@ -96,7 +96,7 @@ Most inference engines optimize a single GPU or a single node. Dynamo is the **o
 
 | Capability | What it does | Why it matters |
 |------------|-------------|----------------|
-| [**Disaggregated Prefill/Decode**](https://docs.nvidia.com/dynamo/design-docs/disaggregated-serving) | Separates prefill and decode into independently scalable GPU pools | Maximizes GPU utilization; each phase runs on hardware tuned for its workload |
+| [**Disaggregated Prefill/Decode**](https://docs.nvidia.com/dynamo/dev/knowledge-base/concepts/system-architecture/disaggregated-serving) | Separates prefill and decode into independently scalable GPU pools | Maximizes GPU utilization; each phase runs on hardware tuned for its workload |
 | [**KV-Aware Routing**](https://docs.nvidia.com/dynamo/components/router) | Routes requests based on worker load and KV cache overlap | Eliminates redundant prefill computation — 2x faster TTFT |
 | [**KV Block Manager (KVBM)**](https://docs.nvidia.com/dynamo/components/kvbm) | Offloads KV cache across GPU → CPU → SSD → remote storage | Extends effective context length beyond GPU memory |
 | [**ModelExpress**](https://github.com/ai-dynamo/modelexpress) | Streams model weights GPU-to-GPU via NIXL/NVLink | 7x faster cold-start for new replicas |

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -238,8 +238,16 @@ impl DefaultWorkerSelector {
             self.kv_router_config.decode_active_request_weight * worker_load.active_requests as f64;
         let logit = prefill_cost_blocks + decode_cost_blocks + active_request_cost_blocks;
 
+        // These rows are emitted from the `SchedulerQueueActor` task, which `scheduling::queue`
+        // spawns without the caller's request span, so the logging layer cannot attach
+        // `x_request_id`/`trace_id` to them. Stamp the identity the row needs to be self-joining:
+        // `request_id` is the same value `[ROUTING] Best` logs, and `worker_type` separates the
+        // prefill-pool and decode-pool decisions that interleave into one log. Both are evaluated
+        // inside the macro so they cost nothing when DEBUG is disabled.
         if shared_beyond > 0 {
             tracing::debug!(
+                request_id = request.mode.request_id().unwrap_or("-"),
+                worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks, \
                  {shared_beyond} shared blocks beyond device (multiplier={shared_cache_multiplier:.2}): {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks + active_request_cost_blocks \
@@ -253,6 +261,8 @@ impl DefaultWorkerSelector {
             );
         } else {
             tracing::debug!(
+                request_id = request.mode.request_id().unwrap_or("-"),
+                worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks: {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks + active_request_cost_blocks \
                  = {prefill_load_scale:.3} * {adjusted_prefill_blocks:.3} + {decode_cost_blocks:.3} + {active_request_cost_blocks:.3} \
@@ -300,6 +310,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
         }
 
         let request_blocks = request.request_blocks(block_size);
+        // Borrowed, never allocated; bridges the winner row to `[ROUTING] Best`.
+        let request_id = request.mode.request_id().unwrap_or("-");
 
         let weights = LogitWeights {
             overlap_score_credit: request
@@ -344,6 +356,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             let cached_tokens = request.effective_cached_tokens_for(worker);
 
             tracing::info!(
+                request_id,
                 "Selected pinned worker: worker_type={}, worker_id={} dp_rank={:?}, logit: {:.3}, effective cached blocks: {:.2}",
                 self.worker_type,
                 worker.worker_id,
@@ -501,6 +514,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
         if self.worker_type == "decode" {
             tracing::info!(
                 router_mode = "kv",
+                request_id,
                 worker_id = best_worker.worker_id,
                 worker_type = %self.worker_type,
                 dp_rank = ?best_worker.dp_rank,
@@ -529,6 +543,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
 
         tracing::info!(
             router_mode = "kv",
+            request_id,
             worker_id = best_worker.worker_id,
             worker_type = %self.worker_type,
             dp_rank = ?best_worker.dp_rank,


### PR DESCRIPTION
## Overview:

`selector.rs` emits one `tracing::debug!` per candidate carrying the whole cost breakdown — `overlap_blocks`, `raw_prefill_blocks`, `overlap_credit_blocks`, `overlap_credit_decay`, `prefill_load_scale`, `adjusted_prefill_blocks`, `decode_blocks`, and the resulting logit. It is the only place the router explains why it picked a worker. But the row carries no identity, so anything reading these logs can only group candidates into decisions **by line adjacency**.

This PR stamps `request_id` and `worker_type` on those rows, and `request_id` on the winner rows, making them self-joining. The selector change is +15/−0 and logging-only. The branch also repairs two pre-existing README links to the disaggregated-serving architecture page; their old redirect resolves to HTTP 404 and was failing the repository-wide docs-link check.

## Details:

Adjacency is not sound here, for two structural reasons:

1. **The rows are outside the request span.** They are emitted from the `SchedulerQueueActor` task, which `scheduling/queue.rs:409` spawns via `tokio::spawn(actor.run(admission_rx))` with no `.instrument(...)`. The caller's request span is therefore not in scope, and the logging layer cannot attach `x_request_id`/`trace_id`. This is exactly why `[ROUTING] Best` — emitted on the *caller's* task at `llm/src/kv_router/push_router/selection.rs:183` — does carry `x_request_id` while these rows do not.
2. **There is one actor per scheduler.** A disaggregated deployment runs two (prefill and decode), so two concurrent tasks interleave into one log.

Measured on a 1.24 GB frontend-log sample from a 6-prefill + 1-decode deployment:

| metric | value |
|---|---|
| candidate→winner agreement, overall | 72.46% |
| …on 24-candidate prefill decisions | 99.82% |
| …on 8-candidate decode decisions | **42.98%** |
| winners with no preceding candidate rows | 14.40% |

Decode-pool analysis is not currently possible from these logs, and the smaller a pool's candidate set, the more adjacency corrupts it.

**The two fields:**

- **`request_id`** — `request.mode.request_id()` is already reachable at the emission site and returns the same value `[ROUTING] Best` logs. That makes the candidate row self-joining to the client record in **one hop**, rather than requiring a bridge through the winner row (which is absent for 14.40% of decisions).
- **`worker_type`** — separates the two pools with no join at all. This matters beyond bookkeeping: the pools score differently. `prefill_router/mod.rs`'s `build_decode_router_override` forces `overlap_score_credit = 0.0` and `track_prefill_tokens = false` on the decode path, so decode candidates are load-only and have `raw_prefill_blocks == 0` by construction. Aggregating the two pools mixes two different scoring regimes.

**Alternatives considered:**

- *A monotonic decision counter.* Rejected — it is a surrogate for a natural key already in hand, it does not survive a process restart, and it collides across router replicas (`router_replica_sync`), so aggregated logs from two frontends would share ids. It also puts mutable global state in a component `scheduling/CLAUDE.md` declares side-effect free.
- *Propagating the caller's span across `AdmissionCommand::Enqueue`.* This is the framework-correct fix — it would give `x_request_id`, `trace_id`, `span_id` and `parent_id` on every event inside selection, permanently. It is a larger, cross-crate change to the actor message type, so it belongs in its own PR. This one is the minimal change that makes the existing rows usable.

**Cost:** both fields are evaluated *inside* the macro, so they cost nothing when DEBUG is disabled. When enabled, `request_id` is a borrowed `&str` and `worker_type` a `&'static str` — nothing is allocated in `selector.rs`.

**No scoring behaviour changes, and no function signatures change.**

## Where should the reviewer start?

`lib/kv-router/src/scheduling/selector.rs` contains the code change; `README.md` contains only the two URL corrections described above. Start with two places in `selector.rs`:

1. **`worker_logit`** (the two `tracing::debug!` candidate rows) — confirm the added fields are inside the macro invocation, so they are not evaluated when DEBUG is off, and that `request.mode.request_id()` introduces no allocation.
2. **`select_worker`** (the three `tracing::info!` winner rows: pinned, decode, general) — `request_id` is bound once and reused; confirm it matches what `[ROUTING] Best` logs so the two rows join.

Worth a skeptical eye: the `unwrap_or("-")` fallback. `ScheduleMode::QueryOnly` permits a `None` request id (`prefill_router/query.rs` passes `None`), so those rows are deliberately labelled rather than dropped — an explicit sentinel beats today's silent misattribution by adjacency, but say so if you'd prefer a different sentinel or an omitted field.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `cargo test -p dynamo-kv-router --lib` — **849 passed, 0 failed, 2 ignored**
- `cargo clippy -p dynamo-kv-router --no-deps --all-targets -- -D warnings` — clean
- `cargo fmt -p dynamo-kv-router` — applied
- Lychee `v0.24.2` with the workflow flags against `README.md` — **102 links checked, 0 errors**
- `pre-commit run --all-files` — all hooks passed
- No selector test changes were needed, which is itself the behaviour-preservation check: the selector change is additive logging fields only.
