### PR TITLE
feat(frontend): add opt-in SSE keep-alive

### DIFF
--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -56,6 +56,11 @@ The Rust HTTP server also reads these environment variables, which are not expos
   cached when the HTTP service initializes.
 </ParamField>
 
+<ParamField path="DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS" type="integer" default="0">
+  Interval in milliseconds between SSE comment frames while a streaming response has no data.
+  Unset, `0`, invalid, or unrepresentable values disable keep-alive comments.
+</ParamField>
+
 ## Router
 
 This section is the canonical CLI and environment-variable reference for the frontend's embedded

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -105,6 +105,7 @@ pub struct State {
     // Frontend API behavior read by request handlers after the service is built.
     frontend_api_config: FrontendApiConfig,
     nvext_enabled: bool,
+    sse_keep_alive: Option<Duration>,
 }
 
 /// Typed config needed only to construct HTTP shared state.
@@ -115,6 +116,52 @@ struct StateConfig {
     metrics_config: MetricsConfig,
     frontend_api_config: FrontendApiConfig,
     nvext_enabled: bool,
+    sse_keep_alive: Option<Duration>,
+}
+
+fn parse_sse_keep_alive(value: Result<String, std::env::VarError>) -> Option<Duration> {
+    let value = match value {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return None,
+        Err(error @ std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                env = env_llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
+                %error,
+                "ignoring invalid SSE keep-alive interval"
+            );
+            return None;
+        }
+    };
+
+    match value.parse::<u64>() {
+        Ok(0) => None,
+        Ok(milliseconds) => {
+            let interval = Duration::from_millis(milliseconds);
+            if std::time::Instant::now().checked_add(interval).is_some() {
+                Some(interval)
+            } else {
+                tracing::warn!(
+                    env = env_llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
+                    value,
+                    "ignoring SSE keep-alive interval outside the platform range"
+                );
+                None
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                env = env_llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
+                value,
+                %error,
+                "ignoring invalid SSE keep-alive interval"
+            );
+            None
+        }
+    }
+}
+
+fn sse_keep_alive_from_env() -> Option<Duration> {
+    parse_sse_keep_alive(std::env::var(env_llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS))
 }
 
 /// Lifecycle stage for the HTTP frontend.
@@ -381,6 +428,7 @@ impl State {
             },
             cancel_token,
             frontend_api_config: config.frontend_api_config,
+            sse_keep_alive: config.sse_keep_alive,
         }
     }
 
@@ -452,9 +500,13 @@ impl State {
         &self.cancel_token
     }
 
-    // TODO
+    /// Interval for SSE comment frames while the response stream is idle.
+    ///
+    /// Disabled by default because some OpenAI-compatible clients do not
+    /// ignore SSE comments. Provider-facing deployments can opt in with
+    /// `DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS`.
     pub fn sse_keep_alive(&self) -> Option<Duration> {
-        None
+        self.sse_keep_alive
     }
 
     /// Returns true if Anthropic billing preamble stripping is enabled.
@@ -607,6 +659,11 @@ pub struct HttpServiceConfig {
     /// Distributed runtime used by the RL worker discovery API.
     #[builder(default = "None")]
     runtime: Option<Arc<DistributedRuntime>>,
+
+    /// Interval for SSE comment frames while a streaming response is idle.
+    /// Defaults to `DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS` when not set explicitly.
+    #[builder(setter(strip_option), default = "sse_keep_alive_from_env()")]
+    sse_keep_alive: Option<Duration>,
 }
 
 fn default_rl_port() -> u16 {
@@ -968,7 +1025,6 @@ impl HttpServiceConfigBuilder {
             config.enable_nvext && !env_is_truthy(env_llm::DYN_DISABLE_FRONTEND_NVEXT);
         let admin_api_enabled =
             config.enable_admin_api && !env_is_truthy(env_llm::DYN_DISABLE_FRONTEND_ADMIN_API);
-
         let state = Arc::new(State::new(
             model_manager,
             discovery_client,
@@ -977,6 +1033,7 @@ impl HttpServiceConfigBuilder {
                 metrics_config,
                 frontend_api_config,
                 nvext_enabled,
+                sse_keep_alive: config.sse_keep_alive,
             },
         ));
         state
@@ -1797,6 +1854,39 @@ mod tests {
                 "builder=false wins even if disable is unset"
             );
         });
