### PR TITLE
fix(sglang): split Kimi K3 reasoning and strip terminal tokens in SGLang chat processor

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -99,6 +99,7 @@ _THINKING_BY_DEFAULT = {
     "nemotron_3",
     "interns1",
     "kimi_k2",
+    "kimi_k3",
 }
 _THINKING_OPT_IN = {"deepseek-v3", "deepseek-v4", "gemma4"}
 
@@ -108,6 +109,7 @@ _SGLANG_PARSER_NAME_ALIASES = {
     "minimax_m3": "minimax-m3",
     "minimax_m3_nom": "minimax-m3",
     "minimax-m3-nom": "minimax-m3",
+    "kimi-k3": "kimi_k3",
 }
 
 
@@ -127,9 +129,9 @@ def resolve_request_force_reasoning(
     Mirrors sglang.srt.entrypoints.openai.serving_chat._get_reasoning_from_request
     combined with template_manager.force_reasoning:
 
-      * opt-out families (``glm45``/``qwen3``/``kimi_k2``/...): on by
+      * opt-out families (``glm45``/``qwen3``/``kimi_k2``/``kimi_k3``/...): on by
         default, ``chat_template_kwargs.enable_thinking=False`` (or
-        ``thinking=False`` for ``kimi_k2``) disables it.
+        ``thinking=False`` for Kimi) disables it.
       * MiniMax-M3 defaults to adaptive, but SGLang still enables the
         reasoning parser unless ``chat_template_kwargs.thinking_mode`` is
         explicitly ``"disabled"``.
@@ -158,7 +160,9 @@ def resolve_request_force_reasoning(
 
     if reasoning_parser_name in _THINKING_BY_DEFAULT:
         flag_key = (
-            "thinking" if reasoning_parser_name == "kimi_k2" else "enable_thinking"
+            "thinking"
+            if reasoning_parser_name in {"kimi_k2", "kimi_k3"}
+            else "enable_thinking"
         )
         return kwargs.get(flag_key) is not False
 

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -85,6 +85,42 @@ def _tokenizer_eos_token_ids(tokenizer: Any) -> list[int]:
     return _normalize_eos_token_ids(getattr(tokenizer, "eos_token_id", None))
 
 
+def _model_eos_token_ids(tokenizer: Any, source_path: str) -> list[int]:
+    """Merge tokenizer EOS IDs with the model generation configuration.
+
+    SGLang mode detokenizes in the frontend, bypassing both Dynamo's Rust EOS
+    resolution and SGLang's own ``trim_matched_stop``, so the merge is redone here.
+    For most models the tokenizer's EOS is already the real terminal token and this
+    is a no-op. Kimi-K3 splits them: it closes messages with the XTML protocol token
+    163586 ``<|end_of_msg|>``, declared only in generation config, while the
+    tokenizer reports a different token, 163585 ``[EOS]``.
+    Strips the trailing token only; splitting reasoning is ``force_reasoning``'s job.
+    """
+    token_ids = _tokenizer_eos_token_ids(tokenizer)
+    generation_config_path = os.path.join(source_path, "generation_config.json")
+    try:
+        with open(generation_config_path, encoding="utf-8") as config_file:
+            generation_config = json.load(config_file)
+    except FileNotFoundError:
+        return token_ids
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "Could not read EOS IDs from %s: %s",
+            generation_config_path,
+            exc,
+        )
+        return token_ids
+
+    configured_ids = _normalize_eos_token_ids(
+        generation_config.get("eos_token_id")
+        if isinstance(generation_config, dict)
+        else None
+    )
+    seen = set(token_ids)
+    token_ids.extend(token_id for token_id in configured_ids if token_id not in seen)
+    return token_ids
+
+
 def _load_tokenizer(source_path: str, trust_remote_code: bool):
     """Load the SGLang tokenizer, falling back to an on-disk chat template
     (e.g. chat_template.json) when the tokenizer defines none."""
@@ -781,7 +817,7 @@ class SglangEngineFactory:
             logger.info("Using custom chat template override")
             tokenizer.chat_template = chat_template
 
-        eos_token_ids = _tokenizer_eos_token_ids(tokenizer)
+        eos_token_ids = _model_eos_token_ids(tokenizer, local_dir)
 
         # Static reasoning-template scan (mirrors sglang's template_manager).
         # Shared with worker-pool processes via initargs so they compute the

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -46,6 +46,7 @@ from dynamo.frontend.sglang_processor import (
     _init_worker,
     _load_chat_template,
     _map_finish_reason,
+    _model_eos_token_ids,
     _normalize_eos_token_ids,
     _preprocess_worker,
     _runtime_config_parser_name,
@@ -308,6 +309,20 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
     def test_tokenizer_eos_token_ids_falls_back_to_single_id(self):
         tokenizer = types.SimpleNamespace(eos_token_id=2)
         assert _tokenizer_eos_token_ids(tokenizer) == [2]
+
+    def test_model_eos_token_ids_merge_generation_config(self, tmp_path):
+        tokenizer = types.SimpleNamespace(eos_token_ids=[2, 3], eos_token_id=2)
+        (tmp_path / "generation_config.json").write_text(
+            json.dumps({"eos_token_id": [3, 4, 5]}),
+            encoding="utf-8",
+        )
+
+        assert _model_eos_token_ids(tokenizer, str(tmp_path)) == [2, 3, 4, 5]
+
+    def test_model_eos_token_ids_fall_back_when_config_is_absent(self, tmp_path):
+        tokenizer = types.SimpleNamespace(eos_token_id=2)
+
+        assert _model_eos_token_ids(tokenizer, str(tmp_path)) == [2]
 
     def test_normalize_eos_token_ids_ignores_non_ints_and_bools(self):
         assert _normalize_eos_token_ids([2, True, "3", 4, 2]) == [2, 4]
@@ -697,6 +712,7 @@ def test_normalize_sglang_parser_name_accepts_minimax_m3_aliases():
     assert _normalize_sglang_parser_name("minimax_m3_nom") == "minimax-m3"
     assert _normalize_sglang_parser_name("minimax-m3-nom") == "minimax-m3"
     assert _normalize_sglang_parser_name("kimi_k2") == "kimi_k2"
+    assert _normalize_sglang_parser_name("kimi-k3") == "kimi_k3"
 
 
 def test_minimax_m3_force_reasoning_uses_thinking_mode():
@@ -2674,6 +2690,118 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
         )
         assert result.force_reasoning is True
         assert result.reasoning_parser is not None
