### PR TITLE
fix(operator): preserve metadata in partial conversion responses

### DIFF
--- a/deploy/operator/api/conversion_webhook_test.go
+++ b/deploy/operator/api/conversion_webhook_test.go
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	webhookconversion "sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
+
+	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+func TestConversionWebhook_PartialObjectsRetainMetadata(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1 to scheme: %v", err)
+	}
+	if err := v1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 to scheme: %v", err)
+	}
+	handler := webhookconversion.NewWebhookHandler(scheme, webhookconversion.NewRegistry())
+
+	for _, kind := range []string{
+		"DynamoGraphDeployment",
+		"DynamoComponentDeployment",
+		"DynamoGraphDeploymentRequest",
+	} {
+		t.Run(kind, func(t *testing.T) {
+			source := map[string]any{
+				"apiVersion": v1alpha1.GroupVersion.String(),
+				"kind":       kind,
+				"metadata":   map[string]any{},
+			}
+			sourceRaw, err := json.Marshal(source)
+			if err != nil {
+				t.Fatalf("marshal source object: %v", err)
+			}
+
+			review := apiextensionsv1.ConversionReview{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
+					Kind:       "ConversionReview",
+				},
+				Request: &apiextensionsv1.ConversionRequest{
+					UID:               types.UID("partial-" + kind),
+					DesiredAPIVersion: v1beta1.GroupVersion.String(),
+					Objects: []runtime.RawExtension{
+						{Raw: sourceRaw},
+					},
+				},
+			}
+			payload, err := json.Marshal(review)
+			if err != nil {
+				t.Fatalf("marshal conversion review: %v", err)
+			}
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest("POST", "/convert", bytes.NewReader(payload))
+			handler.ServeHTTP(recorder, request)
+			if recorder.Code != http.StatusOK {
+				t.Fatalf("conversion webhook status = %d, body = %s", recorder.Code, recorder.Body)
+			}
+
+			var response apiextensionsv1.ConversionReview
+			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+				t.Fatalf("unmarshal conversion response: %v", err)
+			}
+			if response.Response == nil {
+				t.Fatalf("conversion response is nil: %s", recorder.Body)
+			}
+			if response.Response.Result.Status != metav1.StatusSuccess {
+				t.Fatalf("conversion failed: %#v", response.Response.Result)
+			}
+			if len(response.Response.ConvertedObjects) != 1 {
+				t.Fatalf("converted object count = %d, want 1", len(response.Response.ConvertedObjects))
+			}
+
+			var converted map[string]any
+			if err := json.Unmarshal(response.Response.ConvertedObjects[0].Raw, &converted); err != nil {
+				t.Fatalf("unmarshal converted object: %v", err)
+			}
+			metadata, found := converted["metadata"]
+			if !found {
+				t.Fatalf("converted object is missing metadata: %s", response.Response.ConvertedObjects[0].Raw)
+			}
+			metadataMap, ok := metadata.(map[string]any)
+			if !ok {
+				t.Fatalf("converted metadata has type %T, want object", metadata)
+			}
+			if len(metadataMap) != 0 {
+				t.Fatalf("converted metadata = %v, want empty object", metadataMap)
+			}
+		})
+	}
+}

