### PR TITLE
docs(kubernetes): fix Helm chart URL in quickstart

### DIFF
--- a/docs/fern/assets/releases.json
+++ b/docs/fern/assets/releases.json
@@ -1214,7 +1214,7 @@
       "tags": [
         {
           "label": "helm install · dynamo-platform 1.3.0",
-          "clipboard": "helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 1.3.0"
+          "clipboard": "helm install dynamo-platform https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.3.0.tgz"
         }
       ]
     },
@@ -1226,7 +1226,7 @@
       "tags": [
         {
           "label": "helm install · snapshot 1.3.0",
-          "clipboard": "helm install snapshot oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot --version 1.3.0"
+          "clipboard": "helm install snapshot https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.3.0.tgz"
         }
       ]
     },

--- a/docs/fern/components/releases.data.ts
+++ b/docs/fern/components/releases.data.ts
@@ -652,7 +652,7 @@ export const ARTIFACTS: Artifact[] = [
       {
         label: "helm install · dynamo-platform 1.3.0",
         clipboard:
-          "helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 1.3.0",
+          "helm install dynamo-platform https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.3.0.tgz",
       },
     ],
   },
@@ -664,7 +664,7 @@ export const ARTIFACTS: Artifact[] = [
     tags: [
       {
         label: "helm install · snapshot 1.3.0",
-        clipboard: "helm install snapshot oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot --version 1.3.0",
+        clipboard: "helm install snapshot https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.3.0.tgz",
       },
     ],
   },

