### PR TITLE
feat(logging): decouple OTLP export from console log format

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -359,12 +359,11 @@ publish loop observe the shutdown signal before resources are released.
 
 ## Telemetry
 
-> **Requires `DYN_LOGGING_JSONL=1` + `OTEL_EXPORT_ENABLED=1`** for engine
-> telemetry to record anything. In any other configuration the calls
-> silently no-op; one process-level `WARN` fires on first such call so the
-> misconfiguration is visible at default log levels. Trace propagation
-> (`context.trace_headers()`) and the auto-recorded `engine.generate`
-> attributes are NOT subject to this gate — they work regardless.
+> Engine telemetry requires the trace-context layer, enabled by
+> `OTEL_EXPORT_ENABLED=1`, `DYN_LOGGING_CONSOLE_FORMAT=jsonl`, or the legacy
+> `DYN_LOGGING_JSONL=1` switch. `OTEL_EXPORT_ENABLED=1` is still required to
+> export the resulting spans. Without the layer, calls silently no-op and one
+> process-level `WARN` fires on the first call.
 
 The framework opens an `engine.generate` span around every `generate()` call
 (see the Rust backend-common README for the full attribute table). Engine
@@ -410,8 +409,9 @@ Two entry points, one `SpanProxy` returned by both:
 `set_status(status, description)`, `close()`.
 
 **Bridge dependency.** The recording surface needs the
-`tracing-opentelemetry` layer installed, which today happens only when
-`DYN_LOGGING_JSONL=1` AND `OTEL_EXPORT_ENABLED=1`. Without the bridge:
+`tracing-opentelemetry` layer installed. Enable it with `OTEL_EXPORT_ENABLED=1`,
+`DYN_LOGGING_CONSOLE_FORMAT=jsonl`, or the legacy `DYN_LOGGING_JSONL=1` switch.
+Without the bridge:
 
 - `current_span(...)` returns a no-op `SpanProxy` (all method calls silent).
 - `start_span(...)` returns a no-op `SpanProxy`.
@@ -419,9 +419,9 @@ Two entry points, one `SpanProxy` returned by both:
   hit the missing-bridge path, so operators can discover the missing
   configuration. Subsequent no-ops in the same process are silent.
 
-Trace propagation (`context.trace_headers()`) and the `Context` cancellation
-/ identity surface do NOT depend on the bridge — those work regardless of
-mode.
+Trace propagation (`context.trace_headers()`) also needs an available local or
+inbound trace context. The `Context` cancellation and request-identity surface
+does not depend on the bridge.
 
 Performance note: attribute values are rendered via Python `repr()` for
 non-primitive types. Don't pass large objects per-token inside hot loops;

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/observability.md
@@ -248,7 +248,8 @@ Key implementation files:
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `DYN_LOGGING_JSONL` | Enable JSONL logging (required for tracing) | `false` | `true` |
+| `DYN_LOGGING_CONSOLE_FORMAT` | Console output format (`readable` or `jsonl`) | `readable` | `readable` |
+| `DYN_LOGGING_JSONL` | Legacy JSONL and local trace-context fallback | `false` | `true` |
 | `OTEL_EXPORT_ENABLED` | Enable OTLP trace export | `false` | `true` |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP gRPC endpoint for Tempo | `http://localhost:4317` | `http://tempo:4317` |
 | `OTEL_SERVICE_NAME` | Service name shown in Grafana Tempo | `dynamo` | `dynamo-worker-decode` |
@@ -304,7 +305,7 @@ cd examples/backends/sglang/launch
 Or manually for an aggregated deployment:
 
 ```bash
-export DYN_LOGGING_JSONL=true
+export DYN_LOGGING_CONSOLE_FORMAT=readable
 export OTEL_EXPORT_ENABLED=true
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
 

--- a/docs/fern/pages/kubernetes/installation/observability.md
+++ b/docs/fern/pages/kubernetes/installation/observability.md
@@ -13,7 +13,7 @@ Dynamo emits three signals — **metrics** (Prometheus), **logs** (structured te
 |--------|-----------------|--------------|
 | Metrics | `DYN_SYSTEM_PORT` (workers/router); the frontend serves metrics on its HTTP port | Prometheus |
 | Traces | `OTEL_EXPORT_ENABLED=true` + an OTLP endpoint | Tempo |
-| Logs | `DYN_LOGGING_JSONL=true` (+ `OTEL_EXPORT_ENABLED` to export) | Loki |
+| Logs | `DYN_LOGGING_CONSOLE_FORMAT=jsonl` for console JSONL; `OTEL_EXPORT_ENABLED=true` to export | Loki |
 | FPM traces | `DYN_FPM_TRACE=1` or `--fpm-trace` | Rotating gzip JSONL files |
 | Health status | `/live` and `/health` endpoints | Supervisors or Kubernetes probes |
 | Request traces | `DYN_REQUEST_TRACE=1` or `DYN_REQUEST_TRACE_RECORDS` | Files, NATS, stderr, or OTLP logs |

--- a/docs/fern/pages/kubernetes/operations/observability.mdx
+++ b/docs/fern/pages/kubernetes/operations/observability.mdx
@@ -179,8 +179,8 @@ metadata:
   name: vllm-agg-logging
 spec:
   envs:
-    - name: DYN_LOGGING_JSONL
-      value: "true"
+    - name: DYN_LOGGING_CONSOLE_FORMAT
+      value: "jsonl"
     - name: DYN_LOG
       value: "info"
 ```

