### PR TITLE
fix(operator): allow component-scoped topology

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -279,13 +279,14 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 	}
 
 	constraintPath := fldPath.Child("topologyConstraint")
-	hasAnyConstraint := spec.TopologyConstraint != nil
+	hasComponentConstraint := false
 	for i := range spec.Components {
 		if spec.Components[i].TopologyConstraint != nil {
-			hasAnyConstraint = true
+			hasComponentConstraint = true
 			break
 		}
 	}
+	hasAnyConstraint := spec.TopologyConstraint != nil || hasComponentConstraint
 	if hasAnyConstraint {
 		topologyErrs := field.ErrorList{}
 		if spec.TopologyConstraint == nil {
@@ -294,15 +295,11 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 				"is required when any component topology constraint is set",
 			))
 		} else {
-			if spec.TopologyConstraint.PackDomain == "" {
-				for i := range spec.Components {
-					if spec.Components[i].TopologyConstraint == nil {
-						topologyErrs = append(topologyErrs, field.Required(
-							componentsPath.Index(i).Child("topologyConstraint"),
-							"is required because spec.topologyConstraint.packDomain is not set",
-						))
-					}
-				}
+			if spec.TopologyConstraint.PackDomain == "" && !hasComponentConstraint {
+				topologyErrs = append(topologyErrs, field.Required(
+					constraintPath.Child("packDomain"),
+					"is required when no component topologyConstraint is set",
+				))
 			}
 
 			var topologyInfo *clusterTopologyInfo

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go
@@ -1148,13 +1148,20 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantSchemaErr: `spec.components[0].topologyConstraint.packDomain: Invalid value: "": spec.components[0].topologyConstraint.packDomain in body should match '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'`,
 		},
 		{
-			name: "deployment topology without pack domain requires every component topology",
+			name: "deployment topology without pack domain allows unconstrained components",
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Generation = 2
 				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
 				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
-			wantWebhookErrs: []string{"spec.components[0].topologyConstraint: Required value: is required because spec.topologyConstraint.packDomain is not set"},
+		},
+		{
+			name: "deployment topology without pack domain requires a component topology",
+			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
+				dgd.Generation = 2
+				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "grove-topology"}
+			}),
+			wantWebhookErrs: []string{"spec.topologyConstraint.packDomain: Required value: is required when no component topologyConstraint is set"},
 		},
 		{
 			name: "deployment pack domain can be inherited",
@@ -1199,10 +1206,9 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			withoutTopology: true,
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.TopologyConstraint = &nvidiacomv1beta1.SpecTopologyConstraint{ClusterTopologyName: "missing-topology"}
-				dgd.Spec.Components[1].TopologyConstraint = &nvidiacomv1beta1.TopologyConstraint{PackDomain: "rack"}
 			}),
 			wantWebhookErrs: []string{
-				"spec.components[0].topologyConstraint: Required value: is required because spec.topologyConstraint.packDomain is not set",
+				`spec.topologyConstraint.packDomain: Required value: is required when no component topologyConstraint is set`,
 				`spec.topologyConstraint.clusterTopologyName: Invalid value: "missing-topology": references a ClusterTopologyBinding resource that was not found`,
 			},
 		},


### PR DESCRIPTION
## Overview

Align DGD webhook validation with the existing component-scoped topology design. This allows GPU workers to be rack-packed while CPU frontends and auxiliary components remain topology-free.

## Details

- Allow a deployment topology without `packDomain` when at least one component defines its own topology constraint.
- Continue rejecting configurations with neither a deployment-level `packDomain` nor any component-scoped constraint.
- Add positive and negative admission coverage while preserving independent topology error aggregation.

This matches the documented service-level-only topology behavior and the existing Grove render path.

## Where should the reviewer start?

- `deploy/operator/internal/webhook/validation/dynamographdeployment.go`
- `deploy/operator/internal/webhook/validation/dynamographdeployment_validation_envtest_test.go`

## Validation

- `make envtest ENVTEST_PACKAGES=./internal/webhook/validation`
- `go vet ./internal/webhook/validation`

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #11399

Related design: ai-dynamo/enhancements#69
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for deployment and component topology constraints.
  - Component-level constraints with a pack domain now allow other components to remain unconstrained.
  - Added clearer required-field validation when no deployment- or component-level topology constraint is configured.
  - Updated validation error reporting for more accurate field paths and aggregated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->