### PR TITLE
fix(responses): Prevent Reversed Reasoning and Tool-Call Timelines in Unary Responses

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -1003,21 +1003,6 @@ pub fn chat_completion_to_response(
         output_limit_reached =
             choice.finish_reason == Some(dynamo_protocols::types::FinishReason::Length);
 
-        // Handle structured tool calls
-        if let Some(tool_calls) = choice.message.tool_calls {
-            for tc in &tool_calls {
-                output.push(OutputItem::FunctionCall(FunctionToolCall {
-                    arguments: tc.function.arguments.clone(),
-                    call_id: tc.id.clone(),
-                    namespace: None,
-                    name: tc.function.name.clone(),
-                    id: Some(format!("fc_{}", Uuid::new_v4().simple())),
-                    status: Some(OutputStatus::Completed),
-                }));
-            }
-        }
-
-        // Map reasoning_content to a Reasoning output item
         if let Some(reasoning_text) = choice.message.reasoning_content
             && !reasoning_text.is_empty()
             && params.reasoning_summary_requested()
@@ -1031,6 +1016,20 @@ pub fn chat_completion_to_response(
                 encrypted_content: None,
                 status: Some(OutputStatus::Completed),
             }));
+        }
+
+        // Handle structured tool calls
+        if let Some(tool_calls) = choice.message.tool_calls {
+            for tc in &tool_calls {
+                output.push(OutputItem::FunctionCall(FunctionToolCall {
+                    arguments: tc.function.arguments.clone(),
+                    call_id: tc.id.clone(),
+                    namespace: None,
+                    name: tc.function.name.clone(),
+                    id: Some(format!("fc_{}", Uuid::new_v4().simple())),
+                    status: Some(OutputStatus::Completed),
+                }));
+            }
         }
 
         // Handle text content -- also parse <tool_call> blocks from models
@@ -3004,6 +3003,39 @@ thinking
                 text: "summary".into(),
             })]
         );
+    }
+
+    #[test]
+    fn test_reasoning_summary_precedes_structured_tool_calls() {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        let mut chat_resp = make_chat_resp_with_reasoning("look up the weather");
+        let message = &mut chat_resp.inner.choices[0].message;
+        // Message content is omitted: a unary Chat Completions response cannot
+        // say whether text or the tool call came first, so only the reasoning
+        // and function-call order is asserted here.
+        message.content = None;
+        message.tool_calls = Some(vec![ChatCompletionMessageToolCall {
+            id: "call_weather".into(),
+            r#type: FunctionType::Function,
+            function: dynamo_protocols::types::FunctionCall {
+                name: "get_weather".into(),
+                arguments: r#"{"location":"SF"}"#.into(),
+            },
+        }]);
+        let params = ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..Default::default()
+        };
+
+        let response = chat_completion_to_response(chat_resp, &params, None).unwrap();
+        assert!(matches!(
+            response.inner.output.as_slice(),
+            [OutputItem::Reasoning(_), OutputItem::FunctionCall(_)]
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Prevent Reversed Reasoning and Tool-Call Timelines in Unary Responses

## Details:

<!-- Describe the changes made in this PR. -->

The unary  /v1/responses  converter appended structured  FunctionCall  items before converting  reasoning_content  into a  Reasoning  item.  When a client sends a non-streaming Responses request with  reasoning.summary  enabled and function tools configured, and the model returns both reasoning content and structured tool calls, the resulting  output  array places the tool call before the reasoning that motivated it. 

Clients that render or replay output in array order therefore show or process the action before its explanation, diverging from the streaming SSE lifecycle. The converter should append the requested  Reasoning  item first, then append structured  FunctionCall  items, followed by any message content.

```
{
  "output": [
    { "type": "reasoning", "summary": [...] },
    { "type": "function_call", "name": "get_weather", ... },
    { "type": "message", ... }
  ]
}
```

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12411" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured reasoning content appears before function-call outputs in responses that contain both.
* **Tests**
  * Added regression coverage to verify the correct output ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->