### PR TITLE
feat(agents): add code-review workflow

### DIFF
--- a/.agents/workflows/README.md
+++ b/.agents/workflows/README.md
@@ -1,0 +1,32 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Agent Workflows
+
+Multi-agent orchestration scripts for Claude Code's workflow runner. A workflow
+deterministically fans work out across many subagents — to be comprehensive, to
+be confident (independent perspectives + adversarial verification before
+committing), or to take on scale one context can't hold.
+
+Workflows live **canonically here** (`.agents/workflows/`); `.claude/workflows/`
+is a symlink to this directory, so the runner discovers them while the source of
+truth stays under `.agents/`. **Edit only the canonical copy.**
+
+Each workflow is a self-contained JavaScript file that begins with
+`export const meta = { name, description, phases }` (a pure literal) followed by
+the script body using `agent()` / `pipeline()` / `parallel()` / `phase()`.
+
+| Workflow | What it does |
+|----------|--------------|
+| [`code-review`](code-review.js) | Runs an adversarial framing pass, then fans out **pluggable expert reviewers** (built-ins: correctness, concurrency, distributed, simplicity, perf, comment-hygiene, tests/API — add more in [`reviewers/`](reviewers/)), reviews the diff, adversarially verifies every finding, and returns a ranked report. Optional args: `{ base, reviewers, votes, exhaustive }` (default base `origin/main`). |
+
+## Adding a workflow
+
+1. Add `<name>.js` here with a pure-literal `meta` block; use the same phase
+   titles in `meta.phases` as in the `phase()` calls.
+2. List it in the table above.
+3. Scripts run in a sandboxed JS context: no filesystem or shell access, and
+   `Date.now()` / `Math.random()` are unavailable. Do repo inspection (git,
+   file reads) inside `agent()` subagents, which have tool access.

