### PR TITLE
docs: add parallel media decoding guide

### DIFF
--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -368,6 +368,8 @@ navigation:
         contents:
           - page: Overview
             path: pages/use-cases/multimodal-serving/overview.md
+          - page: Parallel Media Decoding
+            path: pages/use-cases/multimodal-serving/parallel-media-decoding.md
           - page: Embedding Cache
             path: pages/use-cases/multimodal-serving/embedding-cache.md
           - page: Multimodal KV Routing

--- a/docs/fern/pages/use-cases/multimodal-serving/overview.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/overview.md
@@ -13,7 +13,7 @@ Dynamo provides support for improving latency and throughput for multimodal work
 
 | Workload | Feature | Benefit |
 |----------|---------|---------|
-| Workload where significant time is spent preprocessing. | Frontend media decoding | Move base64 decoding and pixel conversion off the worker's critical path, and use all CPU cores to preprocess in parallel. |
+| Workload where significant time is spent preprocessing. | [Parallel media decoding](parallel-media-decoding.md) | Move image fetching and decompression off the worker's critical path. |
 | Workload includes repeated multimodal content across requests. | [Embedding cache](embedding-cache.md) | Skip re-encoding repeated multimodal content. |
 | Workload includes repeated multimodal content across requests, and multiple backend workers serve multimodal requests. | [Multimodal KV routing](multimodal-kv-routing.md) | Maximize KV cache hit rates for multimodal content. |
 | Workload where media encoding is a bottleneck. | [EPD disaggregation](encoder-disaggregation.md) | Scale encoders independently of LLM workers. |
@@ -25,8 +25,8 @@ Dynamo provides support for improving latency and throughput for multimodal work
 ## Multimodal Performance Optimization Features
 
 <CardGroup cols={2}>
-  <Card title="Frontend Media Decoding" icon="regular image">
-    Move base64 decoding and pixel conversion off the worker's critical path. Documentation coming soon.
+  <Card title="Parallel Media Decoding" icon="regular image" href="parallel-media-decoding.md">
+    Decode image inputs concurrently in the Rust frontend and transfer pixels through NIXL
   </Card>
   <Card title="Embedding Cache" icon="regular database" href="embedding-cache.md">
     Cache vision encoder embeddings to skip re-encoding repeated multimodal content

--- a/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
@@ -22,7 +22,8 @@ vision encoding.
 | Video | Not supported | Not supported | Not supported |
 | Audio | Not supported | Not supported | Not supported |
 
-`Agg` refers to an aggregated worker.
+`Agg` refers to an aggregated worker. The entries in this matrix represent the
+supported topologies for frontend decoding.
 
 This matrix describes parallel media decoding, not the overall multimodal
 support of each backend. A backend can support video or audio by decoding it on
@@ -69,9 +70,11 @@ registers the model.
 
 ## Requirements and Limitations
 
