### PR TITLE
refactor(frontend): scope native generate routing by capability

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -372,6 +372,13 @@ impl Model {
             .any(|entry| entry.value().has_generate_engine())
     }
 
+    pub fn has_generate_engine_for_capability(&self, capability: &str) -> bool {
+        self.worker_sets.iter().any(|entry| {
+            let worker_set = entry.value();
+            worker_set.has_generate_engine() && worker_set.supports_runtime_capability(capability)
+        })
+    }
+
     // -- Model serving readiness --
     //
     // The set of WorkerSets in this Model that share the same `namespace`
@@ -716,6 +723,19 @@ impl Model {
     pub fn get_generate_engine(&self) -> Result<GenerateStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.generate_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_generate_engine()))
+    }
+
+    pub fn get_generate_engine_for_capability(
+        &self,
+        capability: &str,
+    ) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|worker_set| {
+            worker_set
+                .supports_runtime_capability(capability)
+                .then(|| worker_set.generate_engine.clone())
+                .flatten()
+        })
+        .ok_or_else(|| self.engine_error(self.has_generate_engine_for_capability(capability)))
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -372,6 +372,7 @@ impl Model {
             .any(|entry| entry.value().has_generate_engine())
     }
 
+    /// Check whether a Generate worker also advertises `capability`.
     pub fn has_generate_engine_for_capability(&self, capability: &str) -> bool {
         self.worker_sets.iter().any(|entry| {
             let worker_set = entry.value();
@@ -724,7 +725,7 @@ impl Model {
         self.select_worker_set_with(|ws| ws.generate_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_generate_engine()))
     }
-
+    /// Get a Generate engine from a worker advertising `capability`.
     pub fn get_generate_engine_for_capability(
         &self,
         capability: &str,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -600,6 +600,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_generate_models_for_capability(&self, capability: &str) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_generate_engine_for_capability(capability))
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_prefill_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -696,6 +704,17 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_generate_engine()
+    }
+
+    pub fn get_generate_engine_for_capability(
+        &self,
+        model: &str,
+        capability: &str,
+    ) -> Result<GenerateStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_generate_engine_for_capability(capability)
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -35,7 +35,10 @@ use crate::{
         KvEventSourceRequirement, KvRouter, router_endpoint_id, scheduler::DefaultWorkerSelector,
         shared_cache::HicacheSharedKvCache,
     },
-    local_model::runtime_config::{DisaggregatedEndpoint, ModelRuntimeConfig, topology_taint},
+    local_model::runtime_config::{
+        DisaggregatedEndpoint, ModelRuntimeConfig, VLLM_INFERENCE_V1_GENERATE_CAPABILITY,
+        topology_taint,
+    },
     lora::{LoraFilter, LoraRoutingTable, LoraStateTracker, load_estimator::LoadEstimator},
     model_card::ModelDeploymentCard,
     types::{
@@ -600,6 +603,7 @@ impl ModelManager {
             .collect()
     }
 
+    /// List Generate models with an engine that advertises `capability`.
     pub fn list_generate_models_for_capability(&self, capability: &str) -> Vec<String> {
         self.models
             .iter()
@@ -705,7 +709,7 @@ impl ModelManager {
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_generate_engine()
     }
-
+    /// Get a Generate engine for `model` from a worker advertising `capability`.
     pub fn get_generate_engine_for_capability(
         &self,
         model: &str,
@@ -964,11 +968,12 @@ impl ModelManager {
             return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
         }
         let namespace = format!("__local_generate_{}", model);
-        let mut ws = WorkerSet::new(
-            namespace.clone(),
-            card_checksum.to_string(),
-            Self::aggregated_local_card(),
+        let mut card = Self::aggregated_local_card();
+        card.runtime_config.runtime_data.insert(
+            VLLM_INFERENCE_V1_GENERATE_CAPABILITY.to_string(),
+            serde_json::Value::Bool(true),
         );
+        let mut ws = WorkerSet::new(namespace.clone(), card_checksum.to_string(), card);
         ws.generate_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
         Ok(())

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -37,7 +37,7 @@ use crate::{
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
     kv_router::{EncoderRouter, PrefillRouter},
-    local_model::runtime_config::{TokenizerBackend, VLLM_INFERENCE_V1_GENERATE_CAPABILITY},
+    local_model::runtime_config::TokenizerBackend,
     model_card::ModelDeploymentCard,
     model_type::{ModelInput, ModelType},
     preprocessor::{
@@ -169,13 +169,17 @@ fn uses_multimodal_cache_routing(card: &ModelDeploymentCard) -> bool {
             .any(|worker_type| *worker_type == WorkerType::Encode)
 }
 
-fn supports_vllm_generate(card: &ModelDeploymentCard) -> bool {
+fn supports_generate_capability(card: &ModelDeploymentCard, capability: &str) -> bool {
     matches!(
-        card.runtime_config
-            .runtime_data
-            .get(VLLM_INFERENCE_V1_GENERATE_CAPABILITY),
+        card.runtime_config.runtime_data.get(capability),
         Some(serde_json::Value::Bool(true))
     )
+}
+
+fn supports_enabled_engine_generate(card: &ModelDeploymentCard, capabilities: &[&str]) -> bool {
+    capabilities
+        .iter()
+        .any(|capability| supports_generate_capability(card, capability))
 }
 
 const ENCODER_RESULT_HANDOFF_CAPABILITY: &str = "encoder_result_handoff";
@@ -258,9 +262,9 @@ pub struct ModelWatcher {
     local_model_path: Option<PathBuf>,
     /// Frontend-level tokenizer backend override for discovered model cards.
     tokenizer_backend: Option<TokenizerBackend>,
-    /// Whether the frontend configured the vLLM-compatible Generate API.
-    /// Keep the raw Generate pipeline out of non-HTTP and default-off paths.
-    generate_engine_enabled: bool,
+    /// Worker capabilities accepted by the frontend's engine-native Generate routes.
+    /// Keep raw pipelines out of default-off and backend-mismatched paths.
+    generate_engine_capabilities: Vec<&'static str>,
 }
 
 const ALL_MODEL_TYPES: &[ModelType] = &[
@@ -384,7 +388,7 @@ impl ModelWatcher {
             pending_lora_adds: DashMap::new(),
             local_model_path: None,
             tokenizer_backend: None,
-            generate_engine_enabled: false,
+            generate_engine_capabilities: Vec::new(),
         }
     }
 
@@ -400,8 +404,8 @@ impl ModelWatcher {
         self.tokenizer_backend = tokenizer_backend;
     }
 
-    pub fn set_generate_engine_enabled(&mut self, enabled: bool) {
-        self.generate_engine_enabled = enabled;
+    pub(crate) fn set_generate_engine_capabilities(&mut self, capabilities: Vec<&'static str>) {
+        self.generate_engine_capabilities = capabilities;
     }
 
     fn apply_tokenizer_backend_override(&self, card: &mut ModelDeploymentCard) {
@@ -1042,7 +1046,6 @@ impl ModelWatcher {
                 card.name() == model_name && namespace_filter.matches(&endpoint_id.namespace)
             })
             .collect::<Vec<_>>();
-
         let card = match self.manager.remove_model_card(&key) {
             Some(card) => card,
             None => {
@@ -1103,6 +1106,7 @@ impl ModelWatcher {
                 && eid.component == *worker_component
                 && worker_set_key(eid, other_card.model_type, other_card.worker_type) == ws_key
         });
+
         let endpoint_has_instances =
             has_live_endpoint_card(&all_cards, worker_namespace, worker_component);
 
@@ -1600,7 +1604,7 @@ impl ModelWatcher {
             let needs_factory_chat_pipeline =
                 card.model_type.supports_chat() && self.chat_engine_factory.is_some();
             let needs_generate_pipeline =
-                self.generate_engine_enabled && supports_vllm_generate(card);
+                supports_enabled_engine_generate(card, &self.generate_engine_capabilities);
             let needs_preprocessed_routing =
                 needs_factory_chat_pipeline || tokenizer.is_some() || needs_generate_pipeline;
 
@@ -2195,6 +2199,7 @@ fn seed_lora_state_from_card(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
     use crate::model_card::ModelDeploymentCard;
 
     fn test_endpoint_id(name: &str) -> EndpointId {
@@ -2218,20 +2223,23 @@ mod tests {
     }
 
     #[test]
-    fn vllm_generate_requires_explicit_worker_capability() {
+    fn generate_requires_enabled_matching_worker_capability() {
+        const OTHER_GENERATE_CAPABILITY: &str = "other_generate";
         let mut card = ModelDeploymentCard::with_name_only("model");
         card.model_type = ModelType::Chat | ModelType::Completions;
-        assert!(!supports_vllm_generate(&card));
-
         card.runtime_config
             .set_engine_specific(VLLM_INFERENCE_V1_GENERATE_CAPABILITY, true)
             .unwrap();
-        assert!(supports_vllm_generate(&card));
 
-        card.runtime_config
-            .set_engine_specific(VLLM_INFERENCE_V1_GENERATE_CAPABILITY, false)
-            .unwrap();
-        assert!(!supports_vllm_generate(&card));
+        assert!(supports_enabled_engine_generate(
+            &card,
+            &[VLLM_INFERENCE_V1_GENERATE_CAPABILITY]
+        ));
+        assert!(!supports_enabled_engine_generate(&card, &[]));
+        assert!(!supports_enabled_engine_generate(
+            &card,
+            &[OTHER_GENERATE_CAPABILITY]
+        ));
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -37,7 +37,7 @@ use crate::{
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
     kv_router::{EncoderRouter, PrefillRouter},
-    local_model::runtime_config::TokenizerBackend,
+    local_model::runtime_config::{TokenizerBackend, VLLM_INFERENCE_V1_GENERATE_CAPABILITY},
     model_card::ModelDeploymentCard,
     model_type::{ModelInput, ModelType},
     preprocessor::{
@@ -406,6 +406,13 @@ impl ModelWatcher {
 
     pub(crate) fn set_generate_engine_capabilities(&mut self, capabilities: Vec<&'static str>) {
         self.generate_engine_capabilities = capabilities;
+    }
+    /// Compatibility wrapper for callers that enable the vLLM Generate route.
+    pub fn set_generate_engine_enabled(&mut self, enabled: bool) {
+        self.generate_engine_capabilities = enabled
+            .then_some(VLLM_INFERENCE_V1_GENERATE_CAPABILITY)
+            .into_iter()
+            .collect();
     }
 
     fn apply_tokenizer_backend_override(&self, card: &mut ModelDeploymentCard) {

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -152,6 +152,7 @@ impl WorkerSet {
         self.generate_engine.is_some()
     }
 
+    /// Check whether this worker set advertises `capability` in its runtime configuration.
     pub fn supports_runtime_capability(&self, capability: &str) -> bool {
         matches!(
             self.card.runtime_config.runtime_data.get(capability),

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -152,6 +152,13 @@ impl WorkerSet {
         self.generate_engine.is_some()
     }
 
+    pub fn supports_runtime_capability(&self, capability: &str) -> bool {
+        matches!(
+            self.card.runtime_config.runtime_data.get(capability),
+            Some(serde_json::Value::Bool(true))
+        )
+    }
+
     /// Whether this set has any decode engine (chat or completions)
     pub fn has_decode_engine(&self) -> bool {
         self.has_chat_engine() || self.has_completions_engine()

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -107,7 +107,7 @@ pub async fn run_with_frontend_route_extensions(
             );
             let local_model_path =
                 (!model.path().as_os_str().is_empty()).then(|| model.path().to_path_buf());
-            let generate_engine_enabled = http_service.generate_api_enabled();
+            let generate_engine_capabilities = http_service.generate_engine_capabilities();
             run_watcher(
                 distributed_runtime.clone(),
                 http_service.state().manager_clone(),
@@ -121,7 +121,7 @@ pub async fn run_with_frontend_route_extensions(
                 prefill_load_estimator.clone(),
                 local_model_path,
                 model.runtime_config().tokenizer_backend,
-                generate_engine_enabled,
+                generate_engine_capabilities,
             )
             .await?;
             http_service
@@ -203,7 +203,7 @@ async fn run_watcher(
     prefill_load_estimator: Option<Arc<dyn dynamo_kv_router::PrefillLoadEstimator>>,
     local_model_path: Option<PathBuf>,
     tokenizer_backend: Option<TokenizerBackend>,
-    generate_engine_enabled: bool,
+    generate_engine_capabilities: Vec<&'static str>,
 ) -> anyhow::Result<()> {
     // Start the LoRA allocation controller when LoRA serving is enabled. The
     // controller itself is additionally gated on the allocation config
@@ -225,7 +225,7 @@ async fn run_watcher(
     );
     watch_obj.set_local_model_path(local_model_path);
     watch_obj.set_tokenizer_backend(tokenizer_backend);
-    watch_obj.set_generate_engine_enabled(generate_engine_enabled);
+    watch_obj.set_generate_engine_capabilities(generate_engine_capabilities);
     tracing::debug!("Waiting for remote model");
     let discovery = runtime.discovery();
     let discovery_stream = discovery

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -31,6 +31,7 @@ use super::openai::{
     get_or_create_request_id, smart_json_error_middleware,
 };
 use super::{RouteDoc, service_v2};
+use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
 use crate::protocols::common::preprocessor::PreprocessedRequest;
 use crate::protocols::common::{SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
@@ -284,7 +285,9 @@ async fn handler_generate(
     let model = match &request.model {
         Some(model) => model.clone(),
         None => {
-            let models = state.manager().list_generate_models();
+            let models = state
+                .manager()
+                .list_generate_models_for_capability(VLLM_INFERENCE_V1_GENERATE_CAPABILITY);
             match models.len() {
                 1 => models.into_iter().next().unwrap(),
                 0 => {
@@ -310,7 +313,10 @@ async fn handler_generate(
         return response.into_response();
     }
 
-    let engine = match state.manager().get_generate_engine(&model) {
+    let engine = match state
+        .manager()
+        .get_generate_engine_for_capability(&model, VLLM_INFERENCE_V1_GENERATE_CAPABILITY)
+    {
         Ok(engine) => engine,
         Err(error) => {
             let (status, error_type) = match error {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -978,6 +978,19 @@ pub(super) static VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV: &str =
 /// Environment variable to set the vLLM Generate endpoint path
 /// (default: `/inference/v1/generate`).
 pub(super) static HTTP_SVC_VLLM_GENERATE_PATH_ENV: &str = "DYN_HTTP_SVC_VLLM_GENERATE_PATH";
+fn validate_generate_route_path(path: &str) -> Result<()> {
+    if !path.starts_with("/") {
+        anyhow::bail!("Generate route path must start with '/': {path:?}");
+    }
+    if path
+        .split('/')
+        .any(|segment| segment.starts_with([':', '*']))
+    {
+        anyhow::bail!("Generate route path segment must not start with ':' or '*': {path:?}");
+    }
+    Ok(())
+}
+
 fn append_route_docs(
     all_docs: &mut Vec<RouteDoc>,
     seen_routes: &mut HashSet<RouteDoc>,
@@ -1173,7 +1186,7 @@ impl HttpServiceConfigBuilder {
             &config.request_template,
             anthropic_endpoints_enabled,
             generate_endpoint_enabled,
-        );
+        )?;
         let mut inference_router = axum::Router::new();
         for (route_docs, route) in endpoint_routes {
             append_route_docs(&mut all_docs, &mut seen_route_docs, route_docs)?;
@@ -1292,7 +1305,7 @@ impl HttpServiceConfigBuilder {
         request_template: &Option<RequestTemplate>,
         enable_anthropic_endpoints: bool,
         enable_generate_endpoint: bool,
-    ) -> Vec<(Vec<RouteDoc>, axum::Router)> {
+    ) -> Result<Vec<(Vec<RouteDoc>, axum::Router)>> {
         let mut routes = Vec::new();
         // Add chat completions route with conditional middleware
         let (chat_docs, chat_route) = super::openai::chat_completions_router(
@@ -1344,10 +1357,12 @@ impl HttpServiceConfigBuilder {
 
         if enable_generate_endpoint {
             tracing::warn!("The vLLM-compatible /inference/v1/generate API is experimental.");
-            let (generate_docs, generate_route) = super::generate::generate_router(
-                state.clone(),
-                var(HTTP_SVC_VLLM_GENERATE_PATH_ENV).ok(),
-            );
+            let generate_path = var(HTTP_SVC_VLLM_GENERATE_PATH_ENV).ok();
+            if let Some(path) = generate_path.as_deref() {
+                validate_generate_route_path(path)?;
+            }
+            let (generate_docs, generate_route) =
+                super::generate::generate_router(state.clone(), generate_path);
             endpoint_routes.insert(EndpointType::Generate, (generate_docs, generate_route));
         }
 
@@ -1375,7 +1390,7 @@ impl HttpServiceConfigBuilder {
             ));
             routes.push((docs, route));
         }
-        routes
+        Ok(routes)
     }
 }
 
@@ -1951,5 +1966,19 @@ mod tests {
                 assert!(!route_docs.contains(&"POST /inference/v1/generate".to_string()));
             },
         );
+    }
+    #[test]
+    #[serial_test::serial]
+    fn vllm_generate_route_path_rejects_invalid_env_override() {
+        for path in ["", "native/vllm", "/:model", "/*path"] {
+            temp_env::with_var(HTTP_SVC_VLLM_GENERATE_PATH_ENV, Some(path), || {
+                assert!(
+                    HttpService::builder()
+                        .enable_engine_apis(true)
+                        .build()
+                        .is_err()
+                );
+            });
+        }
     }
 }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -49,6 +49,7 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 
 use crate::frontend_config::{FrontendApiConfig, MetricsConfig};
+use crate::local_model::runtime_config::VLLM_INFERENCE_V1_GENERATE_CAPABILITY;
 
 /// Middleware that echoes `x-request-id` from request to response headers.
 async fn echo_request_id_header(
@@ -698,6 +699,13 @@ impl HttpService {
         self.generate_api_enabled
     }
 
+    pub(crate) fn generate_engine_capabilities(&self) -> Vec<&'static str> {
+        self.generate_api_enabled
+            .then_some(VLLM_INFERENCE_V1_GENERATE_CAPABILITY)
+            .into_iter()
+            .collect()
+    }
+
     pub async fn spawn(&self, cancel_token: CancellationToken) -> JoinHandle<Result<()>> {
         let this = self.clone();
         tokio::spawn(async move { this.run(cancel_token).await })
@@ -967,6 +975,9 @@ static HTTP_SVC_ANTHROPIC_PATH_ENV: &str = "DYN_HTTP_SVC_ANTHROPIC_PATH";
 pub(super) static VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV: &str =
     "DYN_VLLM_ENABLE_INFERENCE_V1_GENERATE";
 
+/// Environment variable to set the vLLM Generate endpoint path
+/// (default: `/inference/v1/generate`).
+pub(super) static HTTP_SVC_VLLM_GENERATE_PATH_ENV: &str = "DYN_HTTP_SVC_VLLM_GENERATE_PATH";
 fn append_route_docs(
     all_docs: &mut Vec<RouteDoc>,
     seen_routes: &mut HashSet<RouteDoc>,
@@ -1333,8 +1344,10 @@ impl HttpServiceConfigBuilder {
 
         if enable_generate_endpoint {
             tracing::warn!("The vLLM-compatible /inference/v1/generate API is experimental.");
-            let (generate_docs, generate_route) =
-                super::generate::generate_router(state.clone(), None);
+            let (generate_docs, generate_route) = super::generate::generate_router(
+                state.clone(),
+                var(HTTP_SVC_VLLM_GENERATE_PATH_ENV).ok(),
+            );
             endpoint_routes.insert(EndpointType::Generate, (generate_docs, generate_route));
         }
 
@@ -1895,17 +1908,48 @@ mod tests {
         temp_env::with_var_unset(VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV, || {
             let disabled = HttpService::builder().build().unwrap();
             assert!(!disabled.generate_api_enabled());
+            assert!(disabled.generate_engine_capabilities().is_empty());
 
             let enabled = HttpService::builder()
                 .enable_engine_apis(true)
                 .build()
                 .unwrap();
             assert!(enabled.generate_api_enabled());
+            assert_eq!(
+                enabled.generate_engine_capabilities(),
+                vec![VLLM_INFERENCE_V1_GENERATE_CAPABILITY]
+            );
         });
 
         temp_env::with_var(VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV, Some("1"), || {
             let enabled = HttpService::builder().build().unwrap();
             assert!(enabled.generate_api_enabled());
+            assert_eq!(
+                enabled.generate_engine_capabilities(),
+                vec![VLLM_INFERENCE_V1_GENERATE_CAPABILITY]
+            );
         });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn vllm_generate_route_path_follows_env_override() {
+        temp_env::with_vars(
+            [
+                (VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV, Some("1")),
+                (HTTP_SVC_VLLM_GENERATE_PATH_ENV, Some("/native/vllm")),
+            ],
+            || {
+                let service = HttpService::builder().build().unwrap();
+                let route_docs: Vec<_> = service
+                    .route_docs()
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect();
+
+                assert!(route_docs.contains(&"POST /native/vllm".to_string()));
+                assert!(!route_docs.contains(&"POST /inference/v1/generate".to_string()));
+            },
+        );
     }
 }


### PR DESCRIPTION
## Summary

- select native Generate worker pipelines by their advertised runtime capability
- pass enabled Generate capabilities through frontend discovery instead of a vLLM-specific boolean
- add `DYN_HTTP_SVC_VLLM_GENERATE_PATH` for overriding the existing vLLM route path
- preserve the existing `/inference/v1/generate` request, response, and streaming behavior

This is the frontend/discovery prerequisite for the SGLang `/generate` endpoint in #11640. It is intended to merge first; #11640 will be restacked on this branch.

## Validation

- `cargo fmt --all`
- `cargo test -p dynamo-llm generate_requires_enabled_matching_worker_capability --lib`
- `cargo test -p dynamo-llm vllm_generate_route_path_follows_env_override --lib`
- `cargo test -p dynamo-llm http::service::generate::tests --lib`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12466" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generate requests now select models and engines based on the required runtime capability.
  * Model discovery can list and retrieve models supporting a specific Generate capability.
  * The Generate route path can be customized through an environment variable.
  * Generate engine support is detected from configured model capabilities.

* **Bug Fixes**
  * Improved handling when models or engines do not support the requested capability.

* **Tests**
  * Added coverage for supported, missing, and unrelated capabilities, including custom route paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->