+    }
+
+    #[test]
+    fn test_sse_keep_alive_env_var() {
+        assert_eq!(
+            parse_sse_keep_alive(Err(std::env::VarError::NotPresent)),
+            None
+        );
+        assert_eq!(parse_sse_keep_alive(Ok("0".to_string())), None);
+        assert_eq!(
+            parse_sse_keep_alive(Ok("5000".to_string())),
+            Some(Duration::from_millis(5000))
+        );
+        assert_eq!(parse_sse_keep_alive(Ok("invalid".to_string())), None);
+
+        #[cfg(unix)]
+        {
+            use std::ffi::OsString;
+            use std::os::unix::ffi::OsStringExt;
+
+            assert_eq!(
+                parse_sse_keep_alive(Err(std::env::VarError::NotUnicode(OsString::from_vec(
+                    vec![0xff]
+                ),))),
+                None
+            );
+        }
+
+        let interval = Duration::from_millis(u64::MAX);
+        let expected = std::time::Instant::now()
+            .checked_add(interval)
+            .map(|_| interval);
+        assert_eq!(parse_sse_keep_alive(Ok(u64::MAX.to_string())), expected);
     }
 
     #[test]

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -42,6 +42,10 @@ use ports::bind_random_port;
 
 struct CounterEngine {}
 
+struct FirstTokenGateEngine {
+    release: Arc<tokio::sync::Notify>,
+}
+
 // Add a new long-running test engine
 struct LongRunningEngine {
     delay_ms: u64,
@@ -58,6 +62,33 @@ impl LongRunningEngine {
 
     fn was_cancelled(&self) -> bool {
         self.cancelled.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateChatCompletionRequest>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        Error,
+    > for FirstTokenGateEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateChatCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+        let mut generator = request.response_generator(ctx.id().to_string());
+        let release = self.release.clone();
+
+        let stream = stream! {
+            release.notified().await;
+            let output = generator.create_choice(0, Some("choice 0".to_string()), None, None);
+            yield Annotated::from_data(output);
+        };
+
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
     }
 }
 
@@ -619,6 +650,100 @@ async fn wait_for_service_ready(port: u16) {
             Err(e) => panic!("Service failed to start within timeout: {}", e),
         }
     }
