### PR TITLE
perf(mocker): batch attention-DP completions

### DIFF
--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -36,11 +36,11 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
 - `lib/mocker/src/replay/offline/state.rs`
   Per-worker wrapper around `EngineCore`, including optional KV event capture.
 - `lib/mocker/src/replay/offline/events.rs`
-  `SimulationEvent` + `SimulationEventKind` priority-queue types used by the multi-worker harness.
+  `SimulationEvent`, `SimulationEventKind`, and worker-completion payload types used by the multi-worker harness.
 - `lib/mocker/src/replay/offline/core.rs`
   Small `ReplayWorkerCore` wrapper used by the single-worker path.
 - `lib/mocker/src/replay/offline/runtime_utils.rs`
-  Shared helpers used by `agg.rs` and `disagg.rs`: `WorkerCompletionPayload`, event scheduling, `next_timestamp`.
+  Shared helpers used by `agg.rs` and `disagg.rs`: event scheduling and `next_timestamp`.
 - `lib/mocker/src/replay/offline/progress.rs`
   `ReplayProgress`, the indicatif-based progress bar used by the harnesses.
 - `lib/mocker/src/replay/offline/components/`
@@ -48,7 +48,7 @@ Offline replay starts in `lib/mocker/src/replay/offline/mod.rs`.
   - `router.rs` — `OfflineReplayRouter` (synchronous in-process router, KV + round-robin modes) and `OfflineRouterSnapshot`.
   - `engine.rs` — `EngineComponent`, `EngineEffects`, `EnginePassMode` wrappers around `EngineCore`.
   - `admission.rs` — admission queue and trace/workload request gating.
-  - `types.rs` — `WorkerAdmission`, `RouterEffects`, `ScheduledWorkerCompletion`, `TrafficAccumulator`, `TrafficStats`, `ReplayMode`.
+  - `types.rs` — `WorkerAdmission`, `RouterEffects`, `ScheduledWorkerCompletions`, `TrafficAccumulator`, `TrafficStats`, `ReplayMode`.
   - `mod.rs` — re-exports.
 
 ## Single-Worker Fast Path