--- a/.agents/workflows/code-review.js
+++ b/.agents/workflows/code-review.js
@@ -1,0 +1,177 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Multi-agent code review for a diff. Runs a high-level adversarial framing
+// pass, fans out across a pluggable set of expert reviewers, adversarially
+// verifies every finding, and synthesizes a ranked report.
+//
+// EXTENDING: add an expert by dropping a markdown file in
+// `.agents/workflows/reviewers/<key>.md` (YAML frontmatter `key` + optional
+// `applies_to` globs; the body is the review focus). The loader merges those
+// with the built-in experts below by `key` (a same-key file overrides). No
+// change to this orchestration is needed. See `reviewers/README.md`.
+//
+// Run with the workflow runner. Optional args:
+//   { base?: string,                 // ref to diff against (default "origin/main")
+//     reviewers?: [{key,focus}],     // explicit expert set (skips file loading/gating)
+//     votes?: number,                // adversarial refuters per finding (default 2)
+//     exhaustive?: boolean }         // keep nit-severity findings too (default false)
+//
+// The branch under review must be checked out; the workflow reviews HEAD vs
+// `base`. Agents run git / read files themselves (the script has no shell access).
+
+export const meta = {
+  name: 'code-review',
+  description: 'Multi-agent review of a diff: adversarial framing pass, fan out across a pluggable set of expert reviewers, adversarially verify every finding, and synthesize a ranked report.',
+  whenToUse: 'Before opening or merging a PR, for a thorough self-verifying review of the changes against Dynamo\'s Rust/systems standards and comment hygiene.',
+  phases: [
+    { title: 'Scout', detail: 'list changed files; load + gate the relevant expert reviewers' },
+    { title: 'Frame', detail: 'adversarial pass on the premise, approach, and validation' },
+    { title: 'Review', detail: 'one agent per active expert over the diff' },
+    { title: 'Verify', detail: 'adversarially refute each finding; drop the ones that fall' },
+    { title: 'Synthesize', detail: 'dedupe, filter nits, and rank the survivors' },
+  ],
+}
+
+// The runner may deliver `args` as a parsed object or as a JSON string; normalize both.
+const A = (() => {
+  if (typeof args === 'string') { try { return JSON.parse(args) } catch (e) { return {} } }
+  return (args && typeof args === 'object') ? args : {}
+})()
+const BASE = A.base || 'origin/main'
+const VOTES = A.votes || 2
+const EXHAUSTIVE = !!A.exhaustive
+// Scout resolves this to the concrete git diff spec that actually shows the
+// changes (three-dot BASE...HEAD, else two-dot BASE for uncommitted work), so
+// the framing/review/verify agents can't diff a different range than Scout did.
+let DIFF = `${BASE}...HEAD`
+
+// Shared discipline injected into every reviewer: material, changed-line
+// concerns only — no nit padding or speculation.
+const MATERIALITY =
+  'Report only material concerns on lines this change touches. Do NOT report: cosmetic nits, ' +
+  'style-only preferences, speculative concerns without evidence, tradeoffs that are clearly ' +
+  'intended and acceptable, tiny overhead in obviously cold code, or generic "add tests" notes ' +
+  'not tied to a concrete risk. Do not hunt pre-existing issues in surrounding code unless they ' +
+  'are severe or this change amplifies them. If your expert lens has no meaningful surface here, ' +
+  'return an empty findings array in one pass — do not invent work.'
+
+// Built-in experts. `reviewers/*.md` files are merged on top of these by key.
+// `distributed` and `concurrency` matter most for a datacenter-scale framework.
+const BUILTIN_REVIEWERS = [
+  { key: 'correctness', focus: 'logic bugs, unhandled errors, edge cases, off-by-one, wrong types, incorrect Result/Option handling, API/schema drift, unwrap()/expect() in non-test code' },
+  { key: 'concurrency', focus: 'async/tokio: locks held across .await, blocking work on the executor, spawned-task shutdown/cancellation, tight loops without yield, channel backpressure, unbounded channels, shared-state races' },
+  { key: 'distributed', focus: 'idempotency, crash/failover recovery gaps, state divergence across replicas, atomicity across layers, missing backpressure, stale versioning, invariants that break mid-rollout' },
+  { key: 'simplicity', focus: 'over-engineering, needless abstraction, duplicated logic, one-hop wrappers, layering violations, premature generalization, dead code, unnecessary clone()/Arc/Mutex, reflexive Arc<Mutex<...>>, scope creep' },
+  { key: 'perf', focus: 'hot-path heap allocation, boxing/allocation churn, avoidable clones/copies, intermediate collections, per-token or per-request work that should be hoisted, logging in hot paths' },
+  { key: 'comment-hygiene', focus: 'comments in ANY file type (Rust, Dockerfile, YAML, shell) that restate the line, enumerate mechanical detail a reader can look up, or decoratively label structure; keep only a non-obvious why. Also AI-smell/obvious comments and historical/changelog comments.' },
+  { key: 'tests-and-api', focus: 'behavior coverage vs line coverage, missing pytest markers, over-enumerated AI-style tests, breaking changes without migration; misleading names, unjustified interface/error-message churn' },
+]
+
+const FINDINGS = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['findings'],
+  properties: {
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['file', 'line', 'severity', 'claim', 'why'],
+        properties: {
+          file: { type: 'string' },
+          line: { type: 'integer' },
+          severity: { type: 'string', enum: ['blocking', 'major', 'minor', 'nit'] },
+          claim: { type: 'string' },
+          why: { type: 'string', description: 'concrete failure scenario or the rule violated' },
+          suggestion: { type: 'string' },
+        },
+      },
+    },
+  },
+}
+
+const VERDICT = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['refuted', 'reason'],
+  properties: {
+    refuted: { type: 'boolean', description: 'true if the finding is wrong, out of scope, immaterial, or not on a changed line' },
+    reason: { type: 'string' },
+  },
+}
+
+const EXPERT = { type: 'object', additionalProperties: false, required: ['key', 'focus'], properties: { key: { type: 'string' }, focus: { type: 'string' } } }
+
+// Spawn VOTES independent skeptics, each told to refute; survive on majority-can't-refute.
+const verifyFinding = (f, lens) =>
+  parallel(Array.from({ length: VOTES }, (_, i) => () =>
+    agent(
+      `Adversarially verify this ${lens} finding. Default to refuted=true unless, by inspecting the diff (git --no-pager diff ${DIFF}) at ${f.file}:${f.line}, you can confirm it is a real, material defect ON A CHANGED LINE and in scope for this change.\n\nFINDING [${f.severity}]: ${f.claim}\nWHY: ${f.why}`,
+      { label: `verify:${lens}:${f.file}:${f.line}#${i}`, phase: 'Verify', schema: VERDICT }
+    )
+  )).then(votes => {
+    const live = votes.filter(Boolean)
+    const refutes = live.filter(v => v.refuted).length
+    return { ...f, lens, survived: live.length > 0 && refutes < Math.ceil(live.length / 2) }
+  })
+
+phase('Scout')
+const scout = await agent(
+  `List the source/config files changed vs ${BASE} (\`git --no-pager diff --name-only ${BASE}...HEAD\`, or \`... ${BASE}\` if that range is empty; exclude lockfiles, generated code, binary/data).\n\n` +
+  `Built-in reviewer experts (JSON):\n${JSON.stringify(BUILTIN_REVIEWERS)}\n\n` +
+  `Also load additional experts from \`.agents/workflows/reviewers/*.md\` if that directory exists — each file has YAML frontmatter with \`key\` (required) and optional \`applies_to\` (comma/space-separated globs); the markdown body is that expert's review focus. Merge them with the built-ins by \`key\` (a same-key file overrides the built-in focus).\n\n` +
+  `From the merged set, select only the experts RELEVANT to this diff: honor each expert's \`applies_to\` globs when present, and skip experts with no meaningful surface for these files (e.g. skip concurrency/distributed/perf for a docs-only change). Return the changed paths, the selected experts as {key, focus} (focus verbatim from its source), and diff_spec = the exact git diff argument that shows these files: ${BASE}...HEAD if that range is non-empty, else ${BASE}.`,
+  { label: 'scout:load+gate', phase: 'Scout', schema: { type: 'object', additionalProperties: false, required: ['files', 'experts', 'diff_spec'], properties: { files: { type: 'array', items: { type: 'string' } }, experts: { type: 'array', items: EXPERT }, diff_spec: { type: 'string' } } } }
+)
+
+const files = (scout && scout.files) || []
+if (!files.length) {
+  log(`No changed files vs ${BASE} — nothing to review.`)
+  return { base: BASE, files: [], findings: [] }
+}
+DIFF = (scout && scout.diff_spec) || DIFF
+// args.reviewers overrides file loading/gating; else use the loader's selection; else fall back to built-ins.
+const override = Array.isArray(A.reviewers) ? A.reviewers.filter(e => e && e.key && e.focus) : []
+let active = override.length ? override : ((scout && scout.experts) || [])
+if (!active.length) active = BUILTIN_REVIEWERS
+const fileList = files.join(', ')
+log(`Reviewing ${files.length} changed file(s) vs ${BASE} with ${active.length} expert(s): ${active.map(e => e.key).join(', ')}.`)
+
+// Framing pass and per-expert review run concurrently; each self-verifies.
+const [framed, reviewed] = await parallel([
+  () => agent(
+    `Adversarially review the CHANGE vs ${BASE} at the design level (files: ${fileList}). Inspect it with \`git --no-pager diff ${DIFF}\`. Challenge: is the problem framed correctly and does the approach address the real outcome? What hidden assumptions, missing dependencies, or rollout constraints does it carry? Can local checks pass while the end-to-end system still fails? Is there a materially simpler or safer alternative? Does the validation give false confidence? ${MATERIALITY} Anchor each finding to a file:line in the diff.`,
+    { label: 'frame:adversarial', phase: 'Frame', schema: FINDINGS }
+  ).then(r => parallel(((r && r.findings) || []).map(f => () => verifyFinding(f, 'framing')))),
+
+  () => pipeline(
+    active,
+    e => agent(
+      `You are a strict Dynamo code reviewer. Apply the \`graham-code-review\` skill's philosophy and rules. Review ONLY the diff vs ${BASE} for these files: ${fileList} — inspect the actual changes with \`git --no-pager diff ${DIFF} -- <file>\`.\n\nEXPERT LENS: ${e.key} — ${e.focus}\n\n${MATERIALITY}`,
+      { label: `review:${e.key}`, phase: 'Review', schema: FINDINGS }
+    ),
+    (review, e) => parallel(((review && review.findings) || []).map(f => () => verifyFinding(f, e.key)))
+  ),
+])
+
+phase('Synthesize')
+const all = [...(framed || []), ...((reviewed || []).flat())].filter(Boolean)
+const seen = new Set()
+const confirmed = []
+for (const f of all) {
+  if (!f.survived) continue
+  // Drop nit-severity noise by default — but never for comment-hygiene, the lens
+  // we most want surfaced, so it can't be silenced as a "nit".
+  if (!EXHAUSTIVE && f.severity === 'nit' && f.lens !== 'comment-hygiene') continue
+  const key = `${f.file}:${f.line}:${f.claim}`
+  if (seen.has(key)) continue
+  seen.add(key)
+  confirmed.push(f)
+}
+const rank = { blocking: 0, major: 1, minor: 2, nit: 3 }
+confirmed.sort((a, b) => (rank[a.severity] ?? 9) - (rank[b.severity] ?? 9))
+
+log(`${confirmed.length} confirmed finding(s) after adversarial verification (${all.length - confirmed.length} refuted, filtered, or duplicate).`)
+return { base: BASE, files, experts: active.map(e => e.key), findings: confirmed }