--- a/deploy/operator/api/conversion_webhook_test.go
+++ b/deploy/operator/api/conversion_webhook_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestConversionWebhook_PartialObjectsRetainMetadata(t *testing.T) {
+	t.Log("Set up the conversion webhook")
 	scheme := runtime.NewScheme()
 	if err := v1alpha1.AddToScheme(scheme); err != nil {
 		t.Fatalf("add v1alpha1 to scheme: %v", err)
@@ -38,6 +39,7 @@ func TestConversionWebhook_PartialObjectsRetainMetadata(t *testing.T) {
 		"DynamoGraphDeploymentRequest",
 	} {
 		t.Run(kind, func(t *testing.T) {
+			t.Log("Build a partial v1alpha1 object with an empty metadata envelope")
 			source := map[string]any{
 				"apiVersion": v1alpha1.GroupVersion.String(),
 				"kind":       kind,
@@ -48,6 +50,7 @@ func TestConversionWebhook_PartialObjectsRetainMetadata(t *testing.T) {
 				t.Fatalf("marshal source object: %v", err)
 			}
 
+			t.Log("Submit the partial object to the conversion webhook")
 			review := apiextensionsv1.ConversionReview{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: apiextensionsv1.SchemeGroupVersion.String(),
@@ -73,6 +76,7 @@ func TestConversionWebhook_PartialObjectsRetainMetadata(t *testing.T) {
 				t.Fatalf("conversion webhook status = %d, body = %s", recorder.Code, recorder.Body)
 			}
 
+			t.Log("Verify the converted v1beta1 object retains an empty metadata envelope")
 			var response apiextensionsv1.ConversionReview
 			if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
 				t.Fatalf("unmarshal conversion response: %v", err)

--- a/deploy/operator/api/v1beta1/marshal.go
+++ b/deploy/operator/api/v1beta1/marshal.go
@@ -61,10 +61,13 @@
 // The normalizer below walks the serialized JSON in lockstep with the Go
 // type tree via reflection and strips a map entry iff (a) its JSON value
 // is an empty object AND (b) the corresponding Go field is a non-pointer
-// struct type. Pointer-typed empty objects are preserved as sentinels.
+// struct type. Pointer-typed empty objects are preserved as sentinels, and
+// the top-level metadata object of a Kubernetes runtime.Object is preserved
+// because conversion webhook responses require that object envelope even
+// when Server-Side Apply sends a partial object whose metadata has no fields.
 // Adding a new API field with a value-typed sub-struct automatically
-// participates in the normalization without further code changes, and
-// adding a new pointer-typed sentinel struct is automatically preserved.
+// participates in the normalization without further code changes, and adding
+// a new pointer-typed sentinel struct is automatically preserved.
 //
 // # Scope
 //
@@ -96,6 +99,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // normalizeV1Beta1JSON strips Go-encoder empty-struct artefacts from the
@@ -111,7 +116,28 @@ func normalizeV1Beta1JSON(raw []byte, rootType reflect.Type) ([]byte, error) {
 		return nil, err
 	}
 	stripEmptyValueStructs(rootType, v)
+	ensureRuntimeObjectMetadata(rootType, v)
 	return json.Marshal(v)
+}
+
+var runtimeObjectType = reflect.TypeOf((*k8sruntime.Object)(nil)).Elem()
+
+// ensureRuntimeObjectMetadata restores the top-level metadata envelope after
+// empty-struct normalization. Kubernetes API objects must return metadata from
+// conversion webhooks even when Server-Side Apply supplies a partial object
+// with no metadata fields.
+func ensureRuntimeObjectMetadata(goType reflect.Type, jsonVal any) {
+	goType = derefToConcrete(goType)
+	if goType == nil || goType.Kind() != reflect.Struct || !reflect.PointerTo(goType).Implements(runtimeObjectType) {
+		return
+	}
+	root, ok := jsonVal.(map[string]any)
+	if !ok {
+		return
+	}
+	if metadata, found := root["metadata"]; !found || metadata == nil {
+		root["metadata"] = map[string]any{}
+	}
 }
 
 // stripEmptyValueStructs walks `jsonVal` in lockstep with `goType`, deleting

--- a/deploy/operator/api/v1beta1/marshal_test.go
+++ b/deploy/operator/api/v1beta1/marshal_test.go
@@ -49,6 +49,71 @@ func TestNormalizeJSON_OuterFieldWinsEmbeddedCollision(t *testing.T) {
 	}
 }
 
+func TestRootMarshal_PreservesEmptyMetadata(t *testing.T) {
+	tests := []struct {
+		name string
+		obj  any
+	}{
+		{
+			name: "DynamoGraphDeployment",
+			obj: &DynamoGraphDeployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "nvidia.com/v1beta1",
+					Kind:       "DynamoGraphDeployment",
+				},
+			},
+		},
+		{
+			name: "DynamoComponentDeployment",
+			obj: &DynamoComponentDeployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "nvidia.com/v1beta1",
+					Kind:       "DynamoComponentDeployment",
+				},
+			},
+		},
+		{
+			name: "DynamoGraphDeploymentRequest",
+			obj: &DynamoGraphDeploymentRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "nvidia.com/v1beta1",
+					Kind:       "DynamoGraphDeploymentRequest",
+				},
+			},
+		},
+		{
+			name: "DynamoGraphDeploymentScalingAdapter",
+			obj: &DynamoGraphDeploymentScalingAdapter{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "nvidia.com/v1beta1",
+					Kind:       "DynamoGraphDeploymentScalingAdapter",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, err := json.Marshal(tt.obj)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			root := unmarshalToMap(t, raw)
+			metadata, found := root["metadata"]
+			if !found {
+				t.Fatalf("root metadata is missing from %s", raw)
+			}
+			metadataMap, ok := metadata.(map[string]any)
+			if !ok {
+				t.Fatalf("root metadata has type %T, want object", metadata)
+			}
+			if len(metadataMap) != 0 {
+				t.Fatalf("root metadata = %v, want empty object", metadataMap)
+			}
+		})
+	}
+}
+
 // TestDGDMarshal_StripsEmptyPodTemplateMetadata locks in the fix for the
 // kubectl-apply generation-bump regression: when the stored v1alpha1 object
 // has no ExtraPodMetadata, the v1beta1 projection built by buildPodTemplateTo

--- a/deploy/operator/api/v1beta1/marshal_test.go
+++ b/deploy/operator/api/v1beta1/marshal_test.go
@@ -94,10 +94,13 @@ func TestRootMarshal_PreservesEmptyMetadata(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Marshal a v1beta1 root object with empty metadata")
 			raw, err := json.Marshal(tt.obj)
 			if err != nil {
 				t.Fatalf("marshal: %v", err)
 			}
+
+			t.Log("Verify the root metadata envelope is preserved")
 			root := unmarshalToMap(t, raw)
 			metadata, found := root["metadata"]
 			if !found {


### PR DESCRIPTION
## Summary

Fixes #12351.

Kubernetes Server-Side Apply can send partial objects through the CRD conversion webhook while reconciling fields owned under another API version. The v1beta1 JSON normalizer removed the empty top-level `metadata: {}` object, causing the API server to reject the conversion response with:

```text
returned invalid metadata: missing metadata in converted object
```

This change:

- restores the top-level metadata envelope after normalizing Kubernetes `runtime.Object` values;
- preserves the removal of nested encoder artifacts such as `podTemplate.metadata: {}`;
- adds marshal regression coverage for all v1beta1 root resource types; and
- adds conversion-webhook regression coverage for partial DGD, DCD, and DGDR objects.

## Validation

```text
go test ./api/... -count=1
```

All Operator API tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the top-level `metadata` field as an empty object when converting Kubernetes objects with minimal metadata.
  * Ensured conversion webhook responses retain valid runtime-object structure for partial objects.

* **Tests**
  * Added coverage for metadata preservation across supported API versions and object kinds.
  * Added validation for successful webhook conversions and returned object counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->