### PR TITLE
chore(backend): rename remaining "unified backend" wording to "Backend SDK"

### DIFF
--- a/components/src/dynamo/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/backend/tests/test_logprobs.py
@@ -411,7 +411,7 @@ def test_sglang_extract_returns_offset_unchanged_when_no_new_entries():
 
 
 # ---------------------------------------------------------------------------
-# Legacy ↔ unified behavioural parity corner cases.
+# Legacy ↔ backend behavioural parity corner cases.
 #
 # The legacy handlers and Backend SDK engines call the same shared helpers, so
 # the call sites should produce byte-identical output for any given input.
@@ -433,7 +433,7 @@ def _vllm_legacy_call(output, num_so_far, tokenizer=None):
     )
 
 
-def _vllm_unified_call(output, tokenizer=None):
+def _vllm_backend_call(output, tokenizer=None):
     """Mirror of ``VllmLLMEngine.generate``'s per-chunk extraction.
     DELTA outputs always slice from offset 0."""
     return extract_from_completion_output(
@@ -479,17 +479,17 @@ def test_parity_vllm_delta_vs_cumulative_yields_same_logprobs():
         if lp:
             legacy_flat.extend(lp)
 
-    unified_flat: list[float] = []
+    backend_flat: list[float] = []
     for i in range(len(cumulative_tokens)):
         output = SimpleNamespace(
             token_ids=[cumulative_tokens[i]],
             logprobs=[cumulative_logprobs[i]],
         )
-        lp, _ = _vllm_unified_call(output)
+        lp, _ = _vllm_backend_call(output)
         if lp:
-            unified_flat.extend(lp)
+            backend_flat.extend(lp)
 
-    assert legacy_flat == unified_flat == [-0.7, -0.8, -0.9]
+    assert legacy_flat == backend_flat == [-0.7, -0.8, -0.9]
 
 
 def test_parity_vllm_delta_vs_cumulative_yields_same_top_logprobs():
@@ -510,23 +510,23 @@ def test_parity_vllm_delta_vs_cumulative_yields_same_top_logprobs():
         if top:
             legacy_top.extend(top)
 
-    unified_top: list[list[dict]] = []
+    backend_top: list[list[dict]] = []
     for i in range(len(cumulative_tokens)):
         output = SimpleNamespace(
             token_ids=[cumulative_tokens[i]],
             logprobs=[cumulative_logprobs[i]],
         )
-        _, top = _vllm_unified_call(output)
+        _, top = _vllm_backend_call(output)
         if top:
-            unified_top.extend(top)
+            backend_top.extend(top)
 
-    assert legacy_top == unified_top
+    assert legacy_top == backend_top
     # Confirm `bytes` field is included on both paths (vLLM-specific).
     assert legacy_top[0][0]["bytes"] == list("a".encode("utf-8"))
 
 
 def test_parity_trtllm_extraction_is_idempotent_across_call_sites():
-    """TRT-LLM's legacy `_extract_logprobs` and the unified call use the
+    """TRT-LLM's legacy `_extract_logprobs` and the backend call use the
     same flags and same offset — confirm a representative payload
     produces byte-identical output through both call patterns."""
     output = SimpleNamespace(
@@ -540,16 +540,16 @@ def test_parity_trtllm_extraction_is_idempotent_across_call_sites():
     )
 
     legacy_log, legacy_top = _trtllm_call(output, num_so_far=0)
-    unified_log, unified_top = _trtllm_call(output, num_so_far=0)
+    backend_log, backend_top = _trtllm_call(output, num_so_far=0)
 
-    assert legacy_log == unified_log == [-0.7, -0.8, -1.9]
-    assert legacy_top == unified_top
-    # Confirm bytes NOT included on TRT-LLM (legacy & unified).
+    assert legacy_log == backend_log == [-0.7, -0.8, -1.9]
+    assert legacy_top == backend_top
+    # Confirm bytes NOT included on TRT-LLM (legacy & backend).
     assert "bytes" not in legacy_top[0][0]
 
 
 def test_parity_sglang_per_choice_offset_tracking_multi_choice():
-    """The unified SGLang generate() tracks `num_logprobs_per_choice` —
+    """The backend SGLang generate() tracks `num_logprobs_per_choice` —
     a dict keyed by output_idx. Without per-choice tracking, interleaved
     n>1 chunks would mis-slice each other's cumulative arrays. Simulate
     interleaved chunks for choice 0 and choice 1 and confirm each
@@ -604,7 +604,7 @@ def test_parity_sglang_per_choice_offset_tracking_multi_choice():
 
 def test_parity_sglang_single_offset_misslices_under_n_gt_1():
     """Negative control for the bug we fixed: a *scalar* offset (the
-    pre-fix unified behaviour) would mis-slice when chunks for two
+    pre-fix backend behaviour) would mis-slice when chunks for two
     different choices are interleaved on the same offset cursor. This
     test exists so the regression is obvious if the per-choice dict
     ever gets simplified back into a scalar."""
@@ -763,7 +763,7 @@ def test_parity_sglang_legacy_kwargs_wrapper_matches_shared(monkeypatch):
 def test_parity_vllm_full_stream_byte_identical_top_logprobs():
     """Whole-stream parity: a 4-token generation with non-trivial top-k
     alternatives must emit byte-identical top_logprobs through both
