### PR TITLE
docs: add experimental sidecar architecture and launch guides

### DIFF
--- a/docs/fern/backends/sglang/README.md
+++ b/docs/fern/backends/sglang/README.md
@@ -13,6 +13,13 @@ We recommend using the [latest stable release](https://github.com/ai-dynamo/dyna
 
 Dynamo SGLang integrates [SGLang](https://github.com/sgl-project/sglang) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with SGLang's native engine arguments. It supports LLM inference, embedding models, multimodal vision models, and diffusion-based generation (LLM, image, video).
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside SGLang and
+connects through SGLang's native gRPC API. It keeps SGLang's native server and
+argument surface while separating Dynamo and engine dependencies. See
+[SGLang Sidecar](sidecar.md) for current readiness and launch examples.
+
 ## Prerequisites
 
 - **CUDA toolkit headers** for bare-metal builds (e.g. `nvcc`, `cuda_runtime.h`). See [CUDA Requirements](../../getting-started/local-installation.mdx#system-requirements). Not required when running the pre-built `sglang-runtime` container.

--- a/docs/fern/backends/sglang/sidecar.md
+++ b/docs/fern/backends/sglang/sidecar.md
@@ -1,0 +1,75 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: SGLang Sidecar
+subtitle: Run Dynamo beside a stock SGLang engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The SGLang sidecar, launchers, packaging, and feature
+> coverage can change without notice.
+
+`dynamo-sglang-sidecar` is a CPU-only Dynamo worker that connects to SGLang's
+native gRPC service. It preserves the upstream engine process and argument
+surface while using Dynamo for request handling and distributed serving. See
+the [Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Validated on two GPUs with NIXL |
+| Kubernetes example | Validated | Validated with NIXL |
+
+This table covers launch topology only. The
+[SGLang feature matrix](README.md#feature-support-matrix) describes the
+in-process backend; sidecar feature parity is still under evaluation. See the
+[SGLang sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/README.md)
+for current protocol details.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-sglang-sidecar` is on `PATH`. Install SGLang v0.5.16 or later, which
+provides the native `--grpc-port` server option.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/sglang/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+To run separate prefill and decode engines on two GPUs:
+
+```bash
+./lib/sidecar/sglang/launch/disagg.sh --model Qwen/Qwen3-0.6B
+```
+
+Each launcher starts the Dynamo frontend, the SGLang engine process or
+processes, and the matching sidecar workers. It binds SGLang's HTTP and native
+gRPC endpoints to loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published SGLang sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream SGLang
+image. The source tree includes
+[aggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/deploy/agg.yaml)
+and
+[disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/deploy/disagg.yaml)
+manifests.

--- a/docs/fern/backends/trtllm/README.md
+++ b/docs/fern/backends/trtllm/README.md
@@ -13,6 +13,14 @@ We recommend using the [latest stable release](https://github.com/ai-dynamo/dyna
 
 Dynamo TensorRT-LLM integrates [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, multi-node deployments, and request cancellation. It supports LLM inference, multimodal models, video diffusion, and advanced features like speculative decoding and attention data parallelism.
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside TensorRT-LLM and
+connects through TensorRT-LLM's native gRPC API. It keeps TensorRT-LLM's native
+server and argument surface while separating Dynamo and engine dependencies.
+See [TensorRT-LLM Sidecar](sidecar.md) for current readiness and a launch
+example.
+
 ## Feature Support Matrix
 
 ### Core Dynamo Features

--- a/docs/fern/backends/trtllm/sidecar.md
+++ b/docs/fern/backends/trtllm/sidecar.md
@@ -1,0 +1,68 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: TensorRT-LLM Sidecar
+subtitle: Run Dynamo beside a stock TensorRT-LLM engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The TensorRT-LLM sidecar, launcher, packaging, and feature
+> coverage can change without notice.
+
+`dynamo-trtllm-sidecar` is a CPU-only Dynamo worker that connects to
+TensorRT-LLM's native gRPC service. It preserves the upstream engine process
+and argument surface while using Dynamo for request handling and distributed
+serving. See the
+[Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Not supported |
+| Kubernetes example | Validated | Not supported |
+
+This table covers launch topology only. The
+[TensorRT-LLM feature matrix](README.md#feature-support-matrix) describes the
+in-process backend; sidecar feature parity is still under evaluation. The
+current native gRPC contract does not provide the prefill/decode handoff needed
+for disaggregated serving. See the
+[TensorRT-LLM sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/README.md)
+for other protocol limitations.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-trtllm-sidecar` is on `PATH`. Install a TensorRT-LLM release that
+provides `tensorrt_llm.commands.serve --grpc`.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/trtllm/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+The launcher starts the Dynamo frontend, TensorRT-LLM engine, and sidecar. It
+binds TensorRT-LLM's native gRPC endpoint to loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published TensorRT-LLM sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream
+TensorRT-LLM image. The source tree includes an
+[aggregated deployment manifest](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/deploy/agg.yaml).

--- a/docs/fern/backends/vllm/README.md
+++ b/docs/fern/backends/vllm/README.md
@@ -6,6 +6,13 @@ title: vLLM
 
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside vLLM and connects
+through vLLM's native gRPC API. It keeps vLLM's native server and argument
+surface while separating Dynamo and engine dependencies. See
+[vLLM Sidecar](sidecar.md) for current readiness and launch examples.
+
 ## Installation
 
 ### Install Latest Release

--- a/docs/fern/backends/vllm/sidecar.md
+++ b/docs/fern/backends/vllm/sidecar.md
@@ -1,0 +1,75 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: vLLM Sidecar
+subtitle: Run Dynamo beside a stock vLLM engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The vLLM sidecar, launchers, packaging, and feature coverage
+> can change without notice.
+
+`dynamo-vllm-sidecar` is a CPU-only Dynamo worker that connects to vLLM's native
+gRPC service. It preserves the upstream engine process and argument surface
+while using Dynamo for request handling and distributed serving. See the
+[Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Validated on two GPUs with NIXL |
+| Kubernetes example | Validated | Validated with NIXL |
+
+This table covers launch topology only. The
+[vLLM feature matrix](README.md#feature-support-matrix) describes the in-process
+backend; sidecar feature parity is still under evaluation. See the
+[vLLM sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/README.md)
+for current protocol limitations.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-vllm-sidecar` is on `PATH`. Install a vLLM build that provides
+`vllm-rs` and its native gRPC server.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/vllm/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+To run separate prefill and decode engines on two GPUs:
+
+```bash
+./lib/sidecar/vllm/launch/disagg.sh --model Qwen/Qwen3-0.6B
+```
+
+Each launcher starts the Dynamo frontend, the vLLM engine process or processes,
+and the matching sidecar workers. It binds the native gRPC endpoints to
+loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published vLLM sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream vLLM
+image. The source tree includes
+[aggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/deploy/agg.yaml)
+and
+[disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/deploy/disagg.yaml)
+manifests.

--- a/docs/fern/cli/overview.mdx
+++ b/docs/fern/cli/overview.mdx
@@ -10,6 +10,14 @@ This guide walks through the basic **aggregated deployment** flow: a single fron
 
 A deployment is always a **frontend** (`python -m dynamo.frontend`, the HTTP ingress) plus **one or more workers** (`python -m dynamo.<backend>`, which wrap an inference engine). Workers register with the frontend automatically on startup. The steps below start one of each.
 
+<Warning>
+**Experimental sidecar launch mode.** The steps below run an integrated backend,
+with the Dynamo worker and inference engine in the same process. The
+[Sidecar Backends](../design-docs/sidecar-backends.md) page explains how to run
+a stock engine server beside a CPU-only Dynamo worker and links to the
+framework-specific launch guides.
+</Warning>
+
 > **Prerequisites.** Dynamo installed for your backend (see the [installation guide](../getting-started/local-installation.mdx)), and etcd + NATS reachable on localhost so the frontend and worker can discover each other:
 >
 > ```bash

--- a/docs/fern/design-docs/architecture.md
+++ b/docs/fern/design-docs/architecture.md
@@ -41,6 +41,22 @@ Dynamo addresses these constraints by separating serving, control, and state pro
 
 ## System Model
 
+### Backend Execution Modes
+
+Dynamo supports two ways to connect an inference engine to the request plane:
+
+- An **integrated backend** runs the Dynamo worker and inference engine in the
+  same process.
+- An **experimental sidecar backend** runs a stock inference engine server
+  beside a CPU-only Dynamo worker and connects them through the engine's native
+  gRPC API.
+
+Both modes present the same worker boundary to the frontend and router. The
+sidecar mode preserves the engine's native serve interface and separates
+engine dependencies from Dynamo, but it does not yet match the integrated
+backends' feature coverage. See [Sidecar Backends](sidecar-backends.md) for the
+architecture and current readiness.
+
 ### Request Plane (critical data path)
 
 The request plane is responsible for request/response execution:

--- a/docs/fern/design-docs/architecture.md
+++ b/docs/fern/design-docs/architecture.md
@@ -48,11 +48,10 @@ Dynamo supports two ways to connect an inference engine to the request plane:
 - An **integrated backend** runs the Dynamo worker and inference engine in the
   same process.
 - An **experimental sidecar backend** runs a stock inference engine server
-  beside a CPU-only Dynamo worker and connects them through the engine's native
-  gRPC API.
+  beside a CPU-only Dynamo sidecar. The request plane calls the engine's native
+  gRPC API directly, while discovery and events flow through the sidecar.
 
-Both modes present the same worker boundary to the frontend and router. The
-sidecar mode preserves the engine's native serve interface and separates
+The sidecar mode preserves the engine's native serve interface and separates
 engine dependencies from Dynamo, but it does not yet match the integrated
 backends' feature coverage. See [Sidecar Backends](sidecar-backends.md) for the
 architecture and current readiness.

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -12,8 +12,8 @@ subtitle: Run Dynamo beside a stock inference engine through its native gRPC API
 
 A Dynamo sidecar runs beside the inference engine process. It registers the
 engine with Dynamo discovery and forwards engine events into the Dynamo event
-plane. The Dynamo request plane connects directly to the engine's native gRPC
-service.
+plane. Today, requests also pass through the sidecar. The target design routes
+requests directly to the engine's native gRPC service.
 
 ## Design Goals
 
@@ -36,15 +36,18 @@ flowchart LR
     S[Dynamo Sidecar] <-->|Native gRPC| E[Inference Engine]
   end
   S -->|Discovery and Event planes| F
-  F -->|Request plane<br/>Native gRPC| E
+  F -->|Request plane*<br/>Native gRPC| E
 ```
 
-The frontend and router resolve the engine endpoint through discovery, then
-send requests directly to the engine. The sidecar stays off the request path
-and uses the engine's native gRPC service for metadata and event integration
-with Dynamo's discovery and event planes.
+<sup>*</sup> The direct request path is the target design. Today, requests pass
+through the sidecar.
 
-## Responsibilities
+In the target design, the frontend and router resolve the engine endpoint
+through discovery, then send requests directly to the engine. The sidecar stays
+off the request path and uses the engine's native gRPC service for metadata and
+event integration with Dynamo's discovery and event planes.
+
+## Target Responsibilities
 
 | Layer | Responsibility |
 |---|---|

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -49,7 +49,7 @@ with Dynamo's discovery and event planes.
 | Layer | Responsibility |
 |---|---|
 | Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and direct native gRPC requests to the engine |
-| Dynamo sidecar | Engine registration and discovery, plus metadata and event forwarding over native gRPC |
+| Dynamo sidecar | Engine registration and discovery, plus metadata and event forwarding |
 | Inference engine | Native gRPC request serving, scheduling, sampling, token generation, KV cache, and GPU execution |
 
 ## Current Readiness

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -30,20 +30,26 @@ service.
 
 ```mermaid
 flowchart LR
-  S[Dynamo Sidecar] -->|Discovery and Event planes| F[Dynamo Frontend]
-  F -->|Request plane<br/>Native gRPC| E[Inference Engine]
+  F[Dynamo Frontend]
+  subgraph W[Same host or Kubernetes pod]
+    direction TB
+    S[Dynamo Sidecar] <-->|Native gRPC| E[Inference Engine]
+  end
+  S -->|Discovery and Event planes| F
+  F -->|Request plane<br/>Native gRPC| E
 ```
 
 The frontend and router resolve the engine endpoint through discovery, then
 send requests directly to the engine. The sidecar stays off the request path
-and integrates the engine with Dynamo's discovery and event planes.
+and uses the engine's native gRPC service for metadata and event integration
+with Dynamo's discovery and event planes.
 
 ## Responsibilities
 
 | Layer | Responsibility |
 |---|---|
 | Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and direct native gRPC requests to the engine |
-| Dynamo sidecar | Engine registration and discovery, plus event forwarding |
+| Dynamo sidecar | Engine registration and discovery, plus metadata and event forwarding over native gRPC |
 | Inference engine | Native gRPC request serving, scheduling, sampling, token generation, KV cache, and GPU execution |
 
 ## Current Readiness

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -1,0 +1,71 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Sidecar Backends
+subtitle: Run Dynamo beside a stock inference engine through its native gRPC API.
+---
+
+> [!WARNING]
+> **Experimental.** Sidecar packaging, launchers, and API coverage are still
+> evolving. The sidecar path does not yet match every feature of the in-process
+> backends.
+
+A Dynamo sidecar runs the Dynamo worker outside the inference engine process.
+It connects the Dynamo request plane to the engine's native gRPC service while
+the engine keeps ownership of scheduling, token generation, and GPU resources.
+
+## Design Goals
+
+- Keep the upstream engine's native serve path and argument surface.
+- Move toward public, versioned gRPC contracts with explicit backward
+  compatibility instead of importing private engine APIs.
+- Isolate Dynamo and engine dependencies in separate processes.
+- Attribute failures through engine-specific and Dynamo-specific logs and health
+  checks.
+- Reuse Dynamo's frontend, routing, planning, and disaggregated-serving
+  orchestration.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  C[Client] -->|OpenAI-compatible HTTP| F[Dynamo Frontend]
+  F <-->|Dynamo request plane| S[Dynamo Sidecar<br/>CPU-only worker]
+
+  subgraph H[Same host or Kubernetes pod]
+    S <-->|Native gRPC on loopback| E[Stock inference engine<br/>vLLM, SGLang, or TensorRT-LLM]
+  end
+```
+
+The sidecar registers as a Dynamo worker, translates requests and responses,
+and manages cancellation and lifecycle signals. The engine continues to use its
+native server and owns the GPU, scheduler, sampler, and KV cache.
+
+> [!IMPORTANT]
+> The native gRPC listeners are unauthenticated and plaintext. Keep them on
+> loopback or another private, access-controlled interface. The provided
+> launchers bind them to loopback.
+
+## Responsibilities
+
+| Layer | Responsibility |
+|---|---|
+| Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and prefill/decode orchestration |
+| Dynamo sidecar | Worker registration, engine protocol translation, streaming, cancellation, and health bridging |
+| Inference engine | Native serve API, scheduling, sampling, token generation, KV cache, and GPU execution |
+
+## Current Readiness
+
+| Backend | Local launcher | Kubernetes example |
+|---|---|---|
+| [vLLM](../backends/vllm/sidecar.md) | Aggregated and disaggregated | Aggregated and disaggregated |
+| [SGLang](../backends/sglang/sidecar.md) | Aggregated and disaggregated | Aggregated and disaggregated |
+| [TensorRT-LLM](../backends/trtllm/sidecar.md) | Aggregated | Aggregated |
+
+Disaggregated launch paths require multiple GPUs and use NIXL for KV transfer.
+This table describes validated launch topologies, not feature parity with the
+in-process backends.
+
+See the
+[sidecar source and engine-specific READMEs](https://github.com/ai-dynamo/dynamo/tree/main/lib/sidecar)
+for implementation details.

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -10,9 +10,10 @@ subtitle: Run Dynamo beside a stock inference engine through its native gRPC API
 > evolving. The sidecar path does not yet match every feature of the in-process
 > backends.
 
-A Dynamo sidecar runs the Dynamo worker outside the inference engine process.
-It connects the Dynamo request plane to the engine's native gRPC service while
-the engine keeps ownership of scheduling, token generation, and GPU resources.
+A Dynamo sidecar runs beside the inference engine process. It registers the
+engine with Dynamo discovery and forwards engine events into the Dynamo event
+plane. The Dynamo request plane connects directly to the engine's native gRPC
+service.
 
 ## Design Goals
 
@@ -29,30 +30,31 @@ the engine keeps ownership of scheduling, token generation, and GPU resources.
 
 ```mermaid
 flowchart LR
-  C[Client] -->|OpenAI-compatible HTTP| F[Dynamo Frontend]
-  F <-->|Dynamo request plane| S[Dynamo Sidecar<br/>CPU-only worker]
+  C[Client] -->|OpenAI-compatible HTTP| F[Dynamo Frontend and Router]
+  D[Dynamo Discovery Plane] -.->|Engine endpoint| F
 
   subgraph H[Same host or Kubernetes pod]
-    S <-->|Native gRPC on loopback| E[Stock inference engine<br/>vLLM, SGLang, or TensorRT-LLM]
+    E[Stock inference engine<br/>vLLM, SGLang, or TensorRT-LLM]
+    S[Dynamo Sidecar<br/>CPU-only]
   end
+
+  F -->|Native gRPC| E
+  S -->|Register engine| D
+  E -->|KV events| S
+  S -->|Publish events| V[Dynamo Event Plane]
 ```
 
-The sidecar registers as a Dynamo worker, translates requests and responses,
-and manages cancellation and lifecycle signals. The engine continues to use its
-native server and owns the GPU, scheduler, sampler, and KV cache.
-
-> [!IMPORTANT]
-> The native gRPC listeners are unauthenticated and plaintext. Keep them on
-> loopback or another private, access-controlled interface. The provided
-> launchers bind them to loopback.
+The frontend and router resolve the engine endpoint through discovery, then
+send requests directly to the engine. The sidecar stays off the request path
+and integrates the engine with Dynamo's discovery and event planes.
 
 ## Responsibilities
 
 | Layer | Responsibility |
 |---|---|
-| Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and prefill/decode orchestration |
-| Dynamo sidecar | Worker registration, engine protocol translation, streaming, cancellation, and health bridging |
-| Inference engine | Native serve API, scheduling, sampling, token generation, KV cache, and GPU execution |
+| Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and direct native gRPC requests to the engine |
+| Dynamo sidecar | Engine registration and discovery, plus event forwarding |
+| Inference engine | Native gRPC request serving, scheduling, sampling, token generation, KV cache, and GPU execution |
 
 ## Current Readiness
 

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -30,18 +30,8 @@ service.
 
 ```mermaid
 flowchart LR
-  C[Client] -->|OpenAI-compatible HTTP| F[Dynamo Frontend and Router]
-  D[Dynamo Discovery Plane] -.->|Engine endpoint| F
-
-  subgraph H[Same host or Kubernetes pod]
-    E[Stock inference engine<br/>vLLM, SGLang, or TensorRT-LLM]
-    S[Dynamo Sidecar<br/>CPU-only]
-  end
-
-  F -->|Native gRPC| E
-  S -->|Register engine| D
-  E -->|KV events| S
-  S -->|Publish events| V[Dynamo Event Plane]
+  S[Dynamo Sidecar] -->|Discovery and Event planes| F[Dynamo Frontend]
+  F -->|Request plane<br/>Native gRPC| E[Inference Engine]
 ```
 
 The frontend and router resolve the engine endpoint through discovery, then

--- a/docs/fern/getting-started/introduction.mdx
+++ b/docs/fern/getting-started/introduction.mdx
@@ -115,6 +115,9 @@ This page covers the **Kubernetes** path. To run Dynamo directly on a workstatio
       <Card title="Model Deployment Introduction" icon="regular circle-info" href="kubernetes-deployment.mdx">
         Choose a deployment workflow and learn the core Kubernetes resources.
       </Card>
+      <Card title="Sidecar Backends (Experimental)" icon="regular server" href="../design-docs/sidecar-backends.md">
+        Run Dynamo beside a stock inference engine and find backend-specific deployment examples.
+      </Card>
       <Card title="Deploy with DGD" icon="regular cloud-arrow-up" href="../kubernetes/dgd-guide.md">
         Define and apply a DynamoGraphDeployment.
       </Card>

--- a/docs/fern/getting-started/kubernetes-deployment.mdx
+++ b/docs/fern/getting-started/kubernetes-deployment.mdx
@@ -14,6 +14,13 @@ The DGD is the deployment artifact that ultimately serves traffic, regardless of
 whether you start from a tuned manifest, copy a template, generate one, or write the
 resource directly.
 
+<Warning>
+**Experimental sidecar launch mode.** A DGD can run a stock inference engine
+server beside a CPU-only Dynamo sidecar in the same pod. See
+[Sidecar Backends](../design-docs/sidecar-backends.md) for supported backends,
+topologies, and framework-specific deployment examples.
+</Warning>
+
 ## Create a DGD
 
 Choose the starting point that best matches your model, hardware, and desired level

--- a/docs/fern/getting-started/kubernetes-deployment.mdx
+++ b/docs/fern/getting-started/kubernetes-deployment.mdx
@@ -14,13 +14,6 @@ The DGD is the deployment artifact that ultimately serves traffic, regardless of
 whether you start from a tuned manifest, copy a template, generate one, or write the
 resource directly.
 
-<Warning>
-**Experimental sidecar launch mode.** A DGD can run a stock inference engine
-server beside a CPU-only Dynamo sidecar in the same pod. See
-[Sidecar Backends](../design-docs/sidecar-backends.md) for supported backends,
-topologies, and framework-specific deployment examples.
-</Warning>
-
 ## Create a DGD
 
 Choose the starting point that best matches your model, hardware, and desired level

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -138,6 +138,8 @@ navigation:
         contents:
           - page: Introduction
             path: getting-started/kubernetes-deployment.mdx
+          - page: Sidecar Backends (Experimental)
+            path: design-docs/sidecar-backends.md
           - page: Deploy with DGD
             path: kubernetes/dgd-guide.md
           - page: Expose the Frontend

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -554,6 +554,8 @@ navigation:
                     path: design-docs/dynamo-flow.md
                   - page: Distributed Runtime
                     path: design-docs/distributed-runtime.md
+                  - page: Sidecar Backends (Experimental)
+                    path: design-docs/sidecar-backends.md
                   - page: Disaggregated Serving
                     path: design-docs/disagg-serving.md
               - section: Communication Planes
@@ -707,6 +709,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/sglang/README.md
+                      - page: Sidecar
+                        path: backends/sglang/sidecar.md
                       - page: Reference Guide
                         path: backends/sglang/sglang-reference-guide.md
                       - page: Agents on SGLang
@@ -729,6 +733,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/trtllm/README.md
+                      - page: Sidecar
+                        path: backends/trtllm/sidecar.md
                       - page: Reference Guide
                         path: backends/trtllm/trtllm-reference-guide.md
                       - page: Observability
@@ -743,6 +749,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/vllm/README.md
+                      - page: Sidecar
+                        path: backends/vllm/sidecar.md
                       - page: Reference Guide
                         path: backends/vllm/vllm-reference-guide.md
                       - page: Chat Processor


### PR DESCRIPTION
## Overview

Document the experimental Sidecar backend execution mode for vLLM, SGLang, and TensorRT-LLM in the public Fern documentation.

The Dynamo request plane calls the stock inference engine directly over its native gRPC API. A CPU-only Dynamo sidecar integrates the engine with Dynamo's Discovery and Event planes. This preserves the engine's serve interface and dependency boundary while connecting it to Dynamo's frontend, routing, planning, and distributed-serving infrastructure.

This PR is documentation-only.

## Details

* Add an engine-agnostic Sidecar architecture page with design goals, a process-boundary diagram, responsibilities, and a readiness matrix.
* Add backend-specific local and Kubernetes launch guides for vLLM, SGLang, and TensorRT-LLM.
* Add short discovery notes to the overall architecture and local/Kubernetes deployment landing pages.
* Add an Experimental Sidecar section to each backend overview.
* Mark Sidecar as experimental and distinguish validated launch topologies from feature parity with integrated backends.

### Dependency status

Merged:

* ai-dynamo/dynamo#12238 — vLLM Kubernetes deployment examples
* ai-dynamo/dynamo#12265 — vLLM local launchers
* ai-dynamo/dynamo#12272 — TensorRT-LLM local launcher

Open:

* ai-dynamo/dynamo#12249 — SGLang delta-token correctness
* ai-dynamo/dynamo#12239 — SGLang Kubernetes deployment examples
* ai-dynamo/dynamo#12271 — SGLang local launchers
* ai-dynamo/dynamo#12206 — TensorRT-LLM Kubernetes deployment example

## User Impact

Users can understand the Sidecar execution model, evaluate current backend and topology readiness, and find runnable local or Kubernetes examples. This PR does not change runtime behavior.

## Where should the reviewer start?

1. `docs/fern/design-docs/sidecar-backends.md`
2. `docs/fern/backends/vllm/sidecar.md`
3. `docs/fern/backends/sglang/sidecar.md`
4. `docs/fern/backends/trtllm/sidecar.md`
5. `docs/fern/index.yml`

## Validation

* `fern check` — 0 errors
* `fern docs broken-links` — all checks passed
* Repository link checker — 1,075 links checked, 0 broken
* Applicable pre-commit documentation hooks
* `git diff --check`

## Related Issues

* Closes [DIS-2490](https://linear.app/nvidia/issue/DIS-2490/documentation-added-for-each-sidecar-and-a-general-doc-on-how-it-works)
* Relates to ai-dynamo/dynamo#10835