### PR TITLE
ci(buildkit): probe pod ordinals up to the KEDA replica ceiling (OPS-7960)

### DIFF
--- a/.github/scripts/route_buildkit.sh
+++ b/.github/scripts/route_buildkit.sh
@@ -146,7 +146,10 @@ fi
 # --- CONFIGURATION ---
 NAMESPACE="buildkit"
 PORT="1234"
-MAX_POD_CHECK=10
+# Highest buildkit pod ordinal to probe, exclusive. Must be >= the KEDA
+# maxReplicaCount for the buildkit StatefulSet, or pods above this ordinal are
+# never discovered and sit idle while builds queue on the pods below it.
+MAX_POD_CHECK=${MAX_POD_CHECK:-16}
 # ---------------------
 
 if ! command -v nslookup &> /dev/null; then


### PR DESCRIPTION
## Summary

`get_active_indices()` in `.github/scripts/route_buildkit.sh` discovers builder pods by resolving `buildkit-<arch>-<i>` over DNS for `i` in `[0, MAX_POD_CHECK)`. That bound was `10`, matching the KEDA `maxReplicaCount` at the time it was written.

Raising the builder pool above 10 without raising this leaves the extra pods **undiscovered**: they start, hold a Karpenter node, and never receive a build, while the pods below the bound absorb the entire queue. This bumps the default to `16` and makes it environment-overridable.

Prerequisite for ai-dynamo/velonix#545, which takes the pool from 9 to 15 pods per arch. Raising this first is safe on its own — ordinals with no pod behind them fail to resolve and are skipped, so on today's 9-pod fleet the behavior is unchanged apart from a few extra NXDOMAIN lookups.

## Why it matters beyond the pod count

`compute_group_pools()` splits discovered pods into three cache groups — `vllm`, `sglang`, and `general`+`trtllm` — via `pool_size=$(( (count + 2) / 3 ))`. The split is driven by `count`, so a stale `MAX_POD_CHECK` silently pins the group sizes too.

Running the real algorithm over contiguous fleets (it reproduces the pools seen in production logs at n=9 — `{6,7,8}` amd64, `{0,2,8}` arm64):

| pods | vllm | sglang | general+trtllm | overlap |
|---|---|---|---|---|
| 9 | 3 | 3 | 3 | none |
| 15 | 5 | 5 | 5 | none |
| 16 | 6 | 6 | 6 | **yes** — 18 slots over 16 pods |

Note 16 is not a better 15: `pool_size` rounds up, so three pools of 6 over 16 pods forces two pods into two cache domains at once. Multiples of 3 stay disjoint while the group count is 3.

## Measured motivation

First-attempt build outcomes, stratified sample of 14 PR runs/day over 2026-07-24..07-29 (670 build jobs; runs cancelled by a superseding push excluded, since those cancel long builds before they can time out):

| day | vllm | sglang | general | trtllm |
|---|---|---|---|---|
| 07-24 | 0% | 0% | 5% | 0% |
| 07-25 | 0% | 0% | 5% | 0% |
| 07-26 | 11% | 4% | 33% | 12% |
| 07-27 | 0% | 0% | 5% | 0% |
| 07-28 | 0% | 0% | 32% | 17% |
| 07-29 | 0% | 0% | 28% | 23% |

Timeouts are confined to the shared `general`+`trtllm` group. Successful builds in that group have a median of 9–17 min against 30/45/60 min caps, so the failures are contention, not work that outgrew its budget.

## Validation

- `bash -n .github/scripts/route_buildkit.sh` passes.
- `MAX_POD_CHECK` unset resolves to `16`; exported value takes precedence.
- Extracted `compute_group_pools` verbatim and ran it over contiguous fleets; at n=9 it reproduces the exact pools observed in production build logs, confirming the harness matches the deployed algorithm.
- No behavior change on the current 9-pod fleet: ordinals 9–15 do not resolve and are skipped by the existing `nslookup` guard.

Linear: OPS-7960

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12377" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BuildKit pod discovery by allowing DNS probing across a larger range of pod ordinals.
  * Added clearer guidance around pod discovery limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->