### PR TITLE
feat(router): opt-in fractional-busy queue admission for large pools

### DIFF
--- a/examples/router/policy-class-queues.yaml
+++ b/examples/router/policy-class-queues.yaml
@@ -22,6 +22,16 @@ policy_classes:
     queue_policy: fcfs
     quantum: 512
     prefill_busy_threshold_frac: 16.0
+    # Pool-level gate for large fleets: start queueing once 95% of the eligible
+    # workers are prefill-busy instead of waiting for literally all of them.
+    # Omit it to keep the default all-workers-busy rule.
+    #
+    # Note the different scales: prefill_busy_threshold_frac above is a
+    # multiplier on a single worker's max_num_batched_tokens, while
+    # busy_worker_ratio is a true fraction of the worker count in (0.0, 1.0].
+    # It requires prefill_busy_threshold or prefill_busy_threshold_frac to be
+    # set, since on its own it cannot define what "busy" means.
+    busy_worker_ratio: 0.95
     request_queue_limit_per_worker: 512
     raw_isl_token_queue_limit_per_worker: 1048576
   - name: latency_cached

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -38,6 +38,16 @@ pub struct PolicyClassConfig {
     pub quantum: usize,
     pub prefill_busy_threshold: Option<usize>,
     pub prefill_busy_threshold_frac: Option<f64>,
+    /// Share of *eligible workers* that must be prefill-busy before the pool
+    /// counts as busy for queue admission, in `(0.0, 1.0]`.
+    ///
+    /// This is a pool-level ratio and is deliberately NOT named `*_frac`: the
+    /// sibling `prefill_busy_threshold_frac` is a multiplier on a single
+    /// worker's `max_num_batched_tokens` (values such as `16.0`), whereas this
+    /// knob is a true fraction of the worker count.
+    ///
+    /// `None` (the default) preserves the historical all-workers-busy rule.
+    pub busy_worker_ratio: Option<f64>,
     pub request_queue_limit_per_worker: Option<usize>,
     pub raw_isl_token_queue_limit_per_worker: Option<usize>,
     pub cached_token_queue_limit_per_worker: Option<usize>,
@@ -56,6 +66,28 @@ impl PolicyClassConfig {
             (active_tokens as f64) > threshold * (max_batched_tokens as f64)
         });
         absolute_busy || fractional_busy
+    }
+
+    /// Whether an eligible worker pool counts as busy for queue admission.
+    ///
+    /// Default (`busy_worker_ratio == None`) keeps the historical rule: the
+    /// pool is busy only when *every* eligible worker is busy.
+    ///
+    /// When set, the pool is busy once the busy share reaches the ratio. A high
+    /// ratio degrades to the historical rule on small pools, which is why no
+    /// separate minimum-pool-size knob is needed: with 2 eligible workers and a
+    /// ratio of `0.95`, `2 >= 1.9` still requires both workers to be busy.
+    ///
+    /// Returns `false` when no eligible workers were inspected so the request
+    /// falls through to `schedule`, which reports a proper `NoEndpoints` error.
+    pub fn pool_is_busy(&self, busy_workers: usize, eligible_workers: usize) -> bool {
+        if eligible_workers == 0 {
+            return false;
+        }
+        match self.busy_worker_ratio {
+            Some(ratio) => (busy_workers as f64) >= ratio * (eligible_workers as f64),
+            None => busy_workers == eligible_workers,
+        }
     }
 }
 
@@ -120,6 +152,7 @@ impl PolicyProfile {
             quantum: 1,
             prefill_busy_threshold: None,
             prefill_busy_threshold_frac: router_queue_threshold,
+            busy_worker_ratio: None,
             request_queue_limit_per_worker: None,
             raw_isl_token_queue_limit_per_worker: None,
             cached_token_queue_limit_per_worker: None,
@@ -303,6 +336,8 @@ struct RawPolicyClassConfig {
     #[serde(default)]
     prefill_busy_threshold_frac: Option<f64>,
     #[serde(default)]
+    busy_worker_ratio: Option<f64>,
+    #[serde(default)]
     request_queue_limit_per_worker: Option<usize>,
     #[serde(default)]
     raw_isl_token_queue_limit_per_worker: Option<usize>,
@@ -462,6 +497,32 @@ fn resolve_policy_class(
             raw.name
         )));
     }