--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -29,7 +29,7 @@ Every Dynamo process reads its own environment at startup, so set these on each 
 
     ```bash
     export DYN_SYSTEM_PORT=8081
-    export DYN_LOGGING_JSONL=true
+    export DYN_LOGGING_CONSOLE_FORMAT=jsonl
     export DYN_LOG=info
 
     # Frontend (serves dynamo_frontend_* on DYN_HTTP_PORT, default 8000)
@@ -51,8 +51,8 @@ Every Dynamo process reads its own environment at startup, so set these on each 
       name: vllm-agg-tracing
     spec:
       envs:                              # applied to every component
-        - name: DYN_LOGGING_JSONL
-          value: "true"
+        - name: DYN_LOGGING_CONSOLE_FORMAT
+          value: "jsonl"
         - name: OTEL_EXPORT_ENABLED
           value: "true"
         - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
@@ -150,8 +150,14 @@ Every Dynamo process reads its own environment at startup, so set these on each 
 
 ## Logging
 
+<ParamField path="DYN_LOGGING_CONSOLE_FORMAT" type="string" default="readable">
+  Console output format. Supported values are `readable` and `jsonl`; surrounding whitespace is ignored. When unset or blank, Dynamo falls back to `DYN_LOGGING_JSONL` for backward compatibility. This setting does not control OTLP export.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>readable</Badge> <Badge intent="note" minimal>jsonl</Badge></span>
+</ParamField>
+
 <ParamField path="DYN_LOGGING_JSONL" type="boolean" default="false">
-  Emit logs as JSONL. When enabled, logs include `trace_id` and `span_id` fields and spans are created per request. Recommended for Loki.
+  Legacy JSONL switch used when `DYN_LOGGING_CONSOLE_FORMAT` is unset or blank. It also remains a local trace-context enablement signal for backward compatibility when the new setting explicitly selects readable output.
 </ParamField>
 
 <ParamField path="DYN_LOGGING_SPAN_EVENTS" type="boolean" default="false">

--- a/docs/fern/pages/reference/observability/logging.mdx
+++ b/docs/fern/pages/reference/observability/logging.mdx
@@ -11,17 +11,22 @@ Loki workflow, see [Observe a Local Deployment](../../cli/operations/observabili
 
 ## Output Formats
 
-Set `DYN_LOGGING_JSONL=false` for readable text:
+Set `DYN_LOGGING_CONSOLE_FORMAT=readable` for readable text (the default):
 
 ```text
 2025-09-02T15:50:01.770028Z INFO main.init: VllmWorker for Qwen/Qwen3-0.6B has been initialized
 ```
 
-Set `DYN_LOGGING_JSONL=true` for structured output:
+Set `DYN_LOGGING_CONSOLE_FORMAT=jsonl` for structured output:
 
 ```json
 {"time":"2025-10-31T21:06:45.397194Z","level":"DEBUG","target":"dynamo_runtime::pipeline::network::tcp::server","message":"Registering new TcpStream","span_name":"http-request","trace_id":"80196f3e3a6fdf06d23bb9ada3788518","span_id":"f7e487a9d2a6bf38","x_request_id":"test-trace-001"}
 ```
+
+`DYN_LOGGING_CONSOLE_FORMAT` accepts only `readable` or `jsonl`, ignoring surrounding whitespace.
+When it is unset or blank, Dynamo falls back to the legacy `DYN_LOGGING_JSONL` switch. The legacy
+switch also continues to enable local trace-context propagation for backward compatibility, even
+when the new setting explicitly selects readable output.
 
 Fields vary by event and active span. Common fields include:
 
@@ -64,11 +69,14 @@ export DYN_LOG='info,dynamo_runtime::system_status_server=trace'
 generic endpoint for both signals:
 
 ```bash
-export DYN_LOGGING_JSONL=true
+export DYN_LOGGING_CONSOLE_FORMAT=readable
 export OTEL_EXPORT_ENABLED=true
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 ```
+
+Console formatting does not affect OTLP export; use `jsonl` instead if the local stderr stream also
+needs machine-readable records.
 
 Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` for signal-specific
 destinations. Signal-specific endpoints are used as-is. For a generic `http/protobuf` endpoint,

--- a/lib/backend-common/src/adapter.rs
+++ b/lib/backend-common/src/adapter.rs
@@ -258,8 +258,8 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         }
 
         // Capture this worker's trace identity once, for stamping on the
