### PR TITLE
feat(llm): emit token IDs in chat logprobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.1.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
+checksum = "97fd951c32c033f4f220b6087db91d7f7d475f1bf1f886c8e60798ac1cf4cc9a"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.4.0" }
 dynamo-memory = { path = "lib/memory", version = "1.4.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.4.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.4.0" }
-dynamo-protocols = { version = "=5.1.0" }
+dynamo-protocols = { version = "=5.3.1" }
 dynamo-parsers = { version = "7.0.1" }
 
 # Published on crates.io. To see all available versions:

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -945,7 +945,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.1.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
+checksum = "97fd951c32c033f4f220b6087db91d7f7d475f1bf1f886c8e60798ac1cf4cc9a"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -5486,7 +5486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5506,7 +5506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -5527,7 +5527,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -5540,7 +5540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -8345,7 +8345,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1462,7 +1462,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2492,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.1.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
+checksum = "97fd951c32c033f4f220b6087db91d7f7d475f1bf1f886c8e60798ac1cf4cc9a"
 dependencies = [
  "async-openai",
  "derive_builder",
@@ -6631,7 +6631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -6651,7 +6651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6672,7 +6672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -6685,7 +6685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -9995,7 +9995,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -7325,6 +7325,7 @@ mod tests {
             content: Some(vec![ChatCompletionTokenLogprob {
                 token: "h".to_string(),
                 logprob: -0.5,
+                token_id: None,
                 bytes: Some(vec![104]),
                 top_logprobs: vec![],
             }]),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -6684,6 +6684,7 @@ mod tests {
             content: Some(vec![ChatCompletionTokenLogprob {
                 token: "h".to_string(),
                 logprob: -0.5,
+                token_id: None,
                 bytes: Some(vec![104]),
                 top_logprobs: vec![],
             }]),

--- a/lib/llm/src/perf/logprobs.rs
+++ b/lib/llm/src/perf/logprobs.rs
@@ -876,6 +876,7 @@ mod tests {
         let token_logprobs = vec![ChatCompletionTokenLogprob {
             token: "unlikely_selection".to_string(),
             logprob: (0.15_f32).ln(), // Selected but not optimal: 15%
+            token_id: None,
             bytes: None,
             top_logprobs: vec![
                 TopLogprobs {
@@ -932,6 +933,7 @@ mod tests {
         ChatCompletionTokenLogprob {
             token: token.to_string(),
             logprob: prob.ln(),
+            token_id: None,
             bytes: None,
             top_logprobs: top_probs
                 .into_iter()

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -592,6 +592,7 @@ mod tests {
                 content: Some(vec![dynamo_protocols::types::ChatCompletionTokenLogprob {
                     token: token.clone(),
                     logprob: lp,
+                    token_id: None,
                     bytes: token_to_utf8_bytes(&token),
                     top_logprobs: vec![],
                 }]),

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -609,6 +609,7 @@ mod tests {
                 content: Some(vec![dynamo_protocols::types::ChatCompletionTokenLogprob {
                     token: token.clone(),
                     logprob: lp,
+                    token_id: None,
                     bytes: token_to_utf8_bytes(&token),
                     top_logprobs: vec![],
                 }]),

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -128,6 +128,7 @@ impl DeltaGenerator {
                     dynamo_protocols::types::ChatCompletionTokenLogprob {
                         token: token_str.clone(),
                         logprob: lp,
+                        token_id: Some(*tid),
                         bytes: token_to_utf8_bytes(&token_str),
                         top_logprobs: converted,
                     }
@@ -545,6 +546,35 @@ mod tests {
         );
         assert_eq!(second_choice_zero.inner.choices[0].delta.role, None);
         assert_eq!(second_choice_one.inner.choices[0].delta.role, None);
+    }
+
+    #[test]
+    fn test_chat_logprobs_include_backend_token_id() {
+        let mut request = create_test_request();
+        request.inner.logprobs = Some(true);
+        let mut generator = request.response_generator("req-logprob-token-id".to_string());
+        let mut output = final_backend_output();
+        output.log_probs = Some(vec![-0.5]);
+        output.top_logprobs = Some(vec![vec![]]);
+
+        let response = generator
+            .choice_from_postprocessor(output)
+            .expect("choice generation");
+
+        let logprob = &response.inner.choices[0]
+            .logprobs
+            .as_ref()
+            .expect("logprobs")
+            .content
+            .as_ref()
+            .expect("logprob content")[0];
+        assert_eq!(logprob.token_id, Some(1));
+
+        let response_json = serde_json::to_value(response).expect("serialize response");
+        assert_eq!(
+            response_json["choices"][0]["logprobs"]["content"][0]["token_id"],
+            1
+        );
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -884,6 +884,7 @@ mod tests {
         let expected = dynamo_protocols::types::ChatCompletionTokenLogprob {
             token: "token_id:100".to_string(),
             logprob: -9999.0,
+            token_id: None,
             bytes: Some(b"token_id:100".to_vec()),
             top_logprobs: vec![
                 dynamo_protocols::types::TopLogprobs {

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -885,6 +885,7 @@ mod tests {
         let expected = dynamo_protocols::types::ChatCompletionTokenLogprob {
             token: "token_id:100".to_string(),
             logprob: -9999.0,
+            token_id: None,
             bytes: Some(b"token_id:100".to_vec()),
             top_logprobs: vec![
                 dynamo_protocols::types::TopLogprobs {

--- a/lib/llm/tests/logprob_analysis_integration.rs
+++ b/lib/llm/tests/logprob_analysis_integration.rs
@@ -371,6 +371,7 @@ fn create_response_with_linear_probs(
             ChatCompletionTokenLogprob {
                 token: token.to_string(),
                 logprob: prob.ln(),
+                token_id: None,
                 bytes: None,
                 top_logprobs,
             }
@@ -452,6 +453,7 @@ fn create_multi_choice_response(
                     ChatCompletionTokenLogprob {
                         token,
                         logprob: prob.ln(),
+                        token_id: None,
                         bytes: None,
                         top_logprobs,
                     }


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Dynamo now emits the backend token ID in each Chat Completions logprob entry. It pins the released `dynamo-protocols` 5.3.1 type so the field is available consistently across every checked-in lockfile.

### How This Was Implemented
- Copy the existing `BackendOutput.token_ids` value into `ChatCompletionTokenLogprob.token_id`.
- Update the root, Python binding, and KVBM binding lockfiles to `dynamo-protocols` 5.3.1.
- Keep `None` only in synthetic response fixtures that have no backend token ID.
- Cover the typed field and serialized JSON response in one focused test.

<details>
<summary>Walkthrough</summary>

The backend output already aligns token IDs with logprobs. `DeltaGenerator::create_logprobs` zips those existing vectors and now writes the same ID into the optional protocol field before serializing the Chat Completions response.

```mermaid
flowchart LR
  B["BackendOutput token_ids"] --> D["DeltaGenerator::create_logprobs"]
  D --> P["ChatCompletionTokenLogprob.token_id"]
  P --> R["Chat Completions JSON"]
```

No engine adapter, `/generate` response shape, or logprob extraction behavior changes.

</details>

### Validation
- `cargo test -p dynamo-llm test_chat_logprobs_include_backend_token_id --lib` (1 passed).
- `cargo clippy -p dynamo-llm --lib --tests -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.
<!-- codex-pr-description:end -->