+}
+
+#[tokio::test]
+async fn test_sse_keep_alive_emits_comments_during_idle_stream() {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder()
+        .port(port)
+        .enable_chat_endpoints(true)
+        .sse_keep_alive(std::time::Duration::from_millis(25))
+        .build()
+        .unwrap();
+    let state = service.state_clone();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task = tokio::spawn(async move { service.run_with_listener(token, listener).await });
+    wait_for_service_ready(port).await;
+
+    let first_token_gate = Arc::new(tokio::sync::Notify::new());
+    let card = ModelDeploymentCard::with_name_only("idle-stream-model");
+    state
+        .manager()
+        .add_chat_completions_model(
+            "idle-stream-model",
+            card.mdcsum(),
+            Arc::new(FirstTokenGateEngine {
+                release: first_token_gate.clone(),
+            }),
+        )
+        .unwrap();
+
+    let message = dynamo_protocols::types::ChatCompletionRequestMessage::User(
+        dynamo_protocols::types::ChatCompletionRequestUserMessage {
+            content: dynamo_protocols::types::ChatCompletionRequestUserMessageContent::Text(
+                "hi".to_string(),
+            ),
+            name: None,
+        },
+    );
+    let mut request = dynamo_protocols::types::CreateChatCompletionRequestArgs::default()
+        .model("idle-stream-model")
+        .messages(vec![message])
+        .build()
+        .expect("failed to build request");
+    request.stream = Some(true);
+
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/chat/completions"))
+        .json(&request)
+        .send()
+        .await
+        .unwrap();
+    assert!(response.status().is_success(), "{response:?}");
+
+    let mut stream = response.bytes_stream();
+    let mut body = Vec::new();
+    loop {
+        let chunk = timeout(std::time::Duration::from_secs(5), stream.next())
+            .await
+            .expect("idle stream did not emit an SSE comment frame")
+            .expect("idle stream ended before emitting an SSE comment frame")
+            .expect("failed to read stream");
+        body.extend_from_slice(&chunk);
+
+        let body_text = String::from_utf8_lossy(&body);
+        if body_text.contains(":\n\n") {
+            assert!(
+                !body_text.contains("data:"),
+                "model data arrived before the keep-alive comment: {body_text}"
+            );
+            break;
+        }
+    }
+
+    first_token_gate.notify_one();
+    while let Some(chunk) = timeout(std::time::Duration::from_secs(5), stream.next())
+        .await
+        .expect("stream did not finish")
+    {
+        body.extend_from_slice(&chunk.expect("failed to read stream"));
+    }
+
+    let body = String::from_utf8(body).expect("SSE response was not UTF-8");
+    assert!(
+        body.contains("data:"),
+        "stream did not emit model data: {body}"
+    );
+    assert!(
+        body.contains("data: [DONE]"),
+        "stream did not terminate with [DONE]: {body}"
+    );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -307,6 +307,11 @@ pub mod llm {
     /// back to 529.
     pub const DYN_HTTP_OVERLOAD_STATUS_CODE: &str = "DYN_HTTP_OVERLOAD_STATUS_CODE";
 
+    /// Emit an SSE comment at this interval while a streaming response has no
+    /// data. Unset, `0`, invalid, or unrepresentable values keep SSE comments
+    /// disabled.
+    pub const DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS: &str = "DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS";
+
     /// Enable LoRA adapter support (set to "true" to enable)
     pub const DYN_LORA_ENABLED: &str = "DYN_LORA_ENABLED";
 
@@ -870,6 +875,7 @@ mod tests {
             llm::DYN_LORA_ALLOCATION_PREDICTOR_TYPE,
             llm::DYN_LORA_ALLOCATION_EMA_ALPHA,
             llm::DYN_LORA_MCF_CONFIG,
+            llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS,
             llm::metrics::DYN_METRICS_PREFIX,
             llm::audit::DYN_AUDIT_SINKS,
             llm::audit::DYN_AUDIT_FORCE_LOGGING,


### PR DESCRIPTION
## Overview:

PR #408 disabled unconditional SSE keep-alive after #401 exposed clients that did not ignore comment frames, while explicitly deferring a configurable option. This restores keep-alive as opt-in behavior without changing the default.

## Details:

Set `DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS` to a positive interval to emit spec-compliant SSE comments during idle streams. Unset, `0`, or invalid values preserve the current disabled behavior.

## Where should the reviewer start?

`lib/llm/src/http/service/service_v2.rs` contains the environment parsing and shared-state wiring; existing SSE endpoints already consume `State::sse_keep_alive()`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #401

## Validation:

- synthetic check with OAI official client demonstrates this is a non-issue
- historical context from #401 indicates this was an issue with custom aiohttp python clients for engine benchmarks
- basic tests/linting
  - `cargo test -p dynamo-llm test_sse_keep_alive_env_var`
  - `cargo test -p dynamo-runtime test_no_duplicate_env_var_names`
  - `cargo test -p dynamo-runtime test_naming_conventions`
  - Clippy passed for `dynamo-llm` and `dynamo-runtime`
  - `cargo fmt --all -- --check`
  - Pre-commit checks passed
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Server-Sent Events keep-alive intervals through an environment setting.
  * Positive millisecond values enable periodic keep-alive messages; unset, zero, or invalid values disable the feature.
  * Invalid settings now produce a warning.

* **Documentation**
  * Documented the new environment setting, including its default behavior and accepted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->