### PR TITLE
refactor(llm): migrate Mocker execution to LiveEngine

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -1296,11 +1296,6 @@ mod tests {
         let engine = MockerExecutionContext::new(args);
 
         assert!(engine.prepare_bootstrap().await.is_err());
-        assert!(engine.engines.get().is_none());
-        assert!(engine.handoff_session_permits.get().is_none());
-        assert!(engine._relay_publishers.get().is_none());
-        assert!(!engine.handoff_shutdown.is_cancelled());
-        assert!(!engine.metrics_shutdown.is_cancelled());
 
         drop(occupied);
         let prepared = engine

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -39,15 +39,15 @@ use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::{
     component::Endpoint,
-    engine::AsyncEngineContextProvider,
+    engine::{AsyncEngineContext, AsyncEngineContextProvider},
     pipeline::{AsyncEngine, Error, ManyOut, ResponseStream, SingleIn, async_trait},
     traits::DistributedRuntimeProvider,
 };
 use futures::StreamExt;
 use rand::Rng;
 use serde::Deserialize;
-use tokio::sync::{Notify, OnceCell, Semaphore, mpsc, oneshot};
-use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio::sync::{OnceCell, Semaphore, mpsc, oneshot, watch};
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use uuid::Uuid;
@@ -59,6 +59,7 @@ use self::handoff::{
 use self::metrics::NativeMockerMetrics;
 
 pub const MOCKER_COMPONENT: &str = "mocker";
+const RESPONSE_STREAM_CAPACITY: usize = 8;
 
 #[derive(Debug, Clone, Deserialize)]
 struct ResponseReplayTraceRow {
@@ -218,10 +219,26 @@ fn no_bootstrap_handoff_delay(
     Some(Duration::from_secs_f64(delay_ms.max(0.0) / 1000.0))
 }
 
+async fn send_response(
+    stream_tx: &mpsc::Sender<LLMEngineOutput>,
+    output: LLMEngineOutput,
+    context: &Arc<dyn AsyncEngineContext>,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = stream_tx.closed() => false,
+        _ = context.stopped() => {
+            let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+            false
+        }
+        result = stream_tx.send(output) => result.is_ok(),
+    }
+}
+
 struct MockerExecutionContext {
     engines: OnceCell<Vec<LiveEngine>>,
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,
-    engines_ready: Notify,
+    startup_state: watch::Sender<StartupState>,
     engine_args: MockEngineArgs,
     response_replay_table: Option<ResponseReplayTable>,
     unset_dp_rank_counter: AtomicU32,
@@ -242,10 +259,36 @@ struct MockerExecutionContext {
 struct PreparedBootstrap {
     server: Arc<BootstrapServer>,
     max_sessions: usize,
+    cancel: Option<CancellationToken>,
+}
+
+impl PreparedBootstrap {
+    async fn shutdown(mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            cancel.cancel();
+        }
+        self.server.wait_closed().await;
+    }
+}
+
+impl Drop for PreparedBootstrap {
+    fn drop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            cancel.cancel();
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum StartupState {
+    Starting,
+    Ready,
+    Failed(Arc<str>),
 }
 
 impl MockerExecutionContext {
     fn new(engine_args: MockEngineArgs) -> Self {
+        let (startup_state, _) = watch::channel(StartupState::Starting);
         let native_metrics = NativeMockerMetrics::new(engine_args.engine_type, engine_args.dp_size)
             .expect("mocker native metrics collectors should be valid");
         let response_replay_table = engine_args
@@ -268,7 +311,7 @@ impl MockerExecutionContext {
         Self {
             engines: OnceCell::new(),
             handoff_session_permits: OnceCell::new(),
-            engines_ready: Notify::new(),
+            startup_state,
             engine_args,
             response_replay_table,
             unset_dp_rank_counter: AtomicU32::new(0),
@@ -304,9 +347,10 @@ impl MockerExecutionContext {
             .effective_handoff_capacity()
             .checked_mul(self.engine_args.dp_size as usize)
             .expect("mocker handoff session limit overflow");
+        let cancel = self.handoff_shutdown.child_token();
         let server = BootstrapServer::start(
             port,
-            self.handoff_shutdown.clone(),
+            cancel.clone(),
             BootstrapServerConfig {
                 max_pending_connections: max_sessions,
                 ..BootstrapServerConfig::default()
@@ -316,14 +360,15 @@ impl MockerExecutionContext {
         Ok(Some(PreparedBootstrap {
             server,
             max_sessions,
+            cancel: Some(cancel),
         }))
     }
 
-    fn commit_bootstrap(&self, prepared: PreparedBootstrap) {
-        let PreparedBootstrap {
-            server,
-            max_sessions,
-        } = prepared;
+    fn commit_bootstrap(&self, mut prepared: PreparedBootstrap) {
+        prepared.cancel.take();
+        let server = Arc::clone(&prepared.server);
+        let max_sessions = prepared.max_sessions;
+        drop(prepared);
         let incoming_rx = server
             .take_incoming_receiver()
             .expect("new bootstrap server must own its incoming receiver");
@@ -348,6 +393,22 @@ impl MockerExecutionContext {
     }
 
     async fn start(self: Arc<Self>, endpoint: dynamo_runtime::component::Endpoint) -> Result<()> {
+        let result = Arc::clone(&self).start_inner(endpoint).await;
+        match &result {
+            Ok(()) => {
+                self.startup_state.send_replace(StartupState::Ready);
+            }
+            Err(error) => {
+                self.set_startup_failure(format!("{error:#}"));
+            }
+        }
+        result
+    }
+
+    async fn start_inner(
+        self: Arc<Self>,
+        endpoint: dynamo_runtime::component::Endpoint,
+    ) -> Result<()> {
         let component = endpoint.component().clone();
         // Use primary_token() instead of child_token() so the mocker continues running
         // during graceful shutdown (Phase 1/2) and only stops in Phase 3.
@@ -374,57 +435,79 @@ impl MockerExecutionContext {
         } else {
             None
         };
-        let prepared_bootstrap = self.prepare_bootstrap().await?;
+        let mut prepared_bootstrap = self.prepare_bootstrap().await?;
 
         // Create FPM publisher upfront and get per-dp-rank sink handles.
         let worker_id = component.drt().connection_id().to_string();
-        let fpm_sinks = match crate::fpm_publisher::FpmDirectPublisher::new(
+        let (fpm_publisher, fpm_sinks) = match crate::fpm_publisher::FpmDirectPublisher::new(
             endpoint.clone(),
             worker_id,
             self.engine_args.dp_size,
         )
         .await
         {
-            Ok((publisher, sinks)) => {
-                let _ = self._fpm_publisher.set(publisher);
-                sinks
-            }
+            Ok((publisher, sinks)) => (Some(publisher), sinks),
             Err(e) => {
                 tracing::error!("Failed to start FPM publisher: {e}");
-                (0..self.engine_args.dp_size)
-                    .map(|_| dynamo_mocker::common::protocols::FpmPublisher::default())
-                    .collect()
+                (
+                    None,
+                    (0..self.engine_args.dp_size)
+                        .map(|_| dynamo_mocker::common::protocols::FpmPublisher::default())
+                        .collect(),
+                )
             }
         };
 
         let (engines, relay_publishers, handoff_session_permits) =
-            self.start_engines(kv_endpoint, fpm_sinks).await?;
+            match self.start_engines(kv_endpoint, fpm_sinks).await {
+                Ok(started) => started,
+                Err(error) => {
+                    if let Some(prepared) = prepared_bootstrap.take() {
+                        prepared.shutdown().await;
+                    }
+                    return Err(error);
+                }
+            };
 
-        self.engines
-            .set(engines)
-            .map_err(|_| anyhow::anyhow!("live Mocker engines initialized more than once"))?;
-        self._relay_publishers
-            .set(relay_publishers)
-            .map_err(|_| anyhow::anyhow!("mocker relay publishers initialized more than once"))?;
-        self.handoff_session_permits
-            .set(handoff_session_permits)
-            .map_err(|_| anyhow::anyhow!("mocker handoff permits initialized more than once"))?;
-        self.engines_ready.notify_waiters();
-
-        if let Some(prepared) = prepared_bootstrap {
-            self.commit_bootstrap(prepared);
-        }
-
-        Self::start_metrics_publishing(
-            self.engines
-                .get()
-                .expect("live Mocker engines were initialized above"),
+        if let Err(error) = Self::start_metrics_publishing(
+            &engines,
             endpoint,
             self.native_metrics.clone(),
             self.metrics_shutdown.clone(),
             self.metrics_tasks.clone(),
         )
-        .await?;
+        .await
+        {
+            Self::shutdown_engines(&engines).await;
+            if let Some(prepared) = prepared_bootstrap.take() {
+                prepared.shutdown().await;
+            }
+            return Err(error);
+        }
+
+        assert!(
+            self.engines.set(engines).is_ok(),
+            "live Mocker engines initialized more than once"
+        );
+        assert!(
+            self._relay_publishers.set(relay_publishers).is_ok(),
+            "mocker relay publishers initialized more than once"
+        );
+        assert!(
+            self.handoff_session_permits
+                .set(handoff_session_permits)
+                .is_ok(),
+            "mocker handoff permits initialized more than once"
+        );
+        if let Some(publisher) = fpm_publisher {
+            assert!(
+                self._fpm_publisher.set(publisher).is_ok(),
+                "mocker FPM publisher initialized more than once"
+            );
+        }
+        if let Some(prepared) = prepared_bootstrap.take() {
+            self.commit_bootstrap(prepared);
+        }
 
         let shutdown = Arc::clone(&self);
         tokio::spawn(async move {
@@ -439,13 +522,7 @@ impl MockerExecutionContext {
             }
             shutdown.handoff_tasks.wait().await;
             if let Some(engines) = shutdown.engines.get() {
-                for result in
-                    futures::future::join_all(engines.iter().map(LiveEngine::shutdown)).await
-                {
-                    if let Err(error) = result {
-                        tracing::error!(%error, "failed to shut down live Mocker engine");
-                    }
-                }
+                Self::shutdown_engines(engines).await;
             }
             shutdown.metrics_shutdown.cancel();
             shutdown.metrics_tasks.close();
@@ -455,35 +532,62 @@ impl MockerExecutionContext {
         Ok(())
     }
 
-    async fn engine(&self, dp_rank: usize) -> LiveEngine {
-        if let Some(engines) = self.engines.get() {
-            return engines[dp_rank].clone();
+    async fn shutdown_engines(engines: &[LiveEngine]) {
+        for result in futures::future::join_all(engines.iter().map(LiveEngine::shutdown)).await {
+            if let Err(error) = result {
+                tracing::error!(%error, "failed to shut down live Mocker engine");
+            }
         }
-
-        let notified = self.engines_ready.notified();
-        if let Some(engines) = self.engines.get() {
-            return engines[dp_rank].clone();
-        }
-        notified.await;
-        self.engines
-            .get()
-            .expect("live Mocker engines must be initialized before notification")[dp_rank]
-            .clone()
     }
 
-    async fn handoff_session_permit(&self, dp_rank: usize) -> Arc<Semaphore> {
-        if let Some(permits) = self.handoff_session_permits.get() {
-            return permits[dp_rank].clone();
+    fn set_startup_failure(&self, error: impl Into<Arc<str>>) {
+        self.startup_state
+            .send_replace(StartupState::Failed(error.into()));
+    }
+
+    async fn wait_for_startup(&self) -> Result<()> {
+        let mut state = self.startup_state.subscribe();
+        loop {
+            let current = state.borrow().clone();
+            match current {
+                StartupState::Starting => {}
+                StartupState::Ready => return Ok(()),
+                StartupState::Failed(error) => {
+                    bail!("mocker startup failed: {error}");
+                }
+            }
+            state
+                .changed()
+                .await
+                .map_err(|_| anyhow::anyhow!("mocker startup state channel closed"))?;
         }
-        let notified = self.engines_ready.notified();
-        if let Some(permits) = self.handoff_session_permits.get() {
-            return permits[dp_rank].clone();
+    }
+
+    async fn engine(&self, dp_rank: usize) -> Result<LiveEngine> {
+        if let Some(engines) = self.engines.get() {
+            return Ok(engines[dp_rank].clone());
         }
-        notified.await;
-        self.handoff_session_permits
+
+        self.wait_for_startup().await?;
+        Ok(self
+            .engines
             .get()
-            .expect("handoff session permits must be initialized before notification")[dp_rank]
-            .clone()
+            .ok_or_else(|| anyhow::anyhow!("mocker reported ready without live engines"))?[dp_rank]
+            .clone())
+    }
+
+    async fn handoff_session_permit(&self, dp_rank: usize) -> Result<Arc<Semaphore>> {
+        if let Some(permits) = self.handoff_session_permits.get() {
+            return Ok(permits[dp_rank].clone());
+        }
+
+        self.wait_for_startup().await?;
+        Ok(self
+            .handoff_session_permits
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("mocker reported ready without handoff permits"))?
+            [dp_rank]
+            .clone())
     }
 
     async fn start_engines(
@@ -689,7 +793,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                 dp_rank, self.engine_args.dp_size
             )));
         }
-        let engine = self.engine(dp_rank as usize).await;
+        let engine = self
+            .engine(dp_rank as usize)
+            .await
+            .map_err(|error| Error::msg(error.to_string()))?;
 
         let request_uuid = ctx.id().parse().unwrap_or(Uuid::new_v4());
         let is_prefill = self.engine_args.is_prefill();
@@ -750,8 +857,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             ..Default::default()
         };
 
-        // Create a simple channel for the stream
-        let (stream_tx, stream_rx) = mpsc::unbounded_channel::<LLMEngineOutput>();
+        let (stream_tx, stream_rx) = mpsc::channel::<LLMEngineOutput>(RESPONSE_STREAM_CAPACITY);
 
         let handoff_id = request
             .bootstrap_info
@@ -791,6 +897,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             let session_permit = match self
                 .handoff_session_permit(dp_rank as usize)
                 .await
+                .map_err(|error| Error::msg(error.to_string()))?
                 .try_acquire_owned()
             {
                 Ok(permit) => permit,
@@ -919,13 +1026,23 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                         match source_completion {
                             Ok(Ok(())) => source_handoff_complete = true,
                             Ok(Err(error)) => {
-                                let _ = stream_tx.send(LLMEngineOutput::error(error));
+                                let _ = send_response(
+                                    &stream_tx,
+                                    LLMEngineOutput::error(error),
+                                    &async_context,
+                                )
+                                .await;
                                 break;
                             }
                             Err(_) => {
-                                let _ = stream_tx.send(LLMEngineOutput::error(
-                                    "source handoff session ended without completion".to_string(),
-                                ));
+                                let _ = send_response(
+                                    &stream_tx,
+                                    LLMEngineOutput::error(
+                                        "source handoff session ended without completion".to_string(),
+                                    ),
+                                    &async_context,
+                                )
+                                .await;
                                 break;
                             }
                         }
@@ -938,7 +1055,12 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                     }, if destination_error_rx.is_some() => {
                         match destination_error {
                             Some(error) => {
-                                let _ = stream_tx.send(LLMEngineOutput::error(error));
+                                let _ = send_response(
+                                    &stream_tx,
+                                    LLMEngineOutput::error(error),
+                                    &async_context,
+                                )
+                                .await;
                                 break;
                             }
                             None => destination_error_rx = None,
@@ -946,7 +1068,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                     }
                     maybe_signal = live_request.recv() => {
                         let Some(signal) = maybe_signal else {
-                            let _ = stream_tx.send(LLMEngineOutput::error("All output transmitters closed".to_string()));
+                            let _ = send_response(
+                                &stream_tx,
+                                LLMEngineOutput::error("All output transmitters closed".to_string()),
+                                &async_context,
+                            ).await;
                             break;
                         };
 
@@ -956,9 +1082,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                         // token/prefill bookkeeping.
                         if signal.rejected {
                             handoff_cancel.cancel();
-                            let _ = stream_tx.send(LLMEngineOutput::error(
-                                "request rejected: request exceeds worker admission limits".to_string(),
-                            ));
+                            let _ = send_response(
+                                &stream_tx,
+                                LLMEngineOutput::error(
+                                    "request rejected: request exceeds worker admission limits".to_string(),
+                                ),
+                                &async_context,
+                            )
+                            .await;
                             break;
                         }
 
@@ -981,51 +1112,89 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                         };
 
                         if signal.completed && token_count < effective_max_output_tokens {
-                            let _ = stream_tx.send(LLMEngineOutput::error("Completion signal received before max tokens reached".to_string()));
+                            let _ = send_response(
+                                &stream_tx,
+                                LLMEngineOutput::error(
+                                    "Completion signal received before max tokens reached".to_string(),
+                                ),
+                                &async_context,
+                            )
+                            .await;
                             break;
                         }
 
                         if signal.completed {
-                            if stream_tx.send(output).is_err() {
+                            if !send_response(&stream_tx, output, &async_context).await {
                                 tracing::error!("Output stream receiver closed.");
                                 break;
                             }
                             native_timing.record_tokens(1);
 
-                            wait_for_no_bootstrap_handoff_delay(
-                                is_prefill,
-                                has_handoff_session,
-                                signal.handoff_delay_ms,
-                            )
-                            .await;
+                            let delay_completed = tokio::select! {
+                                _ = wait_for_no_bootstrap_handoff_delay(
+                                    is_prefill,
+                                    has_handoff_session,
+                                    signal.handoff_delay_ms,
+                                ) => true,
+                                _ = stream_tx.closed() => false,
+                                _ = async_context.stopped() => {
+                                    handoff_cancel.cancel();
+                                    let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+                                    false
+                                }
+                            };
+                            if !delay_completed {
+                                break;
+                            }
 
                             if !source_handoff_complete
                                 && let Some(completion_rx) = source_completion_rx.take()
                             {
                                 let completion = tokio::select! {
                                     completion = completion_rx => completion,
+                                    _ = stream_tx.closed() => {
+                                        handoff_cancel.cancel();
+                                        break;
+                                    }
                                     _ = async_context.stopped() => {
                                         handoff_cancel.cancel();
-                                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
+                                        let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
                                         break;
                                     }
                                 };
                                 match completion {
                                     Ok(Ok(())) => {}
                                     Ok(Err(error)) => {
-                                        let _ = stream_tx.send(LLMEngineOutput::error(error));
+                                        let _ = send_response(
+                                            &stream_tx,
+                                            LLMEngineOutput::error(error),
+                                            &async_context,
+                                        )
+                                        .await;
                                         break;
                                     }
                                     Err(_) => {
-                                        let _ = stream_tx.send(LLMEngineOutput::error(
-                                            "source handoff session ended without completion".to_string(),
-                                        ));
+                                        let _ = send_response(
+                                            &stream_tx,
+                                            LLMEngineOutput::error(
+                                                "source handoff session ended without completion"
+                                                    .to_string(),
+                                            ),
+                                            &async_context,
+                                        )
+                                        .await;
                                         break;
                                     }
                                 }
                             }
 
-                            if stream_tx.send(LLMEngineOutput::length()).is_err() {
+                            if !send_response(
+                                &stream_tx,
+                                LLMEngineOutput::length(),
+                                &async_context,
+                            )
+                            .await
+                            {
                                 tracing::error!("Output stream receiver closed.");
                                 break;
                             }
@@ -1034,7 +1203,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                             break;
                         }
 
-                        if stream_tx.send(output).is_err() {
+                        if !send_response(&stream_tx, output, &async_context).await {
                             tracing::error!("Output stream receiver closed.");
                             break;
                         }
@@ -1043,7 +1212,12 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
                     _ = async_context.stopped() => {
                         handoff_cancel.cancel();
-                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
+                        let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+                        break;
+                    }
+
+                    _ = stream_tx.closed() => {
+                        handoff_cancel.cancel();
                         break;
                     }
                 }
@@ -1063,7 +1237,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             tokio::spawn(response_task);
         }
 
-        let stream = UnboundedReceiverStream::new(stream_rx).map(Annotated::from_data);
+        let stream = ReceiverStream::new(stream_rx).map(Annotated::from_data);
         Ok(ResponseStream::new(Box::pin(stream), ctx.context()))
     }
 }
@@ -1082,6 +1256,7 @@ pub async fn make_mocker_engine(
         let component = loop {
             if cancel_token.is_cancelled() {
                 tracing::debug!("Mocker engine startup cancelled");
+                startup_engine.set_startup_failure("mocker startup was cancelled");
                 return;
             }
 
@@ -1222,6 +1397,7 @@ mod tests {
         let args = MockEngineArgs::builder()
             .block_size(4)
             .num_gpu_blocks(64)
+            .max_num_seqs(Some(1))
             .max_num_batched_tokens(Some(64))
             .speedup_ratio(0.1)
             .build()
@@ -1229,6 +1405,18 @@ mod tests {
         let live = LiveEngine::start(args.clone(), 0).unwrap();
         let engine = MockerExecutionContext::new(args);
         assert!(engine.engines.set(vec![live.clone()]).is_ok());
+        let blocker_id = Uuid::from_u128(98);
+        let mut blocker = live
+            .submit(DirectRequest {
+                tokens: vec![1],
+                max_output_tokens: 10_000,
+                output_token_ids: Some(vec![7; 10_000]),
+                uuid: Some(blocker_id),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let blocker_drain = tokio::spawn(async move { while blocker.recv().await.is_some() {} });
         let request_id = Uuid::from_u128(99);
         let input = SingleIn::with_id_and_metadata(
             decode_request(1, 100),
@@ -1240,11 +1428,7 @@ mod tests {
 
         tokio::time::timeout(Duration::from_secs(2), async {
             loop {
-                let metrics = live.metrics_receiver().borrow().clone();
-                if live.active_request_count() == 0
-                    && metrics.running_requests == 0
-                    && metrics.waiting_requests == 0
-                {
+                if live.active_request_count() == 1 {
                     break;
                 }
                 tokio::task::yield_now().await;
@@ -1252,6 +1436,8 @@ mod tests {
         })
         .await
         .expect("dropped response must cancel its live request");
+        assert!(live.cancel(blocker_id).await.unwrap());
+        blocker_drain.await.unwrap();
 
         let input = SingleIn::with_id_and_metadata(
             decode_request(1, 1),
@@ -1283,7 +1469,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn bootstrap_bind_failure_leaves_startup_state_retryable() {
+    async fn startup_failure_wakes_engine_waiters() {
+        let engine = Arc::new(MockerExecutionContext::new(
+            MockEngineArgs::builder().build().unwrap(),
+        ));
+        let waiting_engine = Arc::clone(&engine);
+        let waiter = tokio::spawn(async move { waiting_engine.engine(0).await });
+        tokio::task::yield_now().await;
+        assert!(!waiter.is_finished());
+
+        engine.set_startup_failure("rank initialization failed");
+        let error = tokio::time::timeout(Duration::from_secs(1), waiter)
+            .await
+            .expect("startup waiter should wake")
+            .unwrap()
+            .err()
+            .expect("startup waiter should return the initialization failure");
+        assert!(error.to_string().contains("rank initialization failed"));
+    }
+
+    #[tokio::test]
+    async fn prepared_bootstrap_shutdown_releases_the_listener() {
         let occupied = std::net::TcpListener::bind(("0.0.0.0", 0)).unwrap();
         let port = occupied.local_addr().unwrap().port();
         let args = MockEngineArgs::builder()
@@ -1303,8 +1509,13 @@ mod tests {
             .await
             .unwrap()
             .expect("released bootstrap port must be reusable");
-        engine.handoff_shutdown.cancel();
-        prepared.server.wait_closed().await;
+        prepared.shutdown().await;
+        let retry = engine
+            .prepare_bootstrap()
+            .await
+            .unwrap()
+            .expect("failed startup cleanup must release the bootstrap port");
+        retry.shutdown().await;
     }
 
     fn write_replay_trace(lines: &[serde_json::Value]) -> tempfile::NamedTempFile {

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -22,16 +22,13 @@ use crate::kv_router::publisher::{KvEventPublisher, KvEventSourceConfig, WorkerM
 use crate::protocols::TokenIdType;
 use crate::protocols::common::llm_backend::{LLMEngineOutput, PreprocessedRequest};
 use anyhow::{Context, Result, bail};
-use dashmap::DashMap;
 use dynamo_kv_router::protocols::{KvCacheEvent, StorageTier};
 use dynamo_mocker::common::handoff::HandoffId;
 use dynamo_mocker::common::protocols::{
-    DirectRequest, KvCacheEventSink, KvEventPublishers, MockEngineArgs, OutputSignal,
-    RawKvEventSink,
+    DirectRequest, KvCacheEventSink, KvEventPublishers, MockEngineArgs, RawKvEventSink,
 };
-use dynamo_mocker::engine::create_engine;
+use dynamo_mocker::live::{LiveEngine, LiveEngineConfig};
 use dynamo_mocker::loadgen::{OUTPUT_REPLAY_ID_ANNOTATION_KEY, effective_replay_key};
-use dynamo_mocker::scheduler::{SchedulerCommandEnvelope, SchedulerHandle};
 use dynamo_mocker::services::bootstrap::{
     BootstrapIdentity, BootstrapParticipantRole, BootstrapServer, BootstrapServerConfig,
     ParticipantRegistration, connect_to_prefill,
@@ -56,8 +53,8 @@ use tokio_util::task::TaskTracker;
 use uuid::Uuid;
 
 use self::handoff::{
-    HandoffEventRegistry, SourceHandoffManager, SourceRegistration, cancel_destination,
-    order_for_engine, run_destination_session,
+    HandoffControl, SourceHandoffManager, SourceRegistration, cancel_destination,
+    live_handoff_boundary, order_for_engine, run_destination_session,
 };
 use self::metrics::NativeMockerMetrics;
 
@@ -221,30 +218,23 @@ fn no_bootstrap_handoff_delay(
     Some(Duration::from_secs_f64(delay_ms.max(0.0) / 1000.0))
 }
 
-/// AsyncEngine wrapper around the Scheduler that generates random character tokens
-pub struct MockEngine {
-    active_requests: Arc<DashMap<Uuid, mpsc::UnboundedSender<OutputSignal>>>,
-    request_senders: OnceCell<Vec<mpsc::UnboundedSender<DirectRequest>>>,
-    command_senders: OnceCell<Vec<mpsc::Sender<SchedulerCommandEnvelope>>>,
-    // TODO(DIS-2478): Store the scheduler cancellation senders and connect the AsyncEngine
-    // context stop/response-stream drop path to targeted cancellation. Until then, lib/mocker
-    // cancellation is not wired end to end through MockEngine.
+struct MockerExecutionContext {
+    engines: OnceCell<Vec<LiveEngine>>,
     handoff_session_permits: OnceCell<Vec<Arc<Semaphore>>>,
-    senders_ready: Notify,
+    engines_ready: Notify,
     engine_args: MockEngineArgs,
     response_replay_table: Option<ResponseReplayTable>,
     unset_dp_rank_counter: AtomicU32,
     /// Bootstrap server for prefill workers in disaggregated mode
     bootstrap_server: Arc<OnceCell<Arc<BootstrapServer>>>,
     source_handoff_manager: OnceCell<SourceHandoffManager>,
-    handoff_events: HandoffEventRegistry,
     handoff_shutdown: CancellationToken,
-    scheduler_shutdown: CancellationToken,
+    metrics_shutdown: CancellationToken,
     handoff_tasks: TaskTracker,
-    scheduler_tasks: TaskTracker,
+    metrics_tasks: TaskTracker,
     native_metrics: Arc<NativeMockerMetrics>,
-    /// Keep schedulers alive so their CancelGuards don't fire prematurely.
-    _schedulers: OnceCell<Vec<Box<dyn SchedulerHandle>>>,
+    /// Keep ZMQ relay publishers alive until their engines finish shutting down.
+    _relay_publishers: OnceCell<Vec<Option<KvEventPublisher>>>,
     /// Forward pass metrics publisher (kept alive for the engine lifetime).
     _fpm_publisher: OnceCell<crate::fpm_publisher::FpmDirectPublisher>,
 }
@@ -254,9 +244,8 @@ struct PreparedBootstrap {
     max_sessions: usize,
 }
 
-impl MockEngine {
-    /// Create a new MockEngine with the given parameters
-    pub fn new(engine_args: MockEngineArgs) -> Self {
+impl MockerExecutionContext {
+    fn new(engine_args: MockEngineArgs) -> Self {
         let native_metrics = NativeMockerMetrics::new(engine_args.engine_type, engine_args.dp_size)
             .expect("mocker native metrics collectors should be valid");
         let response_replay_table = engine_args
@@ -277,23 +266,20 @@ impl MockEngine {
             );
         }
         Self {
-            active_requests: Arc::new(DashMap::new()),
-            request_senders: OnceCell::new(),
-            command_senders: OnceCell::new(),
+            engines: OnceCell::new(),
             handoff_session_permits: OnceCell::new(),
-            senders_ready: Notify::new(),
+            engines_ready: Notify::new(),
             engine_args,
             response_replay_table,
             unset_dp_rank_counter: AtomicU32::new(0),
             bootstrap_server: Arc::new(OnceCell::new()),
             source_handoff_manager: OnceCell::new(),
-            handoff_events: HandoffEventRegistry::default(),
             handoff_shutdown: CancellationToken::new(),
-            scheduler_shutdown: CancellationToken::new(),
+            metrics_shutdown: CancellationToken::new(),
             handoff_tasks: TaskTracker::new(),
-            scheduler_tasks: TaskTracker::new(),
+            metrics_tasks: TaskTracker::new(),
             native_metrics,
-            _schedulers: OnceCell::new(),
+            _relay_publishers: OnceCell::new(),
             _fpm_publisher: OnceCell::new(),
         }
     }
@@ -361,7 +347,7 @@ impl MockEngine {
         );
     }
 
-    pub async fn start(&self, endpoint: dynamo_runtime::component::Endpoint) -> Result<()> {
+    async fn start(self: Arc<Self>, endpoint: dynamo_runtime::component::Endpoint) -> Result<()> {
         let component = endpoint.component().clone();
         // Use primary_token() instead of child_token() so the mocker continues running
         // during graceful shutdown (Phase 1/2) and only stops in Phase 3.
@@ -411,88 +397,77 @@ impl MockEngine {
             }
         };
 
-        let schedulers = self
-            .start_schedulers(kv_endpoint, self.scheduler_shutdown.clone(), fpm_sinks)
-            .await;
+        let (engines, relay_publishers, handoff_session_permits) =
+            self.start_engines(kv_endpoint, fpm_sinks).await?;
+
+        self.engines
+            .set(engines)
+            .map_err(|_| anyhow::anyhow!("live Mocker engines initialized more than once"))?;
+        self._relay_publishers
+            .set(relay_publishers)
+            .map_err(|_| anyhow::anyhow!("mocker relay publishers initialized more than once"))?;
+        self.handoff_session_permits
+            .set(handoff_session_permits)
+            .map_err(|_| anyhow::anyhow!("mocker handoff permits initialized more than once"))?;
+        self.engines_ready.notify_waiters();
 
         if let Some(prepared) = prepared_bootstrap {
             self.commit_bootstrap(prepared);
         }
 
         Self::start_metrics_publishing(
-            &schedulers,
+            self.engines
+                .get()
+                .expect("live Mocker engines were initialized above"),
             endpoint,
             self.native_metrics.clone(),
-            self.scheduler_shutdown.clone(),
-            self.scheduler_tasks.clone(),
+            self.metrics_shutdown.clone(),
+            self.metrics_tasks.clone(),
         )
         .await?;
 
-        let _ = self._schedulers.set(schedulers);
-
-        let handoff_shutdown = self.handoff_shutdown.clone();
-        let scheduler_shutdown = self.scheduler_shutdown.clone();
-        let handoff_tasks = self.handoff_tasks.clone();
-        let scheduler_tasks = self.scheduler_tasks.clone();
-        let source_manager = self.source_handoff_manager.get().cloned();
-        let bootstrap_server = self.bootstrap_server.get().cloned();
+        let shutdown = Arc::clone(&self);
         tokio::spawn(async move {
             primary_token.cancelled().await;
-            handoff_shutdown.cancel();
-            handoff_tasks.close();
-            if let Some(manager) = source_manager {
+            shutdown.handoff_shutdown.cancel();
+            shutdown.handoff_tasks.close();
+            if let Some(manager) = shutdown.source_handoff_manager.get().cloned() {
                 manager.wait_closed().await;
             }
-            if let Some(server) = bootstrap_server {
+            if let Some(server) = shutdown.bootstrap_server.get().cloned() {
                 server.wait_closed().await;
             }
-            handoff_tasks.wait().await;
-            scheduler_shutdown.cancel();
-            scheduler_tasks.close();
-            scheduler_tasks.wait().await;
+            shutdown.handoff_tasks.wait().await;
+            if let Some(engines) = shutdown.engines.get() {
+                for result in
+                    futures::future::join_all(engines.iter().map(LiveEngine::shutdown)).await
+                {
+                    if let Err(error) = result {
+                        tracing::error!(%error, "failed to shut down live Mocker engine");
+                    }
+                }
+            }
+            shutdown.metrics_shutdown.cancel();
+            shutdown.metrics_tasks.close();
+            shutdown.metrics_tasks.wait().await;
         });
 
         Ok(())
     }
 
-    /// Send a request to the appropriate scheduler, waiting for initialization if needed.
-    pub async fn direct(&self, request: DirectRequest, dp_rank: usize) {
-        let sender = self.request_sender(dp_rank).await;
-        let _ = sender.send(request);
-    }
-
-    async fn request_sender(&self, dp_rank: usize) -> mpsc::UnboundedSender<DirectRequest> {
-        if let Some(senders) = self.request_senders.get() {
-            return senders[dp_rank].clone();
+    async fn engine(&self, dp_rank: usize) -> LiveEngine {
+        if let Some(engines) = self.engines.get() {
+            return engines[dp_rank].clone();
         }
 
-        // Register the waiter *before* re-checking to avoid a TOCTOU race
-        // where `start_schedulers` sets + notifies between our check and subscribe.
-        let notified = self.senders_ready.notified();
-        if let Some(senders) = self.request_senders.get() {
-            return senders[dp_rank].clone();
+        let notified = self.engines_ready.notified();
+        if let Some(engines) = self.engines.get() {
+            return engines[dp_rank].clone();
         }
         notified.await;
-
-        let senders = self
-            .request_senders
+        self.engines
             .get()
-            .expect("must be set after notify");
-        senders[dp_rank].clone()
-    }
-
-    async fn command_sender(&self, dp_rank: usize) -> mpsc::Sender<SchedulerCommandEnvelope> {
-        if let Some(senders) = self.command_senders.get() {
-            return senders[dp_rank].clone();
-        }
-        let notified = self.senders_ready.notified();
-        if let Some(senders) = self.command_senders.get() {
-            return senders[dp_rank].clone();
-        }
-        notified.await;
-        self.command_senders
-            .get()
-            .expect("scheduler command senders must be initialized before notification")[dp_rank]
+            .expect("live Mocker engines must be initialized before notification")[dp_rank]
             .clone()
     }
 
@@ -500,7 +475,7 @@ impl MockEngine {
         if let Some(permits) = self.handoff_session_permits.get() {
             return permits[dp_rank].clone();
         }
-        let notified = self.senders_ready.notified();
+        let notified = self.engines_ready.notified();
         if let Some(permits) = self.handoff_session_permits.get() {
             return permits[dp_rank].clone();
         }
@@ -511,22 +486,21 @@ impl MockEngine {
             .clone()
     }
 
-    /// Create schedulers and spawn their background tasks for distributing token notifications.
-    async fn start_schedulers(
+    async fn start_engines(
         &self,
         endpoint: Option<&dynamo_runtime::component::Endpoint>,
-        cancel_token: CancellationToken,
         fpm_sinks: Vec<dynamo_mocker::common::protocols::FpmPublisher>,
-    ) -> Vec<Box<dyn SchedulerHandle>> {
+    ) -> Result<(
+        Vec<LiveEngine>,
+        Vec<Option<KvEventPublisher>>,
+        Vec<Arc<Semaphore>>,
+    )> {
         let args = &self.engine_args;
-        let mut schedulers = Vec::<Box<dyn SchedulerHandle>>::new();
-        let mut senders = Vec::with_capacity(args.dp_size as usize);
-        let mut command_senders = Vec::with_capacity(args.dp_size as usize);
+        let mut engines = Vec::<LiveEngine>::with_capacity(args.dp_size as usize);
+        let mut relay_publishers = Vec::with_capacity(args.dp_size as usize);
         let mut handoff_session_permits = Vec::with_capacity(args.dp_size as usize);
 
         for (dp_rank, fpm_publisher) in (0..args.dp_size).zip(fpm_sinks) {
-            let (output_tx, mut output_rx) = mpsc::unbounded_channel::<Vec<OutputSignal>>();
-
             let (kv_event_publishers, relay_publisher): (
                 KvEventPublishers,
                 Option<KvEventPublisher>,
@@ -607,92 +581,39 @@ impl MockEngine {
                 None => (KvEventPublishers::default(), None),
             };
 
-            let mut scheduler = create_engine(
+            let engine = match LiveEngine::start_with_config(
                 args.clone(),
                 dp_rank,
-                Some(output_tx),
-                kv_event_publishers,
-                Some(cancel_token.clone()),
-                fpm_publisher,
-            );
+                LiveEngineConfig {
+                    kv_event_publishers,
+                    fpm_publisher,
+                },
+            ) {
+                Ok(engine) => engine,
+                Err(error) => {
+                    for engine in &engines {
+                        if let Err(shutdown_error) = engine.shutdown().await {
+                            tracing::error!(
+                                %shutdown_error,
+                                "failed to shut down live Mocker engine after startup error"
+                            );
+                        }
+                    }
+                    return Err(error);
+                }
+            };
 
-            senders.push(scheduler.request_sender());
-            command_senders.push(scheduler.command_sender());
+            engines.push(engine);
+            relay_publishers.push(relay_publisher);
             handoff_session_permits
                 .push(Arc::new(Semaphore::new(args.effective_handoff_capacity())));
-            let mut lifecycle_rx = scheduler
-                .take_lifecycle_receiver()
-                .expect("new scheduler must expose one lifecycle receiver");
-            schedulers.push(scheduler);
-
-            let active_requests_clone = self.active_requests.clone();
-            let cancel_token_cloned = cancel_token.clone();
-            let handoff_events = self.handoff_events.clone();
-
-            self.scheduler_tasks.spawn({
-                let cancel_token = cancel_token.clone();
-                async move {
-                    loop {
-                        tokio::select! {
-                            biased;
-                            _ = cancel_token.cancelled() => break,
-                            event = lifecycle_rx.recv() => {
-                                let Some(event) = event else {
-                                    break;
-                                };
-                                handoff_events.deliver(event).await;
-                            }
-                        }
-                    }
-                }
-            });
-
-            self.scheduler_tasks.spawn(async move {
-                // Keep the relay publisher alive for the lifetime of this task.
-                // Dropping it would cancel its background ZMQ→NATS relay tasks.
-                let _relay_publisher = relay_publisher;
-
-                loop {
-                    tokio::select! {
-                        signal_result = output_rx.recv() => {
-                            let Some(output_batch) = signal_result else {
-                                break; // Channel closed
-                            };
-
-                            for signal in output_batch {
-                                if let Some(request_tx) = active_requests_clone.get(&signal.uuid) {
-                                    let _ = request_tx.send(signal);
-                                }
-                            }
-                        }
-                        _ = cancel_token_cloned.cancelled() => {
-                            tracing::info!("Scheduler output task cancelled, clearing active requests");
-                            active_requests_clone.clear();
-                            break;
-                        }
-                    }
-                }
-            });
         }
-
-        // Set the senders once and notify waiters
-        self.request_senders
-            .set(senders)
-            .expect("Already initialized");
-        self.command_senders
-            .set(command_senders)
-            .expect("Already initialized");
-        self.handoff_session_permits
-            .set(handoff_session_permits)
-            .expect("Already initialized");
-        self.senders_ready.notify_waiters();
-
-        schedulers
+        Ok((engines, relay_publishers, handoff_session_permits))
     }
 
     /// Start background tasks to publish metrics on change
     async fn start_metrics_publishing(
-        schedulers: &[Box<dyn SchedulerHandle>],
+        engines: &[LiveEngine],
         endpoint: Endpoint,
         native_metrics: Arc<NativeMockerMetrics>,
         cancel_token: CancellationToken,
@@ -703,8 +624,8 @@ impl MockEngine {
         if let Err(e) = metrics_publisher.create_endpoint(endpoint).await {
             tracing::error!("Metrics endpoint failed: {e}");
         }
-        for scheduler in schedulers.iter() {
-            let mut metrics_rx = scheduler.metrics_receiver();
+        for engine in engines {
+            let mut metrics_rx = engine.metrics_receiver();
             let publisher = metrics_publisher.clone();
             let native_metrics = native_metrics.clone();
             let cancel_token = cancel_token.clone();
@@ -749,11 +670,13 @@ impl MockEngine {
 }
 
 #[async_trait]
-impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error> for MockEngine {
+impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+    for MockerExecutionContext
+{
     async fn generate(
         &self,
         input: SingleIn<PreprocessedRequest>,
-    ) -> Result<ManyOut<LLMEngineOutput>, Error> {
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
         let (request, ctx) = input.into_parts();
         let request_start = Instant::now();
 
@@ -766,6 +689,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                 dp_rank, self.engine_args.dp_size
             )));
         }
+        let engine = self.engine(dp_rank as usize).await;
 
         let request_uuid = ctx.id().parse().unwrap_or(Uuid::new_v4());
         let is_prefill = self.engine_args.is_prefill();
@@ -826,9 +750,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             ..Default::default()
         };
 
-        let (request_tx, mut request_rx) = mpsc::unbounded_channel::<OutputSignal>();
-        self.active_requests.insert(request_uuid, request_tx);
-
         // Create a simple channel for the stream
         let (stream_tx, stream_rx) = mpsc::unbounded_channel::<LLMEngineOutput>();
 
@@ -841,14 +762,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             && (self.engine_args.is_prefill() || self.engine_args.is_decode())
             && handoff_id.is_none()
         {
-            self.active_requests.remove(&request_uuid);
             return Err(Error::msg("disaggregated mocker requires a handoff ID"));
         }
 
         let handoff_cancel = CancellationToken::new();
         let mut source_completion_rx = None;
         let mut destination_error_rx = None;
-        let mut destination_cleanup = None;
+        let mut destination_cleanup: Option<HandoffControl> = None;
+        let mut live_request;
 
         if let Some(handoff_id) = handoff_id {
             let bootstrap_info = request
@@ -864,7 +785,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             let order = match order_for_engine(self.engine_args.engine_type) {
                 Ok(order) => order,
                 Err(error) => {
-                    self.active_requests.remove(&request_uuid);
                     return Err(Error::msg(error.to_string()));
                 }
             };
@@ -875,24 +795,25 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             {
                 Ok(permit) => permit,
                 Err(_) => {
-                    self.active_requests.remove(&request_uuid);
                     return Err(Error::msg(format!(
                         "mocker handoff session limit reached for DP rank {dp_rank}"
                     )));
                 }
             };
-            let command_tx = self.command_sender(dp_rank as usize).await;
-            let lifecycle = match self.handoff_events.register(handoff_id) {
-                Ok(lifecycle) => lifecycle,
+            let (registration, prepared_request) = engine
+                .prepare_request(direct_request)
+                .map_err(|error| Error::msg(error.to_string()))?;
+            live_request = prepared_request;
+            let (control, lifecycle) = match engine.register_handoff(handoff_id) {
+                Ok(boundary) => boundary,
                 Err(error) => {
-                    self.active_requests.remove(&request_uuid);
                     return Err(Error::msg(error.to_string()));
                 }
             };
+            let (control, lifecycle) = live_handoff_boundary(control, lifecycle, registration);
 
             if self.engine_args.is_prefill() {
                 let Some(manager) = self.source_handoff_manager.get() else {
-                    self.active_requests.remove(&request_uuid);
                     return Err(Error::msg("source handoff manager is not initialized"));
                 };
                 let (completion_tx, completion_rx) = oneshot::channel();
@@ -900,15 +821,13 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                     identity,
                     order,
                     engine_type: self.engine_args.engine_type,
-                    request: direct_request,
-                    command_tx,
+                    control,
                     lifecycle,
                     completion_tx,
                     cancel: handoff_cancel.clone(),
                     observer: None,
                     _permit: session_permit,
                 }) {
-                    self.active_requests.remove(&request_uuid);
                     return Err(Error::msg(error.to_string()));
                 }
                 source_completion_rx = Some(completion_rx);
@@ -929,12 +848,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                 {
                     Ok(connection) => connection,
                     Err(error) => {
-                        self.active_requests.remove(&request_uuid);
                         return Err(Error::msg(format!("bootstrap connection failed: {error}")));
                     }
                 };
                 let (error_tx, error_rx) = mpsc::unbounded_channel();
-                let session_command_tx = command_tx.clone();
+                let session_control = control.clone();
                 let session_cancel = handoff_cancel.clone();
                 let session_timeout =
                     Duration::from_millis(self.engine_args.handoff_session_timeout_ms);
@@ -943,8 +861,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                     let _session_permit = session_permit;
                     if let Err(error) = run_destination_session(
                         connection,
-                        direct_request,
-                        session_command_tx,
+                        session_control,
                         lifecycle,
                         session_cancel,
                         session_timeout,
@@ -956,18 +873,19 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                     }
                 });
                 destination_error_rx = Some(error_rx);
-                destination_cleanup = Some((command_tx, handoff_id));
+                destination_cleanup = Some(control);
             } else {
-                self.active_requests.remove(&request_uuid);
                 return Err(Error::msg(
                     "aggregated mocker request cannot carry handoff metadata",
                 ));
             }
         } else {
-            self.direct(direct_request, dp_rank as usize).await;
+            live_request = engine
+                .submit(direct_request)
+                .await
+                .map_err(|error| Error::msg(error.to_string()))?;
         }
 
-        let active_requests = self.active_requests.clone();
         let async_context = ctx.context();
         let reasoning = self.engine_args.reasoning.clone();
         let handoff_session_timeout =
@@ -1026,7 +944,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             None => destination_error_rx = None,
                         }
                     }
-                    maybe_signal = request_rx.recv() => {
+                    maybe_signal = live_request.recv() => {
                         let Some(signal) = maybe_signal else {
                             let _ = stream_tx.send(LLMEngineOutput::error("All output transmitters closed".to_string()));
                             break;
@@ -1133,12 +1051,11 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
 
             if !request_completed_normally {
                 handoff_cancel.cancel();
-                if let Some((command_tx, handoff_id)) = destination_cleanup.as_ref() {
-                    cancel_destination(command_tx, *handoff_id, handoff_session_timeout).await;
+                if let Some(control) = destination_cleanup.as_ref() {
+                    cancel_destination(control, handoff_session_timeout).await;
                 }
+                let _ = live_request.cancel().await;
             }
-
-            active_requests.remove(&request_uuid);
         };
         if let Some(tasks) = response_task_tracker {
             tasks.spawn(response_task);
@@ -1146,75 +1063,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
             tokio::spawn(response_task);
         }
 
-        let stream = UnboundedReceiverStream::new(stream_rx);
+        let stream = UnboundedReceiverStream::new(stream_rx).map(Annotated::from_data);
         Ok(ResponseStream::new(Box::pin(stream), ctx.context()))
-    }
-}
-
-pub struct AnnotatedMockEngine {
-    inner: Arc<MockEngine>,
-}
-
-impl AnnotatedMockEngine {
-    pub fn new(
-        inner: MockEngine,
-        distributed_runtime: DistributedRuntime,
-        endpoint_id: dynamo_runtime::protocols::EndpointId,
-    ) -> Self {
-        let inner = Arc::new(inner);
-        let inner_clone = inner.clone();
-
-        // Start background task to wait for component service and start the engine
-        let cancel_token = distributed_runtime.primary_token();
-        tokio::spawn(async move {
-            let component = loop {
-                if cancel_token.is_cancelled() {
-                    tracing::debug!("Mocker engine startup cancelled");
-                    return;
-                }
-
-                let ready = distributed_runtime
-                    .namespace(&endpoint_id.namespace)
-                    .and_then(|ns| ns.component(&endpoint_id.component))
-                    .ok();
-
-                if let Some(comp) = ready
-                    && let Ok(instances) = comp.list_instances().await
-                    && !instances.is_empty()
-                {
-                    break comp;
-                }
-
-                tracing::debug!("Component service not available yet, retrying...");
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            };
-
-            tracing::debug!("Component service is now available, starting mocker engine");
-            let endpoint = component.endpoint(endpoint_id.name);
-            if let Err(e) = inner_clone.start(endpoint).await {
-                tracing::error!("Failed to start mocker engine: {e}");
-            }
-        });
-
-        Self { inner }
-    }
-}
-
-#[async_trait]
-impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
-    for AnnotatedMockEngine
-{
-    async fn generate(
-        &self,
-        input: SingleIn<PreprocessedRequest>,
-    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
-        let stream = self.inner.generate(input).await?;
-        let context = stream.context();
-
-        // Convert stream of LLMEngineOutput to Annotated<LLMEngineOutput>
-        let annotated_stream = stream.map(Annotated::from_data);
-
-        Ok(ResponseStream::new(Box::pin(annotated_stream), context))
     }
 }
 
@@ -1224,12 +1074,40 @@ pub async fn make_mocker_engine(
     endpoint_id: dynamo_runtime::protocols::EndpointId,
     args: MockEngineArgs,
 ) -> Result<ExecutionContext, Error> {
-    // Create the mocker engine
     tracing::info!("Creating mocker engine with config: {args:?}");
-    let annotated_engine =
-        AnnotatedMockEngine::new(MockEngine::new(args), distributed_runtime, endpoint_id);
+    let engine = Arc::new(MockerExecutionContext::new(args));
+    let startup_engine = Arc::clone(&engine);
+    let cancel_token = distributed_runtime.primary_token();
+    tokio::spawn(async move {
+        let component = loop {
+            if cancel_token.is_cancelled() {
+                tracing::debug!("Mocker engine startup cancelled");
+                return;
+            }
 
-    Ok(Arc::new(annotated_engine))
+            let ready = distributed_runtime
+                .namespace(&endpoint_id.namespace)
+                .and_then(|namespace| namespace.component(&endpoint_id.component))
+                .ok();
+            if let Some(component) = ready
+                && let Ok(instances) = component.list_instances().await
+                && !instances.is_empty()
+            {
+                break component;
+            }
+
+            tracing::debug!("Component service not available yet, retrying...");
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        };
+
+        tracing::debug!("Component service is now available, starting mocker engine");
+        let endpoint = component.endpoint(endpoint_id.name);
+        if let Err(error) = startup_engine.start(endpoint).await {
+            tracing::error!("Failed to start mocker engine: {error}");
+        }
+    });
+
+    Ok(engine)
 }
 
 #[cfg(test)]
@@ -1237,9 +1115,10 @@ mod tests {
     use super::*;
     use crate::protocols::common::llm_backend::PreprocessedRequest;
     use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
-    use dynamo_mocker::common::protocols::{MockEngineArgs, OutputSignal, WorkerType};
+    use dynamo_mocker::common::protocols::{MockEngineArgs, WorkerType};
     use dynamo_runtime::pipeline::{AsyncEngine, SingleIn};
     use futures::StreamExt;
+    use std::collections::BTreeMap;
     use std::io::Write;
     use std::time::Duration;
 
@@ -1279,32 +1158,22 @@ mod tests {
     async fn no_bootstrap_prefill_delays_terminal_finish_once() {
         let args = MockEngineArgs::builder()
             .worker_type(WorkerType::Prefill)
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .speedup_ratio(1000.0)
+            .kv_transfer_bandwidth(Some(1.0))
+            .kv_bytes_per_token(Some(25_000_000))
             .build()
             .unwrap();
-        let engine = MockEngine::new(args);
-        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
-        engine.request_senders.set(vec![request_tx]).unwrap();
+        let live = LiveEngine::start(args.clone(), 0).unwrap();
+        let engine = MockerExecutionContext::new(args);
+        assert!(engine.engines.set(vec![live]).is_ok());
+        let mut request = prefill_request();
+        request.token_ids = vec![1, 2, 3, 4];
 
-        let mut stream = engine
-            .generate(SingleIn::new(prefill_request()))
-            .await
-            .unwrap();
-        let request = request_rx.recv().await.unwrap();
-        let request_id = request.uuid.unwrap();
-        engine
-            .active_requests
-            .get(&request_id)
-            .unwrap()
-            .send(OutputSignal {
-                uuid: request_id,
-                token_id: None,
-                completed: true,
-                rejected: false,
-                handoff_delay_ms: Some(100.0),
-            })
-            .unwrap();
-
-        let token = stream.next().await.unwrap();
+        let mut stream = engine.generate(SingleIn::new(request)).await.unwrap();
+        let token = stream.next().await.unwrap().data.unwrap();
         assert_eq!(token.token_ids.len(), 1);
         assert!(token.finish_reason.is_none());
         assert!(
@@ -1314,7 +1183,7 @@ mod tests {
         );
 
         tokio::time::advance(Duration::from_millis(1)).await;
-        let finish = stream.next().await.unwrap();
+        let finish = stream.next().await.unwrap().data.unwrap();
         assert!(finish.token_ids.is_empty());
         assert!(finish.finish_reason.is_some());
         assert!(stream.next().await.is_none());
@@ -1324,37 +1193,74 @@ mod tests {
     async fn context_capped_completion_maps_to_length() {
         let args = MockEngineArgs::builder()
             .max_model_len(Some(4))
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .speedup_ratio(1000.0)
             .build()
             .unwrap();
-        let engine = MockEngine::new(args);
-        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
-        engine.request_senders.set(vec![request_tx]).unwrap();
+        let live = LiveEngine::start(args.clone(), 0).unwrap();
+        let engine = MockerExecutionContext::new(args);
+        assert!(engine.engines.set(vec![live]).is_ok());
 
         let mut stream = engine
             .generate(SingleIn::new(decode_request(3, 4)))
             .await
             .unwrap();
-        let request = request_rx.recv().await.unwrap();
-        assert_eq!(request.max_output_tokens, 4);
-        let request_id = request.uuid.unwrap();
-        engine
-            .active_requests
-            .get(&request_id)
-            .unwrap()
-            .send(OutputSignal {
-                uuid: request_id,
-                token_id: Some(42),
-                completed: true,
-                rejected: false,
-                handoff_delay_ms: None,
-            })
-            .unwrap();
-
-        let token = stream.next().await.unwrap();
+        let token = stream.next().await.unwrap().data.unwrap();
         assert_eq!(token.token_ids.len(), 1);
         assert!(token.finish_reason.is_none());
-        assert_eq!(stream.next().await.unwrap(), LLMEngineOutput::length());
+        assert_eq!(
+            stream.next().await.unwrap().data.unwrap(),
+            LLMEngineOutput::length()
+        );
         assert!(stream.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_response_cancels_live_request_and_allows_id_reuse() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .speedup_ratio(0.1)
+            .build()
+            .unwrap();
+        let live = LiveEngine::start(args.clone(), 0).unwrap();
+        let engine = MockerExecutionContext::new(args);
+        assert!(engine.engines.set(vec![live.clone()]).is_ok());
+        let request_id = Uuid::from_u128(99);
+        let input = SingleIn::with_id_and_metadata(
+            decode_request(1, 100),
+            request_id.to_string(),
+            BTreeMap::new(),
+        );
+        let stream = engine.generate(input).await.unwrap();
+        drop(stream);
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let metrics = live.metrics_receiver().borrow().clone();
+                if live.active_request_count() == 0
+                    && metrics.running_requests == 0
+                    && metrics.waiting_requests == 0
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropped response must cancel its live request");
+
+        let input = SingleIn::with_id_and_metadata(
+            decode_request(1, 1),
+            request_id.to_string(),
+            BTreeMap::new(),
+        );
+        let mut replacement = engine.generate(input).await.unwrap();
+        while replacement.next().await.is_some() {}
+        assert_eq!(live.active_request_count(), 0);
     }
 
     #[test]
@@ -1387,15 +1293,14 @@ mod tests {
             .unwrap()
             .normalized()
             .unwrap();
-        let engine = MockEngine::new(args);
+        let engine = MockerExecutionContext::new(args);
 
         assert!(engine.prepare_bootstrap().await.is_err());
-        assert!(engine.request_senders.get().is_none());
-        assert!(engine.command_senders.get().is_none());
+        assert!(engine.engines.get().is_none());
         assert!(engine.handoff_session_permits.get().is_none());
-        assert!(engine._schedulers.get().is_none());
+        assert!(engine._relay_publishers.get().is_none());
         assert!(!engine.handoff_shutdown.is_cancelled());
-        assert!(!engine.scheduler_shutdown.is_cancelled());
+        assert!(!engine.metrics_shutdown.is_cancelled());
 
         drop(occupied);
         let prepared = engine

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -1124,7 +1124,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
                         if signal.completed {
                             if !send_response(&stream_tx, output, &async_context).await {
-                                tracing::error!("Output stream receiver closed.");
                                 break;
                             }
                             native_timing.record_tokens(1);
@@ -1194,7 +1193,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                             )
                             .await
                             {
-                                tracing::error!("Output stream receiver closed.");
                                 break;
                             }
                             native_timing.record_normal_completion();
@@ -1203,7 +1201,6 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                         }
 
                         if !send_response(&stream_tx, output, &async_context).await {
-                            tracing::error!("Output stream receiver closed.");
                             break;
                         }
                         native_timing.record_tokens(1);

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -47,7 +47,7 @@ use futures::StreamExt;
 use rand::Rng;
 use serde::Deserialize;
 use tokio::sync::{OnceCell, Semaphore, mpsc, oneshot, watch};
-use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use uuid::Uuid;
@@ -59,7 +59,6 @@ use self::handoff::{
 use self::metrics::NativeMockerMetrics;
 
 pub const MOCKER_COMPONENT: &str = "mocker";
-const RESPONSE_STREAM_CAPACITY: usize = 8;
 
 #[derive(Debug, Clone, Deserialize)]
 struct ResponseReplayTraceRow {
@@ -220,7 +219,7 @@ fn no_bootstrap_handoff_delay(
 }
 
 async fn send_response(
-    stream_tx: &mpsc::Sender<LLMEngineOutput>,
+    stream_tx: &mpsc::UnboundedSender<LLMEngineOutput>,
     output: LLMEngineOutput,
     context: &Arc<dyn AsyncEngineContext>,
 ) -> bool {
@@ -228,10 +227,10 @@ async fn send_response(
         biased;
         _ = stream_tx.closed() => false,
         _ = context.stopped() => {
-            let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+            let _ = stream_tx.send(LLMEngineOutput::cancelled());
             false
         }
-        result = stream_tx.send(output) => result.is_ok(),
+        result = async { stream_tx.send(output) } => result.is_ok(),
     }
 }
 
@@ -857,7 +856,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             ..Default::default()
         };
 
-        let (stream_tx, stream_rx) = mpsc::channel::<LLMEngineOutput>(RESPONSE_STREAM_CAPACITY);
+        let (stream_tx, stream_rx) = mpsc::unbounded_channel::<LLMEngineOutput>();
 
         let handoff_id = request
             .bootstrap_info
@@ -1139,7 +1138,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                                 _ = stream_tx.closed() => false,
                                 _ = async_context.stopped() => {
                                     handoff_cancel.cancel();
-                                    let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+                                    let _ = stream_tx.send(LLMEngineOutput::cancelled());
                                     false
                                 }
                             };
@@ -1158,7 +1157,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                                     }
                                     _ = async_context.stopped() => {
                                         handoff_cancel.cancel();
-                                        let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+                                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
                                         break;
                                     }
                                 };
@@ -1212,7 +1211,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 
                     _ = async_context.stopped() => {
                         handoff_cancel.cancel();
-                        let _ = stream_tx.try_send(LLMEngineOutput::cancelled());
+                        let _ = stream_tx.send(LLMEngineOutput::cancelled());
                         break;
                     }
 
@@ -1237,7 +1236,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             tokio::spawn(response_task);
         }
 
-        let stream = ReceiverStream::new(stream_rx).map(Annotated::from_data);
+        let stream = UnboundedReceiverStream::new(stream_rx).map(Annotated::from_data);
         Ok(ResponseStream::new(Box::pin(stream), ctx.context()))
     }
 }
@@ -1447,6 +1446,44 @@ mod tests {
         let mut replacement = engine.generate(input).await.unwrap();
         while replacement.next().await.is_some() {}
         assert_eq!(live.active_request_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn unread_response_completes_without_overflow_cancellation() {
+        let args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(64))
+            .speedup_ratio(1000.0)
+            .build()
+            .unwrap();
+        let live = LiveEngine::start(args.clone(), 0).unwrap();
+        let engine = MockerExecutionContext::new(args);
+        assert!(engine.engines.set(vec![live.clone()]).is_ok());
+
+        let mut stream = engine
+            .generate(SingleIn::new(decode_request(1, 32)))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while live.active_request_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("generation should finish while the response remains unread");
+
+        let mut output_tokens = 0;
+        let mut finish = None;
+        while let Some(output) = stream.next().await {
+            let output = output.data.unwrap();
+            output_tokens += output.token_ids.len();
+            if output.finish_reason.is_some() {
+                finish = output.finish_reason;
+            }
+        }
+        assert_eq!(output_tokens, 32);
+        assert_eq!(finish, LLMEngineOutput::length().finish_reason);
     }
 
     #[test]

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -1511,7 +1511,7 @@ pub(crate) async fn cancel_destination(control: &HandoffControl, timeout: Durati
 fn action_outcome(result: Result<HandoffActionOutcome>) -> HandoffActionOutcome {
     match result {
         Ok(outcome) => outcome,
-        Err(error) => return HandoffActionOutcome::Failed(error.to_string()),
+        Err(error) => HandoffActionOutcome::Failed(error.to_string()),
     }
 }
 

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -6,17 +6,15 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow, bail};
-use dashmap::DashMap;
-use dashmap::mapref::entry::Entry;
+use async_trait::async_trait;
 use dynamo_mocker::common::handoff::{
     HandoffAction, HandoffActionId, HandoffActionOutcome, HandoffCoordinatorCore, HandoffFact,
     HandoffId, HandoffOrder, HandoffTransferTiming, IssuedHandoffAction, NormalizedHandoffEvent,
     validate_transfer_delay_ms, validate_transfer_timing,
 };
-use dynamo_mocker::common::protocols::{DirectRequest, EngineType, KvTransferTimingMode};
-use dynamo_mocker::scheduler::{
-    SchedulerCommand, SchedulerCommandEffects, SchedulerCommandEnvelope, SchedulerCommandResult,
-    SchedulerLifecycleEvent,
+use dynamo_mocker::common::protocols::{EngineType, KvTransferTimingMode};
+use dynamo_mocker::live::{
+    LiveHandoffControl, LiveHandoffEvent, LiveHandoffEvents, LiveRequestRegistration,
 };
 use dynamo_mocker::services::bootstrap::{
     BootstrapConnection, BootstrapIdentity, BootstrapMessage, IncomingBootstrapConnection,
@@ -59,99 +57,129 @@ pub(crate) fn order_for_engine(engine_type: EngineType) -> Result<HandoffOrder> 
     }
 }
 
-#[derive(Clone, Default)]
-pub(crate) struct HandoffEventRegistry {
-    routes: Arc<DashMap<HandoffId, mpsc::Sender<HandoffEventEnvelope>>>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum HandoffControlAction {
+    SubmitPrefill,
+    ReleaseSource,
+    CancelSource,
+    ReserveDestination,
+    ActivateDestination,
+    CancelDestination,
 }
 
-struct HandoffEventEnvelope {
-    event: SchedulerLifecycleEvent,
-    #[cfg(test)]
-    received: Option<oneshot::Sender<()>>,
+#[async_trait]
+trait HandoffSchedulerControl: Send + Sync {
+    async fn execute(&self, action: HandoffControlAction) -> Result<HandoffActionOutcome>;
 }
 
-impl HandoffEventRegistry {
-    pub(crate) fn register(&self, handoff_id: HandoffId) -> Result<HandoffEventRoute> {
-        let (tx, rx) = mpsc::channel(SESSION_INBOX_CAPACITY);
-        match self.routes.entry(handoff_id) {
-            Entry::Vacant(entry) => {
-                entry.insert(tx);
+#[derive(Clone)]
+pub(crate) struct HandoffControl {
+    inner: Arc<dyn HandoffSchedulerControl>,
+}
+
+impl HandoffControl {
+    fn new(inner: Arc<dyn HandoffSchedulerControl>) -> Self {
+        Self { inner }
+    }
+
+    async fn execute(&self, action: HandoffControlAction) -> Result<HandoffActionOutcome> {
+        self.inner.execute(action).await
+    }
+}
+
+struct LiveHandoffAdapter {
+    control: LiveHandoffControl,
+    registration: tokio::sync::Mutex<Option<LiveRequestRegistration>>,
+}
+
+#[async_trait]
+impl HandoffSchedulerControl for LiveHandoffAdapter {
+    async fn execute(&self, action: HandoffControlAction) -> Result<HandoffActionOutcome> {
+        match action {
+            HandoffControlAction::SubmitPrefill => {
+                let registration = self
+                    .registration
+                    .lock()
+                    .await
+                    .take()
+                    .ok_or_else(|| anyhow!("source request was submitted more than once"))?;
+                self.control.submit_prefill(registration).await?;
+                Ok(HandoffActionOutcome::Submitted)
             }
-            Entry::Occupied(_) => {
-                bail!("handoff {handoff_id:?} already has a lifecycle route");
+            HandoffControlAction::ReserveDestination => {
+                let registration =
+                    self.registration.lock().await.take().ok_or_else(|| {
+                        anyhow!("destination request was reserved more than once")
+                    })?;
+                self.control.reserve_destination(registration).await?;
+                Ok(HandoffActionOutcome::Accepted)
+            }
+            HandoffControlAction::ReleaseSource => {
+                self.control.release_source().await?;
+                Ok(HandoffActionOutcome::Applied)
+            }
+            HandoffControlAction::CancelSource => {
+                self.control.cancel_source().await?;
+                Ok(HandoffActionOutcome::Applied)
+            }
+            HandoffControlAction::ActivateDestination => {
+                self.control.activate_destination().await?;
+                Ok(HandoffActionOutcome::Applied)
+            }
+            HandoffControlAction::CancelDestination => {
+                self.control.cancel_destination().await?;
+                Ok(HandoffActionOutcome::Applied)
             }
         }
-        Ok(HandoffEventRoute {
-            handoff_id,
-            routes: self.routes.clone(),
-            rx,
-        })
-    }
-
-    pub(crate) async fn deliver(&self, event: SchedulerLifecycleEvent) {
-        let handoff_id = event.handoff_id();
-        let sender = self.routes.get(&handoff_id).map(|entry| entry.clone());
-        if let Some(sender) = sender {
-            let _ = sender
-                .send(HandoffEventEnvelope {
-                    event,
-                    #[cfg(test)]
-                    received: None,
-                })
-                .await;
-        }
-    }
-
-    #[cfg(test)]
-    async fn deliver_and_wait(&self, event: SchedulerLifecycleEvent) {
-        let handoff_id = event.handoff_id();
-        let Some(sender) = self.routes.get(&handoff_id).map(|entry| entry.clone()) else {
-            return;
-        };
-        let (received, wait) = oneshot::channel();
-        if sender
-            .send(HandoffEventEnvelope {
-                event,
-                received: Some(received),
-            })
-            .await
-            .is_ok()
-        {
-            let _ = wait.await;
-        }
     }
 }
 
-pub(crate) struct HandoffEventRoute {
-    handoff_id: HandoffId,
-    routes: Arc<DashMap<HandoffId, mpsc::Sender<HandoffEventEnvelope>>>,
-    rx: mpsc::Receiver<HandoffEventEnvelope>,
+#[async_trait]
+trait HandoffEventStream: Send {
+    async fn recv(&mut self) -> Option<LiveHandoffEvent>;
 }
 
-impl HandoffEventRoute {
-    async fn recv(&mut self) -> Option<SchedulerLifecycleEvent> {
-        let envelope = self.rx.recv().await?;
-        #[cfg(test)]
-        if let Some(received) = envelope.received {
-            let _ = received.send(());
-        }
-        Some(envelope.event)
+#[async_trait]
+impl HandoffEventStream for LiveHandoffEvents {
+    async fn recv(&mut self) -> Option<LiveHandoffEvent> {
+        LiveHandoffEvents::recv(self).await
     }
 }
 
-impl Drop for HandoffEventRoute {
-    fn drop(&mut self) {
-        self.routes.remove(&self.handoff_id);
+pub(crate) struct HandoffEvents {
+    inner: Box<dyn HandoffEventStream>,
+}
+
+impl HandoffEvents {
+    fn new(inner: Box<dyn HandoffEventStream>) -> Self {
+        Self { inner }
     }
+
+    async fn recv(&mut self) -> Option<LiveHandoffEvent> {
+        self.inner.recv().await
+    }
+}
+
+pub(crate) fn live_handoff_boundary(
+    control: LiveHandoffControl,
+    events: LiveHandoffEvents,
+    registration: LiveRequestRegistration,
+) -> (HandoffControl, HandoffEvents) {
+    (
+        HandoffControl::new(Arc::new(LiveHandoffAdapter {
+            control,
+            registration: tokio::sync::Mutex::new(Some(registration)),
+        })),
+        HandoffEvents::new(Box::new(events)),
+    )
 }
 
 pub(crate) struct SourceRegistration {
     pub identity: BootstrapIdentity,
     pub order: HandoffOrder,
     pub engine_type: EngineType,
-    pub request: DirectRequest,
-    pub command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
-    pub lifecycle: HandoffEventRoute,
+    pub control: HandoffControl,
+    pub lifecycle: HandoffEvents,
     pub completion_tx: oneshot::Sender<Result<(), String>>,
     pub cancel: CancellationToken,
     pub observer: Option<mpsc::UnboundedSender<NormalizedHandoffEvent>>,
@@ -170,8 +198,6 @@ pub(crate) struct SourceHandoffManager {
 #[derive(Clone, Default)]
 struct SourceHandoffManagerTestState {
     pending_sources: HashSet<HandoffId>,
-    pending_destinations: HashSet<HandoffId>,
-    active: HashSet<HandoffId>,
     retired: HashSet<HandoffId>,
 }
 
@@ -243,22 +269,6 @@ impl SourceHandoffManager {
         let mut state = self.state_rx.clone();
         let _ = state
             .wait_for(|state| state.pending_sources.contains(&handoff_id))
-            .await;
-    }
-
-    #[cfg(test)]
-    async fn wait_for_pending_destination(&self, handoff_id: HandoffId) {
-        let mut state = self.state_rx.clone();
-        let _ = state
-            .wait_for(|state| state.pending_destinations.contains(&handoff_id))
-            .await;
-    }
-
-    #[cfg(test)]
-    async fn wait_for_active(&self, handoff_id: HandoffId) {
-        let mut state = self.state_rx.clone();
-        let _ = state
-            .wait_for(|state| state.active.contains(&handoff_id))
             .await;
     }
 
@@ -490,16 +500,8 @@ async fn run_manager(
                 .iter()
                 .filter_map(|(handoff_id, session)| session.source.is_some().then_some(*handoff_id))
                 .collect();
-            let pending_destinations = pending
-                .iter()
-                .filter_map(|(handoff_id, session)| {
-                    session.destination.is_some().then_some(*handoff_id)
-                })
-                .collect();
             let _ = state_tx.send(SourceHandoffManagerTestState {
                 pending_sources,
-                pending_destinations,
-                active: active.clone(),
                 retired: retired.keys().copied().collect(),
             });
         }
@@ -656,7 +658,7 @@ fn prune_retired(
 }
 
 enum SourceSessionEvent {
-    Scheduler(SchedulerLifecycleEvent),
+    Scheduler(LiveHandoffEvent),
     Remote(std::result::Result<Option<BootstrapMessage>, String>),
     LocalOutcome {
         action_id: HandoffActionId,
@@ -805,8 +807,7 @@ async fn run_source_session(
         identity,
         order,
         engine_type: _,
-        request,
-        command_tx,
+        control,
         mut lifecycle,
         completion_tx,
         cancel,
@@ -842,7 +843,6 @@ async fn run_source_session(
     queue_source_message(&outbound_tx, BootstrapMessage::Registered)?;
     let mut coordinator = HandoffCoordinatorCore::new(handoff_id, order);
     let mut actions = VecDeque::from(coordinator.start()?);
-    let mut request = Some(request);
     let deadline = tokio::time::sleep_until(session_deadline);
     tokio::pin!(deadline);
 
@@ -850,14 +850,11 @@ async fn run_source_session(
         loop {
             while let Some(action) = actions.pop_front() {
                 match action.action {
-                    HandoffAction::SubmitPrefill { handoff_id } => {
-                        let Some(request) = request.take() else {
-                            bail!("source request was submitted more than once");
-                        };
+                    HandoffAction::SubmitPrefill { .. } => {
                         if pending_submit_action.replace(action.id).is_some() {
                             bail!("source prefill submission was already pending");
                         }
-                        let command_tx = command_tx.clone();
+                        let control = control.clone();
                         let event_tx = event_tx.clone();
                         let cancel = cancel.clone();
                         let shutdown = shutdown.clone();
@@ -867,12 +864,9 @@ async fn run_source_session(
                             let result = tokio::select! {
                                 biased;
                                 _ = action_stop.cancelled() => return,
-                                result = send_source_command(
-                                    &command_tx,
-                                    SchedulerCommand::SubmitHandoffPrefill {
-                                        handoff_id,
-                                        request,
-                                    },
+                                result = execute_source_action(
+                                    &control,
+                                    HandoffControlAction::SubmitPrefill,
                                     deadline,
                                     &cancel,
                                     &shutdown,
@@ -883,10 +877,7 @@ async fn run_source_session(
                                 &action_stop,
                                 SourceSessionEvent::LocalOutcome {
                                     action_id: action.id,
-                                    outcome: command_outcome(
-                                        result,
-                                        SchedulerCommandResultKind::Submitted,
-                                    ),
+                                    outcome: action_outcome(result),
                                 },
                             )
                             .await;
@@ -920,26 +911,23 @@ async fn run_source_session(
                             }
                         });
                     }
-                    HandoffAction::ReleaseSource { handoff_id }
-                    | HandoffAction::CancelSource { handoff_id } => {
+                    HandoffAction::ReleaseSource { .. } | HandoffAction::CancelSource { .. } => {
                         if matches!(action.action, HandoffAction::ReleaseSource { .. }) {
                             observe_handoff(
                                 &observer,
                                 NormalizedHandoffEvent::DestinationActivated,
                             );
                         }
-                        let (command, expected) = match action.action {
-                            HandoffAction::ReleaseSource { .. } => (
-                                SchedulerCommand::ReleaseSource { handoff_id },
-                                SchedulerCommandResultKind::AppliedOrNoop,
-                            ),
-                            HandoffAction::CancelSource { .. } => (
-                                SchedulerCommand::CancelSource { handoff_id },
-                                SchedulerCommandResultKind::AppliedOrNoop,
-                            ),
+                        let control_action = match action.action {
+                            HandoffAction::ReleaseSource { .. } => {
+                                HandoffControlAction::ReleaseSource
+                            }
+                            HandoffAction::CancelSource { .. } => {
+                                HandoffControlAction::CancelSource
+                            }
                             _ => unreachable!(),
                         };
-                        let command_tx = command_tx.clone();
+                        let control = control.clone();
                         let event_tx = event_tx.clone();
                         let cancel = cancel.clone();
                         let shutdown = shutdown.clone();
@@ -949,9 +937,9 @@ async fn run_source_session(
                             let result = tokio::select! {
                                 biased;
                                 _ = action_stop.cancelled() => return,
-                                result = send_source_command(
-                                    &command_tx,
-                                    command,
+                                result = execute_source_action(
+                                    &control,
+                                    control_action,
                                     deadline,
                                     &cancel,
                                     &shutdown,
@@ -962,7 +950,7 @@ async fn run_source_session(
                                 &action_stop,
                                 SourceSessionEvent::LocalOutcome {
                                     action_id: action.id,
-                                    outcome: command_outcome(result, expected),
+                                    outcome: action_outcome(result),
                                 },
                             )
                             .await;
@@ -1027,11 +1015,7 @@ async fn run_source_session(
                 })?,
             };
             match event {
-                SourceSessionEvent::Scheduler(SchedulerLifecycleEvent::SourceHeld {
-                    handoff_id: observed,
-                    transfer_timing,
-                    ..
-                }) if observed == handoff_id => {
+                SourceSessionEvent::Scheduler(LiveHandoffEvent::SourceHeld { transfer_timing }) => {
                     validate_transfer_timing(transfer_timing)?;
                     source_transfer_timing = Some(transfer_timing);
                     if let Some(Some(timeout_delay)) = transfer_timeout_delay(
@@ -1066,12 +1050,9 @@ async fn run_source_session(
                         transfer_timing,
                     )?;
                 }
-                SourceSessionEvent::Scheduler(SchedulerLifecycleEvent::SourceHeld { .. }) => {
-                    bail!("source lifecycle event belongs to another handoff")
+                SourceSessionEvent::Scheduler(LiveHandoffEvent::DestinationReserved { .. }) => {
+                    bail!("source scheduler emitted a destination lifecycle event")
                 }
-                SourceSessionEvent::Scheduler(SchedulerLifecycleEvent::DestinationReserved {
-                    ..
-                }) => bail!("source scheduler emitted a destination lifecycle event"),
                 SourceSessionEvent::Remote(Ok(Some(BootstrapMessage::ActionAck {
                     action_id,
                     outcome,
@@ -1166,9 +1147,9 @@ async fn run_source_session(
     if let Err(error) = &result {
         let cleanup_deadline =
             tokio::time::Instant::now() + session_timeout.max(PARTICIPANT_RENDEZVOUS_TIMEOUT);
-        let cleanup = send_cleanup_command(
-            &command_tx,
-            SchedulerCommand::CancelSource { handoff_id },
+        let cleanup = execute_cleanup_action(
+            &control,
+            HandoffControlAction::CancelSource,
             cleanup_deadline,
         );
         let abort = send_source_message_and_wait(
@@ -1192,15 +1173,13 @@ async fn run_source_session(
 
 pub(crate) async fn run_destination_session(
     mut connection: BootstrapConnection,
-    request: DirectRequest,
-    command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
-    mut lifecycle: HandoffEventRoute,
+    control: HandoffControl,
+    mut lifecycle: HandoffEvents,
     cancel: CancellationToken,
     session_timeout: Duration,
     shutdown: CancellationToken,
 ) -> Result<()> {
     let handoff_id = connection.identity().handoff_id;
-    let mut request = Some(request);
     let mut outcomes = HashMap::<HandoffActionId, (HandoffAction, HandoffActionOutcome)>::new();
     let mut complete = false;
     let mut session_started = None;
@@ -1272,13 +1251,9 @@ pub(crate) async fn run_destination_session(
                     break;
                 };
                 match event {
-                    SchedulerLifecycleEvent::DestinationReserved {
-                        handoff_id: observed,
+                    LiveHandoffEvent::DestinationReserved {
                         transferable_prompt_tokens: observed_transferable_prompt_tokens,
-                        ..
-                    }
-                        if observed == handoff_id =>
-                    {
+                    } => {
                         if destination_reserved_sent || pending_destination_reserved.is_some() {
                             continue;
                         }
@@ -1322,10 +1297,9 @@ pub(crate) async fn run_destination_session(
                             bail!("destination reserved before its action was pending");
                         }
                     }
-                    SchedulerLifecycleEvent::SourceHeld { .. } => {
+                    LiveHandoffEvent::SourceHeld { .. } => {
                         bail!("destination scheduler emitted a source lifecycle event")
                     }
-                    _ => bail!("destination lifecycle event belongs to another handoff"),
                 }
             }
             message = connection.recv() => {
@@ -1387,10 +1361,7 @@ pub(crate) async fn run_destination_session(
                         if outcomes.len() >= 16 {
                             bail!("bootstrap action outcome cache exceeded its bound");
                         }
-                        let (command, expected) = match prepare_destination_action(
-                            &mut request,
-                            action,
-                        ) {
+                        let control_action = match prepare_destination_action(action) {
                             Ok(prepared) => prepared,
                             Err(outcome) => {
                                 outcomes.insert(action.id, (action.action, outcome.clone()));
@@ -1402,7 +1373,7 @@ pub(crate) async fn run_destination_session(
                             }
                         };
                         pending_action = Some(action);
-                        let command_tx = command_tx.clone();
+                        let control = control.clone();
                         let cancel = cancel.clone();
                         let shutdown = shutdown.clone();
                         let action_stop = action_stop.clone();
@@ -1412,15 +1383,15 @@ pub(crate) async fn run_destination_session(
                             let result = tokio::select! {
                                 biased;
                                 _ = action_stop.cancelled() => return,
-                                result = send_destination_command(
-                                    &command_tx,
-                                    command,
+                                result = execute_destination_action(
+                                    &control,
+                                    control_action,
                                     action_deadline,
                                     &cancel,
                                     &shutdown,
                                 ) => result,
                             };
-                            let outcome = command_outcome(result, expected);
+                            let outcome = action_outcome(result);
                             tokio::select! {
                                 biased;
                                 _ = action_stop.cancelled() => {}
@@ -1456,9 +1427,9 @@ pub(crate) async fn run_destination_session(
     if !matches!(result, Ok(true)) {
         let cleanup_deadline =
             tokio::time::Instant::now() + session_timeout.max(PARTICIPANT_RENDEZVOUS_TIMEOUT);
-        let _ = send_cleanup_command(
-            &command_tx,
-            SchedulerCommand::CancelDestination { handoff_id },
+        let _ = execute_cleanup_action(
+            &control,
+            HandoffControlAction::CancelDestination,
             cleanup_deadline,
         )
         .await;
@@ -1471,147 +1442,76 @@ pub(crate) async fn run_destination_session(
 }
 
 fn prepare_destination_action(
-    request: &mut Option<DirectRequest>,
     action: IssuedHandoffAction,
-) -> std::result::Result<(SchedulerCommand, SchedulerCommandResultKind), HandoffActionOutcome> {
-    let (command, expected) = match action.action {
-        HandoffAction::ReserveDestination { handoff_id } => {
-            let Some(request) = request.take() else {
-                return Err(HandoffActionOutcome::Failed(
-                    "destination request was reserved more than once".to_string(),
-                ));
-            };
-            (
-                SchedulerCommand::ReserveDestination {
-                    handoff_id,
-                    request,
-                },
-                SchedulerCommandResultKind::Accepted,
-            )
-        }
-        HandoffAction::ActivateDestination { handoff_id } => (
-            SchedulerCommand::ActivateDestination { handoff_id },
-            SchedulerCommandResultKind::Applied,
-        ),
-        HandoffAction::CancelDestination { handoff_id } => (
-            SchedulerCommand::CancelDestination { handoff_id },
-            SchedulerCommandResultKind::AppliedOrNoop,
-        ),
+) -> std::result::Result<HandoffControlAction, HandoffActionOutcome> {
+    let action = match action.action {
+        HandoffAction::ReserveDestination { .. } => HandoffControlAction::ReserveDestination,
+        HandoffAction::ActivateDestination { .. } => HandoffControlAction::ActivateDestination,
+        HandoffAction::CancelDestination { .. } => HandoffControlAction::CancelDestination,
         _ => {
             return Err(HandoffActionOutcome::Failed(
                 "source sent a non-destination scheduler action".to_string(),
             ));
         }
     };
-    Ok((command, expected))
+    Ok(action)
 }
 
-async fn send_source_command(
-    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
-    command: SchedulerCommand,
+async fn execute_source_action(
+    control: &HandoffControl,
+    action: HandoffControlAction,
     deadline: tokio::time::Instant,
     cancel: &CancellationToken,
     shutdown: &CancellationToken,
-) -> Result<SchedulerCommandEffects> {
+) -> Result<HandoffActionOutcome> {
     tokio::select! {
         biased;
         _ = shutdown.cancelled() => bail!("mocker is shutting down"),
         _ = cancel.cancelled() => bail!("source request was canceled"),
         _ = tokio::time::sleep_until(deadline) => bail!("handoff session timed out"),
-        result = send_command(command_tx, command) => result,
+        result = control.execute(action) => result,
     }
 }
 
-async fn send_destination_command(
-    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
-    command: SchedulerCommand,
+async fn execute_destination_action(
+    control: &HandoffControl,
+    action: HandoffControlAction,
     deadline: tokio::time::Instant,
     cancel: &CancellationToken,
     shutdown: &CancellationToken,
-) -> Result<SchedulerCommandEffects> {
+) -> Result<HandoffActionOutcome> {
     tokio::select! {
         biased;
         _ = shutdown.cancelled() => bail!("mocker is shutting down"),
         _ = cancel.cancelled() => bail!("destination request was canceled"),
         _ = tokio::time::sleep_until(deadline) => bail!("handoff session timed out"),
-        result = send_command(command_tx, command) => result,
+        result = control.execute(action) => result,
     }
 }
 
-async fn send_cleanup_command(
-    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
-    command: SchedulerCommand,
+async fn execute_cleanup_action(
+    control: &HandoffControl,
+    action: HandoffControlAction,
     deadline: tokio::time::Instant,
-) -> Result<SchedulerCommandEffects> {
-    tokio::time::timeout_at(deadline, send_command(command_tx, command))
+) -> Result<HandoffActionOutcome> {
+    tokio::time::timeout_at(deadline, control.execute(action))
         .await
         .map_err(|_| anyhow!("scheduler cleanup command timed out"))?
 }
 
-async fn send_command(
-    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
-    command: SchedulerCommand,
-) -> Result<SchedulerCommandEffects> {
-    let (reply_tx, reply_rx) = oneshot::channel();
-    command_tx
-        .send(SchedulerCommandEnvelope {
-            command,
-            reply: reply_tx,
-        })
-        .await
-        .map_err(|_| anyhow!("scheduler command channel closed"))?;
-    reply_rx
-        .await
-        .map_err(|_| anyhow!("scheduler command reply was dropped"))?
-}
-
-pub(crate) async fn cancel_destination(
-    command_tx: &mpsc::Sender<SchedulerCommandEnvelope>,
-    handoff_id: HandoffId,
-    timeout: Duration,
-) {
-    let _ = send_cleanup_command(
-        command_tx,
-        SchedulerCommand::CancelDestination { handoff_id },
+pub(crate) async fn cancel_destination(control: &HandoffControl, timeout: Duration) {
+    let _ = execute_cleanup_action(
+        control,
+        HandoffControlAction::CancelDestination,
         tokio::time::Instant::now() + timeout,
     )
     .await;
 }
 
-#[derive(Clone, Copy)]
-enum SchedulerCommandResultKind {
-    Submitted,
-    Accepted,
-    Applied,
-    AppliedOrNoop,
-}
-
-fn command_outcome(
-    result: Result<SchedulerCommandEffects>,
-    expected: SchedulerCommandResultKind,
-) -> HandoffActionOutcome {
-    let effects = match result {
-        Ok(effects) => effects,
+fn action_outcome(result: Result<HandoffActionOutcome>) -> HandoffActionOutcome {
+    match result {
+        Ok(outcome) => outcome,
         Err(error) => return HandoffActionOutcome::Failed(error.to_string()),
-    };
-    match (expected, effects.result) {
-        (SchedulerCommandResultKind::Submitted, SchedulerCommandResult::Submitted(_)) => {
-            HandoffActionOutcome::Submitted
-        }
-        (
-            SchedulerCommandResultKind::Accepted,
-            SchedulerCommandResult::DestinationAccepted { .. },
-        ) => HandoffActionOutcome::Accepted,
-        (SchedulerCommandResultKind::Applied, SchedulerCommandResult::Applied) => {
-            HandoffActionOutcome::Applied
-        }
-        (SchedulerCommandResultKind::AppliedOrNoop, SchedulerCommandResult::Applied) => {
-            HandoffActionOutcome::Applied
-        }
-        (SchedulerCommandResultKind::AppliedOrNoop, SchedulerCommandResult::Noop) => {
-            HandoffActionOutcome::Noop
-        }
-        _ => HandoffActionOutcome::Failed("scheduler returned an unexpected result".to_string()),
     }
 }
 

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -1381,7 +1381,7 @@ pub(crate) async fn run_destination_session(
                         if outcomes.len() >= 16 {
                             bail!("bootstrap action outcome cache exceeded its bound");
                         }
-                        let control_action = match prepare_destination_action(action) {
+                        let control_action = match prepare_destination_action(handoff_id, action) {
                             Ok(prepared) => prepared,
                             Err(outcome) => {
                                 outcomes.insert(action.id, (action.action, outcome.clone()));
@@ -1462,18 +1462,30 @@ pub(crate) async fn run_destination_session(
 }
 
 fn prepare_destination_action(
+    expected_handoff_id: HandoffId,
     action: IssuedHandoffAction,
 ) -> std::result::Result<HandoffControlAction, HandoffActionOutcome> {
-    let action = match action.action {
-        HandoffAction::ReserveDestination { .. } => HandoffControlAction::ReserveDestination,
-        HandoffAction::ActivateDestination { .. } => HandoffControlAction::ActivateDestination,
-        HandoffAction::CancelDestination { .. } => HandoffControlAction::CancelDestination,
+    let (observed_handoff_id, action) = match action.action {
+        HandoffAction::ReserveDestination { handoff_id } => {
+            (handoff_id, HandoffControlAction::ReserveDestination)
+        }
+        HandoffAction::ActivateDestination { handoff_id } => {
+            (handoff_id, HandoffControlAction::ActivateDestination)
+        }
+        HandoffAction::CancelDestination { handoff_id } => {
+            (handoff_id, HandoffControlAction::CancelDestination)
+        }
         _ => {
             return Err(HandoffActionOutcome::Failed(
                 "source sent a non-destination scheduler action".to_string(),
             ));
         }
     };
+    if observed_handoff_id != expected_handoff_id {
+        return Err(HandoffActionOutcome::Failed(format!(
+            "destination action handoff {observed_handoff_id:?} does not match bootstrap handoff {expected_handoff_id:?}"
+        )));
+    }
     Ok(action)
 }
 

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -198,6 +198,7 @@ pub(crate) struct SourceHandoffManager {
 #[derive(Clone, Default)]
 struct SourceHandoffManagerTestState {
     pending_sources: HashSet<HandoffId>,
+    pending_destinations: HashSet<HandoffId>,
     retired: HashSet<HandoffId>,
 }
 
@@ -269,6 +270,14 @@ impl SourceHandoffManager {
         let mut state = self.state_rx.clone();
         let _ = state
             .wait_for(|state| state.pending_sources.contains(&handoff_id))
+            .await;
+    }
+
+    #[cfg(test)]
+    async fn wait_for_pending_destination(&self, handoff_id: HandoffId) {
+        let mut state = self.state_rx.clone();
+        let _ = state
+            .wait_for(|state| state.pending_destinations.contains(&handoff_id))
             .await;
     }
 
@@ -500,8 +509,15 @@ async fn run_manager(
                 .iter()
                 .filter_map(|(handoff_id, session)| session.source.is_some().then_some(*handoff_id))
                 .collect();
+            let pending_destinations = pending
+                .iter()
+                .filter_map(|(handoff_id, session)| {
+                    session.destination.is_some().then_some(*handoff_id)
+                })
+                .collect();
             let _ = state_tx.send(SourceHandoffManagerTestState {
                 pending_sources,
+                pending_destinations,
                 retired: retired.keys().copied().collect(),
             });
         }

--- a/lib/llm/src/mocker/handoff.rs
+++ b/lib/llm/src/mocker/handoff.rs
@@ -119,6 +119,8 @@ impl HandoffSchedulerControl for LiveHandoffAdapter {
                 Ok(HandoffActionOutcome::Applied)
             }
             HandoffControlAction::CancelSource => {
+                let registration = self.registration.lock().await.take();
+                drop(registration);
                 self.control.cancel_source().await?;
                 Ok(HandoffActionOutcome::Applied)
             }
@@ -127,6 +129,8 @@ impl HandoffSchedulerControl for LiveHandoffAdapter {
                 Ok(HandoffActionOutcome::Applied)
             }
             HandoffControlAction::CancelDestination => {
+                let registration = self.registration.lock().await.take();
+                drop(registration);
                 self.control.cancel_destination().await?;
                 Ok(HandoffActionOutcome::Applied)
             }

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -2,25 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use async_trait::async_trait;
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
-use dynamo_mocker::common::handoff::{
-    HandoffCompletion, HandoffTransferTiming, NormalizedHandoffConformance, NormalizedStoredTiming,
-};
+use dynamo_mocker::common::handoff::{HandoffTransferTiming, NormalizedHandoffEvent};
 use dynamo_mocker::common::protocols::{
-    FpmPublisher, KvCacheEventSink, KvEventPublishers, KvTransferTimingMode, MockEngineArgs,
-    OutputSignal, WorkerType,
+    EngineType, FpmPublisher, KvCacheEventSink, KvEventPublishers, KvTransferTimingMode,
+    MockEngineArgs, WorkerType,
 };
-use dynamo_mocker::engine::create_engine;
-use dynamo_mocker::scheduler::{MockerMetrics, SchedulerHandle};
+use dynamo_mocker::live::{LiveEngine, LiveEngineConfig, LiveRequest};
 use dynamo_mocker::services::bootstrap::{
     BootstrapParticipantRole, BootstrapServer, BootstrapServerConfig, ParticipantRegistration,
     connect_to_prefill,
 };
+use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use uuid::Uuid;
-
-fn args(engine_type: EngineType, worker_type: WorkerType) -> MockEngineArgs {
-    args_with_mode(engine_type, worker_type, KvTransferTimingMode::FullPrompt)
-}
 
 fn args_with_mode(
     engine_type: EngineType,
@@ -45,10 +40,11 @@ fn args_with_mode(
     builder.build().unwrap()
 }
 
-fn request(uuid: Uuid, output_tokens: usize) -> DirectRequest {
-    DirectRequest {
+fn request(uuid: Uuid, output_tokens: usize) -> dynamo_mocker::common::protocols::DirectRequest {
+    dynamo_mocker::common::protocols::DirectRequest {
         tokens: (0..8).collect(),
         max_output_tokens: output_tokens,
+        output_token_ids: Some(vec![42; output_tokens]),
         uuid: Some(uuid),
         ..Default::default()
     }
@@ -81,177 +77,75 @@ fn timeout_delay_resolves_at_the_mode_specific_boundary() {
     assert_eq!(transfer_timeout_delay(missing, Some(4)), Some(Some(4.0)));
 }
 
-fn start_scheduler(
-    engine_type: EngineType,
-    worker_type: WorkerType,
-    cancel: CancellationToken,
-) -> (
-    Box<dyn SchedulerHandle>,
-    mpsc::UnboundedReceiver<Vec<OutputSignal>>,
-) {
-    let (output_tx, output_rx) = mpsc::unbounded_channel();
-    let scheduler = create_engine(
-        args(engine_type, worker_type),
-        0,
-        Some(output_tx),
-        KvEventPublishers::default(),
-        Some(cancel),
-        FpmPublisher::default(),
-    );
-    (scheduler, output_rx)
+struct ControlInvocation {
+    action: HandoffControlAction,
+    reply: oneshot::Sender<Result<HandoffActionOutcome>>,
 }
 
-fn start_scheduler_with_mode(
-    engine_type: EngineType,
-    worker_type: WorkerType,
-    transfer_timing_mode: KvTransferTimingMode,
-    cancel: CancellationToken,
-) -> (
-    Box<dyn SchedulerHandle>,
-    mpsc::UnboundedReceiver<Vec<OutputSignal>>,
-) {
-    let (output_tx, output_rx) = mpsc::unbounded_channel();
-    let scheduler = create_engine(
-        args_with_mode(engine_type, worker_type, transfer_timing_mode),
-        0,
-        Some(output_tx),
-        KvEventPublishers::default(),
-        Some(cancel),
-        FpmPublisher::default(),
-    );
-    (scheduler, output_rx)
+struct SemanticControl {
+    calls: mpsc::UnboundedSender<ControlInvocation>,
 }
 
-#[derive(Clone)]
-struct CapturingKvSink {
-    tx: mpsc::UnboundedSender<KvCacheEvent>,
-}
-
-impl KvCacheEventSink for CapturingKvSink {
-    fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()> {
-        self.tx
-            .send(event)
-            .map_err(|_| anyhow::anyhow!("conformance KV event receiver closed"))
+#[async_trait]
+impl HandoffSchedulerControl for SemanticControl {
+    async fn execute(&self, action: HandoffControlAction) -> Result<HandoffActionOutcome> {
+        let (reply, response) = oneshot::channel();
+        self.calls
+            .send(ControlInvocation { action, reply })
+            .map_err(|_| anyhow!("semantic handoff control closed"))?;
+        response
+            .await
+            .map_err(|_| anyhow!("semantic handoff control reply dropped"))?
     }
 }
 
-fn start_scheduler_with_kv_events_and_mode(
-    engine_type: EngineType,
-    worker_type: WorkerType,
-    transfer_timing_mode: KvTransferTimingMode,
-    cancel: CancellationToken,
-) -> (
-    Box<dyn SchedulerHandle>,
-    mpsc::UnboundedReceiver<Vec<OutputSignal>>,
-    mpsc::UnboundedReceiver<KvCacheEvent>,
+struct SemanticEvents {
+    events: mpsc::UnboundedReceiver<LiveHandoffEvent>,
+}
+
+#[async_trait]
+impl HandoffEventStream for SemanticEvents {
+    async fn recv(&mut self) -> Option<LiveHandoffEvent> {
+        self.events.recv().await
+    }
+}
+
+fn semantic_boundary() -> (
+    HandoffControl,
+    mpsc::UnboundedReceiver<ControlInvocation>,
+    HandoffEvents,
+    mpsc::UnboundedSender<LiveHandoffEvent>,
 ) {
-    let (output_tx, output_rx) = mpsc::unbounded_channel();
+    let (call_tx, call_rx) = mpsc::unbounded_channel();
     let (event_tx, event_rx) = mpsc::unbounded_channel();
-    let scheduler = create_engine(
-        args_with_mode(engine_type, worker_type, transfer_timing_mode),
-        0,
-        Some(output_tx),
-        KvEventPublishers::new(Some(Arc::new(CapturingKvSink { tx: event_tx })), None),
-        Some(cancel),
-        FpmPublisher::default(),
-    );
-    (scheduler, output_rx, event_rx)
+    (
+        HandoffControl::new(Arc::new(SemanticControl { calls: call_tx })),
+        call_rx,
+        HandoffEvents::new(Box::new(SemanticEvents { events: event_rx })),
+        event_tx,
+    )
 }
 
-fn drain_stored_hashes(
-    receiver: &mut mpsc::UnboundedReceiver<KvCacheEvent>,
-) -> Vec<dynamo_kv_router::protocols::ExternalSequenceBlockHash> {
-    std::iter::from_fn(|| receiver.try_recv().ok())
-        .flat_map(|event| match event.data {
-            KvCacheEventData::Stored(data) => data
-                .blocks
-                .into_iter()
-                .map(|block| block.block_hash)
-                .collect(),
-            KvCacheEventData::Removed(_) | KvCacheEventData::Cleared => Vec::new(),
-        })
-        .collect()
+fn acknowledge(invocation: ControlInvocation, outcome: HandoffActionOutcome) {
+    invocation.reply.send(Ok(outcome)).unwrap();
 }
 
-async fn wait_for_scheduler_idle(mut metrics: tokio::sync::watch::Receiver<MockerMetrics>) {
-    tokio::time::timeout(Duration::from_secs(2), async move {
-        loop {
-            let current = metrics.borrow().clone();
-            if current.running_requests == 0 && current.waiting_requests == 0 {
-                return;
-            }
-            metrics.changed().await.unwrap();
-        }
-    })
-    .await
-    .unwrap();
-}
-
-fn spawn_lifecycle_dispatcher(
-    mut receiver: mpsc::Receiver<SchedulerLifecycleEvent>,
-    registry: HandoffEventRegistry,
-) {
-    tokio::spawn(async move {
-        while let Some(event) = receiver.recv().await {
-            registry.deliver(event).await;
-        }
-    });
-}
-
-#[derive(Default)]
-struct OutputObservation {
-    output_tokens: usize,
-    completed_requests: usize,
-}
-
-fn observe_output_batch(
-    observation: &mut OutputObservation,
-    batch: Vec<OutputSignal>,
+async fn bootstrap_pair(
+    handoff_id: HandoffId,
     request_id: Uuid,
+    order: HandoffOrder,
+    engine_type: EngineType,
+) -> (
+    Arc<BootstrapServer>,
+    BootstrapConnection,
+    BootstrapConnection,
+    CancellationToken,
 ) {
-    for signal in batch {
-        if signal.uuid != request_id || signal.rejected {
-            continue;
-        }
-        observation.output_tokens += 1;
-        observation.completed_requests += usize::from(signal.completed);
-    }
-}
-
-async fn observe_through_first_terminal(
-    receiver: &mut mpsc::UnboundedReceiver<Vec<OutputSignal>>,
-    request_id: Uuid,
-) -> OutputObservation {
-    tokio::time::timeout(Duration::from_secs(2), async {
-        let mut observation = OutputObservation::default();
-        while observation.completed_requests == 0 {
-            observe_output_batch(&mut observation, receiver.recv().await.unwrap(), request_id);
-        }
-        observation
-    })
-    .await
-    .unwrap()
-}
-
-fn drain_output_observation(
-    receiver: &mut mpsc::UnboundedReceiver<Vec<OutputSignal>>,
-    request_id: Uuid,
-    observation: &mut OutputObservation,
-) {
-    while let Ok(batch) = receiver.try_recv() {
-        observe_output_batch(observation, batch, request_id);
-    }
-}
-
-#[tokio::test]
-async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
     let shutdown = CancellationToken::new();
     let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
         .await
         .unwrap();
     let mut incoming = server.take_incoming_receiver().unwrap();
-    let request_id = Uuid::from_u128(70_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(70_001));
     let identity = BootstrapIdentity {
         handoff_id,
         bootstrap_room: 17,
@@ -264,22 +158,39 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
         ParticipantRegistration {
             role: BootstrapParticipantRole::Destination,
             dp_rank: 0,
-            order: HandoffOrder::DestinationFirst,
-            engine_type: EngineType::Sglang,
+            order,
+            engine_type,
         },
     )
     .await
     .unwrap();
-    let mut source = incoming.recv().await.unwrap().connection;
-    let registry = HandoffEventRegistry::default();
-    let route = registry.register(handoff_id).unwrap();
-    let (command_tx, mut command_rx) = mpsc::channel(1);
+    let source = incoming.recv().await.unwrap().connection;
+    (server, source, destination, shutdown)
+}
+
+async fn finish_test_transport(server: Arc<BootstrapServer>, shutdown: CancellationToken) {
+    shutdown.cancel();
+    server.wait_closed().await;
+}
+
+#[tokio::test]
+async fn destination_ack_precedes_an_early_reservation_fact() {
+    let request_id = Uuid::from_u128(70_000);
+    let handoff_id = HandoffId::from(Uuid::from_u128(70_001));
+    let (server, mut source, destination, shutdown) = bootstrap_pair(
+        handoff_id,
+        request_id,
+        HandoffOrder::DestinationFirst,
+        EngineType::Sglang,
+    )
+    .await;
+    let (control, mut calls, events, event_tx) = semantic_boundary();
+    let cancel = CancellationToken::new();
     let session = tokio::spawn(run_destination_session(
         destination,
-        request(request_id, 2),
-        command_tx,
-        route,
-        CancellationToken::new(),
+        control,
+        events,
+        cancel.clone(),
         Duration::from_secs(2),
         shutdown.clone(),
     ));
@@ -291,31 +202,22 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
         .send(BootstrapMessage::Action(reserve))
         .await
         .unwrap();
-    let envelope = command_rx.recv().await.unwrap();
-    assert!(matches!(
-        envelope.command,
-        SchedulerCommand::ReserveDestination {
-            handoff_id: observed,
-            ..
-        } if observed == handoff_id
-    ));
+    let invocation = calls.recv().await.unwrap();
+    assert_eq!(invocation.action, HandoffControlAction::ReserveDestination);
 
-    registry
-        .deliver_and_wait(SchedulerLifecycleEvent::DestinationReserved {
-            handoff_id,
-            request_id,
-            transferable_prompt_tokens: 1,
+    event_tx
+        .send(LiveHandoffEvent::DestinationReserved {
+            transferable_prompt_tokens: 4,
         })
-        .await;
-    envelope
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::DestinationAccepted { request_id },
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
         .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), source.recv())
+            .await
+            .is_err(),
+        "reservation fact must wait for the scheduler acknowledgement"
+    );
 
+    acknowledge(invocation, HandoffActionOutcome::Accepted);
     assert!(matches!(
         source.recv().await.unwrap(),
         Some(BootstrapMessage::ActionAck {
@@ -327,136 +229,34 @@ async fn destination_reservation_ack_precedes_an_early_lifecycle_fact() {
         source.recv().await.unwrap(),
         Some(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
             handoff_id: observed,
-            ..
+            transferable_prompt_tokens: 4,
         })) if observed == handoff_id
     ));
 
-    assert!(
-        coordinator
-            .on_action_outcome(reserve.id, HandoffActionOutcome::Accepted)
-            .unwrap()
-            .is_empty()
-    );
-    let submit = coordinator
-        .on_fact(HandoffFact::DestinationReserved {
-            handoff_id,
-            transferable_prompt_tokens: 1,
-        })
-        .unwrap()
-        .pop()
-        .unwrap();
-    assert!(matches!(submit.action, HandoffAction::SubmitPrefill { .. }));
-    assert!(
-        coordinator
-            .on_action_outcome(submit.id, HandoffActionOutcome::Submitted)
-            .unwrap()
-            .is_empty()
-    );
-    let transfer = coordinator
-        .on_fact(HandoffFact::SourceHeld {
-            handoff_id,
-            transfer_timing: transfer_timing(Some(0.0)),
-        })
-        .unwrap()
-        .pop()
-        .unwrap();
-    assert!(matches!(
-        transfer.action,
-        HandoffAction::StartTransfer { .. }
-    ));
-    assert!(
-        coordinator
-            .on_action_outcome(transfer.id, HandoffActionOutcome::Scheduled)
-            .unwrap()
-            .is_empty()
-    );
-    let activate = coordinator
-        .on_fact(HandoffFact::TransferCompleted { handoff_id })
-        .unwrap()
-        .pop()
-        .unwrap();
-    source
-        .send(BootstrapMessage::Action(activate))
-        .await
-        .unwrap();
-    let envelope = command_rx.recv().await.unwrap();
-    assert!(matches!(
-        envelope.command,
-        SchedulerCommand::ActivateDestination {
-            handoff_id: observed,
-        } if observed == handoff_id
-    ));
-    envelope
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::Applied,
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
-        .unwrap();
-    assert!(matches!(
-        source.recv().await.unwrap(),
-        Some(BootstrapMessage::ActionAck {
-            action_id,
-            outcome: HandoffActionOutcome::Applied,
-        }) if action_id == activate.id
-    ));
-    let release = coordinator
-        .on_action_outcome(activate.id, HandoffActionOutcome::Applied)
-        .unwrap()
-        .pop()
-        .unwrap();
-    let complete = coordinator
-        .on_action_outcome(release.id, HandoffActionOutcome::Applied)
-        .unwrap()
-        .pop()
-        .unwrap();
-    assert!(matches!(complete.action, HandoffAction::Complete { .. }));
-    assert!(coordinator.is_complete());
-    assert_eq!(coordinator.completion(), Some(HandoffCompletion::Success));
-
-    source.send(BootstrapMessage::Complete).await.unwrap();
-    session.await.unwrap().unwrap();
-    assert!(registry.register(handoff_id).is_ok());
-    shutdown.cancel();
-    server.wait_closed().await;
+    cancel.cancel();
+    let cleanup = calls.recv().await.unwrap();
+    assert_eq!(cleanup.action, HandoffControlAction::CancelDestination);
+    acknowledge(cleanup, HandoffActionOutcome::Applied);
+    assert!(session.await.unwrap().is_err());
+    finish_test_transport(server, shutdown).await;
 }
 
 #[tokio::test]
-async fn premature_complete_keeps_destination_cleanup_active() {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
-        .await
-        .unwrap();
-    let mut incoming = server.take_incoming_receiver().unwrap();
-    let request_id = Uuid::from_u128(70_100);
-    let handoff_id = HandoffId::from(Uuid::from_u128(70_101));
-    let identity = BootstrapIdentity {
+async fn premature_complete_waits_for_destination_cleanup() {
+    let request_id = Uuid::from_u128(71_000);
+    let handoff_id = HandoffId::from(Uuid::from_u128(71_001));
+    let (server, mut source, destination, shutdown) = bootstrap_pair(
         handoff_id,
-        bootstrap_room: 19,
         request_id,
-    };
-    let destination = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::DestinationFirst,
-            engine_type: EngineType::Sglang,
-        },
+        HandoffOrder::DestinationFirst,
+        EngineType::Sglang,
     )
-    .await
-    .unwrap();
-    let mut source = incoming.recv().await.unwrap().connection;
-    let registry = HandoffEventRegistry::default();
-    let (command_tx, mut command_rx) = mpsc::channel(1);
+    .await;
+    let (control, mut calls, events, event_tx) = semantic_boundary();
     let session = tokio::spawn(run_destination_session(
         destination,
-        request(request_id, 2),
-        command_tx,
-        registry.register(handoff_id).unwrap(),
+        control,
+        events,
         CancellationToken::new(),
         Duration::from_secs(2),
         shutdown.clone(),
@@ -469,154 +269,63 @@ async fn premature_complete_keeps_destination_cleanup_active() {
         .send(BootstrapMessage::Action(reserve))
         .await
         .unwrap();
-    let reserve_command = command_rx.recv().await.unwrap();
-    reserve_command
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::DestinationAccepted { request_id },
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
-        .unwrap();
-    registry
-        .deliver_and_wait(SchedulerLifecycleEvent::DestinationReserved {
-            handoff_id,
-            request_id,
-            transferable_prompt_tokens: 1,
+    acknowledge(calls.recv().await.unwrap(), HandoffActionOutcome::Accepted);
+    event_tx
+        .send(LiveHandoffEvent::DestinationReserved {
+            transferable_prompt_tokens: 4,
         })
-        .await;
-    assert!(matches!(
-        source.recv().await.unwrap(),
-        Some(BootstrapMessage::ActionAck {
-            action_id,
-            outcome: HandoffActionOutcome::Accepted,
-        }) if action_id == reserve.id
-    ));
-    assert!(matches!(
-        source.recv().await.unwrap(),
-        Some(BootstrapMessage::Fact(
-            HandoffFact::DestinationReserved { .. }
-        ))
-    ));
-
-    coordinator
-        .on_action_outcome(reserve.id, HandoffActionOutcome::Accepted)
         .unwrap();
-    let submit = coordinator
-        .on_fact(HandoffFact::DestinationReserved {
-            handoff_id,
-            transferable_prompt_tokens: 1,
-        })
-        .unwrap()
-        .pop()
-        .unwrap();
-    coordinator
-        .on_action_outcome(submit.id, HandoffActionOutcome::Submitted)
-        .unwrap();
-    let transfer = coordinator
-        .on_fact(HandoffFact::SourceHeld {
-            handoff_id,
-            transfer_timing: transfer_timing(None),
-        })
-        .unwrap()
-        .pop()
-        .unwrap();
-    coordinator
-        .on_action_outcome(transfer.id, HandoffActionOutcome::Scheduled)
-        .unwrap();
-    let activate = coordinator
-        .on_fact(HandoffFact::TransferCompleted { handoff_id })
-        .unwrap()
-        .pop()
-        .unwrap();
-    source
-        .send(BootstrapMessage::Action(activate))
-        .await
-        .unwrap();
-    let pending_activation = command_rx.recv().await.unwrap();
-    assert!(matches!(
-        pending_activation.command,
-        SchedulerCommand::ActivateDestination { handoff_id: observed }
-            if observed == handoff_id
-    ));
+    let _ = source.recv().await.unwrap();
+    let _ = source.recv().await.unwrap();
 
     source.send(BootstrapMessage::Complete).await.unwrap();
-    let cleanup = tokio::time::timeout(Duration::from_secs(1), command_rx.recv())
-        .await
-        .expect("premature completion must trigger destination cleanup")
-        .unwrap();
-    assert!(matches!(
-        cleanup.command,
-        SchedulerCommand::CancelDestination { handoff_id: observed }
-            if observed == handoff_id
-    ));
-    cleanup
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::Applied,
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
-        .unwrap();
-    drop(pending_activation);
-
-    let error = session.await.unwrap().unwrap_err();
+    let cleanup = calls.recv().await.unwrap();
+    assert_eq!(cleanup.action, HandoffControlAction::CancelDestination);
+    let mut session = Box::pin(session);
     assert!(
-        error
-            .to_string()
-            .contains("source completed before destination activation finished")
+        tokio::time::timeout(Duration::from_millis(20), &mut session)
+            .await
+            .is_err(),
+        "destination session must retain cleanup ownership until acknowledgement"
     );
-    shutdown.cancel();
-    server.wait_closed().await;
+    acknowledge(cleanup, HandoffActionOutcome::Applied);
+    assert!(session.await.unwrap().is_err());
+    finish_test_transport(server, shutdown).await;
 }
 
 #[tokio::test]
 async fn source_held_waits_for_submit_outcome_before_progressing() {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
-        .await
-        .unwrap();
-    let mut incoming = server.take_incoming_receiver().unwrap();
-    let request_id = Uuid::from_u128(71_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(71_001));
-    let identity = BootstrapIdentity {
+    let request_id = Uuid::from_u128(72_000);
+    let handoff_id = HandoffId::from(Uuid::from_u128(72_001));
+    let (server, source_connection, mut destination, shutdown) = bootstrap_pair(
         handoff_id,
-        bootstrap_room: 18,
         request_id,
-    };
-    let mut destination = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity.clone(),
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
+        HandoffOrder::SourceFirst,
+        EngineType::Vllm,
+    )
+    .await;
+    let (control, mut calls, events, event_tx) = semantic_boundary();
+    let cancel = CancellationToken::new();
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let permit = Arc::new(tokio::sync::Semaphore::new(1))
+        .try_acquire_owned()
+        .unwrap();
+    let session = tokio::spawn(run_source_session(
+        SourceRegistration {
+            identity: BootstrapIdentity {
+                handoff_id,
+                bootstrap_room: 17,
+                request_id,
+            },
             order: HandoffOrder::SourceFirst,
             engine_type: EngineType::Vllm,
+            control,
+            lifecycle: events,
+            completion_tx,
+            cancel: cancel.clone(),
+            observer: None,
+            _permit: permit,
         },
-    )
-    .await
-    .unwrap();
-    let source_connection = incoming.recv().await.unwrap().connection;
-    let registry = HandoffEventRegistry::default();
-    let route = registry.register(handoff_id).unwrap();
-    let (command_tx, mut command_rx) = mpsc::channel(2);
-    let (completion_tx, completion_rx) = oneshot::channel();
-    let permits = Arc::new(tokio::sync::Semaphore::new(1));
-    let source = SourceRegistration {
-        identity,
-        order: HandoffOrder::SourceFirst,
-        engine_type: EngineType::Vllm,
-        request: request(request_id, 1),
-        command_tx,
-        lifecycle: route,
-        completion_tx,
-        cancel: CancellationToken::new(),
-        observer: None,
-        _permit: permits.clone().try_acquire_owned().unwrap(),
-    };
-    let session = tokio::spawn(run_source_session(
-        source,
         source_connection,
         Duration::from_secs(2),
         shutdown.clone(),
@@ -626,1457 +335,288 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
         destination.recv().await.unwrap(),
         Some(BootstrapMessage::Registered)
     ));
-    let submit = command_rx.recv().await.unwrap();
-    assert!(matches!(
-        submit.command,
-        SchedulerCommand::SubmitHandoffPrefill {
-            handoff_id: observed,
-            ..
-        } if observed == handoff_id
-    ));
-
-    registry
-        .deliver_and_wait(SchedulerLifecycleEvent::SourceHeld {
-            handoff_id,
-            request_id,
-            transfer_timing: transfer_timing(Some(0.0)),
+    let submit = calls.recv().await.unwrap();
+    assert_eq!(submit.action, HandoffControlAction::SubmitPrefill);
+    event_tx
+        .send(LiveHandoffEvent::SourceHeld {
+            transfer_timing: transfer_timing(None),
         })
-        .await;
-    submit
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::Submitted(request_id),
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
         .unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), destination.recv())
+            .await
+            .is_err(),
+        "source-held fact must wait for submit acknowledgement"
+    );
 
+    acknowledge(submit, HandoffActionOutcome::Submitted);
     assert!(matches!(
         destination.recv().await.unwrap(),
         Some(BootstrapMessage::Fact(HandoffFact::SourceHeld {
             handoff_id: observed,
-            transfer_timing: observed_timing,
-        })) if observed == handoff_id
-            && observed_timing == transfer_timing(Some(0.0))
-    ));
-    let reserve = match destination.recv().await.unwrap().unwrap() {
-        BootstrapMessage::Action(
-            action @ IssuedHandoffAction {
-                action: HandoffAction::ReserveDestination { .. },
-                ..
-            },
-        ) => action,
-        other => panic!("expected destination reservation, got {other:?}"),
-    };
-    destination
-        .send(BootstrapMessage::ActionAck {
-            action_id: reserve.id,
-            outcome: HandoffActionOutcome::Accepted,
-        })
-        .await
-        .unwrap();
-    destination
-        .send(BootstrapMessage::Fact(HandoffFact::DestinationReserved {
-            handoff_id,
-            transferable_prompt_tokens: 1,
-        }))
-        .await
-        .unwrap();
-
-    let activate = match destination.recv().await.unwrap().unwrap() {
-        BootstrapMessage::Action(
-            action @ IssuedHandoffAction {
-                action: HandoffAction::ActivateDestination { .. },
-                ..
-            },
-        ) => action,
-        other => panic!("expected destination activation, got {other:?}"),
-    };
-    destination
-        .send(BootstrapMessage::ActionAck {
-            action_id: activate.id,
-            outcome: HandoffActionOutcome::Applied,
-        })
-        .await
-        .unwrap();
-
-    let release = command_rx.recv().await.unwrap();
-    assert!(matches!(
-        release.command,
-        SchedulerCommand::ReleaseSource {
-            handoff_id: observed,
-        } if observed == handoff_id
-    ));
-    release
-        .reply
-        .send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::Applied,
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }))
-        .unwrap();
-    assert!(matches!(
-        destination.recv().await.unwrap(),
-        Some(BootstrapMessage::Complete)
-    ));
-
-    session.await.unwrap().unwrap();
-    completion_rx.await.unwrap().unwrap();
-    assert_eq!(permits.available_permits(), 1);
-    drop(registry.register(handoff_id).unwrap());
-    shutdown.cancel();
-    server.wait_closed().await;
-}
-
-enum SourceTerminalTrigger {
-    Cancel,
-    CloseLifecycle,
-}
-
-async fn run_source_terminal_trigger(trigger: SourceTerminalTrigger, id: u128) -> String {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
-        .await
-        .unwrap();
-    let mut incoming = server.take_incoming_receiver().unwrap();
-    let request_id = Uuid::from_u128(id);
-    let handoff_id = HandoffId::from(Uuid::from_u128(id + 1));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 19,
-        request_id,
-    };
-    let mut destination = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity.clone(),
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-        },
-    )
-    .await
-    .unwrap();
-    let source_connection = incoming.recv().await.unwrap().connection;
-    let registry = HandoffEventRegistry::default();
-    let route = registry.register(handoff_id).unwrap();
-    let (command_tx, mut command_rx) = mpsc::channel::<SchedulerCommandEnvelope>(4);
-    let command_task = tokio::spawn(async move {
-        let mut canceled = false;
-        while let Some(envelope) = command_rx.recv().await {
-            let result = match envelope.command {
-                SchedulerCommand::SubmitHandoffPrefill { .. } => {
-                    SchedulerCommandResult::Submitted(request_id)
-                }
-                SchedulerCommand::CancelSource {
-                    handoff_id: observed,
-                } if observed == handoff_id => {
-                    canceled = true;
-                    SchedulerCommandResult::Applied
-                }
-                _ => panic!("unexpected source command during cleanup"),
-            };
-            let _ = envelope.reply.send(Ok(SchedulerCommandEffects {
-                result,
-                lifecycle_events: Vec::new(),
-                kv_events: Vec::new(),
-            }));
-            if canceled {
-                break;
-            }
-        }
-        canceled
-    });
-    let cancel = CancellationToken::new();
-    let permits = Arc::new(tokio::sync::Semaphore::new(1));
-    let (completion_tx, completion_rx) = oneshot::channel();
-    let source = SourceRegistration {
-        identity,
-        order: HandoffOrder::SourceFirst,
-        engine_type: EngineType::Vllm,
-        request: request(request_id, 1),
-        command_tx,
-        lifecycle: route,
-        completion_tx,
-        cancel: cancel.clone(),
-        observer: None,
-        _permit: permits.clone().try_acquire_owned().unwrap(),
-    };
-    let session = tokio::spawn(run_source_session(
-        source,
-        source_connection,
-        Duration::from_secs(2),
-        shutdown.clone(),
-    ));
-    assert!(matches!(
-        destination.recv().await.unwrap(),
-        Some(BootstrapMessage::Registered)
-    ));
-
-    match trigger {
-        SourceTerminalTrigger::Cancel => cancel.cancel(),
-        SourceTerminalTrigger::CloseLifecycle => {
-            registry.routes.remove(&handoff_id);
-        }
-    }
-
-    let error = tokio::time::timeout(Duration::from_secs(1), session)
-        .await
-        .expect("source terminal watcher did not wake")
-        .unwrap()
-        .unwrap_err()
-        .to_string();
-    assert!(completion_rx.await.unwrap().is_err());
-    assert!(
-        command_task.await.unwrap(),
-        "source cleanup command was not sent"
-    );
-    assert_eq!(permits.available_permits(), 1);
-    shutdown.cancel();
-    server.wait_closed().await;
-    error
-}
-
-#[tokio::test]
-async fn active_source_request_cancellation_runs_exact_cleanup() {
-    let error = run_source_terminal_trigger(SourceTerminalTrigger::Cancel, 72_000).await;
-    assert!(error.contains("source request was canceled"));
-}
-
-#[tokio::test]
-async fn source_lifecycle_channel_closure_runs_exact_cleanup() {
-    let error = run_source_terminal_trigger(SourceTerminalTrigger::CloseLifecycle, 73_000).await;
-    assert!(error.contains("source lifecycle channel closed"));
-}
-
-#[derive(Default)]
-struct DestinationKvObservation {
-    before_activation: usize,
-    activation_hashes: Vec<dynamo_kv_router::protocols::ExternalSequenceBlockHash>,
-}
-
-fn destination_command_proxy(
-    real_command_tx: mpsc::Sender<SchedulerCommandEnvelope>,
-    mut kv_events: mpsc::UnboundedReceiver<KvCacheEvent>,
-) -> (
-    mpsc::Sender<SchedulerCommandEnvelope>,
-    tokio::task::JoinHandle<(
-        DestinationKvObservation,
-        mpsc::UnboundedReceiver<KvCacheEvent>,
-    )>,
-) {
-    let (proxy_tx, mut proxy_rx) = mpsc::channel::<SchedulerCommandEnvelope>(8);
-    let task = tokio::spawn(async move {
-        let mut observation = DestinationKvObservation::default();
-        while let Some(SchedulerCommandEnvelope { command, reply }) = proxy_rx.recv().await {
-            enum Phase {
-                Reserve,
-                Activate,
-                Other,
-            }
-            let phase = match &command {
-                SchedulerCommand::ReserveDestination { .. } => Phase::Reserve,
-                SchedulerCommand::ActivateDestination { .. } => Phase::Activate,
-                _ => Phase::Other,
-            };
-            let (inner_reply, inner_result) = oneshot::channel();
-            let result = if real_command_tx
-                .send(SchedulerCommandEnvelope {
-                    command,
-                    reply: inner_reply,
-                })
-                .await
-                .is_err()
-            {
-                Err(anyhow::anyhow!(
-                    "destination scheduler command channel closed"
-                ))
-            } else {
-                inner_result.await.unwrap_or_else(|_| {
-                    Err(anyhow::anyhow!(
-                        "destination scheduler command reply was dropped"
-                    ))
-                })
-            };
-            match phase {
-                Phase::Reserve => {
-                    observation.before_activation += drain_stored_hashes(&mut kv_events).len();
-                }
-                Phase::Activate => {
-                    observation
-                        .activation_hashes
-                        .extend(drain_stored_hashes(&mut kv_events));
-                }
-                Phase::Other => {}
-            }
-            let _ = reply.send(result);
-        }
-        (observation, kv_events)
-    });
-    (proxy_tx, task)
-}
-
-async fn run_live_handoff_conformance(
-    engine_type: EngineType,
-    transfer_timing_mode: KvTransferTimingMode,
-    source_arrives_first: bool,
-    case: usize,
-) -> NormalizedHandoffConformance {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 2,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let incoming = server.take_incoming_receiver().unwrap();
-    let manager =
-        SourceHandoffManager::start(incoming, 2, Duration::from_secs(2), shutdown.clone());
-
-    let (mut source_scheduler, mut source_output) = start_scheduler_with_mode(
-        engine_type,
-        WorkerType::Prefill,
-        transfer_timing_mode,
-        shutdown.clone(),
-    );
-    let (mut destination_scheduler, mut destination_output, destination_kv_events) =
-        start_scheduler_with_kv_events_and_mode(
-            engine_type,
-            WorkerType::Decode,
-            transfer_timing_mode,
-            shutdown.clone(),
-        );
-    let (destination_command_tx, destination_kv_observer) = destination_command_proxy(
-        destination_scheduler.command_sender(),
-        destination_kv_events,
-    );
-    let source_metrics = source_scheduler.metrics_receiver();
-    let destination_metrics = destination_scheduler.metrics_receiver();
-    let source_registry = HandoffEventRegistry::default();
-    let destination_registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        source_scheduler.take_lifecycle_receiver().unwrap(),
-        source_registry.clone(),
-    );
-    spawn_lifecycle_dispatcher(
-        destination_scheduler.take_lifecycle_receiver().unwrap(),
-        destination_registry.clone(),
-    );
-
-    let request_id = Uuid::from_u128(60_000 + case as u128);
-    let handoff_id = HandoffId::from(Uuid::from_u128(61_000 + case as u128));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 7,
-        request_id,
-    };
-    let order = order_for_engine(engine_type).unwrap();
-    let source_route = source_registry.register(handoff_id).unwrap();
-    let destination_route = destination_registry.register(handoff_id).unwrap();
-    let (completion_tx, mut completion_rx) = oneshot::channel();
-    let (observer_tx, mut observer_rx) = mpsc::unbounded_channel();
-    let observer = tokio::spawn(async move {
-        let mut lifecycle = Vec::new();
-        loop {
-            let event = observer_rx.recv().await.unwrap();
-            lifecycle.push(event);
-            if event == NormalizedHandoffEvent::Completed {
-                return lifecycle;
-            }
-        }
-    });
-    let source_permits = Arc::new(tokio::sync::Semaphore::new(1));
-    let mut source_registration = Some(SourceRegistration {
-        identity: identity.clone(),
-        order,
-        engine_type,
-        request: request(request_id, 1),
-        command_tx: source_scheduler.command_sender(),
-        lifecycle: source_route,
-        completion_tx,
-        cancel: CancellationToken::new(),
-        observer: Some(observer_tx),
-        _permit: source_permits.clone().try_acquire_owned().unwrap(),
-    });
-    let destination_registration = ParticipantRegistration {
-        role: BootstrapParticipantRole::Destination,
-        dp_rank: 0,
-        order,
-        engine_type,
-    };
-
-    if source_arrives_first {
-        manager
-            .try_register(source_registration.take().unwrap())
-            .unwrap();
-    }
-    let connection = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        destination_registration,
-    )
-    .await
-    .unwrap();
-    if !source_arrives_first {
-        manager.wait_for_pending_destination(handoff_id).await;
-        manager
-            .try_register(source_registration.take().unwrap())
-            .unwrap();
-    }
-    let destination_session = tokio::spawn(run_destination_session(
-        connection,
-        request(request_id, 2),
-        destination_command_tx,
-        destination_route,
-        CancellationToken::new(),
-        Duration::from_secs(2),
-        shutdown.clone(),
-    ));
-
-    let mut source_outputs = observe_through_first_terminal(&mut source_output, request_id).await;
-    assert!(matches!(
-        completion_rx.try_recv(),
-        Err(tokio::sync::oneshot::error::TryRecvError::Empty)
-    ));
-    tokio::time::timeout(Duration::from_secs(2), completion_rx)
-        .await
-        .unwrap()
-        .unwrap()
-        .unwrap();
-    destination_session.await.unwrap().unwrap();
-    let mut destination_outputs =
-        observe_through_first_terminal(&mut destination_output, request_id).await;
-    let lifecycle = observer.await.unwrap();
-    let (destination_kv, mut remaining_kv_events) = destination_kv_observer.await.unwrap();
-    let activation_hashes = destination_kv.activation_hashes;
-    let activation_set = activation_hashes.iter().copied().collect::<HashSet<_>>();
-    let repeated_activation_hashes_after_activation = drain_stored_hashes(&mut remaining_kv_events)
-        .into_iter()
-        .filter(|hash| activation_set.contains(hash))
-        .count();
-
-    wait_for_scheduler_idle(source_metrics).await;
-    wait_for_scheduler_idle(destination_metrics).await;
-    drain_output_observation(&mut source_output, request_id, &mut source_outputs);
-    drain_output_observation(
-        &mut destination_output,
-        request_id,
-        &mut destination_outputs,
-    );
-    let source_drained = send_command(
-        &source_scheduler.command_sender(),
-        SchedulerCommand::CancelSource { handoff_id },
-    )
-    .await
-    .unwrap()
-    .result
-        == SchedulerCommandResult::Noop;
-    let destination_drained = send_command(
-        &destination_scheduler.command_sender(),
-        SchedulerCommand::CancelDestination { handoff_id },
-    )
-    .await
-    .unwrap()
-    .result
-        == SchedulerCommandResult::Noop;
-    shutdown.cancel();
-    manager.wait_closed().await;
-    server.wait_closed().await;
-    let driver_drained = source_permits.available_permits() == 1
-        && source_registry.register(handoff_id).is_ok()
-        && destination_registry.register(handoff_id).is_ok();
-
-    let report = NormalizedHandoffConformance {
-        engine_type,
-        order,
-        lifecycle,
-        source_output_tokens: source_outputs.output_tokens,
-        destination_output_tokens: destination_outputs.output_tokens,
-        completed_requests: destination_outputs.completed_requests,
-        destination_stored: NormalizedStoredTiming {
-            before_activation: destination_kv.before_activation,
-            on_activation: activation_hashes.len(),
-            repeated_activation_hashes_after_activation,
-        },
-        source_drained,
-        destination_drained,
-        driver_drained,
-    };
-    assert_eq!(source_outputs.completed_requests, 1);
-    report.validate().unwrap();
-    report
-}
-
-#[tokio::test]
-async fn live_and_offline_handoff_surfaces_share_one_conformance_report() {
-    let mut case = 0;
-    for transfer_timing_mode in [
-        KvTransferTimingMode::FullPrompt,
-        KvTransferTimingMode::DestinationMissing,
-    ] {
-        for (engine_type, source_arrives_first) in [
-            (EngineType::Vllm, true),
-            (EngineType::Vllm, false),
-            (EngineType::Sglang, true),
-            (EngineType::Sglang, false),
-        ] {
-            let live = run_live_handoff_conformance(
-                engine_type,
-                transfer_timing_mode,
-                source_arrives_first,
-                case,
-            )
-            .await;
-            let offline = dynamo_mocker::replay::run_offline_handoff_conformance(
-                engine_type,
-                transfer_timing_mode,
-            )
-            .unwrap();
-            assert_eq!(live, offline);
-            case += 1;
-        }
-    }
-}
-
-#[tokio::test]
-async fn bootstrap_rendezvous_rejects_backend_mismatch_before_scheduler_ownership() {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
-        .await
-        .unwrap();
-    let incoming = server.take_incoming_receiver().unwrap();
-    let manager =
-        SourceHandoffManager::start(incoming, 1, Duration::from_secs(2), shutdown.clone());
-    let handoff_id = HandoffId::from(Uuid::from_u128(62_000));
-    let request_id = Uuid::from_u128(62_001);
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 8,
-        request_id,
-    };
-    let registry = HandoffEventRegistry::default();
-    let permit_pool = Arc::new(tokio::sync::Semaphore::new(1));
-    let (command_tx, mut command_rx) = mpsc::channel(1);
-    let (completion_tx, completion_rx) = oneshot::channel();
-    manager
-        .try_register(SourceRegistration {
-            identity: identity.clone(),
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-            request: request(request_id, 1),
-            command_tx,
-            lifecycle: registry.register(handoff_id).unwrap(),
-            completion_tx,
-            cancel: CancellationToken::new(),
-            observer: None,
-            _permit: permit_pool.clone().try_acquire_owned().unwrap(),
-        })
-        .unwrap();
-
-    let mut destination = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Sglang,
-        },
-    )
-    .await
-    .unwrap();
-
-    let source_error = completion_rx.await.unwrap().unwrap_err();
-    assert!(source_error.contains("identity or backend mismatch"));
-    assert!(matches!(
-        destination.recv().await.unwrap(),
-        Some(BootstrapMessage::ProtocolError { message })
-            if message.contains("identity or backend mismatch")
-    ));
-    assert!(command_rx.try_recv().is_err());
-    assert_eq!(permit_pool.available_permits(), 1);
-
-    shutdown.cancel();
-    manager.wait_closed().await;
-    server.wait_closed().await;
-}
-
-async fn assert_destination_disconnect_cleans_ownership(
-    engine_type: EngineType,
-    activate_before_disconnect: bool,
-) {
-    let shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 1,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let mut incoming_rx = server.take_incoming_receiver().unwrap();
-    let (mut destination_scheduler, _output) =
-        start_scheduler(engine_type, WorkerType::Decode, shutdown.clone());
-    let registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        destination_scheduler.take_lifecycle_receiver().unwrap(),
-        registry.clone(),
-    );
-    let request_id = Uuid::from_u128(70_000 + u128::from(activate_before_disconnect));
-    let handoff_id = HandoffId::from(Uuid::from_u128(
-        70_010 + u128::from(activate_before_disconnect),
-    ));
-    let order = order_for_engine(engine_type).unwrap();
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 9,
-        request_id,
-    };
-    let client = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order,
-            engine_type,
-        },
-    )
-    .await
-    .unwrap();
-    let mut incoming = incoming_rx.recv().await.unwrap();
-    let command_tx = destination_scheduler.command_sender();
-    let route = registry.register(handoff_id).unwrap();
-    let destination = tokio::spawn(run_destination_session(
-        client,
-        request(request_id, 16),
-        command_tx.clone(),
-        route,
-        CancellationToken::new(),
-        Duration::from_secs(2),
-        shutdown.clone(),
-    ));
-
-    incoming
-        .connection
-        .send(BootstrapMessage::Registered)
-        .await
-        .unwrap();
-    let mut coordinator = HandoffCoordinatorCore::new(handoff_id, order);
-    let reserve = match order {
-        HandoffOrder::DestinationFirst => coordinator.start().unwrap().pop().unwrap(),
-        HandoffOrder::SourceFirst => {
-            let submit = coordinator.start().unwrap().pop().unwrap();
-            coordinator
-                .on_action_outcome(submit.id, HandoffActionOutcome::Submitted)
-                .unwrap();
-            coordinator
-                .on_fact(HandoffFact::SourceHeld {
-                    handoff_id,
-                    transfer_timing: transfer_timing(None),
-                })
-                .unwrap()
-                .pop()
-                .unwrap()
-        }
-    };
-    incoming
-        .connection
-        .send(BootstrapMessage::Action(reserve))
-        .await
-        .unwrap();
-    let mut accepted = false;
-    let mut reserved = false;
-    while !accepted || !reserved {
-        match incoming.connection.recv().await.unwrap().unwrap() {
-            BootstrapMessage::ActionAck { action_id, outcome }
-                if action_id == reserve.id && outcome == HandoffActionOutcome::Accepted =>
-            {
-                accepted = true;
-            }
-            BootstrapMessage::Fact(HandoffFact::DestinationReserved {
-                handoff_id: observed,
-                ..
-            }) if observed == handoff_id => reserved = true,
-            other => panic!("unexpected destination message: {other:?}"),
-        }
-    }
-    if activate_before_disconnect {
-        coordinator
-            .on_action_outcome(reserve.id, HandoffActionOutcome::Accepted)
-            .unwrap();
-        let after_reserved = coordinator
-            .on_fact(HandoffFact::DestinationReserved {
-                handoff_id,
-                transferable_prompt_tokens: 1,
-            })
-            .unwrap();
-        let transfer = match order {
-            HandoffOrder::SourceFirst => after_reserved.into_iter().next().unwrap(),
-            HandoffOrder::DestinationFirst => {
-                let submit = after_reserved.into_iter().next().unwrap();
-                coordinator
-                    .on_action_outcome(submit.id, HandoffActionOutcome::Submitted)
-                    .unwrap();
-                coordinator
-                    .on_fact(HandoffFact::SourceHeld {
-                        handoff_id,
-                        transfer_timing: transfer_timing(None),
-                    })
-                    .unwrap()
-                    .pop()
-                    .unwrap()
-            }
-        };
-        coordinator
-            .on_action_outcome(transfer.id, HandoffActionOutcome::Scheduled)
-            .unwrap();
-        let activation = coordinator
-            .on_fact(HandoffFact::TransferCompleted { handoff_id })
-            .unwrap()
-            .pop()
-            .unwrap();
-        incoming
-            .connection
-            .send(BootstrapMessage::Action(activation))
-            .await
-            .unwrap();
-        assert!(matches!(
-            incoming.connection.recv().await.unwrap(),
-            Some(BootstrapMessage::ActionAck {
-                action_id,
-                outcome: HandoffActionOutcome::Applied,
-            }) if action_id == activation.id
-        ));
-    }
-    drop(incoming);
-
-    assert!(destination.await.unwrap().is_err());
-    assert_eq!(
-        send_command(
-            &command_tx,
-            SchedulerCommand::CancelDestination { handoff_id },
-        )
-        .await
-        .unwrap()
-        .result,
-        SchedulerCommandResult::Noop
-    );
-    shutdown.cancel();
-    server.wait_closed().await;
-}
-
-#[tokio::test]
-async fn destination_disconnect_cleans_reserved_and_activated_ownership() {
-    assert_destination_disconnect_cleans_ownership(EngineType::Vllm, false).await;
-    assert_destination_disconnect_cleans_ownership(EngineType::Vllm, true).await;
-    assert_destination_disconnect_cleans_ownership(EngineType::Sglang, true).await;
-}
-
-#[tokio::test]
-async fn lost_reserve_or_activation_ack_cleans_ambiguous_destination_ownership() {
-    for (case, lose_activation_ack) in [false, true].into_iter().enumerate() {
-        let shutdown = CancellationToken::new();
-        let server = BootstrapServer::start(
-            0,
-            shutdown.clone(),
-            BootstrapServerConfig {
-                max_pending_connections: 1,
-                ..BootstrapServerConfig::default()
-            },
-        )
-        .await
-        .unwrap();
-        let mut incoming_rx = server.take_incoming_receiver().unwrap();
-        let (mut destination_scheduler, _output) =
-            start_scheduler(EngineType::Vllm, WorkerType::Decode, shutdown.clone());
-        let registry = HandoffEventRegistry::default();
-        spawn_lifecycle_dispatcher(
-            destination_scheduler.take_lifecycle_receiver().unwrap(),
-            registry.clone(),
-        );
-        let request_id = Uuid::from_u128(72_000 + case as u128);
-        let handoff_id = HandoffId::from(Uuid::from_u128(72_100 + case as u128));
-        let identity = BootstrapIdentity {
-            handoff_id,
-            bootstrap_room: 14 + case as u64,
-            request_id,
-        };
-        let client = connect_to_prefill(
-            "127.0.0.1",
-            server.port(),
-            identity,
-            ParticipantRegistration {
-                role: BootstrapParticipantRole::Destination,
-                dp_rank: 0,
-                order: HandoffOrder::SourceFirst,
-                engine_type: EngineType::Vllm,
-            },
-        )
-        .await
-        .unwrap();
-        let mut source = incoming_rx.recv().await.unwrap();
-        let command_tx = destination_scheduler.command_sender();
-        let destination = tokio::spawn(run_destination_session(
-            client,
-            request(request_id, 2),
-            command_tx.clone(),
-            registry.register(handoff_id).unwrap(),
-            CancellationToken::new(),
-            Duration::from_secs(2),
-            shutdown.clone(),
-        ));
-        source
-            .connection
-            .send(BootstrapMessage::Registered)
-            .await
-            .unwrap();
-
-        let mut coordinator = HandoffCoordinatorCore::new(handoff_id, HandoffOrder::SourceFirst);
-        let submit = coordinator.start().unwrap().pop().unwrap();
-        coordinator
-            .on_action_outcome(submit.id, HandoffActionOutcome::Submitted)
-            .unwrap();
-        let reserve = coordinator
-            .on_fact(HandoffFact::SourceHeld {
-                handoff_id,
-                transfer_timing: transfer_timing(None),
-            })
-            .unwrap()
-            .pop()
-            .unwrap();
-        source
-            .connection
-            .send(BootstrapMessage::Action(reserve))
-            .await
-            .unwrap();
-
-        if lose_activation_ack {
-            let reserve_ack = source.connection.recv().await.unwrap().unwrap();
-            let BootstrapMessage::ActionAck { action_id, outcome } = reserve_ack else {
-                panic!("expected reserve acknowledgement");
-            };
-            coordinator.on_action_outcome(action_id, outcome).unwrap();
-            assert!(matches!(
-                source.connection.recv().await.unwrap(),
-                Some(BootstrapMessage::Fact(
-                    HandoffFact::DestinationReserved { .. }
-                ))
-            ));
-            let transfer = coordinator
-                .on_fact(HandoffFact::DestinationReserved {
-                    handoff_id,
-                    transferable_prompt_tokens: 1,
-                })
-                .unwrap()
-                .pop()
-                .unwrap();
-            coordinator
-                .on_action_outcome(transfer.id, HandoffActionOutcome::Scheduled)
-                .unwrap();
-            let activation = coordinator
-                .on_fact(HandoffFact::TransferCompleted { handoff_id })
-                .unwrap()
-                .pop()
-                .unwrap();
-            source
-                .connection
-                .send(BootstrapMessage::Action(activation))
-                .await
-                .unwrap();
-        }
-        drop(source);
-
-        assert!(destination.await.unwrap().is_err());
-        assert_eq!(
-            send_command(
-                &command_tx,
-                SchedulerCommand::CancelDestination { handoff_id },
-            )
-            .await
-            .unwrap()
-            .result,
-            SchedulerCommandResult::Noop
-        );
-        shutdown.cancel();
-        server.wait_closed().await;
-    }
-}
-
-#[tokio::test(start_paused = true)]
-async fn cleanup_ack_can_wait_beyond_the_rendezvous_timeout() {
-    let (command_tx, mut command_rx) = mpsc::channel(1);
-    tokio::spawn(async move {
-        let envelope: SchedulerCommandEnvelope = command_rx.recv().await.unwrap();
-        tokio::time::sleep(Duration::from_secs(31)).await;
-        let _ = envelope.reply.send(Ok(SchedulerCommandEffects {
-            result: SchedulerCommandResult::Noop,
-            lifecycle_events: Vec::new(),
-            kv_events: Vec::new(),
-        }));
-    });
-
-    let effects = send_cleanup_command(
-        &command_tx,
-        SchedulerCommand::CancelSource {
-            handoff_id: HandoffId::new(),
-        },
-        tokio::time::Instant::now() + Duration::from_secs(40),
-    )
-    .await
-    .unwrap();
-    assert_eq!(effects.result, SchedulerCommandResult::Noop);
-}
-
-#[tokio::test]
-async fn duplicate_lifecycle_route_does_not_replace_the_active_route() {
-    let registry = HandoffEventRegistry::default();
-    let handoff_id = HandoffId::from(Uuid::from_u128(80_000));
-    let request_id = Uuid::from_u128(80_001);
-    let mut route = registry.register(handoff_id).unwrap();
-
-    assert!(registry.register(handoff_id).is_err());
-    registry
-        .deliver(SchedulerLifecycleEvent::SourceHeld {
-            handoff_id,
-            request_id,
-            transfer_timing: transfer_timing(None),
-        })
-        .await;
-
-    assert!(matches!(
-        tokio::time::timeout(Duration::from_secs(1), route.recv())
-            .await
-            .unwrap(),
-        Some(SchedulerLifecycleEvent::SourceHeld {
-            handoff_id: observed,
-            request_id: observed_request,
             ..
-        }) if observed == handoff_id && observed_request == request_id
+        })) if observed == handoff_id
     ));
+
+    cancel.cancel();
+    let cleanup = calls.recv().await.unwrap();
+    assert_eq!(cleanup.action, HandoffControlAction::CancelSource);
+    acknowledge(cleanup, HandoffActionOutcome::Applied);
+    assert!(session.await.unwrap().is_err());
+    assert!(matches!(completion_rx.await.unwrap(), Err(_)));
+    finish_test_transport(server, shutdown).await;
 }
 
 #[tokio::test]
-async fn pending_source_cancellation_releases_session_capacity_before_rendezvous_timeout() {
+async fn pending_source_cancellation_releases_session_permit() {
     let (_incoming_tx, incoming_rx) = mpsc::channel(1);
     let shutdown = CancellationToken::new();
-    let manager =
-        SourceHandoffManager::start(incoming_rx, 1, Duration::from_secs(1), shutdown.clone());
-    let registry = HandoffEventRegistry::default();
-    let handoff_id = HandoffId::from(Uuid::from_u128(81_000));
+    let manager = SourceHandoffManager::start_with_rendezvous_timeout(
+        incoming_rx,
+        1,
+        Duration::from_secs(1),
+        Duration::from_secs(30),
+        shutdown.clone(),
+    );
+    let handoff_id = HandoffId::from(Uuid::from_u128(73_001));
+    let request_id = Uuid::from_u128(73_002);
+    let (control, _calls, events, _event_tx) = semantic_boundary();
     let cancel = CancellationToken::new();
-    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
-    let permit = semaphore.clone().try_acquire_owned().unwrap();
-    let (command_tx, _command_rx) = mpsc::channel(1);
+    let permits = Arc::new(tokio::sync::Semaphore::new(1));
+    let permit = permits.clone().try_acquire_owned().unwrap();
     let (completion_tx, completion_rx) = oneshot::channel();
     manager
         .try_register(SourceRegistration {
             identity: BootstrapIdentity {
                 handoff_id,
-                bootstrap_room: 11,
-                request_id: Uuid::from_u128(81_001),
+                bootstrap_room: 18,
+                request_id,
             },
             order: HandoffOrder::SourceFirst,
             engine_type: EngineType::Vllm,
-            request: request(Uuid::from_u128(81_001), 1),
-            command_tx,
-            lifecycle: registry.register(handoff_id).unwrap(),
+            control,
+            lifecycle: events,
             completion_tx,
             cancel: cancel.clone(),
             observer: None,
             _permit: permit,
         })
         .unwrap();
-
     manager.wait_for_pending_source(handoff_id).await;
+
     cancel.cancel();
-    let error = completion_rx.await.unwrap().unwrap_err();
-    assert!(error.contains("canceled before rendezvous"));
-    assert_eq!(semaphore.available_permits(), 1);
-    shutdown.cancel();
-    manager.wait_closed().await;
-}
-
-#[tokio::test(start_paused = true)]
-async fn rendezvous_timeout_retires_the_session_id() {
-    let (_incoming_tx, incoming_rx) = mpsc::channel(1);
-    let shutdown = CancellationToken::new();
-    let manager = SourceHandoffManager::start_with_rendezvous_timeout(
-        incoming_rx,
-        1,
-        Duration::from_secs(10),
-        Duration::from_secs(1),
-        shutdown.clone(),
-    );
-    let registry = HandoffEventRegistry::default();
-    let handoff_id = HandoffId::from(Uuid::from_u128(81_500));
-    let permit_pool = Arc::new(tokio::sync::Semaphore::new(1));
-    let (command_tx, _command_rx) = mpsc::channel(1);
-    let make_registration = |completion_tx| SourceRegistration {
-        identity: BootstrapIdentity {
-            handoff_id,
-            bootstrap_room: 15,
-            request_id: Uuid::from_u128(81_501),
-        },
-        order: HandoffOrder::SourceFirst,
-        engine_type: EngineType::Vllm,
-        request: request(Uuid::from_u128(81_501), 1),
-        command_tx: command_tx.clone(),
-        lifecycle: registry.register(handoff_id).unwrap(),
-        completion_tx,
-        cancel: CancellationToken::new(),
-        observer: None,
-        _permit: permit_pool.clone().try_acquire_owned().unwrap(),
-    };
-
-    let (completion_tx, completion_rx) = oneshot::channel();
-    manager
-        .try_register(make_registration(completion_tx))
-        .unwrap();
-    let error = completion_rx.await.unwrap().unwrap_err();
-    assert!(error.contains("rendezvous timed out"));
-    tokio::task::yield_now().await;
-    assert_eq!(permit_pool.available_permits(), 1);
-
-    let (completion_tx, completion_rx) = oneshot::channel();
-    manager
-        .try_register(make_registration(completion_tx))
-        .unwrap();
-    let error = completion_rx.await.unwrap().unwrap_err();
-    assert!(error.contains("retired"));
-    tokio::task::yield_now().await;
-    assert_eq!(permit_pool.available_permits(), 1);
-
-    shutdown.cancel();
-    manager.wait_closed().await;
-}
-
-#[tokio::test]
-async fn pending_destination_disconnect_is_retired_without_rendezvous_timeout() {
-    let manager_shutdown = CancellationToken::new();
-    let scheduler_shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        manager_shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 1,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let incoming = server.take_incoming_receiver().unwrap();
-    let manager = SourceHandoffManager::start(
-        incoming,
-        1,
-        Duration::from_secs(2),
-        manager_shutdown.clone(),
-    );
-    let (mut source_scheduler, _output) = start_scheduler(
-        EngineType::Vllm,
-        WorkerType::Prefill,
-        scheduler_shutdown.clone(),
-    );
-    let registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        source_scheduler.take_lifecycle_receiver().unwrap(),
-        registry.clone(),
-    );
-    let request_id = Uuid::from_u128(82_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(82_001));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 12,
-        request_id,
-    };
-    let client = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity.clone(),
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-        },
-    )
-    .await
-    .unwrap();
-    manager.wait_for_pending_destination(handoff_id).await;
-    drop(client);
+    assert!(matches!(completion_rx.await.unwrap(), Err(_)));
     manager.wait_for_retired(handoff_id).await;
+    assert_eq!(permits.available_permits(), 1);
 
-    let permit_pool = Arc::new(tokio::sync::Semaphore::new(1));
-    let (completion_tx, completion_rx) = oneshot::channel();
-    manager
-        .try_register(SourceRegistration {
-            identity,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-            request: request(request_id, 1),
-            command_tx: source_scheduler.command_sender(),
-            lifecycle: registry.register(handoff_id).unwrap(),
-            completion_tx,
-            cancel: CancellationToken::new(),
-            observer: None,
-            _permit: permit_pool.clone().try_acquire_owned().unwrap(),
-        })
-        .unwrap();
-    let error = completion_rx.await.unwrap().unwrap_err();
-    assert!(error.contains("retired"));
-    assert_eq!(permit_pool.available_permits(), 1);
-
-    manager_shutdown.cancel();
+    shutdown.cancel();
     manager.wait_closed().await;
-    server.wait_closed().await;
-    scheduler_shutdown.cancel();
 }
 
-#[tokio::test]
-async fn active_shutdown_joins_sessions_after_exact_cleanup() {
-    let manager_shutdown = CancellationToken::new();
-    let scheduler_shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        manager_shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 1,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let incoming = server.take_incoming_receiver().unwrap();
-    let manager = SourceHandoffManager::start(
-        incoming,
-        1,
-        Duration::from_secs(2),
-        manager_shutdown.clone(),
-    );
-    let (mut source_scheduler, _source_output) = start_scheduler(
-        EngineType::Vllm,
-        WorkerType::Prefill,
-        scheduler_shutdown.clone(),
-    );
-    let (mut destination_scheduler, _destination_output) = start_scheduler(
-        EngineType::Vllm,
-        WorkerType::Decode,
-        scheduler_shutdown.clone(),
-    );
-    let source_registry = HandoffEventRegistry::default();
-    let destination_registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        source_scheduler.take_lifecycle_receiver().unwrap(),
-        source_registry.clone(),
-    );
-    spawn_lifecycle_dispatcher(
-        destination_scheduler.take_lifecycle_receiver().unwrap(),
-        destination_registry.clone(),
-    );
-    let request_id = Uuid::from_u128(83_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(83_001));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 13,
-        request_id,
-    };
-    let permit_pool = Arc::new(tokio::sync::Semaphore::new(1));
-    let (completion_tx, completion_rx) = oneshot::channel();
-    manager
-        .try_register(SourceRegistration {
-            identity: identity.clone(),
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-            request: request(request_id, 1),
-            command_tx: source_scheduler.command_sender(),
-            lifecycle: source_registry.register(handoff_id).unwrap(),
-            completion_tx,
-            cancel: CancellationToken::new(),
-            observer: None,
-            _permit: permit_pool.clone().try_acquire_owned().unwrap(),
-        })
-        .unwrap();
-    let connection = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-        },
-    )
-    .await
-    .unwrap();
-    let source_command_tx = source_scheduler.command_sender();
-    let destination_command_tx = destination_scheduler.command_sender();
-    let destination = tokio::spawn(run_destination_session(
-        connection,
-        request(request_id, 2),
-        destination_command_tx.clone(),
-        destination_registry.register(handoff_id).unwrap(),
-        CancellationToken::new(),
-        Duration::from_secs(2),
-        manager_shutdown.clone(),
-    ));
-    manager.wait_for_active(handoff_id).await;
-    manager_shutdown.cancel();
-
-    manager.wait_closed().await;
-    server.wait_closed().await;
-    assert!(completion_rx.await.unwrap().is_err());
-    assert!(destination.await.unwrap().is_err());
-    assert_eq!(permit_pool.available_permits(), 1);
-    assert_eq!(
-        send_command(
-            &source_command_tx,
-            SchedulerCommand::CancelSource { handoff_id },
-        )
-        .await
-        .unwrap()
-        .result,
-        SchedulerCommandResult::Noop
-    );
-    assert_eq!(
-        send_command(
-            &destination_command_tx,
-            SchedulerCommand::CancelDestination { handoff_id },
-        )
-        .await
-        .unwrap()
-        .result,
-        SchedulerCommandResult::Noop
-    );
-    assert!(source_registry.register(handoff_id).is_ok());
-    assert!(destination_registry.register(handoff_id).is_ok());
-    scheduler_shutdown.cancel();
+#[derive(Clone)]
+struct CapturingKvSink {
+    tx: mpsc::UnboundedSender<KvCacheEvent>,
 }
 
-#[tokio::test]
-async fn expired_source_session_deadline_still_cleans_held_ownership() {
-    let transport_shutdown = CancellationToken::new();
-    let scheduler_shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        transport_shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 1,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let mut incoming = server.take_incoming_receiver().unwrap();
-    let (mut source_scheduler, _output) = start_scheduler(
-        EngineType::Vllm,
-        WorkerType::Prefill,
-        scheduler_shutdown.clone(),
-    );
-    let registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        source_scheduler.take_lifecycle_receiver().unwrap(),
-        registry.clone(),
-    );
-    let request_id = Uuid::from_u128(84_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(84_001));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 14,
-        request_id,
-    };
-    let mut destination_connection = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity.clone(),
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::SourceFirst,
-            engine_type: EngineType::Vllm,
-        },
-    )
-    .await
-    .unwrap();
-    let source_connection = incoming.recv().await.unwrap().connection;
-    let source_command_tx = source_scheduler.command_sender();
-    let (completion_tx, completion_rx) = oneshot::channel();
-    let source = SourceRegistration {
-        identity,
-        order: HandoffOrder::SourceFirst,
-        engine_type: EngineType::Vllm,
-        request: request(request_id, 1),
-        command_tx: source_command_tx.clone(),
-        lifecycle: registry.register(handoff_id).unwrap(),
-        completion_tx,
-        cancel: CancellationToken::new(),
-        observer: None,
-        _permit: Arc::new(tokio::sync::Semaphore::new(1))
-            .try_acquire_owned()
-            .unwrap(),
-    };
-    let source_task = tokio::spawn(run_source_session(
-        source,
-        source_connection,
-        Duration::from_millis(100),
-        transport_shutdown.clone(),
-    ));
+impl KvCacheEventSink for CapturingKvSink {
+    fn publish(&self, event: KvCacheEvent) -> anyhow::Result<()> {
+        self.tx
+            .send(event)
+            .map_err(|_| anyhow!("KV event receiver closed"))
+    }
+}
 
-    assert!(matches!(
-        destination_connection.recv().await.unwrap(),
-        Some(BootstrapMessage::Registered)
-    ));
-    loop {
-        let message = destination_connection.recv().await.unwrap().unwrap();
-        if matches!(
-            message,
-            BootstrapMessage::Action(IssuedHandoffAction {
-                action: HandoffAction::ReserveDestination { .. },
-                ..
-            })
-        ) {
+fn start_live_engine(
+    engine_type: EngineType,
+    worker_type: WorkerType,
+    transfer_timing_mode: KvTransferTimingMode,
+) -> (LiveEngine, mpsc::UnboundedReceiver<KvCacheEvent>) {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let engine = LiveEngine::start_with_config(
+        args_with_mode(engine_type, worker_type, transfer_timing_mode),
+        0,
+        LiveEngineConfig {
+            kv_event_publishers: KvEventPublishers::new(
+                Some(Arc::new(CapturingKvSink { tx: event_tx })),
+                None,
+            ),
+            fpm_publisher: FpmPublisher::default(),
+        },
+    )
+    .unwrap();
+    (engine, event_rx)
+}
+
+async fn collect_output(
+    mut request: LiveRequest,
+) -> Vec<dynamo_mocker::common::protocols::OutputSignal> {
+    let mut output = Vec::new();
+    while let Some(signal) = request.recv().await {
+        let terminal = signal.completed;
+        output.push(signal);
+        if terminal {
             break;
         }
     }
+    output
+}
 
-    assert!(
-        tokio::time::timeout(Duration::from_secs(2), source_task)
-            .await
-            .unwrap()
-            .unwrap()
-            .is_err()
-    );
-    assert!(completion_rx.await.unwrap().is_err());
-    assert_eq!(
-        send_command(
-            &source_command_tx,
-            SchedulerCommand::CancelSource { handoff_id },
-        )
-        .await
-        .unwrap()
-        .result,
-        SchedulerCommandResult::Noop
-    );
+fn stored_event_count(events: &mut mpsc::UnboundedReceiver<KvCacheEvent>) -> usize {
+    std::iter::from_fn(|| events.try_recv().ok())
+        .map(|event| match event.data {
+            KvCacheEventData::Stored(data) => data.blocks.len(),
+            KvCacheEventData::Removed(_) | KvCacheEventData::Cleared => 0,
+        })
+        .sum()
+}
 
-    transport_shutdown.cancel();
-    server.wait_closed().await;
-    scheduler_shutdown.cancel();
+async fn wait_for_idle(engine: &LiveEngine) {
+    tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let metrics = engine.metrics_receiver().borrow().clone();
+            if engine.active_request_count() == 0
+                && metrics.running_requests == 0
+                && metrics.waiting_requests == 0
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("live handoff engine must return to idle");
 }
 
 #[tokio::test]
-async fn expired_destination_session_deadline_still_cleans_reserved_ownership() {
-    let transport_shutdown = CancellationToken::new();
-    let scheduler_shutdown = CancellationToken::new();
-    let server = BootstrapServer::start(
-        0,
-        transport_shutdown.clone(),
-        BootstrapServerConfig {
-            max_pending_connections: 1,
-            ..BootstrapServerConfig::default()
-        },
-    )
-    .await
-    .unwrap();
-    let mut incoming = server.take_incoming_receiver().unwrap();
-    let (mut destination_scheduler, _output) = start_scheduler(
-        EngineType::Vllm,
-        WorkerType::Decode,
-        scheduler_shutdown.clone(),
-    );
-    let registry = HandoffEventRegistry::default();
-    spawn_lifecycle_dispatcher(
-        destination_scheduler.take_lifecycle_receiver().unwrap(),
-        registry.clone(),
-    );
-    let request_id = Uuid::from_u128(85_000);
-    let handoff_id = HandoffId::from(Uuid::from_u128(85_001));
-    let identity = BootstrapIdentity {
-        handoff_id,
-        bootstrap_room: 15,
-        request_id,
-    };
-    let destination_connection = connect_to_prefill(
-        "127.0.0.1",
-        server.port(),
-        identity,
-        ParticipantRegistration {
-            role: BootstrapParticipantRole::Destination,
-            dp_rank: 0,
-            order: HandoffOrder::DestinationFirst,
-            engine_type: EngineType::Vllm,
-        },
-    )
-    .await
-    .unwrap();
-    let mut source_connection = incoming.recv().await.unwrap().connection;
-    let destination_command_tx = destination_scheduler.command_sender();
-    let destination_task = tokio::spawn(run_destination_session(
-        destination_connection,
-        request(request_id, 2),
-        destination_command_tx.clone(),
-        registry.register(handoff_id).unwrap(),
-        CancellationToken::new(),
-        Duration::from_millis(100),
-        transport_shutdown.clone(),
-    ));
+async fn live_handoff_preserves_timing_kv_and_cleanup_for_supported_engines() {
+    for engine_type in [EngineType::Vllm, EngineType::Sglang] {
+        for transfer_timing_mode in [
+            KvTransferTimingMode::FullPrompt,
+            KvTransferTimingMode::DestinationMissing,
+        ] {
+            let (source_engine, mut source_kv) =
+                start_live_engine(engine_type, WorkerType::Prefill, transfer_timing_mode);
+            let (destination_engine, mut destination_kv) =
+                start_live_engine(engine_type, WorkerType::Decode, transfer_timing_mode);
+            let shutdown = CancellationToken::new();
+            let server =
+                BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
+                    .await
+                    .unwrap();
+            let incoming = server.take_incoming_receiver().unwrap();
+            let manager =
+                SourceHandoffManager::start(incoming, 1, Duration::from_secs(2), shutdown.clone());
+            let handoff_id = HandoffId::new();
+            let request_id = Uuid::new_v4();
+            let identity = BootstrapIdentity {
+                handoff_id,
+                bootstrap_room: 19,
+                request_id,
+            };
+            let order = order_for_engine(engine_type).unwrap();
+            let destination_connection = connect_to_prefill(
+                "127.0.0.1",
+                server.port(),
+                identity.clone(),
+                ParticipantRegistration {
+                    role: BootstrapParticipantRole::Destination,
+                    dp_rank: 0,
+                    order,
+                    engine_type,
+                },
+            )
+            .await
+            .unwrap();
 
-    source_connection
-        .send(BootstrapMessage::Registered)
-        .await
-        .unwrap();
-    let mut coordinator = HandoffCoordinatorCore::new(handoff_id, HandoffOrder::DestinationFirst);
-    let reserve = coordinator.start().unwrap().pop().unwrap();
-    source_connection
-        .send(BootstrapMessage::Action(reserve))
-        .await
-        .unwrap();
-    let mut accepted = false;
-    let mut reserved = false;
-    while !accepted || !reserved {
-        match source_connection.recv().await.unwrap().unwrap() {
-            BootstrapMessage::ActionAck { action_id, outcome }
-                if action_id == reserve.id && outcome == HandoffActionOutcome::Accepted =>
-            {
-                accepted = true;
+            let (source_registration, source_request) = source_engine
+                .prepare_request(request(request_id, 1))
+                .unwrap();
+            let (source_control, source_events) =
+                source_engine.register_handoff(handoff_id).unwrap();
+            let (source_control, source_events) =
+                live_handoff_boundary(source_control, source_events, source_registration);
+            let (destination_registration, destination_request) = destination_engine
+                .prepare_request(request(request_id, 1))
+                .unwrap();
+            let (destination_control, destination_events) =
+                destination_engine.register_handoff(handoff_id).unwrap();
+            let (destination_control, destination_events) = live_handoff_boundary(
+                destination_control,
+                destination_events,
+                destination_registration,
+            );
+
+            let permits = Arc::new(tokio::sync::Semaphore::new(1));
+            let permit: OwnedSemaphorePermit = permits.clone().try_acquire_owned().unwrap();
+            let (completion_tx, completion_rx) = oneshot::channel();
+            let (observer_tx, mut observer_rx) = mpsc::unbounded_channel();
+            manager
+                .try_register(SourceRegistration {
+                    identity,
+                    order,
+                    engine_type,
+                    control: source_control,
+                    lifecycle: source_events,
+                    completion_tx,
+                    cancel: CancellationToken::new(),
+                    observer: Some(observer_tx),
+                    _permit: permit,
+                })
+                .unwrap();
+            let destination_session = tokio::spawn(run_destination_session(
+                destination_connection,
+                destination_control,
+                destination_events,
+                CancellationToken::new(),
+                Duration::from_secs(2),
+                shutdown.clone(),
+            ));
+
+            let (source_output, destination_output, source_completion, destination_completion) =
+                tokio::time::timeout(Duration::from_secs(5), async {
+                    tokio::join!(
+                        collect_output(source_request),
+                        collect_output(destination_request),
+                        completion_rx,
+                        destination_session,
+                    )
+                })
+                .await
+                .expect("live handoff timed out");
+            assert!(source_completion.unwrap().is_ok());
+            assert!(destination_completion.unwrap().is_ok());
+            assert!(source_output.last().is_some_and(|signal| signal.completed));
+            assert!(
+                destination_output
+                    .last()
+                    .is_some_and(|signal| signal.completed)
+            );
+            assert_eq!(permits.available_permits(), 1);
+
+            let observed = std::iter::from_fn(|| observer_rx.try_recv().ok()).collect::<Vec<_>>();
+            for expected in [
+                NormalizedHandoffEvent::SourceHeld,
+                NormalizedHandoffEvent::DestinationAccepted,
+                NormalizedHandoffEvent::DestinationReserved,
+                NormalizedHandoffEvent::DestinationActivated,
+                NormalizedHandoffEvent::SourceReleased,
+                NormalizedHandoffEvent::Completed,
+            ] {
+                assert!(
+                    observed.contains(&expected),
+                    "missing {expected:?} for {engine_type:?}/{transfer_timing_mode:?}: {observed:?}"
+                );
             }
-            BootstrapMessage::Fact(HandoffFact::DestinationReserved {
-                handoff_id: observed,
-                ..
-            }) if observed == handoff_id => reserved = true,
-            other => panic!("unexpected destination message: {other:?}"),
+            assert!(stored_event_count(&mut source_kv) > 0);
+            assert!(stored_event_count(&mut destination_kv) > 0);
+            wait_for_idle(&source_engine).await;
+            wait_for_idle(&destination_engine).await;
+
+            shutdown.cancel();
+            manager.wait_closed().await;
+            server.wait_closed().await;
+            source_engine.shutdown().await.unwrap();
+            destination_engine.shutdown().await.unwrap();
         }
     }
-
-    assert!(
-        tokio::time::timeout(Duration::from_secs(2), destination_task)
-            .await
-            .unwrap()
-            .unwrap()
-            .is_err()
-    );
-    assert_eq!(
-        send_command(
-            &destination_command_tx,
-            SchedulerCommand::CancelDestination { handoff_id },
-        )
-        .await
-        .unwrap()
-        .result,
-        SchedulerCommandResult::Noop
-    );
-
-    transport_shutdown.cancel();
-    server.wait_closed().await;
-    scheduler_shutdown.cancel();
 }

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -363,7 +363,7 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
     assert_eq!(cleanup.action, HandoffControlAction::CancelSource);
     acknowledge(cleanup, HandoffActionOutcome::Applied);
     assert!(session.await.unwrap().is_err());
-    assert!(matches!(completion_rx.await.unwrap(), Err(_)));
+    assert!(completion_rx.await.unwrap().is_err());
     finish_test_transport(server, shutdown).await;
 }
 
@@ -405,7 +405,7 @@ async fn pending_source_cancellation_releases_session_permit() {
     manager.wait_for_pending_source(handoff_id).await;
 
     cancel.cancel();
-    assert!(matches!(completion_rx.await.unwrap(), Err(_)));
+    assert!(completion_rx.await.unwrap().is_err());
     manager.wait_for_retired(handoff_id).await;
     assert_eq!(permits.available_permits(), 1);
 

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -270,6 +270,62 @@ async fn destination_ack_precedes_an_early_reservation_fact() {
 }
 
 #[tokio::test]
+async fn destination_rejects_an_action_for_another_handoff() {
+    let request_id = Uuid::from_u128(70_100);
+    let handoff_id = HandoffId::from(Uuid::from_u128(70_101));
+    let other_handoff_id = HandoffId::from(Uuid::from_u128(70_102));
+    let (server, mut source, destination, shutdown) = bootstrap_pair(
+        handoff_id,
+        request_id,
+        HandoffOrder::DestinationFirst,
+        EngineType::Sglang,
+    )
+    .await;
+    let (control, mut calls, events, _event_tx) = semantic_boundary();
+    let cancel = CancellationToken::new();
+    let session = tokio::spawn(run_destination_session(
+        destination,
+        control,
+        events,
+        cancel.clone(),
+        Duration::from_secs(2),
+        shutdown.clone(),
+    ));
+
+    source.send(BootstrapMessage::Registered).await.unwrap();
+    let mut other_coordinator =
+        HandoffCoordinatorCore::new(other_handoff_id, HandoffOrder::DestinationFirst);
+    let reserve = other_coordinator.start().unwrap().pop().unwrap();
+    source
+        .send(BootstrapMessage::Action(reserve))
+        .await
+        .unwrap();
+    let response = tokio::select! {
+        response = source.recv() => response.unwrap(),
+        invocation = calls.recv() => {
+            panic!(
+                "mismatched action reached typed control: {:?}",
+                invocation.unwrap().action
+            );
+        }
+    };
+    assert!(matches!(
+        response,
+        Some(BootstrapMessage::ActionAck {
+            action_id,
+            outcome: HandoffActionOutcome::Failed(message),
+        }) if action_id == reserve.id && message.contains("does not match bootstrap handoff")
+    ));
+
+    cancel.cancel();
+    let cleanup = calls.recv().await.unwrap();
+    assert_eq!(cleanup.action, HandoffControlAction::CancelDestination);
+    acknowledge(cleanup, HandoffActionOutcome::Applied);
+    assert!(session.await.unwrap().is_err());
+    finish_test_transport(server, shutdown).await;
+}
+
+#[tokio::test]
 async fn premature_complete_waits_for_destination_cleanup() {
     let request_id = Uuid::from_u128(71_000);
     let handoff_id = HandoffId::from(Uuid::from_u128(71_001));

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -3,8 +3,11 @@
 
 use super::*;
 use async_trait::async_trait;
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
-use dynamo_mocker::common::handoff::{HandoffTransferTiming, NormalizedHandoffEvent};
+use dynamo_kv_router::protocols::{ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData};
+use dynamo_mocker::common::handoff::{
+    HandoffTransferTiming, NormalizedHandoffConformance, NormalizedHandoffEvent,
+    NormalizedStoredTiming,
+};
 use dynamo_mocker::common::protocols::{
     EngineType, FpmPublisher, KvCacheEventSink, KvEventPublishers, KvTransferTimingMode,
     MockEngineArgs, WorkerType,
@@ -16,6 +19,8 @@ use dynamo_mocker::services::bootstrap::{
 };
 use tokio::sync::{OwnedSemaphorePermit, mpsc, oneshot};
 use uuid::Uuid;
+
+use std::collections::HashSet;
 
 fn args_with_mode(
     engine_type: EngineType,
@@ -461,17 +466,65 @@ async fn collect_output(
     output
 }
 
-fn stored_event_count(events: &mut mpsc::UnboundedReceiver<KvCacheEvent>) -> usize {
+fn drain_stored_hashes(
+    events: &mut mpsc::UnboundedReceiver<KvCacheEvent>,
+) -> Vec<ExternalSequenceBlockHash> {
     std::iter::from_fn(|| events.try_recv().ok())
-        .map(|event| match event.data {
-            KvCacheEventData::Stored(data) => data.blocks.len(),
-            KvCacheEventData::Removed(_) | KvCacheEventData::Cleared => 0,
+        .flat_map(|event| match event.data {
+            KvCacheEventData::Stored(data) => data
+                .blocks
+                .into_iter()
+                .map(|block| block.block_hash)
+                .collect(),
+            KvCacheEventData::Removed(_) | KvCacheEventData::Cleared => Vec::new(),
         })
-        .sum()
+        .collect()
+}
+
+struct LiveHandoffObservation {
+    lifecycle: Vec<NormalizedHandoffEvent>,
+    before_activation: usize,
+    activation_hashes: Vec<ExternalSequenceBlockHash>,
+    remaining_kv: mpsc::UnboundedReceiver<KvCacheEvent>,
+}
+
+async fn observe_live_handoff(
+    mut lifecycle_rx: mpsc::UnboundedReceiver<NormalizedHandoffEvent>,
+    mut destination_kv: mpsc::UnboundedReceiver<KvCacheEvent>,
+) -> LiveHandoffObservation {
+    let mut lifecycle = Vec::new();
+    let mut before_activation = 0;
+    let mut activation_hashes = Vec::new();
+    let mut activated = false;
+    loop {
+        let event = lifecycle_rx
+            .recv()
+            .await
+            .expect("handoff observer closed before completion");
+        lifecycle.push(event);
+        match event {
+            NormalizedHandoffEvent::DestinationActivated => {
+                activation_hashes.extend(drain_stored_hashes(&mut destination_kv));
+                activated = true;
+            }
+            NormalizedHandoffEvent::Completed => {
+                return LiveHandoffObservation {
+                    lifecycle,
+                    before_activation,
+                    activation_hashes,
+                    remaining_kv: destination_kv,
+                };
+            }
+            _ if !activated => {
+                before_activation += drain_stored_hashes(&mut destination_kv).len();
+            }
+            _ => {}
+        }
+    }
 }
 
 async fn wait_for_idle(engine: &LiveEngine) {
-    tokio::time::timeout(Duration::from_secs(2), async {
+    let result = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             let metrics = engine.metrics_receiver().borrow().clone();
             if engine.active_request_count() == 0
@@ -483,76 +536,103 @@ async fn wait_for_idle(engine: &LiveEngine) {
             tokio::task::yield_now().await;
         }
     })
+    .await;
+    if result.is_err() {
+        let metrics = engine.metrics_receiver().borrow().clone();
+        panic!(
+            "live handoff engine must return to idle: routes={}, running={}, waiting={}, active_blocks={}",
+            engine.active_request_count(),
+            metrics.running_requests,
+            metrics.waiting_requests,
+            metrics.active_decode_blocks,
+        );
+    }
+}
+
+async fn probe_engine_drained(engine: &LiveEngine) -> bool {
+    let mut probe = engine
+        .submit(dynamo_mocker::common::protocols::DirectRequest {
+            tokens: (10_000..10_252).collect(),
+            max_output_tokens: 1,
+            output_token_ids: Some(vec![42]),
+            uuid: Some(Uuid::new_v4()),
+            ..Default::default()
+        })
+        .await
+        .expect("drain probe submission failed");
+    let completed = tokio::time::timeout(Duration::from_secs(2), async {
+        while let Some(signal) = probe.recv().await {
+            if signal.completed {
+                return true;
+            }
+        }
+        false
+    })
     .await
-    .expect("live handoff engine must return to idle");
+    .unwrap_or(false);
+    drop(probe);
+    wait_for_idle(engine).await;
+    completed && engine.active_request_count() == 0
 }
 
 #[tokio::test]
-async fn live_handoff_preserves_timing_kv_and_cleanup_for_supported_engines() {
+async fn live_and_offline_handoff_surfaces_share_one_conformance_report() {
     for engine_type in [EngineType::Vllm, EngineType::Sglang] {
         for transfer_timing_mode in [
             KvTransferTimingMode::FullPrompt,
             KvTransferTimingMode::DestinationMissing,
         ] {
-            let (source_engine, mut source_kv) =
-                start_live_engine(engine_type, WorkerType::Prefill, transfer_timing_mode);
-            let (destination_engine, mut destination_kv) =
-                start_live_engine(engine_type, WorkerType::Decode, transfer_timing_mode);
-            let shutdown = CancellationToken::new();
-            let server =
-                BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
-                    .await
+            for source_arrives_first in [true, false] {
+                let (source_engine, mut source_kv) =
+                    start_live_engine(engine_type, WorkerType::Prefill, transfer_timing_mode);
+                let (destination_engine, destination_kv) =
+                    start_live_engine(engine_type, WorkerType::Decode, transfer_timing_mode);
+                let shutdown = CancellationToken::new();
+                let server =
+                    BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
+                        .await
+                        .unwrap();
+                let incoming = server.take_incoming_receiver().unwrap();
+                let manager = SourceHandoffManager::start(
+                    incoming,
+                    1,
+                    Duration::from_secs(2),
+                    shutdown.clone(),
+                );
+                let handoff_id = HandoffId::new();
+                let request_id = Uuid::new_v4();
+                let identity = BootstrapIdentity {
+                    handoff_id,
+                    bootstrap_room: 19,
+                    request_id,
+                };
+                let order = order_for_engine(engine_type).unwrap();
+
+                let (source_registration, source_request) = source_engine
+                    .prepare_request(request(request_id, 1))
                     .unwrap();
-            let incoming = server.take_incoming_receiver().unwrap();
-            let manager =
-                SourceHandoffManager::start(incoming, 1, Duration::from_secs(2), shutdown.clone());
-            let handoff_id = HandoffId::new();
-            let request_id = Uuid::new_v4();
-            let identity = BootstrapIdentity {
-                handoff_id,
-                bootstrap_room: 19,
-                request_id,
-            };
-            let order = order_for_engine(engine_type).unwrap();
-            let destination_connection = connect_to_prefill(
-                "127.0.0.1",
-                server.port(),
-                identity.clone(),
-                ParticipantRegistration {
-                    role: BootstrapParticipantRole::Destination,
-                    dp_rank: 0,
-                    order,
-                    engine_type,
-                },
-            )
-            .await
-            .unwrap();
+                let (source_control, source_events) =
+                    source_engine.register_handoff(handoff_id).unwrap();
+                let (source_control, source_events) =
+                    live_handoff_boundary(source_control, source_events, source_registration);
+                let (destination_registration, destination_request) = destination_engine
+                    .prepare_request(request(request_id, 2))
+                    .unwrap();
+                let (destination_control, destination_events) =
+                    destination_engine.register_handoff(handoff_id).unwrap();
+                let (destination_control, destination_events) = live_handoff_boundary(
+                    destination_control,
+                    destination_events,
+                    destination_registration,
+                );
 
-            let (source_registration, source_request) = source_engine
-                .prepare_request(request(request_id, 1))
-                .unwrap();
-            let (source_control, source_events) =
-                source_engine.register_handoff(handoff_id).unwrap();
-            let (source_control, source_events) =
-                live_handoff_boundary(source_control, source_events, source_registration);
-            let (destination_registration, destination_request) = destination_engine
-                .prepare_request(request(request_id, 1))
-                .unwrap();
-            let (destination_control, destination_events) =
-                destination_engine.register_handoff(handoff_id).unwrap();
-            let (destination_control, destination_events) = live_handoff_boundary(
-                destination_control,
-                destination_events,
-                destination_registration,
-            );
-
-            let permits = Arc::new(tokio::sync::Semaphore::new(1));
-            let permit: OwnedSemaphorePermit = permits.clone().try_acquire_owned().unwrap();
-            let (completion_tx, completion_rx) = oneshot::channel();
-            let (observer_tx, mut observer_rx) = mpsc::unbounded_channel();
-            manager
-                .try_register(SourceRegistration {
-                    identity,
+                let permits = Arc::new(tokio::sync::Semaphore::new(1));
+                let permit: OwnedSemaphorePermit = permits.clone().try_acquire_owned().unwrap();
+                let (completion_tx, completion_rx) = oneshot::channel();
+                let (observer_tx, observer_rx) = mpsc::unbounded_channel();
+                let observer = tokio::spawn(observe_live_handoff(observer_rx, destination_kv));
+                let mut source = Some(SourceRegistration {
+                    identity: identity.clone(),
                     order,
                     engine_type,
                     control: source_control,
@@ -561,62 +641,123 @@ async fn live_handoff_preserves_timing_kv_and_cleanup_for_supported_engines() {
                     cancel: CancellationToken::new(),
                     observer: Some(observer_tx),
                     _permit: permit,
-                })
+                });
+                if source_arrives_first {
+                    manager.try_register(source.take().unwrap()).unwrap();
+                }
+                let destination_connection = connect_to_prefill(
+                    "127.0.0.1",
+                    server.port(),
+                    identity,
+                    ParticipantRegistration {
+                        role: BootstrapParticipantRole::Destination,
+                        dp_rank: 0,
+                        order,
+                        engine_type,
+                    },
+                )
+                .await
                 .unwrap();
-            let destination_session = tokio::spawn(run_destination_session(
-                destination_connection,
-                destination_control,
-                destination_events,
-                CancellationToken::new(),
-                Duration::from_secs(2),
-                shutdown.clone(),
-            ));
+                if !source_arrives_first {
+                    manager.wait_for_pending_destination(handoff_id).await;
+                    manager.try_register(source.take().unwrap()).unwrap();
+                }
+                let destination_session = tokio::spawn(run_destination_session(
+                    destination_connection,
+                    destination_control,
+                    destination_events,
+                    CancellationToken::new(),
+                    Duration::from_secs(2),
+                    shutdown.clone(),
+                ));
 
-            let (source_output, destination_output, source_completion, destination_completion) =
-                tokio::time::timeout(Duration::from_secs(5), async {
+                let (
+                    source_output,
+                    destination_output,
+                    source_completion,
+                    destination_completion,
+                    observation,
+                ) = tokio::time::timeout(Duration::from_secs(5), async {
                     tokio::join!(
                         collect_output(source_request),
                         collect_output(destination_request),
                         completion_rx,
                         destination_session,
+                        observer,
                     )
                 })
                 .await
                 .expect("live handoff timed out");
-            assert!(source_completion.unwrap().is_ok());
-            assert!(destination_completion.unwrap().is_ok());
-            assert!(source_output.last().is_some_and(|signal| signal.completed));
-            assert!(
-                destination_output
-                    .last()
-                    .is_some_and(|signal| signal.completed)
-            );
-            assert_eq!(permits.available_permits(), 1);
-
-            let observed = std::iter::from_fn(|| observer_rx.try_recv().ok()).collect::<Vec<_>>();
-            for expected in [
-                NormalizedHandoffEvent::SourceHeld,
-                NormalizedHandoffEvent::DestinationAccepted,
-                NormalizedHandoffEvent::DestinationReserved,
-                NormalizedHandoffEvent::DestinationActivated,
-                NormalizedHandoffEvent::SourceReleased,
-                NormalizedHandoffEvent::Completed,
-            ] {
+                assert!(source_completion.unwrap().is_ok());
+                assert!(destination_completion.unwrap().is_ok());
+                assert!(source_output.last().is_some_and(|signal| signal.completed));
                 assert!(
-                    observed.contains(&expected),
-                    "missing {expected:?} for {engine_type:?}/{transfer_timing_mode:?}: {observed:?}"
+                    destination_output
+                        .last()
+                        .is_some_and(|signal| signal.completed)
                 );
-            }
-            assert!(stored_event_count(&mut source_kv) > 0);
-            assert!(stored_event_count(&mut destination_kv) > 0);
-            wait_for_idle(&source_engine).await;
-            wait_for_idle(&destination_engine).await;
+                assert_eq!(permits.available_permits(), 1);
 
-            shutdown.cancel();
-            manager.wait_closed().await;
-            server.wait_closed().await;
-            source_engine.shutdown().await.unwrap();
-            destination_engine.shutdown().await.unwrap();
+                let mut observation = observation.unwrap();
+                let activation_set = observation
+                    .activation_hashes
+                    .iter()
+                    .copied()
+                    .collect::<HashSet<_>>();
+                let repeated_activation_hashes_after_activation =
+                    drain_stored_hashes(&mut observation.remaining_kv)
+                        .into_iter()
+                        .filter(|hash| activation_set.contains(hash))
+                        .count();
+                assert!(!drain_stored_hashes(&mut source_kv).is_empty());
+                wait_for_idle(&source_engine).await;
+                wait_for_idle(&destination_engine).await;
+                let source_drained = probe_engine_drained(&source_engine).await;
+                let destination_drained = probe_engine_drained(&destination_engine).await;
+                let source_route_reusable = source_engine.register_handoff(handoff_id).is_ok();
+                let destination_route_reusable =
+                    destination_engine.register_handoff(handoff_id).is_ok();
+                let report = NormalizedHandoffConformance {
+                    engine_type,
+                    order,
+                    lifecycle: observation.lifecycle,
+                    source_output_tokens: source_output
+                        .iter()
+                        .filter(|signal| signal.token_id.is_some())
+                        .count(),
+                    destination_output_tokens: destination_output
+                        .iter()
+                        .filter(|signal| signal.token_id.is_some())
+                        .count(),
+                    completed_requests: destination_output
+                        .iter()
+                        .filter(|signal| signal.completed)
+                        .count(),
+                    destination_stored: NormalizedStoredTiming {
+                        before_activation: observation.before_activation,
+                        on_activation: observation.activation_hashes.len(),
+                        repeated_activation_hashes_after_activation,
+                    },
+                    source_drained,
+                    destination_drained,
+                    driver_drained: permits.available_permits() == 1
+                        && source_route_reusable
+                        && destination_route_reusable,
+                };
+                report.validate().unwrap();
+                let offline = dynamo_mocker::replay::run_offline_handoff_conformance(
+                    engine_type,
+                    transfer_timing_mode,
+                )
+                .unwrap();
+                assert_eq!(report, offline);
+
+                shutdown.cancel();
+                manager.wait_closed().await;
+                server.wait_closed().await;
+                source_engine.shutdown().await.unwrap();
+                destination_engine.shutdown().await.unwrap();
+            }
         }
     }
 }

--- a/lib/llm/src/mocker/handoff_tests.rs
+++ b/lib/llm/src/mocker/handoff_tests.rs
@@ -104,14 +104,36 @@ impl HandoffSchedulerControl for SemanticControl {
     }
 }
 
+struct SemanticEvent {
+    event: LiveHandoffEvent,
+    consumed: oneshot::Sender<()>,
+}
+
+struct SemanticEventSender {
+    events: mpsc::UnboundedSender<SemanticEvent>,
+}
+
+impl SemanticEventSender {
+    fn send(&self, event: LiveHandoffEvent) -> oneshot::Receiver<()> {
+        let (consumed, consumed_rx) = oneshot::channel();
+        assert!(
+            self.events.send(SemanticEvent { event, consumed }).is_ok(),
+            "semantic handoff event stream closed"
+        );
+        consumed_rx
+    }
+}
+
 struct SemanticEvents {
-    events: mpsc::UnboundedReceiver<LiveHandoffEvent>,
+    events: mpsc::UnboundedReceiver<SemanticEvent>,
 }
 
 #[async_trait]
 impl HandoffEventStream for SemanticEvents {
     async fn recv(&mut self) -> Option<LiveHandoffEvent> {
-        self.events.recv().await
+        let event = self.events.recv().await?;
+        let _ = event.consumed.send(());
+        Some(event.event)
     }
 }
 
@@ -119,7 +141,7 @@ fn semantic_boundary() -> (
     HandoffControl,
     mpsc::UnboundedReceiver<ControlInvocation>,
     HandoffEvents,
-    mpsc::UnboundedSender<LiveHandoffEvent>,
+    SemanticEventSender,
 ) {
     let (call_tx, call_rx) = mpsc::unbounded_channel();
     let (event_tx, event_rx) = mpsc::unbounded_channel();
@@ -127,7 +149,7 @@ fn semantic_boundary() -> (
         HandoffControl::new(Arc::new(SemanticControl { calls: call_tx })),
         call_rx,
         HandoffEvents::new(Box::new(SemanticEvents { events: event_rx })),
-        event_tx,
+        SemanticEventSender { events: event_tx },
     )
 }
 
@@ -210,11 +232,12 @@ async fn destination_ack_precedes_an_early_reservation_fact() {
     let invocation = calls.recv().await.unwrap();
     assert_eq!(invocation.action, HandoffControlAction::ReserveDestination);
 
-    event_tx
-        .send(LiveHandoffEvent::DestinationReserved {
-            transferable_prompt_tokens: 4,
-        })
-        .unwrap();
+    let consumed = event_tx.send(LiveHandoffEvent::DestinationReserved {
+        transferable_prompt_tokens: 4,
+    });
+    consumed
+        .await
+        .expect("destination session should consume the reservation event");
     assert!(
         tokio::time::timeout(Duration::from_millis(20), source.recv())
             .await
@@ -275,11 +298,9 @@ async fn premature_complete_waits_for_destination_cleanup() {
         .await
         .unwrap();
     acknowledge(calls.recv().await.unwrap(), HandoffActionOutcome::Accepted);
-    event_tx
-        .send(LiveHandoffEvent::DestinationReserved {
-            transferable_prompt_tokens: 4,
-        })
-        .unwrap();
+    let _consumed = event_tx.send(LiveHandoffEvent::DestinationReserved {
+        transferable_prompt_tokens: 4,
+    });
     let _ = source.recv().await.unwrap();
     let _ = source.recv().await.unwrap();
 
@@ -342,11 +363,12 @@ async fn source_held_waits_for_submit_outcome_before_progressing() {
     ));
     let submit = calls.recv().await.unwrap();
     assert_eq!(submit.action, HandoffControlAction::SubmitPrefill);
-    event_tx
-        .send(LiveHandoffEvent::SourceHeld {
-            transfer_timing: transfer_timing(None),
-        })
-        .unwrap();
+    let consumed = event_tx.send(LiveHandoffEvent::SourceHeld {
+        transfer_timing: transfer_timing(None),
+    });
+    consumed
+        .await
+        .expect("source session should consume the held event");
     assert!(
         tokio::time::timeout(Duration::from_millis(20), destination.recv())
             .await
@@ -416,6 +438,198 @@ async fn pending_source_cancellation_releases_session_permit() {
 
     shutdown.cancel();
     manager.wait_closed().await;
+}
+
+#[tokio::test]
+async fn destination_cleanup_abandons_an_unsubmitted_registration() {
+    let engine = LiveEngine::start(
+        args_with_mode(
+            EngineType::Vllm,
+            WorkerType::Decode,
+            KvTransferTimingMode::FullPrompt,
+        ),
+        0,
+    )
+    .unwrap();
+    let handoff_id = HandoffId::from(Uuid::from_u128(74_001));
+    let request_id = Uuid::from_u128(74_002);
+    let (registration, request_stream) = engine.prepare_request(request(request_id, 1)).unwrap();
+    let (control, events) = engine.register_handoff(handoff_id).unwrap();
+    let (control, events) = live_handoff_boundary(control, events, registration);
+    let retained_control = control.clone();
+
+    assert_eq!(
+        control
+            .execute(HandoffControlAction::CancelDestination)
+            .await
+            .unwrap(),
+        HandoffActionOutcome::Applied
+    );
+    assert!(
+        !tokio::time::timeout(Duration::from_secs(1), request_stream.cancel())
+            .await
+            .expect("prepared request cancellation should not hang")
+            .unwrap()
+    );
+    wait_for_idle(&engine).await;
+    assert_eq!(engine.metrics_receiver().borrow().active_decode_blocks, 0);
+
+    let (replacement, replacement_stream) = engine
+        .prepare_request(request(request_id, 1))
+        .expect("abandoned client request ID should be reusable");
+    drop(replacement);
+    drop(replacement_stream);
+    drop(control);
+    drop(retained_control);
+    drop(events);
+    let (replacement_control, replacement_events) = engine
+        .register_handoff(handoff_id)
+        .expect("abandoned handoff ID should be reusable");
+    drop(replacement_control);
+    drop(replacement_events);
+    engine.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn active_handoff_shutdown_releases_scheduler_and_session_ownership() {
+    let engine_type = EngineType::Vllm;
+    let transfer_timing_mode = KvTransferTimingMode::FullPrompt;
+    let (source_engine, _source_kv) =
+        start_live_engine(engine_type, WorkerType::Prefill, transfer_timing_mode);
+    let (destination_engine, _destination_kv) =
+        start_live_engine(engine_type, WorkerType::Decode, transfer_timing_mode);
+    let shutdown = CancellationToken::new();
+    let server = BootstrapServer::start(0, shutdown.clone(), BootstrapServerConfig::default())
+        .await
+        .unwrap();
+    let manager = SourceHandoffManager::start(
+        server.take_incoming_receiver().unwrap(),
+        1,
+        Duration::from_secs(2),
+        shutdown.clone(),
+    );
+    let handoff_id = HandoffId::from(Uuid::from_u128(75_001));
+    let request_id = Uuid::from_u128(75_002);
+    let identity = BootstrapIdentity {
+        handoff_id,
+        bootstrap_room: 20,
+        request_id,
+    };
+    let order = order_for_engine(engine_type).unwrap();
+
+    let (source_registration, source_request) = source_engine
+        .prepare_request(request(request_id, 1))
+        .unwrap();
+    let (source_control, source_events) = source_engine.register_handoff(handoff_id).unwrap();
+    let (source_control, source_events) =
+        live_handoff_boundary(source_control, source_events, source_registration);
+    let (destination_registration, destination_request) = destination_engine
+        .prepare_request(request(request_id, 2))
+        .unwrap();
+    let (destination_control, destination_events) =
+        destination_engine.register_handoff(handoff_id).unwrap();
+    let (destination_control, destination_events) = live_handoff_boundary(
+        destination_control,
+        destination_events,
+        destination_registration,
+    );
+
+    let permits = Arc::new(tokio::sync::Semaphore::new(1));
+    let permit = permits.clone().try_acquire_owned().unwrap();
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let (observer_tx, mut observer_rx) = mpsc::unbounded_channel();
+    manager
+        .try_register(SourceRegistration {
+            identity: identity.clone(),
+            order,
+            engine_type,
+            control: source_control,
+            lifecycle: source_events,
+            completion_tx,
+            cancel: CancellationToken::new(),
+            observer: Some(observer_tx),
+            _permit: permit,
+        })
+        .unwrap();
+    let destination_connection = connect_to_prefill(
+        "127.0.0.1",
+        server.port(),
+        identity,
+        ParticipantRegistration {
+            role: BootstrapParticipantRole::Destination,
+            dp_rank: 0,
+            order,
+            engine_type,
+        },
+    )
+    .await
+    .unwrap();
+    let destination_session = tokio::spawn(run_destination_session(
+        destination_connection,
+        destination_control,
+        destination_events,
+        CancellationToken::new(),
+        Duration::from_secs(2),
+        shutdown.clone(),
+    ));
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let mut source_held = false;
+        let mut destination_reserved = false;
+        while !source_held || !destination_reserved {
+            match observer_rx.recv().await.unwrap() {
+                NormalizedHandoffEvent::SourceHeld => source_held = true,
+                NormalizedHandoffEvent::DestinationReserved => destination_reserved = true,
+                _ => {}
+            }
+        }
+    })
+    .await
+    .expect("handoff should acquire source and destination ownership");
+
+    shutdown.cancel();
+    let (source_completion, destination_completion) =
+        tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(completion_rx, destination_session)
+        })
+        .await
+        .expect("active handoff shutdown should join both participants");
+    assert!(source_completion.unwrap().is_err());
+    assert!(destination_completion.unwrap().is_err());
+    manager.wait_closed().await;
+    server.wait_closed().await;
+
+    let (source_cleanup, destination_cleanup) =
+        tokio::time::timeout(Duration::from_secs(2), async {
+            tokio::join!(source_request.cancel(), destination_request.cancel())
+        })
+        .await
+        .expect("request cleanup should complete after handoff shutdown");
+    source_cleanup.unwrap();
+    destination_cleanup.unwrap();
+    wait_for_idle(&source_engine).await;
+    wait_for_idle(&destination_engine).await;
+    assert_eq!(
+        destination_engine
+            .metrics_receiver()
+            .borrow()
+            .active_decode_blocks,
+        0
+    );
+    assert_eq!(permits.available_permits(), 1);
+
+    let (source_replacement, source_replacement_events) =
+        source_engine.register_handoff(handoff_id).unwrap();
+    drop(source_replacement);
+    drop(source_replacement_events);
+    let (destination_replacement, destination_replacement_events) =
+        destination_engine.register_handoff(handoff_id).unwrap();
+    drop(destination_replacement);
+    drop(destination_replacement_events);
+    assert!(probe_engine_drained(&source_engine).await);
+    assert!(probe_engine_drained(&destination_engine).await);
+    source_engine.shutdown().await.unwrap();
+    destination_engine.shutdown().await.unwrap();
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Overview:

Completes DIS-2481 by migrating the `lib/llm` Mocker adapter to the typed `LiveEngine` API introduced in #12380 and deleting its duplicated scheduler bridge. The supported `make_mocker_engine` contract and existing scheduling, output, metrics, KV/FPM, replay, and bootstrap behavior are preserved.

## Details:

- Collapse the legacy Mocker wrappers into a private annotated execution context backed by one `LiveEngine` per DP rank.
- Start each rank with configured KV/FPM publishers while preserving bootstrap timing, metrics publication, capacity limits, relay lifetimes, and shutdown ordering.
- Route aggregated requests through `LiveEngine::submit` and disaggregated requests through prepared registrations plus typed handoff controls/events.
- Replace raw scheduler-channel handoff plumbing with a private semantic control boundary and boxed event stream.
- Propagate startup failures to waiting requests and clean up prepared bootstrap resources and already-started engines on partial initialization failure.
- Bound adapter output buffering and cancel scheduler state when the context stops or the response stream is dropped.
- Delete duplicated request routing, scheduler construction, output/lifecycle demultiplexing, command sender cells, task ownership, and the stale DIS-2478 TODO.
- This PR is stacked on #12380.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker` — 691 passed
- `cargo test -p dynamo-llm --lib mocker` — 18 passed
- CPU Mocker E2E soak: `python -m pytest -vv -s tests/router/test_router_e2e_with_mockers.py::test_mocker_router_soak` — 6 variants passed and 6,144 requests completed successfully (1,024 each across KV, round-robin, and random routing over NATS and TCP) in 103.25s; no error-level logs or panics
- `git diff --check`
- Scoped legacy-symbol and `TODO(DIS-2478)` search is clean

## Where should the reviewer start?

- `lib/llm/src/mocker.rs` for startup, per-rank engine ownership, request generation, response cancellation, metrics, and shutdown.
- `lib/llm/src/mocker/handoff.rs` for the semantic adapter over typed handoff control/events.
- `lib/llm/src/mocker/handoff_tests.rs` for acknowledgment ordering, cleanup, cancellation, timing, KV publication, and engine coverage.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related GitHub issue
- Tracked in Linear as DIS-2481