--- a/docs/fern/kubernetes/gateway-api-installation.mdx
+++ b/docs/fern/kubernetes/gateway-api-installation.mdx
@@ -101,8 +101,7 @@ If Istio sidecars mediate traffic from the Gateway proxy to the EPP Service, ena
 
 ```bash
 helm upgrade -i dynamo-platform \
-  oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform \
-  --version "$DYNAMO_VERSION" \
+  "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_VERSION}.tgz" \
   --namespace "$DYNAMO_SYSTEM_NAMESPACE" \
   --reuse-values \
   --set dynamo.serviceMesh.enabled=true \

--- a/docs/fern/kubernetes/quickstart.mdx
+++ b/docs/fern/kubernetes/quickstart.mdx
@@ -70,8 +70,7 @@ export NAMESPACE=dynamo-system
 export DYNAMO_VERSION=1.3.0
 
 helm upgrade --install dynamo-platform \
-  oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform \
-  --version "$DYNAMO_VERSION" \
+  "https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-${DYNAMO_VERSION}.tgz" \
   --namespace "$NAMESPACE" \
   --create-namespace \
   --wait \

--- a/docs/fern/reference/release-artifacts.mdx
+++ b/docs/fern/reference/release-artifacts.mdx
@@ -101,8 +101,8 @@ Current stable release: v1.3.0 (container tag `1.3.0`, wheel version `1.3.0.post
 | wheel | ai-dynamo | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install ai-dynamo==1.3.0.post1` |
 | wheel | ai-dynamo-runtime | Core Python bindings for the Dynamo runtime | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install ai-dynamo-runtime==1.3.0.post1` |
 | wheel | kvbm | KV Block Manager for disaggregated KV cache | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install kvbm==1.3.0.post1` |
-| helm | dynamo-platform | Platform services (etcd, NATS) and the Dynamo Operator for a Dynamo cluster | - | `helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 1.3.0` |
-| helm | snapshot | Snapshot DaemonSet for fast GPU worker recovery | - | `helm install snapshot oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot --version 1.3.0` |
+| helm | dynamo-platform | Platform services (etcd, NATS) and the Dynamo Operator for a Dynamo cluster | - | `helm install dynamo-platform https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.3.0.tgz` |
+| helm | snapshot | Snapshot DaemonSet for fast GPU worker recovery | - | `helm install snapshot https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.3.0.tgz` |
 | crate | dynamo-runtime | Core distributed runtime library | MSRV Rust v1.82 | `cargo add dynamo-runtime@1.3.0` |
 | crate | dynamo-llm | LLM inference engine | MSRV Rust v1.82 | `cargo add dynamo-llm@1.3.0` |
 | crate | dynamo-protocols | Async OpenAI-compatible API client | MSRV Rust v1.82 | `cargo add dynamo-protocols@1.3.0` |

--- a/docs/fern/reference/releases-data.mdx
+++ b/docs/fern/reference/releases-data.mdx
@@ -154,8 +154,8 @@ Release highlights (stable releases):
 | wheel | ai-dynamo | Main package with backend integrations (vLLM, SGLang, TRT-LLM) | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install ai-dynamo==1.3.0.post1` |
 | wheel | ai-dynamo-runtime | Core Python bindings for the Dynamo runtime | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install ai-dynamo-runtime==1.3.0.post1` |
 | wheel | kvbm | KV Block Manager for disaggregated KV cache | Python 3.10–3.12 · Linux (glibc v2.28+) | `uv pip install kvbm==1.3.0.post1` |
-| helm | dynamo-platform | Platform services (etcd, NATS) and the Dynamo Operator for a Dynamo cluster | - | `helm install dynamo-platform oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform --version 1.3.0` |
-| helm | snapshot | Snapshot DaemonSet for fast GPU worker recovery | - | `helm install snapshot oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot --version 1.3.0` |
+| helm | dynamo-platform | Platform services (etcd, NATS) and the Dynamo Operator for a Dynamo cluster | - | `helm install dynamo-platform https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.3.0.tgz` |
+| helm | snapshot | Snapshot DaemonSet for fast GPU worker recovery | - | `helm install snapshot https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.3.0.tgz` |
 | crate | dynamo-runtime | Core distributed runtime library | MSRV Rust v1.82 | `cargo add dynamo-runtime@1.3.0` |
 | crate | dynamo-llm | LLM inference engine | MSRV Rust v1.82 | `cargo add dynamo-llm@1.3.0` |
 | crate | dynamo-protocols | Async OpenAI-compatible API client | MSRV Rust v1.82 | `cargo add dynamo-protocols@1.3.0` |


### PR DESCRIPTION
## Overview:

Replace unsupported NGC OCI chart references with the published HTTPS Helm package URLs.

## Details:

- Update the Kubernetes quickstart and Gateway API installation commands to download the version selected by `DYNAMO_VERSION`.
- Update the release-artifact source for both `dynamo-platform` and `snapshot`.
- Regenerate the Markdown and JSON release-data mirrors.

The release workflow publishes these charts to the ChartMuseum-style NGC Helm repository with `helm cm-push`. The documented `/v2/` OCI lookups therefore return 404 even though the chart packages exist.

## Where should the reviewer start?

Start with `docs/fern/kubernetes/quickstart.mdx`, then review the source-of-truth artifact commands in `docs/fern/components/releases.data.ts`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #12372

## Summary

This change restores copy-pasteable Helm installation commands and removes all unsupported `oci://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/` references from the documentation.

## Validation

- `helm template dynamo-platform https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-1.3.0.tgz --namespace dynamo-system`
- `helm show chart https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/snapshot-1.3.0.tgz`
- `python3 docs/fern/scripts/gen_llms_tables.py --check`
- `npx --yes fern-api@5.80.2 check` — 0 errors
- `npx --yes fern-api@5.80.2 docs broken-links` — all checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Helm chart installation commands for Dynamo Platform and Snapshot to download charts from direct HTTPS NGC `.tgz` URLs rather than using `oci://` chart references.
  * Dynamo Platform chart source in the Kubernetes quickstart and Gateway API instructions now uses the `.tgz` URL with `DYNAMO_VERSION`.
  * Refreshed the release artifacts and release-data documentation so install commands stay consistent across the documentation site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->