### PR TITLE
fix(ci): run dind test container as runner uid to fix shared model cache

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -142,10 +142,15 @@ runs:
         REQUESTED_HF_HOME="${{ inputs.hf_home }}"
         FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
         # Prefer the requested cache path when it is usable in this job container.
+        # Probe hub/ subdirectory with a touch test: HF writes into hub/ subdirs, and a
+        # UID mismatch from a prior run can leave hub/ unwritable even when the top-level
+        # directory passes a simple -w test.
+        _hf_hub_dir="${REQUESTED_HF_HOME}/hub"
         if
           [[ -n "${REQUESTED_HF_HOME}" ]] &&          # caller provided a preferred HF cache path
-          mkdir -p "${REQUESTED_HF_HOME}" 2>/dev/null && # path exists or can be created; hide expected permission noise
-          [[ -w "${REQUESTED_HF_HOME}" ]]             # current runner uid can write model/cache metadata there
+          mkdir -p "${_hf_hub_dir}" 2>/dev/null &&    # path exists or can be created; hide expected permission noise
+          touch "${_hf_hub_dir}/.write_probe" 2>/dev/null &&  # current runner uid can write into hub/ subdir
+          rm -f "${_hf_hub_dir}/.write_probe" 2>/dev/null
         then
           export HF_HOME="${REQUESTED_HF_HOME}"
           echo "✅ HF cache available at ${HF_HOME}"

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -139,7 +139,20 @@ runs:
           WORK_DIR="/tmp"
         fi
 
-        export HF_HOME="${{ inputs.hf_home }}"
+        REQUESTED_HF_HOME="${{ inputs.hf_home }}"
+        FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
+        if
+          [[ -n "${REQUESTED_HF_HOME}" ]] &&          # caller provided a preferred HF cache path
+          mkdir -p "${REQUESTED_HF_HOME}" 2>/dev/null && # path exists or can be created; hide expected permission noise
+          [[ -w "${REQUESTED_HF_HOME}" ]]             # current runner uid can write model/cache metadata there
+        then
+          export HF_HOME="${REQUESTED_HF_HOME}"
+          echo "✅ HF cache available at ${HF_HOME}"
+        else
+          export HF_HOME="${FALLBACK_HF_HOME}"
+          mkdir -p "${HF_HOME}"
+          echo "⚠️  HF cache '${REQUESTED_HF_HOME}' unavailable or not writable; using ${HF_HOME}"
+        fi
         echo "HF_HOME=${HF_HOME}" >> $GITHUB_ENV
 
         # HOME must stay at GITHUB_WORKSPACE: ARC, upload-artifact, and checkout require it.

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -139,27 +139,7 @@ runs:
           WORK_DIR="/tmp"
         fi
 
-        REQUESTED_HF_HOME="${{ inputs.hf_home }}"
-        FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
-        # Prefer the requested cache path when it is usable in this job container.
-        # Probe hub/ with a touch test: HF writes into hub/ subdirs, not the top level,
-        # so -w on the parent is insufficient. The dind path (pytest/action.yml) previously
-        # ran docker without --user and wrote model files as root; those dirs are unwritable
-        # by the UID-1001 runner even though /models itself passes -w.
-        _hf_hub_dir="${REQUESTED_HF_HOME}/hub"
-        if
-          [[ -n "${REQUESTED_HF_HOME}" ]] &&          # caller provided a preferred HF cache path
-          mkdir -p "${_hf_hub_dir}" 2>/dev/null &&    # path exists or can be created; hide expected permission noise
-          touch "${_hf_hub_dir}/.write_probe" 2>/dev/null &&  # current runner uid can write into hub/ subdir
-          rm -f "${_hf_hub_dir}/.write_probe" 2>/dev/null
-        then
-          export HF_HOME="${REQUESTED_HF_HOME}"
-          echo "✅ HF cache available at ${HF_HOME}"
-        else
-          export HF_HOME="${FALLBACK_HF_HOME}"
-          mkdir -p "${HF_HOME}"
-          echo "⚠️  HF cache '${REQUESTED_HF_HOME}' unavailable or not writable; using ${HF_HOME}"
-        fi
+        export HF_HOME="${{ inputs.hf_home }}"
         echo "HF_HOME=${HF_HOME}" >> $GITHUB_ENV
 
         # HOME must stay at GITHUB_WORKSPACE: ARC, upload-artifact, and checkout require it.

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -142,9 +142,10 @@ runs:
         REQUESTED_HF_HOME="${{ inputs.hf_home }}"
         FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
         # Prefer the requested cache path when it is usable in this job container.
-        # Probe hub/ subdirectory with a touch test: HF writes into hub/ subdirs, and a
-        # UID mismatch from a prior run can leave hub/ unwritable even when the top-level
-        # directory passes a simple -w test.
+        # Probe hub/ with a touch test: HF writes into hub/ subdirs, not the top level,
+        # so -w on the parent is insufficient. The dind path (pytest/action.yml) previously
+        # ran docker without --user and wrote model files as root; those dirs are unwritable
+        # by the UID-1001 runner even though /models itself passes -w.
         _hf_hub_dir="${REQUESTED_HF_HOME}/hub"
         if
           [[ -n "${REQUESTED_HF_HOME}" ]] &&          # caller provided a preferred HF cache path

--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -141,6 +141,7 @@ runs:
 
         REQUESTED_HF_HOME="${{ inputs.hf_home }}"
         FALLBACK_HF_HOME="${WORK_DIR}/.cache/huggingface"
+        # Prefer the requested cache path when it is usable in this job container.
         if
           [[ -n "${REQUESTED_HF_HOME}" ]] &&          # caller provided a preferred HF cache path
           mkdir -p "${REQUESTED_HF_HOME}" 2>/dev/null && # path exists or can be created; hide expected permission noise

--- a/.github/actions/pytest/action.yml
+++ b/.github/actions/pytest/action.yml
@@ -310,6 +310,7 @@ runs:
           "${DOCKER_EXTRA_FLAGS[@]}" \
           --rm -w /workspace \
           --network host \
+          --user "$(id -u):$(id -g)" \
           "${DOCKER_ENV_FLAGS[@]}" \
           --name ${{ env.CONTAINER_ID }}_pytest \
           -v "${TEST_RESULTS_DIR}:/workspace/test-results" \


### PR DESCRIPTION
## Summary

The dind test container in `pytest/action.yml` was running `docker run` without `--user`, so it wrote `/models/hub/` entries as root. The `pytest-local` path (ARC runner, UID 1001) cannot create new subdirs in those root-owned directories, causing `INTERNALERROR` in conftest's `download_models()` before any tests run.

Add `--user $(id -u):$(id -g)` to the dind `docker run` so both paths write to `/models/hub/` as the same UID and can share the model cache.

## Validation

- dind and `pytest-local` now both run as UID 1001; new model cache entries are writable by both paths
- No other `docker run` in CI mounts `/models`, so no other callers need this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)