### PR TITLE
fix(snapshot): isolate Linux mount operations

### DIFF
--- a/deploy/snapshot/internal/runtime/mounts.go
+++ b/deploy/snapshot/internal/runtime/mounts.go
@@ -1,42 +1,14 @@
 package runtime
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"github.com/moby/sys/mountinfo"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
-
-// ReadMountInfo reads and parses mountinfo for a container process via /host/proc.
-func ReadMountInfo(pid int) ([]types.MountInfo, error) {
-	mountinfoPath := fmt.Sprintf("%s/%d/mountinfo", HostProcPath, pid)
-	f, err := os.Open(mountinfoPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open mountinfo: %w", err)
-	}
-	defer f.Close()
-
-	infos, err := mountinfo.GetMountsFromReader(f, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse mountinfo: %w", err)
-	}
-
-	mounts := make([]types.MountInfo, 0, len(infos))
-	for _, info := range infos {
-		mounts = append(mounts, types.MountInfo{
-			MountPoint: info.Mountpoint,
-			FSType:     info.FSType,
-			VFSOptions: info.VFSOptions,
-		})
-	}
-	return mounts, nil
-}
 
 // ClassifyMounts sets IsOCIManaged on each mount by matching against the
 // container's OCI spec (mounts, masked paths, readonly paths).
@@ -109,20 +81,4 @@ func BuildMountPolicy(mounts []types.MountInfo, rootFS string, maskedPaths []str
 	}
 
 	return extMap, skipped
-}
-
-// RemountProcSys remounts /proc/sys read-write or read-only.
-func RemountProcSys(rw bool) error {
-	flags := uintptr(syscall.MS_BIND | syscall.MS_REMOUNT)
-	if !rw {
-		flags |= syscall.MS_RDONLY
-	}
-	if err := syscall.Mount("proc", "/proc/sys", "", flags, ""); err != nil {
-		mode := "rw"
-		if !rw {
-			mode = "ro"
-		}
-		return fmt.Errorf("failed to remount /proc/sys %s: %w", mode, err)
-	}
-	return nil
 }

--- a/deploy/snapshot/internal/runtime/mounts_linux.go
+++ b/deploy/snapshot/internal/runtime/mounts_linux.go
@@ -1,0 +1,54 @@
+//go:build linux
+
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/moby/sys/mountinfo"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+)
+
+// ReadMountInfo reads and parses mountinfo for a container process via /host/proc.
+func ReadMountInfo(pid int) ([]types.MountInfo, error) {
+	mountinfoPath := fmt.Sprintf("%s/%d/mountinfo", HostProcPath, pid)
+	f, err := os.Open(mountinfoPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open mountinfo: %w", err)
+	}
+	defer f.Close()
+
+	infos, err := mountinfo.GetMountsFromReader(f, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse mountinfo: %w", err)
+	}
+
+	mounts := make([]types.MountInfo, 0, len(infos))
+	for _, info := range infos {
+		mounts = append(mounts, types.MountInfo{
+			MountPoint: info.Mountpoint,
+			FSType:     info.FSType,
+			VFSOptions: info.VFSOptions,
+		})
+	}
+	return mounts, nil
+}
+
+// RemountProcSys remounts /proc/sys read-write or read-only.
+func RemountProcSys(rw bool) error {
+	flags := uintptr(syscall.MS_BIND | syscall.MS_REMOUNT)
+	if !rw {
+		flags |= syscall.MS_RDONLY
+	}
+	if err := syscall.Mount("proc", "/proc/sys", "", flags, ""); err != nil {
+		mode := "rw"
+		if !rw {
+			mode = "ro"
+		}
+		return fmt.Errorf("failed to remount /proc/sys %s: %w", mode, err)
+	}
+	return nil
+}

--- a/deploy/snapshot/internal/runtime/mounts_unsupported.go
+++ b/deploy/snapshot/internal/runtime/mounts_unsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package runtime
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
+)
+
+// ReadMountInfo is unsupported outside Linux.
+func ReadMountInfo(_ int) ([]types.MountInfo, error) {
+	return nil, fmt.Errorf("reading mountinfo is not supported on %s", runtime.GOOS)
+}
+
+// RemountProcSys is unsupported outside Linux.
+func RemountProcSys(_ bool) error {
+	return fmt.Errorf("remounting /proc/sys is not supported on %s", runtime.GOOS)
+}


### PR DESCRIPTION
## Summary

- allow Darwin development builds by isolating Linux-only mountinfo parsing and remount syscalls behind a Linux build constraint
- keep platform-independent mount classification and policy logic available on Darwin
- return explicit errors when Linux-only mount operations are invoked on Darwin
- Windows and general non-Unix portability are outside the scope of this change

## Validation

- `TMPDIR=/tmp go test ./...` on `darwin/arm64`
- `GOOS=linux GOARCH=amd64 go test -exec=/usr/bin/true ./...`
- `git diff --check`