### PR TITLE
fix(test): add requested_sglang_vram_gib marker to diffusion_llada

### DIFF
--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -815,6 +815,7 @@ sglang_configs = {
             pytest.mark.gpu_1,
             pytest.mark.h100,
             pytest.mark.profiled_vram_gib(56.0),
+            pytest.mark.requested_sglang_vram_gib(56.0),
             # 32-token H100 smoke runs ~135s; ~4.4x headroom for cold pulls.
             pytest.mark.timeout(600),
             pytest.mark.nightly,


### PR DESCRIPTION
## Summary

- `test_sglang_deployment[diffusion_llada-4]` was excluded from the parallel pytest phase in nightly CI with the error: `1 test(s) lack a requested_*_vram_gib marker and cannot run in parallel`
- The `diffusion_llada` SGLangConfig had `profiled_vram_gib(56.0)` but was missing the required `requested_sglang_vram_gib` reservation marker that the GPU bin-packer uses for scheduling
- Add `requested_sglang_vram_gib(56.0)` to match the profiled peak (model uses `--mem-fraction-static 0.7` on H100 80 GB = 56 GB)

## Validation

- Confirmed the marker value matches the existing `profiled_vram_gib(56.0)` annotation and the `--mem-fraction-static 0.7` launch argument
- No functional change; marker is metadata for the parallel test scheduler only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the diffusion SGLang test configuration to accurately account for its requested GPU memory requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->