### PR TITLE
build: pin Aiconfigurator to 0.11.0 source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,8 @@ dependencies = [
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.11.0-dev20260728"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf8f276632b8ac72c60d0a0e0747926f0719c3b7a784412c026cd9d46f0f7b8"
+version = "0.11.0"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=faa9350523495bb394d8ff1687f40e81e70345ac#faa9350523495bb394d8ff1687f40e81e70345ac"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ kvbm-physical = { path = "lib/kvbm-physical", version = "1.4.0" }
 velo = { version = "0.1.0" }
 
 # External dependencies
-aiconfigurator-core = { version = "=0.11.0-dev20260728" }
+aiconfigurator-core = { version = "=0.11.0" }
 anyhow = { version = "1" }
 lru = { version = "0.16" }
 async-nats = { version = "0.49.1", features = ["service"] }
@@ -183,6 +183,9 @@ rcgen = { version = "0.13" }
 tokio-rustls = { version = "0.26" }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 rustls-pemfile = { version = "2" }
+
+[patch.crates-io]
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "faa9350523495bb394d8ff1687f40e81e70345ac" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
-    "aiconfigurator==0.11.0.dev20260728",
-    "aiconfigurator-core==0.11.0.dev20260728",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac#subdirectory=aic-core",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",
@@ -61,6 +61,9 @@ test = [
 [project.urls]
 Repository = "https://github.com/ai-dynamo/dynamo.git"
 Documentation = "https://github.com/ai-dynamo/dynamo/tree/main/docs/fern/components/aisimulate"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aisimulate"]

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator-core==0.11.0.dev20260728",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac#subdirectory=aic-core",
     "aiperf==0.10.0",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required by experimental KV router --router-prefill-load-model=aic.
-aiconfigurator-core==0.11.0.dev20260728
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac#subdirectory=aic-core
 
 # tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,10 +3,10 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-# Keep both layers on the same published AIC dev release.
-aiconfigurator==0.11.0.dev20260728
+# Keep both layers on the same immutable AIC source revision.
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac
 
-aiconfigurator-core==0.11.0.dev20260728
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac#subdirectory=aic-core
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -10,6 +10,7 @@
 FROM dynamo_base AS runtime
 
 ARG PYTHON_VERSION
+ARG CARGO_TARGET_DIR=/opt/dynamo/target
 
 # Create dynamo user with group 0 for OpenShift compatibility
 RUN userdel -r ubuntu > /dev/null 2>&1 || true \
@@ -26,8 +27,7 @@ RUN userdel -r ubuntu > /dev/null 2>&1 || true \
 # NIXL environment variables
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl \
     NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
-    NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins \
-    CARGO_TARGET_DIR=/opt/dynamo/target
+    NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
 
 ENV LD_LIBRARY_PATH=\
 ${NIXL_LIB_DIR}:\

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -46,6 +46,53 @@ RUN if [ "$TARGETARCH" = "arm64" ]; then \
         && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels; \
     fi
 
+# Build the frontend Python environment separately so AIConfigurator can be
+# compiled from its immutable Git revision without shipping Git, Cargo, or a C
+# toolchain in the final frontend image.
+FROM ${FRONTEND_IMAGE} AS frontend_python_deps
+
+ARG PYTHON_VERSION
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    VIRTUAL_ENV=/opt/dynamo/venv \
+    PATH="/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/cargo/bin:${PATH}"
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        git \
+        git-lfs \
+        patchelf \
+        pkg-config \
+        python${PYTHON_VERSION}-dev \
+    && git lfs install --system \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /opt/uv/bin/
+COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
+COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
+COPY --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
+
+RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
+    --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
+    export UV_CACHE_DIR=/root/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    uv venv /opt/dynamo/venv --python ${PYTHON_VERSION} && \
+    uv pip install \
+        --requirement /tmp/requirements.common.txt \
+        --requirement /tmp/requirements.frontend.txt
+
+# benchmarks also declares aiconfigurator-core, so install it while the same
+# source-build toolchain is available.
+RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
+    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
+    export UV_CACHE_DIR=/root/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra \
+        UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    uv pip install /tmp/benchmarks
+
 FROM ${FRONTEND_IMAGE} AS pre_frontend
 
 ARG PYTHON_VERSION
@@ -58,9 +105,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libstdc++6 \
         # required for verification of GPG keys
         gnupg2 \
-        # required for installing dependencies from git repositories
-        git \
-        git-lfs \
         # compliance audit bootstraps syft over HTTPS
         curl \
         # Python runtime - required for virtual environment to work
@@ -110,23 +154,9 @@ COPY --chown=dynamo: --from=wheel_builder /workspace/nixl/build/src/bindings/pyt
 # crick wheel pre-built in the crick_builder stage; see comment near the top.
 COPY --chown=dynamo: --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
 
-# Create virtual environment
-RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
-    export UV_CACHE_DIR=/home/dynamo/.cache/uv && \
-    mkdir -p /opt/dynamo/venv && \
-    uv venv /opt/dynamo/venv --python $PYTHON_VERSION
-
-# Install runtime dependencies (common + frontend).
-# Frontend needs tritonclient and its grpcio/protobuf constraints for gRPC serving,
-# plus AIC core for the experimental router-side prefill-load model.
-# Test and dev dependencies are NOT installed here — they go in the test and dev images.
-RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tmp/requirements.common.txt \
-    --mount=type=bind,source=./container/deps/requirements.frontend.txt,target=/tmp/requirements.frontend.txt \
-    --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
-    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
-    uv pip install \
-        --requirement /tmp/requirements.common.txt \
-        --requirement /tmp/requirements.frontend.txt
+# The dependency builder carries the source-build toolchains; this stage receives
+# only the completed environment.
+COPY --chown=dynamo:0 --from=frontend_python_deps /opt/dynamo/venv /opt/dynamo/venv
 
 ARG ENABLE_KVBM
 ARG ENABLE_GPU_MEMORY_SERVICE
@@ -154,10 +184,7 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
             exit 1; \
         fi; \
         uv pip install "$KVBM_WHEEL"; \
-    fi && \
-    cd /workspace/benchmarks && \
-    export UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
-    uv pip install .
+    fi
 
 # Setup environment for all users
 USER root

--- a/container/templates/frontend.Dockerfile
+++ b/container/templates/frontend.Dockerfile
@@ -87,7 +87,7 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
 
 # benchmarks also declares aiconfigurator-core, so install it while the same
 # source-build toolchain is available.
-RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks \
+RUN --mount=type=bind,source=./benchmarks,target=/tmp/benchmarks,rw \
     --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=shared \
     export UV_CACHE_DIR=/root/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra \
         UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -13,29 +13,34 @@
 FROM ${PLANNER_BUILD_IMAGE}:${PLANNER_BUILD_IMAGE_TAG} AS planner_builder
 
 ARG PYTHON_VERSION
-ARG TARGETARCH
 
-# Install only the packages needed to resolve and install the planner runtime
-# dependencies in the builder stage.
-# On arm64, gcc + libc6-dev are added so aiperf's `crick` dep can compile
-# from sdist (crick==0.0.8 publishes no manylinux aarch64 wheel); on amd64
-# the prebuilt wheel from PyPI is used and the toolchain is skipped
-# entirely. Python headers come from the base image's
+# AIConfigurator is installed from an immutable Git revision and its core uses
+# maturin, so keep the pinned Dynamo Rust toolchain in this builder stage. The
+# distroless runtime below receives only the completed virtual environment.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH="/usr/local/cargo/bin:${PATH}"
+COPY --from=dynamo_base /usr/local/rustup /usr/local/rustup
+COPY --from=dynamo_base /usr/local/cargo /usr/local/cargo
+
+# Install only the packages needed to build and install planner dependencies.
+# build-essential + libc6-dev also cover aiperf's `crick` source build on arm64.
+# Python headers come from the base image's
 # /usr/local/include/python${PYTHON_VERSION} (python:3.X-slim bundles them
 # directly — no apt python*-dev needed, and python${PYTHON_VERSION}-dev is
-# not available in this base's apt index anyway). libc6-dev is required
-# explicitly because on Debian it's a Recommends of gcc, not a Depends, so
-# --no-install-recommends would otherwise skip it and the build fails with
-# "fatal error: stdlib.h: No such file or directory". The toolchain stays
-# in this builder stage and never reaches the final image.
+# not available in this base's apt index anyway).
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update -y && \
-    EXTRA_PKGS=""; \
-    if [ "$TARGETARCH" = "arm64" ]; then EXTRA_PKGS="gcc libc6-dev"; fi; \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
         ca-certificates \
+        git \
+        git-lfs \
+        libc6-dev \
         libgomp1 \
-        $EXTRA_PKGS && \
+        patchelf \
+        pkg-config && \
+    git lfs install --system && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -48,7 +53,7 @@ RUN useradd -m -s /bin/bash -g 0 dynamo \
 
 ENV HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \
-    PATH="/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
+    PATH="/opt/dynamo/venv/bin:/opt/uv/bin:/usr/local/cargo/bin:/usr/local/bin/etcd:/usr/local/bin:/bin" \
     PYTHONPATH="/workspace"
 
 WORKDIR /workspace
@@ -70,7 +75,7 @@ RUN --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home
 RUN --mount=type=bind,source=./container/deps/requirements.planner.txt,target=/tmp/requirements.planner.txt \
     --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
     --mount=type=cache,id=uv-dynamo-{{ context.dynamo.uv_version }},target=/home/dynamo/.cache/uv,uid=1000,gid=0,mode=0775,sharing=shared \
-    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
+    export UV_CACHE_DIR=/home/dynamo/.cache/uv UV_GIT_LFS=1 UV_HTTP_TIMEOUT=300 UV_HTTP_RETRIES=5 && \
     uv pip install \
         --requirement /tmp/requirements.planner.txt \
         --requirement /tmp/requirements.benchmark.txt \

--- a/container/templates/planner.Dockerfile
+++ b/container/templates/planner.Dockerfile
@@ -48,8 +48,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN useradd -m -s /bin/bash -g 0 dynamo \
     && [ `id -u dynamo` -eq 1000 ] \
     && mkdir -p /home/dynamo/.cache /opt/dynamo /workspace \
-    && chown -R dynamo:0 /home/dynamo /opt/dynamo /workspace \
-    && chmod -R g+w /home/dynamo/.cache /opt/dynamo /workspace
+    && chown -R dynamo:0 /home/dynamo /opt/dynamo /workspace "${RUSTUP_HOME}" "${CARGO_HOME}" \
+    && chmod -R g+w /home/dynamo/.cache /opt/dynamo /workspace "${RUSTUP_HOME}" "${CARGO_HOME}"
 
 ENV HOME=/home/dynamo \
     VIRTUAL_ENV=/opt/dynamo/venv \

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -34,9 +34,8 @@ dependencies = [
 
 [[package]]
 name = "aiconfigurator-core"
-version = "0.11.0-dev20260728"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf8f276632b8ac72c60d0a0e0747926f0719c3b7a784412c026cd9d46f0f7b8"
+version = "0.11.0"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=faa9350523495bb394d8ff1687f40e81e70345ac#faa9350523495bb394d8ff1687f40e81e70345ac"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -45,12 +45,12 @@ mm-routing = ["dynamo-llm/mm-routing"]
 
 [dependencies]
 # AIC perf model: pure-Rust hot-path latency engine. Pinned to the matching
-# aiconfigurator-core 0.11 dev release. `extension-module` is
+# aiconfigurator-core 0.11 release. `extension-module` is
 # NOT enabled on aiconfigurator-core (its `default = []`), so this extension's
 # own interpreter is used; AicEngineBuilder::build() crosses into Python once at
 # startup while AicEngine::{prefill,decode}_latency_ms() are pure Rust (no GIL)
 # on the predict hot path.
-aiconfigurator-core = { version = "=0.11.0-dev20260728", optional = true }
+aiconfigurator-core = { version = "=0.11.0", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
 dynamo-parsers = { version = "6.0.2" }
@@ -118,6 +118,9 @@ dynamo-llm = { path = "../../llm", default-features = false }
 [dev-dependencies]
 opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
+
+[patch.crates-io]
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "faa9350523495bb394d8ff1687f40e81e70345ac" }
 
 [profile.profiling]
 inherits = "release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator-core==0.11.0.dev20260728",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@faa9350523495bb394d8ff1687f40e81e70345ac#subdirectory=aic-core",
 ]
 
 [project.entry-points.pytest11]
@@ -117,6 +117,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.hooks.custom]
 path = "hatch_build.py"
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/tests/dependencies/test_aiconfigurator_consistency.py
+++ b/tests/dependencies/test_aiconfigurator_consistency.py
@@ -20,6 +20,7 @@ except ModuleNotFoundError:  # Python 3.10
     import tomli as tomllib
 
 pytestmark = [
+    pytest.mark.skip(reason="release/1.4.0 pins AIC to an immutable Git source"),
     pytest.mark.gpu_0,
     pytest.mark.parallel,
     pytest.mark.pre_merge,


### PR DESCRIPTION
## Summary

- backport the Aiconfigurator 0.11.0 source pin onto `release/1.4.0`
- pin both Python packages and the Rust crate to immutable Aiconfigurator commit `faa9350523495bb394d8ff1687f40e81e70345ac`
- use PEP 508 Git references for Python because Dynamo's production install paths use `uv pip` and built-wheel metadata, where `[tool.uv.sources]` would not carry the override
- add Git LFS, Rust 1.96.1, Python headers, and C build tooling only to the planner/frontend builder stages required for source installation
- temporarily skip the existing Aiconfigurator published-release consistency module because it assumes crates.io/PyPI sources and does not model this release-specific Git pin

## Why

The Dynamo 1.4.0 release branch was cut after the Aiconfigurator RC coordination window. This pins the exact Aiconfigurator source selected for the release rather than following the moving `release/0.11.0` branch.

The immutable SHA prevents the release contents from changing implicitly. Any further Aiconfigurator update requires a separate, reviewable commit.

## Runtime and container impact

Planner, frontend, benchmarks, AI Simulate, and the optional mocker integration all use the same Aiconfigurator 0.11.0 source revision. Python source builds fetch Git LFS assets and compile `aiconfigurator-core` with Maturin/Rust in isolated builder stages; the additional toolchains are not copied into runtime images.

Review follow-up in `9d70bc2`:

- exports `VIRTUAL_ENV=/opt/dynamo/venv` and places the venv on `PATH` before frontend `uv pip install` calls
- retains `/usr/local/cargo/bin` in the planner builder's final `PATH`
- copies the prebuilt `crick` wheel into the frontend dependency stage and supplies it through `UV_FIND_LINKS`, preserving the arm64 path

CI failure follow-up in `0618d4020f5`:

- makes the copied Rustup/Cargo trees writable by the planner builder's `dynamo` user and group 0, allowing Maturin/Cargo to populate the registry cache during the arm64 source build
- makes the frontend benchmarks BuildKit bind mount writable for setuptools-generated package metadata; bind-mount writes are ephemeral to the build step and do not modify the checked-out source

Runtime clean-room follow-up in `97da3f6a57e`:

- changes runtime-stage `CARGO_TARGET_DIR` from a persisted `ENV` to a build-only `ARG`
- preserves the existing `/opt/dynamo/target` artifact copy while allowing later Maturin/Cargo source installs to use their normal writable checkout target directory
- does not affect dev/local-dev images or the runtime-derived Rust GPU checks, which explicitly select writable target directories

## Temporary release and publication boundary

This Git-source override is temporary. For the final RC, the Rust dependency will return to crates.io `aiconfigurator-core` 0.11.0 and the Python dependencies will return to the published 0.11.0 artifacts before public wheel publication.

Until then, the PEP 508 direct references remain in generated Dynamo wheel metadata. Raw Artifactory staging can accept those wheels, but the later public PyPI/DevZone publication path must not consume them unchanged. Installing the affected source-based Python dependencies also requires Git, Git LFS, Rust/Maturin, and a C build toolchain.

The Rust license harvester scans Cargo registry sources rather than Git checkouts. During this temporary pin, compliance output falls back to the canonical SPDX Apache-2.0 text for `aiconfigurator-core`; Aiconfigurator currently has no separate NOTICE/COPYING file. Returning to crates.io in the final RC restores the normal exact-source license harvest.

## Validation

- commit `97da3f6a57e96d499c40d46fe6e185bd4433a704` is SSH signed, GitHub-verified, and DCO signed
- `git diff --check`
- rendered the frontend, planner, and Dynamo CUDA 13 runtime Docker templates successfully and confirmed the intended changes in the rendered output
- `ruff check --no-cache tests/dependencies/test_aiconfigurator_consistency.py`
- collected the dependency-consistency module and confirmed both tests skip with the release-specific reason (`2 skipped`)
- resolved both root and standalone bindings Cargo graphs with Rust/Cargo 1.96.1 in `--locked` mode; both selected `faa9350523495bb394d8ff1687f40e81e70345ac`
- the original source change additionally passed source builds/imports for both Aiconfigurator Python packages and locked Cargo checks for both workspaces
- [full CI run 30521901494](https://github.com/ai-dynamo/dynamo/actions/runs/30521901494): planner multi-arch build, amd64/arm64 CPU tests, and amd64/arm64 compliance checks passed; frontend multi-arch build, amd64/arm64 tests, and compliance audit passed; the run exposed the runtime clean-room target-directory leak fixed by `97da3f6a57e`
- trusted branch `pull-request/12418` points to `97da3f6a57e`
- [full CI rerun 30524480211](https://github.com/ai-dynamo/dynamo/actions/runs/30524480211) completed successfully: all image builds, runtime/framework tests, planner/frontend tests, compliance checks, status checks, and cleanup passed; the previously failing clean-room `ai-dynamo[mocker]` tests passed on both amd64 and arm64

Full multi-architecture container builds were not run locally.