### PR TITLE
ci: raise build timeouts while the BuildKit pool re-warms (OPS-7961)

### DIFF
--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -60,7 +60,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   sglang-build:
@@ -74,7 +74,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   trtllm-build:
@@ -88,7 +88,7 @@ jobs:
       cuda_version: '["13.1"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   vllm-copy-to-acr:

--- a/.github/workflows/build-on-demand.yml
+++ b/.github/workflows/build-on-demand.yml
@@ -60,7 +60,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
     secrets: inherit
 
   sglang-build:
@@ -74,7 +74,7 @@ jobs:
       cuda_version: '["13.0"]'
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.init.outputs.builder_name }}
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
     secrets: inherit
 
   trtllm-build:

--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -27,7 +27,7 @@ on:
       build_timeout_minutes:
         required: false
         type: number
-        default: 30
+        default: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       no_cache:
         description: 'Disable BuildKit cache-from/to. Nightly sets true for regression detection.'
         required: false

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -223,7 +223,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       push_image: true
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-dev' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-dev-{0}', github.sha) || '' }}
@@ -288,7 +288,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       push_image: true
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-dev' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-dev-{0}', github.sha) || '' }}

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -223,7 +223,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       push_image: true
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-dev' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-dev-{0}', github.sha) || '' }}
@@ -288,7 +288,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       push_image: true
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-dev' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-dev-{0}', github.sha) || '' }}
@@ -353,7 +353,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       push_image: true
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-dev' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-dev-{0}', github.sha) || '' }}
@@ -394,7 +394,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
-      build_timeout_minutes: 45
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: post-merge context. main -> previous commit;
       # release/* -> prior release tag (see resolve_diff_base.py).
       diff_event_context: push
@@ -417,7 +417,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
-      build_timeout_minutes: 45
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: post-merge context. main -> previous commit;
       # release/* -> prior release tag (see resolve_diff_base.py).
       diff_event_context: push

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,7 +327,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -354,7 +354,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
     secrets: inherit
 
   sglang-build:
@@ -378,7 +378,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -405,7 +405,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
     secrets: inherit
 
   trtllm-build:
@@ -473,7 +473,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -502,7 +502,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
+      build_timeout_minutes: 60
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -327,7 +327,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -354,7 +354,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   sglang-build:
@@ -378,7 +378,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -405,7 +405,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   trtllm-build:
@@ -429,7 +429,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -456,7 +456,7 @@ jobs:
       platform: 'linux/amd64,linux/arm64'
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
     secrets: inherit
 
   vllm-efa-build:
@@ -473,7 +473,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -502,7 +502,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -531,7 +531,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 60
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -562,7 +562,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 45
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr
@@ -631,7 +631,7 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       inline_compliance: true
       artifact_retention_days: '7'
-      build_timeout_minutes: 45
+      build_timeout_minutes: 90  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
       # OSRB CSV diff baseline: the target branch selects the rule, while the
       # merge-base pins PR->main diffs to the PR's fork point.
       diff_event_context: pr

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -27,6 +27,30 @@ on:
         description: 'Buildkit builder name'
         required: true
         type: string