-        // first non-empty chunk. Yields None in non-JSONL deployments where
-        // `DistributedTraceIdLayer` is not installed.
+        // first non-empty chunk. Yields None when `DistributedTraceIdLayer`
+        // is not installed.
         let worker_trace_link: Option<dynamo_llm::protocols::common::preprocessor::TraceLink> = {
             let link = span.in_scope(|| {
                 dynamo_runtime::logging::get_distributed_tracing_context().map(|tc| {
@@ -272,7 +272,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             if link.is_none() {
                 tracing::trace!(
                     "worker_trace_link inactive — no DistributedTraceContext on \
-                     engine.generate (requires JSONL mode + OTEL_EXPORT_ENABLED)"
+                     engine.generate (enable OTLP export or JSONL trace context)"
                 );
             }
             link

--- a/lib/bindings/python/rust/context.rs
+++ b/lib/bindings/python/rust/context.rs
@@ -25,7 +25,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Process-wide guard: once-per-process WARN when telemetry calls hit a
 /// parent `engine.generate` span that has no OTel context (i.e., the
-/// `tracing-opentelemetry` layer isn't installed — non-JSONL deployments).
+/// `tracing-opentelemetry` layer isn't installed).
 /// One log line is enough to surface the configuration issue; rate-limiting
 /// to once avoids flooding logs in high-QPS workers.
 ///
@@ -40,7 +40,8 @@ fn warn_bridge_missing_once(method: &str) {
         tracing::warn!(
             method,
             "telemetry call is a no-op: OTel bridge layer not installed \
-             (needs DYN_LOGGING_JSONL=1 + OTEL_EXPORT_ENABLED=1). \
+             (enable OTEL_EXPORT_ENABLED=1, DYN_LOGGING_CONSOLE_FORMAT=jsonl, \
+             or the legacy DYN_LOGGING_JSONL=1 switch). \
              Engine telemetry attributes / events / child spans are NOT \
              being recorded. Further no-ops in this process are silent."
         );
@@ -425,8 +426,8 @@ impl Context {
     /// bridge is installed, so downstream engine internals (vLLM scheduler,
     /// TRT-LLM forward, SGLang KV transfer) nest UNDER `engine.generate`.
     /// Falls back to the inbound `DistributedTraceContext` for legacy
-    /// callers, Python-instantiated test contexts, and non-JSONL deployments
-    /// without the bridge.
+    /// callers, Python-instantiated test contexts, and deployments without
+    /// the bridge.
     ///
     /// Always emits `traceparent`. Also emits `tracestate`, `x-request-id`,
     /// and `request-id` when the upstream propagated them.

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -436,8 +436,8 @@ pub enum ConsoleLogFormat {
 impl ConsoleLogFormat {
     fn from_env_value(value: &str) -> Option<Self> {
         match value.to_ascii_lowercase().as_str() {
-            "readable" | "text" => Some(Self::Readable),
-            "jsonl" | "json" => Some(Self::Jsonl),
+            "readable" => Some(Self::Readable),
+            "jsonl" => Some(Self::Jsonl),
             _ => None,
         }
     }
@@ -450,19 +450,30 @@ impl ConsoleLogFormat {
     }
 }
 
-/// Check whether JSONL logging enabled
-/// Set the `DYN_LOGGING_JSONL` environment variable a [`is_truthy`] value
-pub fn jsonl_logging_enabled() -> bool {
+/// Return whether the legacy `DYN_LOGGING_JSONL` switch is enabled.
+///
+/// This remains a separate compatibility signal because older deployments
+/// also use it to enable local trace-context propagation.
+pub(crate) fn legacy_jsonl_logging_enabled() -> bool {
     env_is_truthy(environment_names::logging::DYN_LOGGING_JSONL)
 }
 
 /// Return the console log format.
 ///
 /// `DYN_LOGGING_CONSOLE_FORMAT` takes precedence. `DYN_LOGGING_JSONL` remains
-/// supported as a legacy alias for selecting JSONL console output.
+/// supported as a legacy fallback when the new setting is unset or blank.
 pub fn console_log_format() -> ConsoleLogFormat {
+    let legacy_format = || {
+        if legacy_jsonl_logging_enabled() {
+            ConsoleLogFormat::Jsonl
+        } else {
+            ConsoleLogFormat::Readable
+        }
+    };
+
     match std::env::var(environment_names::logging::DYN_LOGGING_CONSOLE_FORMAT) {
-        Ok(value) => match ConsoleLogFormat::from_env_value(&value) {
+        Ok(value) if value.trim().is_empty() => legacy_format(),
+        Ok(value) => match ConsoleLogFormat::from_env_value(value.trim()) {
             Some(format) => format,
             None => {
                 eprintln!(
@@ -473,9 +484,13 @@ pub fn console_log_format() -> ConsoleLogFormat {
                 ConsoleLogFormat::Readable
             }
         },
-        Err(_) if jsonl_logging_enabled() => ConsoleLogFormat::Jsonl,
-        Err(_) => ConsoleLogFormat::Readable,
+        Err(_) => legacy_format(),
     }
+}
+
+/// Return whether the effective console log format is JSONL.
+pub fn jsonl_logging_enabled() -> bool {
+    console_log_format() == ConsoleLogFormat::Jsonl
 }
 
 /// Check whether logging with ANSI terminal escape codes and colors is disabled.
@@ -562,44 +577,30 @@ mod tests {
     fn test_console_log_format() {
         use environment_names::logging;
 
-        temp_env::with_vars(
-            vec![
-                (logging::DYN_LOGGING_CONSOLE_FORMAT, None::<&str>),
-                (logging::DYN_LOGGING_JSONL, None::<&str>),
-            ],
-            || {
-                assert_eq!(console_log_format(), ConsoleLogFormat::Readable);
-            },
-        );
-
-        temp_env::with_vars(
-            vec![
-                (logging::DYN_LOGGING_CONSOLE_FORMAT, None::<&str>),
-                (logging::DYN_LOGGING_JSONL, Some("true")),
-            ],
-            || {
-                assert_eq!(console_log_format(), ConsoleLogFormat::Jsonl);
-            },
-        );
-
-        temp_env::with_vars(
-            vec![
-                (logging::DYN_LOGGING_CONSOLE_FORMAT, Some("readable")),
-                (logging::DYN_LOGGING_JSONL, Some("true")),
-            ],
-            || {
-                assert_eq!(console_log_format(), ConsoleLogFormat::Readable);
-            },
-        );
-
-        temp_env::with_vars(
-            vec![
-                (logging::DYN_LOGGING_CONSOLE_FORMAT, Some("jsonl")),
-                (logging::DYN_LOGGING_JSONL, Some("false")),
-            ],
-            || {
-                assert_eq!(console_log_format(), ConsoleLogFormat::Jsonl);
-            },
-        );
+        for (console_format, legacy_jsonl, expected) in [
+            (None, None, ConsoleLogFormat::Readable),
+            (None, Some("true"), ConsoleLogFormat::Jsonl),
+            (Some(""), Some("true"), ConsoleLogFormat::Jsonl),
+            (Some("   "), Some("true"), ConsoleLogFormat::Jsonl),
+            (Some(" jsonl "), Some("false"), ConsoleLogFormat::Jsonl),
+            (Some("readable"), Some("true"), ConsoleLogFormat::Readable),
+            (Some("jsonl"), Some("false"), ConsoleLogFormat::Jsonl),
+            (
+                Some("unsupported"),
+                Some("true"),
+                ConsoleLogFormat::Readable,
+            ),
+        ] {
+            temp_env::with_vars(
+                [
+                    (logging::DYN_LOGGING_CONSOLE_FORMAT, console_format),
+                    (logging::DYN_LOGGING_JSONL, legacy_jsonl),
+                ],
+                || {
+                    assert_eq!(console_log_format(), expected);
+                    assert_eq!(jsonl_logging_enabled(), expected == ConsoleLogFormat::Jsonl);
+                },
+            );
+        }
     }
 }

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -427,10 +427,55 @@ pub use dynamo_truthy::{
     env_is_falsey, env_is_truthy, is_falsey, is_truthy, parse_bool, parse_bool_opt,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsoleLogFormat {
+    Readable,
+    Jsonl,
+}
+
+impl ConsoleLogFormat {
+    fn from_env_value(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "readable" | "text" => Some(Self::Readable),
+            "jsonl" | "json" => Some(Self::Jsonl),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Readable => "readable",
+            Self::Jsonl => "jsonl",
+        }
+    }
+}
+
 /// Check whether JSONL logging enabled
 /// Set the `DYN_LOGGING_JSONL` environment variable a [`is_truthy`] value
 pub fn jsonl_logging_enabled() -> bool {
     env_is_truthy(environment_names::logging::DYN_LOGGING_JSONL)
+}
+
+/// Return the console log format.
+///
+/// `DYN_LOGGING_CONSOLE_FORMAT` takes precedence. `DYN_LOGGING_JSONL` remains
+/// supported as a legacy alias for selecting JSONL console output.
+pub fn console_log_format() -> ConsoleLogFormat {
+    match std::env::var(environment_names::logging::DYN_LOGGING_CONSOLE_FORMAT) {
+        Ok(value) => match ConsoleLogFormat::from_env_value(&value) {
+            Some(format) => format,
+            None => {
+                eprintln!(
+                    "Invalid {} value '{}'; using readable console logs",
+                    environment_names::logging::DYN_LOGGING_CONSOLE_FORMAT,
+                    value
+                );
+                ConsoleLogFormat::Readable
+            }
+        },
+        Err(_) if jsonl_logging_enabled() => ConsoleLogFormat::Jsonl,
+        Err(_) => ConsoleLogFormat::Readable,
+    }
 }
 
 /// Check whether logging with ANSI terminal escape codes and colors is disabled.
@@ -511,5 +556,50 @@ mod tests {
         // Test opposite behavior
         assert!(!is_truthy("0"));
         assert!(!is_falsey("1"));
+    }
+
+    #[test]
+    fn test_console_log_format() {
+        use environment_names::logging;
+
+        temp_env::with_vars(
+            vec![
+                (logging::DYN_LOGGING_CONSOLE_FORMAT, None::<&str>),
+                (logging::DYN_LOGGING_JSONL, None::<&str>),
+            ],
+            || {
+                assert_eq!(console_log_format(), ConsoleLogFormat::Readable);
+            },
+        );
+
+        temp_env::with_vars(
+            vec![
+                (logging::DYN_LOGGING_CONSOLE_FORMAT, None::<&str>),
+                (logging::DYN_LOGGING_JSONL, Some("true")),
+            ],
+            || {
+                assert_eq!(console_log_format(), ConsoleLogFormat::Jsonl);
+            },
+        );
+
+        temp_env::with_vars(
+            vec![
+                (logging::DYN_LOGGING_CONSOLE_FORMAT, Some("readable")),
+                (logging::DYN_LOGGING_JSONL, Some("true")),
+            ],
+            || {
+                assert_eq!(console_log_format(), ConsoleLogFormat::Readable);
+            },
+        );
+
+        temp_env::with_vars(
+            vec![
+                (logging::DYN_LOGGING_CONSOLE_FORMAT, Some("jsonl")),
+                (logging::DYN_LOGGING_JSONL, Some("false")),
+            ],
+            || {
+                assert_eq!(console_log_format(), ConsoleLogFormat::Jsonl);
+            },
+        );
     }
 }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -34,7 +34,7 @@ pub mod logging {
     /// Enable JSONL logging format
     pub const DYN_LOGGING_JSONL: &str = "DYN_LOGGING_JSONL";
 
-    /// Console log format: "readable" or "jsonl"
+    /// Console log format: "readable" or "jsonl"; blank uses the legacy fallback
     pub const DYN_LOGGING_CONSOLE_FORMAT: &str = "DYN_LOGGING_CONSOLE_FORMAT";
 
     /// Disable ANSI terminal colors in logs

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -34,6 +34,9 @@ pub mod logging {
     /// Enable JSONL logging format
     pub const DYN_LOGGING_JSONL: &str = "DYN_LOGGING_JSONL";
 
+    /// Console log format: "readable" or "jsonl"
+    pub const DYN_LOGGING_CONSOLE_FORMAT: &str = "DYN_LOGGING_CONSOLE_FORMAT";
+
     /// Disable ANSI terminal colors in logs
     pub const DYN_SDK_DISABLE_ANSI_LOGGING: &str = "DYN_SDK_DISABLE_ANSI_LOGGING";
 
@@ -825,6 +828,7 @@ mod tests {
             logging::DYN_LOG,
             logging::DYN_LOGGING_CONFIG_PATH,
             logging::DYN_LOGGING_JSONL,
+            logging::DYN_LOGGING_CONSOLE_FORMAT,
             logging::DYN_SDK_DISABLE_ANSI_LOGGING,
             logging::DYN_LOG_USE_LOCAL_TZ,
             logging::DYN_LOGGING_SPAN_EVENTS,

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -49,7 +49,7 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{filter::Directive, fmt};
 
 use crate::config::{
-    disable_ansi_logging, env_is_truthy, jsonl_logging_enabled, span_events_enabled,
+    ConsoleLogFormat, console_log_format, disable_ansi_logging, env_is_truthy, span_events_enabled,
 };
 use async_nats::{HeaderMap, HeaderValue};
 use axum::extract::FromRequestParts;
@@ -315,17 +315,23 @@ fn span_events_for_logging() -> FmtSpan {
     }
 }
 
-fn log_otel_init_status(service_name: &str, endpoint_opt: Option<(OtlpProtocol, String)>) {
+fn log_otel_init_status(
+    service_name: &str,
+    endpoint_opt: Option<(OtlpProtocol, String)>,
+    console_format: ConsoleLogFormat,
+) {
     if let Some((protocol, endpoint)) = endpoint_opt {
         tracing::info!(
             endpoint = %endpoint,
             protocol = %protocol.as_str(),
             service = %service_name,
+            console_format = console_format.as_str(),
             "OpenTelemetry OTLP export enabled (traces and logs)"
         );
     } else {
         tracing::info!(
             service = %service_name,
+            console_format = console_format.as_str(),
             "OpenTelemetry OTLP export disabled, traces local only"
         );
     }
@@ -1292,10 +1298,19 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     let trace_filter_layer = filters(load_config());
     let otel_filter_layer = filters(load_config());
     let otel_logs_filter_layer = filters(load_config());
-    let jsonl_enabled = jsonl_logging_enabled();
+    let console_format = console_log_format();
     let otlp_enabled = otlp_exporter_enabled();
+    // Trace context (span CLOSE events, trace IDs, the OTel bridge) is required
+    // for OTLP export or when the console itself emits JSONL; the console
+    // format choice is decoupled from the OTel export decision.
+    let trace_context_enabled = otlp_enabled || console_format == ConsoleLogFormat::Jsonl;
+    let span_events = if trace_context_enabled {
+        span_events_for_logging()
+    } else {
+        FmtSpan::NONE
+    };
 
-    if jsonl_enabled || otlp_enabled {
+    if trace_context_enabled {
         let service_name = get_service_name();
         let sample_ratio = trace_sample_ratio_from_env();
 
@@ -1399,50 +1414,87 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
             .as_ref()
             .map(|lp| OpenTelemetryTracingBridge::new(lp).with_filter(otel_logs_filter_layer));
 
-        macro_rules! init_otel_subscriber {
-            ($fmt_layer:expr) => {
-                tracing_subscriber::registry()
-                    .with(
-                        tracing_opentelemetry::layer()
-                            .with_tracer(tracer)
-                            .with_filter(otel_filter_layer),
-                    )
-                    .with(otel_logs_layer)
-                    .with(DistributedTraceIdLayer.with_filter(trace_filter_layer))
-                    .with($fmt_layer)
-                    .init();
-            };
-        }
+        let l = console_layer(console_format, span_events, fmt_filter_layer);
+        tracing_subscriber::registry()
+            .with(
+                tracing_opentelemetry::layer()
+                    .with_tracer(tracer)
+                    .with_filter(otel_filter_layer),
+            )
+            .with(otel_logs_layer)
+            .with(DistributedTraceIdLayer.with_filter(trace_filter_layer))
+            .with(l)
+            .init();
 
-        if jsonl_enabled {
-            let l = fmt::layer()
-                .with_ansi(false)
-                .with_span_events(span_events_for_logging())
-                .event_format(CustomJsonFormatter::new())
-                .with_writer(std::io::stderr)
-                .with_filter(fmt_filter_layer);
-            init_otel_subscriber!(l);
-        } else {
-            let l = fmt::layer()
-                .with_ansi(!disable_ansi_logging())
-                .event_format(fmt::format().compact().with_timer(TimeFormatter::new()))
-                .with_writer(std::io::stderr)
-                .with_filter(fmt_filter_layer);
-            init_otel_subscriber!(l);
-        }
-
-        log_otel_init_status(&service_name, endpoint_opt);
+        log_otel_init_status(&service_name, endpoint_opt, console_format);
     } else {
-        let l = fmt::layer()
-            .with_ansi(!disable_ansi_logging())
-            .event_format(fmt::format().compact().with_timer(TimeFormatter::new()))
-            .with_writer(std::io::stderr)
-            .with_filter(fmt_filter_layer);
+        let l = console_layer(console_format, span_events, fmt_filter_layer);
 
         tracing_subscriber::registry().with(l).init();
     }
 
     Ok(())
+}
+
+/// Console (stderr) fmt layer whose event format is selected by
+/// `DYN_LOGGING_CONSOLE_FORMAT`, independent of the OTel export state.
+fn console_layer<S>(
+    format: ConsoleLogFormat,
+    span_events: FmtSpan,
+    filter_layer: LoggingFilter,
+) -> impl Layer<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a> + 'static,
+{
+    fmt::layer()
+        .with_ansi(format == ConsoleLogFormat::Readable && !disable_ansi_logging())
+        .with_span_events(span_events)
+        .event_format(ConsoleEventFormatter::new(format))
+        .with_writer(std::io::stderr)
+        .with_filter(filter_layer)
+}
+
+type ReadableEventFormatter = tracing_subscriber::fmt::format::Format<
+    tracing_subscriber::fmt::format::Compact,
+    TimeFormatter,
+>;
+
+enum ConsoleEventFormatter {
+    Readable(ReadableEventFormatter),
+    Jsonl(CustomJsonFormatter),
+}
+
+impl ConsoleEventFormatter {
+    fn new(format: ConsoleLogFormat) -> Self {
+        match format {
+            ConsoleLogFormat::Readable => {
+                Self::Readable(fmt::format().compact().with_timer(TimeFormatter::new()))
+            }
+            ConsoleLogFormat::Jsonl => Self::Jsonl(CustomJsonFormatter::new()),
+        }
+    }
+}
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for ConsoleEventFormatter
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        match self {
+            Self::Readable(formatter) => {
+                tracing_subscriber::fmt::FormatEvent::format_event(formatter, ctx, writer, event)
+            }
+            Self::Jsonl(formatter) => {
+                tracing_subscriber::fmt::FormatEvent::format_event(formatter, ctx, writer, event)
+            }
+        }
+    }
 }
 
 #[allow(clippy::large_enum_variant)] // Constructed once during logging initialization.
@@ -2960,6 +3012,80 @@ pub mod tests {
     #[tracing::instrument(level = "info", target = "other_module", skip_all)]
     async fn other_target_info_span() {
         tracing::info!(target: "other_module", "inside other target span");
+    }
+
+    #[test]
+    fn test_readable_console_with_otel_export() {
+        use std::process::Command;
+
+        let output = Command::new("cargo")
+            .args([
+                "test",
+                "-p",
+                "dynamo-runtime",
+                "test_readable_console_with_otel_export_subprocess",
+                "--",
+                "--nocapture",
+            ])
+            .env("DYN_TEST_LOGGING_READABLE_OTEL", "1")
+            .env("DYN_LOGGING_CONSOLE_FORMAT", "readable")
+            .env("DYN_LOGGING_JSONL", "1")
+            .env("OTEL_EXPORT_ENABLED", "1")
+            .env("DYN_LOG", "info")
+            .env("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+            .env("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+            .output()
+            .expect("Failed to execute subprocess test");
+
+        if !output.status.success() {
+            eprintln!(
+                "=== STDOUT ===\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprintln!(
+                "=== STDERR ===\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        assert!(
+            output.status.success(),
+            "Subprocess test failed with exit code: {:?}",
+            output.status.code()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_readable_console_with_otel_export_subprocess() -> Result<()> {
+        if std::env::var("DYN_TEST_LOGGING_READABLE_OTEL").is_err() {
+            return Ok(());
+        }
+
+        let tmp_file = NamedTempFile::new().unwrap();
+        let file_name = tmp_file.path().to_str().unwrap();
+        let guard = StderrOverride::from_file(file_name)?;
+        init();
+        tracing::info!("readable console with otel marker");
+        drop(guard);
+
+        let content = std::fs::read_to_string(file_name)?;
+        assert!(
+            content.contains("OpenTelemetry OTLP export enabled"),
+            "expected OTLP init log in captured stderr, got: {content}"
+        );
+        assert!(
+            content.contains("readable console with otel marker"),
+            "expected marker log in captured stderr, got: {content}"
+        );
+
+        for line in content.lines().filter(|line| !line.trim().is_empty()) {
+            assert!(
+                serde_json::from_str::<Value>(line).is_err(),
+                "expected readable log line, got JSON: {line}"
+            );
+        }
+
+        Ok(())
     }
 
     /// Comprehensive test for span events covering:

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -1283,11 +1283,7 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
         .with_default(LevelFilter::ERROR)
         .with_target("runtime", LevelFilter::TRACE)
         .with_target("tokio", LevelFilter::TRACE);
-    let l = fmt::layer()
-        .with_ansi(!disable_ansi_logging())
-        .event_format(fmt::format().compact().with_timer(TimeFormatter::new()))
-        .with_writer(std::io::stderr)
-        .with_filter(filters(load_config()));
+    let l = console_layer(console_log_format(), FmtSpan::NONE, filters(load_config()));
     tracing_subscriber::registry()
         .with(l)
         .with(tokio_console_layer.with_filter(tokio_console_target))
@@ -3091,6 +3087,76 @@ pub mod tests {
                 "expected readable log line, got JSON: {line}"
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_tokio_console_respects_console_format() {
+        use std::process::Command;
+
+        let output = Command::new("cargo")
+            .args([
+                "test",
+                "-p",
+                "dynamo-runtime",
+                "--features",
+                "tokio-console",
+                "logging::tests::test_tokio_console_respects_console_format_subprocess",
+                "--",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("DYN_TEST_LOGGING_TOKIO_CONSOLE_JSONL", "1")
+            .env("DYN_LOGGING_CONSOLE_FORMAT", "jsonl")
+            .env_remove("DYN_LOGGING_JSONL")
+            .env_remove("OTEL_EXPORT_ENABLED")
+            .env("DYN_LOG", "info")
+            .output()
+            .expect("Failed to execute subprocess test");
+
+        if !output.status.success() {
+            eprintln!(
+                "=== STDOUT ===\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprintln!(
+                "=== STDERR ===\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        assert!(
+            output.status.success(),
+            "Subprocess test failed with exit code: {:?}",
+            output.status.code()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tokio_console_respects_console_format_subprocess() -> Result<()> {
+        if std::env::var("DYN_TEST_LOGGING_TOKIO_CONSOLE_JSONL").is_err() {
+            return Ok(());
+        }
+        assert!(
+            cfg!(feature = "tokio-console"),
+            "subprocess test must run with the tokio-console feature"
+        );
+
+        let tmp_file = NamedTempFile::new().unwrap();
+        let file_name = tmp_file.path().to_str().unwrap();
+        let guard = StderrOverride::from_file(file_name)?;
+        init();
+        tracing::info!("tokio console jsonl marker");
+        drop(guard);
+
+        let content = std::fs::read_to_string(file_name)?;
+        let marker_line = content
+            .lines()
+            .find(|line| line.contains("tokio console jsonl marker"))
+            .unwrap_or_else(|| panic!("expected marker log in captured stderr, got: {content}"));
+        serde_json::from_str::<Value>(marker_line)
+            .unwrap_or_else(|error| panic!("expected JSONL marker, got '{marker_line}': {error}"));
 
         Ok(())
     }

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -8,8 +8,10 @@
 //!   2. Optional TOML file pointed to by the `DYN_LOGGING_CONFIG_PATH` environment variable.
 //!   3. `/opt/dynamo/etc/logging.toml`.
 //!
-//! Logging can take two forms: `READABLE` or `JSONL`. The default is `READABLE`. `JSONL`
-//! can be enabled by setting the `DYN_LOGGING_JSONL` environment variable to `1`.
+//! Logging can take two console forms: `READABLE` or `JSONL`. Select one with
+//! `DYN_LOGGING_CONSOLE_FORMAT=readable|jsonl`; the default is `READABLE`.
+//! `DYN_LOGGING_JSONL=1` remains a legacy fallback when the new setting is unset or blank.
+//! Console presentation is independent of OpenTelemetry export.
 //!
 //! To use local timezone for logging timestamps, set the `DYN_LOG_USE_LOCAL_TZ` environment variable to `1`.
 //!
@@ -49,7 +51,8 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::{filter::Directive, fmt};
 
 use crate::config::{
-    ConsoleLogFormat, console_log_format, disable_ansi_logging, env_is_truthy, span_events_enabled,
+    ConsoleLogFormat, console_log_format, disable_ansi_logging, env_is_truthy,
+    legacy_jsonl_logging_enabled, span_events_enabled,
 };
 use async_nats::{HeaderMap, HeaderValue};
 use axum::extract::FromRequestParts;
@@ -1299,11 +1302,13 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     let otel_filter_layer = filters(load_config());
     let otel_logs_filter_layer = filters(load_config());
     let console_format = console_log_format();
+    let legacy_jsonl_enabled = legacy_jsonl_logging_enabled();
     let otlp_enabled = otlp_exporter_enabled();
-    // Trace context (span CLOSE events, trace IDs, the OTel bridge) is required
-    // for OTLP export or when the console itself emits JSONL; the console
-    // format choice is decoupled from the OTel export decision.
-    let trace_context_enabled = otlp_enabled || console_format == ConsoleLogFormat::Jsonl;
+    // Keep the legacy JSONL switch as a trace-context signal even when the new
+    // setting overrides console presentation. Older deployments rely on it for
+    // downstream trace propagation without OTLP export.
+    let trace_context_enabled =
+        otlp_enabled || legacy_jsonl_enabled || console_format == ConsoleLogFormat::Jsonl;
     let span_events = if trace_context_enabled {
         span_events_for_logging()
     } else {
@@ -2864,6 +2869,7 @@ pub mod tests {
                 "--nocapture",
             ])
             .env("OTEL_EXPORT_ENABLED", "1")
+            .env_remove("DYN_LOGGING_CONSOLE_FORMAT")
             .env_remove("DYN_LOGGING_JSONL")
             .output()
             .expect("Failed to execute subprocess test");
@@ -3023,8 +3029,9 @@ pub mod tests {
                 "test",
                 "-p",
                 "dynamo-runtime",
-                "test_readable_console_with_otel_export_subprocess",
+                "logging::tests::test_readable_console_with_otel_export_subprocess",
                 "--",
+                "--exact",
                 "--nocapture",
             ])
             .env("DYN_TEST_LOGGING_READABLE_OTEL", "1")
@@ -3088,6 +3095,89 @@ pub mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_readable_console_preserves_legacy_trace_context() {
+        use std::process::Command;
+
+        let output = Command::new("cargo")
+            .args([
+                "test",
+                "-p",
+                "dynamo-runtime",
+                "logging::tests::test_readable_console_preserves_legacy_trace_context_subprocess",
+                "--",
+                "--exact",
+                "--nocapture",
+            ])
+            .env("DYN_TEST_LOGGING_READABLE_LEGACY_TRACE", "1")
+            .env("DYN_LOGGING_CONSOLE_FORMAT", "readable")
+            .env("DYN_LOGGING_JSONL", "1")
+            .env_remove("OTEL_EXPORT_ENABLED")
+            .env("DYN_LOG", "info")
+            .output()
+            .expect("Failed to execute subprocess test");
+
+        if !output.status.success() {
+            eprintln!(
+                "=== STDOUT ===\n{}",
+                String::from_utf8_lossy(&output.stdout)
+            );
+            eprintln!(
+                "=== STDERR ===\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
+        assert!(
+            output.status.success(),
+            "Subprocess test failed with exit code: {:?}",
+            output.status.code()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_readable_console_preserves_legacy_trace_context_subprocess() -> Result<()> {
+        if std::env::var("DYN_TEST_LOGGING_READABLE_LEGACY_TRACE").is_err() {
+            return Ok(());
+        }
+
+        let tmp_file = NamedTempFile::new().unwrap();
+        let file_name = tmp_file.path().to_str().unwrap();
+        let guard = StderrOverride::from_file(file_name)?;
+        init();
+
+        let span = tracing::info_span!("legacy_trace_context");
+        let trace_context = span.in_scope(get_distributed_tracing_context);
+        assert!(
+            trace_context.is_some(),
+            "legacy DYN_LOGGING_JSONL should keep local trace context enabled"
+        );
+
+        let mut headers = HashMap::new();
+        span.in_scope(|| inject_trace_headers_into_map(&mut headers));
+        assert!(
+            headers.contains_key("traceparent"),
+            "legacy trace context should remain available for propagation"
+        );
+
+        tracing::info!("readable console with legacy trace marker");
+        drop(guard);
+
+        let content = std::fs::read_to_string(file_name)?;
+        assert!(
+            content.contains("readable console with legacy trace marker"),
+            "expected marker log in captured stderr, got: {content}"
+        );
+        for line in content.lines().filter(|line| !line.trim().is_empty()) {
+            assert!(
+                serde_json::from_str::<Value>(line).is_err(),
+                "expected readable log line, got JSON: {line}"
+            );
+        }
+
+        Ok(())
+    }
+
     /// Comprehensive test for span events covering:
     /// - SPAN_FIRST_ENTRY and SPAN_CLOSED event emission
     /// - Trace context (trace_id, span_id) in span events
@@ -3108,11 +3198,12 @@ pub mod tests {
                 "test",
                 "-p",
                 "dynamo-runtime",
-                "test_span_events_subprocess",
+                "logging::tests::test_span_events_subprocess",
                 "--",
                 "--exact",
                 "--nocapture",
             ])
+            .env("DYN_LOGGING_CONSOLE_FORMAT", "jsonl")
             .env("DYN_LOGGING_JSONL", "1")
             .env("DYN_LOGGING_SPAN_EVENTS", "1")
             .env("DYN_LOG", "warn,dynamo_runtime::logging::tests=debug")

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -3138,10 +3138,6 @@ pub mod tests {
         if std::env::var("DYN_TEST_LOGGING_TOKIO_CONSOLE_JSONL").is_err() {
             return Ok(());
         }
-        assert!(
-            cfg!(feature = "tokio-console"),
-            "subprocess test must run with the tokio-console feature"
-        );
 
         let tmp_file = NamedTempFile::new().unwrap();
         let file_name = tmp_file.path().to_str().unwrap();


### PR DESCRIPTION
## Overview:

Decouple the stderr console log format from OpenTelemetry export configuration.

This allows Dynamo to export traces and structured log records through OTLP while keeping human-readable console output. Existing deployments using `DYN_LOGGING_JSONL` remain backward compatible.

## Details:

- Add `DYN_LOGGING_CONSOLE_FORMAT` with `readable` and `jsonl` values.
- Make `DYN_LOGGING_CONSOLE_FORMAT` take precedence over the legacy `DYN_LOGGING_JSONL` setting.
- Keep `DYN_LOGGING_JSONL` as a backward-compatible fallback when the new setting is not provided.
- Select the stderr formatter independently from OTLP exporter initialization.
- Consolidate readable and JSONL console setup in a shared `console_layer`.
- Include the selected console format in the OpenTelemetry initialization log.
- Add tests covering:
  - the default readable format;
  - the legacy JSONL setting;
  - precedence of the new setting;
  - readable console output while OTLP export is enabled.

## Where should the reviewer start?

Start with `lib/runtime/src/logging.rs`, particularly:

- `setup_logging`, where console formatting and telemetry initialization are separated;
- `console_layer` and `ConsoleEventFormatter`, which select the stderr format without duplicating subscriber setup;
- `test_readable_console_with_otel_export`, which covers the primary use case.

Then review `lib/runtime/src/config.rs` for environment-variable parsing, precedence, and legacy compatibility.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable console logging formats: readable text or JSON Lines.
  * Added support for selecting the format through `DYN_LOGGING_CONSOLE_FORMAT`.
  * Preserved compatibility with the legacy `DYN_LOGGING_JSONL` setting.
  * Console format can now be selected independently of OpenTelemetry export settings.

* **Bug Fixes**
  * Invalid format values now produce a warning and safely fall back to readable output.
  * Readable console logs remain readable when OpenTelemetry exporting is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->