--- a/.agents/workflows/reviewers/README.md
+++ b/.agents/workflows/reviewers/README.md
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Code-review experts
+
+Each file here defines **one expert reviewer** for the [`code-review`](../code-review.js)
+workflow. Drop a new file to add an expert — the workflow's loader picks it up
+and fans out a reviewer for it. No change to the orchestration is needed.
+
+The loader **merges** these files with the workflow's built-in experts by `key`:
+a file whose `key` matches a built-in (`correctness`, `concurrency`,
+`distributed`, `simplicity`, `perf`, `comment-hygiene`, `tests-and-api`)
+**overrides** that built-in's focus; a new `key` **adds** an expert.
+
+## File format
+
+```markdown
+---
+key: security            # required, kebab-case, unique. Same key as a built-in overrides it.
+name: Security           # optional, human label
+applies_to: "**/*.rs, **/*.py, **/Dockerfile"   # optional globs; expert runs only when the diff touches a match
+---
+The review focus: the concrete concerns this expert looks for, phrased as a
+checklist an agent can apply to a diff. This body becomes the reviewer's lens.
+```
+
+- **`key`** is the only required field.
+- **`applies_to`** is a relevance pre-filter. Omit it to let the loader decide
+  relevance from the change itself (it already skips experts with no surface —
+  e.g. `perf` on a docs-only diff).
+- The body should describe *material* concerns; the workflow already enforces
+  the shared "report only material, changed-line issues" discipline.
+
+## Findings contract
+
+Every reviewer returns findings shaped as
+`{ file, line, severity: blocking|major|minor|nit, claim, why, suggestion? }`.
+Each finding is then adversarially verified before it reaches the report, so an
+expert should surface candidates freely and let verification filter them.