@@ -150,12 +150,14 @@ pub(crate) struct SimulationEvent {
 
 pub(crate) enum SimulationEventKind {
     WorkerCompletion { stage, worker_idx, completed_requests, output_signals, kv_events },
+    WorkerCompletionBatch { payloads },
     DecodeHandoff { uuid },
     WorkerReady { stage, worker_id },
 }
 ```
 
 - `WorkerCompletion` is emitted after a worker pass is executed and applied when the harness clock reaches `pass.end_ms`. It carries the `stage` (`Aggregated`, `Prefill`, or `Decode`), `worker_idx`, `completed_requests`, `output_signals`, and router-visible `kv_events`.
+- `WorkerCompletionBatch` stores the ordered rank payloads for one positive-duration attention-DP epoch in a single heap event. Each payload is still applied independently in rank order.
 - `DecodeHandoff` is used by the disaggregated harness to move a request from prefill to decode at the same logical timestamp (see below).
 - `WorkerReady` marks the point at which a worker returns to the admission pool after a pass completes.
 

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -11,14 +11,15 @@ use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::extensions::kv_router::AggRuntime;
 use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_worker_completion,
-    pop_ready_worker_ready, push_planner_tick, push_worker_completion, push_worker_ready,
+    ReadyWorkerCompletions, next_timestamp as choose_next_timestamp, pop_ready_planner_tick,
+    pop_ready_worker_completions, pop_ready_worker_ready, push_planner_tick,
+    push_worker_completions, push_worker_ready,
 };
 #[cfg(test)]
 use super::state::AggRequestPhase;
@@ -27,8 +28,7 @@ use super::state::OfflineWorkerSnapshot;
 use super::{
     components::{
         AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, NoReplayMetadata,
-        ReplayAdmissionMetadata, ReplayEngineObservation, ScheduledWorkerCompletion,
-        TrafficAccumulator,
+        ReplayAdmissionMetadata, ReplayEngineObservation, TrafficAccumulator,
     },
     state::AggRequestState,
 };
@@ -634,26 +634,42 @@ where
         // each pass may drain router-pending work before its sibling ranks are applied.
         // Preserve this lower-rank-first tie-break for now. Atomic settlement requires
         // splitting router state mutation from pending-admission draining.
-        while let Some(payload) = pop_ready_worker_completion(&mut self.events, self.now_ms) {
-            debug_assert_eq!(payload.stage, SimulationWorkerStage::Aggregated);
-            let payload = self.engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.record_fpm(payload.worker_idx, fpm)?;
+        while let Some(completions) = pop_ready_worker_completions(&mut self.events, self.now_ms) {
+            match completions {
+                ReadyWorkerCompletions::Single(payload) => {
+                    self.apply_worker_completion(payload)?;
+                }
+                ReadyWorkerCompletions::Batch(payloads) => {
+                    for payload in payloads {
+                        self.apply_worker_completion(payload)?;
+                    }
+                }
             }
-            self.process_completed_pass(
-                payload.worker_idx,
-                payload.completed_requests,
-                payload.output_signals,
-                payload.engine_events,
-                payload.accept_length_output_tokens,
-                payload.accept_length_decode_forwards,
-            )?;
             changed = true;
         }
 
         Ok(changed)
+    }
+
+    fn apply_worker_completion(
+        &mut self,
+        payload: WorkerCompletionPayload<Observation::Batch>,
+    ) -> anyhow::Result<()> {
+        debug_assert_eq!(payload.stage, SimulationWorkerStage::Aggregated);
+        let payload = self.engine.on_scheduled_completion(payload)?;
+        if self.collect_fpm
+            && let Some(fpm) = payload.fpm
+        {
+            self.record_fpm(payload.worker_idx, fpm)?;
+        }
+        self.process_completed_pass(
+            payload.worker_idx,
+            payload.completed_requests,
+            payload.output_signals,
+            payload.engine_events,
+            payload.accept_length_output_tokens,
+            payload.accept_length_decode_forwards,
+        )
     }
 
     /// Release every admission made ready by the shared admission queue.
@@ -703,23 +719,10 @@ where
     ) -> anyhow::Result<()> {
         self.apply_engine_observations(effects.pass_start_events)?;
         for payload in effects.immediate_completions {
-            let payload = self.engine.on_scheduled_completion(payload)?;
-            if self.collect_fpm
-                && let Some(fpm) = payload.fpm
-            {
-                self.record_fpm(payload.worker_idx, fpm)?;
-            }
-            self.process_completed_pass(
-                payload.worker_idx,
-                payload.completed_requests,
-                payload.output_signals,
-                payload.engine_events,
-                payload.accept_length_output_tokens,
-                payload.accept_length_decode_forwards,
-            )?;
+            self.apply_worker_completion(payload)?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -8,17 +8,13 @@ use anyhow::bail;
 use smallvec::SmallVec;
 
 use super::super::core::{EngineEventBatch, EngineProgress, NoEngineEvents, WorkerTopology};
-use super::super::events::SimulationWorkerStage;
-use super::super::runtime_utils::WorkerCompletionPayload;
+use super::super::events::{SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::super::state::OfflineWorkerSnapshot;
 use super::super::state::OfflineWorkerState;
 #[cfg(feature = "kvbm-offload")]
 use super::ObservedOffloadEffects;
-use super::{
-    EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineObservation,
-    ScheduledWorkerCompletion,
-};
+use super::{EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineObservation};
 use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
 use crate::scheduler::{EnginePassResult, RouterEventVisibility, SchedulerCommand};
@@ -620,12 +616,7 @@ where
 
         if boundary.end_ms > boundary.start_ms {
             Self::required_worker_mut(workers, rank_id).mark_busy();
-            effects
-                .scheduled_completions
-                .push(ScheduledWorkerCompletion {
-                    at_ms: boundary.end_ms,
-                    payload,
-                });
+            effects.schedule_completion(boundary.end_ms, payload);
             return;
         }
 
@@ -764,6 +755,9 @@ where
                 start_ms: now_ms,
                 end_ms: group_end_ms,
             };
+            if group_end_ms > now_ms {
+                effects.prepare_scheduled_completion(group_end_ms, rank_ids.len());
+            }
 
             for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
                 let Some(executed) = executed else {
@@ -771,26 +765,24 @@ where
                         // Empty ranks still participate in the barrier so work
                         // arriving mid-epoch cannot start ahead of a sibling.
                         Self::required_worker_mut(&mut self.workers, rank_id).mark_busy();
-                        effects
-                            .scheduled_completions
-                            .push(ScheduledWorkerCompletion {
-                                at_ms: group_end_ms,
-                                payload: WorkerCompletionPayload {
-                                    stage: self.stage,
-                                    worker_idx: rank_id,
-                                    completed_requests: 0,
-                                    output_signals: Vec::new(),
-                                    lifecycle_events: Vec::new(),
-                                    engine_events: Observation::Batch::default(),
-                                    progress: EngineProgress::default(),
-                                    fpm: Some(ForwardPassSnapshot {
-                                        wall_time_secs: boundary.wall_time_secs(),
-                                        ..Default::default()
-                                    }),
-                                    accept_length_output_tokens: 0,
-                                    accept_length_decode_forwards: 0,
-                                },
-                            });
+                        effects.schedule_completion(
+                            group_end_ms,
+                            WorkerCompletionPayload {
+                                stage: self.stage,
+                                worker_idx: rank_id,
+                                completed_requests: 0,
+                                output_signals: Vec::new(),
+                                lifecycle_events: Vec::new(),
+                                engine_events: Observation::Batch::default(),
+                                progress: EngineProgress::default(),
+                                fpm: Some(ForwardPassSnapshot {
+                                    wall_time_secs: boundary.wall_time_secs(),
+                                    ..Default::default()
+                                }),
+                                accept_length_output_tokens: 0,
+                                accept_length_decode_forwards: 0,
+                            },
+                        );
                     }
                     continue;
                 };
@@ -970,11 +962,15 @@ mod tests {
         mut effects: EngineEffects<Events>,
     ) -> WorkerCompletionPayload<Events> {
         if let Some(payload) = effects.immediate_completions.pop() {
-            assert!(effects.scheduled_completions.is_empty());
+            assert!(effects.scheduled_completion.is_none());
             return payload;
         }
-        assert_eq!(effects.scheduled_completions.len(), 1);
-        effects.scheduled_completions.pop().unwrap().payload
+        let mut scheduled = effects
+            .scheduled_completion
+            .take()
+            .expect("one scheduled completion must be present");
+        assert_eq!(scheduled.payloads.len(), 1);
+        scheduled.payloads.pop().unwrap()
     }
 
     fn decode_engine_with_chunking(enable_chunked_prefill: bool) -> EngineComponent {
@@ -1060,15 +1056,22 @@ mod tests {
 
         let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
 
-        assert_eq!(effects.scheduled_completions.len(), 2);
+        let scheduled = effects.scheduled_completion.as_ref().unwrap();
+        assert_eq!(scheduled.payloads.len(), 2);
         assert!(
-            effects
-                .scheduled_completions
-                .iter()
-                .all(|completion| (completion.at_ms - 9.0).abs() < f64::EPSILON)
+            (scheduled.at_ms - 9.0).abs() < f64::EPSILON,
+            "batch must fire at the slowest-rank boundary"
         );
-        assert!(effects.scheduled_completions.iter().all(|completion| {
-            (completion.payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
+        assert_eq!(
+            scheduled
+                .payloads
+                .iter()
+                .map(|payload| payload.worker_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
+        assert!(scheduled.payloads.iter().all(|payload| {
+            (payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
         }));
         assert_eq!(collector.request_latencies(fast).unwrap().0, 9.0);
         assert_eq!(collector.request_latencies(slow).unwrap().0, 9.0);
@@ -1082,15 +1085,15 @@ mod tests {
         let mut collector = TraceCollector::default();
         collector.on_arrival(slow, 0.0, 8, 1);
 
-        let first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert_eq!(first_epoch.scheduled_completions.len(), 2);
+        let mut first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let first_scheduled = first_epoch.scheduled_completion.as_ref().unwrap();
+        assert_eq!(first_scheduled.payloads.len(), 2);
         assert!(engine.debug_snapshots().iter().all(|rank| rank.busy));
-        let idle_fpm = first_epoch
-            .scheduled_completions
+        let idle_fpm = first_scheduled
+            .payloads
             .iter()
-            .find(|completion| completion.payload.worker_idx == 1)
+            .find(|payload| payload.worker_idx == 1)
             .unwrap()
-            .payload
             .fpm
             .as_ref()
             .expect("idle DP rank must emit an empty FPM");
@@ -1109,17 +1112,13 @@ mod tests {
                 .is_empty()
         );
 
-        for completion in first_epoch.scheduled_completions {
-            engine.on_scheduled_completion(completion.payload).unwrap();
+        for payload in first_epoch.scheduled_completion.take().unwrap().payloads {
+            engine.on_scheduled_completion(payload).unwrap();
         }
         let second_epoch = engine.drive_ready(9.0, Some(&mut collector)).unwrap();
-        assert_eq!(second_epoch.scheduled_completions.len(), 2);
-        assert!(
-            second_epoch
-                .scheduled_completions
-                .iter()
-                .all(|completion| (completion.at_ms - 14.0).abs() < f64::EPSILON)
-        );
+        let second_scheduled = second_epoch.scheduled_completion.as_ref().unwrap();
+        assert_eq!(second_scheduled.payloads.len(), 2);
+        assert!((second_scheduled.at_ms - 14.0).abs() < f64::EPSILON);
         assert_eq!(collector.request_latencies(mid_epoch).unwrap().0, 10.0);
     }
 
@@ -1137,16 +1136,11 @@ mod tests {
             while engine.in_flight() > 0 {
                 let effects = engine.drive_ready(now_ms, Some(&mut collector)).unwrap();
                 assert!(effects.immediate_completions.is_empty());
-                assert_eq!(effects.scheduled_completions.len(), dp_size as usize);
-                now_ms = effects.scheduled_completions[0].at_ms;
-                assert!(
-                    effects
-                        .scheduled_completions
-                        .iter()
-                        .all(|completion| completion.at_ms == now_ms)
-                );
-                for completion in effects.scheduled_completions {
-                    engine.on_scheduled_completion(completion.payload).unwrap();
+                let scheduled = effects.scheduled_completion.unwrap();
+                assert_eq!(scheduled.payloads.len(), dp_size as usize);
+                now_ms = scheduled.at_ms;
+                for payload in scheduled.payloads {
+                    engine.on_scheduled_completion(payload).unwrap();
                 }
             }
             collector.request_latencies(uuid).unwrap()
@@ -1413,7 +1407,7 @@ mod tests {
         let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(second.admissions.is_empty());
         assert_eq!(second.immediate_completions.len(), 1);
-        assert!(second.scheduled_completions.is_empty());
+        assert!(second.scheduled_completion.is_none());
         let second = take_only_completion(second);
         assert_eq!(second.fpm.as_ref().unwrap().num_prefill_requests, 1);
         assert_eq!(second.completed_requests, 0);
@@ -1527,7 +1521,10 @@ mod tests {
             .unwrap();
         let mut collector = TraceCollector::default();
         let mut pass = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert_eq!(pass.scheduled_completions.len(), 1);
+        assert_eq!(
+            pass.scheduled_completion.as_ref().unwrap().payloads.len(),
+            1
+        );
 
         let handoff_id = HandoffId::from(Uuid::from_u128(2));
         let effects = engine
@@ -1557,8 +1554,14 @@ mod tests {
         assert!(engine.active_worker_ids().is_empty());
         assert_eq!(engine.worker_count(), 1);
 
-        let completion = pass.scheduled_completions.pop().unwrap();
-        let payload = engine.on_scheduled_completion(completion.payload).unwrap();
+        let payload = pass
+            .scheduled_completion
+            .take()
+            .unwrap()
+            .payloads
+            .pop()
+            .unwrap();
+        let payload = engine.on_scheduled_completion(payload).unwrap();
         assert!(payload.lifecycle_events.iter().any(|event| matches!(
             event,
             SchedulerLifecycleEvent::DestinationReserved {
@@ -1625,15 +1628,17 @@ mod tests {
                 .any(|event| { event.storage_tier == StorageTier::Device })
         );
         assert_eq!(
-            seed.immediate_completions.len() + seed.scheduled_completions.len(),
+            seed.immediate_completions.len() + usize::from(seed.scheduled_completion.is_some()),
             1,
             "seed request should produce exactly one completion boundary"
         );
         let completion = seed.immediate_completions.pop().unwrap_or_else(|| {
-            seed.scheduled_completions
-                .pop()
+            seed.scheduled_completion
+                .take()
                 .expect("seed request completion must be present")
-                .payload
+                .payloads
+                .pop()
+                .expect("singleton completion batch must contain one payload")
         });
         // Model a reservation attempt at the t=0 boundary, before the GPU
         // compute interval becomes externally busy.

--- a/lib/mocker/src/replay/offline/components/mod.rs
+++ b/lib/mocker/src/replay/offline/components/mod.rs
@@ -18,6 +18,6 @@ pub(in crate::replay) use types::ReplayMode;
 pub use types::TrafficStats;
 pub(in crate::replay::offline) use types::{
     EngineEffects, EnginePassMode, ObservedCommandEffects, ObservedWorkerEvents,
-    ReplayEngineObservation, ScheduledWorkerCompletion, TrafficAccumulator,
+    ReplayEngineObservation, ScheduledWorkerCompletions, TrafficAccumulator,
 };
 pub(crate) use worker_core::ReplayWorkerCore;

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -4,7 +4,7 @@
 use uuid::Uuid;
 
 use super::super::core::{EngineEventBatch, EngineProgress, NoEngineEvents};
-use super::super::runtime_utils::WorkerCompletionPayload;
+use super::super::events::WorkerCompletionPayload;
 use super::super::state::OfflineWorkerState;
 use crate::common::protocols::DirectRequest;
 use crate::loadgen::ReplayRequestPayload;
@@ -111,9 +111,9 @@ pub(in crate::replay) struct ObservedOffloadEffects<Events: EngineEventBatch> {
 }
 
 #[derive(Debug)]
-pub(in crate::replay::offline) struct ScheduledWorkerCompletion<Events: EngineEventBatch = ()> {
+pub(in crate::replay::offline) struct ScheduledWorkerCompletions<Events: EngineEventBatch = ()> {
     pub(in crate::replay::offline) at_ms: f64,
-    pub(in crate::replay::offline) payload: WorkerCompletionPayload<Events>,
+    pub(in crate::replay::offline) payloads: Vec<WorkerCompletionPayload<Events>>,
 }
 
 #[derive(Debug, Default)]
@@ -121,16 +121,50 @@ pub(in crate::replay::offline) struct EngineEffects<Events: EngineEventBatch = (
     pub(in crate::replay::offline) admissions: Vec<AdmissionEvent>,
     pub(in crate::replay::offline) pass_start_events: Events,
     pub(in crate::replay::offline) immediate_completions: Vec<WorkerCompletionPayload<Events>>,
-    pub(in crate::replay::offline) scheduled_completions: Vec<ScheduledWorkerCompletion<Events>>,
+    pub(in crate::replay::offline) scheduled_completion: Option<ScheduledWorkerCompletions<Events>>,
     pub(in crate::replay::offline) progress: EngineProgress,
 }
 
 impl<Events: EngineEventBatch> EngineEffects<Events> {
+    pub(in crate::replay::offline) fn prepare_scheduled_completion(
+        &mut self,
+        at_ms: f64,
+        capacity: usize,
+    ) {
+        assert!(
+            self.scheduled_completion.is_none(),
+            "offline replay engine effects already contain a scheduled completion"
+        );
+        self.scheduled_completion = Some(ScheduledWorkerCompletions {
+            at_ms,
+            payloads: Vec::with_capacity(capacity),
+        });
+    }
+
+    pub(in crate::replay::offline) fn schedule_completion(
+        &mut self,
+        at_ms: f64,
+        payload: WorkerCompletionPayload<Events>,
+    ) {
+        let scheduled =
+            self.scheduled_completion
+                .get_or_insert_with(|| ScheduledWorkerCompletions {
+                    at_ms,
+                    payloads: Vec::with_capacity(1),
+                });
+        assert_eq!(
+            scheduled.at_ms.to_bits(),
+            at_ms.to_bits(),
+            "offline replay engine effects contain mismatched completion timestamps"
+        );
+        scheduled.payloads.push(payload);
+    }
+
     pub(in crate::replay::offline) fn is_empty(&self) -> bool {
         self.admissions.is_empty()
             && self.pass_start_events.is_empty()
             && self.immediate_completions.is_empty()
-            && self.scheduled_completions.is_empty()
+            && self.scheduled_completion.is_none()
             && !self.progress.made_progress
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -11,15 +11,14 @@ pub(super) use super::components::ReplayMode;
 use super::components::TrafficStats;
 use super::components::{
     AdmissionQueue, EngineComponent, EngineEffects, EnginePassMode, NoReplayMetadata,
-    ReplayAdmissionMetadata, ReplayEngineObservation, ScheduledWorkerCompletion,
-    TrafficAccumulator,
+    ReplayAdmissionMetadata, ReplayEngineObservation, TrafficAccumulator,
 };
 use super::core::round_robin::PoolRoundRobinPlacement;
 use super::core::{
     AdmissionSource as CoreAdmissionSource, EngineEventBatch, NoEngineEvents, Placement,
     PlacementDecision, PlacementPolicy, ReadyArrival, WorkerTopology,
 };
-use super::events::{SimulationEvent, SimulationWorkerStage};
+use super::events::{SimulationEvent, SimulationWorkerStage, WorkerCompletionPayload};
 #[cfg(test)]
 use super::extensions::kv_router::{
     DisaggRuntime, ReplayKvRouterConfig, derive_decode_router_config, derive_prefill_router_config,
@@ -27,9 +26,9 @@ use super::extensions::kv_router::{
 use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
-    next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_transfer_complete,
-    pop_ready_worker_completion, pop_ready_worker_ready, push_planner_tick, push_transfer_complete,
-    push_worker_completion, push_worker_ready,
+    ReadyWorkerCompletions, next_timestamp as choose_next_timestamp, pop_ready_planner_tick,
+    pop_ready_transfer_complete, pop_ready_worker_completions, pop_ready_worker_ready,
+    push_planner_tick, push_transfer_complete, push_worker_completions, push_worker_ready,
 };
 #[cfg(test)]
 use super::state::DisaggRequestSnapshot;
@@ -1834,49 +1833,65 @@ where
     /// Drain all worker-completion events scheduled for the current logical timestamp.
     fn apply_worker_completions(&mut self) -> Result<bool> {
         let mut changed = false;
-        while let Some(payload) = pop_ready_worker_completion(&mut self.events, self.now_ms) {
-            match payload.stage {
-                SimulationWorkerStage::Prefill => {
-                    let payload = self.prefill_engine.on_scheduled_completion(payload)?;
-                    self.wake_deferred_actions(SimulationWorkerStage::Prefill, payload.worker_idx);
-                    if self.collect_fpm
-                        && let Some(fpm) = payload.fpm
-                    {
-                        self.prefill_fpm_buffer
-                            .insert(payload.worker_idx, fpm, self.now_ms);
-                    }
-                    self.process_prefill_pass(
-                        payload.worker_idx,
-                        payload.completed_requests,
-                        payload.output_signals,
-                        payload.lifecycle_events,
-                        payload.engine_events,
-                    )?;
+        while let Some(completions) = pop_ready_worker_completions(&mut self.events, self.now_ms) {
+            match completions {
+                ReadyWorkerCompletions::Single(payload) => {
+                    self.apply_worker_completion(payload)?;
                 }
-                SimulationWorkerStage::Decode => {
-                    let payload = self.decode_engine.on_scheduled_completion(payload)?;
-                    self.wake_deferred_actions(SimulationWorkerStage::Decode, payload.worker_idx);
-                    if self.collect_fpm
-                        && let Some(fpm) = payload.fpm
-                    {
-                        self.decode_fpm_buffer
-                            .insert(payload.worker_idx, fpm, self.now_ms);
+                ReadyWorkerCompletions::Batch(payloads) => {
+                    for payload in payloads {
+                        self.apply_worker_completion(payload)?;
                     }
-                    self.process_decode_pass(
-                        payload.output_signals,
-                        payload.lifecycle_events,
-                        payload.engine_events,
-                        payload.accept_length_output_tokens,
-                        payload.accept_length_decode_forwards,
-                    )?;
-                }
-                SimulationWorkerStage::Aggregated => {
-                    bail!("offline disagg replay received an aggregated completion event")
                 }
             }
             changed = true;
         }
         Ok(changed)
+    }
+
+    fn apply_worker_completion(
+        &mut self,
+        payload: WorkerCompletionPayload<Observation::Batch>,
+    ) -> Result<()> {
+        match payload.stage {
+            SimulationWorkerStage::Prefill => {
+                let payload = self.prefill_engine.on_scheduled_completion(payload)?;
+                self.wake_deferred_actions(SimulationWorkerStage::Prefill, payload.worker_idx);
+                if self.collect_fpm
+                    && let Some(fpm) = payload.fpm
+                {
+                    self.prefill_fpm_buffer
+                        .insert(payload.worker_idx, fpm, self.now_ms);
+                }
+                self.process_prefill_pass(
+                    payload.worker_idx,
+                    payload.completed_requests,
+                    payload.output_signals,
+                    payload.lifecycle_events,
+                    payload.engine_events,
+                )
+            }
+            SimulationWorkerStage::Decode => {
+                let payload = self.decode_engine.on_scheduled_completion(payload)?;
+                self.wake_deferred_actions(SimulationWorkerStage::Decode, payload.worker_idx);
+                if self.collect_fpm
+                    && let Some(fpm) = payload.fpm
+                {
+                    self.decode_fpm_buffer
+                        .insert(payload.worker_idx, fpm, self.now_ms);
+                }
+                self.process_decode_pass(
+                    payload.output_signals,
+                    payload.lifecycle_events,
+                    payload.engine_events,
+                    payload.accept_length_output_tokens,
+                    payload.accept_length_decode_forwards,
+                )
+            }
+            SimulationWorkerStage::Aggregated => {
+                bail!("offline disagg replay received an aggregated completion event")
+            }
+        }
     }
 
     /// Drain transfer completions scheduled for the current logical timestamp.
@@ -1976,8 +1991,8 @@ where
                 payload.engine_events,
             )?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }
@@ -2040,8 +2055,8 @@ where
                 payload.accept_length_decode_forwards,
             )?;
         }
-        for ScheduledWorkerCompletion { at_ms, payload } in effects.scheduled_completions {
-            push_worker_completion(&mut self.events, &mut self.next_event_seq, at_ms, payload);
+        if let Some(scheduled) = effects.scheduled_completion {
+            push_worker_completions(&mut self.events, &mut self.next_event_seq, scheduled);
         }
         Ok(())
     }

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -3,9 +3,9 @@
 
 use std::cmp::Ordering;
 
-use super::core::EngineEventBatch;
+use super::core::{EngineEventBatch, EngineProgress};
 use crate::common::handoff::HandoffId;
-use crate::common::protocols::OutputSignal;
+use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
 use crate::scheduler::SchedulerLifecycleEvent;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -13,6 +13,20 @@ pub(crate) enum SimulationWorkerStage {
     Aggregated,
     Prefill,
     Decode,
+}
+
+#[derive(Debug)]
+pub(crate) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
+    pub stage: SimulationWorkerStage,
+    pub worker_idx: usize,
+    pub completed_requests: usize,
+    pub output_signals: Vec<OutputSignal>,
+    pub lifecycle_events: Vec<SchedulerLifecycleEvent>,
+    pub engine_events: Events,
+    pub progress: EngineProgress,
+    pub fpm: Option<ForwardPassSnapshot>,
+    pub accept_length_output_tokens: usize,
+    pub accept_length_decode_forwards: usize,
 }
 
 #[derive(Debug)]
@@ -29,6 +43,9 @@ pub(crate) enum SimulationEventKind<Events: EngineEventBatch = ()> {
         fpm: Option<Box<crate::common::protocols::ForwardPassSnapshot>>,
         accept_length_output_tokens: usize,
         accept_length_decode_forwards: usize,
+    },
+    WorkerCompletionBatch {
+        payloads: Box<[WorkerCompletionPayload<Events>]>,
     },
     TransferComplete {
         handoff_id: HandoffId,

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -5,26 +5,23 @@ use std::collections::BinaryHeap;
 #[cfg(test)]
 use std::collections::VecDeque;
 
+use super::components::ScheduledWorkerCompletions;
 use super::core::{EngineEventBatch, EngineProgress};
-use super::events::{SimulationEvent, SimulationEventKind, SimulationWorkerStage};
+use super::events::{
+    SimulationEvent, SimulationEventKind, SimulationWorkerStage, WorkerCompletionPayload,
+};
 use crate::common::handoff::HandoffId;
 #[cfg(test)]
 use crate::common::protocols::DirectRequest;
-use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
-use crate::scheduler::SchedulerLifecycleEvent;
+#[cfg(test)]
+use crate::common::protocols::OutputSignal;
 
-#[derive(Debug)]
-pub(super) struct WorkerCompletionPayload<Events: EngineEventBatch = ()> {
-    pub stage: SimulationWorkerStage,
-    pub worker_idx: usize,
-    pub completed_requests: usize,
-    pub output_signals: Vec<OutputSignal>,
-    pub lifecycle_events: Vec<SchedulerLifecycleEvent>,
-    pub engine_events: Events,
-    pub progress: EngineProgress,
-    pub fpm: Option<ForwardPassSnapshot>,
-    pub accept_length_output_tokens: usize,
-    pub accept_length_decode_forwards: usize,
+// Keep the large singleton inline: boxing it would add an allocation to every
+// DP1 and disaggregated completion solely to shrink this transient pop result.
+#[allow(clippy::large_enum_variant)]
+pub(super) enum ReadyWorkerCompletions<Events: EngineEventBatch = ()> {
+    Single(WorkerCompletionPayload<Events>),
+    Batch(Box<[WorkerCompletionPayload<Events>]>),
 }
 
 pub(super) fn next_timestamp(
@@ -68,16 +65,26 @@ pub(super) fn pop_next_concurrency_ready(
     Some((request, now_ms))
 }
 
-pub(super) fn push_worker_completion<Events: EngineEventBatch>(
+pub(super) fn push_worker_completions<Events: EngineEventBatch>(
     events: &mut BinaryHeap<SimulationEvent<Events>>,
     next_event_seq: &mut u64,
-    at_ms: f64,
-    payload: WorkerCompletionPayload<Events>,
+    scheduled: ScheduledWorkerCompletions<Events>,
 ) {
-    events.push(SimulationEvent {
+    let ScheduledWorkerCompletions {
         at_ms,
-        seq_no: *next_event_seq,
-        kind: SimulationEventKind::WorkerCompletion {
+        mut payloads,
+    } = scheduled;
+    let payload_count =
+        u64::try_from(payloads.len()).expect("completion payload count must fit in u64");
+    assert!(
+        payload_count > 0,
+        "scheduled completion batch must not be empty"
+    );
+    let kind = if payloads.len() == 1 {
+        let payload = payloads
+            .pop()
+            .expect("singleton scheduled completion must contain one payload");
+        SimulationEventKind::WorkerCompletion {
             stage: payload.stage,
             worker_idx: payload.worker_idx,
             completed_requests: payload.completed_requests,
@@ -89,36 +96,39 @@ pub(super) fn push_worker_completion<Events: EngineEventBatch>(
             fpm: payload.fpm.map(Box::new),
             accept_length_output_tokens: payload.accept_length_output_tokens,
             accept_length_decode_forwards: payload.accept_length_decode_forwards,
-        },
+        }
+    } else {
+        SimulationEventKind::WorkerCompletionBatch {
+            payloads: payloads.into_boxed_slice(),
+        }
+    };
+    events.push(SimulationEvent {
+        at_ms,
+        seq_no: *next_event_seq,
+        kind,
     });
-    *next_event_seq += 1;
+    *next_event_seq = next_event_seq
+        .checked_add(payload_count)
+        .expect("offline replay event sequence overflow");
 }
 
-pub(super) fn pop_ready_worker_completion<Events: EngineEventBatch>(
+pub(super) fn pop_ready_worker_completions<Events: EngineEventBatch>(
     events: &mut BinaryHeap<SimulationEvent<Events>>,
     now_ms: f64,
-) -> Option<WorkerCompletionPayload<Events>> {
+) -> Option<ReadyWorkerCompletions<Events>> {
     let event = events.peek()?;
     if event.at_ms != now_ms {
         return None;
     }
-    let SimulationEventKind::WorkerCompletion { .. } = &event.kind else {
+    if !matches!(
+        event.kind,
+        SimulationEventKind::WorkerCompletion { .. }
+            | SimulationEventKind::WorkerCompletionBatch { .. }
+    ) {
         return None;
-    };
+    }
     let event = events.pop().expect("event must exist after peek");
-    let (
-        stage,
-        worker_idx,
-        completed_requests,
-        output_signals,
-        lifecycle_events,
-        engine_events,
-        made_progress,
-        had_raw_observations,
-        fpm,
-        accept_length_output_tokens,
-        accept_length_decode_forwards,
-    ) = match event.kind {
+    match event.kind {
         SimulationEventKind::WorkerCompletion {
             stage,
             worker_idx,
@@ -131,40 +141,30 @@ pub(super) fn pop_ready_worker_completion<Events: EngineEventBatch>(
             fpm,
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        } => (
+        } => Some(ReadyWorkerCompletions::Single(WorkerCompletionPayload {
             stage,
             worker_idx,
             completed_requests,
             output_signals,
             lifecycle_events,
             engine_events,
-            made_progress,
-            had_raw_observations,
-            fpm.map(|fpm| *fpm),
+            progress: EngineProgress {
+                made_progress,
+                had_raw_observations,
+            },
+            fpm: fpm.map(|fpm| *fpm),
             accept_length_output_tokens,
             accept_length_decode_forwards,
-        ),
+        })),
+        SimulationEventKind::WorkerCompletionBatch { payloads } => {
+            Some(ReadyWorkerCompletions::Batch(payloads))
+        }
         SimulationEventKind::TransferComplete { .. }
         | SimulationEventKind::WorkerReady { .. }
         | SimulationEventKind::PlannerTick => {
             unreachable!("peeked worker completion event must match popped event")
         }
-    };
-    Some(WorkerCompletionPayload {
-        stage,
-        worker_idx,
-        completed_requests,
-        output_signals,
-        lifecycle_events,
-        engine_events,
-        progress: EngineProgress {
-            made_progress,
-            had_raw_observations,
-        },
-        fpm,
-        accept_length_output_tokens,
-        accept_length_decode_forwards,
-    })
+    }
 }
 
 pub(super) fn push_transfer_complete<Events: EngineEventBatch>(
@@ -282,6 +282,27 @@ mod tests {
         }
     }
 
+    fn completion_payload(worker_idx: usize, completed_requests: usize) -> WorkerCompletionPayload {
+        WorkerCompletionPayload {
+            stage: SimulationWorkerStage::Aggregated,
+            worker_idx,
+            completed_requests,
+            output_signals: vec![OutputSignal {
+                uuid: Uuid::from_u128(worker_idx as u128),
+                token_id: None,
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            }],
+            lifecycle_events: Vec::new(),
+            engine_events: (),
+            progress: EngineProgress::default(),
+            fpm: None,
+            accept_length_output_tokens: 1,
+            accept_length_decode_forwards: 1,
+        }
+    }
+
     #[test]
     fn test_next_timestamp_matches_current_choice_logic() {
         assert_eq!(next_timestamp(Some(1.0), Some(2.0)), Some(1.0));
@@ -324,67 +345,50 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_completion_helpers_preserve_same_time_sequence_ordering() {
+    fn test_worker_completion_batch_preserves_payload_and_event_ordering() {
         let mut events = BinaryHeap::new();
         let mut next_event_seq = 0;
 
-        push_worker_completion(
+        push_worker_completions(
+            &mut events,
+            &mut next_event_seq,
+            ScheduledWorkerCompletions {
+                at_ms: 10.0,
+                payloads: vec![completion_payload(7, 1), completion_payload(8, 2)],
+            },
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(next_event_seq, 2);
+
+        push_worker_ready(
             &mut events,
             &mut next_event_seq,
             10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 7,
-                completed_requests: 1,
-                output_signals: vec![OutputSignal {
-                    uuid: Uuid::from_u128(7),
-                    token_id: None,
-                    completed: true,
-                    rejected: false,
-                    handoff_delay_ms: None,
-                }],
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 1,
-                accept_length_decode_forwards: 1,
-            },
+            SimulationWorkerStage::Aggregated,
+            5,
         );
-        push_worker_completion(
-            &mut events,
-            &mut next_event_seq,
-            10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 8,
-                completed_requests: 2,
-                output_signals: vec![OutputSignal {
-                    uuid: Uuid::from_u128(8),
-                    token_id: None,
-                    completed: false,
-                    rejected: false,
-                    handoff_delay_ms: None,
-                }],
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 1,
-                accept_length_decode_forwards: 1,
-            },
+        assert_eq!(next_event_seq, 3);
+        push_planner_tick(&mut events, &mut next_event_seq, 10.0);
+        assert_eq!(next_event_seq, 4);
+
+        assert!(pop_ready_worker_completions(&mut events, 9.0).is_none());
+        let ReadyWorkerCompletions::Batch(payloads) =
+            pop_ready_worker_completions(&mut events, 10.0).unwrap()
+        else {
+            panic!("DP2 completions must use one batched heap event");
+        };
+        assert_eq!(
+            payloads
+                .iter()
+                .map(|payload| (payload.worker_idx, payload.completed_requests))
+                .collect::<Vec<_>>(),
+            vec![(7, 1), (8, 2)]
         );
-
-        assert!(pop_ready_worker_completion(&mut events, 9.0).is_none());
-
-        let first = pop_ready_worker_completion(&mut events, 10.0).unwrap();
-        let second = pop_ready_worker_completion(&mut events, 10.0).unwrap();
-        assert_eq!(first.stage, SimulationWorkerStage::Aggregated);
-        assert_eq!(first.worker_idx, 7);
-        assert_eq!(first.completed_requests, 1);
-        assert_eq!(second.stage, SimulationWorkerStage::Aggregated);
-        assert_eq!(second.worker_idx, 8);
-        assert_eq!(second.completed_requests, 2);
+        assert_eq!(
+            pop_ready_worker_ready(&mut events, 10.0),
+            Some((SimulationWorkerStage::Aggregated, 5))
+        );
+        assert!(pop_ready_planner_tick(&mut events, 10.0));
         assert!(events.is_empty());
     }
 
@@ -423,8 +427,8 @@ mod tests {
             1,
         );
 
-        // pop_ready_worker_completion must return None (wrong event kind).
-        assert!(pop_ready_worker_completion(&mut events, 10.0).is_none());
+        // pop_ready_worker_completions must return None (wrong event kind).
+        assert!(pop_ready_worker_completions(&mut events, 10.0).is_none());
         // The event should still be in the heap.
         assert_eq!(events.len(), 1);
         // pop_ready_worker_ready should succeed.
@@ -436,21 +440,12 @@ mod tests {
         let mut events = BinaryHeap::new();
         let mut next_event_seq = 0;
 
-        push_worker_completion(
+        push_worker_completions(
             &mut events,
             &mut next_event_seq,
-            10.0,
-            WorkerCompletionPayload {
-                stage: SimulationWorkerStage::Aggregated,
-                worker_idx: 0,
-                completed_requests: 1,
-                output_signals: Vec::new(),
-                lifecycle_events: Vec::new(),
-                engine_events: (),
-                progress: EngineProgress::default(),
-                fpm: None,
-                accept_length_output_tokens: 0,
-                accept_length_decode_forwards: 0,
+            ScheduledWorkerCompletions {
+                at_ms: 10.0,
+                payloads: vec![completion_payload(0, 1)],
             },
         );
         push_worker_ready(
@@ -462,11 +457,15 @@ mod tests {
         );
 
         // The completion was pushed first (lower seq_no) so it pops first.
-        let completion = pop_ready_worker_completion(&mut events, 10.0).unwrap();
+        let ReadyWorkerCompletions::Single(completion) =
+            pop_ready_worker_completions(&mut events, 10.0).unwrap()
+        else {
+            panic!("singleton completion must retain its existing representation");
+        };
         assert_eq!(completion.worker_idx, 0);
 
         // Now the ready event is at the front.
-        assert!(pop_ready_worker_completion(&mut events, 10.0).is_none());
+        assert!(pop_ready_worker_completions(&mut events, 10.0).is_none());
         let (stage, worker_id) = pop_ready_worker_ready(&mut events, 10.0).unwrap();
         assert_eq!(stage, SimulationWorkerStage::Aggregated);
         assert_eq!(worker_id, 5);


### PR DESCRIPTION
## Summary

- represent each positive-duration attention-DP epoch with one ordered completion event instead of one heap event per rank
- preserve per-rank completion, FPM, lifecycle, admission, output, and barrier processing order
- retain the existing singleton event representation for DP1 and disaggregated replay

## Validation

- `cargo test -p dynamo-mocker replay::offline` (175 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` (178 passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Exact `99e975ee98` baseline versus candidate, ordinary release builds, AgentX
32 logical workers / DP4 / 128 ranks and sessions, native G1, KV routing/events,
block size 16, trace block size 64, speedup 20, seed 42, CPU 0. One matched pair
per backend, no warm-ups; all CPU preflights were 100% idle.

| Backend | Baseline processed tok/s | Candidate processed tok/s | Gain |
| --- | ---: | ---: | ---: |
| vLLM | 97,292,732 | 115,701,733 | +18.92% |
| SGLang | 112,896,058 | 144,153,017 | +27.69% |

Normalized reports are byte-identical after removing wall-clock time and its
derived throughput fields. Each run completed 38,114 requests and processed
4,692,062,939 tokens.

One no-warm-up candidate profile per backend recorded zero lost samples. Against
the existing pre-change DP4 structural profiles, completion push/pop helper
samples fell 82-96%, heap push samples fell 72-78%, and aggregate heap pop
samples fell 60-70%. `on_scheduled_completion`, token-time alignment, and
KV-event capture remain visible as expected.
