### PR TITLE
fix(docs): repair the LANDING_CSS template literal and orbit base rule

### DIFF
--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -957,10 +957,23 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
 }
 
 .dynamo-story-core,
+.dynamo-story-orbit .node {
+  position: absolute;
+  display: grid;
+  place-items: center;
+  border: 1px solid rgba(118, 185, 0, 0.4);
+  background: rgba(12, 18, 8, 0.94);
+  color: #d8f4aa;
+  box-shadow: 0 14px 30px rgba(18, 32, 0, 0.25);
+  font-family: RobotoMono, ui-monospace, monospace;
+}
+
 /* Orbit node positions. These modifiers are unprefixed in the markup
-   (`node node--k8s`), so they must travel with the orbit rules -- left in
+   (node node--k8s), so they must travel with the orbit rules -- left in
    main.css they are dropped by the production theme and the three labels
-   collapse to the container's static position. */
+   collapse to the container's static position. No backticks in here: this
+   comment sits inside the LANDING_CSS template literal, and a raw backtick
+   closes it. */
 .node--k8s {
   top: 3%;
   left: 50%;
@@ -973,17 +986,6 @@ article:has(.dynamo-welcome) > header .fern-page-subtitle p {
 .node--local {
   bottom: 19%;
   left: -2%;
-}
-
-.dynamo-story-orbit .node {
-  position: absolute;
-  display: grid;
-  place-items: center;
-  border: 1px solid rgba(118, 185, 0, 0.4);
-  background: rgba(12, 18, 8, 0.94);
-  color: #d8f4aa;
-  box-shadow: 0 14px 30px rgba(18, 32, 0, 0.25);
-  font-family: RobotoMono, ui-monospace, monospace;
 }
 
 .dynamo-story-core {


### PR DESCRIPTION
## Summary

`docs/fern/components/LandingStyles.tsx` on `main` does not parse. Two defects arrived together in #12330 (`642ba9c7f31`), both from a single comment added inside the `LANDING_CSS` template literal.

## Defect 1: raw backticks close the template literal

`LANDING_CSS` opens at line 40 and is meant to close at 2126. The comment at line 961 contains two unescaped backticks, which terminate it early:

```
 *   (`node node--k8s`), so they must travel with the orbit rules -- left in
```

`esbuild` against `origin/main`:

```
[ERROR] Expected ";" but found "node"

    LandingStyles.tsx:961:5:
      961 |    (`node node--k8s`), so they must travel with the orbit rules -...
```

`fern check` does not catch this — it validates configuration and navigation, not component syntax. Only a step that actually compiles `experimental.mdx-components` does, which is why this merged green.

`sync_site_css.py` already treats a backtick in CSS as fatal for exactly this reason, but that guard only covers `main.css` to `CustomFooter.tsx`, so it does not see this file.

## Defect 2: the comment landed inside a selector list

`.dynamo-story-core,` is the first selector of the shared orbit rule. The block went in between it and `.dynamo-story-orbit .node`, so the comma rebinds. What a browser actually parses on `main`:

| Selector | Declarations |
|---|---|
| `.dynamo-story-core, .node--k8s` | `top: 3%; left: 50%; transform: translateX(-50%)` |
| `.dynamo-story-orbit .node` | `position: absolute; display: grid; place-items: center; border; background; color; box-shadow; font-family` |

`.dynamo-story-core` loses the entire shared base rule. Its own later rule still sets `inset: 50% auto auto 50%`, but `inset` is inert on a statically-positioned element, so the orbit's centre box drops out of the layout and renders without its panel treatment. It also picks up the k8s `top`/`left`.

The three orbit labels themselves were fixed correctly by #12330 — that half worked.

## What changed

Moves the comment and the three `.node--*` modifiers below the shared rule's closing brace, restoring `.dynamo-story-core, .dynamo-story-orbit .node` as a pair, and drops the backticks. The comment now records why they cannot come back.

`BlogStyles.tsx` is unaffected — it parses clean and carries no such comment.

## Verification

| Check | On `main` | On this branch |
|---|---|---|
| `esbuild LandingStyles.tsx` | `Expected ";" but found "node"` at 961:5 | parses, 52.0kb |
| Shared base rule | `.dynamo-story-core, .node--k8s` | `.dynamo-story-core, .dynamo-story-orbit .node` |
| `.node--k8s` / `--slurm` / `--local` | k8s grouped with the core | standalone with their offsets |
| Backticks in `LANDING_CSS` | 2 | 0 |
| Braces | — | 332/332 balanced |
| `fern check` | — | 0 errors |

The CSS was re-parsed with comments stripped, the way a browser sees it, rather than read off the diff. I also re-ran the completeness scan over every selector #12330 moved out of `main.css`, looking for any that reach no page-level bundle (excluding `CustomFooter`, which the production theme also replaces) while still being emitted by a live component: zero gaps.

## Follow-up

A one-line `esbuild --outfile=/dev/null` sweep over `docs/fern/components/*.tsx` in the lint job would have caught Defect 1 before merge. Worth adding alongside the component-import scanner in #12388.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated orbit-node styling for improved stylesheet organization.
  * Clarified inline documentation for styling template syntax requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->