--- a/.agents/workflows/reviewers/security.md
+++ b/.agents/workflows/reviewers/security.md
@@ -1,0 +1,13 @@
+---
+key: security
+name: Security
+applies_to: "**/*.rs, **/*.py, **/*.go, **/Dockerfile, **/deploy/**, **/*.yaml, **/*.yml"
+---
+Hardcoded secrets, credentials, or tokens; secrets or PII written to logs;
+new or changed endpoints missing authentication/authorization; unvalidated
+external input reaching a shell, SQL, path, or deserialization sink; `unsafe`
+Rust without a justifying `SAFETY:` comment; command execution built from
+untrusted strings; TLS or certificate verification disabled; overly broad
+container capabilities, `runAsUser: 0`, `privileged: true`, or host mounts;
+world-writable file modes; dependencies pinned to a mutable tag where an
+integrity-checked pin is expected.

--- a/.claude/workflows
+++ b/.claude/workflows
@@ -1,0 +1,1 @@
+../.agents/workflows

--- a/.gitignore
+++ b/.gitignore
@@ -139,8 +139,10 @@ core.*
 /.cursor
 /.claude/*
 !/.claude/skills
+!/.claude/workflows
 /.agents/*
 !/.agents/skills
+!/.agents/workflows
 /.codex
 /CLAUDE.md
 /CLAUDE.md.bak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,21 @@ exactly. All of this is enforced by `scripts/validate_skills.py` (pre-commit hoo
 `validate-skills`). Changes under `.agents/skills/` are also validated by NVSkills CI —
 a maintainer comments `/nvskills-ci` on the PR.
 
+## Workflows
+
+Multi-agent orchestration scripts for Claude Code's workflow runner live
+canonically in `.agents/workflows/`; `.claude/workflows/` is a symlink to it —
+edit only the canonical copy. Each is a self-contained JavaScript file that
+begins with a pure-literal `export const meta` block. See
+[`.agents/workflows/README.md`](.agents/workflows/README.md).
+
+- `code-review` — runs an adversarial framing pass, then fans out pluggable
+  expert reviewers (built-ins: correctness, concurrency, distributed, simplicity,
+  perf, comment-hygiene, tests/API; add more by dropping a file in
+  `.agents/workflows/reviewers/`), reviews the diff, and adversarially verifies
+  every finding before returning a ranked report. Reuses the `graham-code-review`
+  skill as the review engine. Optional args: `{ base, reviewers, votes, exhaustive }`.
+
 ## Ecosystem
 
 Sibling repositories this repo integrates with:


### PR DESCRIPTION
## Summary

Adds a reusable multi-agent **code-review workflow** and establishes the `.agents/workflows/` convention (canonical source of truth; `.claude/workflows/` is a symlink to it, mirroring how `.claude/skills` → `.agents/skills` works).

`code-review` reviews a diff (default `HEAD` vs `origin/main`) in five phases:
- **Scout** — list changed files, then load and relevance-gate the expert reviewers.
- **Frame** — a high-level *adversarial* pass challenging the change's premise, approach, hidden assumptions, "local passes but e2e fails," simpler alternatives, and false-confidence validation.
- **Review** — one agent per active expert. Experts are **pluggable**: built-ins live in the script, and dropping `.agents/workflows/reviewers/<key>.md` (frontmatter `key` + optional `applies_to` globs; body = review focus) adds or overrides one *by key* — no orchestration change. Ships a worked `security` reviewer as an example.
- **Verify** — every finding (framing and per-expert) faces N independent skeptics prompted to *refute*; it survives only on majority-can't-refute.
- **Synthesize** — dedupe, drop nit-severity noise (except the comment-hygiene lens), and rank.

Reuses the `graham-code-review` skill as the review engine and injects a shared materiality filter ("report only material, changed-line concerns"). Optional args: `{ base, reviewers, votes, exhaustive }`.

## Validation

- Script body parses as the runner executes it (async-wrapped); `meta` is a pure literal; reviewer frontmatter parses.
- CI-gate compatibility traced: `copyright-check` skips `.md` and treats `.js`/the extensionless symlink as *unsupported* (non-failing); `validate-skills` only scans `.agents/skills/`, and the new `## Workflows` (level-2) heading correctly terminates the Skills index so the `code-review` bullet is not read as a skill.
- End-to-end: ran the workflow against its own diff (dogfood) to exercise the loader, relevance gating, framing, review, and adversarial verification.

Draft — landing the convention + first workflow; feedback welcome on the reviewer set and defaults.