### PR TITLE
feat(frontend): add basetenkenizer tokenizer backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basetenkenizer"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55524e9467214686afafb60b7cedf28549f0ce964457658842999f6ef7ccbae7"
+dependencies = [
+ "chrono",
+ "daachorse",
+ "fancy-regex 0.17.0",
+ "icu_normalizer",
+ "icu_properties",
+ "memchr",
+ "minijinja",
+ "minijinja-contrib",
+ "pcre2",
+ "rayon",
+ "serde",
+ "serde_json",
+ "strum",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1554,7 +1576,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2902,13 +2924,14 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.5.4"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5513d4b084bbc3dfe874fb945188454d9f61dcbefc7f7dbda3b84aafd2620839"
+checksum = "c34434cf1ad218688425702e3f51c97014365e0013fbfd212d4db74982668241"
 dependencies = [
  "aho-corasick",
  "anyhow",
  "base64 0.22.1",
+ "basetenkenizer",
  "blake3",
  "fastokens",
  "moka",
@@ -4145,7 +4168,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -5388,6 +5411,7 @@ checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
 dependencies = [
  "indexmap 2.14.0",
  "memo-map",
+ "percent-encoding",
  "serde",
  "serde_json",
 ]
@@ -6950,8 +6974,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6970,8 +6994,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.10.5",
+ "heck 0.5.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6992,7 +7016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7005,7 +7029,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -7195,7 +7219,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7232,7 +7256,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -10541,7 +10565,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.4.0" }
 dynamo-llm = { path = "lib/llm", version = "1.4.0" }
 dynamo-rl = { path = "lib/rl", version = "1.4.0" }
-dynamo-tokenizers = { version = "=1.5.4" }
+dynamo-tokenizers = { version = "=1.6.0" }
 dynamo-renderer = { version = "=4.0.0" }
 dynamo-tokens = { path = "lib/tokens", version = "1.4.0" }
 dynamo-truthy = { path = "lib/truthy", version = "1.4.0" }

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -505,11 +505,12 @@ class FrontendArgGroup(ArgGroup):
             default="default",
             dest="tokenizer_backend",
             help=(
-                "Tokenizer backend for BPE models: 'default' (HuggingFace tokenizers library) "
-                "or 'fastokens' (fastokens crate for high-performance BPE encoding). "
+                "Tokenizer backend for BPE models: 'default' (HuggingFace tokenizers library), "
+                "'fastokens' (fastokens crate for high-performance BPE encoding), "
+                "or 'basetenkenizer' (Baseten tokenizer). "
                 "Decoding always uses HuggingFace. Has no effect on TikToken models."
             ),
-            choices=["default", "fastokens"],
+            choices=["default", "fastokens", "basetenkenizer"],
         )
 
         add_negatable_bool_argument(

--- a/docs/fern/components/frontend/Tokenizer.md
+++ b/docs/fern/components/frontend/Tokenizer.md
@@ -2,10 +2,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Tokenizer
-subtitle: Selects between the default HuggingFace and fastokens tokenizer backends for BPE models served through the Dynamo Frontend.
+subtitle: Selects between the default HuggingFace, fastokens, and Baseten tokenizer backends for BPE models served through the Dynamo Frontend.
 ---
 
-The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the default HuggingFace path and the `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
+The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: the default HuggingFace path, the `fastokens` path, and the `basetenkenizer` path can all serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
 
 ## Tokenizer Backends
 
@@ -21,6 +21,13 @@ It is a _hybrid_ backend: encoding uses `fastokens` while decoding falls back to
 
 Use this backend when tokenization is a measurable bottleneck, for example on high-concurrency prefill-heavy workloads.
 
+#### `basetenkenizer` Baseten Tokenizer
+
+The `basetenkenizer` backend uses the Baseten tokenizer from the [`dynamo-tokenizers`](https://crates.io/crates/dynamo-tokenizers) crate.
+Unlike `fastokens`, it merges the special tokens declared in `tokenizer_config.json` before encoding, and it supports segmented encoding, which preserves the trust boundary between renderer-produced control tokens and user content.
+
+It accepts a narrower set of `tokenizer.json` files than the default backend. Files using an unsupported normalizer or model type are rejected at load time and fall back to HuggingFace in the same way as `fastokens`.
+
 #### Compatibility notes:
 
 - Works with standard BPE `tokenizer.json` files (Qwen, LLaMA, GPT-family, Mistral, DeepSeek, etc.).
@@ -33,7 +40,7 @@ Set the backend with a CLI flag or environment variable. The CLI flag takes prec
 
 | CLI Argument | Env Var | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens` | `default` |
+| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens`, `basetenkenizer` | `default` |
 
 **Examples:**
 

--- a/docs/fern/features/tokenizer/README.md
+++ b/docs/fern/features/tokenizer/README.md
@@ -156,7 +156,7 @@ For any new model, validate on representative prompts before rolling out broadly
   </Accordion>
 
   <Accordion title="Why do the logs show an unrecognized DYN_TOKENIZER value?">
-    Use only `default`, `fastokens`, or `basetenkenizer` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `huggingface` are benchmark-runner aliases, not valid values for the frontend environment variable. See [Tokenizer](/components/frontend/Tokenizer) for what each backend does.
+    Use only `default`, `fastokens`, or `basetenkenizer` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `huggingface` are benchmark-runner aliases, not valid values for the frontend environment variable. See [Tokenizer](../../components/frontend/Tokenizer.md) for what each backend does.
   </Accordion>
 
   <Accordion title="What happens when the model uses .model or .tiktoken files?">

--- a/docs/fern/features/tokenizer/README.md
+++ b/docs/fern/features/tokenizer/README.md
@@ -156,7 +156,7 @@ For any new model, validate on representative prompts before rolling out broadly
   </Accordion>
 
   <Accordion title="Why do the logs show an unrecognized DYN_TOKENIZER value?">
-    Use only `fastokens` or `default` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `huggingface` are benchmark-runner aliases, not valid values for the frontend environment variable.
+    Use only `default`, `fastokens`, or `basetenkenizer` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `huggingface` are benchmark-runner aliases, not valid values for the frontend environment variable. See [Tokenizer](/components/frontend/Tokenizer) for what each backend does.
   </Accordion>
 
   <Accordion title="What happens when the model uses .model or .tiktoken files?">

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -62,6 +62,7 @@ pub const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_gener
 pub enum TokenizerBackend {
     Default,
     Fastokens,
+    Basetenkenizer,
 }
 
 impl TokenizerBackend {
@@ -69,6 +70,7 @@ impl TokenizerBackend {
         match self {
             Self::Default => "default",
             Self::Fastokens => "fastokens",
+            Self::Basetenkenizer => "basetenkenizer",
         }
     }
 
@@ -78,15 +80,12 @@ impl TokenizerBackend {
 
     pub fn from_env_or_default() -> Self {
         match std::env::var(ENV_TOKENIZER_BACKEND) {
-            Ok(v) if v == "fastokens" => Self::Fastokens,
-            Ok(v) if v == "default" || v.is_empty() => Self::Default,
-            Ok(v) => {
-                tracing::warn!(
-                    value = %v,
-                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to default"
-                );
+            Ok(v) if v.is_empty() => Self::Default,
+            // Parse through `FromStr` so the accepted values are listed once.
+            Ok(v) => v.parse().unwrap_or_else(|err| {
+                tracing::warn!(%err, "Unrecognized DYN_TOKENIZER value; falling back to default");
                 Self::Default
-            }
+            }),
             Err(_) => Self::Default,
         }
     }
@@ -99,8 +98,9 @@ impl FromStr for TokenizerBackend {
         match value {
             "default" => Ok(Self::Default),
             "fastokens" => Ok(Self::Fastokens),
+            "basetenkenizer" => Ok(Self::Basetenkenizer),
             _ => Err(format!(
-                "invalid tokenizer backend '{value}' (expected 'default' or 'fastokens')"
+                "invalid tokenizer backend '{value}' (expected 'default', 'fastokens', or 'basetenkenizer')"
             )),
         }
     }
@@ -688,10 +688,49 @@ mod tests {
             assert_eq!(cfg.effective_tokenizer_backend(), TokenizerBackend::Default);
         });
 
+        temp_env::with_vars([(ENV_TOKENIZER_BACKEND, Some("basetenkenizer"))], || {
+            let cfg = ModelRuntimeConfig::default();
+            assert_eq!(
+                cfg.effective_tokenizer_backend(),
+                TokenizerBackend::Basetenkenizer
+            );
+        });
+
         temp_env::with_vars_unset([ENV_TOKENIZER_BACKEND], || {
             let cfg = ModelRuntimeConfig::default();
             assert_eq!(cfg.effective_tokenizer_backend(), TokenizerBackend::Default);
         });
+
+        // An empty or unrecognized value must degrade to `Default`, not error.
+        for value in ["", "baseten", "basetenkenizer2", "BASETENKENIZER"] {
+            temp_env::with_vars([(ENV_TOKENIZER_BACKEND, Some(value))], || {
+                let cfg = ModelRuntimeConfig::default();
+                assert_eq!(
+                    cfg.effective_tokenizer_backend(),
+                    TokenizerBackend::Default,
+                    "DYN_TOKENIZER={value:?} should fall back to default"
+                );
+            });
+        }
+    }
+
+    #[test]
+    fn tokenizer_backend_parses_and_displays_every_variant() {
+        for (text, backend) in [
+            ("default", TokenizerBackend::Default),
+            ("fastokens", TokenizerBackend::Fastokens),
+            ("basetenkenizer", TokenizerBackend::Basetenkenizer),
+        ] {
+            assert_eq!(text.parse::<TokenizerBackend>().unwrap(), backend);
+            assert_eq!(backend.as_str(), text);
+        }
+
+        // The parse error names every accepted value, and `from_env_or_default`
+        // surfaces it, so operators can see what they should have typed.
+        let err = "nope".parse::<TokenizerBackend>().unwrap_err();
+        for value in ["default", "fastokens", "basetenkenizer"] {
+            assert!(err.contains(value), "{err:?} should mention {value}");
+        }
     }
 
     #[test]
@@ -719,14 +758,19 @@ mod tests {
 
     #[test]
     fn tokenizer_backend_roundtrips_through_serde_json() {
-        let cfg = ModelRuntimeConfig {
-            tokenizer_backend: Some(TokenizerBackend::Fastokens),
-            ..Default::default()
-        };
-        let json = serde_json::to_string(&cfg).unwrap();
-        assert!(json.contains("\"tokenizer_backend\":\"fastokens\""));
-        let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(parsed.tokenizer_backend, Some(TokenizerBackend::Fastokens));
+        for (backend, wire) in [
+            (TokenizerBackend::Fastokens, "fastokens"),
+            (TokenizerBackend::Basetenkenizer, "basetenkenizer"),
+        ] {
+            let cfg = ModelRuntimeConfig {
+                tokenizer_backend: Some(backend),
+                ..Default::default()
+            };
+            let json = serde_json::to_string(&cfg).unwrap();
+            assert!(json.contains(&format!("\"tokenizer_backend\":\"{wire}\"")));
+            let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
+            assert_eq!(parsed.tokenizer_backend, Some(backend));
+        }
     }
 
     #[test]

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -19,6 +19,7 @@ use std::sync::{Arc, OnceLock};
 use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
+use crate::local_model::runtime_config::TokenizerBackend;
 use crate::model_type::{ModelInput, ModelType};
 use crate::protocols::tensor::TensorModelConfig;
 use anyhow::{Context, Result};
@@ -1185,10 +1186,7 @@ impl ModelDeploymentCard {
     ///   per-turn tokenization cost flat instead of growing with history. Set to `0` to
     ///   fall back to the original hit-without-insert behavior.
     pub fn tokenizer(&self) -> anyhow::Result<crate::tokenizers::Tokenizer> {
-        let use_fast = self
-            .runtime_config
-            .effective_tokenizer_backend()
-            .is_fastokens();
+        let backend = self.runtime_config.effective_tokenizer_backend();
 
         let cache_enabled =
             tokenizer_cache_enabled(std::env::var("DYN_TOKENIZER_CACHE").ok().as_deref());
@@ -1259,31 +1257,64 @@ impl ModelDeploymentCard {
                 let wrap_hf =
                     |hf: HfTokenizer| crate::tokenizers::HuggingFaceTokenizer::from_tokenizer(hf);
 
-                // Pick the inner backend.
-                let raw: Arc<dyn crate::tokenizers::traits::Tokenizer> = if use_fast {
-                    if let Some(path_str) = p.to_str() {
-                        match crate::tokenizers::FastTokenizer::from_file(path_str) {
-                            Ok(fast) => {
-                                tracing::info!("Using fastokens tokenizer backend");
-                                Arc::new(fast)
+                // Pick the inner backend. Every alternative backend loads from
+                // `tokenizer.json` by path and falls back to HuggingFace if that
+                // fails, so they share one flow.
+                let raw: Arc<dyn crate::tokenizers::traits::Tokenizer> = match backend {
+                    TokenizerBackend::Default => Arc::new(wrap_hf(hf)),
+                    TokenizerBackend::Fastokens | TokenizerBackend::Basetenkenizer => {
+                        match p.to_str() {
+                            Some(path_str) => {
+                                let loaded = match backend {
+                                    TokenizerBackend::Fastokens => {
+                                        crate::tokenizers::FastTokenizer::from_file(path_str).map(
+                                            |t| {
+                                                Arc::new(t)
+                                                    as Arc<dyn crate::tokenizers::traits::Tokenizer>
+                                            },
+                                        )
+                                    }
+                                    TokenizerBackend::Basetenkenizer => {
+                                        crate::tokenizers::BasetenTokenizer::from_file(path_str)
+                                            .map(|t| {
+                                                Arc::new(t)
+                                                    as Arc<dyn crate::tokenizers::traits::Tokenizer>
+                                            })
+                                    }
+                                    TokenizerBackend::Default => {
+                                        unreachable!("guarded by the outer match")
+                                    }
+                                };
+                                match loaded {
+                                    Ok(t) => {
+                                        // Keep the historical wording: operators and the
+                                        // docs grep for "Using fastokens tokenizer backend".
+                                        tracing::info!(
+                                            "Using {} tokenizer backend",
+                                            backend.as_str()
+                                        );
+                                        t
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            %e,
+                                            "Failed to load {}, falling back to HuggingFace",
+                                            backend.as_str()
+                                        );
+                                        Arc::new(wrap_hf(hf))
+                                    }
+                                }
                             }
-                            Err(e) => {
+                            None => {
                                 tracing::warn!(
-                                    %e,
-                                    "Failed to load fastokens, falling back to HuggingFace"
+                                    path = %p.display(),
+                                    "Tokenizer path contains non-UTF-8 characters, skipping {}; falling back to HuggingFace",
+                                    backend.as_str()
                                 );
                                 Arc::new(wrap_hf(hf))
                             }
                         }
-                    } else {
-                        tracing::warn!(
-                            path = %p.display(),
-                            "Tokenizer path contains non-UTF-8 characters, skipping fastokens; falling back to HuggingFace"
-                        );
-                        Arc::new(wrap_hf(hf))
                     }
-                } else {
-                    Arc::new(wrap_hf(hf))
                 };
 
                 if cache_enabled {

--- a/lib/llm/tests/data/sample-models/mock-minimal-bpe/config.json
+++ b/lib/llm/tests/data/sample-models/mock-minimal-bpe/config.json
@@ -1,0 +1,4 @@
+{
+  "architectures": ["FakeForCausalLM"],
+  "model_type": "fake"
+}

--- a/lib/llm/tests/data/sample-models/mock-minimal-bpe/tokenizer.json
+++ b/lib/llm/tests/data/sample-models/mock-minimal-bpe/tokenizer.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "truncation": null,
+  "padding": null,
+  "added_tokens": [],
+  "normalizer": null,
+  "pre_tokenizer": null,
+  "post_processor": null,
+  "decoder": null,
+  "model": {
+    "type": "BPE",
+    "dropout": null,
+    "unk_token": "<unk>",
+    "continuing_subword_prefix": null,
+    "end_of_word_suffix": null,
+    "fuse_unk": false,
+    "byte_fallback": false,
+    "ignore_merges": false,
+    "vocab": {
+      "<unk>": 0,
+      " ": 1,
+      "!": 2,
+      ",": 3,
+      ".": 4,
+      "H": 5,
+      "T": 6,
+      "a": 7,
+      "d": 8,
+      "e": 9,
+      "h": 10,
+      "i": 11,
+      "l": 12,
+      "o": 13,
+      "r": 14,
+      "s": 15,
+      "t": 16,
+      "w": 17,
+      "He": 18,
+      "ll": 19,
+      "llo": 20,
+      "or": 21,
+      "ld": 22
+    },
+    "merges": [
+      "H e",
+      "l l",
+      "ll o",
+      "o r",
+      "l d"
+    ]
+  }
+}

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dynamo_llm::local_model::runtime_config::TokenizerBackend;
 use dynamo_llm::model_card::{ModelDeploymentCard, PromptFormatterArtifact, TokenizerKind};
-use dynamo_llm::tokenizers::{TikTokenTokenizer, traits::Encoder};
+use dynamo_llm::tokenizers::{BasetenTokenizer, EncodeSegment, TikTokenTokenizer, traits::Encoder};
 use tempfile::tempdir;
 
 const HF_PATH: &str = "tests/data/sample-models/TinyLlama_v1.1";
@@ -140,5 +141,162 @@ async fn test_chat_template_json_fallback() {
             );
         }
         other => panic!("Expected HfChatTemplateJson, got {:?}", other),
+    }
+}
+
+/// A minimal BPE `tokenizer.json` with no normalizer, pre-tokenizer or decoder.
+/// `BasetenTokenizer` rejects the Llama-style tokenizers used by the other
+/// fixtures (see `test_basetenkenizer_falls_back_when_unsupported`), so this is
+/// the fixture that exercises the backend rather than its fallback.
+const MINIMAL_BPE_PATH: &str = "tests/data/sample-models/mock-minimal-bpe";
+
+fn tokenizer_for(
+    path: &str,
+    name: &str,
+    backend: TokenizerBackend,
+) -> dynamo_llm::tokenizers::Tokenizer {
+    let mut mdc = ModelDeploymentCard::load_from_disk(path, None).unwrap();
+    mdc.set_name(name);
+    mdc.runtime_config.tokenizer_backend = Some(backend);
+    mdc.tokenizer().unwrap()
+}
+
+/// Selecting `basetenkenizer` must actually route `tokenizer()` to
+/// `BasetenTokenizer`.
+///
+/// Token IDs cannot prove this: on this fixture Baseten and HuggingFace agree
+/// exactly (see `test_basetenkenizer_token_parity_with_huggingface`), so a
+/// regression that silently kept HuggingFace would still compare equal.
+/// `encode_segments` is the discriminator. `BasetenTokenizer` implements it,
+/// HuggingFace and fastokens inherit the trait default that returns an error,
+/// and the L1 prefix cache forwards it to the inner tokenizer. So it succeeding
+/// through the production path means Baseten really is underneath.
+#[test]
+fn test_basetenkenizer_backend_is_selected() {
+    let production = tokenizer_for(
+        MINIMAL_BPE_PATH,
+        "model-card-basetenkenizer-selection",
+        TokenizerBackend::Basetenkenizer,
+    );
+    let direct =
+        BasetenTokenizer::from_file(&format!("{MINIMAL_BPE_PATH}/tokenizer.json")).unwrap();
+
+    for prompt in ["Hello, world!", "Hello", " world", "He llo", ""] {
+        assert_eq!(
+            production.encode(prompt).unwrap().token_ids().to_vec(),
+            direct.encode(prompt).unwrap().token_ids().to_vec(),
+            "production path must match a directly constructed BasetenTokenizer for {prompt:?}"
+        );
+    }
+
+    let segments = [
+        EncodeSegment::new("Hello", true),
+        EncodeSegment::new(", world!", false),
+    ];
+    assert!(
+        production.encode_segments(&segments).is_ok(),
+        "segmented encoding must reach BasetenTokenizer, so the backend was selected"
+    );
+
+    let default_backend = tokenizer_for(
+        MINIMAL_BPE_PATH,
+        "model-card-basetenkenizer-selection-default",
+        TokenizerBackend::Default,
+    );
+    assert!(
+        default_backend.encode_segments(&segments).is_err(),
+        "the default backend does not support segmented encoding, which is what \
+         makes the assertion above a real discriminator"
+    );
+}
+
+/// Token parity with the default HuggingFace backend on a tokenizer both can
+/// load. A new backend that silently changed token IDs would corrupt KV-cache
+/// reuse and prompt accounting, so this is the assertion that matters most.
+#[test]
+fn test_basetenkenizer_token_parity_with_huggingface() {
+    let baseten = tokenizer_for(
+        MINIMAL_BPE_PATH,
+        "model-card-basetenkenizer-parity",
+        TokenizerBackend::Basetenkenizer,
+    );
+    let hf = tokenizer_for(
+        MINIMAL_BPE_PATH,
+        "model-card-basetenkenizer-parity-hf",
+        TokenizerBackend::Default,
+    );
+
+    for prompt in ["Hello, world!", "Hello", " world", "He llo", "the sailor"] {
+        assert_eq!(
+            baseten.encode(prompt).unwrap().token_ids().to_vec(),
+            hf.encode(prompt).unwrap().token_ids().to_vec(),
+            "basetenkenizer and HuggingFace must agree on token IDs for {prompt:?}"
+        );
+    }
+}
+
+/// `BasetenTokenizer` does not support every `tokenizer.json`; TinyLlama uses a
+/// `Prepend` normalizer it rejects. Selecting the backend must then degrade to
+/// HuggingFace rather than failing the model, matching fastokens' behavior.
+/// Asserting equality with the default backend proves it fell back rather than
+/// producing something else.
+#[test]
+fn test_basetenkenizer_falls_back_when_unsupported() {
+    assert!(
+        BasetenTokenizer::from_file(&format!("{HF_PATH}/tokenizer.json")).is_err(),
+        "fixture is only meaningful while BasetenTokenizer rejects it"
+    );
+
+    let requested = tokenizer_for(
+        HF_PATH,
+        "model-card-basetenkenizer-fallback",
+        TokenizerBackend::Basetenkenizer,
+    );
+    let hf = tokenizer_for(
+        HF_PATH,
+        "model-card-basetenkenizer-fallback-hf",
+        TokenizerBackend::Default,
+    );
+
+    for prompt in ["Explain prefix caching.", "Now include Unicode: 北京 😀."] {
+        let ids = requested.encode(prompt).unwrap().token_ids().to_vec();
+        assert!(!ids.is_empty(), "fallback must still tokenize {prompt:?}");
+        assert_eq!(
+            ids,
+            hf.encode(prompt).unwrap().token_ids().to_vec(),
+            "unsupported backend must fall back to HuggingFace for {prompt:?}"
+        );
+    }
+}
+
+/// `tokenizer()` wraps whichever backend it selected in the L1 prefix cache, so
+/// the new backend has to survive that wrapping and stay token-exact across
+/// repeated and shared-prefix requests. Cache *accounting* is already covered by
+/// `test_tiktoken_model_card_cache_matches_direct_tokenizer_and_records_tokens`;
+/// this fixture declares no special tokens, so there are no prefix boundaries to
+/// drive those counters and asserting on them here would test the cache's
+/// heuristics rather than this backend.
+#[test]
+fn test_basetenkenizer_cached_path_is_token_exact() {
+    let cached = tokenizer_for(
+        MINIMAL_BPE_PATH,
+        "model-card-basetenkenizer-cache",
+        TokenizerBackend::Basetenkenizer,
+    );
+    let direct =
+        BasetenTokenizer::from_file(&format!("{MINIMAL_BPE_PATH}/tokenizer.json")).unwrap();
+
+    // Repeat the first prompt and share its prefix with the second, so any
+    // caching in play is actually exercised.
+    for prompt in [
+        "the sailor the sailor",
+        "the sailor the sailor",
+        "the sailor the world",
+    ] {
+        assert_eq!(
+            cached.encode(prompt).unwrap().token_ids().to_vec(),
+            direct.encode(prompt).unwrap().token_ids().to_vec(),
+            "cached path must remain token-exact for {prompt:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #12325.

Makes the Baseten tokenizer selectable through `DYN_TOKENIZER` / `--tokenizer`, alongside `default` and `fastokens`. Before this it could only be reached by constructing `BasetenTokenizer` in Rust.

**Rust**

- `TokenizerBackend` gains a `Basetenkenizer` variant, wired through `as_str`, `FromStr`, and `from_env_or_default`.
- `model_card.rs::tokenizer()` now matches on the enum instead of a `use_fast` boolean. Both alternative backends load from `tokenizer.json` by path and fall back to HuggingFace if that fails, so they share one flow instead of duplicating it.
- `from_env_or_default` parses through `FromStr`, so the accepted values are listed in one place and adding a backend later is a single edit rather than two that can drift.

**Python and docs**

- `--tokenizer` / `DYN_TOKENIZER` accepts `basetenkenizer` in `frontend_args.py`.
- `docs/fern/components/frontend/Tokenizer.md` documents the backend and updates the values table.
- One factually wrong line in `docs/fern/features/tokenizer/README.md` corrected: its FAQ said to use "only `fastokens` or `default`". That page is otherwise fastokens-specific, so I left the rest of it alone.

### The dependency bump is required, and it is additive

`BasetenTokenizer` does not exist in the pinned `dynamo-tokenizers` `=1.5.4`, so this moves the pin to `=1.6.0`. The frontend-crates PR merged at 21:49 on 28 Jul and 1.6.0 was published at 22:03 the same evening, which is why the issue could be filed before a consumable release existed.

I diffed the two published crates rather than assuming compatibility. The public API change is purely additive: the `basetenkenizer` module, the `BasetenTokenizer` re-export, a new `EncodeSegment` struct, and an `encode_segments` trait method that ships a default implementation, so existing implementors are unaffected. This also pulls in one new transitive crate, `basetenkenizer 0.2.8`, which is MIT and therefore already on `deny.toml`'s allow list.

### Two deliberate non-changes

**`preprocessor.rs` is untouched.** The mm-routing guard there disables MM-aware KV routing when fastokens is active, because fastokens cannot merge the special tokens declared in `tokenizer_config.json`. Generalizing that guard to the new backend would be wrong: `basetenkenizer.rs` in 1.6.0 ships its own `merge_special_tokens_from_config` reading `added_tokens_decoder`, so it does not have that limitation. Worth a second opinion if you disagree.

**The log wording is preserved.** `docs/fern/features/tokenizer/README.md` tells operators to look for the literal line `Using fastokens tokenizer backend`, so the message is now formatted as `"Using {} tokenizer backend"` rather than being restructured into a field. That keeps existing greps and any log-based alerting working.

## Validation

`cargo test -p dynamo-llm --no-default-features`: **1595 unit tests and 76 integration tests pass, 0 failures.** `cargo fmt --all`, `cargo clippy -p dynamo-llm --no-default-features --all-targets`, and `pre-commit run` over every changed file are all clean.

One environment note: `dynamo-llm` does not build on macOS with default features, because `block_manager` needs `O_DIRECT`, `fallocate`, and NUMA. I confirmed those three errors are identical on an unmodified `main`, so they are pre-existing and unrelated. `--no-default-features` compiles and tests cleanly, which covers every path this PR touches.

New tests in `lib/llm/tests/model_card.rs`:

| Test | Purpose |
|---|---|
| `test_basetenkenizer_backend_is_selected` | the backend is actually chosen, not silently skipped |
| `test_basetenkenizer_token_parity_with_huggingface` | identical token IDs to the default backend |
| `test_basetenkenizer_falls_back_when_unsupported` | an unsupported `tokenizer.json` degrades to HuggingFace |
| `test_basetenkenizer_cached_path_is_token_exact` | the backend survives the L1 prefix cache wrapper |

Plus configuration coverage in `runtime_config.rs`: every variant parses and renders, unrecognized and empty `DYN_TOKENIZER` values degrade to `default`, the parse error names all accepted values, and serde round-trips.

### One thing worth reading, because my first version of it was wrong

I originally asserted selection by comparing the production tokenizer against a directly constructed `BasetenTokenizer`. Reverting the source change showed that test still passing, because on a `tokenizer.json` both backends accept they produce **identical** token IDs, so the comparison cannot tell them apart.

Selection is now asserted through `encode_segments`, which only `BasetenTokenizer` implements. HuggingFace and fastokens inherit the trait default that returns an error, and the L1 cache forwards the call to the inner tokenizer, so it succeeding proves which backend is underneath. With the source change reverted, that test now fails and the other three still pass, which is the intended split between the selection proof and the behavioural guards.

### A new test fixture was needed

`BasetenTokenizer` rejects every existing `tokenizer.json` under `lib/llm/tests/data/sample-models/`: TinyLlama uses a `Prepend` normalizer, and the mock tokenizers report model type `Other`. There was therefore no fixture that exercised the backend rather than its fallback, so this adds `mock-minimal-bpe`, a 23-token synthetic BPE tokenizer with no normalizer, pre-tokenizer, or decoder, mirroring the minimal fixture used by the tokenizers crate's own tests. No model download, so `.ai/test-model-size-guardrails.md` does not apply.

That rejection is also what makes the fallback test meaningful: TinyLlama is a real unsupported case, and the test asserts the resulting token IDs equal the default backend's, proving it fell back rather than doing something else.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12382" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `basetenkenizer` tokenizer backend for supported BPE `tokenizer.json` models.
  * Added CLI and environment configuration support for selecting this backend.
  * Added segmented encoding support while preserving special-token handling and trust boundaries.
  * Added graceful fallback to the default tokenizer when the selected backend cannot load.

* **Documentation**
  * Updated tokenizer configuration and troubleshooting guidance with the new backend and valid values.

* **Tests**
  * Added coverage for backend selection, fallback behavior, token parity, and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->