### PR TITLE
fix(ci): isolate sidecar changes from E2E filters

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -14,6 +14,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `snapshot_vllm` / `snapshot_sglang` / `snapshot_trtllm` | That framework's DynamoCheckpoint deploy suite |
 | `deploy` | Deploy-specific tests |
 | `vllm` / `sglang` / `trtllm` | Backend-specific tests |
+| `sidecar` | Nothing directly; sidecar source and proto files also match `rust` |
 | `benchmarks` | Dynamo runtime pipeline (runs `tests/benchmarks/**` pytest suite) |
 | `sample` | Sample-backend unified test (piggybacks on vllm image) |
 | `efa` | EFA runtime image builds for vLLM, SGLang, TRT-LLM (`container/templates/aws.Dockerfile` change) |
@@ -22,7 +23,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | `ignore` | Nothing (classification only) |
 | `rust` | Rust pre merge checks |
 
-> **Note:** `docs`, `examples`, and `ignore` don't trigger any CI jobs. They exist to satisfy coverage requirements - every file must match at least one filter.
+> **Note:** `docs`, `examples`, `ignore`, and `sidecar` don't directly trigger CI jobs. They exist to satisfy coverage requirements - every file must match at least one filter. Sidecar source and proto files also match `rust`, which runs the workspace Rust checks.
 
 ## Fixing "Uncovered Files" Errors
 

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -46,6 +46,9 @@ outputs:
   planner:
     description: 'Whether planner files changed'
     value: ${{ steps.filter.outputs.planner_any_modified }}
+  sidecar:
+    description: 'Whether sidecar files changed'
+    value: ${{ steps.filter.outputs.sidecar_any_modified }}
   frontend:
     description: 'Whether frontend files changed'
     value: ${{ steps.filter.outputs.frontend_any_modified }}
@@ -149,6 +152,7 @@ runs:
         echo "power_agent: ${{ steps.filter.outputs.power_agent_any_modified }}"
         echo "deploy: ${{ steps.filter.outputs.deploy_any_modified }}"
         echo "planner: ${{ steps.filter.outputs.planner_any_modified }}"
+        echo "sidecar: ${{ steps.filter.outputs.sidecar_any_modified }}"
         echo "vllm: ${{ steps.filter.outputs.vllm_any_modified }}"
         echo "sglang: ${{ steps.filter.outputs.sglang_any_modified }}"
         echo "trtllm: ${{ steps.filter.outputs.trtllm_any_modified }}"
@@ -170,6 +174,7 @@ runs:
         echo "power_agent: ${{ steps.filter.outputs.power_agent_all_modified_files }}"
         echo "deploy: ${{ steps.filter.outputs.deploy_all_modified_files }}"
         echo "planner: ${{ steps.filter.outputs.planner_all_modified_files }}"
+        echo "sidecar: ${{ steps.filter.outputs.sidecar_all_modified_files }}"
         echo "vllm: ${{ steps.filter.outputs.vllm_all_modified_files }}"
         echo "sglang: ${{ steps.filter.outputs.sglang_all_modified_files }}"
         echo "trtllm: ${{ steps.filter.outputs.trtllm_all_modified_files }}"
@@ -183,7 +188,7 @@ runs:
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.sidecar_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -275,9 +275,7 @@ rust:
   - 'deny.toml'
   # Sidecar protobuf contracts are compiled by crate build scripts and need the
   # same workspace checks as sidecar Rust sources.
-  - 'lib/sidecar/**'
-  - '!lib/sidecar/**/*.md'
-  - '!lib/sidecar/**/*.rst'
+  - 'lib/sidecar/**/*.proto'
 
 benchmarks:
   - 'benchmarks/**'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -14,10 +14,11 @@
 #   frontend -> frontend EPP image build, dynamo build-test
 #   benchmarks -> dynamo build-test (runs tests/benchmarks/** pytest suite)
 #   efa      -> all framework EFA runtime image builds (changes to container/templates/aws.Dockerfile)
+#   sidecar  -> classification only; source and proto files also match rust
 #   docs     -> fern docs lint, sync, and version release (docs/ directory)
 #
 # Filters for coverage only (no CI triggered):
-#   examples, ignore
+#   examples, ignore, sidecar
 
 all:
   - '**'
@@ -38,6 +39,8 @@ docs:
   - '.agents/**'
   # Canonical agent skills live in .agents/skills; root skills/ is a symlink there.
   - 'skills/**'
+  # Sidecar documentation is not part of the Fern docs site.
+  - '!lib/sidecar/**'
 
 examples:
   - 'recipes/**'
@@ -129,6 +132,9 @@ core:
   # Negation patterns MUST come after positive patterns — micromatch processes
   # patterns left-to-right, so negations only filter matches accumulated by
   # preceding patterns. Placing them first has no effect.
+  # Rust sidecars have their own classification and do not use the framework
+  # container or E2E pipelines triggered by `core`.
+  - '!lib/sidecar/**'
   - '!**/*.md'
   - '!**/*.rst'
   - '!**/*.txt'
@@ -199,13 +205,14 @@ planner:
   - 'deploy/power-agent/**'
   - 'deploy/helm/charts/power-agent/**'
 
+sidecar:
+  - 'lib/sidecar/**'
+
 vllm:
   - 'container/deps/requirements.vllm.txt'
   - 'container/deps/vllm/**'
   - 'examples/backends/vllm/**'
   - 'components/src/dynamo/vllm/**'
-  - 'lib/sidecar/common/**'
-  - 'lib/sidecar/vllm/**'
   - 'container/templates/vllm_*'
   - '!**/*.md'
   - '!**/*.rst'
