### PR TITLE
docs(sidecar): simplify comments

### DIFF
--- a/lib/backend-common/src/disagg.rs
+++ b/lib/backend-common/src/disagg.rs
@@ -18,12 +18,6 @@ use serde::{Deserialize, Serialize};
 use crate::error::{BackendError, DynamoError, ErrorType};
 
 /// Disaggregation role this worker is playing.
-///
-/// `Aggregated` is the default: the worker handles prefill and decode in the
-/// same engine. `Prefill` and `Decode` workers split the two phases across
-/// processes / GPUs and exchange KV cache via the engine-specific transport.
-/// `Encode` workers run a multimodal encoder upstream of Prefill/Aggregated
-/// and emit an opaque `encoder_result` payload on their terminal chunk.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
 pub enum DisaggregationMode {
@@ -68,17 +62,14 @@ impl DisaggregationMode {
         }
     }
 
-    /// `true` when this worker only runs the prefill phase.
     pub fn is_prefill(&self) -> bool {
         matches!(self, Self::Prefill)
     }
 
-    /// `true` when this worker only runs the decode phase.
     pub fn is_decode(&self) -> bool {
         matches!(self, Self::Decode)
     }
 
-    /// `true` when this worker runs the encoder phase.
     pub fn is_encode(&self) -> bool {
         matches!(self, Self::Encode)
     }

--- a/lib/sidecar/vllm/Dockerfile
+++ b/lib/sidecar/vllm/Dockerfile
@@ -2,23 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Minimal image for the vLLM Rust sidecar (`dynamo-vllm-sidecar`).
+# A pure gRPC connector — no GPU, no engine runtime — that runs beside the
+# engine container over loopback (see deploy/agg.yaml).
 #
-# The sidecar is a pure gRPC connector + tokenizer; it needs no GPU and no vLLM
-# runtime, so it ships in a slim Debian image separate from the heavy vLLM engine
-# container. The two run side by side in one pod and talk over loopback (see
-# deploy/agg.yaml).
-#
-# Build from the repository root (the workspace is needed to compile the crate):
 #   docker build -f lib/sidecar/vllm/Dockerfile -t dynamo-vllm-sidecar:1.3.0 .
 
-# ---- builder ----------------------------------------------------------------
-# Pinned to the workspace toolchain (rust-toolchain.toml: 1.96.1).
 FROM rust:1.96.1-bookworm AS builder
-
-# aws-lc-sys/ring need cmake + a C toolchain (+perl); bindgen needs libclang;
-# tonic-build (build.rs) needs protoc. libprotobuf-dev supplies the well-known
-# protos (vllm_grpc.proto imports google/protobuf/struct.proto). gcc/make/git
-# come with the rust image.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         clang \
@@ -32,17 +21,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /src
 COPY . .
 
-# Build only the sidecar binary; --locked pins the checked-in Cargo.lock. There
-# is no dependency-cache layer, so a source change recompiles deps — acceptable
-# for this occasional image build.
 RUN cargo build --release --locked -p dynamo-vllm-sidecar \
     && strip target/release/dynamo-vllm-sidecar
 
-# ---- runtime (minimal) ------------------------------------------------------
 FROM debian:bookworm-slim AS runtime
-
-# ca-certificates: HTTPS to Hugging Face for the tokenizer, and rustls TLS to
-# etcd/NATS. TLS crypto (aws-lc-rs) is statically linked, so no libssl needed.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
@@ -50,9 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY --from=builder /src/target/release/dynamo-vllm-sidecar /usr/local/bin/dynamo-vllm-sidecar
 
-# Numeric UID (not the name) so Kubernetes runAsNonRoot can verify it; the home
-# dir created above holds the Hugging Face tokenizer cache.
+# Numeric UID so Kubernetes runAsNonRoot can verify it.
 USER 1000
-# Dynamo system endpoints (/live, /health) — the operator sets DYN_SYSTEM_PORT=9090.
 EXPOSE 9090
 ENTRYPOINT ["/usr/local/bin/dynamo-vllm-sidecar"]

--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -34,8 +34,7 @@ spec:
     podTemplate:
       spec:
         # vllm-engine as a native sidecar (initContainer + restartPolicy: Always):
-        # starts before `main`, stops after. Stock vLLM v0.26.0 ships vllm-rs, whose
-        # gRPC matches the sidecar's vendored proto.
+        # starts before `main`, stops after.
         initContainers:
         - name: vllm-engine
           image: vllm/vllm-openai:v0.26.0

--- a/lib/sidecar/vllm/deploy/agg.yaml
+++ b/lib/sidecar/vllm/deploy/agg.yaml
@@ -3,19 +3,15 @@
 #
 # EXPERIMENTAL. Aggregated vLLM deployment using the Rust sidecar.
 #
