### PR TITLE
feat(mocker): add typed LiveEngine handoff control

### DIFF
--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -19,6 +19,7 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::common::handoff::{HandoffId, HandoffTransferTiming};
 use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
@@ -26,6 +27,7 @@ use crate::engine::{LiveEngineScheduler, create_engine_with_event_sender};
 use crate::scheduler::{
     LiveEngineEvent, MockerMetrics, SchedulerCancellationEnvelope, SchedulerCommand,
     SchedulerCommandEnvelope, SchedulerCommandResult, SchedulerEventSender, SchedulerHandle,
+    SchedulerLifecycleEvent,
 };
 
 #[derive(Default)]
@@ -38,6 +40,62 @@ type Routes = Arc<RequestRoutes>;
 
 const SCHEDULER_EVENT_CAPACITY: usize = 8;
 const DEFAULT_REQUEST_OUTPUT_CAPACITY: usize = 8;
+const HANDOFF_EVENT_CAPACITY: usize = 8;
+
+/// Runtime publishers used by one live Mocker scheduler.
+#[derive(Clone, Default)]
+pub struct LiveEngineConfig {
+    pub kv_event_publishers: KvEventPublishers,
+    pub fpm_publisher: FpmPublisher,
+}
+
+#[derive(Default)]
+struct HandoffRoutes {
+    by_id: DashMap<HandoffId, Arc<HandoffRoute>>,
+}
+
+type SharedHandoffRoutes = Arc<HandoffRoutes>;
+
+struct HandoffRoute {
+    handoff_id: HandoffId,
+    event_tx: Mutex<Option<mpsc::Sender<LiveHandoffEvent>>>,
+}
+
+impl HandoffRoute {
+    fn new(handoff_id: HandoffId, event_tx: mpsc::Sender<LiveHandoffEvent>) -> Self {
+        Self {
+            handoff_id,
+            event_tx: Mutex::new(Some(event_tx)),
+        }
+    }
+
+    async fn send(&self, event: LiveHandoffEvent, cancel: &CancellationToken) -> bool {
+        let event_tx = self.event_tx.lock().unwrap().as_ref().cloned();
+        let Some(event_tx) = event_tx else {
+            return false;
+        };
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => false,
+            result = event_tx.send(event) => result.is_ok(),
+        }
+    }
+
+    fn shutdown(&self) {
+        self.event_tx.lock().unwrap().take();
+    }
+}
+
+/// Scheduler lifecycle events normalized for a registered disaggregated handoff.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LiveHandoffEvent {
+    SourceHeld {
+        transfer_timing: HandoffTransferTiming,
+    },
+    DestinationReserved {
+        transferable_prompt_tokens: usize,
+    },
+}
 
 pub(crate) struct ObservedAdmission {
     pub(crate) event: crate::scheduler::AdmissionEvent,
@@ -245,6 +303,7 @@ struct LiveEngineInner {
     command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
     cancellation_tx: mpsc::Sender<SchedulerCancellationEnvelope>,
     routes: Routes,
+    handoff_routes: SharedHandoffRoutes,
     metrics_rx: tokio::sync::watch::Receiver<MockerMetrics>,
     request_output_capacity: Option<NonZeroUsize>,
     allow_zero_output: bool,
@@ -259,12 +318,31 @@ struct LiveEngineInner {
 struct LiveEngineTasks {
     scheduler_actor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
     dispatcher_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    lifecycle_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
 }
 
 impl LiveEngine {
     /// Start one live scheduler at `dp_rank`.
     pub fn start(args: MockEngineArgs, dp_rank: u32) -> anyhow::Result<Self> {
         Self::start_internal(args, dp_rank, LiveEngineOptions::default(), None)
+    }
+
+    /// Start one live scheduler with runtime-owned KV and FPM publishers.
+    pub fn start_with_config(
+        args: MockEngineArgs,
+        dp_rank: u32,
+        config: LiveEngineConfig,
+    ) -> anyhow::Result<Self> {
+        Self::start_internal(
+            args,
+            dp_rank,
+            LiveEngineOptions {
+                kv_event_publishers: config.kv_event_publishers,
+                fpm_publisher: config.fpm_publisher,
+                ..LiveEngineOptions::default()
+            },
+            None,
+        )
     }
 
     pub(crate) fn start_with_options(
@@ -318,7 +396,7 @@ impl LiveEngine {
         let cancel = CancellationToken::new();
         let (event_tx, event_rx) = mpsc::channel::<LiveEngineEvent>(SCHEDULER_EVENT_CAPACITY);
         let LiveEngineScheduler {
-            handle: scheduler,
+            handle: mut scheduler,
             actor: scheduler_actor,
         } = create_engine_with_event_sender(
             args,
@@ -331,7 +409,11 @@ impl LiveEngine {
         let command_tx = scheduler.command_sender();
         let cancellation_tx = scheduler.cancellation_sender();
         let metrics_rx = scheduler.metrics_receiver();
+        let lifecycle_rx = scheduler
+            .take_lifecycle_receiver()
+            .expect("new live scheduler must expose one lifecycle receiver");
         let routes = Arc::new(RequestRoutes::default());
+        let handoff_routes = Arc::new(HandoffRoutes::default());
         let dispatcher = runtime.spawn(run_event_dispatcher(
             event_rx,
             Arc::clone(&routes),
@@ -344,6 +426,18 @@ impl LiveEngine {
         let dispatcher_supervisor = runtime.spawn(supervise_event_dispatcher(
             dispatcher,
             Arc::clone(&routes),
+            Arc::clone(&handoff_routes),
+            cancel.clone(),
+        ));
+        let lifecycle_dispatcher = runtime.spawn(run_lifecycle_dispatcher(
+            lifecycle_rx,
+            Arc::clone(&handoff_routes),
+            cancel.clone(),
+        ));
+        let lifecycle_supervisor = runtime.spawn(supervise_lifecycle_dispatcher(
+            lifecycle_dispatcher,
+            Arc::clone(&routes),
+            Arc::clone(&handoff_routes),
             cancel.clone(),
         ));
 
@@ -352,6 +446,7 @@ impl LiveEngine {
                 command_tx,
                 cancellation_tx,
                 routes,
+                handoff_routes,
                 metrics_rx,
                 request_output_capacity: options.request_output_capacity,
                 allow_zero_output: options.allow_zero_output,
@@ -360,21 +455,26 @@ impl LiveEngine {
                 tasks: Mutex::new(LiveEngineTasks {
                     scheduler_actor: Some(scheduler_actor),
                     dispatcher_supervisor: Some(dispatcher_supervisor),
+                    lifecycle_supervisor: Some(lifecycle_supervisor),
                 }),
                 scheduler,
             }),
         })
     }
 
-    /// Submit a request and return its scoped output receiver.
-    pub async fn submit(&self, mut request: DirectRequest) -> anyhow::Result<LiveRequest> {
+    /// Register a request route without submitting it to the scheduler.
+    ///
+    /// Disaggregated handoff commands consume the returned registration after
+    /// their bootstrap session is ready. Dropping an unused registration
+    /// removes the route and closes the paired response stream.
+    pub fn prepare_request(
+        &self,
+        mut request: DirectRequest,
+    ) -> anyhow::Result<(LiveRequestRegistration, LiveRequest)> {
         anyhow::ensure!(
             !self.inner.cancel.is_cancelled(),
             "live Mocker engine is not running"
         );
-        // Both scheduler cores treat an explicit token plan as authoritative.
-        // Normalize the effective length while keeping delivery buffering
-        // independent of a caller's declared maximum response length.
         let output_length = request
             .output_token_ids
             .as_ref()
@@ -387,9 +487,6 @@ impl LiveEngine {
         let client_id = request.uuid.unwrap_or_else(Uuid::new_v4);
         let scheduler_id = Uuid::new_v4();
         request.uuid = Some(scheduler_id);
-        // The dispatcher never waits on a request stream. A caller that leaves
-        // this fixed queue full is cancelled so it cannot block unrelated
-        // requests or turn its declared response length into admission policy.
         let output_capacity = self.inner.request_output_capacity.map_or_else(
             || output_length.max(1),
             |capacity| output_length.max(1).min(capacity.get()),
@@ -411,10 +508,7 @@ impl LiveEngine {
                 entry.insert(Arc::clone(&route));
             }
         }
-        // Own the registration before the first await. The scheduler admission
-        // task survives cancellation of this submit future, so stream-drop
-        // cleanup can wait for admission before using the independent
-        // cancellation lane.
+
         let live = LiveRequest {
             client_id,
             rx,
@@ -423,21 +517,73 @@ impl LiveEngine {
             cancellation_tx: self.inner.cancellation_tx.clone(),
             runtime: self.inner.runtime.clone(),
         };
+        let registration = LiveRequestRegistration {
+            engine: Arc::downgrade(&self.inner),
+            routes: Arc::clone(&self.inner.routes),
+            prepared: Some(PreparedRequest { request, route }),
+        };
+        Ok((registration, live))
+    }
 
+    /// Submit a request and return its scoped output receiver.
+    pub async fn submit(&self, request: DirectRequest) -> anyhow::Result<LiveRequest> {
+        let (registration, live) = self.prepare_request(request)?;
+        self.submit_prepared(registration, PreparedSubmission::Ordinary)
+            .await?;
+        Ok(live)
+    }
+
+    /// Register one disaggregated handoff and its normalized lifecycle stream.
+    pub fn register_handoff(
+        &self,
+        handoff_id: HandoffId,
+    ) -> anyhow::Result<(LiveHandoffControl, LiveHandoffEvents)> {
+        anyhow::ensure!(
+            !self.inner.cancel.is_cancelled(),
+            "live Mocker engine is not running"
+        );
+        let (event_tx, event_rx) = mpsc::channel(HANDOFF_EVENT_CAPACITY);
+        let route = Arc::new(HandoffRoute::new(handoff_id, event_tx));
+        match self.inner.handoff_routes.by_id.entry(handoff_id) {
+            Entry::Occupied(_) => {
+                bail!("handoff {handoff_id:?} already has a lifecycle route")
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&route));
+            }
+        }
+        Ok((
+            LiveHandoffControl {
+                engine: self.clone(),
+                handoff_id,
+            },
+            LiveHandoffEvents {
+                route,
+                routes: Arc::clone(&self.inner.handoff_routes),
+                event_rx,
+            },
+        ))
+    }
+
+    async fn submit_prepared(
+        &self,
+        mut registration: LiveRequestRegistration,
+        submission: PreparedSubmission,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.inner.cancel.is_cancelled(),
+            "live Mocker engine is not running"
+        );
+        let PreparedRequest { request, route } = registration.take_for(&self.inner)?;
+        let scheduler_id = route.scheduler_id;
+        let client_id = route.client_id;
         let routes = Arc::clone(&self.inner.routes);
         let submission_route = Arc::clone(&route);
         let command_tx = self.inner.command_tx.clone();
-        let submission = self.inner.runtime.spawn(async move {
-            let result = send_command(&command_tx, SchedulerCommand::Submit(request)).await;
-            let admission = match result {
-                Ok(SchedulerCommandResult::Submitted(submitted)) if submitted == scheduler_id => {
-                    Ok(())
-                }
-                Ok(result) => Err(anyhow!(
-                    "unexpected scheduler submit result for {client_id}: {result:?}"
-                )),
-                Err(error) => Err(error),
-            };
+        let task = self.inner.runtime.spawn(async move {
+            let command = submission.command(request);
+            let result = send_command(&command_tx, command).await;
+            let admission = submission.validate(result, client_id, scheduler_id);
             if admission.is_ok() {
                 submission_route.activate();
             } else {
@@ -446,7 +592,7 @@ impl LiveEngine {
             }
             admission
         });
-        match submission.await {
+        match task.await {
             Ok(result) => result?,
             Err(error) => {
                 route.shutdown();
@@ -459,8 +605,7 @@ impl LiveEngine {
             remove_route(&self.inner.routes, &route);
             bail!("live Mocker engine stopped during submission");
         }
-
-        Ok(live)
+        Ok(())
     }
 
     /// Cancel an active request and wait until the scheduler applies it.
@@ -498,14 +643,16 @@ impl LiveEngine {
         self.inner.routes.by_client.len()
     }
 
-    pub(crate) async fn shutdown(&self) -> anyhow::Result<()> {
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
         self.inner.cancel.cancel();
         shutdown_routes(&self.inner.routes);
-        let (scheduler_actor, dispatcher_supervisor) = {
+        shutdown_handoff_routes(&self.inner.handoff_routes);
+        let (scheduler_actor, dispatcher_supervisor, lifecycle_supervisor) = {
             let mut tasks = self.inner.tasks.lock().unwrap();
             (
                 tasks.scheduler_actor.take(),
                 tasks.dispatcher_supervisor.take(),
+                tasks.lifecycle_supervisor.take(),
             )
         };
 
@@ -531,13 +678,32 @@ impl LiveEngine {
                 Ok(Err(_)) | Err(_) => {}
             }
         }
+        if let Some(lifecycle_supervisor) = lifecycle_supervisor {
+            match lifecycle_supervisor.await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) if first_error.is_none() => {
+                    first_error = Some(error.context("live Mocker lifecycle dispatcher failed"))
+                }
+                Err(error) if first_error.is_none() => {
+                    first_error = Some(anyhow!(
+                        "live Mocker lifecycle dispatcher supervisor failed: {error}"
+                    ))
+                }
+                Ok(Err(_)) | Err(_) => {}
+            }
+        }
         shutdown_routes(&self.inner.routes);
+        shutdown_handoff_routes(&self.inner.handoff_routes);
         if let Some(error) = first_error {
             return Err(error);
         }
         anyhow::ensure!(
             self.inner.routes.by_client.is_empty() && self.inner.routes.by_scheduler.is_empty(),
             "live Mocker shutdown left active request routes"
+        );
+        anyhow::ensure!(
+            self.inner.handoff_routes.by_id.is_empty(),
+            "live Mocker shutdown left active handoff routes"
         );
         Ok(())
     }
@@ -546,6 +712,214 @@ impl LiveEngine {
 impl Drop for LiveEngineInner {
     fn drop(&mut self) {
         self.cancel.cancel();
+    }
+}
+
+struct PreparedRequest {
+    request: DirectRequest,
+    route: Arc<RequestRoute>,
+}
+
+/// An output route prepared for ordinary or disaggregated scheduler admission.
+pub struct LiveRequestRegistration {
+    engine: Weak<LiveEngineInner>,
+    routes: Routes,
+    prepared: Option<PreparedRequest>,
+}
+
+impl LiveRequestRegistration {
+    fn take_for(&mut self, engine: &Arc<LiveEngineInner>) -> anyhow::Result<PreparedRequest> {
+        let Some(owner) = self.engine.upgrade() else {
+            bail!("live Mocker engine no longer exists");
+        };
+        anyhow::ensure!(
+            Arc::ptr_eq(&owner, engine),
+            "prepared request belongs to a different live Mocker engine"
+        );
+        self.prepared
+            .take()
+            .ok_or_else(|| anyhow!("prepared request was already consumed"))
+    }
+}
+
+impl Drop for LiveRequestRegistration {
+    fn drop(&mut self) {
+        if let Some(prepared) = self.prepared.take() {
+            prepared.route.shutdown();
+            remove_route(&self.routes, &prepared.route);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PreparedSubmission {
+    Ordinary,
+    Source(HandoffId),
+    Destination(HandoffId),
+}
+
+impl PreparedSubmission {
+    fn command(self, request: DirectRequest) -> SchedulerCommand {
+        match self {
+            Self::Ordinary => SchedulerCommand::Submit(request),
+            Self::Source(handoff_id) => SchedulerCommand::SubmitHandoffPrefill {
+                handoff_id,
+                request,
+            },
+            Self::Destination(handoff_id) => SchedulerCommand::ReserveDestination {
+                handoff_id,
+                request,
+            },
+        }
+    }
+
+    fn validate(
+        self,
+        result: anyhow::Result<SchedulerCommandResult>,
+        client_id: Uuid,
+        scheduler_id: Uuid,
+    ) -> anyhow::Result<()> {
+        match (self, result) {
+            (
+                Self::Ordinary | Self::Source(_),
+                Ok(SchedulerCommandResult::Submitted(submitted)),
+            ) if submitted == scheduler_id => Ok(()),
+            (
+                Self::Destination(_),
+                Ok(SchedulerCommandResult::DestinationAccepted { request_id }),
+            ) if request_id == scheduler_id => Ok(()),
+            (_, Ok(result)) => Err(anyhow!(
+                "unexpected scheduler submit result for {client_id}: {result:?}"
+            )),
+            (_, Err(error)) => Err(error),
+        }
+    }
+}
+
+/// Typed scheduler controls for one disaggregated handoff.
+#[derive(Clone)]
+pub struct LiveHandoffControl {
+    engine: LiveEngine,
+    handoff_id: HandoffId,
+}
+
+impl LiveHandoffControl {
+    pub fn handoff_id(&self) -> HandoffId {
+        self.handoff_id
+    }
+
+    pub async fn submit_prefill(
+        &self,
+        registration: LiveRequestRegistration,
+    ) -> anyhow::Result<()> {
+        self.engine
+            .submit_prepared(registration, PreparedSubmission::Source(self.handoff_id))
+            .await
+    }
+
+    pub async fn reserve_destination(
+        &self,
+        registration: LiveRequestRegistration,
+    ) -> anyhow::Result<()> {
+        self.engine
+            .submit_prepared(
+                registration,
+                PreparedSubmission::Destination(self.handoff_id),
+            )
+            .await
+    }
+
+    pub async fn release_source(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::ReleaseSource {
+                handoff_id: self.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    pub async fn cancel_source(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::CancelSource {
+                handoff_id: self.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    pub async fn activate_destination(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::ActivateDestination {
+                handoff_id: self.handoff_id,
+            },
+            HandoffCommandResult::Applied,
+        )
+        .await
+    }
+
+    pub async fn cancel_destination(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::CancelDestination {
+                handoff_id: self.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    async fn send_handoff_command(
+        &self,
+        command: SchedulerCommand,
+        expected: HandoffCommandResult,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.engine.inner.cancel.is_cancelled(),
+            "live Mocker engine is not running"
+        );
+        let result = send_command(&self.engine.inner.command_tx, command).await?;
+        match (expected, result) {
+            (HandoffCommandResult::Applied, SchedulerCommandResult::Applied)
+            | (
+                HandoffCommandResult::AppliedOrNoop,
+                SchedulerCommandResult::Applied | SchedulerCommandResult::Noop,
+            ) => Ok(()),
+            (_, result) => Err(anyhow!(
+                "unexpected scheduler handoff result for {:?}: {result:?}",
+                self.handoff_id
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HandoffCommandResult {
+    Applied,
+    AppliedOrNoop,
+}
+
+/// Request-owned stream of normalized handoff lifecycle events.
+pub struct LiveHandoffEvents {
+    route: Arc<HandoffRoute>,
+    routes: SharedHandoffRoutes,
+    event_rx: mpsc::Receiver<LiveHandoffEvent>,
+}
+
+impl LiveHandoffEvents {
+    pub fn handoff_id(&self) -> HandoffId {
+        self.route.handoff_id
+    }
+
+    pub async fn recv(&mut self) -> Option<LiveHandoffEvent> {
+        self.event_rx.recv().await
+    }
+}
+
+impl Drop for LiveHandoffEvents {
+    fn drop(&mut self) {
+        self.route.shutdown();
+        remove_handoff_route(&self.routes, &self.route);
     }
 }
 
@@ -627,6 +1001,13 @@ fn route_is_registered(routes: &RequestRoutes, route: &Arc<RequestRoute>) -> boo
             .by_scheduler
             .get(&route.scheduler_id)
             .is_some_and(|current| Arc::ptr_eq(current.value(), route))
+}
+
+fn remove_handoff_route(routes: &HandoffRoutes, route: &Arc<HandoffRoute>) -> bool {
+    routes
+        .by_id
+        .remove_if(&route.handoff_id, |_, current| Arc::ptr_eq(current, route))
+        .is_some()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -733,6 +1114,7 @@ fn dispatch_admission_batch(
 async fn supervise_event_dispatcher(
     dispatcher: tokio::task::JoinHandle<anyhow::Result<()>>,
     routes: Routes,
+    handoff_routes: SharedHandoffRoutes,
     cancel: CancellationToken,
 ) -> anyhow::Result<()> {
     let result = match dispatcher.await {
@@ -747,6 +1129,79 @@ async fn supervise_event_dispatcher(
     }
     cancel.cancel();
     shutdown_routes(&routes);
+    shutdown_handoff_routes(&handoff_routes);
+    result
+}
+
+async fn run_lifecycle_dispatcher(
+    mut lifecycle_rx: mpsc::Receiver<SchedulerLifecycleEvent>,
+    routes: SharedHandoffRoutes,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    loop {
+        let event = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(()),
+            event = lifecycle_rx.recv() => {
+                let Some(event) = event else {
+                    if cancel.is_cancelled() {
+                        return Ok(());
+                    }
+                    bail!("live Mocker lifecycle lane closed unexpectedly");
+                };
+                event
+            }
+        };
+        let (handoff_id, event) = match event {
+            SchedulerLifecycleEvent::SourceHeld {
+                handoff_id,
+                transfer_timing,
+                ..
+            } => (handoff_id, LiveHandoffEvent::SourceHeld { transfer_timing }),
+            SchedulerLifecycleEvent::DestinationReserved {
+                handoff_id,
+                transferable_prompt_tokens,
+                ..
+            } => (
+                handoff_id,
+                LiveHandoffEvent::DestinationReserved {
+                    transferable_prompt_tokens,
+                },
+            ),
+        };
+        let route = routes
+            .by_id
+            .get(&handoff_id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(route) = route
+            && !route.send(event, &cancel).await
+        {
+            remove_handoff_route(&routes, &route);
+        }
+    }
+}
+
+async fn supervise_lifecycle_dispatcher(
+    dispatcher: tokio::task::JoinHandle<anyhow::Result<()>>,
+    routes: Routes,
+    handoff_routes: SharedHandoffRoutes,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    let result = match dispatcher.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(error),
+        Err(error) => Err(anyhow!(
+            "live Mocker lifecycle dispatcher task failed: {error}"
+        )),
+    };
+    if let Err(error) = &result {
+        tracing::error!(%error, "live Mocker lifecycle dispatcher failed");
+    } else if !cancel.is_cancelled() {
+        tracing::error!("live Mocker lifecycle dispatcher exited unexpectedly");
+    }
+    cancel.cancel();
+    shutdown_routes(&routes);
+    shutdown_handoff_routes(&handoff_routes);
     result
 }
 
@@ -761,6 +1216,18 @@ fn shutdown_routes(routes: &RequestRoutes) {
     }
     routes.by_client.clear();
     routes.by_scheduler.clear();
+}
+
+fn shutdown_handoff_routes(routes: &HandoffRoutes) {
+    let active_routes = routes
+        .by_id
+        .iter()
+        .map(|entry| Arc::clone(entry.value()))
+        .collect::<Vec<_>>();
+    for route in active_routes {
+        route.shutdown();
+    }
+    routes.by_id.clear();
 }
 
 fn dispatch_output_batch(

--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -39,8 +39,8 @@ use handoff::{
     supervise_lifecycle_dispatcher,
 };
 use request::{
-    ObservedOutput, OutputDelivery, RequestRoute, RequestRoutes, Routes, remove_route,
-    route_is_registered, shutdown_routes,
+    ObservedOutput, OutputDelivery, RequestCancellation, RequestRoute, RequestRoutes, Routes,
+    remove_route, route_is_registered, shutdown_routes,
 };
 
 const SCHEDULER_EVENT_CAPACITY: usize = 8;
@@ -209,6 +209,7 @@ impl LiveEngine {
         let dispatcher = runtime.spawn(run_event_dispatcher(
             event_rx,
             Arc::clone(&routes),
+            command_tx.clone(),
             cancellation_tx.clone(),
             runtime.clone(),
             cancel.clone(),
@@ -307,6 +308,7 @@ impl LiveEngine {
             rx,
             route: Arc::downgrade(&route),
             routes: Arc::clone(&self.inner.routes),
+            command_tx: self.inner.command_tx.clone(),
             cancellation_tx: self.inner.cancellation_tx.clone(),
             runtime: self.inner.runtime.clone(),
         };
@@ -348,7 +350,7 @@ impl LiveEngine {
             let result = send_command(&command_tx, command).await;
             let admission = submission.validate(result, client_id, scheduler_id);
             if admission.is_ok() {
-                submission_route.activate();
+                submission_route.activate(submission.cancellation());
             } else {
                 submission_route.shutdown();
                 remove_route(&routes, &submission_route);
@@ -388,6 +390,7 @@ impl LiveEngine {
         route.abandon_stream();
         await_cancellation(spawn_cancellation(
             &self.inner.runtime,
+            self.inner.command_tx.clone(),
             self.inner.cancellation_tx.clone(),
             Arc::clone(&self.inner.routes),
             route,
@@ -537,6 +540,13 @@ enum PreparedSubmission {
 }
 
 impl PreparedSubmission {
+    fn cancellation(self) -> RequestCancellation {
+        match self {
+            Self::Destination(handoff_id) => RequestCancellation::Destination(handoff_id),
+            Self::Ordinary | Self::Source(_) => RequestCancellation::Request,
+        }
+    }
+
     fn command(self, request: DirectRequest) -> SchedulerCommand {
         match self {
             Self::Ordinary => SchedulerCommand::Submit(request),
@@ -580,6 +590,7 @@ pub struct LiveRequest {
     rx: mpsc::Receiver<ObservedOutput>,
     route: Weak<RequestRoute>,
     routes: Routes,
+    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
     cancellation_tx: mpsc::Sender<SchedulerCancellationEnvelope>,
     runtime: Handle,
 }
@@ -605,6 +616,7 @@ impl LiveRequest {
         route.abandon_stream();
         await_cancellation(spawn_cancellation(
             &self.runtime,
+            self.command_tx.clone(),
             self.cancellation_tx.clone(),
             Arc::clone(&self.routes),
             route,
@@ -622,6 +634,7 @@ impl Drop for LiveRequest {
         route.abandon_stream();
         drop(spawn_cancellation(
             &self.runtime,
+            self.command_tx.clone(),
             self.cancellation_tx.clone(),
             Arc::clone(&self.routes),
             route,
@@ -634,6 +647,7 @@ impl Drop for LiveRequest {
 async fn run_event_dispatcher(
     mut event_rx: mpsc::Receiver<LiveEngineEvent>,
     routes: Routes,
+    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
     cancellation_tx: mpsc::Sender<SchedulerCancellationEnvelope>,
     runtime: Handle,
     cancel: CancellationToken,
@@ -694,7 +708,14 @@ async fn run_event_dispatcher(
                 pending_event = Some(LiveEngineEvent::Outputs(batch));
             }
             LiveEngineEvent::Outputs(batch) => {
-                if !dispatch_output_batch(batch, &routes, &runtime, &cancellation_tx, &cancel) {
+                if !dispatch_output_batch(
+                    batch,
+                    &routes,
+                    &runtime,
+                    &command_tx,
+                    &cancellation_tx,
+                    &cancel,
+                ) {
                     return Ok(());
                 }
             }
@@ -757,6 +778,7 @@ fn dispatch_output_batch(
     batch: Vec<OutputSignal>,
     routes: &Routes,
     runtime: &Handle,
+    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
     cancellation_tx: &mpsc::Sender<SchedulerCancellationEnvelope>,
     cancel: &CancellationToken,
 ) -> bool {
@@ -790,6 +812,7 @@ fn dispatch_output_batch(
             }
             drop(spawn_cancellation(
                 runtime,
+                command_tx.clone(),
                 cancellation_tx.clone(),
                 Arc::clone(routes),
                 Arc::clone(&route),
@@ -805,6 +828,7 @@ fn dispatch_output_batch(
 
 fn spawn_cancellation(
     runtime: &Handle,
+    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
     cancellation_tx: mpsc::Sender<SchedulerCancellationEnvelope>,
     routes: Routes,
     route: Arc<RequestRoute>,
@@ -822,16 +846,23 @@ fn spawn_cancellation(
         if abandon_stream {
             route.abandon_stream();
         }
-        if !route.begin_cancellation() {
+        let Some(cancellation) = route.begin_cancellation() else {
             return Ok(false);
-        }
+        };
 
-        let result = cancel_request(
-            &cancellation_tx,
-            route.scheduler_id,
-            abandon_stream,
-        )
-        .await;
+        let result = match cancellation {
+            RequestCancellation::Request => {
+                cancel_request(
+                    &cancellation_tx,
+                    route.scheduler_id,
+                    abandon_stream,
+                )
+                .await
+            }
+            RequestCancellation::Destination(handoff_id) => {
+                cancel_destination(&command_tx, handoff_id).await
+            }
+        };
         if route.finish_cancellation(&result) {
             remove_route(&routes, &route);
         }
@@ -873,6 +904,24 @@ async fn cancel_request(
         SchedulerCommandResult::Noop => Ok(false),
         result => Err(anyhow!(
             "unexpected scheduler cancellation result for {request_id}: {result:?}"
+        )),
+    }
+}
+
+async fn cancel_destination(
+    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
+    handoff_id: HandoffId,
+) -> anyhow::Result<bool> {
+    match send_command(
+        command_tx,
+        SchedulerCommand::CancelDestination { handoff_id },
+    )
+    .await?
+    {
+        SchedulerCommandResult::Applied => Ok(true),
+        SchedulerCommandResult::Noop => Ok(false),
+        result => Err(anyhow!(
+            "unexpected scheduler destination cancellation result for {handoff_id:?}: {result:?}"
         )),
     }
 }

--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -12,14 +12,14 @@ use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex, Weak};
 
 use anyhow::{Context, anyhow, bail};
-use dashmap::DashMap;
 use dashmap::mapref::entry::Entry;
+use futures::future::{BoxFuture, FutureExt, Shared};
 use tokio::runtime::Handle;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
-use crate::common::handoff::{HandoffId, HandoffTransferTiming};
+use crate::common::handoff::HandoffId;
 use crate::common::protocols::{
     DirectRequest, FpmPublisher, KvEventPublishers, MockEngineArgs, OutputSignal,
 };
@@ -27,20 +27,24 @@ use crate::engine::{LiveEngineScheduler, create_engine_with_event_sender};
 use crate::scheduler::{
     LiveEngineEvent, MockerMetrics, SchedulerCancellationEnvelope, SchedulerCommand,
     SchedulerCommandEnvelope, SchedulerCommandResult, SchedulerEventSender, SchedulerHandle,
-    SchedulerLifecycleEvent,
 };
 
-#[derive(Default)]
-struct RequestRoutes {
-    by_client: DashMap<Uuid, Arc<RequestRoute>>,
-    by_scheduler: DashMap<Uuid, Arc<RequestRoute>>,
-}
+mod handoff;
+mod request;
 
-type Routes = Arc<RequestRoutes>;
+pub use handoff::{LiveHandoffControl, LiveHandoffEvent, LiveHandoffEvents};
+
+use handoff::{
+    HandoffRoutes, SharedHandoffRoutes, run_lifecycle_dispatcher, shutdown_handoff_routes,
+    supervise_lifecycle_dispatcher,
+};
+use request::{
+    ObservedOutput, OutputDelivery, RequestRoute, RequestRoutes, Routes, remove_route,
+    route_is_registered, shutdown_routes,
+};
 
 const SCHEDULER_EVENT_CAPACITY: usize = 8;
 const DEFAULT_REQUEST_OUTPUT_CAPACITY: usize = 8;
-const HANDOFF_EVENT_CAPACITY: usize = 8;
 
 /// Runtime publishers used by one live Mocker scheduler.
 #[derive(Clone, Default)]
@@ -49,61 +53,8 @@ pub struct LiveEngineConfig {
     pub fpm_publisher: FpmPublisher,
 }
 
-#[derive(Default)]
-struct HandoffRoutes {
-    by_id: DashMap<HandoffId, Arc<HandoffRoute>>,
-}
-
-type SharedHandoffRoutes = Arc<HandoffRoutes>;
-
-struct HandoffRoute {
-    handoff_id: HandoffId,
-    event_tx: Mutex<Option<mpsc::Sender<LiveHandoffEvent>>>,
-}
-
-impl HandoffRoute {
-    fn new(handoff_id: HandoffId, event_tx: mpsc::Sender<LiveHandoffEvent>) -> Self {
-        Self {
-            handoff_id,
-            event_tx: Mutex::new(Some(event_tx)),
-        }
-    }
-
-    async fn send(&self, event: LiveHandoffEvent, cancel: &CancellationToken) -> bool {
-        let event_tx = self.event_tx.lock().unwrap().as_ref().cloned();
-        let Some(event_tx) = event_tx else {
-            return false;
-        };
-        tokio::select! {
-            biased;
-            _ = cancel.cancelled() => false,
-            result = event_tx.send(event) => result.is_ok(),
-        }
-    }
-
-    fn shutdown(&self) {
-        self.event_tx.lock().unwrap().take();
-    }
-}
-
-/// Scheduler lifecycle events normalized for a registered disaggregated handoff.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub enum LiveHandoffEvent {
-    SourceHeld {
-        transfer_timing: HandoffTransferTiming,
-    },
-    DestinationReserved {
-        transferable_prompt_tokens: usize,
-    },
-}
-
 pub(crate) struct ObservedAdmission {
     pub(crate) event: crate::scheduler::AdmissionEvent,
-    pub(crate) observed_at: tokio::time::Instant,
-}
-
-pub(crate) struct ObservedOutput {
-    pub(crate) event: OutputSignal,
     pub(crate) observed_at: tokio::time::Instant,
 }
 
@@ -125,172 +76,6 @@ impl Default for LiveEngineOptions {
             allow_zero_output: false,
         }
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum RequestState {
-    Submitting,
-    Active,
-    Cancelling,
-    Closed,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct RequestLifecycle {
-    state: RequestState,
-    stream_abandoned: bool,
-    terminal_seen: bool,
-}
-
-struct RequestRoute {
-    client_id: Uuid,
-    scheduler_id: Uuid,
-    output_tx: Mutex<Option<mpsc::Sender<ObservedOutput>>>,
-    lifecycle_tx: watch::Sender<RequestLifecycle>,
-    cancel_lock: tokio::sync::Mutex<()>,
-}
-
-impl RequestRoute {
-    fn new(client_id: Uuid, scheduler_id: Uuid, output_tx: mpsc::Sender<ObservedOutput>) -> Self {
-        let (lifecycle_tx, _) = watch::channel(RequestLifecycle {
-            state: RequestState::Submitting,
-            stream_abandoned: false,
-            terminal_seen: false,
-        });
-        Self {
-            client_id,
-            scheduler_id,
-            output_tx: Mutex::new(Some(output_tx)),
-            lifecycle_tx,
-            cancel_lock: tokio::sync::Mutex::new(()),
-        }
-    }
-
-    fn activate(&self) {
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            if lifecycle.state != RequestState::Submitting {
-                return false;
-            }
-            lifecycle.state = RequestState::Active;
-            true
-        });
-    }
-
-    fn abandon_stream(&self) -> bool {
-        self.close_output();
-        let mut abandoned = false;
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            if lifecycle.stream_abandoned {
-                return false;
-            }
-            lifecycle.stream_abandoned = true;
-            abandoned = true;
-            true
-        });
-        abandoned
-    }
-
-    async fn wait_for_admission(&self) -> bool {
-        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
-        loop {
-            match lifecycle_rx.borrow_and_update().state {
-                RequestState::Submitting | RequestState::Cancelling => {}
-                RequestState::Active => return true,
-                RequestState::Closed => return false,
-            }
-            if lifecycle_rx.changed().await.is_err() {
-                return false;
-            }
-        }
-    }
-
-    fn begin_cancellation(&self) -> bool {
-        let mut started = false;
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            if lifecycle.state == RequestState::Active {
-                lifecycle.state = RequestState::Cancelling;
-                started = true;
-                return true;
-            }
-            false
-        });
-        started
-    }
-
-    fn finish_cancellation(&self, result: &anyhow::Result<bool>) -> bool {
-        let mut remove = false;
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            if lifecycle.state != RequestState::Cancelling {
-                return false;
-            }
-            remove = match result {
-                Ok(true) => true,
-                Ok(false) => lifecycle.stream_abandoned || lifecycle.terminal_seen,
-                Err(_) => lifecycle.terminal_seen,
-            };
-            lifecycle.state = if remove {
-                RequestState::Closed
-            } else {
-                RequestState::Active
-            };
-            true
-        });
-        if remove {
-            self.close_output();
-        }
-        remove
-    }
-
-    fn send_output(&self, output: ObservedOutput) -> OutputDelivery {
-        let output_tx = self.output_tx.lock().unwrap().as_ref().cloned();
-        let Some(output_tx) = output_tx else {
-            return OutputDelivery::Closed;
-        };
-        match output_tx.try_send(output) {
-            Ok(()) => OutputDelivery::Delivered,
-            Err(mpsc::error::TrySendError::Full(_)) => OutputDelivery::Full,
-            Err(mpsc::error::TrySendError::Closed(_)) => OutputDelivery::Closed,
-        }
-    }
-
-    /// Record a terminal signal and return whether the route can be removed.
-    /// An in-flight cancellation retains it until the scheduler acknowledges
-    /// cleanup; its scheduler ID is never reused by a replacement request.
-    fn observe_terminal(&self) -> bool {
-        self.close_output();
-        let mut remove = false;
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            lifecycle.terminal_seen = true;
-            if lifecycle.state != RequestState::Cancelling {
-                lifecycle.state = RequestState::Closed;
-                remove = true;
-            }
-            true
-        });
-        remove
-    }
-
-    fn shutdown(&self) {
-        self.close_output();
-        self.lifecycle_tx.send_if_modified(|lifecycle| {
-            if lifecycle.state == RequestState::Closed {
-                return false;
-            }
-            lifecycle.state = RequestState::Closed;
-            true
-        });
-    }
-
-    fn close_output(&self) {
-        self.output_tx.lock().unwrap().take();
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum OutputDelivery {
-    Delivered,
-    Full,
-    Closed,
 }
 
 /// A running Mocker scheduler with request-scoped output streams.
@@ -319,7 +104,10 @@ struct LiveEngineTasks {
     scheduler_actor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
     dispatcher_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
     lifecycle_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    shutdown: Option<SharedShutdown>,
 }
+
+type SharedShutdown = Shared<BoxFuture<'static, Result<(), Arc<str>>>>;
 
 impl LiveEngine {
     /// Start one live scheduler at `dp_rank`.
@@ -395,13 +183,17 @@ impl LiveEngine {
             .context("invalid Mocker engine arguments")?;
         let cancel = CancellationToken::new();
         let (event_tx, event_rx) = mpsc::channel::<LiveEngineEvent>(SCHEDULER_EVENT_CAPACITY);
+        let forward_admissions = options.admission_tx.is_some();
         let LiveEngineScheduler {
             handle: mut scheduler,
             actor: scheduler_actor,
         } = create_engine_with_event_sender(
             args,
             dp_rank,
-            Some(SchedulerEventSender::Ordered(event_tx)),
+            Some(SchedulerEventSender::Ordered {
+                tx: event_tx,
+                forward_admissions,
+            }),
             options.kv_event_publishers,
             Some(cancel.clone()),
             options.fpm_publisher,
@@ -456,6 +248,7 @@ impl LiveEngine {
                     scheduler_actor: Some(scheduler_actor),
                     dispatcher_supervisor: Some(dispatcher_supervisor),
                     lifecycle_supervisor: Some(lifecycle_supervisor),
+                    shutdown: None,
                 }),
                 scheduler,
             }),
@@ -528,47 +321,16 @@ impl LiveEngine {
     /// Submit a request and return its scoped output receiver.
     pub async fn submit(&self, request: DirectRequest) -> anyhow::Result<LiveRequest> {
         let (registration, live) = self.prepare_request(request)?;
-        self.submit_prepared(registration, PreparedSubmission::Ordinary)
+        self.submit_prepared(registration, PreparedSubmission::Ordinary, None)
             .await?;
         Ok(live)
-    }
-
-    /// Register one disaggregated handoff and its normalized lifecycle stream.
-    pub fn register_handoff(
-        &self,
-        handoff_id: HandoffId,
-    ) -> anyhow::Result<(LiveHandoffControl, LiveHandoffEvents)> {
-        anyhow::ensure!(
-            !self.inner.cancel.is_cancelled(),
-            "live Mocker engine is not running"
-        );
-        let (event_tx, event_rx) = mpsc::channel(HANDOFF_EVENT_CAPACITY);
-        let route = Arc::new(HandoffRoute::new(handoff_id, event_tx));
-        match self.inner.handoff_routes.by_id.entry(handoff_id) {
-            Entry::Occupied(_) => {
-                bail!("handoff {handoff_id:?} already has a lifecycle route")
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(Arc::clone(&route));
-            }
-        }
-        Ok((
-            LiveHandoffControl {
-                engine: self.clone(),
-                handoff_id,
-            },
-            LiveHandoffEvents {
-                route,
-                routes: Arc::clone(&self.inner.handoff_routes),
-                event_rx,
-            },
-        ))
     }
 
     async fn submit_prepared(
         &self,
         mut registration: LiveRequestRegistration,
         submission: PreparedSubmission,
+        command_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
     ) -> anyhow::Result<()> {
         anyhow::ensure!(
             !self.inner.cancel.is_cancelled(),
@@ -581,6 +343,7 @@ impl LiveEngine {
         let submission_route = Arc::clone(&route);
         let command_tx = self.inner.command_tx.clone();
         let task = self.inner.runtime.spawn(async move {
+            let _command_guard = command_guard;
             let command = submission.command(request);
             let result = send_command(&command_tx, command).await;
             let admission = submission.validate(result, client_id, scheduler_id);
@@ -647,66 +410,81 @@ impl LiveEngine {
         self.inner.cancel.cancel();
         shutdown_routes(&self.inner.routes);
         shutdown_handoff_routes(&self.inner.handoff_routes);
-        let (scheduler_actor, dispatcher_supervisor, lifecycle_supervisor) = {
+        let shutdown = {
             let mut tasks = self.inner.tasks.lock().unwrap();
-            (
-                tasks.scheduler_actor.take(),
-                tasks.dispatcher_supervisor.take(),
-                tasks.lifecycle_supervisor.take(),
-            )
+            if let Some(shutdown) = tasks.shutdown.as_ref() {
+                shutdown.clone()
+            } else {
+                let shutdown = shutdown_engine(
+                    tasks.scheduler_actor.take(),
+                    tasks.dispatcher_supervisor.take(),
+                    tasks.lifecycle_supervisor.take(),
+                    Arc::clone(&self.inner.routes),
+                    Arc::clone(&self.inner.handoff_routes),
+                )
+                .boxed()
+                .shared();
+                tasks.shutdown = Some(shutdown.clone());
+                shutdown
+            }
         };
-
-        let mut first_error = None;
-        if let Some(scheduler_actor) = scheduler_actor {
-            match scheduler_actor.await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) => first_error = Some(error.context("live Mocker scheduler failed")),
-                Err(error) => {
-                    first_error = Some(anyhow!("live Mocker scheduler task failed: {error}"))
-                }
-            }
-        }
-        if let Some(dispatcher_supervisor) = dispatcher_supervisor {
-            match dispatcher_supervisor.await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) if first_error.is_none() => {
-                    first_error = Some(error.context("live Mocker event dispatcher failed"))
-                }
-                Err(error) if first_error.is_none() => {
-                    first_error = Some(anyhow!("live Mocker dispatcher supervisor failed: {error}"))
-                }
-                Ok(Err(_)) | Err(_) => {}
-            }
-        }
-        if let Some(lifecycle_supervisor) = lifecycle_supervisor {
-            match lifecycle_supervisor.await {
-                Ok(Ok(())) => {}
-                Ok(Err(error)) if first_error.is_none() => {
-                    first_error = Some(error.context("live Mocker lifecycle dispatcher failed"))
-                }
-                Err(error) if first_error.is_none() => {
-                    first_error = Some(anyhow!(
-                        "live Mocker lifecycle dispatcher supervisor failed: {error}"
-                    ))
-                }
-                Ok(Err(_)) | Err(_) => {}
-            }
-        }
-        shutdown_routes(&self.inner.routes);
-        shutdown_handoff_routes(&self.inner.handoff_routes);
-        if let Some(error) = first_error {
-            return Err(error);
-        }
-        anyhow::ensure!(
-            self.inner.routes.by_client.is_empty() && self.inner.routes.by_scheduler.is_empty(),
-            "live Mocker shutdown left active request routes"
-        );
-        anyhow::ensure!(
-            self.inner.handoff_routes.by_id.is_empty(),
-            "live Mocker shutdown left active handoff routes"
-        );
-        Ok(())
+        shutdown.await.map_err(|error| anyhow!("{error}"))
     }
+}
+
+async fn shutdown_engine(
+    scheduler_actor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    dispatcher_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    lifecycle_supervisor: Option<tokio::task::JoinHandle<anyhow::Result<()>>>,
+    routes: Routes,
+    handoff_routes: SharedHandoffRoutes,
+) -> Result<(), Arc<str>> {
+    let mut first_error = None;
+    if let Some(scheduler_actor) = scheduler_actor {
+        match scheduler_actor.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => first_error = Some(error.context("live Mocker scheduler failed")),
+            Err(error) => first_error = Some(anyhow!("live Mocker scheduler task failed: {error}")),
+        }
+    }
+    if let Some(dispatcher_supervisor) = dispatcher_supervisor {
+        match dispatcher_supervisor.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if first_error.is_none() => {
+                first_error = Some(error.context("live Mocker event dispatcher failed"))
+            }
+            Err(error) if first_error.is_none() => {
+                first_error = Some(anyhow!("live Mocker dispatcher supervisor failed: {error}"))
+            }
+            Ok(Err(_)) | Err(_) => {}
+        }
+    }
+    if let Some(lifecycle_supervisor) = lifecycle_supervisor {
+        match lifecycle_supervisor.await {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) if first_error.is_none() => {
+                first_error = Some(error.context("live Mocker lifecycle dispatcher failed"))
+            }
+            Err(error) if first_error.is_none() => {
+                first_error = Some(anyhow!(
+                    "live Mocker lifecycle dispatcher supervisor failed: {error}"
+                ))
+            }
+            Ok(Err(_)) | Err(_) => {}
+        }
+    }
+    shutdown_routes(&routes);
+    shutdown_handoff_routes(&handoff_routes);
+    if let Some(error) = first_error {
+        return Err(Arc::from(format!("{error:#}")));
+    }
+    if !routes.by_client.is_empty() || !routes.by_scheduler.is_empty() {
+        return Err(Arc::from("live Mocker shutdown left active request routes"));
+    }
+    if !handoff_routes.is_empty() {
+        return Err(Arc::from("live Mocker shutdown left active handoff routes"));
+    }
+    Ok(())
 }
 
 impl Drop for LiveEngineInner {
@@ -796,133 +574,6 @@ impl PreparedSubmission {
     }
 }
 
-/// Typed scheduler controls for one disaggregated handoff.
-#[derive(Clone)]
-pub struct LiveHandoffControl {
-    engine: LiveEngine,
-    handoff_id: HandoffId,
-}
-
-impl LiveHandoffControl {
-    pub fn handoff_id(&self) -> HandoffId {
-        self.handoff_id
-    }
-
-    pub async fn submit_prefill(
-        &self,
-        registration: LiveRequestRegistration,
-    ) -> anyhow::Result<()> {
-        self.engine
-            .submit_prepared(registration, PreparedSubmission::Source(self.handoff_id))
-            .await
-    }
-
-    pub async fn reserve_destination(
-        &self,
-        registration: LiveRequestRegistration,
-    ) -> anyhow::Result<()> {
-        self.engine
-            .submit_prepared(
-                registration,
-                PreparedSubmission::Destination(self.handoff_id),
-            )
-            .await
-    }
-
-    pub async fn release_source(&self) -> anyhow::Result<()> {
-        self.send_handoff_command(
-            SchedulerCommand::ReleaseSource {
-                handoff_id: self.handoff_id,
-            },
-            HandoffCommandResult::AppliedOrNoop,
-        )
-        .await
-    }
-
-    pub async fn cancel_source(&self) -> anyhow::Result<()> {
-        self.send_handoff_command(
-            SchedulerCommand::CancelSource {
-                handoff_id: self.handoff_id,
-            },
-            HandoffCommandResult::AppliedOrNoop,
-        )
-        .await
-    }
-
-    pub async fn activate_destination(&self) -> anyhow::Result<()> {
-        self.send_handoff_command(
-            SchedulerCommand::ActivateDestination {
-                handoff_id: self.handoff_id,
-            },
-            HandoffCommandResult::Applied,
-        )
-        .await
-    }
-
-    pub async fn cancel_destination(&self) -> anyhow::Result<()> {
-        self.send_handoff_command(
-            SchedulerCommand::CancelDestination {
-                handoff_id: self.handoff_id,
-            },
-            HandoffCommandResult::AppliedOrNoop,
-        )
-        .await
-    }
-
-    async fn send_handoff_command(
-        &self,
-        command: SchedulerCommand,
-        expected: HandoffCommandResult,
-    ) -> anyhow::Result<()> {
-        anyhow::ensure!(
-            !self.engine.inner.cancel.is_cancelled(),
-            "live Mocker engine is not running"
-        );
-        let result = send_command(&self.engine.inner.command_tx, command).await?;
-        match (expected, result) {
-            (HandoffCommandResult::Applied, SchedulerCommandResult::Applied)
-            | (
-                HandoffCommandResult::AppliedOrNoop,
-                SchedulerCommandResult::Applied | SchedulerCommandResult::Noop,
-            ) => Ok(()),
-            (_, result) => Err(anyhow!(
-                "unexpected scheduler handoff result for {:?}: {result:?}",
-                self.handoff_id
-            )),
-        }
-    }
-}
-
-#[derive(Clone, Copy)]
-enum HandoffCommandResult {
-    Applied,
-    AppliedOrNoop,
-}
-
-/// Request-owned stream of normalized handoff lifecycle events.
-pub struct LiveHandoffEvents {
-    route: Arc<HandoffRoute>,
-    routes: SharedHandoffRoutes,
-    event_rx: mpsc::Receiver<LiveHandoffEvent>,
-}
-
-impl LiveHandoffEvents {
-    pub fn handoff_id(&self) -> HandoffId {
-        self.route.handoff_id
-    }
-
-    pub async fn recv(&mut self) -> Option<LiveHandoffEvent> {
-        self.event_rx.recv().await
-    }
-}
-
-impl Drop for LiveHandoffEvents {
-    fn drop(&mut self) {
-        self.route.shutdown();
-        remove_handoff_route(&self.routes, &self.route);
-    }
-}
-
 /// Request-owned stream of Mocker output signals.
 pub struct LiveRequest {
     client_id: Uuid,
@@ -977,37 +628,6 @@ impl Drop for LiveRequest {
             true,
         ));
     }
-}
-
-fn remove_route(routes: &RequestRoutes, route: &Arc<RequestRoute>) -> bool {
-    let removed = routes
-        .by_client
-        .remove_if(&route.client_id, |_, current| Arc::ptr_eq(current, route))
-        .is_some();
-    routes
-        .by_scheduler
-        .remove_if(&route.scheduler_id, |_, current| {
-            Arc::ptr_eq(current, route)
-        });
-    removed
-}
-
-fn route_is_registered(routes: &RequestRoutes, route: &Arc<RequestRoute>) -> bool {
-    routes
-        .by_client
-        .get(&route.client_id)
-        .is_some_and(|current| Arc::ptr_eq(current.value(), route))
-        && routes
-            .by_scheduler
-            .get(&route.scheduler_id)
-            .is_some_and(|current| Arc::ptr_eq(current.value(), route))
-}
-
-fn remove_handoff_route(routes: &HandoffRoutes, route: &Arc<HandoffRoute>) -> bool {
-    routes
-        .by_id
-        .remove_if(&route.handoff_id, |_, current| Arc::ptr_eq(current, route))
-        .is_some()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1131,103 +751,6 @@ async fn supervise_event_dispatcher(
     shutdown_routes(&routes);
     shutdown_handoff_routes(&handoff_routes);
     result
-}
-
-async fn run_lifecycle_dispatcher(
-    mut lifecycle_rx: mpsc::Receiver<SchedulerLifecycleEvent>,
-    routes: SharedHandoffRoutes,
-    cancel: CancellationToken,
-) -> anyhow::Result<()> {
-    loop {
-        let event = tokio::select! {
-            biased;
-            _ = cancel.cancelled() => return Ok(()),
-            event = lifecycle_rx.recv() => {
-                let Some(event) = event else {
-                    if cancel.is_cancelled() {
-                        return Ok(());
-                    }
-                    bail!("live Mocker lifecycle lane closed unexpectedly");
-                };
-                event
-            }
-        };
-        let (handoff_id, event) = match event {
-            SchedulerLifecycleEvent::SourceHeld {
-                handoff_id,
-                transfer_timing,
-                ..
-            } => (handoff_id, LiveHandoffEvent::SourceHeld { transfer_timing }),
-            SchedulerLifecycleEvent::DestinationReserved {
-                handoff_id,
-                transferable_prompt_tokens,
-                ..
-            } => (
-                handoff_id,
-                LiveHandoffEvent::DestinationReserved {
-                    transferable_prompt_tokens,
-                },
-            ),
-        };
-        let route = routes
-            .by_id
-            .get(&handoff_id)
-            .map(|entry| Arc::clone(entry.value()));
-        if let Some(route) = route
-            && !route.send(event, &cancel).await
-        {
-            remove_handoff_route(&routes, &route);
-        }
-    }
-}
-
-async fn supervise_lifecycle_dispatcher(
-    dispatcher: tokio::task::JoinHandle<anyhow::Result<()>>,
-    routes: Routes,
-    handoff_routes: SharedHandoffRoutes,
-    cancel: CancellationToken,
-) -> anyhow::Result<()> {
-    let result = match dispatcher.await {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => Err(error),
-        Err(error) => Err(anyhow!(
-            "live Mocker lifecycle dispatcher task failed: {error}"
-        )),
-    };
-    if let Err(error) = &result {
-        tracing::error!(%error, "live Mocker lifecycle dispatcher failed");
-    } else if !cancel.is_cancelled() {
-        tracing::error!("live Mocker lifecycle dispatcher exited unexpectedly");
-    }
-    cancel.cancel();
-    shutdown_routes(&routes);
-    shutdown_handoff_routes(&handoff_routes);
-    result
-}
-
-fn shutdown_routes(routes: &RequestRoutes) {
-    let active_routes = routes
-        .by_client
-        .iter()
-        .map(|entry| Arc::clone(entry.value()))
-        .collect::<Vec<_>>();
-    for route in active_routes {
-        route.shutdown();
-    }
-    routes.by_client.clear();
-    routes.by_scheduler.clear();
-}
-
-fn shutdown_handoff_routes(routes: &HandoffRoutes) {
-    let active_routes = routes
-        .by_id
-        .iter()
-        .map(|entry| Arc::clone(entry.value()))
-        .collect::<Vec<_>>();
-    for route in active_routes {
-        route.shutdown();
-    }
-    routes.by_id.clear();
 }
 
 fn dispatch_output_batch(

--- a/lib/mocker/src/live.rs
+++ b/lib/mocker/src/live.rs
@@ -35,8 +35,8 @@ mod request;
 pub use handoff::{LiveHandoffControl, LiveHandoffEvent, LiveHandoffEvents};
 
 use handoff::{
-    HandoffRoutes, SharedHandoffRoutes, run_lifecycle_dispatcher, shutdown_handoff_routes,
-    supervise_lifecycle_dispatcher,
+    DestinationCancellation, HandoffRoutes, SharedHandoffRoutes, run_lifecycle_dispatcher,
+    shutdown_handoff_routes, supervise_lifecycle_dispatcher,
 };
 use request::{
     ObservedOutput, OutputDelivery, RequestCancellation, RequestRoute, RequestRoutes, Routes,
@@ -302,6 +302,11 @@ impl LiveEngine {
                 entry.insert(Arc::clone(&route));
             }
         }
+        if self.inner.cancel.is_cancelled() {
+            route.shutdown();
+            remove_route(&self.inner.routes, &route);
+            bail!("live Mocker engine is not running");
+        }
 
         let live = LiveRequest {
             client_id,
@@ -532,37 +537,39 @@ impl Drop for LiveRequestRegistration {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 enum PreparedSubmission {
     Ordinary,
     Source(HandoffId),
-    Destination(HandoffId),
+    Destination(DestinationCancellation),
 }
 
 impl PreparedSubmission {
-    fn cancellation(self) -> RequestCancellation {
+    fn cancellation(&self) -> RequestCancellation {
         match self {
-            Self::Destination(handoff_id) => RequestCancellation::Destination(handoff_id),
+            Self::Destination(cancellation) => {
+                RequestCancellation::Destination(cancellation.clone())
+            }
             Self::Ordinary | Self::Source(_) => RequestCancellation::Request,
         }
     }
 
-    fn command(self, request: DirectRequest) -> SchedulerCommand {
+    fn command(&self, request: DirectRequest) -> SchedulerCommand {
         match self {
             Self::Ordinary => SchedulerCommand::Submit(request),
             Self::Source(handoff_id) => SchedulerCommand::SubmitHandoffPrefill {
-                handoff_id,
+                handoff_id: *handoff_id,
                 request,
             },
-            Self::Destination(handoff_id) => SchedulerCommand::ReserveDestination {
-                handoff_id,
+            Self::Destination(cancellation) => SchedulerCommand::ReserveDestination {
+                handoff_id: cancellation.handoff_id(),
                 request,
             },
         }
     }
 
     fn validate(
-        self,
+        &self,
         result: anyhow::Result<SchedulerCommandResult>,
         client_id: Uuid,
         scheduler_id: Uuid,
@@ -859,9 +866,7 @@ fn spawn_cancellation(
                 )
                 .await
             }
-            RequestCancellation::Destination(handoff_id) => {
-                cancel_destination(&command_tx, handoff_id).await
-            }
+            RequestCancellation::Destination(cancellation) => cancellation.cancel(&command_tx).await,
         };
         if route.finish_cancellation(&result) {
             remove_route(&routes, &route);

--- a/lib/mocker/src/live/handoff.rs
+++ b/lib/mocker/src/live/handoff.rs
@@ -1,0 +1,405 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{Arc, Mutex, Weak};
+
+use anyhow::{anyhow, bail};
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::common::handoff::{HandoffId, HandoffTransferTiming};
+use crate::scheduler::{SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent};
+
+use super::request::{Routes, shutdown_routes};
+use super::{LiveEngine, LiveRequestRegistration, PreparedSubmission, send_command};
+
+const HANDOFF_EVENT_CAPACITY: usize = 8;
+
+#[derive(Default)]
+pub(super) struct HandoffRoutes {
+    by_id: DashMap<HandoffId, Arc<HandoffRoute>>,
+    last_by_id: DashMap<HandoffId, (Uuid, Weak<HandoffRoute>)>,
+}
+
+pub(super) type SharedHandoffRoutes = Arc<HandoffRoutes>;
+
+impl HandoffRoutes {
+    pub(super) fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+struct HandoffRoute {
+    handoff_id: HandoffId,
+    generation: Uuid,
+    routes: Weak<HandoffRoutes>,
+    event_tx: Mutex<Option<mpsc::Sender<LiveHandoffEvent>>>,
+    command_lock: Arc<tokio::sync::Mutex<()>>,
+}
+
+impl HandoffRoute {
+    fn new(
+        handoff_id: HandoffId,
+        routes: Weak<HandoffRoutes>,
+        event_tx: mpsc::Sender<LiveHandoffEvent>,
+    ) -> Self {
+        Self {
+            handoff_id,
+            generation: Uuid::new_v4(),
+            routes,
+            event_tx: Mutex::new(Some(event_tx)),
+            command_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
+    }
+
+    async fn send(&self, event: LiveHandoffEvent, cancel: &CancellationToken) -> bool {
+        let event_tx = self.event_tx.lock().unwrap().as_ref().cloned();
+        let Some(event_tx) = event_tx else {
+            return false;
+        };
+        let delivered = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => false,
+            result = event_tx.send(event) => result.is_ok(),
+        };
+        if !delivered {
+            self.shutdown();
+        }
+        delivered
+    }
+
+    fn shutdown(&self) {
+        self.event_tx.lock().unwrap().take();
+    }
+}
+
+impl Drop for HandoffRoute {
+    fn drop(&mut self) {
+        let Some(routes) = self.routes.upgrade() else {
+            return;
+        };
+        routes
+            .last_by_id
+            .remove_if(&self.handoff_id, |_, (generation, _)| {
+                *generation == self.generation
+            });
+    }
+}
+
+/// Scheduler lifecycle events normalized for a registered disaggregated handoff.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LiveHandoffEvent {
+    SourceHeld {
+        transfer_timing: HandoffTransferTiming,
+    },
+    DestinationReserved {
+        transferable_prompt_tokens: usize,
+    },
+}
+
+impl LiveEngine {
+    /// Register one disaggregated handoff and its normalized lifecycle stream.
+    pub fn register_handoff(
+        &self,
+        handoff_id: HandoffId,
+    ) -> anyhow::Result<(LiveHandoffControl, LiveHandoffEvents)> {
+        anyhow::ensure!(
+            !self.inner.cancel.is_cancelled(),
+            "live Mocker engine is not running"
+        );
+        let (event_tx, event_rx) = mpsc::channel(HANDOFF_EVENT_CAPACITY);
+        let previous_route = self
+            .inner
+            .handoff_routes
+            .last_by_id
+            .get(&handoff_id)
+            .and_then(|entry| entry.value().1.upgrade());
+        let _previous_command = match previous_route {
+            Some(route) => Some(route.command_lock.clone().try_lock_owned().map_err(|_| {
+                anyhow!("handoff {handoff_id:?} still has a scheduler command in progress")
+            })?),
+            None => None,
+        };
+        let route = Arc::new(HandoffRoute::new(
+            handoff_id,
+            Arc::downgrade(&self.inner.handoff_routes),
+            event_tx,
+        ));
+        match self.inner.handoff_routes.by_id.entry(handoff_id) {
+            Entry::Occupied(_) => {
+                bail!("handoff {handoff_id:?} already has a lifecycle route")
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::clone(&route));
+            }
+        }
+        self.inner
+            .handoff_routes
+            .last_by_id
+            .insert(handoff_id, (route.generation, Arc::downgrade(&route)));
+        Ok((
+            LiveHandoffControl {
+                engine: self.clone(),
+                route: Arc::clone(&route),
+            },
+            LiveHandoffEvents {
+                route,
+                routes: Arc::clone(&self.inner.handoff_routes),
+                event_rx,
+            },
+        ))
+    }
+}
+
+/// Typed scheduler controls for one disaggregated handoff.
+#[derive(Clone)]
+pub struct LiveHandoffControl {
+    engine: LiveEngine,
+    route: Arc<HandoffRoute>,
+}
+
+impl LiveHandoffControl {
+    pub fn handoff_id(&self) -> HandoffId {
+        self.route.handoff_id
+    }
+
+    pub async fn submit_prefill(
+        &self,
+        registration: LiveRequestRegistration,
+    ) -> anyhow::Result<()> {
+        let command_guard = self.route.command_lock.clone().lock_owned().await;
+        self.ensure_generation(false)?;
+        self.engine
+            .submit_prepared(
+                registration,
+                PreparedSubmission::Source(self.route.handoff_id),
+                Some(command_guard),
+            )
+            .await
+    }
+
+    pub async fn reserve_destination(
+        &self,
+        registration: LiveRequestRegistration,
+    ) -> anyhow::Result<()> {
+        let command_guard = self.route.command_lock.clone().lock_owned().await;
+        self.ensure_generation(false)?;
+        self.engine
+            .submit_prepared(
+                registration,
+                PreparedSubmission::Destination(self.route.handoff_id),
+                Some(command_guard),
+            )
+            .await
+    }
+
+    pub async fn release_source(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::ReleaseSource {
+                handoff_id: self.route.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    pub async fn cancel_source(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::CancelSource {
+                handoff_id: self.route.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    pub async fn activate_destination(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::ActivateDestination {
+                handoff_id: self.route.handoff_id,
+            },
+            HandoffCommandResult::Applied,
+        )
+        .await
+    }
+
+    pub async fn cancel_destination(&self) -> anyhow::Result<()> {
+        self.send_handoff_command(
+            SchedulerCommand::CancelDestination {
+                handoff_id: self.route.handoff_id,
+            },
+            HandoffCommandResult::AppliedOrNoop,
+        )
+        .await
+    }
+
+    async fn send_handoff_command(
+        &self,
+        command: SchedulerCommand,
+        expected: HandoffCommandResult,
+    ) -> anyhow::Result<()> {
+        let _command_guard = self.route.command_lock.clone().lock_owned().await;
+        self.ensure_generation(true)?;
+        anyhow::ensure!(
+            !self.engine.inner.cancel.is_cancelled(),
+            "live Mocker engine is not running"
+        );
+        let result = send_command(&self.engine.inner.command_tx, command).await?;
+        match (expected, result) {
+            (HandoffCommandResult::Applied, SchedulerCommandResult::Applied)
+            | (
+                HandoffCommandResult::AppliedOrNoop,
+                SchedulerCommandResult::Applied | SchedulerCommandResult::Noop,
+            ) => Ok(()),
+            (_, result) => Err(anyhow!(
+                "unexpected scheduler handoff result for {:?}: {result:?}",
+                self.route.handoff_id
+            )),
+        }
+    }
+
+    fn ensure_generation(&self, allow_unregistered: bool) -> anyhow::Result<()> {
+        match self
+            .engine
+            .inner
+            .handoff_routes
+            .by_id
+            .get(&self.route.handoff_id)
+        {
+            Some(current) if Arc::ptr_eq(current.value(), &self.route) => Ok(()),
+            Some(_) => bail!(
+                "handoff {:?} control belongs to an earlier registration",
+                self.route.handoff_id
+            ),
+            None if allow_unregistered => Ok(()),
+            None => bail!(
+                "handoff {:?} lifecycle route is no longer registered",
+                self.route.handoff_id
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum HandoffCommandResult {
+    Applied,
+    AppliedOrNoop,
+}
+
+/// Request-owned stream of normalized handoff lifecycle events.
+pub struct LiveHandoffEvents {
+    route: Arc<HandoffRoute>,
+    routes: SharedHandoffRoutes,
+    event_rx: mpsc::Receiver<LiveHandoffEvent>,
+}
+
+impl LiveHandoffEvents {
+    pub fn handoff_id(&self) -> HandoffId {
+        self.route.handoff_id
+    }
+
+    pub async fn recv(&mut self) -> Option<LiveHandoffEvent> {
+        self.event_rx.recv().await
+    }
+}
+
+impl Drop for LiveHandoffEvents {
+    fn drop(&mut self) {
+        self.route.shutdown();
+        remove_handoff_route(&self.routes, &self.route);
+    }
+}
+
+fn remove_handoff_route(routes: &HandoffRoutes, route: &Arc<HandoffRoute>) -> bool {
+    routes
+        .by_id
+        .remove_if(&route.handoff_id, |_, current| Arc::ptr_eq(current, route))
+        .is_some()
+}
+
+pub(super) async fn run_lifecycle_dispatcher(
+    mut lifecycle_rx: mpsc::Receiver<SchedulerLifecycleEvent>,
+    routes: SharedHandoffRoutes,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    loop {
+        let event = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(()),
+            event = lifecycle_rx.recv() => {
+                let Some(event) = event else {
+                    if cancel.is_cancelled() {
+                        return Ok(());
+                    }
+                    bail!("live Mocker lifecycle lane closed unexpectedly");
+                };
+                event
+            }
+        };
+        let (handoff_id, event) = match event {
+            SchedulerLifecycleEvent::SourceHeld {
+                handoff_id,
+                transfer_timing,
+                ..
+            } => (handoff_id, LiveHandoffEvent::SourceHeld { transfer_timing }),
+            SchedulerLifecycleEvent::DestinationReserved {
+                handoff_id,
+                transferable_prompt_tokens,
+                ..
+            } => (
+                handoff_id,
+                LiveHandoffEvent::DestinationReserved {
+                    transferable_prompt_tokens,
+                },
+            ),
+        };
+        let route = routes
+            .by_id
+            .get(&handoff_id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(route) = route
+            && !route.send(event, &cancel).await
+        {
+            remove_handoff_route(&routes, &route);
+        }
+    }
+}
+
+pub(super) async fn supervise_lifecycle_dispatcher(
+    dispatcher: tokio::task::JoinHandle<anyhow::Result<()>>,
+    routes: Routes,
+    handoff_routes: SharedHandoffRoutes,
+    cancel: CancellationToken,
+) -> anyhow::Result<()> {
+    let result = match dispatcher.await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => Err(error),
+        Err(error) => Err(anyhow!(
+            "live Mocker lifecycle dispatcher task failed: {error}"
+        )),
+    };
+    if let Err(error) = &result {
+        tracing::error!(%error, "live Mocker lifecycle dispatcher failed");
+    } else if !cancel.is_cancelled() {
+        tracing::error!("live Mocker lifecycle dispatcher exited unexpectedly");
+    }
+    cancel.cancel();
+    shutdown_routes(&routes);
+    shutdown_handoff_routes(&handoff_routes);
+    result
+}
+
+pub(super) fn shutdown_handoff_routes(routes: &HandoffRoutes) {
+    let active_routes = routes
+        .by_id
+        .iter()
+        .map(|entry| Arc::clone(entry.value()))
+        .collect::<Vec<_>>();
+    for route in active_routes {
+        route.shutdown();
+    }
+    routes.by_id.clear();
+}

--- a/lib/mocker/src/live/handoff.rs
+++ b/lib/mocker/src/live/handoff.rs
@@ -14,7 +14,9 @@ use crate::common::handoff::{HandoffId, HandoffTransferTiming};
 use crate::scheduler::{SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent};
 
 use super::request::{Routes, shutdown_routes};
-use super::{LiveEngine, LiveRequestRegistration, PreparedSubmission, send_command};
+use super::{
+    LiveEngine, LiveEngineInner, LiveRequestRegistration, PreparedSubmission, send_command,
+};
 
 const HANDOFF_EVENT_CAPACITY: usize = 8;
 
@@ -142,7 +144,7 @@ impl LiveEngine {
             .insert(handoff_id, (route.generation, Arc::downgrade(&route)));
         Ok((
             LiveHandoffControl {
-                engine: self.clone(),
+                engine: Arc::downgrade(&self.inner),
                 route: Arc::clone(&route),
             },
             LiveHandoffEvents {
@@ -157,7 +159,7 @@ impl LiveEngine {
 /// Typed scheduler controls for one disaggregated handoff.
 #[derive(Clone)]
 pub struct LiveHandoffControl {
-    engine: LiveEngine,
+    engine: Weak<LiveEngineInner>,
     route: Arc<HandoffRoute>,
 }
 
@@ -171,8 +173,9 @@ impl LiveHandoffControl {
         registration: LiveRequestRegistration,
     ) -> anyhow::Result<()> {
         let command_guard = self.route.command_lock.clone().lock_owned().await;
-        self.ensure_generation(false)?;
-        self.engine
+        let engine = self.engine()?;
+        self.ensure_generation(&engine, false)?;
+        LiveEngine { inner: engine }
             .submit_prepared(
                 registration,
                 PreparedSubmission::Source(self.route.handoff_id),
@@ -186,8 +189,9 @@ impl LiveHandoffControl {
         registration: LiveRequestRegistration,
     ) -> anyhow::Result<()> {
         let command_guard = self.route.command_lock.clone().lock_owned().await;
-        self.ensure_generation(false)?;
-        self.engine
+        let engine = self.engine()?;
+        self.ensure_generation(&engine, false)?;
+        LiveEngine { inner: engine }
             .submit_prepared(
                 registration,
                 PreparedSubmission::Destination(self.route.handoff_id),
@@ -242,12 +246,13 @@ impl LiveHandoffControl {
         expected: HandoffCommandResult,
     ) -> anyhow::Result<()> {
         let _command_guard = self.route.command_lock.clone().lock_owned().await;
-        self.ensure_generation(true)?;
+        let engine = self.engine()?;
+        self.ensure_generation(&engine, true)?;
         anyhow::ensure!(
-            !self.engine.inner.cancel.is_cancelled(),
+            !engine.cancel.is_cancelled(),
             "live Mocker engine is not running"
         );
-        let result = send_command(&self.engine.inner.command_tx, command).await?;
+        let result = send_command(&engine.command_tx, command).await?;
         match (expected, result) {
             (HandoffCommandResult::Applied, SchedulerCommandResult::Applied)
             | (
@@ -261,14 +266,18 @@ impl LiveHandoffControl {
         }
     }
 
-    fn ensure_generation(&self, allow_unregistered: bool) -> anyhow::Result<()> {
-        match self
-            .engine
-            .inner
-            .handoff_routes
-            .by_id
-            .get(&self.route.handoff_id)
-        {
+    fn engine(&self) -> anyhow::Result<Arc<LiveEngineInner>> {
+        self.engine
+            .upgrade()
+            .ok_or_else(|| anyhow!("live Mocker engine no longer exists"))
+    }
+
+    fn ensure_generation(
+        &self,
+        engine: &LiveEngineInner,
+        allow_unregistered: bool,
+    ) -> anyhow::Result<()> {
+        match engine.handoff_routes.by_id.get(&self.route.handoff_id) {
             Some(current) if Arc::ptr_eq(current.value(), &self.route) => Ok(()),
             Some(_) => bail!(
                 "handoff {:?} control belongs to an earlier registration",

--- a/lib/mocker/src/live/handoff.rs
+++ b/lib/mocker/src/live/handoff.rs
@@ -76,6 +76,13 @@ impl HandoffRoute {
     fn shutdown(&self) {
         self.event_tx.lock().unwrap().take();
     }
+
+    fn is_latest_generation(&self, routes: &HandoffRoutes) -> bool {
+        match routes.last_by_id.get(&self.handoff_id) {
+            Some(current) => current.value().0 == self.generation,
+            None => false,
+        }
+    }
 }
 
 impl Drop for HandoffRoute {
@@ -142,6 +149,11 @@ impl LiveEngine {
             .handoff_routes
             .last_by_id
             .insert(handoff_id, (route.generation, Arc::downgrade(&route)));
+        if self.inner.cancel.is_cancelled() {
+            route.shutdown();
+            remove_handoff_route(&self.inner.handoff_routes, &route);
+            bail!("live Mocker engine is not running");
+        }
         Ok((
             LiveHandoffControl {
                 engine: Arc::downgrade(&self.inner),
@@ -194,7 +206,9 @@ impl LiveHandoffControl {
         LiveEngine { inner: engine }
             .submit_prepared(
                 registration,
-                PreparedSubmission::Destination(self.route.handoff_id),
+                PreparedSubmission::Destination(DestinationCancellation {
+                    route: Arc::clone(&self.route),
+                }),
                 Some(command_guard),
             )
             .await
@@ -283,12 +297,45 @@ impl LiveHandoffControl {
                 "handoff {:?} control belongs to an earlier registration",
                 self.route.handoff_id
             ),
-            None if allow_unregistered => Ok(()),
+            None if allow_unregistered
+                && self.route.is_latest_generation(&engine.handoff_routes) =>
+            {
+                Ok(())
+            }
+            None if allow_unregistered => bail!(
+                "handoff {:?} control belongs to an earlier registration",
+                self.route.handoff_id
+            ),
             None => bail!(
                 "handoff {:?} lifecycle route is no longer registered",
                 self.route.handoff_id
             ),
         }
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct DestinationCancellation {
+    route: Arc<HandoffRoute>,
+}
+
+impl DestinationCancellation {
+    pub(super) fn handoff_id(&self) -> HandoffId {
+        self.route.handoff_id
+    }
+
+    pub(super) async fn cancel(
+        &self,
+        command_tx: &mpsc::Sender<crate::scheduler::SchedulerCommandEnvelope>,
+    ) -> anyhow::Result<bool> {
+        let _command_guard = self.route.command_lock.clone().lock_owned().await;
+        let Some(routes) = self.route.routes.upgrade() else {
+            return Ok(false);
+        };
+        if !self.route.is_latest_generation(&routes) {
+            return Ok(false);
+        }
+        super::cancel_destination(command_tx, self.route.handoff_id).await
     }
 }
 

--- a/lib/mocker/src/live/request.rs
+++ b/lib/mocker/src/live/request.rs
@@ -7,6 +7,7 @@ use dashmap::DashMap;
 use tokio::sync::{mpsc, watch};
 use uuid::Uuid;
 
+use crate::common::handoff::HandoffId;
 use crate::common::protocols::OutputSignal;
 
 #[derive(Default)]
@@ -31,8 +32,15 @@ enum RequestState {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RequestCancellation {
+    Request,
+    Destination(HandoffId),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct RequestLifecycle {
     state: RequestState,
+    cancellation: RequestCancellation,
     stream_abandoned: bool,
     terminal_seen: bool,
 }
@@ -53,6 +61,7 @@ impl RequestRoute {
     ) -> Self {
         let (lifecycle_tx, _) = watch::channel(RequestLifecycle {
             state: RequestState::Submitting,
+            cancellation: RequestCancellation::Request,
             stream_abandoned: false,
             terminal_seen: false,
         });
@@ -65,12 +74,13 @@ impl RequestRoute {
         }
     }
 
-    pub(super) fn activate(&self) {
+    pub(super) fn activate(&self, cancellation: RequestCancellation) {
         self.lifecycle_tx.send_if_modified(|lifecycle| {
             if lifecycle.state != RequestState::Submitting {
                 return false;
             }
             lifecycle.state = RequestState::Active;
+            lifecycle.cancellation = cancellation;
             true
         });
     }
@@ -103,17 +113,17 @@ impl RequestRoute {
         }
     }
 
-    pub(super) fn begin_cancellation(&self) -> bool {
-        let mut started = false;
+    pub(super) fn begin_cancellation(&self) -> Option<RequestCancellation> {
+        let mut cancellation = None;
         self.lifecycle_tx.send_if_modified(|lifecycle| {
             if lifecycle.state == RequestState::Active {
                 lifecycle.state = RequestState::Cancelling;
-                started = true;
+                cancellation = Some(lifecycle.cancellation);
                 return true;
             }
             false
         });
-        started
+        cancellation
     }
 
     pub(super) fn finish_cancellation(&self, result: &anyhow::Result<bool>) -> bool {

--- a/lib/mocker/src/live/request.rs
+++ b/lib/mocker/src/live/request.rs
@@ -7,8 +7,9 @@ use dashmap::DashMap;
 use tokio::sync::{mpsc, watch};
 use uuid::Uuid;
 
-use crate::common::handoff::HandoffId;
 use crate::common::protocols::OutputSignal;
+
+use super::handoff::DestinationCancellation;
 
 #[derive(Default)]
 pub(super) struct RequestRoutes {
@@ -31,13 +32,13 @@ enum RequestState {
     Closed,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 pub(super) enum RequestCancellation {
     Request,
-    Destination(HandoffId),
+    Destination(DestinationCancellation),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone)]
 struct RequestLifecycle {
     state: RequestState,
     cancellation: RequestCancellation,
@@ -118,7 +119,7 @@ impl RequestRoute {
         self.lifecycle_tx.send_if_modified(|lifecycle| {
             if lifecycle.state == RequestState::Active {
                 lifecycle.state = RequestState::Cancelling;
-                cancellation = Some(lifecycle.cancellation);
+                cancellation = Some(lifecycle.cancellation.clone());
                 return true;
             }
             false

--- a/lib/mocker/src/live/request.rs
+++ b/lib/mocker/src/live/request.rs
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{Arc, Mutex};
+
+use dashmap::DashMap;
+use tokio::sync::{mpsc, watch};
+use uuid::Uuid;
+
+use crate::common::protocols::OutputSignal;
+
+#[derive(Default)]
+pub(super) struct RequestRoutes {
+    pub(super) by_client: DashMap<Uuid, Arc<RequestRoute>>,
+    pub(super) by_scheduler: DashMap<Uuid, Arc<RequestRoute>>,
+}
+
+pub(super) type Routes = Arc<RequestRoutes>;
+
+pub(crate) struct ObservedOutput {
+    pub(crate) event: OutputSignal,
+    pub(crate) observed_at: tokio::time::Instant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RequestState {
+    Submitting,
+    Active,
+    Cancelling,
+    Closed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RequestLifecycle {
+    state: RequestState,
+    stream_abandoned: bool,
+    terminal_seen: bool,
+}
+
+pub(super) struct RequestRoute {
+    pub(super) client_id: Uuid,
+    pub(super) scheduler_id: Uuid,
+    output_tx: Mutex<Option<mpsc::Sender<ObservedOutput>>>,
+    lifecycle_tx: watch::Sender<RequestLifecycle>,
+    pub(super) cancel_lock: tokio::sync::Mutex<()>,
+}
+
+impl RequestRoute {
+    pub(super) fn new(
+        client_id: Uuid,
+        scheduler_id: Uuid,
+        output_tx: mpsc::Sender<ObservedOutput>,
+    ) -> Self {
+        let (lifecycle_tx, _) = watch::channel(RequestLifecycle {
+            state: RequestState::Submitting,
+            stream_abandoned: false,
+            terminal_seen: false,
+        });
+        Self {
+            client_id,
+            scheduler_id,
+            output_tx: Mutex::new(Some(output_tx)),
+            lifecycle_tx,
+            cancel_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    pub(super) fn activate(&self) {
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            if lifecycle.state != RequestState::Submitting {
+                return false;
+            }
+            lifecycle.state = RequestState::Active;
+            true
+        });
+    }
+
+    pub(super) fn abandon_stream(&self) -> bool {
+        self.close_output();
+        let mut abandoned = false;
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            if lifecycle.stream_abandoned {
+                return false;
+            }
+            lifecycle.stream_abandoned = true;
+            abandoned = true;
+            true
+        });
+        abandoned
+    }
+
+    pub(super) async fn wait_for_admission(&self) -> bool {
+        let mut lifecycle_rx = self.lifecycle_tx.subscribe();
+        loop {
+            match lifecycle_rx.borrow_and_update().state {
+                RequestState::Submitting | RequestState::Cancelling => {}
+                RequestState::Active => return true,
+                RequestState::Closed => return false,
+            }
+            if lifecycle_rx.changed().await.is_err() {
+                return false;
+            }
+        }
+    }
+
+    pub(super) fn begin_cancellation(&self) -> bool {
+        let mut started = false;
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            if lifecycle.state == RequestState::Active {
+                lifecycle.state = RequestState::Cancelling;
+                started = true;
+                return true;
+            }
+            false
+        });
+        started
+    }
+
+    pub(super) fn finish_cancellation(&self, result: &anyhow::Result<bool>) -> bool {
+        let mut remove = false;
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            if lifecycle.state != RequestState::Cancelling {
+                return false;
+            }
+            remove = match result {
+                Ok(true) => true,
+                Ok(false) => lifecycle.stream_abandoned || lifecycle.terminal_seen,
+                Err(_) => lifecycle.terminal_seen,
+            };
+            lifecycle.state = if remove {
+                RequestState::Closed
+            } else {
+                RequestState::Active
+            };
+            true
+        });
+        if remove {
+            self.close_output();
+        }
+        remove
+    }
+
+    pub(super) fn send_output(&self, output: ObservedOutput) -> OutputDelivery {
+        let output_tx = self.output_tx.lock().unwrap();
+        let Some(output_tx) = output_tx.as_ref() else {
+            return OutputDelivery::Closed;
+        };
+        match output_tx.try_send(output) {
+            Ok(()) => OutputDelivery::Delivered,
+            Err(mpsc::error::TrySendError::Full(_)) => OutputDelivery::Full,
+            Err(mpsc::error::TrySendError::Closed(_)) => OutputDelivery::Closed,
+        }
+    }
+
+    /// Record a terminal signal and return whether the route can be removed.
+    /// An in-flight cancellation retains it until the scheduler acknowledges
+    /// cleanup; its scheduler ID is never reused by a replacement request.
+    pub(super) fn observe_terminal(&self) -> bool {
+        self.close_output();
+        let mut remove = false;
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            lifecycle.terminal_seen = true;
+            if lifecycle.state != RequestState::Cancelling {
+                lifecycle.state = RequestState::Closed;
+                remove = true;
+            }
+            true
+        });
+        remove
+    }
+
+    pub(super) fn shutdown(&self) {
+        self.close_output();
+        self.lifecycle_tx.send_if_modified(|lifecycle| {
+            if lifecycle.state == RequestState::Closed {
+                return false;
+            }
+            lifecycle.state = RequestState::Closed;
+            true
+        });
+    }
+
+    fn close_output(&self) {
+        self.output_tx.lock().unwrap().take();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum OutputDelivery {
+    Delivered,
+    Full,
+    Closed,
+}
+
+pub(super) fn remove_route(routes: &RequestRoutes, route: &Arc<RequestRoute>) -> bool {
+    let removed = routes
+        .by_client
+        .remove_if(&route.client_id, |_, current| Arc::ptr_eq(current, route))
+        .is_some();
+    routes
+        .by_scheduler
+        .remove_if(&route.scheduler_id, |_, current| {
+            Arc::ptr_eq(current, route)
+        });
+    removed
+}
+
+pub(super) fn route_is_registered(routes: &RequestRoutes, route: &Arc<RequestRoute>) -> bool {
+    routes
+        .by_client
+        .get(&route.client_id)
+        .is_some_and(|current| Arc::ptr_eq(current.value(), route))
+        && routes
+            .by_scheduler
+            .get(&route.scheduler_id)
+            .is_some_and(|current| Arc::ptr_eq(current.value(), route))
+}
+
+pub(super) fn shutdown_routes(routes: &RequestRoutes) {
+    let active_routes = routes
+        .by_client
+        .iter()
+        .map(|entry| Arc::clone(entry.value()))
+        .collect::<Vec<_>>();
+    for route in active_routes {
+        route.shutdown();
+    }
+    routes.by_client.clear();
+    routes.by_scheduler.clear();
+}

--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -4,7 +4,8 @@
 use std::time::Duration;
 
 use super::*;
-use crate::common::protocols::EngineType;
+use crate::common::handoff::HandoffId;
+use crate::common::protocols::{EngineType, WorkerType};
 use dynamo_kv_router::protocols::StorageTier;
 
 struct NoopKvSink;
@@ -26,6 +27,20 @@ impl crate::common::protocols::KvCacheEventSink for NoopKvSink {
 fn args(engine_type: EngineType) -> MockEngineArgs {
     MockEngineArgs::builder()
         .engine_type(engine_type)
+        .block_size(4)
+        .num_gpu_blocks(128)
+        .max_num_seqs(Some(8))
+        .max_num_batched_tokens(Some(64))
+        .speedup_ratio(1000.0)
+        .dp_size(1)
+        .build()
+        .unwrap()
+}
+
+fn handoff_args(engine_type: EngineType, worker_type: WorkerType) -> MockEngineArgs {
+    MockEngineArgs::builder()
+        .engine_type(engine_type)
+        .worker_type(worker_type)
         .block_size(4)
         .num_gpu_blocks(128)
         .max_num_seqs(Some(8))
@@ -139,6 +154,117 @@ async fn duplicate_request_id_does_not_replace_the_original_stream() {
     assert_eq!(engine.active_request_count(), 1);
     original.cancel().await.unwrap();
     assert_eq!(engine.active_request_count(), 0);
+}
+
+#[tokio::test]
+async fn dropping_prepared_registration_closes_route_and_allows_id_reuse() {
+    let engine = LiveEngine::start(args(EngineType::Vllm), 0).unwrap();
+    let uuid = Uuid::from_u128(30);
+    let (registration, mut prepared) = engine
+        .prepare_request(DirectRequest {
+            tokens: vec![1, 2, 3],
+            max_output_tokens: 1,
+            uuid: Some(uuid),
+            ..Default::default()
+        })
+        .unwrap();
+    assert_eq!(engine.active_request_count(), 1);
+
+    drop(registration);
+    assert!(prepared.recv().await.is_none());
+    assert_eq!(engine.active_request_count(), 0);
+
+    let replacement = engine
+        .submit(DirectRequest {
+            tokens: vec![4, 5, 6],
+            max_output_tokens: 100,
+            uuid: Some(uuid),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    replacement.cancel().await.unwrap();
+    assert_eq!(engine.active_request_count(), 0);
+}
+
+#[tokio::test]
+async fn typed_handoff_routes_output_and_lifecycle_for_supported_engines() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        let source = LiveEngine::start(handoff_args(engine_type, WorkerType::Prefill), 0).unwrap();
+        let source_handoff = HandoffId::from(Uuid::new_v4());
+        let (source_control, mut source_events) = source.register_handoff(source_handoff).unwrap();
+        let duplicate = source.register_handoff(source_handoff);
+        assert!(matches!(
+            duplicate,
+            Err(error) if error.to_string().contains("already has a lifecycle route")
+        ));
+        let (source_registration, mut source_request) = source
+            .prepare_request(DirectRequest {
+                tokens: vec![1, 2, 3],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![41]),
+                uuid: Some(Uuid::new_v4()),
+                ..Default::default()
+            })
+            .unwrap();
+        source_control
+            .submit_prefill(source_registration)
+            .await
+            .unwrap();
+
+        let source_output = tokio::time::timeout(Duration::from_secs(1), source_request.recv())
+            .await
+            .expect("source output timed out")
+            .expect("source output stream closed");
+        assert_eq!(source_output.token_id, Some(41));
+        assert!(source_output.completed);
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), source_events.recv())
+                .await
+                .expect("source lifecycle event timed out"),
+            Some(LiveHandoffEvent::SourceHeld { .. })
+        ));
+        source_control.release_source().await.unwrap();
+        source.shutdown().await.unwrap();
+        assert!(source_events.recv().await.is_none());
+
+        let destination =
+            LiveEngine::start(handoff_args(engine_type, WorkerType::Decode), 0).unwrap();
+        let destination_handoff = HandoffId::from(Uuid::new_v4());
+        let (destination_control, mut destination_events) =
+            destination.register_handoff(destination_handoff).unwrap();
+        let (destination_registration, mut destination_request) = destination
+            .prepare_request(DirectRequest {
+                tokens: vec![1, 2, 3, 4],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![42]),
+                uuid: Some(Uuid::new_v4()),
+                ..Default::default()
+            })
+            .unwrap();
+        destination_control
+            .reserve_destination(destination_registration)
+            .await
+            .unwrap();
+        assert!(matches!(
+            tokio::time::timeout(Duration::from_secs(1), destination_events.recv())
+                .await
+                .expect("destination lifecycle event timed out"),
+            Some(LiveHandoffEvent::DestinationReserved {
+                transferable_prompt_tokens,
+            }) if transferable_prompt_tokens > 0
+        ));
+        destination_control.activate_destination().await.unwrap();
+        let destination_output =
+            tokio::time::timeout(Duration::from_secs(1), destination_request.recv())
+                .await
+                .expect("destination output timed out")
+                .expect("destination output stream closed");
+        assert_eq!(destination_output.token_id, Some(42));
+        assert!(destination_output.completed);
+        destination.shutdown().await.unwrap();
+        assert!(destination_events.recv().await.is_none());
+    }
 }
 
 #[tokio::test]
@@ -494,12 +620,12 @@ async fn replay_options_allow_zero_output_and_full_response_buffering() {
 async fn shutdown_waits_for_scheduler_owned_publishers_to_drop() {
     let sink: Arc<dyn crate::common::protocols::KvCacheEventSink> = Arc::new(NoopKvSink);
     let sink_weak = Arc::downgrade(&sink);
-    let engine = LiveEngine::start_with_options(
+    let engine = LiveEngine::start_with_config(
         args(EngineType::Vllm),
         0,
-        LiveEngineOptions {
+        LiveEngineConfig {
             kv_event_publishers: KvEventPublishers::new(Some(sink), None),
-            ..LiveEngineOptions::default()
+            ..LiveEngineConfig::default()
         },
     )
     .unwrap();

--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -337,6 +337,7 @@ async fn stale_handoff_control_cannot_mutate_a_replacement_registration() {
         current_events.recv().await,
         Some(LiveHandoffEvent::DestinationReserved { .. })
     ));
+    drop(current_events);
 
     let error = stale_control.cancel_destination().await.unwrap_err();
     assert!(error.to_string().contains("earlier registration"));
@@ -345,6 +346,93 @@ async fn stale_handoff_control_cannot_mutate_a_replacement_registration() {
     assert_eq!(output.token_id, Some(43));
     assert!(output.completed);
     engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn late_request_cancellation_cannot_cancel_a_reused_handoff_id() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        let (gate_tx, gate_rx) = watch::channel(false);
+        let engine = LiveEngine::start_with_output_gate(
+            handoff_args(engine_type, WorkerType::Decode),
+            0,
+            Some(gate_rx),
+            2,
+        )
+        .unwrap();
+        let handoff_id = HandoffId::from(Uuid::new_v4());
+        let (old_control, mut old_events) = engine.register_handoff(handoff_id).unwrap();
+        let (old_registration, old_request) = engine
+            .prepare_request(DirectRequest {
+                tokens: vec![1, 2, 3, 4],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![42]),
+                uuid: Some(Uuid::new_v4()),
+                ..Default::default()
+            })
+            .unwrap();
+        old_control
+            .reserve_destination(old_registration)
+            .await
+            .unwrap();
+        assert!(matches!(
+            old_events.recv().await,
+            Some(LiveHandoffEvent::DestinationReserved { .. })
+        ));
+        old_control.activate_destination().await.unwrap();
+
+        let mut metrics = engine.metrics_receiver();
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if metrics.borrow().running_requests == 0 && metrics.borrow().waiting_requests == 0
+                {
+                    break;
+                }
+                metrics.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("old destination should finish before handoff ID reuse");
+        drop(old_events);
+        drop(old_control);
+
+        let (current_control, mut current_events) = engine.register_handoff(handoff_id).unwrap();
+        let (current_registration, mut current_request) = engine
+            .prepare_request(DirectRequest {
+                tokens: vec![5, 6, 7, 8],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![43]),
+                uuid: Some(Uuid::new_v4()),
+                ..Default::default()
+            })
+            .unwrap();
+        current_control
+            .reserve_destination(current_registration)
+            .await
+            .unwrap();
+        assert!(matches!(
+            current_events.recv().await,
+            Some(LiveHandoffEvent::DestinationReserved { .. })
+        ));
+
+        drop(old_request);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while engine.active_request_count() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("old request route should be removed");
+
+        current_control.activate_destination().await.unwrap();
+        gate_tx.send(true).unwrap();
+        let output = tokio::time::timeout(Duration::from_secs(1), current_request.recv())
+            .await
+            .expect("replacement output timed out")
+            .expect("replacement output stream closed");
+        assert_eq!(output.token_id, Some(43));
+        assert!(output.completed);
+        engine.shutdown().await.unwrap();
+    }
 }
 
 #[tokio::test]

--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -268,6 +268,41 @@ async fn typed_handoff_routes_output_and_lifecycle_for_supported_engines() {
 }
 
 #[tokio::test]
+async fn stale_handoff_control_cannot_mutate_a_replacement_registration() {
+    let engine = LiveEngine::start(handoff_args(EngineType::Vllm, WorkerType::Decode), 0).unwrap();
+    let handoff_id = HandoffId::from(Uuid::new_v4());
+    let (stale_control, stale_events) = engine.register_handoff(handoff_id).unwrap();
+    drop(stale_events);
+
+    let (current_control, mut current_events) = engine.register_handoff(handoff_id).unwrap();
+    let (registration, mut request) = engine
+        .prepare_request(DirectRequest {
+            tokens: vec![1, 2, 3, 4],
+            max_output_tokens: 1,
+            output_token_ids: Some(vec![43]),
+            uuid: Some(Uuid::new_v4()),
+            ..Default::default()
+        })
+        .unwrap();
+    current_control
+        .reserve_destination(registration)
+        .await
+        .unwrap();
+    assert!(matches!(
+        current_events.recv().await,
+        Some(LiveHandoffEvent::DestinationReserved { .. })
+    ));
+
+    let error = stale_control.cancel_destination().await.unwrap_err();
+    assert!(error.to_string().contains("earlier registration"));
+    current_control.activate_destination().await.unwrap();
+    let output = request.recv().await.unwrap();
+    assert_eq!(output.token_id, Some(43));
+    assert!(output.completed);
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
 async fn queued_output_does_not_reach_a_reused_request_id() {
     let (gate_tx, gate_rx) = watch::channel(false);
     let engine =
@@ -666,5 +701,10 @@ async fn shutdown_surfaces_admission_forwarding_failure() {
     assert!(
         format!("{error:#}").contains("admission receiver closed"),
         "{error:#}"
+    );
+    let repeated_error = engine.shutdown().await.unwrap_err();
+    assert!(
+        format!("{repeated_error:#}").contains("admission receiver closed"),
+        "{repeated_error:#}"
     );
 }

--- a/lib/mocker/src/live/tests.rs
+++ b/lib/mocker/src/live/tests.rs
@@ -126,6 +126,22 @@ async fn dropping_engine_closes_outstanding_request_streams() {
 }
 
 #[tokio::test]
+async fn retained_handoff_control_does_not_keep_engine_alive() {
+    let engine = LiveEngine::start(handoff_args(EngineType::Vllm, WorkerType::Decode), 0).unwrap();
+    let (control, mut events) = engine
+        .register_handoff(HandoffId::from(Uuid::new_v4()))
+        .unwrap();
+
+    drop(engine);
+    let event = tokio::time::timeout(Duration::from_secs(1), events.recv())
+        .await
+        .expect("engine shutdown should close outstanding handoff events");
+    assert!(event.is_none());
+    let error = control.cancel_destination().await.unwrap_err();
+    assert!(error.to_string().contains("engine no longer exists"));
+}
+
+#[tokio::test]
 async fn duplicate_request_id_does_not_replace_the_original_stream() {
     let engine = LiveEngine::start(args(EngineType::Vllm), 0).unwrap();
     let uuid = Uuid::from_u128(3);
@@ -264,6 +280,35 @@ async fn typed_handoff_routes_output_and_lifecycle_for_supported_engines() {
         assert!(destination_output.completed);
         destination.shutdown().await.unwrap();
         assert!(destination_events.recv().await.is_none());
+    }
+}
+
+#[tokio::test]
+async fn dropping_reserved_destination_releases_scheduler_capacity() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        let engine = LiveEngine::start(handoff_args(engine_type, WorkerType::Decode), 0).unwrap();
+        let handoff_id = HandoffId::from(Uuid::new_v4());
+        let (control, mut events) = engine.register_handoff(handoff_id).unwrap();
+        let (registration, request) = engine
+            .prepare_request(DirectRequest {
+                tokens: vec![1, 2, 3, 4],
+                max_output_tokens: 1,
+                output_token_ids: Some(vec![42]),
+                uuid: Some(Uuid::new_v4()),
+                ..Default::default()
+            })
+            .unwrap();
+        control.reserve_destination(registration).await.unwrap();
+        assert!(matches!(
+            events.recv().await,
+            Some(LiveHandoffEvent::DestinationReserved { .. })
+        ));
+
+        drop(request);
+        wait_for_idle(&engine).await;
+        assert_eq!(engine.metrics_receiver().borrow().active_decode_blocks, 0);
+        control.cancel_destination().await.unwrap();
+        engine.shutdown().await.unwrap();
     }
 }
 

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -379,7 +379,10 @@ pub(crate) enum LiveEngineEvent {
 #[derive(Clone)]
 pub(crate) enum SchedulerEventSender {
     Outputs(SchedulerOutputSender),
-    Ordered(mpsc::Sender<LiveEngineEvent>),
+    Ordered {
+        tx: mpsc::Sender<LiveEngineEvent>,
+        forward_admissions: bool,
+    },
 }
 
 pub(crate) enum SchedulerEventSendError {
@@ -400,7 +403,11 @@ impl SchedulerEventSender {
                 // Legacy output-only consumers do not have an admission event sink.
                 Ok(())
             }
-            Self::Ordered(tx) => tx
+            Self::Ordered {
+                forward_admissions: false,
+                ..
+            } => Ok(()),
+            Self::Ordered { tx, .. } => tx
                 .send(LiveEngineEvent::Admissions(admissions.to_vec()))
                 .await
                 .map_err(|_| SchedulerEventSendError::OrderedLaneClosed),
@@ -416,7 +423,7 @@ impl SchedulerEventSender {
                 .send(signals)
                 .await
                 .map_err(SchedulerEventSendError::OutputClosed),
-            Self::Ordered(tx) => tx
+            Self::Ordered { tx, .. } => tx
                 .send(LiveEngineEvent::Outputs(signals))
                 .await
                 .map_err(|_| SchedulerEventSendError::OrderedLaneClosed),


### PR DESCRIPTION
## Overview:

Implements the first half of DIS-2481 by adding the typed `LiveEngine` boundary needed to remove duplicated Mocker scheduler plumbing from `lib/llm`. This PR is additive: `LiveEngine::start` remains unchanged, and replay-only controls remain private.

## Details:

- Add `LiveEngineConfig` and `LiveEngine::start_with_config` for configured KV-event and FPM publishers.
- Add prepared request registration with route ownership, client/scheduler ID isolation, bounded output, duplicate-ID rejection, and stream-drop cancellation.
- Add typed handoff control and normalized lifecycle events while keeping scheduler IDs and command types private.
- Move lifecycle demultiplexing, dispatcher supervision, route cleanup, and idempotent graceful shutdown into `LiveEngine`.
- Prevent stale handoff controls from mutating replacement registrations and serialize admission acknowledgements with cleanup commands.
- Avoid forwarding admission events when no observer is configured.
- This is the first PR in the stack; it is followed by #12381.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker` — 691 passed
- `git diff --check`

## Where should the reviewer start?

- `lib/mocker/src/live.rs` for engine startup, dispatcher supervision, and shared shutdown behavior.
- `lib/mocker/src/live/request.rs` for request registration, submission, cancellation, and route ownership.
- `lib/mocker/src/live/handoff.rs` for the typed handoff API and generation-safe command routing.
- `lib/mocker/src/live/tests.rs` for lifecycle, route reuse, shutdown, and handoff regressions.
- `lib/mocker/src/scheduler/mod.rs` for the optional admission-forwarding path.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related GitHub issue
- Tracked in Linear as DIS-2481