+      # TEMPORARY SIZING — raised during the BuildKit pool scale-up.
+      #
+      # Builds run on a shared pool of persistent BuildKit worker pods. There is
+      # no registry layer cache on this path (see .github/actions/docker-remote-build:
+      # the buildx invocation has no --cache-from/--cache-to), so the ONLY layer
+      # cache is whatever is resident on the pod a build happens to land on.
+      # route_buildkit.sh assigns pods to cache groups by rendezvous-hashing the
+      # group key against the ACTIVE pod index set, so every change in pod count
+      # reshuffles which pods serve which group and their local caches restart
+      # cold. Measured effect during the transient: 48-77% of build wall-clock is
+      # spent stalled between BuildKit vertices, with sccache still reporting a
+      # ~100% hit rate — i.e. the builds are queueing, not compiling.
+      #
+      # These budgets absorb that transient. They are NOT steady-state sizing:
+      # steady-state successful builds are p50 ~11-17 min. Reduce them back —
+      # the PR pipeline first — once BOTH are true:
+      #   1. layer-cache hit rates recover after the pool settles at its new size, and
+      #   2. the general/TRT-LLM cache group is rebalanced. It currently carries
+      #      ~52% of build demand (dynamo-runtime, frontend, planner, operator,
+      #      snapshot AND every trtllm build) on a flat one-third of the pods,
+      #      because pool_size is ceil(active_pods/3) and flavor_to_group() maps
+      #      'trtllm|general|*' to the same group. Scaling the pool up raises
+      #      absolute headroom but does not change that share, so a load spike
+      #      will saturate this group again at the higher caps.
       build_timeout_minutes:
         description: 'Timeout in minutes for the build step'
         required: false
@@ -366,7 +390,7 @@ jobs:
           IMAGE_REPOSITORY: ai-dynamo/dynamo
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           SCCACHE_S3_BUCKET: ${{ secrets.SCCACHE_S3_BUCKET }}
-        timeout-minutes: 30
+        timeout-minutes: 60  # TEMP: raised for BuildKit pool scale-up; reduce back once caching stabilizes
         run: |
           set -x
           EPP_REPOSITORY="${{ env.IMAGE_REPOSITORY }}/dynamo-epp"

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -40,8 +40,16 @@ on:
       # spent stalled between BuildKit vertices, with sccache still reporting a
       # ~100% hit rate — i.e. the builds are queueing, not compiling.
       #
+      # Only the affected builds were raised — the ones that actually bump their
+      # cap, all of them members of the general/TRT-LLM cache group:
+      #   dynamo-runtime 20% of runs, planner 16%, trtllm-* 9-10%, frontend 2.7%.
+      # vLLM and SGLang builds are deliberately LEFT at 60: they sit in their own
+      # cache groups, run p90 6-16 min, and time out on <1% of runs. Raising them
+      # would only let a wedged build hold a pod for an extra 30 min of capacity
+      # the fleet needs, and would delay detection of a real regression.
+      #
       # These budgets absorb that transient. They are NOT steady-state sizing:
-      # steady-state successful builds are p50 ~11-17 min. Reduce them back —
+      # steady-state successful builds are p50 ~11-19 min. Reduce them back —
       # the PR pipeline first — once BOTH are true:
       #   1. layer-cache hit rates recover after the pool settles at its new size, and
       #   2. the general/TRT-LLM cache group is rebalanced. It currently carries


### PR DESCRIPTION
Linear: OPS-7961

Follow-on to OPS-7960 (BuildKit warm pool 9 -> 15 per arch). **Temporary measure** — the exit condition is tracked by OPS-7962.

## Summary

Two independent reasons the current build caps are too tight:

**1. The pool scale-up makes layer caches cold.** There is no registry layer cache on this path — `.github/actions/docker-remote-build:159-164` invokes buildx with no `--cache-from`/`--cache-to`, so the only layer cache is whatever is resident on the pod a build lands on. `route_buildkit.sh` assigns pods to cache groups by rendezvous-hashing the group key against the **active pod index set**, so every change in pod count reshuffles which pods serve which group and their local caches restart cold. KEDA scales up 1 pod / 600s, so the transient is long (observed 9 -> 10 pods over several hours on 2026-07-29).

**2. The caps were already truncating the distributions,** independent of the scale-up. Successful-build percentiles (n=439/372/405, sampled 2026-07-08 -> 07-29):

| Job | p50 | p95 | p99 | max success | cap |
| --- | --- | --- | --- | --- | --- |
| dynamo-runtime | 10.8 | 27.2 | 28.7 | **29.9** | 30 |
| frontend | 16.8 | 38.1 | 42.7 | **44.3** | 45 |
| planner | 10.9 | 35.2 | 41.7 | **44.5** | 45 |