-    legacy cumulative+offset and unified DELTA+0 paths."""
+    legacy cumulative+offset and backend DELTA+0 paths."""
     cumulative_tokens = [10, 20, 30, 40]
     # Each position has 3 alternatives — selected first, then two off-pol.
     cumulative_logprobs = [
@@ -800,25 +800,25 @@ def test_parity_vllm_full_stream_byte_identical_top_logprobs():
                 flat.extend(top)
         return flat
 
-    def _run_unified() -> list[list[dict]]:
-        # Unified: receives the DELTA chunk each step, offset always 0.
+    def _run_backend() -> list[list[dict]]:
+        # Backend: receives the DELTA chunk each step, offset always 0.
         flat: list[list[dict]] = []
         for i in range(len(cumulative_tokens)):
             output = SimpleNamespace(
                 token_ids=[cumulative_tokens[i]],
                 logprobs=[cumulative_logprobs[i]],
             )
-            _, top = _vllm_unified_call(output)
+            _, top = _vllm_backend_call(output)
             if top:
                 flat.extend(top)
         return flat
 
     legacy = _run_legacy()
-    unified = _run_unified()
+    backend = _run_backend()
 
     # Byte-identical comparison on the full structure: rank, token_id,
     # token, logprob, bytes are all included.
-    assert legacy == unified
+    assert legacy == backend
     assert len(legacy) == 4
     # Spot-check a representative entry.
     assert legacy[2] == [
@@ -874,23 +874,23 @@ def test_parity_vllm_with_none_position_mid_stream():
         if lp:
             legacy.extend(lp)
 
-    unified: list[float] = []
+    backend: list[float] = []
     for i in range(len(cumulative_tokens)):
         output = SimpleNamespace(
             token_ids=[cumulative_tokens[i]],
             logprobs=[cumulative_logprobs[i]],
         )
-        lp, _ = _vllm_unified_call(output)
+        lp, _ = _vllm_backend_call(output)
         if lp:
-            unified.extend(lp)
+            backend.extend(lp)
 
     # Both skip the None position (one fewer entry than tokens emitted).
-    assert legacy == unified == [-0.1, -0.3]
+    assert legacy == backend == [-0.1, -0.3]
 
 
 def test_parity_trtllm_selected_token_missing_fallback_consistent():
     """TRT-LLM fallback: when the engine doesn't include the selected
-    token in the logprob dict, both legacy and unified fall back to the
+    token in the logprob dict, both legacy and backend fall back to the
     first dict entry. Confirm the fallback is consistent across a
     multi-position stream where SOME positions hit the fallback."""
     output = SimpleNamespace(

--- a/components/src/dynamo/common/utils/graceful_shutdown.py
+++ b/components/src/dynamo/common/utils/graceful_shutdown.py
@@ -88,7 +88,7 @@ async def graceful_shutdown_with_discovery(
             Any exception raised by drain_callback is logged and swallowed so that
             shutdown still proceeds even if draining times out or fails.
         cleanup_callback: Optional async callable awaited after drain_callback
-            but *before* runtime.shutdown(). Used by unified backends to release
+            but *before* runtime.shutdown(). Used by backends to release
             engine resources (GPU memory, PyTorch process groups) before the Rust
             runtime tears down — the Python ``Worker.run()`` ``finally`` block
             cannot be relied on for this because ``runtime.shutdown()`` collapses

--- a/components/src/dynamo/common/utils/tests/test_graceful_shutdown.py
+++ b/components/src/dynamo/common/utils/tests/test_graceful_shutdown.py
@@ -166,7 +166,7 @@ def test_drain_callback_exception_does_not_block_shutdown():
 # ---------------------------------------------------------------------------
 # cleanup_callback tests
 #
-# Regression coverage for the unified backend leak: when the Rust runtime
+# Regression coverage for the Backend SDK leak: when the Rust runtime
 # tears down on SIGTERM, the Python Worker.run() finally block cannot finish
 # engine.cleanup() before the loop's native backing collapses. cleanup_callback
 # moves engine.cleanup() into the signal-handler path, *before* runtime.shutdown().
@@ -176,7 +176,7 @@ def test_drain_callback_exception_does_not_block_shutdown():
 def test_cleanup_callback_called_before_shutdown():
     """Cleanup callback must be awaited before runtime.shutdown().
 
-    This is the regression test for the unified backend GPU/process-group leak:
+    This is the regression test for the Backend SDK GPU/process-group leak:
     engine.cleanup() must run before the Rust runtime tears down, otherwise
     PyTorch's destroy_process_group() never fires.
     """

--- a/components/src/dynamo/sglang/_disagg.py
+++ b/components/src/dynamo/sglang/_disagg.py
@@ -7,7 +7,7 @@
 * :func:`compute_bootstrap_address` — resolve the `(host, port)` triple a
   prefill worker advertises to decode peers from a live `sgl.Engine`.
   Returns `(None, None)` on any failure so legacy callers can keep their
-  graceful-degradation behaviour; the unified path treats `None` as a
+  graceful-degradation behaviour; the Backend SDK treats `None` as a
   fatal configuration error and raises.
 
 * :func:`get_sglang_worker_group_id` — normalize the SGLang multinode
@@ -50,7 +50,7 @@ def compute_bootstrap_address(
     Returns `(None, None)` when the engine doesn't advertise a
     `disaggregation_bootstrap_port` or when address resolution raises.
     Caller decides whether `None` is fatal — legacy `register.py` treats
-    it as soft-skip; the unified path treats it as a fatal misconfig.
+    it as soft-skip; the Backend SDK treats it as a fatal misconfig.
     """
     # Deferred to function body so pre-commit test collection can import
     # `_disagg` without sglang installed.

--- a/components/src/dynamo/sglang/args.py
+++ b/components/src/dynamo/sglang/args.py
@@ -100,7 +100,7 @@ def _forward_pass_metrics_source(
 
     unsupported_role = _unsupported_fpm_trace_role(dynamo_config)
     if unsupported_role is None and not fpm_trace_relay_supported:
-        unsupported_role = "unified backend"
+        unsupported_role = "Backend SDK"
     if unsupported_role is None:
         return "--fpm-trace/DYN_FPM_TRACE"
 

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -774,7 +774,7 @@ async def test_invalid_fpm_trace_is_disabled_by_arg_parser(
 @pytest.mark.parametrize(
     ("overrides", "role", "fpm_trace_relay_supported"),
     [
-        ({}, "unified backend", False),
+        ({}, "Backend SDK", False),
         ({"embedding_worker": True}, "embedding", True),
         ({"multimodal_encode_worker": True}, "dedicated multimodal", True),
         ({"multimodal_worker": True}, "dedicated multimodal", True),

--- a/components/src/dynamo/trtllm/tests/test_trtllm_logits_runtime.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_logits_runtime.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit tests for the TRT-LLM slice of the
-DYN_ENABLE_TEST_LOGITS_PROCESSOR hook: the unified `from_args`
-tokenizer-init flip, the unified `generate` attach/skip matrix
+DYN_ENABLE_TEST_LOGITS_PROCESSOR hook: the Backend SDK `from_args`
+tokenizer-init flip, the Backend SDK `generate` attach/skip matrix
 threaded through the shared spec entry layer in
 `dynamo.backend._engine`, the TRT-LLM realizer (spec entry →
 live `BaseLogitsProcessor` → `TrtllmDynamoLogitsAdapter`), the
@@ -13,7 +13,7 @@ no-op-on-empty contract.
 Shared-layer policy itself (generation-stage gating, spec entry
 composition, env-gated spec resolver) is tested in
 `dynamo.backend.tests.test_engine` without GPU or tensorrt_llm.
-These tests exercise the same policy through the unified TRT-LLM
+These tests exercise the same policy through the Backend SDK TRT-LLM
 engine to confirm the wiring."""
 
 from __future__ import annotations

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -256,7 +256,7 @@ def _forward_pass_metrics_enabled(
 
     unsupported_role = _unsupported_fpm_trace_role(dynamo_config)
     if unsupported_role is None and not fpm_trace_relay_supported:
-        unsupported_role = "unified backend"
+        unsupported_role = "Backend SDK"
     if unsupported_role is None:
         return True
 

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -3,7 +3,7 @@
 
 """Shared vLLM multimodal request preparation.
 
-The legacy handler and unified backend both receive Dynamo's
+The legacy handler and Backend SDK both receive Dynamo's
 ``PreprocessedRequest`` wire shape. This module owns the engine-facing
 translation: media loading, frontend-transferred ``mm_kwargs``, stable
 multimodal UUIDs, and the model-specific prefill/decode handoff.
@@ -656,7 +656,7 @@ class VllmMultimodalRequestProcessor:
 
         Entry points must call :meth:`validate_multimodal_request` on the raw
         request before invoking this transformation. ``prepare_prompt`` does
-        that for unified engines; the legacy handler validates at ``generate``
+        that for Backend SDK engines; the legacy handler validates at ``generate``
         so text and token modes share the same security boundary.
         """
         mm_processor_kwargs = get_mm_processor_kwargs(request)
@@ -739,7 +739,7 @@ class VllmMultimodalRequestProcessor:
         context: Any,
         mode: DisaggregationMode,
     ) -> PreparedMultimodalPrompt:
-        """Prepare the complete engine prompt for the unified backend."""
+        """Prepare the complete engine prompt for the Backend SDK."""
         self.validate_multimodal_request(request)
         prepared = await self.prepare_input(request, request_id, context, mode)
         prompt = prepared.pre_rendered_prompt or self.build_tokens_prompt(

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -3,7 +3,7 @@
 
 """Legacy worker-factory LoRA lifecycle tests.
 
-The unified vLLM engine has separate lifecycle coverage. These tests protect
+The Backend SDK vLLM engine has separate lifecycle coverage. These tests protect
 the still-supported ``BaseWorkerHandler`` path used by release images.
 """
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1494,7 +1494,7 @@ class TestForwardPassMetricsActivation:
     @pytest.mark.parametrize(
         ("overrides", "role", "fpm_trace_relay_supported"),
         [
-            ({}, "unified backend", False),
+            ({}, "Backend SDK", False),
             ({"embedding_worker": True}, "embedding", True),
             ({"headless": True}, "headless", True),
             (

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -58,7 +58,7 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 | [**KVBM**](../../components/kvbm/README.md) | ✅ | |
 | [**LMCache**](../../integrations/lmcache-integration.md) | ✅ | CUDA 12.9 and arm64/aarch64 containers may require building LMCache from source |
 | [**FlexKV**](../../integrations/flexkv-integration.md) | ✅ | |
-| [**Multimodal Support**](../../features/multimodal/multimodal-vllm.md) | ✅ | Aggregated and P/D image/video serving on legacy and unified Python backends; separate Encode workers use the legacy path |
+| [**Multimodal Support**](../../features/multimodal/multimodal-vllm.md) | ✅ | Aggregated and P/D image/video serving on legacy and Backend SDK Python backends; separate Encode workers use the legacy path |
 | [**Observability**](vllm-observability.md) | ✅ | Metrics and monitoring |
 | **WideEP** | ✅ | Support for DeepEP |
 | **DP Rank Routing** | ✅ | [Hybrid load balancing](https://docs.vllm.ai/en/stable/serving/data_parallel_deployment/?h=external+dp#hybrid-load-balancing) via external DP rank control |
@@ -143,8 +143,8 @@ DYN_SYSTEM_PORT=8081 cargo run -p dynamo-vllm-rs-backend --features vllm_rs -- Q
 ```
 
 The Rust worker starts a managed vLLM engine-core process and registers with
-the Dynamo frontend using the same discovery path as the Python unified
-backend. The Rust backend is expected to become the default only after it
+the Dynamo frontend using the same discovery path as the Python Backend SDK.
+The Rust backend is expected to become the default only after it
 reaches feature and operational parity with the Python vLLM backend.
 
 ## Next Steps

--- a/docs/features/multimodal/multimodal-vllm.md
+++ b/docs/features/multimodal/multimodal-vllm.md
@@ -65,7 +65,7 @@ cd $DYNAMO_HOME/examples/backends/vllm
 # GPU deployment
 bash launch/agg_multimodal.sh --model Qwen/Qwen3-VL-2B-Instruct
 
-# Unified backend
+# Backend SDK
 bash launch/agg_multimodal.sh --unified --model Qwen/Qwen3-VL-2B-Instruct
 
 # XPU deployment
@@ -161,12 +161,12 @@ the same model-specific limitations as the legacy vLLM path.
 ### Unified vLLM Backend
 
 Pass `--unified` to the aggregated or P/D launchers to run
-`python -m dynamo.vllm.unified_main`. The unified path supports HTTP URLs,
+`python -m dynamo.vllm.unified_main`. The Backend SDK supports HTTP URLs,
 data URLs, frontend-decoded images, `mm_processor_kwargs`, frontend-provided
 multimodal hashes, and Kimi-style `vision_chunk` inputs.
 
 The Python vLLM frontend can pre-render multimodal processor inputs and send
-them to an aggregated unified worker. Shared memory is the same-node default;
+them to an aggregated Backend SDK worker. Shared memory is the same-node default;
 NIXL supports the transfer channel used by cross-node deployments:
 
 ```bash

--- a/docs/observability/forward-pass-metrics-tracing.md
+++ b/docs/observability/forward-pass-metrics-tracing.md
@@ -76,12 +76,12 @@ relay:
 | --- | --- | --- |
 | vLLM (`python -m dynamo.vllm`) | Aggregated, prefill, or decode, including native multimodal workers | Supported |
 | vLLM (`python -m dynamo.vllm`) | Embedding, multimodal encode, or headless | Not supported; Dynamo warns and does not inject the FPM scheduler |
-| vLLM (`python -m dynamo.vllm.unified_main`) | All worker topologies | Not supported; the unified path does not yet construct an FPM relay |
+| vLLM (`python -m dynamo.vllm.unified_main`) | All worker topologies | Not supported; the Backend SDK does not yet construct an FPM relay |
 | SGLang (`python -m dynamo.sglang`) | Standard aggregated, prefill, decode, or LLM diffusion; this includes `--enable-multimodal` without a dedicated encoder | Supported |
 | SGLang (`python -m dynamo.sglang`) | Embedding or the dedicated multimodal topology selected by `--dedicated-mm-encoder` (and its legacy worker flags) | Not supported; Dynamo warns and does not auto-enable FPM |
 | SGLang (`python -m dynamo.sglang`) | Image diffusion or video generation | Not supported; these paths do not run the SGLang FPM publisher |
 | SGLang (`python -m dynamo.sglang`) | Snapshot mode | Not supported; FPM is disabled during snapshot startup with a warning |
-| SGLang (`python -m dynamo.sglang.unified_main`) | All worker topologies | Not supported; the unified path does not yet construct an FPM relay |
+| SGLang (`python -m dynamo.sglang.unified_main`) | All worker topologies | Not supported; the Backend SDK does not yet construct an FPM relay |
 
 `DYN_FORWARDPASS_METRIC_PORT` remains a separate legacy opt-in and takes
 precedence when it is set, including on topologies where trace-based activation

--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -147,7 +147,7 @@ impl EngineAdapter {
 ///
 /// The runtime's `HealthCheckManager` fires canary requests as
 /// `SingleIn<serde_json::Value>` against whatever engine is registered for
-/// the endpoint name. The unified backend's network ingress operates on the
+/// the endpoint name. The Backend SDK's network ingress operates on the
 /// typed `PreprocessedRequest`, so we register this adapter alongside the
 /// network handler: it deserializes the JSON canary into `PreprocessedRequest`,
 /// hands it to the same `EngineAdapter`, and re-serializes the response.

--- a/lib/backend-common/src/disagg.rs
+++ b/lib/backend-common/src/disagg.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Disaggregated-serving mode for unified backends.
+//! Disaggregated-serving mode for backends.
 //!
 //! [`DisaggregationMode`] is metadata carried on [`crate::WorkerConfig`]. The
 //! [`crate::Worker`] consumes it for two registration-time decisions (the

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -329,7 +329,7 @@ pub trait LLMEngine: Send + Sync + 'static {
     ///
     /// Engines advertise control keys and implement them via
     /// [`LLMEngine::engine_control`]. Mapping those keys onto runtime routes is
-    /// owned by the unified backend layer.
+    /// owned by the Backend SDK layer.
     async fn supported_controls(&self) -> Result<Vec<String>, DynamoError> {
         Ok(Vec::new())
     }
@@ -353,7 +353,7 @@ pub trait LLMEngine: Send + Sync + 'static {
     /// LoRA load/unload/list) rather than the engine's serving lifecycle.
     /// Keeping them separate avoids inflating the control surface. Engines
     /// advertise update keys and implement them via [`LLMEngine::engine_update`];
-    /// the unified backend maps each key onto an `/engine/update/{key}` route.
+    /// the Backend SDK maps each key onto an `/engine/update/{key}` route.
     async fn supported_updates(&self) -> Result<Vec<String>, DynamoError> {
         Ok(Vec::new())
     }

--- a/lib/backend-common/src/metrics.rs
+++ b/lib/backend-common/src/metrics.rs
@@ -169,7 +169,7 @@ impl LifecycleGauges {
 /// atomic stores into the runtime's `MetricsRegistry`.
 ///
 /// Replaces the previous Python `LLMBackendMetrics` registry on the
-/// unified path. Legacy entry points still use the Python class for
+/// Backend SDK. Legacy entry points still use the Python class for
 /// their own `dynamo_component_*` surface; the two registries never
 /// share a process.
 pub struct ComponentGauges {

--- a/lib/backend-common/src/run.rs
+++ b/lib/backend-common/src/run.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Common entry point for unified backends.
+//! Common entry point for backends.
 //!
 //! Each backend's `main.rs` parses CLI args, constructs its `LLMEngine`, and
 //! hands the pair off to [`run`]:

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1622,7 +1622,7 @@ async fn build_local_model(
 
     // Decode workers don't host the WorkerKvQuery endpoint, so they must not
     // advertise the local indexer regardless of the operator-supplied flag.
-    // Mirrors the legacy non-unified vLLM path (worker_factory.py).
+    // Mirrors the legacy vLLM path (worker_factory.py).
     let enable_local_indexer = config.effective_enable_local_indexer();
 
     // None for raw engines → all-`None` fields → no KV/DP/bootstrap hints.
@@ -3092,7 +3092,7 @@ mod handoff_integration_tests {
             routes.get("update/load_lora").is_some(),
             "advertised update must be registered under update/<name>"
         );
-        // Bare (unprefixed) keys must NOT be registered by the unified Worker.
+        // Bare (unprefixed) keys must NOT be registered by the Backend SDK Worker.
         assert!(
             routes.get("start_profile").is_none(),
             "control must not be registered under its bare name"

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -954,7 +954,7 @@ pub(crate) struct KvEventPublisher {
 impl KvEventPublisher {
     /// Wrap an already-constructed Rust publisher as the Python pyclass.
     ///
-    /// Used by the unified-backend bridge (`crate::backend`) so the Worker
+    /// Used by the Backend SDK bridge (`crate::backend`) so the Worker
     /// can hand a publisher built from a [`PushSource`] back to the Python
     /// engine without going through the Python-side `__init__` (which
     /// requires an `Endpoint` and rebuilds the publisher from scratch).

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -545,9 +545,9 @@ async fn metadata_file_handler(
 /// Helper function to call a LoRA management endpoint for the local worker.
 ///
 /// Resolution order (both are in-process, never network discovery):
-/// 1. The legacy local endpoint registry, populated by non-unified workers via
+/// 1. The legacy local endpoint registry, populated by legacy workers via
 ///    `.register_local_engine()`.
-/// 2. The generic engine-route registry (`/engine/*`). Unified-backend workers
+/// 2. The generic engine-route registry (`/engine/*`). Backend SDK workers
 ///    advertise LoRA lifecycle ops (`load_lora`/`unload_lora`/`list_loras`) as
 ///    engine *updates*, registered under `update/<name>`; this fallback maps the
 ///    bare LoRA name onto that key so the legacy `/v1/loras` surface forwards to
@@ -586,7 +586,7 @@ async fn call_lora_endpoint(
         anyhow::bail!("No response received from endpoint '{}'", endpoint_name)
     }
 
-    // 2. Unified-backend engine-update registry fallback. The unified Worker
+    // 2. Backend SDK engine-update registry fallback. The Backend SDK Worker
     //    registers LoRA ops as engine updates under `update/<name>`, so map the
     //    bare LoRA endpoint name onto that namespaced key.
     let update_key = format!("update/{endpoint_name}");
@@ -1284,7 +1284,7 @@ mod integration_tests {
     /// `/v1/loras` compat shim: with the legacy local registry empty, a LoRA
     /// update registered in `engine_routes()` under `update/<name>` resolves via
     /// the fallback and its JSON response is parsed into a `LoraResponse`. This
-    /// is the path unified-backend workers take for `/v1/loras`.
+    /// is the path Backend SDK workers take for `/v1/loras`.
     #[tokio::test]
     async fn test_call_lora_endpoint_resolves_via_engine_routes() {
         temp_env::async_with_vars([(env_system::DYN_SYSTEM_PORT, None::<&str>)], async {
@@ -1299,7 +1299,7 @@ mod integration_tests {
                     }))
                 })
             });
-            // Unified Worker registers LoRA ops under the `update/` namespace.
+            // Backend SDK Worker registers LoRA ops under the `update/` namespace.
             drt.engine_routes().register("update/load_lora", callback);
 
             // Local registry is empty, so resolution must fall through to
@@ -1358,7 +1358,7 @@ mod integration_tests {
                     }))
                 })
             });
-            // Unified Worker registers LoRA ops under the `update/` namespace.
+            // Backend SDK Worker registers LoRA ops under the `update/` namespace.
             drt.engine_routes().register("update/unload_lora", callback);
 
             let response = call_lora_endpoint(&drt, "unload_lora", serde_json::json!({}))

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -1,6 +1,6 @@
 # SGLang sidecar
 
-`dynamo-sglang-sidecar` connects Dynamo's unified worker lifecycle to an
+`dynamo-sglang-sidecar` connects Dynamo's Backend SDK worker lifecycle to an
 out-of-process SGLang engine through SGLang's native gRPC service. It is a
 standalone Rust executable and is also compiled into `ai-dynamo-runtime` for
 the importable `dynamo.sglang.sidecar` launcher.
@@ -30,4 +30,4 @@ python3 -m sglang.launch_server \
 The entry point configures Dynamo logging when `main()` runs, then calls the
 private `dynamo._core.backend._run_sglang_sidecar(argv)` binding. The binding
 prepends the executable name expected by clap, releases the GIL, and runs the
-same unified worker lifecycle as the standalone executable.
+same Backend SDK worker lifecycle as the standalone executable.

--- a/tests/frontend/conftest.py
+++ b/tests/frontend/conftest.py
@@ -343,7 +343,7 @@ class SampleBackendWorkerProcess(ManagedProcess):
 
     CPU-only Python reference engine that exercises the Backend SDK's
     `Worker.run()` path — the same code path real backends (vllm/trtllm/
-    sglang) go through. Useful for tests that need to validate the unified
+    sglang) go through. Useful for tests that need to validate the Backend SDK
     Worker/EngineAdapter pipeline without a GPU.
 
     Mirrors `MockerWorkerProcess` but uses the Backend SDK entry point. Accepts

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -46,7 +46,7 @@ for seeking out Aeloria, their skills and weaknesses, and any personal connectio
 
 # Deliberately distinct from other cache-test prompts and long enough to span
 # multiple vLLM cache blocks.
-CLEAR_KV_BLOCKS_PROMPT = """This is the unified vLLM block-clearing verification prompt, identified by the unique \
+CLEAR_KV_BLOCKS_PROMPT = """This is the Backend SDK vLLM block-clearing verification prompt, identified by the unique \
 phrase cobalt-orchid-riverstone. Imagine a research station built beside a quiet polar observatory where engineers \
 catalog unusual signals from distant stars. Describe how the team prepares its instruments, checks redundant clocks, \
 records atmospheric conditions, and compares each observation with the previous night. Include the roles of the lead \
@@ -157,7 +157,7 @@ def clear_kv_blocks_payload(
     max_tokens: int = 16,
     timeout: int = 60,
 ) -> ClearKVBlocksPayload:
-    """Create an admin-then-infer payload for unified vLLM cache clearing."""
+    """Create an admin-then-infer payload for Backend SDK vLLM cache clearing."""
     return ClearKVBlocksPayload(
         body={
             "messages": [{"role": "user", "content": CLEAR_KV_BLOCKS_PROMPT}],
@@ -316,7 +316,7 @@ def metric_payload_default(
         expected_log: Expected log messages
         backend: Backend type ('vllm', 'sglang', 'trtllm', 'lmcache')
         port: Port to use for metrics endpoint
-        check_lifecycle_gauges: Assert the unified-only lifecycle gauges
+        check_lifecycle_gauges: Assert the Backend SDK-only lifecycle gauges
             (``cleanup_time_seconds``, ``drain_time_seconds``,
             ``kv_cache_hit_rate``) are registered. Default False because
             legacy entry points don't emit them.

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -1498,7 +1498,7 @@ class MetricsPayload(BasePayload):
     Validates common dynamo_component_* metrics shared across all backends.
     Backend-specific subclasses handle engine-specific metrics.
 
-    Set ``check_lifecycle_gauges=True`` to additionally assert the unified-
+    Set ``check_lifecycle_gauges=True`` to additionally assert the Backend SDK-
     only framework gauges (``cleanup_time_seconds``, ``drain_time_seconds``,
     ``kv_cache_hit_rate``). Off by default because legacy entry points
     don't emit them.
@@ -1599,7 +1599,7 @@ class MetricsPayload(BasePayload):
         ]
 
     def _get_lifecycle_gauge_checks(self) -> list[MetricCheck]:
-        """Unified-only framework lifecycle gauges. Legacy entry points
+        """Backend SDK-only framework lifecycle gauges. Legacy entry points
         don't emit these — gated by ``check_lifecycle_gauges`` so legacy
         callers don't trip on the absence.
 


### PR DESCRIPTION
## Summary

**Part 3 of the 3-PR Backend SDK stack** (stacked on #12461 → #12379; review/merge those first). This PR targets `feat/backend-sdk-migrate`, so its diff is only the prose delta.

A pure, no-logic prose sweep of the peripheral references that still called the in-process backend layer the **"unified backend"**. Comments, docstrings, and a few test-internal identifiers change; no code paths, imports, public interfaces, or test behavior do.

### Deliberately left untouched (different concepts named "unified")
- the `unified` request/response **protocol** (`lib/llm/src/protocols/unified.rs`) and **transport** (`lib/runtime/.../unified_client.rs`, `unified_server.rs`),
- kvbm **unified memory**,
- vLLM's `unified_vision_chunk` multimodal param and "unified processors",
- the `python -m dynamo.<backend>.unified_main` entry points,
- the `sample-unified-test` CI job name.

## Scope
Rust doc/inline comments (`lib/backend-common`, `lib/runtime`, bindings), vLLM/SGLang arg + handler comments, docs (vLLM README, multimodal-vLLM, forward-pass-metrics, sidecar SGLang README), and test wording (logprob legacy-vs-Backend-SDK helpers, TRT-LLM logits-runtime docstrings, payload utils).

## Validation
Comment/prose-only; the resulting tree is the fully-validated end state (**202 passed, 6 skipped**; all touched Python files `py_compile` clean).

> **Draft** — full CI runs after a maintainer comments `/ok to test <sha>`.