-# The worker pod has two containers:
-#   - main: the Dynamo worker (dynamo-vllm-sidecar). No GPU. Handles registration
-#     and talks to the engine over gRPC on 127.0.0.1. The operator adds discovery
-#     env and health probes here, so it must be named "main".
-#   - vllm-engine: the stock vLLM image (ships `vllm-rs`, vLLM's native gRPC
-#     server). Holds the GPU. Runs as a native sidecar; see the initContainers
-#     block below.
+# Worker pod = two containers:
+#   - main: Dynamo worker (dynamo-vllm-sidecar), no GPU; talks to the engine over
+#     gRPC on 127.0.0.1. Must be named "main" (operator injects env + probes).
+#   - vllm-engine: stock vLLM image (ships vllm-rs, vLLM's native gRPC server),
+#     holds the GPU. Runs as a native sidecar (see initContainers).
 #
-# The engine's gRPC has no auth and no TLS. It is only safe because vllm-rs binds
-# 127.0.0.1 (--host below), keeping it on pod loopback.
-#
-# There is no published vLLM sidecar image yet: build your own from
-# lib/sidecar/vllm/Dockerfile and set <your-registry> below (see README).
+# The engine's gRPC has no auth/TLS; safe only because vllm-rs binds 127.0.0.1.
+# No published sidecar image yet — build from lib/sidecar/vllm/Dockerfile and set
+# <your-registry> (see README).
 
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
@@ -29,7 +25,7 @@ spec:
     podTemplate:
       spec:
         containers:
-        # Dynamo frontend. No vLLM needed. The operator adds the command.
+        # Dynamo frontend; operator adds the command.
         - name: main
           image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
   - name: VLLMWorker
@@ -37,20 +33,16 @@ spec:
     replicas: 1
     podTemplate:
       spec:
-        # vllm-engine as a native sidecar (initContainer, restartPolicy: Always):
-        # it starts before `main` and stops after it. Stock multi-arch vLLM image
-        # (v0.26.0 ships vllm-rs; its gRPC matches the sidecar's vendored proto).
+        # vllm-engine as a native sidecar (initContainer + restartPolicy: Always):
+        # starts before `main`, stops after. Stock vLLM v0.26.0 ships vllm-rs, whose
+        # gRPC matches the sidecar's vendored proto.
         initContainers:
         - name: vllm-engine
           image: vllm/vllm-openai:v0.26.0
           restartPolicy: Always
-          # vllm-rs exposes no gRPC health method (grpc.health.v1 and any Generate
-          # HealthCheck both return UNIMPLEMENTED), so unlike the TensorRT-LLM and
-          # SGLang sidecars these probes can only confirm the gRPC port accepts a
-          # connection, not that the model is loaded. exec (not tcpSocket) because
-          # the loopback-bound listener is unreachable from the pod IP. The
-          # readinessProbe still drops the worker if the engine dies at runtime
-          # (port closes -> pod NotReady -> frontend stops routing to it).
+          # vllm-rs has no gRPC health method, so these probes only confirm the port
+          # accepts a connection (not model-loaded). exec, not tcpSocket: the loopback
+          # listener is unreachable from the pod IP. readinessProbe drops a dead engine.
           startupProbe:
             exec:
               command:
@@ -76,10 +68,10 @@ spec:
             limits:
               nvidia.com/gpu: "1"
             requests:
-              # Increase this value for larger models.
+              # Increase for larger models.
               ephemeral-storage: 2Gi
           # vllm-rs is not on PATH; resolve it from the installed vllm package.
-          # --host 127.0.0.1 keeps the unauthenticated gRPC on pod loopback.
+          # --host 127.0.0.1 keeps the unauthenticated gRPC on loopback.
           command:
           - /bin/sh
           - -c
@@ -87,10 +79,10 @@ spec:
             exec "$(python3 -c 'import os,vllm; print(os.path.join(os.path.dirname(vllm.__file__), "vllm-rs"))')"
             serve Qwen/Qwen3-0.6B --host 127.0.0.1 --grpc-port 50051
         containers:
-        # The sidecar worker. No published image yet, so build your own from
-        # lib/sidecar/vllm/Dockerfile and set <your-registry> below (see README).
-        # Add imagePullSecrets if private.
-        # Must be named "main": the operator injects discovery env + probes by name.
+        # Sidecar worker. No published image yet — build from
+        # lib/sidecar/vllm/Dockerfile, set <your-registry> (see README), add
+        # imagePullSecrets if private. Must be named "main" (operator injects
+        # discovery env + probes by name).
         - name: main
           image: <your-registry>/dynamo-vllm-sidecar:1.3.0
           command:
@@ -98,8 +90,8 @@ spec:
           args:
           - --vllm-endpoint
           - 127.0.0.1:50051
-          # vLLM's gRPC does not expose model metadata; the sidecar needs the
-          # model for tokenization, chat templates, and registration.
+          # vLLM's gRPC exposes no model metadata; the sidecar needs it for
+          # tokenization, chat templates, and registration.
           - --model-path
           - Qwen/Qwen3-0.6B
           envFrom:

--- a/lib/sidecar/vllm/deploy/disagg.yaml
+++ b/lib/sidecar/vllm/deploy/disagg.yaml
@@ -3,34 +3,27 @@
 #
 # EXPERIMENTAL. Disaggregated vLLM deployment using the Rust sidecar.
 #
-# Prefill and decode run as separate worker pods. Each pod has two containers:
-#   - main: the Dynamo worker (dynamo-vllm-sidecar). No GPU. Its
-#     --disaggregation-mode (prefill|decode) sets the gRPC kv_transfer_params
-#     handoff. Must be named "main" (operator injects discovery env + probes).
-#   - vllm-engine: the stock vLLM image running vllm-rs with the NIXL KV
-#     connector. Holds the GPU. KV cache moves prefill -> decode engine-to-engine
-#     over NIXL/RDMA (not through the sidecars). Native sidecar; see initContainers.
+# Prefill and decode run as separate worker pods, each with two containers:
+#   - main: Dynamo worker (dynamo-vllm-sidecar), no GPU; --disaggregation-mode
+#     (prefill|decode) sets the gRPC kv_transfer_params handoff. Must be named "main".
+#   - vllm-engine: stock vLLM image running vllm-rs with the NIXL KV connector,
+#     holds the GPU. KV moves prefill -> decode engine-to-engine over NIXL/RDMA
+#     (not through the sidecars). Native sidecar.
 #
-# The frontend routes to a prefill worker, gets kv_transfer_params, then routes
-# to a decode worker with that handoff. This sidecar does NOT publish KV events,
-# so use the default router (not --router-mode kv).
-#
-# kv_role is kv_producer on prefill and kv_consumer on decode (kv_both is
-# deprecated for NixlConnector).
+# The frontend routes to prefill, gets kv_transfer_params, then routes to decode
+# with that handoff. The sidecar publishes no KV events, so use the default router
+# (not --router-mode kv). kv_role is kv_producer on prefill, kv_consumer on decode.
 #
 # PREREQUISITES / CAVEATS:
-#   - Needs a sidecar built from lib/sidecar/vllm/Dockerfile that carries the
-#     disaggregation fixes (component-by-role + NIXL port encoding); older builds
-#     route both roles to one component and generate zero tokens.
-#   - RDMA/NIXL: the engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned
-#     memory (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
-#   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (set via downward API).
-#   - No published vLLM sidecar image yet — build from lib/sidecar/vllm/Dockerfile
-#     and set <your-registry>.
+#   - Sidecar must carry the disaggregation fixes (component-by-role + NIXL port
+#     encoding); older builds route both roles to one component and emit 0 tokens.
+#   - RDMA/NIXL: engine needs rdma/ib devices, IPC_LOCK/SYS_RESOURCE, pinned memory
+#     (ulimit -l unlimited), and UCX tuning; adjust for your fabric.
+#   - VLLM_NIXL_SIDE_CHANNEL_HOST must be a routable pod IP (downward API).
+#   - No published sidecar image yet — build from lib/sidecar/vllm/Dockerfile.
 #
-# The prefill->decode flow was validated on a single node (prefill+decode
-# co-located, NIXL over CUDA-IPC/TCP without rdma/ib); the rdma/ib requests below
-# target a real RDMA fabric.
+# Validated single-node (prefill+decode co-located, NIXL over CUDA-IPC/TCP); the
+# rdma/ib requests below target a real RDMA fabric.
 
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment


### PR DESCRIPTION
## Summary

Follow-up comment cleanup for the sidecar deploy examples. Companion PRs #12206 (TensorRT-LLM) and #12239 (SGLang) apply the same tightening to their Dockerfiles and deploy YAMLs; this PR covers the already-merged vLLM example plus a small `DisaggregationMode` doc tidy.

- **vLLM Dockerfile**: drop the apt-package / TLS build-plumbing rationale, the `--locked` / toolchain notes, and the section dividers; drop the inaccurate `+ tokenizer` from the description (the sidecar loads the tokenizer only to register the model card, so it is a pure gRPC connector). Keep SPDX, a one-line description + build command, and the numeric-UID `runAsNonRoot` note.
- **vLLM `agg.yaml` / `disagg.yaml`**: condense the verbose probe and header comment blocks to terser forms.
- **backend-common `disagg.rs`**: drop the enum-level doc that duplicated the per-variant docs and the `is_prefill` / `is_decode` / `is_encode` doc lines that only echoed the method names. The load-bearing `discovery_component` doc and per-variant docs are kept.

Comment-only — no code, manifest structure, or behavior changes.

## Validation

- `git diff` confirms only comment / blank lines changed across all four files.
- Both deploy YAMLs still parse (`yaml.safe_load_all`).
- `disagg.rs` change removes doc comments only (compile-safe).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12403" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified deployment guidance for aggregated and disaggregated vLLM setups.
  * Documented worker roles, KV-cache routing, networking requirements, and probe limitations.
  * Simplified build and runtime configuration comments while preserving existing behavior.
  * Refined guidance for sidecar images, NIXL connectivity, and single-node RDMA deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->