@@ -214,8 +221,6 @@ sglang:
   - 'container/deps/sglang/**'
   - 'examples/backends/sglang/**'
   - 'components/src/dynamo/sglang*/**'
-  - 'lib/sidecar/sglang/**'
-  - 'lib/sidecar/trtllm/**'
   - 'container/templates/sglang_*'
   - 'container/deps/sglang/**'
   - '!**/*.md'
@@ -256,6 +261,9 @@ frontend:
   - 'components/src/dynamo/common/**'
   - 'deploy/inference-gateway/**'
   - 'container/templates/frontend.Dockerfile'
+  # Sidecars are standalone Rust binaries and are not part of the frontend
+  # image or its E2E test pipeline.
+  - '!lib/sidecar/**'
   - '!**/*.md'
   - '!**/*.rst'
 
@@ -265,6 +273,11 @@ rust:
   - '**/Cargo.toml'
   - '**/Cargo.lock'
   - 'deny.toml'
+  # Sidecar protobuf contracts are compiled by crate build scripts and need the
+  # same workspace checks as sidecar Rust sources.
+  - 'lib/sidecar/**'
+  - '!lib/sidecar/**/*.md'
+  - '!lib/sidecar/**/*.rst'
 
 benchmarks:
   - 'benchmarks/**'

--- a/.github/scripts/test-filters.js
+++ b/.github/scripts/test-filters.js
@@ -81,7 +81,7 @@ const testCases = [
     desc: 'vllm component triggers only vllm'
   },
 
-  // Sidecar files should trigger only their classification and Rust checks
+  // Sidecar Rust and proto files should trigger Rust checks without unrelated E2E
   {
     file: 'lib/sidecar/common/src/lib.rs',
     expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
@@ -101,6 +101,11 @@ const testCases = [
     file: 'lib/sidecar/trtllm/src/lib.rs',
     expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
     desc: 'trtllm sidecar source does not route to sglang or trtllm E2E'
+  },
+  {
+    file: 'lib/sidecar/vllm/deploy/agg.yaml',
+    expect: { sidecar: true, rust: false, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'sidecar deployment config avoids Rust and E2E checks'
   },
   {
     file: 'lib/sidecar/README.md',

--- a/.github/scripts/test-filters.js
+++ b/.github/scripts/test-filters.js
@@ -12,6 +12,7 @@
  *
  * This validates that tj-actions/changed-files will correctly:
  * - Match backend-specific files to their respective filters (vllm, sglang, trtllm)
+ * - Route sidecar files to sidecar/Rust checks without backend or core E2E checks
  * - Exclude doc files (*.md, *.rst, *.txt) from core via negation patterns
  * - Match CI/infrastructure changes to core
  * - (with --coverage) Ensure all files in repo are covered by at least one filter
@@ -78,6 +79,33 @@ const testCases = [
     file: 'components/src/dynamo/vllm/worker.py',
     expect: { core: false, vllm: true },
     desc: 'vllm component triggers only vllm'
+  },
+
+  // Sidecar files should trigger only their classification and Rust checks
+  {
+    file: 'lib/sidecar/common/src/lib.rs',
+    expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'common sidecar source avoids unrelated build and E2E filters'
+  },
+  {
+    file: 'lib/sidecar/vllm/proto/vllm_grpc.proto',
+    expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'vllm sidecar proto triggers Rust checks without backend E2E'
+  },
+  {
+    file: 'lib/sidecar/sglang/src/lib.rs',
+    expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'sglang sidecar source avoids backend E2E'
+  },
+  {
+    file: 'lib/sidecar/trtllm/src/lib.rs',
+    expect: { sidecar: true, rust: true, core: false, frontend: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'trtllm sidecar source does not route to sglang or trtllm E2E'
+  },
+  {
+    file: 'lib/sidecar/README.md',
+    expect: { sidecar: true, rust: false, core: false, frontend: false, docs: false, vllm: false, sglang: false, trtllm: false },
+    desc: 'sidecar README avoids Rust, Fern, and E2E checks'
   },
 
   // Doc files should be excluded from core (negation patterns)


### PR DESCRIPTION
## Summary

- add a dedicated `sidecar` classification for `lib/sidecar/**`
- keep sidecar Rust and protobuf changes covered by workspace Rust CI
- exclude sidecar-only changes from `core`, `frontend`, vLLM, SGLang, TensorRT-LLM, and Fern filter-gated pipelines
- remove the incorrect routing of `lib/sidecar/trtllm/**` through the SGLang filter
- add focused regression cases for all sidecar crates and sidecar documentation

The sidecar crates are standalone Rust workspace members. Their previous overlap with broad framework filters caused unrelated container builds and E2E tests, including TensorRT-LLM sidecar changes incorrectly selecting SGLang CI.

## Validation

- `npm test` — 25/25 filter routing assertions passed
- `pre-commit run --files .github/FILTERS.md .github/actions/changed-files/action.yml .github/filters.yaml .github/scripts/test-filters.js` — passed
- `git diff --check` — passed
- `npm test -- --coverage` — sidecar routing assertions passed; repository-wide coverage still reports 11 pre-existing unrelated unclassified dotfiles/paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Coverage**
  * Added dedicated change detection for sidecar files.
  * Sidecar source and protocol changes are now covered by the appropriate sidecar and Rust checks.
  * Sidecar documentation is classified separately and does not trigger unrelated backend or core end-to-end checks.
  * Improved reporting for changed files and uncovered-file validation.

* **Tests**
  * Added coverage verifying filter behavior for sidecar source, protocol, and documentation files.

* **Documentation**
  * Updated CI filter documentation to clarify sidecar coverage and routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->