### PR TITLE
[codex] align vanilla vLLM GAIE on-ramp docs

### DIFF
--- a/deploy/inference-gateway/ext-proc/examples/onramp/README.md
+++ b/deploy/inference-gateway/ext-proc/examples/onramp/README.md
@@ -24,7 +24,7 @@ KV-aware selection is provided by the runtime-free
 which the EPP runs **in-process**: the EPP and the selection service are compiled into one binary,
 so there is no separate selector Deployment and no HTTP hop. The EPP can run single-replica, or
 **replicated** with cross-replica active-load sync between EPP pods (see
-[Replicated mode](../../../../../docs/fern/kubernetes/vanilla-vllm-onramp.mdx#epp-replication)).
+[EPP Replication](../../../../../docs/fern/design-docs/vanilla-vllm-gaie-onramp.md#epp-replication)).
 
 Whether the EPP uses the Dynamo runtime or not is controlled with the `DYN_EPP_MODE` environment
 variable: `dynamo` uses the Dynamo runtime, while `standalone` runs the runtime-free selection
@@ -92,3 +92,13 @@ flowchart LR
    currently-Ready worker (booking its load via select-and-reserve), and returns
    the worker's endpoint to Envoy as routing headers. The selected
    worker processes the original forwarded request.
+
+For the full procedure, adaptation guidance, and troubleshooting, see
+[Experimental: Vanilla vLLM GAIE On-ramp](../../../../../docs/fern/kubernetes/vanilla-vllm-onramp.mdx).
+
+For architecture and environment details, see
+[Vanilla vLLM GAIE On-ramp Architecture](../../../../../docs/fern/design-docs/vanilla-vllm-gaie-onramp.md)
+and [Gateway API Routing Reference](../../../../../docs/fern/components/router/gateway-api-reference.mdx#standalone-epp-runtime-environment).
+
+For selector replication semantics, see
+[Standalone Selection Service](../../../../../docs/fern/components/router/standalone-selection.md).

--- a/docs/fern/components/router/gateway-api-reference.mdx
+++ b/docs/fern/components/router/gateway-api-reference.mdx
@@ -5,10 +5,7 @@ title: Gateway API Routing Reference
 subtitle: Dynamo Endpoint Picker Plugin fields, generated resources, runtime settings, and request contracts.
 ---
 
-Use this reference for a `DynamoGraphDeployment` (DGD) that routes requests through the Gateway API
-Inference Extension (GAIE) and the Dynamo Endpoint Picker Plugin (EPP). For the procedure, see
-[Route Requests with Gateway API](../../kubernetes/inference-gateway.mdx). For architecture, see
-[Gateway API Routing Architecture](../../design-docs/gateway-api-routing.md).
+Use this reference for Gateway API routing through the Gateway API Inference Extension (GAIE) and the Dynamo Endpoint Picker Plugin (EPP). For the operator-managed `DynamoGraphDeployment` (DGD) procedure, see [Route Requests with Gateway API](../../kubernetes/inference-gateway.mdx). For the standalone vanilla vLLM procedure, see [Vanilla vLLM GAIE On-ramp](../../kubernetes/vanilla-vllm-onramp.mdx). For architecture, see [Gateway API Routing Architecture](../../design-docs/gateway-api-routing.md) and [Vanilla vLLM GAIE On-ramp Architecture](../../design-docs/vanilla-vllm-gaie-onramp.md).
 
 ## DGD EPP Fields
 
@@ -257,6 +254,84 @@ mutated request to the selected Frontend sidecar.
 
 For supported body-bearing OpenAI requests, the EPP can inject precomputed token data into
 `nvext.token_data` so the Frontend sidecar does not repeat tokenization.
+
+## Standalone EPP Runtime Environment
+
+Standalone mode is an experimental operator-free EPP integration for GAIE deployments that route to upstream vLLM workers. Set these values on the standalone EPP container in `spec.template.spec.containers[].env`; for the task-oriented workflow, see [Vanilla vLLM GAIE On-ramp](../../kubernetes/vanilla-vllm-onramp.mdx).
+
+<ParamField path="DYN_EPP_MODE" type="string" required={true}>
+  Runs the embedded selection service without the Dynamo runtime.
+
+  <span className="enum-values"><span className="enum-label">Value:</span> <Badge intent="note" minimal>standalone</Badge></span>
+</ParamField>
+
+<ParamField path="DYN_EPP_INFERENCE_POOL_NAME" type="string" required={true}>
+  Name of the `InferencePool` that drives worker discovery.
+</ParamField>
+
+<ParamField path="POD_NAMESPACE" type="string" required={true}>
+  Namespace containing the EPP, `InferencePool`, and workers. Inject it with the Kubernetes downward API.
+</ParamField>
+
+<ParamField path="DYN_MODEL_NAME" type="string" required={true}>
+  Served model ID. Requests must use the same `model` value.
+</ParamField>
+
+<ParamField path="DYN_EPP_TOKENIZER_SERVICE_URL" type="URL" required={true}>
+  Base URL of the vLLM render Service used for `/v1/chat/completions/render` tokenization.
+</ParamField>
+
+<ParamField path="DYN_EPP_TOKENIZER_PROTOCOL" type="string" required={true}>
+  Tokenizer wire protocol.
+
+  <span className="enum-values"><span className="enum-label">Value:</span> <Badge intent="note" minimal>vllm-render</Badge></span>
+</ParamField>
+
+<ParamField path="DYN_KV_CACHE_BLOCK_SIZE" type="integer" required={true}>
+  Backend KV cache block size. Must equal vLLM `--block-size`; mismatches change prefix block hashes and produce incorrect overlap scores.
+</ParamField>
+
+<ParamField path="DYN_EPP_KV_EVENT_PORT" type="integer" default="5557">
+  Per-pod vLLM KV event port.
+</ParamField>
+
+<ParamField path="DYN_EPP_KV_EVENT_REPLAY_PORT" type="integer">
+  Per-pod replay port for KV event gap recovery.
+</ParamField>
+
+<ParamField path="DYN_EPP_MAX_NUM_BATCHED_TOKENS" type="integer">
+  vLLM maximum batched-token capacity used for load accounting. Set it to the worker `--max-num-batched-tokens` value when router queue thresholds are enabled.
+</ParamField>
+
+<ParamField path="DYN_EPP_TOTAL_KV_BLOCKS" type="integer">
+  Optional per-worker total KV block hint.
+</ParamField>
+
+<ParamField path="DYN_EPP_SELECTION_INDEXER_THREADS" type="integer" default="4">
+  KV indexer thread count.
+</ParamField>
+
+<ParamField path="DYN_EPP_TOKENIZATION_TIMEOUT_MS" type="integer" default="5000">
+  Render request timeout in milliseconds.
+</ParamField>
+
+<ParamField path="DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES" type="integer" default="16777216">
+  Maximum render response size.
+</ParamField>
+
+<ParamField path="DYN_EPP_MAX_INFLIGHT_REQUESTS" type="integer" default="1024">
+  Concurrent EPP request guardrail. Excess requests receive `503`.
+</ParamField>
+
+<ParamField path="DYN_EPP_PEER_SERVICE" type="string">
+  EPP Service used to discover sibling replicas for best-effort active-load synchronization.
+</ParamField>
+
+<ParamField path="POD_IP" type="string">
+  EPP pod IP used to exclude the local replica from its peer set. Required when `DYN_EPP_PEER_SERVICE` is set.
+</ParamField>
+
+The `InferencePool` remains the source of truth for the worker selector and target HTTP port. Do not duplicate those fields in EPP environment variables.
 
 ## Service Mesh Configuration
 

--- a/docs/fern/design-docs/vanilla-vllm-gaie-onramp.md
+++ b/docs/fern/design-docs/vanilla-vllm-gaie-onramp.md
@@ -1,0 +1,64 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Vanilla vLLM GAIE On-ramp Architecture
+subtitle: How standalone Dynamo EPP routing connects GAIE to upstream vLLM workers.
+---
+
+The vanilla vLLM GAIE on-ramp runs the Dynamo Endpoint Picker Plugin (EPP) in standalone mode for deployments that already use Gateway API Inference Extension (GAIE) and upstream `vllm serve` pods. It keeps the Gateway API request path and worker images in place while adding Dynamo's KV-aware endpoint selection.
+
+Use [Vanilla vLLM GAIE On-ramp](../kubernetes/vanilla-vllm-onramp.mdx) for the task-oriented setup. Use [Route Requests with Gateway API](../kubernetes/inference-gateway.mdx) for the operator-managed DGD topology.
+
+## Request Path
+
+```mermaid
+flowchart LR
+    Client["Client"] --> Gateway["Gateway"]
+    Gateway --> Route["HTTPRoute"]
+    Route --> Pool["InferencePool"]
+    Pool --> EPP["Dynamo EPP<br/>standalone mode"]
+    EPP --> Worker["Ready vLLM pod"]
+    Worker -. "KV events<br/>ZMQ :5557" .-> EPP
+    EPP -->|"POST request body<br/>/v1/chat/completions/render"| Render["vLLM HTTP Service<br/>tokenizer endpoint"]
+    Render -->|"routing tokens"| EPP
+    Render -. "selects the same vLLM pods" .-> Worker
+```
+
+The `InferencePool` is the source of truth for worker labels and HTTP port. The EPP watches that pool and Ready pods in its namespace, subscribes directly to each worker's KV event socket, and calls vLLM's `/v1/chat/completions/render` endpoint to tokenize each routing request. The Gateway forwards the original request to the selected pod. The render Service is not a separate renderer workload; it is a stable Kubernetes Service address for the HTTP endpoint served by the same vLLM pods.
+
+| Concern | Standalone on-ramp | Operator-managed Gateway API routing |
+|---|---|---|
+| Workers | Stock vLLM pods | Dynamo workers and direct-mode Frontend sidecars |
+| Resource lifecycle | User-managed Deployments, Services, RBAC, `InferencePool`, and `HTTPRoute` | DGD and Dynamo operator |
+| Worker discovery | Kubernetes pod watch driven by `InferencePool.spec.selector` | Dynamo runtime discovery |
+| KV state | Direct per-pod vLLM ZMQ subscriptions | Dynamo event plane |
+| Tokenization | vLLM `/v1/chat/completions/render` Service | Dynamo model-card preprocessor |
+| Supported serving shape | Aggregated vLLM with data-parallel size 1 per pod | Aggregated and disaggregated Dynamo deployments |
+
+Standalone mode is still a Gateway API routing topology. It changes who creates resources and how the EPP discovers worker state; it does not add a third public request-entry topology. For the operator-managed architecture and generated-resource boundary, see [Gateway API Routing Architecture](gateway-api-routing.md).
+
+## EPP Replication
+
+Each EPP replica has an in-process selector and KV index. When `DYN_EPP_PEER_SERVICE` is set, replicas watch their own Service's `EndpointSlice` resources and discover its named TCP `replica-agg` port. They synchronize admission, prefill-complete, and free events so active-load accounting converges across replicas.
+
+```mermaid
+flowchart LR
+    Pool["InferencePool"] -->|"selection request<br/>gRPC :9002"| Service["dynamo-epp Service"]
+    Service --> ReplicaA["EPP replica A<br/>selector + KV index"]
+    Service --> ReplicaB["EPP replica B<br/>selector + KV index"]
+    Slices["Service EndpointSlices"] -. "discover sibling pod IPs" .-> ReplicaA
+    Slices -. "discover sibling pod IPs" .-> ReplicaB
+    Workers["Ready vLLM pods"] -. "KV events :5557<br/>independent index warm-up" .-> ReplicaA
+    Workers -. "KV events :5557<br/>independent index warm-up" .-> ReplicaB
+    ReplicaA <-->|"replica-agg :9092<br/>admission, prefill-complete, free"| ReplicaB
+```
+
+Replica synchronization does not copy the full KV index to a new EPP. A new replica warms its index from live worker events and optional replay. For consistency details, see [Standalone Selection Service](../components/router/standalone-selection.md).
+
+For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVICE`, `POD_IP`, and the `replica-agg` Service port.
+
+## Scope and Limitations
+
+The standalone path currently targets aggregated vLLM serving with data-parallel size 1 per pod. It does not provide the DGD/operator lifecycle, Dynamo runtime discovery, disaggregated prefill/decode orchestration, request migration, topology-aware routing, or full operator-managed observability.
+
+Use [Route Requests with Gateway API](../kubernetes/inference-gateway.mdx) when you want the supported operator-managed lifecycle, Dynamo workers, or disaggregated serving. Use [Gateway API Routing Reference](../components/router/gateway-api-reference.mdx) for DGD and standalone EPP runtime contracts.

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -836,6 +836,8 @@ navigation:
                     path: kubernetes/disagg-communication-guide.md
                   - page: Gateway API Routing
                     path: design-docs/gateway-api-routing.md
+                  - page: Vanilla vLLM GAIE On-ramp
+                    path: design-docs/vanilla-vllm-gaie-onramp.md
               - section: Multinode
                 collapsed: true
                 contents:

--- a/docs/fern/kubernetes/gateway-api-installation.mdx
+++ b/docs/fern/kubernetes/gateway-api-installation.mdx
@@ -13,8 +13,7 @@ an Endpoint Picker Plugin (EPP). To use the default topology, continue to
 [KV-Aware Routing with the Dynamo Frontend](dgd-kv-routing.md).
 </Note>
 
-Install this integration after the [Dynamo platform](installation-guide.md). The Dynamo operator needs
-the GAIE `InferencePool` API before it can reconcile a `DynamoGraphDeployment` with an EPP component.
+Install this integration when you plan to route requests through a Gateway API data plane and GAIE `InferencePool`. For operator-managed DGD routing, install it after the [Dynamo platform](installation-guide.md) so the Dynamo operator can reconcile a `DynamoGraphDeployment` with an EPP component. For the experimental [Vanilla vLLM GAIE On-ramp](vanilla-vllm-onramp.mdx), the Dynamo operator is not required, but the same Gateway API, GAIE, and Gateway implementation prerequisites apply.
 
 <Steps toc={true} tocDepth={2}>
 
@@ -68,8 +67,7 @@ The script installs:
   controller). Its `http` listener sets `allowedRoutes.namespaces.from: All`, so `HTTPRoute` objects
   in `$NAMESPACE` attach to it across namespaces.
 
-The workload namespace `$NAMESPACE` still holds the model, EPP, `InferencePool`, and `HTTPRoute`.
-Only the Gateway itself lives in `$AGW_NAMESPACE`.
+The workload namespace `$NAMESPACE` still holds the model, EPP, `InferencePool`, and `HTTPRoute`. Only the Gateway itself lives in `$AGW_NAMESPACE`.
 
 The script pins compatible dependency versions. Review it before running it when your platform team
 owns Gateway API or agentgateway lifecycle.

--- a/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
+++ b/docs/fern/kubernetes/vanilla-vllm-onramp.mdx
@@ -7,60 +7,12 @@ subtitle: Add Dynamo's advanced KV-aware routing to GAIE deployments that use up
 ---
 
 <Warning>
-This on-ramp uses the **experimental standalone mode** of the Dynamo Endpoint Picker Plugin (EPP).
-This is a special operator-free integration for existing vanilla vLLM fleets, not the standard
-operator-managed Gateway API path. Standalone mode is not available in a published Dynamo release
-yet. Use an image built from a Dynamo revision that includes standalone EPP support.
+This on-ramp uses the **experimental standalone mode** of the Dynamo Endpoint Picker Plugin (EPP). Standalone mode is a special operator-free integration for existing vanilla vLLM fleets, not the standard operator-managed Gateway API path. It is not available in a published Dynamo release yet; use an image built from a Dynamo revision that includes standalone EPP support.
 </Warning>
 
-Use this on-ramp to add Dynamo's advanced KV-aware routing to
-[Gateway API Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension)
-deployments that run stock `vllm serve` workers. **Stock vLLM** means the upstream vLLM container
-images. You do not need to replace them with Dynamo vLLM images, install the Dynamo operator, or
-migrate the rest of the deployment to Dynamo. The standalone Dynamo Endpoint Picker Plugin (EPP)
-adds the routing layer while your Gateway, `HTTPRoute`, and `InferencePool` remain standard GAIE
-resources and your workers keep running the upstream vLLM images.
+Use this on-ramp to add Dynamo's advanced KV-aware routing to [Gateway API Inference Extension (GAIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) deployments that run stock `vllm serve` workers. **Stock vLLM** means upstream vLLM container images; you do not need to replace them with Dynamo vLLM images, install the Dynamo operator, or migrate the rest of the deployment to Dynamo.
 
-The EPP runs the same Dynamo worker selection service used by a full Dynamo deployment. In standalone
-mode, it runs in-process without a `DynamoGraphDeployment` (DGD) or the Dynamo distributed runtime
-and event plane.
-
-This is still the **Gateway API routing topology** described in
-[KV-Aware Routing on Kubernetes](kv-aware-routing.md). Standalone mode changes who creates the
-resources and how the EPP discovers worker state; it does not add a third request-entry topology.
-
-## Architecture
-
-```mermaid
-flowchart LR
-    Client["Client"] --> Gateway["Gateway"]
-    Gateway --> Route["HTTPRoute"]
-    Route --> Pool["InferencePool"]
-    Pool --> EPP["Dynamo EPP<br/>standalone mode"]
-    EPP --> Worker["Ready vLLM pod"]
-    Worker -. "KV events<br/>ZMQ :5557" .-> EPP
-    EPP -->|"POST request body<br/>/v1/chat/completions/render"| Render["vLLM HTTP Service<br/>tokenizer endpoint"]
-    Render -->|"routing tokens"| EPP
-    Render -. "selects the same vLLM pods" .-> Worker
-```
-
-The `InferencePool` is the source of truth for the worker labels and HTTP port. The EPP watches that
-pool and Ready pods in its namespace, subscribes directly to each worker's KV event socket, and calls
-vLLM's `/v1/chat/completions/render` endpoint to tokenize each routing request. The Gateway forwards
-the original request to the selected pod. The render Service is not a separate renderer workload; it
-is a stable Kubernetes Service address for the HTTP endpoint served by the same vLLM pods.
-
-| Concern | Standalone on-ramp | Operator-managed Gateway API routing |
-|---|---|---|
-| Workers | Stock vLLM pods | Dynamo workers and direct-mode Frontend sidecars |
-| Resource lifecycle | User-managed Deployments, Services, RBAC, `InferencePool`, and `HTTPRoute` | DGD and Dynamo operator |
-| Worker discovery | Kubernetes pod watch driven by `InferencePool.spec.selector` | Dynamo runtime discovery |
-| KV state | Direct per-pod vLLM ZMQ subscriptions | Dynamo event plane |
-| Tokenization | vLLM `/v1/chat/completions/render` Service | Dynamo model-card preprocessor |
-| Supported serving shape | Aggregated vLLM with data-parallel size 1 per pod | Aggregated and disaggregated Dynamo deployments |
-
-For the operator-managed architecture and generated-resource boundary, see
-[Gateway API Routing Architecture](../design-docs/gateway-api-routing.md).
+For how standalone mode differs from the operator-managed Gateway API path, see [Vanilla vLLM GAIE On-ramp Architecture](../design-docs/vanilla-vllm-gaie-onramp.md). For field-level configuration, see [Gateway API Routing Reference](../components/router/gateway-api-reference.mdx#standalone-epp-runtime-environment).
 
 ## Before You Begin
 
@@ -70,118 +22,59 @@ You need:
 - `kubectl` and Helm configured for the cluster.
 - A Dynamo source checkout.
 - A container registry that every cluster node can pull from.
-- Two schedulable GPUs for the example's two vLLM replicas. You can scale the worker Deployment to
-  one replica for a smoke test.
+- A Gateway API, GAIE, and compatible Gateway implementation installed. For a new agentgateway setup, complete [Install Gateway API Routing](gateway-api-installation.mdx).
+- Two schedulable GPUs for the example's two vLLM replicas. You can scale the worker Deployment to one replica for a smoke test.
 
 The example serves the public `Qwen/Qwen3-0.6B` model, which does not require a Hugging Face token.
 
-## Build the EPP Image
+<Steps toc={true} tocDepth={2}>
 
-Standalone mode is not available in a published Dynamo image yet. From the repository root, build
-the Rust EPP from the current source revision and push it to your container registry:
+<Step title="Set the deployment variables">
+
+Set the namespace and image variables used throughout the procedure:
 
 ```bash
+export NAMESPACE=gaie-vllm-onramp
+export AGW_NAMESPACE=agentgateway-system
 export EPP_IMAGE=registry.example.com/your-project/dynamo-rust-epp:standalone
+```
 
+`AGW_NAMESPACE` is the namespace that contains the `inference-gateway` Gateway when you use the repository's agentgateway installer. If your Gateway lives elsewhere, use that namespace when port-forwarding and set `HTTPRoute.spec.parentRefs[].namespace` accordingly.
+
+</Step>
+
+<Step title="Build the standalone EPP image">
+
+Standalone mode is not available in a published Dynamo image yet. From the repository root, build the Rust EPP from the current source revision and push it to your container registry:
+
+```bash
 make -C deploy/inference-gateway/ext-proc \
   IMAGE_TAG="$EPP_IMAGE" \
   image-push
 ```
 
-## Choose a Deployment Path
+</Step>
 
-Choose the path that matches your starting point:
+<Step title="Confirm the Gateway API layer">
 
-- **Deploy from Scratch** installs the Gateway API layer and applies the complete example, including
-  vLLM workers, the EPP, an `InferencePool`, and an `HTTPRoute`.
-- **Use the Dynamo EPP in an Existing GAIE Deployment** keeps your current Gateway, `HTTPRoute`,
-  `InferencePool`, and vLLM workers. Deploy a replacement EPP as shown below, or adapt the existing
-  EPP Deployment in place with the same configuration.
+Use an existing GAIE-compatible Gateway, or install the shared Gateway API layer with [Install Gateway API Routing](gateway-api-installation.mdx). The standalone on-ramp expects a Gateway named `inference-gateway` whose `http` listener allows `HTTPRoute` resources from `$NAMESPACE`.
 
-Both paths use the same example names so the verification commands apply to either path:
+When you use the repository's agentgateway installer, it creates `$NAMESPACE`, installs the Gateway API and GAIE CRDs, installs agentgateway, and creates the cross-namespace `inference-gateway` Gateway in `$AGW_NAMESPACE`.
 
-| Resource | Example Name |
-|---|---|
-| Workload namespace | `gaie-vllm-onramp` (`$NAMESPACE`) |
-| Gateway namespace | `agentgateway-system` (`$AGW_NAMESPACE`) |
-| Gateway | `inference-gateway` |
-| vLLM Deployment | `vllm-qwen` |
-| vLLM HTTP/render Service | `vllm-qwen-render` |
-| EPP Deployment and Service | `dynamo-epp` |
-| InferencePool | `vllm-qwen-pool` |
-| HTTPRoute | `vllm-qwen-route` |
+</Step>
+
+<Step title="Choose a deployment path">
+
+Choose the path that matches your starting point.
 
 <Note>
-For an existing GAIE deployment, these are example names. Replace them in the commands and YAML
-snippets with the names of your existing resources.
+For an existing GAIE deployment, these are example names. Replace them in the commands and YAML snippets with the names of your existing resources.
 </Note>
-
-Set the shared namespace variables:
-
-```bash
-export NAMESPACE=gaie-vllm-onramp
-export AGW_NAMESPACE=agentgateway-system
-```
 
 <Tabs>
 <Tab title="Deploy from Scratch">
 
-### Install the Gateway API Layer
-
-Install Gateway API, GAIE, agentgateway, and the Gateway:
-
-```bash
-./deploy/inference-gateway/scripts/install_gaie_crd_agentgateway.sh
-```
-
-The script pins the supported Gateway API, GAIE, and agentgateway versions. It creates the
-`inference-gateway` Gateway in `$AGW_NAMESPACE`; the `http` listener allows `HTTPRoute` resources
-from workload namespaces. The on-ramp resources remain in `$NAMESPACE`.
-
-Verify that the Gateway is programmed:
-
-```bash
-kubectl wait gateway/inference-gateway -n "$AGW_NAMESPACE" \
-  --for=condition=Programmed --timeout=180s
-```
-
-### Configure Model Access
-
-The public `Qwen/Qwen3-0.6B` model in the example does not require authentication. To substitute a
-gated or private Hugging Face model, create a Secret in the workload namespace before deploying:
-
-```bash
-read -rsp "Hugging Face token: " HF_TOKEN
-echo
-kubectl create secret generic hf-token-secret -n "$NAMESPACE" \
-  --from-literal=HF_TOKEN="$HF_TOKEN"
-unset HF_TOKEN
-```
-
-Add the Secret reference to the vLLM container in `agg.yaml`:
-
-```yaml
-env:
-  - name: HF_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: hf-token-secret
-        key: HF_TOKEN
-```
-
-### Deploy the On-ramp
-
-The installation script above creates the Gateway API and GAIE layer. The example manifest then
-creates the workload layer in `$NAMESPACE`:
-
-- Two stock vLLM workers with prefix caching, KV events, and readiness probes.
-- A `vllm-qwen-render` Service that selects those same workers and exposes their HTTP port for
-  `/v1/chat/completions/render`.
-- Namespaced read-only RBAC for pods, `InferencePool`, and `EndpointSlice` resources.
-- Two standalone EPP replicas and their gRPC and replica-synchronization Service.
-- An `InferencePool` and an `HTTPRoute` that attaches to the cross-namespace Gateway.
-
-Apply the manifest from the repository root using the image you pushed:
+Apply the complete example manifest from the repository root using the EPP image you pushed:
 
 ```bash
 sed "s#dynamo/dynamo-rust-epp:dev#$EPP_IMAGE#" \
@@ -189,57 +82,27 @@ sed "s#dynamo/dynamo-rust-epp:dev#$EPP_IMAGE#" \
   kubectl apply -n "$NAMESPACE" -f -
 ```
 
-The checked-in manifest is also available as
-[`agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
+The manifest creates stock vLLM workers, a render Service for vLLM tokenization, namespaced read-only RBAC, two standalone EPP replicas, an `InferencePool`, and an `HTTPRoute`.
 
 </Tab>
-<Tab title="Use the Dynamo EPP in an Existing GAIE Deployment">
+<Tab title="Use an Existing GAIE Deployment">
 
-The starting point for this path is a working GAIE request path with a Gateway, `HTTPRoute`,
-`InferencePool`, EPP Deployment and Service, and upstream vLLM Deployment. Keep the Gateway,
-`HTTPRoute`, `InferencePool`, and vLLM workload. Choose how to deploy the Dynamo EPP:
+Start from a working GAIE request path with a Gateway, `HTTPRoute`, `InferencePool`, EPP Deployment and Service, and upstream vLLM Deployment. Keep the Gateway, `HTTPRoute`, `InferencePool`, and vLLM workload, then either deploy a replacement Dynamo EPP Service or adapt the existing EPP Deployment in place.
 
-- **Deploy a replacement EPP.** Create a new Dynamo EPP Deployment and Service, switch
-  `InferencePool.spec.endpointPickerRef` to the new Service, and then remove the previous EPP
-  Deployment and Service.
-- **Adapt the existing EPP Deployment in place.** Change its container image and configuration to
-  run the Dynamo EPP. Keep the existing Service name and port so
-  `InferencePool.spec.endpointPickerRef` does not change.
+- **Deploy a replacement EPP.** Create a new Dynamo EPP Deployment and Service, switch `InferencePool.spec.endpointPickerRef` to the new Service, and then remove the previous EPP Deployment and Service.
+- **Adapt the existing EPP Deployment in place.** Change its container image and configuration to run the Dynamo EPP. Keep the existing Service name and port so `InferencePool.spec.endpointPickerRef` does not change.
 
-The steps below demonstrate the replacement path and use `dynamo-epp` for the new Deployment and
-Service. To adapt the existing Deployment instead, apply the same Dynamo image, environment
-variables, ports, readiness probe, ServiceAccount, and RBAC in place. Keep its labels aligned with
-the existing Service selector, and keep the Service and `endpointPickerRef` unchanged.
+To adapt the existing Deployment instead, apply the same Dynamo image, environment variables, ports, readiness probe, ServiceAccount, and RBAC in place. Keep its labels aligned with the existing Service selector, and keep the Service and `endpointPickerRef` unchanged.
 
-Ensure that the Gateway listener allows routes from `$NAMESPACE`. See
-[Install Gateway API Routing](gateway-api-installation.mdx) for the shared agentgateway and Istio
-prerequisites.
+Ensure that the Gateway listener allows routes from `$NAMESPACE`. See [Install Gateway API Routing](gateway-api-installation.mdx) for the shared agentgateway and Istio prerequisites.
 
 ### Configure vLLM
 
-Every worker selected by the `InferencePool` must:
-
-- Expose its OpenAI-compatible server port.
-- Pass a readiness probe before the EPP registers it.
-- Enable prefix caching.
-- Publish KV cache events over ZMQ.
-- Use the same block size and maximum batched-token value configured on the EPP.
-
-The `InferencePool` selects pods, not the Deployment object. Ensure that its selector label is on
-`spec.template.metadata.labels`. To add the example label without replacing existing pod-template
-labels, patch the vLLM Deployment:
-
-```bash
-kubectl patch deployment/vllm-qwen -n "$NAMESPACE" --type merge \
-  --patch '{"spec":{"template":{"metadata":{"labels":{"app":"vllm-qwen"}}}}}'
-```
-
-Do not use `kubectl label deployment` for this step. That command changes
-`Deployment.metadata.labels`, which does not label the worker pods.
+Every worker selected by the `InferencePool` must expose its OpenAI-compatible server port, pass a readiness probe, enable prefix caching, publish KV cache events over ZMQ, and use the same block size and maximum batched-token value configured on the EPP.
 
 Compare a typical existing vLLM container with the changes required by the on-ramp.
 
-**Before — existing vLLM container:**
+**Before:**
 
 ```yaml
 containers:
@@ -255,7 +118,7 @@ containers:
         containerPort: 8000
 ```
 
-**After — vLLM container prepared for the Dynamo EPP:**
+**After:**
 
 ```yaml
 containers:
@@ -286,117 +149,27 @@ containers:
         port: http
 ```
 
-To tokenize each routing request, the Dynamo EPP calls vLLM's
-`/v1/chat/completions/render` endpoint through a stable Service URL. This is not a separate renderer
-deployment; the endpoint runs on the same vLLM pods that serve inference requests. Reuse an existing
-HTTP Service when it selects the same homogeneous vLLM pods, or create a Service such as:
+The `InferencePool` selects pods, not the Deployment object. If you need to add the example selector label, patch the pod template:
 
-```yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: vllm-qwen-render
-spec:
-  selector:
-    app: vllm-qwen
-  ports:
-    - name: http
-      port: 8000
-      targetPort: http
+```bash
+kubectl patch deployment/vllm-qwen -n "$NAMESPACE" --type merge \
+  --patch '{"spec":{"template":{"metadata":{"labels":{"app":"vllm-qwen"}}}}}'
 ```
 
-Because the Service and EPP are in the same namespace, its base URL is
-`http://vllm-qwen-render:8000`. Set `DYN_EPP_TOKENIZER_SERVICE_URL` to that URL, or to the
-corresponding URL for the existing Service you reuse.
+Do not use `kubectl label deployment` for this step. That command changes `Deployment.metadata.labels`, which does not label the worker pods.
 
-### Deploy a Replacement EPP
+Create or reuse a stable Service for the same vLLM pods so the EPP can call `/v1/chat/completions/render`. The example uses `http://vllm-qwen-render:8000` and sets `DYN_EPP_TOKENIZER_SERVICE_URL` to that base URL.
 
-Create a ServiceAccount with namespaced `get`, `list`, and `watch` access to pods, `InferencePool`
-resources, and `EndpointSlice` resources. Then create the replacement Deployment with the Dynamo EPP
-image. The environment variables belong to the EPP container in
-`spec.template.spec.containers[].env`:
-
-```yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: dynamo-epp
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: dynamo-epp
-  template:
-    metadata:
-      labels:
-        app: dynamo-epp
-    spec:
-      serviceAccountName: dynamo-epp
-      containers:
-        - name: epp
-          image: <EPP_IMAGE>
-          env:
-            - name: DYN_EPP_MODE
-              value: standalone
-            - name: DYN_EPP_INFERENCE_POOL_NAME
-              value: vllm-qwen-pool
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: DYN_MODEL_NAME
-              value: Qwen/Qwen3-0.6B
-            - name: DYN_EPP_TOKENIZER_SERVICE_URL
-              value: http://vllm-qwen-render:8000
-            - name: DYN_EPP_TOKENIZER_PROTOCOL
-              value: vllm-render
-            - name: DYN_KV_CACHE_BLOCK_SIZE
-              value: "16"
-            - name: DYN_EPP_KV_EVENT_PORT
-              value: "5557"
-            - name: DYN_EPP_MAX_NUM_BATCHED_TOKENS
-              value: "8192"
-            - name: DYN_EPP_PEER_SERVICE
-              value: dynamo-epp
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-```
-
-The example runs two EPP replicas, so `DYN_EPP_PEER_SERVICE` and `POD_IP` are part of its required
-configuration.
-
-The model name, block size, event port, and maximum batched-token values in the example are one
-coherent configuration. Change them together when adapting another model or vLLM deployment.
-
-Create the replacement `dynamo-epp` Service with gRPC port `9002` and, for two replicas, the named
-`replica-agg` port. The complete ServiceAccount, RBAC, Deployment, and Service definitions are
-available in the
-[`agg.yaml` EPP resources](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml).
-
-### Connect the InferencePool
-
-Confirm these fields on the existing `InferencePool`:
-
-- Confirm that `spec.selector` matches labels on the vLLM pod template, not only the Deployment.
-- Confirm that `spec.targetPorts[0].number` is the vLLM HTTP port.
-- Update `spec.endpointPickerRef` to the replacement `dynamo-epp` Service on port `9002`. When
-  adapting the existing Deployment behind the same Service and port, this field does not change.
-
-The Dynamo EPP reads the pool at runtime. Do not duplicate the worker selector or HTTP port in EPP
-environment variables.
-
-If you deployed a replacement, remove the previous EPP Deployment and Service after switching
-`spec.endpointPickerRef`.
+For the replacement EPP workload, start from the ServiceAccount, RBAC, Deployment, and Service definitions in [`agg.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml), update the image, model, tokenizer Service URL, block size, KV event port, and batched-token settings, then point `InferencePool.spec.endpointPickerRef` to the Dynamo EPP Service on port `9002`.
 
 </Tab>
 </Tabs>
 
-## Verify the Deployment
+</Step>
 
-These commands apply to both paths because they use the same example names. Wait for the vLLM
-workers and EPP:
+<Step title="Verify the request path">
+
+Wait for the workers and EPP:
 
 ```bash
 kubectl wait deployment/vllm-qwen -n "$NAMESPACE" \
@@ -413,8 +186,7 @@ kubectl get httproute/vllm-qwen-route -n "$NAMESPACE" \
   -o jsonpath='{range .status.parents[*]}{.parentRef.name}{"\\t"}{range .conditions[*]}{.type}={.status}{" "}{end}{"\\n"}{end}'
 ```
 
-The output should identify `inference-gateway` and report `Accepted=True` and
-`ResolvedRefs=True`.
+The output should identify `inference-gateway` and report `Accepted=True` and `ResolvedRefs=True`.
 
 Find the Service generated for the Gateway and start a port-forward:
 
@@ -446,74 +218,35 @@ Inspect the EPP logs near the request:
 kubectl logs -n "$NAMESPACE" deployment/dynamo-epp --tail=200
 ```
 
-The logs should show worker discovery and endpoint selection. If the model responds but the EPP logs
-show no selection, the route is bypassing the `InferencePool`.
+The logs should show worker discovery and endpoint selection. If the model responds but the EPP logs show no selection, the route is bypassing the `InferencePool`.
 
-## EPP Replication
+</Step>
 
-Each EPP replica has an in-process selector and KV index. When `DYN_EPP_PEER_SERVICE` is set, replicas
-watch their own Service's `EndpointSlice` resources and discover its named TCP `replica-agg` port.
-They synchronize admission, prefill-complete, and free events so active-load accounting converges
-across replicas.
+<Step title="Clean up the from-scratch example">
 
-```mermaid
-flowchart LR
-    Pool["InferencePool"] -->|"selection request<br/>gRPC :9002"| Service["dynamo-epp Service"]
-    Service --> ReplicaA["EPP replica A<br/>selector + KV index"]
-    Service --> ReplicaB["EPP replica B<br/>selector + KV index"]
-    Slices["Service EndpointSlices"] -. "discover sibling pod IPs" .-> ReplicaA
-    Slices -. "discover sibling pod IPs" .-> ReplicaB
-    Workers["Ready vLLM pods"] -. "KV events :5557<br/>independent index warm-up" .-> ReplicaA
-    Workers -. "KV events :5557<br/>independent index warm-up" .-> ReplicaB
-    ReplicaA <-->|"replica-agg :9092<br/>admission, prefill-complete, free"| ReplicaB
+If you used the **Deploy from Scratch** path, delete the example resources:
+
+```bash
+kubectl delete -n "$NAMESPACE" \
+  -f deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
 ```
 
-Replica synchronization does not copy the full KV index to a new EPP. A new replica warms its index
-from live worker events and optional replay. For consistency details, see
-[Standalone Selection Service](../components/router/standalone-selection.md).
+Delete the namespace only if it contains no resources you want to keep:
 
-For a single EPP replica, set `spec.replicas: 1` and remove `DYN_EPP_PEER_SERVICE`, `POD_IP`, and the
-`replica-agg` Service port.
+```bash
+kubectl delete namespace "$NAMESPACE"
+```
 
-## Standalone EPP Configuration Reference
+</Step>
 
-| Variable | Required | Meaning |
-|---|---|---|
-| `DYN_EPP_MODE=standalone` | Yes | Runs the embedded selection service without the Dynamo runtime. |
-| `DYN_EPP_INFERENCE_POOL_NAME` | Yes | Name of the `InferencePool` that drives worker discovery. |
-| `POD_NAMESPACE` | Yes | Namespace containing the EPP, pool, and workers; inject with the downward API. |
-| `DYN_MODEL_NAME` | Yes | Served model ID. Requests must use the same `model` value. |
-| `DYN_EPP_TOKENIZER_SERVICE_URL` | Yes | Base URL of the vLLM render Service. |
-| `DYN_EPP_TOKENIZER_PROTOCOL=vllm-render` | Yes | Tokenizer wire protocol; this is the only supported value. |
-| `DYN_KV_CACHE_BLOCK_SIZE` | Yes | Must equal vLLM `--block-size`. |
-| `DYN_EPP_KV_EVENT_PORT` | No | Per-pod vLLM KV event port; defaults to `5557`. |
-| `DYN_EPP_KV_EVENT_REPLAY_PORT` | No | Per-pod replay port for KV event gap recovery. |
-| `DYN_EPP_MAX_NUM_BATCHED_TOKENS` | Policy-dependent | Must equal vLLM `--max-num-batched-tokens`; required when router queue thresholds are enabled. |
-| `DYN_EPP_TOTAL_KV_BLOCKS` | No | Optional per-worker total KV block hint. |
-| `DYN_EPP_SELECTION_INDEXER_THREADS` | No | KV indexer thread count; defaults to `4`. |
-| `DYN_EPP_TOKENIZATION_TIMEOUT_MS` | No | Render request timeout; defaults to `5000`. |
-| `DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES` | No | Maximum render response size; defaults to `16777216`. |
-| `DYN_EPP_MAX_INFLIGHT_REQUESTS` | No | Concurrent EPP request guardrail; defaults to `1024`, and excess requests receive `503`. |
-| `DYN_EPP_PEER_SERVICE` | No | EPP Service used to discover sibling replicas. |
-| `POD_IP` | With peer service | EPP pod IP used to exclude the local replica from its peer set. |
-
-## Scope and Limitations
-
-The standalone path currently targets aggregated vLLM serving with data-parallel size 1 per pod. It
-does not provide the DGD/operator lifecycle, Dynamo runtime discovery, disaggregated prefill/decode
-orchestration, request migration, topology-aware routing, or full operator-managed observability.
-
-Use [Route Requests with Gateway API](inference-gateway.mdx) when you want the supported
-operator-managed lifecycle, Dynamo workers, or disaggregated serving. Use
-[Gateway API Routing Reference](../components/router/gateway-api-reference.mdx) for the DGD and
-operator-generated resource contract; that contract does not configure standalone mode.
+</Steps>
 
 ## Troubleshoot
 
 | Symptom | Check |
 |---|---|
 | EPP exits with `standalone is not yet supported` | The image predates the standalone implementation. Build or select the required `dynamo-rust-epp` revision. |
-| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch all three resource types. |
+| EPP stays not ready | Confirm the pool exists, its selector is valid, at least one matching pod is Ready, and EPP RBAC can watch pods, `InferencePool` resources, and `EndpointSlice` resources. |
 | EPP reports no schedulable workers | Set `DYN_EPP_MAX_NUM_BATCHED_TOKENS` to the vLLM `--max-num-batched-tokens` value when queueing is enabled. |
 | Route has no accepted parent | Confirm `parentRefs[].namespace` names the Gateway namespace, `sectionName` names its listener, and the listener allows routes from the workload namespace. |
 | Tokenization fails | Check the render Service endpoints and call `/v1/chat/completions/render` from the EPP namespace. |
@@ -527,19 +260,4 @@ kubectl describe httproute/vllm-qwen-route -n "$NAMESPACE"
 kubectl get inferencepool/vllm-qwen-pool -n "$NAMESPACE" -o yaml
 kubectl get pods -n "$NAMESPACE" -l app=vllm-qwen -o wide
 kubectl logs -n "$NAMESPACE" deployment/dynamo-epp --tail=200
-```
-
-## Clean Up the From-Scratch Example
-
-If you used the **Deploy from Scratch** path, delete the example resources:
-
-```bash
-kubectl delete -n "$NAMESPACE" \
-  -f deploy/inference-gateway/ext-proc/examples/onramp/agg.yaml
-```
-
-Delete the namespace only if it contains no resources you want to keep:
-
-```bash
-kubectl delete namespace "$NAMESPACE"
 ```


### PR DESCRIPTION
## Summary

- Reworks the Vanilla vLLM GAIE on-ramp into a task-oriented Fern `<Steps>` page.
- Moves standalone on-ramp architecture and EPP replication details into Developer Guide / Knowledge Base.
- Moves standalone EPP runtime environment fields into the Gateway API Routing reference.
- Updates the example README links and shared Gateway API install wording to match the docs refactor style.

## Validation

- `npx -y fern-api@5.80.2 check`
- `npx -y fern-api@5.80.2 docs broken-links`