+    // Range is deliberately stricter than `prefill_busy_threshold_frac`, which
+    // is a multiplier on `max_num_batched_tokens` and routinely exceeds 1.0.
+    // Rejecting out-of-range values here stops that scale being pasted into
+    // this knob, where it would silently never trigger.
+    if raw
+        .busy_worker_ratio
+        .is_some_and(|value| !value.is_finite() || value <= 0.0 || value > 1.0)
+    {
+        return Err(RouterPolicyConfigError::Validation(format!(
+            "{location} policy class {:?} busy_worker_ratio must be a finite fraction in (0.0, 1.0]",
+            raw.name
+        )));
+    }
+    // `busy_worker_ratio` only rescales how many busy workers are needed; it
+    // cannot define what "busy" means. Without a per-worker threshold every
+    // worker reports idle, so the ratio would never fire and queueing would
+    // stay disabled. Fail loudly instead of silently doing nothing.
+    if raw.busy_worker_ratio.is_some()
+        && raw.prefill_busy_threshold.is_none()
+        && raw.prefill_busy_threshold_frac.is_none()
+    {
+        return Err(RouterPolicyConfigError::Validation(format!(
+            "{location} policy class {:?} sets busy_worker_ratio but no prefill_busy_threshold or prefill_busy_threshold_frac, so no worker can ever be considered busy",
+            raw.name
+        )));
+    }
 
     let binding = match (raw.policy_family.as_deref(), raw.cache_bucket.as_deref()) {
         (None, None) => ClassBinding::Explicit,
@@ -494,6 +555,7 @@ fn resolve_policy_class(
             quantum: raw.quantum,
             prefill_busy_threshold: raw.prefill_busy_threshold,
             prefill_busy_threshold_frac: raw.prefill_busy_threshold_frac,
+            busy_worker_ratio: raw.busy_worker_ratio,
             request_queue_limit_per_worker: raw.request_queue_limit_per_worker,
             raw_isl_token_queue_limit_per_worker: raw.raw_isl_token_queue_limit_per_worker,
             cached_token_queue_limit_per_worker: raw.cached_token_queue_limit_per_worker,
@@ -645,6 +707,102 @@ models:
         assert_eq!(unmatched.default_class().name, "root-default");
         assert_eq!(unmatched.default_class().prefill_busy_threshold, Some(100));
         assert_eq!(unmatched.default_class().prefill_busy_threshold_frac, None);
+    }
+
+    fn class_with_busy_worker_ratio(ratio: Option<f64>) -> PolicyClassConfig {
+        PolicyClassConfig {
+            name: "test".to_string(),
+            queue_policy: RouterQueuePolicy::Fcfs,
+            admission: None,
+            quantum: 1,
+            prefill_busy_threshold: Some(0),
+            prefill_busy_threshold_frac: None,
+            busy_worker_ratio: ratio,
+            request_queue_limit_per_worker: None,
+            raw_isl_token_queue_limit_per_worker: None,
+            cached_token_queue_limit_per_worker: None,
+        }
+    }
+
+    #[test]
+    fn pool_is_busy_defaults_to_every_worker_busy() {
+        let class = class_with_busy_worker_ratio(None);
+        assert!(!class.pool_is_busy(127, 128));
+        assert!(class.pool_is_busy(128, 128));
+    }
+
+    #[test]
+    fn pool_is_busy_triggers_once_the_ratio_is_reached() {
+        let class = class_with_busy_worker_ratio(Some(0.95));
+        // 0.95 * 128 = 121.6, so 122 busy workers trip the gate while 121 do not.
+        assert!(!class.pool_is_busy(121, 128));
+        assert!(class.pool_is_busy(122, 128));
+    }
+
+    #[test]
+    fn pool_is_busy_high_ratio_keeps_small_pools_on_the_all_busy_rule() {
+        // Why no separate minimum-pool-size knob is needed: on a 2-worker pool
+        // a 0.95 ratio still requires 2 >= 1.9, i.e. every worker busy.
+        let class = class_with_busy_worker_ratio(Some(0.95));
+        assert!(!class.pool_is_busy(1, 2));
+        assert!(class.pool_is_busy(2, 2));
+    }
+
+    #[test]
+    fn pool_is_busy_is_false_without_eligible_workers() {
+        // Must stay false so the request falls through to `schedule` and gets a
+        // proper NoEndpoints error instead of being queued forever.
+        assert!(!class_with_busy_worker_ratio(None).pool_is_busy(0, 0));
+        assert!(!class_with_busy_worker_ratio(Some(0.5)).pool_is_busy(0, 0));
+    }
+
+    fn busy_ratio_yaml(class_fields: &str) -> String {
+        format!(
+            "default_policy_family: standard\nuncached_isl_buckets:\n  - min_tokens: 0\n    bucket: all\npolicy_classes:\n  - name: ratioed\n    policy_family: standard\n    cache_bucket: all\n    quantum: 4\n{class_fields}"
+        )
+    }
+
+    #[test]
+    fn busy_worker_ratio_rejects_the_prefill_threshold_frac_scale() {
+        // `prefill_busy_threshold_frac` is a multiplier and is routinely 16.0.
+        // Pasting that scale here must fail loudly rather than never trigger.
+        let err = RouterPolicyConfig::from_yaml(&busy_ratio_yaml(
+            "    prefill_busy_threshold: 10\n    busy_worker_ratio: 16.0\n",
+        ))
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("busy_worker_ratio"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn busy_worker_ratio_requires_a_per_worker_busy_threshold() {
+        // Without a per-worker threshold no worker is ever busy, so the ratio
+        // would silently never fire.
+        let err = RouterPolicyConfig::from_yaml(&busy_ratio_yaml("    busy_worker_ratio: 0.9\n"))
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("no prefill_busy_threshold"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn busy_worker_ratio_parses_and_defaults_to_none() {
+        let config = RouterPolicyConfig::from_yaml(&busy_ratio_yaml(
+            "    prefill_busy_threshold: 10\n    busy_worker_ratio: 0.9\n",
+        ))
+        .unwrap();
+        let profile = config.resolve_profile(None, None, RouterQueuePolicy::Fcfs);
+        assert_eq!(profile.default_class().busy_worker_ratio, Some(0.9));
+
+        assert_eq!(
+            PolicyProfile::synthetic(Some(16.0), RouterQueuePolicy::Fcfs)
+                .default_class()
+                .busy_worker_ratio,
+            None
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -675,6 +675,33 @@ impl<
     }
 }
 
+/// Count `(busy, eligible)` prefill workers across the eligible set.
+///
+/// Split out of `all_workers_prefill_busy_with` so the counting can be tested
+/// without naming every generic parameter of `SchedulerQueueActor`. Unlike the
+/// default all-workers-busy path this cannot short-circuit, because the
+/// fractional rule needs the total as well as the busy count.
+fn count_busy_eligible_workers<C: WorkerConfigLike>(
+    active_tokens: &HashMap<crate::protocols::WorkerWithDpRank, usize>,
+    configs: &HashMap<WorkerId, C>,
+    class: &PolicyClassConfig,
+    eligibility: RoutingEligibility<'_>,
+) -> (usize, usize) {
+    let mut eligible_workers = 0usize;
+    let mut busy_workers = 0usize;
+    eligibility.for_each_eligible_worker_rank(configs, |worker, config| {
+        eligible_workers += 1;
+        let max_batched = config
+            .max_num_batched_tokens()
+            .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS);
+        let tokens = active_tokens.get(&worker).copied().unwrap_or(0);
+        if class.worker_is_busy(tokens, max_batched) {
+            busy_workers += 1;
+        }
+    });
+    (busy_workers, eligible_workers)
+}
+
 impl<
     P: SequencePublisher + 'static,
     C: WorkerConfigLike + Send + Sync + 'static,
@@ -1636,17 +1663,29 @@ impl<
             return class.worker_is_busy(tokens, max_batched);
         }
 
-        let mut checked_any = false;
-        let has_available = eligibility.any_eligible_worker_rank(configs, |worker, config| {
-            checked_any = true;
-            let max_batched = config
-                .max_num_batched_tokens()
-                .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS);
-            let tokens = active_tokens.get(&worker).copied().unwrap_or(0);
-            !class.worker_is_busy(tokens, max_batched)
-        });
+        // Default rule: stop at the first idle worker. Kept as a separate path
+        // so the common case still short-circuits instead of walking the pool.
+        if class.busy_worker_ratio.is_none() {
+            let mut checked_any = false;
+            let has_available = eligibility.any_eligible_worker_rank(configs, |worker, config| {
+                checked_any = true;
+                let max_batched = config
+                    .max_num_batched_tokens()
+                    .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS);
+                let tokens = active_tokens.get(&worker).copied().unwrap_or(0);
+                !class.worker_is_busy(tokens, max_batched)
+            });
 
-        checked_any && !has_available
+            return checked_any && !has_available;
+        }
+
+        // Fractional rule needs both counts, so it cannot short-circuit.
+        let (busy_workers, eligible_workers) =
+            count_busy_eligible_workers(active_tokens, configs, class, eligibility);
+
+        // Returns false when no eligible workers were inspected, preserving the
+        // fall-through to `schedule` and its `NoEndpoints` error.
+        class.pool_is_busy(busy_workers, eligible_workers)
     }
 
     fn add_class_counters(&self, class_index: usize, snapshot: QueueSnapshot) {
@@ -1715,6 +1754,65 @@ mod tests {
 
     fn decay_now() -> Instant {
         Instant::now()
+    }
+
+    fn busy_counting_class(busy_worker_ratio: Option<f64>) -> PolicyClassConfig {
+        PolicyClassConfig {
+            name: "count-test".to_string(),
+            queue_policy: crate::config::RouterQueuePolicy::Fcfs,
+            admission: None,
+            quantum: 1,
+            // A worker is busy above 50 active prefill tokens.
+            prefill_busy_threshold: Some(50),
+            prefill_busy_threshold_frac: None,
+            busy_worker_ratio,
+            request_queue_limit_per_worker: None,
+            raw_isl_token_queue_limit_per_worker: None,
+            cached_token_queue_limit_per_worker: None,
+        }
+    }
+
+    #[test]
+    fn count_busy_eligible_workers_walks_the_whole_pool() {
+        let worker = |tokens: u64| SimpleWorkerConfig {
+            max_num_batched_tokens: Some(tokens),
+            ..Default::default()
+        };
+        let configs = HashMap::from([(1, worker(100)), (2, worker(100)), (3, worker(100))]);
+        let active_tokens = HashMap::from([
+            (WorkerWithDpRank::new(1, 0), 80),
+            (WorkerWithDpRank::new(2, 0), 80),
+            (WorkerWithDpRank::new(3, 0), 10),
+        ]);
+        let constraints = crate::protocols::RoutingConstraints::default();
+        let class = busy_counting_class(Some(0.6));
+
+        // The idle worker must not stop the walk: 2 busy out of 3 eligible.
+        let counts = count_busy_eligible_workers(
+            &active_tokens,
+            &configs,
+            &class,
+            RoutingEligibility::new(None, None, None, &constraints),
+        );
+        assert_eq!(counts, (2, 3));
+        assert!(class.pool_is_busy(counts.0, counts.1));
+
+        // Same pool under the default rule is not busy, since one worker is idle.
+        assert!(!busy_counting_class(None).pool_is_busy(counts.0, counts.1));
+    }
+
+    #[test]
+    fn count_busy_eligible_workers_reports_zero_for_an_empty_pool() {
+        let configs: HashMap<WorkerId, SimpleWorkerConfig> = HashMap::new();
+        let active_tokens = HashMap::new();
+        let constraints = crate::protocols::RoutingConstraints::default();
+        let counts = count_busy_eligible_workers(
+            &active_tokens,
+            &configs,
+            &busy_counting_class(Some(0.6)),
+            RoutingEligibility::new(None, None, None, &constraints),
+        );
+        assert_eq!(counts, (0, 0));
     }
 
     struct FixedPrefillLoadEstimator {


### PR DESCRIPTION
## Overview:

Adds an opt-in `busy_worker_ratio` to the router policy class so large fleets can start queueing before literally every eligible worker is prefill-busy.

## Details:

The gate is all-or-nothing today: the pool counts as busy only when every eligible worker is busy. With 128 workers and 125 busy it stays open, the remaining three absorb the whole arrival rate, and queueing only kicks in once the deployment is already saturated.

With `busy_worker_ratio` set, the pool counts as busy once the busy share reaches the ratio. Unset, nothing changes — including the short-circuit walk that stops at the first idle worker, so the default path keeps its current cost.

Three decisions worth pushing back on:

**Naming and range.** This is a true fraction in `(0.0, 1.0]`, but the sibling `prefill_busy_threshold_frac` is a multiplier on a single worker's `max_num_batched_tokens` and is `16.0` in our own sample config. Hence the different name and the range validation — pasting `16.0` here would otherwise parse fine and silently never fire. Config also rejects the knob when no per-worker busy threshold is set, since on its own it cannot define what "busy" means.

**No minimum-pool-size knob.** A high ratio already degrades to the old rule on small pools: with 2 eligible workers at 0.95, `2 >= 1.9` still needs both busy. Happy to add an explicit floor if you would rather not rely on that.

**Configurable rather than a fixed fraction.** The issue sketches a boolean. One fixed value will not suit both an 8-worker and a 128-worker deployment, so I made it a ratio. Easy to change.

No CLI argument here. Wiring one means `RouterConfig`, the `PolicyProfile::synthetic` signature and its 11 call sites, and the Python bindings — none of which is needed to use this through the policy config file. Can follow up if you want it.

## Where should the reviewer start?

`PolicyClassConfig::pool_is_busy` in `lib/kv-router/src/scheduling/policy_config.rs` is the entire decision. `all_workers_prefill_busy_with` in `lib/kv-router/src/scheduling/queue.rs` is where the default and fractional paths split.

Two behaviours worth confirming: the empty-pool case still returns false so the request falls through to `schedule` and its `NoEndpoints` error instead of being queued, and the pinned-worker branch is untouched.

## Related Issues

- Closes #12311
