### PR TITLE
docs: remove stale agent guide paths

### DIFF
--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -35,7 +35,7 @@ The `docs-website` branch is CI-managed and must **never** be edited by hand.
 
 Every page under `docs/` (and the READMEs under `examples/` and `recipes/`) follows the
 [Documentation Style Guide](https://github.com/ai-dynamo/dynamo/blob/main/docs/fern/documentation-style-guide.md)
-(`docs/documentation-style-guide.md`). Read it before writing content. The docs bot enforces a
+(`docs/fern/documentation-style-guide.md`). Read it before writing content. The docs bot enforces a
 **must-fix** subset on every PR — get these right or the checks fail:
 
 - **SPDX header** on every file, copyright range `2025-2026`. Fern pages put the two `#` lines
@@ -412,7 +412,7 @@ git commit -s -m "docs: <add|update|move|remove> <page-title>"
 
 | File | Purpose |
 |---|---|
-| `docs/documentation-style-guide.md` | Authoring standard for every page (must-fix + guidance) |
+| `docs/fern/documentation-style-guide.md` | Authoring standard for every page (must-fix + guidance) |
 | `docs/recipes/_catalog/README.md` | Recipe/benchmark page authoring (catalog contract, blueprint, picker) |
 | `docs/recipes/_catalog/validate.py` | Catalog validator (covers both recipe and benchmark catalogs) |
 | `docs/fern/index.yml` | Navigation tree (two tabs: `docs` + `recipes`) |

--- a/lib/kvbm-kernels/CLAUDE.md
+++ b/lib/kvbm-kernels/CLAUDE.md
@@ -62,7 +62,6 @@ These fuse layout permutation with copy for non-standard transfer paths:
 - `cuda/stubs.c` — Abort-on-call fallbacks for all `extern "C"` symbols.
 - `src/tensor_kernels.rs` — Rust FFI wrappers, enums (`TensorDataType`, `BlockLayout`, `MemcpyBatchMode`), and integration tests.
 - `examples/kvbench.rs` — Benchmark harness (Llama 3.1 70B profile, CSV output).
-- `scripts/plot_roofline.py` — Roofline bandwidth plots from kvbench output.
 
 ### Dimension conventions
 


### PR DESCRIPTION
## Overview:

Correct stale file references in two agent guides.

## Details:

- Point the `dynamo-docs` skill at `docs/fern/documentation-style-guide.md`.
- Remove the `scripts/plot_roofline.py` entry because that script is not present.

UnRot v0.5.4 identified these stale references during an open-source agent-config scan. The documentation path and missing script were verified against the current tree.

Validation:
- `uv run --no-project --with pyyaml python scripts/validate_skills.py` — `validated 17 skills: OK`
- `unrot check . --rules broken-refs` — neither stale reference remains

## Where should the reviewer start?

- `.agents/skills/dynamo-docs/SKILL.md`
- `lib/kvbm-kernels/CLAUDE.md`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a documentation style guide reference in the maintenance guide.
  * Improved formatting in the style guidance section.
  * Removed an outdated script reference from the source organization documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->