### PR TITLE
ci: update vCluster to v0.36.0

### DIFF
--- a/.github/actions/install-vcluster-cli/action.yml
+++ b/.github/actions/install-vcluster-cli/action.yml
@@ -5,7 +5,7 @@ inputs:
   vcluster_version:
     description: 'vCluster CLI version to install'
     required: false
-    default: 'v0.33.0'
+    default: 'v0.36.0'
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

- Update the shared vCluster CLI version from v0.33.0 to v0.36.0.
- Apply the new default to setup, connection, existence-check, and teardown workflows.

## Validation

- Confirmed the v0.36.0 AMD64 and ARM64 release assets return HTTP 200.
- Parsed `.github/actions/install-vcluster-cli/action.yml` successfully as YAML.
- Ran `git diff --check`.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default vCluster CLI version used by automated setup workflows from v0.33.0 to v0.36.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->