Every max sits within ~1 minute of its cap — censored distributions, so the true tails are above the caps.

## Changes

Raise the budget to 90 **only for builds that actually bump their cap** — all of them members of the saturated general/TRT-LLM cache group. Per-job timeout rates at the current caps (PR builds, 2026-07-08 -> 07-29):

| Job | p50 | p90 | timed out | change |
| --- | --- | --- | --- | --- |
| dynamo-runtime | 11.1 | 24.5 | **108/533 (20%)** | 30 -> 90 |
| planner | 11.2 | 30.7 | **70/450 (16%)** | 45 -> 90 |
| trtllm-runtime | 18.6 | 43.5 | **49/473 (10.4%)** | 60 -> 90 |
| trtllm-dev | 12.4 | 33.8 | **40/452 (8.8%)** | 60 -> 90 |
| trtllm-runtime-efa | 19.2 | 43.4 | **6/60 (10%)** | 60 -> 90 |
| frontend | 16.7 | 33.7 | 12/437 (2.7%) | 45 -> 90 |
| vllm-runtime | 6.8 | 12.4 | 5/539 (0.9%) | *unchanged, 60* |
| vllm-dev | 2.6 | 10.9 | 1/516 (0.2%) | *unchanged, 60* |
| vllm-runtime-efa | 8.4 | 15.5 | 1/162 | *unchanged, 60* |
| sglang-runtime | 6.1 | 9.4 | 1/481 | *unchanged, 60* |
| sglang-dev | 2.8 | 6.4 | 0/460 | *unchanged, 60* |
| sglang-runtime-efa | 7.7 | 10.0 | 0/87 | *unchanged, 60* |

vLLM and SGLang sit in cache groups 0 and 1, which were never affected — in the natural experiment behind this work, every group-0/1 job finished in 2.0-10.5 min while all five group-2 jobs died at their caps. Raising them buys nothing and costs something: a wedged build would hold a pod for an extra 30 min of capacity the fleet needs, and a 60-minute vLLM build is already anomalous against a p90 of 12 min, so a higher cap only delays detection of a real regression.

Two of the changes are not simple bumps:

- **`dynamo-pipeline.yml:30`** `default: 30` -> `90`. This default is forwarded unconditionally at `:88`, and both `pr.yaml:805` and `post-merge-ci.yml:59` omit the input — so this line, not `shared-build-image.yml`'s own `default: 60`, was the real cap on `dynamo-runtime` in both pipelines. That made the 60 unreachable dead config.
- **`shared-build-image.yml:369`** EPP step-level `timeout-minutes: 30` -> `60`. This is `frontend`'s actual binding constraint: it is the only step-level timeout among the build job's steps, and raising the caller input alone leaves frontend failing at exactly 30m.

Not touched:
- **nightly** — already 120 everywhere and uses `fresh_builder` (permanently cold by design), so already sized for the cold path.
- **release** — builds no images; it republishes post-merge images by SHA.
- **post-merge builds already at 120** — above 90 already.

A block comment at the `build_timeout_minutes` input in `shared-build-image.yml` records why this is temporary and the two conditions for reverting. Each changed line carries a short `# TEMP:` marker.

## Why not fix it properly here

The underlying issue is that `flavor_to_group()` puts `general` and `trtllm` in one cache group carrying ~52% of build demand on a flat `ceil(active_pods/3)` = 33% of the pods. Scale-up raises absolute headroom but not that share, so a load spike will saturate the group again at the higher caps. That rebalance is OPS-7962 and is deliberately a separate PR.

## Validation

- `pre-commit run --files <changed>` — all applicable hooks pass, including `check-yaml`. The `Report pytest markers` hook fails identically on a clean tree (local port exhaustion during collection); unrelated to this diff.
- Diff is `build_timeout_minutes` / `timeout-minutes` values plus comments only — no structural YAML change.
- Effective budgets after the change verified by grep across all callers.
- Real validation is CI itself: these paths only exercise under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