-- Run the frontend with NIXL and UCX available. The image built from
-  [`container/templates/frontend.Dockerfile`](https://github.com/ai-dynamo/dynamo/blob/main/container/templates/frontend.Dockerfile)
-  does not include the required UCX media-transfer support.
+- The published `nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0` image installs
+  NIXL wheels but does not expose the native NIXL and UCX libraries and plugins
+  required by the Rust frontend. It cannot run parallel media decoding as
+  shipped. Run the frontend in a backend runtime image or environment where
+  NIXL and UCX are configured and available.
 - Run the frontend on a node with GPU access. NIXL initialization requires
   `libcuda.so.1`, even though image decompression runs on the CPU.
 - To fetch images from trusted internal IP addresses or ports, set

--- a/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
@@ -1,0 +1,89 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Parallel Media Decoding
+subtitle: Decode image inputs concurrently in the Rust frontend and transfer pixels to inference backends
+---
+
+Parallel media decoding moves image fetching, base64 decoding, and image
+decompression from the inference backend to the NVIDIA Dynamo Rust frontend.
+The frontend schedules media items on a CPU worker pool and transfers the
+decoded pixel buffers to the backend through NIXL.
+
+The backend still runs its model-specific multimodal processor and vision
+encoder. This feature changes where image input is decoded; it does not skip
+vision encoding.
+
+## Support Matrix
+
+| Input modality | vLLM | SGLang | TensorRT-LLM |
+| --- | --- | --- | --- |
+| Image | Supported | Supported | Supported |
+| Video | Not supported | Not supported | Not supported |
+| Audio | Not supported | Not supported | Not supported |
+
+This matrix describes parallel media decoding, not the overall multimodal
+support of each backend. A backend can support video or audio by decoding it on
+the worker even when the frontend decoding path does not support that modality.
+
+## When to Use
+
+Use parallel media decoding when image preprocessing consumes a significant
+part of request latency or backend CPU time. It is most useful for workloads
+with:
+
+- Concurrent requests containing HTTP, HTTPS, or base64-encoded images
+- Multiple images in one request
+- Backend workers whose request path is constrained by image fetching or
+  decompression
+
+Parallel media decoding can also be combined with the [embedding
+cache](embedding-cache.md). Frontend decoding reduces image input processing
+work, while the embedding cache can skip vision encoding for repeated images.
+
+Do not expect this feature to improve text-only requests or workloads dominated
+by model inference. Measure the image fetch and decode path before enabling it
+when preprocessing is not an observed bottleneck.
+
+## How It Works
+
+For each request, the frontend:
+
+1. Fetches the image URL or decodes the base64 data URL.
+2. Schedules image decompression on the Rayon CPU worker pool.
+3. Registers the decoded pixel buffer with NIXL.
+4. Sends the buffer descriptor to the selected backend worker.
+
+The backend reads the decoded pixels through NIXL, then continues with its
+normal multimodal processor and vision encoder.
+
+## Enable Parallel Media Decoding
+
+Add `--frontend-decoding` to the backend worker command. Do not add the flag to
+`dynamo.frontend`; the backend advertises the decoder configuration when it
+registers the model.
+
+| Backend | Worker flags | Environment variable |
+| --- | --- | --- |
+| [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md) | `--enable-multimodal --frontend-decoding` | `DYN_VLLM_FRONTEND_DECODING=1` |
+| [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md) | `--frontend-decoding` | `DYN_SGL_FRONTEND_DECODING=1` |
+| [TensorRT-LLM](../../developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/reference-guide.md) | `--enable-multimodal --frontend-decoding` | `DYN_TRTLLM_FRONTEND_DECODING=1` |
+
+The CLI flag takes precedence over the corresponding environment variable.
+
+## Requirements and Limitations
+
+- Run the frontend with NIXL and UCX available. The image built from
+  [`container/templates/frontend.Dockerfile`](https://github.com/ai-dynamo/dynamo/blob/main/container/templates/frontend.Dockerfile)
+  does not include the required UCX media-transfer support.
+- Run the frontend on a node with GPU access. NIXL initialization requires
+  `libcuda.so.1`, even though image decompression runs on the CPU.
+- To fetch images from trusted internal IP addresses or ports, set
+  `DYN_MM_ALLOW_INTERNAL=1` on the backend worker. Direct IP addresses and
+  nonstandard ports are blocked by default.
+- For vLLM, do not combine `--frontend-decoding` with
+  `--custom-encoder-class`. The custom encoder consumes image URLs rather than
+  frontend-decoded pixel buffers.
+- For SGLang, do not combine `--frontend-decoding` with
+  `--disaggregation-mode=encode` or `--dedicated-mm-encoder`. Dedicated encode
+  workers require the original image URLs.

--- a/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
@@ -18,12 +18,11 @@ vision encoding.
 
 | Input modality | vLLM | SGLang | TensorRT-LLM |
 | --- | --- | --- | --- |
-| Image | Agg | Agg | Agg, E/PD |
+| Image | Agg | Agg | Agg |
 | Video | Not supported | Not supported | Not supported |
 | Audio | Not supported | Not supported | Not supported |
 
-`Agg` refers to an aggregated worker. `E/PD` refers to a separate encode
-worker paired with a combined prefill and decode worker.
+`Agg` refers to an aggregated worker.
 
 This matrix describes parallel media decoding, not the overall multimodal
 support of each backend. A backend can support video or audio by decoding it on

--- a/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
@@ -7,8 +7,8 @@ subtitle: Decode image inputs concurrently in the Rust frontend and transfer pix
 
 Parallel media decoding moves image fetching, base64 decoding, and image
 decompression from the inference backend to the NVIDIA Dynamo Rust frontend.
-The frontend schedules media items on a CPU worker pool and transfers the
-decoded pixel buffers to the backend through NIXL.
+The frontend decodes images concurrently on a CPU worker pool and transfers
+the decoded pixel buffers to the backend through NIXL.
 
 The backend still runs its model-specific multimodal processor and vision
 encoder. This feature changes where image input is decoded; it does not skip
@@ -18,9 +18,12 @@ vision encoding.
 
 | Input modality | vLLM | SGLang | TensorRT-LLM |
 | --- | --- | --- | --- |
-| Image | Supported | Supported | Supported |
+| Image | Agg | Agg | Agg, E/PD |
 | Video | Not supported | Not supported | Not supported |
 | Audio | Not supported | Not supported | Not supported |
+
+`Agg` refers to an aggregated worker. `E/PD` refers to a separate encode
+worker paired with a combined prefill and decode worker.
 
 This matrix describes parallel media decoding, not the overall multimodal
 support of each backend. A backend can support video or audio by decoding it on
@@ -41,16 +44,12 @@ Parallel media decoding can also be combined with the [embedding
 cache](embedding-cache.md). Frontend decoding reduces image input processing
 work, while the embedding cache can skip vision encoding for repeated images.
 
-Do not expect this feature to improve text-only requests or workloads dominated
-by model inference. Measure the image fetch and decode path before enabling it
-when preprocessing is not an observed bottleneck.
-
 ## How It Works
 
 For each request, the frontend:
 
 1. Fetches the image URL or decodes the base64 data URL.
-2. Schedules image decompression on the Rayon CPU worker pool.
+2. Decodes images concurrently on a CPU worker pool.
 3. Registers the decoded pixel buffer with NIXL.
 4. Sends the buffer descriptor to the selected backend worker.
 
@@ -63,13 +62,11 @@ Add `--frontend-decoding` to the backend worker command. Do not add the flag to
 `dynamo.frontend`; the backend advertises the decoder configuration when it
 registers the model.
 
-| Backend | Worker flags | Environment variable |
-| --- | --- | --- |
-| [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md) | `--enable-multimodal --frontend-decoding` | `DYN_VLLM_FRONTEND_DECODING=1` |
-| [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md) | `--frontend-decoding` | `DYN_SGL_FRONTEND_DECODING=1` |
-| [TensorRT-LLM](../../developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/reference-guide.md) | `--enable-multimodal --frontend-decoding` | `DYN_TRTLLM_FRONTEND_DECODING=1` |
-
-The CLI flag takes precedence over the corresponding environment variable.
+| Backend | Worker flags |
+| --- | --- |
+| [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md) | `--enable-multimodal --frontend-decoding` |
+| [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md) | `--frontend-decoding` |
+| [TensorRT-LLM](../../developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/reference-guide.md) | `--enable-multimodal --frontend-decoding` |
 
 ## Requirements and Limitations
 
@@ -81,9 +78,3 @@ The CLI flag takes precedence over the corresponding environment variable.
 - To fetch images from trusted internal IP addresses or ports, set
   `DYN_MM_ALLOW_INTERNAL=1` on the backend worker. Direct IP addresses and
   nonstandard ports are blocked by default.
-- For vLLM, do not combine `--frontend-decoding` with
-  `--custom-encoder-class`. The custom encoder consumes image URLs rather than
-  frontend-decoded pixel buffers.
-- For SGLang, do not combine `--frontend-decoding` with
-  `--disaggregation-mode=encode` or `--dedicated-mm-encoder`. Dedicated encode
-  workers require the original image URLs.

--- a/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/parallel-media-decoding.md
@@ -75,8 +75,3 @@ registers the model.
   required by the Rust frontend. It cannot run parallel media decoding as
   shipped. Run the frontend in a backend runtime image or environment where
   NIXL and UCX are configured and available.
-- Run the frontend on a node with GPU access. NIXL initialization requires
-  `libcuda.so.1`, even though image decompression runs on the CPU.
-- To fetch images from trusted internal IP addresses or ports, set
-  `DYN_MM_ALLOW_INTERNAL=1` on the backend worker. Direct IP addresses and
-  nonstandard ports are blocked by default.


### PR DESCRIPTION
## Why

Parallel media decoding is supported across vLLM, SGLang, and TensorRT-LLM, but the multimodal guide currently ends at “documentation coming soon.” Users need one place to see which modalities and deployment topologies are supported, when moving image decoding to the frontend helps, and which worker flags enable it. This documents the current image-only behavior without changing runtime behavior.

## What Change

- Add a modality-by-backend topology support matrix
- Document frontend decoding flow, CLI enablement, and deployment requirements
- Link the guide from multimodal navigation and feature cards

## Test Plan

- `pre-commit run --files docs/fern/features/multimodal/{README.md,parallel-media-decoding.md} docs/fern/index.yml`
- `cd docs && fern check && fern docs broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for Parallel Media Decoding in multimodal workflows.
  * Documented supported media types, setup requirements, configuration steps, and limitations.
  * Updated multimodal feature recommendations and descriptions to reflect parallel image decoding.
  * Added the new feature page to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->