### PR TITLE
fix(docs): repair the LandingStyles template literal

### DIFF
--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -957,10 +957,22 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
 }
 
 .dynamo-story-core,
-/* Orbit node positions. These modifiers are unprefixed in the markup
-   (`node node--k8s`), so they must travel with the orbit rules -- left in
-   main.css they are dropped by the production theme and the three labels
-   collapse to the container's static position. */
+.dynamo-story-orbit .node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(118, 185, 0, 0.4);
+  background: rgba(12, 18, 8, 0.94);
+  color: #d8f4aa;
+  box-shadow: 0 14px 30px rgba(18, 32, 0, 0.25);
+  font-family: RobotoMono, ui-monospace, monospace;
+}
+
+/* Orbit node positions. The modifiers are unprefixed in the markup
+   (class "node node--k8s"), so the dynamo-* extraction missed them. Left in
+   main.css the production theme drops them and the three labels collapse to
+   the container's static position. No backticks in this comment: it lives
+   inside a template literal. */
 .node--k8s {
   top: 3%;
   left: 50%;
@@ -973,17 +985,6 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
 .node--local {
   bottom: 19%;
   left: -2%;
-}
-
-.dynamo-story-orbit .node {
-  position: absolute;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(118, 185, 0, 0.4);
-  background: rgba(12, 18, 8, 0.94);
-  color: #d8f4aa;
-  box-shadow: 0 14px 30px rgba(18, 32, 0, 0.25);
-  font-family: RobotoMono, ui-monospace, monospace;
 }
 
 .dynamo-story-core {


### PR DESCRIPTION
## Summary

**Home and Community currently fail to render on docs.nvidia.com.** Both pages show Fern's "Failed to render this content" box:

```
components/LandingStyles.tsx:961:5: ERROR: Expected ";" but found "node"
```

I introduced this in #12330. The comment I added above the orbit modifier rules wrote the class names inside backticks — ``(`node node--k8s`)`` — and a backtick closes the template literal holding the CSS. Everything after it parsed as TypeScript, the module failed to compile, and both pages lost their components entirely.

That is worse than the bug #12330 set out to fix: before, the components rendered unstyled; now they do not render at all.

The same edit also split a selector list. The modifiers landed between `.dynamo-story-core,` and `.dynamo-story-orbit .node {`, merging the first selector into the wrong rule and orphaning the second.

## What changed

- Restore the `.dynamo-story-core, .dynamo-story-orbit .node` selector list
- Re-add `node--k8s`, `node--slurm`, `node--local` after that rule closes
- Write the class names without backticks, with a note saying why

The blog is unaffected and is rendering correctly on the live site — `BlogStyles.tsx` has no such comment.

## Verification

Using the parser that produces the production error:

```
$ npx esbuild docs/fern/components/LandingStyles.tsx --loader:.tsx=tsx --outfile=/dev/null
  main today:   FAIL — Expected ";" but found "node"  at 961:5
  this branch:  parses OK
```

All four style components parse: `LandingStyles`, `BlogStyles`, `ReferenceStyles`, `RecipeStyles`.

`fern check` 0 errors. `sync_site_css --check` in sync. The three orbit modifiers are still present and the selector list is intact.

## Why nothing caught it

Worth stating plainly, because the same hole is still open:

- `fern check` validates docs configuration and links, not TSX syntax
- pre-commit has no parser for these files
- previews are unthemed, so `main.css` still loads there and the page renders regardless

The failure only appears in a themed build, which today means production only. #12339 closes the preview half of that. A parse check for the style components should follow — I verified an `esbuild --loader:.tsx=tsx` run catches this exact error, and it takes about a second per file.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12402" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the consistency of orbit styling in the landing page.
  * Removed redundant styling definitions without changing the visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->