+
+    # Only the explicit case is covered: with no `thinking` key we deliberately
+    # do NOT materialize one, so the K3 chat template applies its own default
+    # (measured: an unset `thinking` renders byte-identically to `thinking=True`).
+    # The parser reaches the same conclusion independently via
+    # `_THINKING_BY_DEFAULT`, so template and parser agree without our help.
+    @pytest.mark.parametrize(
+        ("chat_template_kwargs", "expected"),
+        [
+            ({"thinking": False}, False),
+        ],
+    )
+    def test_kimi_k3_template_and_parser_share_thinking_state(
+        self,
+        monkeypatch,
+        chat_template_kwargs,
+        expected,
+    ):
+        captured = {}
+
+        class CapturingTokenizer:
+            chat_template = "template"
+
+            def apply_chat_template(self, messages, **kwargs):
+                captured["kwargs"] = kwargs
+                return [1, 2, 3]
+
+        def fake_create_parsers(*args, force_reasoning=False, **kwargs):
+            return None, types.SimpleNamespace(force_reasoning=force_reasoning)
+
+        monkeypatch.setattr(
+            sglang_prepost_module,
+            "create_parsers",
+            fake_create_parsers,
+        )
+
+        result = preprocess_chat_request(
+            {
+                "model": "moonshotai/Kimi-K3",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "chat_template_kwargs": chat_template_kwargs,
+            },
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name=None,
+            reasoning_parser_name="kimi_k3",
+        )
+
+        assert captured["kwargs"]["thinking"] is expected
+        assert result.request["chat_template_kwargs"]["thinking"] is expected
+        assert result.force_reasoning is expected
+        assert result.reasoning_parser.force_reasoning is expected
+
+    @pytest.mark.multimodal
+    def test_kimi_k3_normalizes_template_media_but_forwards_original_url(
+        self,
+        monkeypatch,
+    ):
+        captured = {}
+
+        class CapturingTokenizer:
+            chat_template = "template"
+
+            def apply_chat_template(self, messages, **kwargs):
+                captured["messages"] = messages
+                return [1, 2, 3]
+
+        def normalize_for_template(message, *args, **kwargs):
+            normalized = copy.deepcopy(message)
+            for part in normalized.get("content", []):
+                if part.get("type") == "image_url":
+                    part["type"] = "image"
+            return normalized
+
+        monkeypatch.setattr(
+            sglang_prepost_module,
+            "process_content_for_template_format",
+            normalize_for_template,
+        )
+        request = {
+            "model": "moonshotai/Kimi-K3",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "https://example.com/k3.png"},
+                        },
+                    ],
+                }
+            ],
+        }
+
+        result = preprocess_chat_request(
+            request,
+            tokenizer=CapturingTokenizer(),
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+        )
+        dynamo_preproc = _build_dynamo_preproc(
+            result.request,
+            result.prompt_token_ids,
+            request["model"],
+            None,
+        )
+
+        assert captured["messages"][0]["content"][1]["type"] == "image"
+        assert request["messages"][0]["content"][1]["type"] == "image_url"
+        assert dynamo_preproc["multi_modal_data"] == {
+            "image_url": [{"Url": "https://example.com/k3.png"}]
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

With `--dyn-chat-processor sglang`, Kimi-K3 responses come back with raw XTML protocol markers inside `content` and `reasoning_content` never populated. Two independent gaps cause it. First, `kimi_k3` is missing from the thinking-by-default parser family, so `force_reasoning` resolves False and SGLang's streaming detector waits for an opening `<|open|>think<|sep|>` marker that K3 never emits — the chat template places it in the prompt, so generation begins already inside the think channel. Second, this mode detokenizes engine token IDs in the frontend and so bypasses SGLang's own `trim_matched_stop`, letting K3's terminal `<|end_of_msg|>` survive into the text; that ID is declared only in `generation_config.json` and differs from the tokenizer's EOS, so neither source alone is sufficient. The Rust chat processor resolves both centrally and is unaffected.

## Effect

Request: `What is 17 + 25? One word.`

```
before:  content           = 'The user is asking...One word.<|close|>think<|sep|>42<|end_of_msg|>'
         reasoning_content = None

after:   content           = '42'
         reasoning_content = 'The user is asking a simple arithmetic question: 17 + 25...'
```

## What Change

- Register `kimi_k3` in the thinking-by-default parser family and aliases.
- Merge tokenizer and generation-config EOS IDs before the trailing-token strip.
- Add unit coverage for EOS merge, thinking state, and media URL forwarding.

## Test Plan

- `pytest components/src/dynamo/frontend/tests/test_sglang_processor_unit.py` — 193 passed.
- Verified serving Kimi-K3 at TP=16 on 16x GB200 via the SGLang chat processor.
