### PR TITLE
ci: update GitHub Actions to Node.js 24

### DIFF
--- a/.github/actions/build-deploy-component/action.yml
+++ b/.github/actions/build-deploy-component/action.yml
@@ -481,7 +481,7 @@ runs:
 
     - name: Upload compliance artifact (NOTICES + CSV + CycloneDX)
       if: ${{ steps.settings.outputs.run_compliance == 'true' && always() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       with:
         # compliance-<git-sha>-<component> (artifact_tag falls back to image_tag,
         # which is already <github.sha>-<component>), matching the framework
@@ -493,7 +493,7 @@ runs:
 
     - name: Upload /sources/ archive (opt-in via archive_sources)
       if: ${{ steps.settings.outputs.run_compliance == 'true' && inputs.archive_sources == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       with:
         name: compliance-${{ inputs.artifact_tag != '' && inputs.artifact_tag || inputs.image_tag }}-sources
         path: /tmp/sources/

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -111,7 +111,7 @@ runs:
         fi
 
     - name: Check for changes
-      uses: tj-actions/changed-files@aa08304bd477b800d468db44fe10f6c61f7f7b11  # v42.1.0
+      uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
       id: filter
       with:
         files_yaml_from_source_file: .github/filters.yaml

--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -48,7 +48,7 @@ runs:
 
     - name: Set up Python
       if: ${{ inputs.component == 'operator' }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: "3.11"
 

--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -385,7 +385,7 @@ runs:
 
     - name: Upload compliance artifact (NOTICES + CSV + CycloneDX)
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       with:
         # compliance-<git-sha>-<container>. artifact_name_prefix == target_tag_plain
         # == the container name (e.g. vllm-runtime, vllm-runtime-efa, dynamo-planner);
@@ -397,7 +397,7 @@ runs:
 
     - name: Upload /sources/ tarball (post-merge / RC / release only)
       if: ${{ inputs.archive_sources == 'true' && always() }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       with:
         name: compliance-${{ inputs.git_sha }}-${{ inputs.artifact_name_prefix }}-sources
         path: /tmp/sources/sources.zip

--- a/.github/actions/compliance-scan/action.yml
+++ b/.github/actions/compliance-scan/action.yml
@@ -122,7 +122,7 @@ runs:
 
     - name: Upload attribution artifacts
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.artifact_name }}*.csv

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -320,7 +320,7 @@ runs:
 
     # Upload comprehensive build metrics as artifact
     - name: Upload Comprehensive Build Metrics
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: always()
       with:
         name: build-metrics-${{ inputs.framework }}-${{ inputs.target }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/actions/dynamo-deploy-test/action.yml
+++ b/.github/actions/dynamo-deploy-test/action.yml
@@ -81,7 +81,7 @@ runs:
         kubectl config get-contexts
 
     - name: Set up Python
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: '3.12'
         cache: 'pip'

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -374,7 +374,7 @@ runs:
         docker rm -f dynamo-minio-test 2>/dev/null || true
 
     - name: Upload Test Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       if: always()  # Always upload test results, even if tests failed
       with:
         name: test-results-${{ inputs.test_suite_name }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -382,7 +382,7 @@ runs:
         retention-days: 7
 
     - name: Upload Coverage Data
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       if: always() && inputs.enable_coverage == 'true'
       with:
         name: coverage-python-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}
@@ -391,7 +391,7 @@ runs:
         retention-days: 7
 
     - name: Upload Allure Results
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       if: always()
       with:
         name: allure-results-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ env.PLATFORM_ARCH }}-${{ github.run_id }}-${{ job.check_run_id }}

--- a/.github/workflows/auto-dep-upgrade-trigger.yml
+++ b/.github/workflows/auto-dep-upgrade-trigger.yml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ secrets.OPS_BOT_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -23,11 +23,11 @@ jobs:
   codeowners:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.12"
       - run: pip install pyyaml pytest

--- a/.github/workflows/compliance-base-drift.yml
+++ b/.github/workflows/compliance-base-drift.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/dco_comment.yml
+++ b/.github/workflows/dco_comment.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Get DCO status
         id: dco
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11'
 

--- a/.github/workflows/generate-allure-report.yml
+++ b/.github/workflows/generate-allure-report.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download Allure Results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           run-id: ${{ inputs.run_id }}
           pattern: allure-results-*

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d  # v6.2.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           configuration-path: .github/labeler.yml

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title and add label
     runs-on: ubuntu-latest
     steps:
-      - uses:  ytanikin/pr-conventional-commits@b628c5a234cc32513014b7bfdd1e47b532124d98
+      - uses: ytanikin/pr-conventional-commits@639145d78959c53c43112365837e3abd21ed67c1  # v1.5.2
         with:
           task_types: '["feat", "fix", "docs", "test", "ci", "refactor", "perf", "chore", "revert", "style", "build"]'
           add_label: 'true'

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -696,7 +696,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/
@@ -725,7 +725,7 @@ jobs:
         SAFE_DIR=$(echo "${{ matrix.dir }}" | sed 's|^\.$|root|' | tr '/' '-')
         echo "RUST_COV_ARTIFACT_NAME=coverage-rust-${SAFE_DIR}-${{ github.run_id }}" >> $GITHUB_ENV
     - name: Upload Rust Coverage Data
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
       if: always()
       with:
         name: ${{ env.RUST_COV_ARTIFACT_NAME }}
@@ -801,7 +801,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -812,14 +812,14 @@ jobs:
           echo "✅ Coverage tools installed"
 
       - name: Download All Python Coverage Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           pattern: coverage-python-*
           path: coverage-artifacts/
           merge-multiple: false
 
       - name: Download All Rust Coverage Artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         continue-on-error: true
         with:
           pattern: coverage-rust-*
@@ -977,7 +977,7 @@ jobs:
         run: cat coverage-summary.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload Coverage Reports
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         if: always()
         with:
           name: coverage-reports-${{ github.run_id }}

--- a/.github/workflows/pr-xpu.yaml
+++ b/.github/workflows/pr-xpu.yaml
@@ -56,7 +56,7 @@ jobs:
       sglang: ${{ steps.changes.outputs.sglang }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Check for changes

--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -47,7 +47,7 @@ jobs:
           fi
       - name: Reminder to run full CI on PR
         if: steps.contributor_check.outputs.is_trusted != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           REPOSITORY: ${{ github.repository }}
           CONTRIBUTOR: ${{ github.actor }}
@@ -66,7 +66,7 @@ jobs:
                 '🚀'
             })
       - name: Add contribution labels to PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           IS_TRUSTED: ${{ steps.contributor_check.outputs.is_trusted }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -60,8 +60,16 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+      with:
+        python-version: "3.12"
+    - run: python -m pip install pre-commit
+    - run: python -m pip freeze --local
+    - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
+      with:
+        path: ~/.cache/pre-commit
+        key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+    - run: pre-commit run --show-diff-on-failure --color=always --all-files
       timeout-minutes: 3
 
   # Safe Fern docs checks run in pre-merge with read-only permissions.
@@ -163,7 +171,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/
@@ -249,7 +257,7 @@ jobs:
         export PATH="$PATH:$HOME/.local/bin"
         protoc --version
     - name: Cache cargo artifacts
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25  # v5.1.0
       with:
         path: |
           ~/.cargo/bin/

--- a/.github/workflows/shared-compliance-audit.yml
+++ b/.github/workflows/shared-compliance-audit.yml
@@ -120,7 +120,7 @@ jobs:
             echo "baseline=" >> "$GITHUB_OUTPUT"
           fi
       - name: Download build compliance artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: ${{ steps.resolve.outputs.artifact }}
           path: /tmp/compliance
@@ -161,7 +161,7 @@ jobs:
             --report /tmp/audit-report.txt -v
       - name: Upload audit report
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           # compliance-audit-<git-sha>-<container>[-cudaN] (image_tag already carries all three).
           name: compliance-audit-${{ steps.resolve.outputs.image_tag }}

--- a/.github/workflows/test_report.yaml
+++ b/.github/workflows/test_report.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: Complete report test status
         if: always()
         id: report_test_status
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/trigger_ci.yml
+++ b/.github/workflows/trigger_ci.yml
@@ -57,7 +57,7 @@ jobs:
         filters: .github/filters.yaml
     - name: Check if Validation Workflow has run
       id: check_workflow
-      uses: actions/github-script@v6
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -142,4 +142,3 @@ jobs:
           --form ref=${REF} \
           "${ci_args[@]}" \
           "${{ secrets.PIPELINE_URL }}"
-

--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: '20'

--- a/.github/workflows/xpu-ci.yaml
+++ b/.github/workflows/xpu-ci.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: xpu
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload build log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: xpu-build-log
           path: |
@@ -148,7 +148,7 @@ jobs:
       TEST_IMAGE_TAG: dynamo-${{ inputs.framework || 'vllm' }}-${{ inputs.target || 'runtime' }}-xpu:${{ github.run_id }}-${{ inputs.source_ref || github.sha }}-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true
@@ -211,7 +211,7 @@ jobs:
       TEST_IMAGE_TAG: dynamo-${{ inputs.framework || 'vllm' }}-${{ inputs.target || 'runtime' }}-xpu:${{ github.run_id }}-${{ inputs.source_ref || github.sha }}-test
     steps:
       - name: Checkout code
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ env.SOURCE_REF }}
           lfs: true


### PR DESCRIPTION
## Summary

- upgrade the stale GitHub Action references that emit Node.js 20 deprecation annotations to pinned Node.js 24-compatible releases
- replace the unmaintained `pre-commit/action` wrapper, which embeds `actions/cache@v4`, with equivalent explicit steps
- pin the pre-commit job to Python 3.12 to remove its implicit-version warning

The warnings were observed across the checks on #12404.

## Validation

- `pre-commit run --files $(git diff --name-only)`
- `git diff --check`
- compared actionlint's unique finding set against `origin/main`: 0 new findings, 1 stale-action finding removed

## Related Issues

- [DIS-2551](https://linear.app/nvidia/issue/DIS-2551/remove-nodejs-20-deprecation-warnings-from-github-actions)