### PR TITLE
Proposal: fall back when conditional decode selection fails

### DIFF
--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
-        preprocessor::{BootstrapInfo, PrefillResult, TraceLink},
+        preprocessor::{BootstrapInfo, PrefillResult, RoutingHints, TraceLink},
         timing::{RequestPhase, RequestTracker},
     },
     session_affinity::{AffinityCoordinator, AffinityTarget},
@@ -37,6 +37,7 @@ mod admission;
 mod conditional_bypass;
 mod query;
 
+use super::push_router::ConditionalDisaggAdmissionError;
 use admission::InnerPrefillRouter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -206,7 +207,7 @@ impl
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
         // Extract request data while preserving context
-        let (mut req, context) = request.into_parts();
+        let (mut req, mut context) = request.into_parts();
         let request_id = context.id().to_string();
         let metadata = context.metadata().clone();
         let policy_class = context.metadata().get("policy-class").cloned();
@@ -263,6 +264,7 @@ impl
                         let _decode_permit = tracker.set_phase(RequestPhase::Decode).await;
                     }
 
+                    let original_routing = req.routing.clone();
                     let routing = req.routing_mut();
                     routing.decode_worker_id = Some(decision.worker.worker_id);
                     routing.dp_rank = Some(decision.worker.dp_rank);
@@ -270,17 +272,39 @@ impl
                     req.annotations
                         .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
 
-                    // TODO: This advisory selection does not reserve decode capacity. If the
-                    // exact pinned admission below races and fails, the no-clone fix is a
-                    // scheduler reservation handoff rather than retrying with a mutated request.
-                    let response_stream = next.generate(context.map(|_| req)).await?;
-                    let ctx = response_stream.context();
-                    let annotation = Annotated::<LLMEngineOutput>::from_annotation(
-                        BYPASS_REMOTE_PREFILL_ANNOTATION,
-                        &true,
-                    )?;
-                    let merged = stream::once(async move { annotation }).chain(response_stream);
-                    return Ok(ResponseStream::new(Box::pin(merged), ctx));
+                    match next.generate(context.map(|_| req)).await {
+                        Ok(response_stream) => {
+                            let ctx = response_stream.context();
+                            let annotation = Annotated::<LLMEngineOutput>::from_annotation(
+                                BYPASS_REMOTE_PREFILL_ANNOTATION,
+                                &true,
+                            )?;
+                            let merged =
+                                stream::once(async move { annotation }).chain(response_stream);
+                            return Ok(ResponseStream::new(Box::pin(merged), ctx));
+                        }
+                        Err(error) => {
+                            let error = match error.downcast::<ConditionalDisaggAdmissionError>() {
+                                Ok(error) => error,
+                                Err(error) => return Err(error),
+                            };
+                            let (failed_request, admission_error) = error.into_parts();
+                            let restored_request =
+                                restore_after_failed_conditional_disagg_admission(
+                                    failed_request,
+                                    original_routing,
+                                );
+                            let (restored_req, restored_context) = restored_request.into_parts();
+                            req = restored_req;
+                            context = restored_context;
+
+                            tracing::warn!(
+                                request_id = %request_id,
+                                error = %admission_error,
+                                "Conditional-disagg decode admission failed before dispatch; falling back to remote prefill"
+                            );
+                        }
+                    }
                 }
                 Ok(None) => {}
                 Err(error) => {
@@ -467,6 +491,17 @@ impl
 
         next.generate(context.map(|_| decode_req)).await
     }
+}
+
+fn restore_after_failed_conditional_disagg_admission(
+    mut request: SingleIn<PreprocessedRequest>,
+    original_routing: Option<RoutingHints>,
+) -> SingleIn<PreprocessedRequest> {
+    request.routing = original_routing;
+    request
+        .annotations
+        .retain(|annotation| annotation != BYPASS_REMOTE_PREFILL_ANNOTATION);
+    request
 }
 
 impl PrefillRouter {
@@ -657,6 +692,76 @@ mod tests {
         assert_eq!(data.token_ids, vec![2]);
         assert_eq!(data.finish_reason, Some(FinishReason::EoS));
         assert!(data.disaggregated_params.is_none());
+    }
+
+    #[test]
+    fn failed_conditional_admission_restores_original_request() {
+        let original_routing = Some(RoutingHints {
+            decode_worker_id: Some(41),
+            dp_rank: Some(3),
+            priority: Some(7),
+            lora_name: Some("adapter".to_string()),
+            ..Default::default()
+        });
+        let expected_routing = serde_json::to_value(&original_routing).unwrap();
+        let mut request = Context::new(
+            PreprocessedRequest::builder()
+                .model("test".to_string())
+                .token_ids(vec![1, 2, 3])
+                .stop_conditions(Default::default())
+                .sampling_options(Default::default())
+                .output_options(Default::default())
+                .routing(original_routing.clone())
+                .annotations(vec![
+                    "keep-this".to_string(),
+                    BYPASS_REMOTE_PREFILL_ANNOTATION.to_string(),
+                ])
+                .build()
+                .unwrap(),
+        );
+        request.routing_mut().decode_worker_id = Some(99);
+        request.routing_mut().dp_rank = Some(0);
+        request.insert_unique("conditional-sentinel", "preserved".to_string());
+        let original_context = request.context();
+
+        let mut restored =
+            restore_after_failed_conditional_disagg_admission(request, original_routing);
+        let restored_context = restored.context();
+
+        assert!(Arc::ptr_eq(&original_context, &restored_context));
+        assert_eq!(
+            serde_json::to_value(&restored.routing).unwrap(),
+            expected_routing
+        );
+        assert_eq!(restored.annotations, vec!["keep-this".to_string()]);
+        assert_eq!(
+            restored
+                .take_unique::<String>("conditional-sentinel")
+                .unwrap(),
+            "preserved"
+        );
+    }
+
+    #[test]
+    fn failed_conditional_admission_restores_absent_routing() {
+        let mut request = Context::new(
+            PreprocessedRequest::builder()
+                .model("test".to_string())
+                .token_ids(vec![1, 2, 3])
+                .stop_conditions(Default::default())
+                .sampling_options(Default::default())
+                .output_options(Default::default())
+                .annotations(vec![BYPASS_REMOTE_PREFILL_ANNOTATION.to_string()])
+                .build()
+                .unwrap(),
+        );
+        request.routing_mut().decode_worker_id = Some(99);
+        request.routing_mut().dp_rank = Some(0);
+
+        let restored = restore_after_failed_conditional_disagg_admission(request, None);
+
+        assert!(restored.routing.is_none());
+        assert!(restored.annotations.is_empty());
     }
 
     #[test]

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -37,7 +37,7 @@ mod admission;
 mod conditional_bypass;
 mod query;
 
-use super::push_router::ConditionalDisaggAdmissionError;
+use super::push_router::ConditionalDisaggSelectionError;
 use admission::InnerPrefillRouter;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -264,6 +264,8 @@ impl
                         let _decode_permit = tracker.set_phase(RequestPhase::Decode).await;
                     }
 
+                    // `routing_mut()` may create RoutingHints where the caller supplied none.
+                    // Fallback must restore the complete original value, not only the worker pin.
                     let original_routing = req.routing.clone();
                     let routing = req.routing_mut();
                     routing.decode_worker_id = Some(decision.worker.worker_id);
@@ -284,13 +286,15 @@ impl
                             return Ok(ResponseStream::new(Box::pin(merged), ctx));
                         }
                         Err(error) => {
-                            let error = match error.downcast::<ConditionalDisaggAdmissionError>() {
+                            // Only this error returns ownership of a request which is known not to
+                            // have been dispatched. Every other downstream error remains terminal.
+                            let error = match error.downcast::<ConditionalDisaggSelectionError>() {
                                 Ok(error) => error,
                                 Err(error) => return Err(error),
                             };
-                            let (failed_request, admission_error) = error.into_parts();
+                            let (failed_request, selection_error) = error.into_parts();
                             let restored_request =
-                                restore_after_failed_conditional_disagg_admission(
+                                restore_after_failed_conditional_disagg_selection(
                                     failed_request,
                                     original_routing,
                                 );
@@ -300,8 +304,8 @@ impl
 
                             tracing::warn!(
                                 request_id = %request_id,
-                                error = %admission_error,
-                                "Conditional-disagg decode admission failed before dispatch; falling back to remote prefill"
+                                error = %selection_error,
+                                "Conditional-disagg decode selection failed before dispatch; falling back to remote prefill"
                             );
                         }
                     }
@@ -493,7 +497,7 @@ impl
     }
 }
 
-fn restore_after_failed_conditional_disagg_admission(
+fn restore_after_failed_conditional_disagg_selection(
     mut request: SingleIn<PreprocessedRequest>,
     original_routing: Option<RoutingHints>,
 ) -> SingleIn<PreprocessedRequest> {
@@ -695,7 +699,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_conditional_admission_restores_original_request() {
+    fn failed_conditional_selection_restores_original_request() {
         let original_routing = Some(RoutingHints {
             decode_worker_id: Some(41),
             dp_rank: Some(3),
@@ -725,7 +729,7 @@ mod tests {
         let original_context = request.context();
 
         let mut restored =
-            restore_after_failed_conditional_disagg_admission(request, original_routing);
+            restore_after_failed_conditional_disagg_selection(request, original_routing);
         let restored_context = restored.context();
 
         assert!(Arc::ptr_eq(&original_context, &restored_context));
@@ -743,7 +747,7 @@ mod tests {
     }
 
     #[test]
-    fn failed_conditional_admission_restores_absent_routing() {
+    fn failed_conditional_selection_restores_absent_routing() {
         let mut request = Context::new(
             PreprocessedRequest::builder()
                 .model("test".to_string())
@@ -758,7 +762,7 @@ mod tests {
         request.routing_mut().decode_worker_id = Some(99);
         request.routing_mut().dp_rank = Some(0);
 
-        let restored = restore_after_failed_conditional_disagg_admission(request, None);
+        let restored = restore_after_failed_conditional_disagg_selection(request, None);
 
         assert!(restored.routing.is_none());
         assert!(restored.annotations.is_empty());

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -17,7 +17,9 @@ use futures::stream::{self, StreamExt};
 use tracing::Instrument;
 
 use crate::{
-    kv_router::{KvRouter, metrics::RouterRequestMetrics},
+    kv_router::{
+        KvRouter, metrics::RouterRequestMetrics, prefill_router::BYPASS_REMOTE_PREFILL_ANNOTATION,
+    },
     preprocessor::PreprocessedRequest,
     protocols::common::{
         FinishReason,
@@ -39,6 +41,24 @@ use selection::{RoutingRequestParts, SelectionOptions, WorkerSelection};
 
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
 const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
+
+#[derive(Debug, thiserror::Error)]
+#[error("conditional-disagg decode admission failed before dispatch: {source}")]
+pub(crate) struct ConditionalDisaggAdmissionError {
+    request: SingleIn<PreprocessedRequest>,
+    #[source]
+    source: Error,
+}
+
+impl ConditionalDisaggAdmissionError {
+    fn new(request: SingleIn<PreprocessedRequest>, source: Error) -> Self {
+        Self { request, source }
+    }
+
+    pub(crate) fn into_parts(self) -> (SingleIn<PreprocessedRequest>, Error) {
+        (self.request, self.source)
+    }
+}
 
 fn is_cancelled(error: &Error) -> bool {
     match_error_chain(error.as_ref(), &[ErrorType::Cancelled], &[])
@@ -517,9 +537,17 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             .unwrap_or(RequestPhase::Aggregated);
         let phase_label = phase.to_string();
         let route_guard = StageGuard::new(STAGE_ROUTE, &phase_label);
-        let (mut selection, mut operation) = self
+        let conditional_disagg_bypass = request.has_annotation(BYPASS_REMOTE_PREFILL_ANNOTATION);
+        let (mut selection, mut operation) = match self
             .select_with_affinity(&request, phase, is_query_only)
-            .await?;
+            .await
+        {
+            Ok(result) => result,
+            Err(error) if conditional_disagg_bypass && !is_cancelled(&error) => {
+                return Err(ConditionalDisaggAdmissionError::new(request, error).into());
+            }
+            Err(error) => return Err(error),
+        };
         if is_query_only {
             let routing_parts = RoutingRequestParts::new(&request);
             if let Some(ref tracker) = request.tracker {
@@ -660,7 +688,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
+        collections::{BTreeMap, HashMap},
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
@@ -809,6 +837,97 @@ mod tests {
     async fn session_affinity_disabled_does_not_create_coordinator() {
         let (router, runtime) = router(None).await;
         assert!(router.affinity.is_none());
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn conditional_disagg_admission_failure_returns_original_context() {
+        let (router, runtime) = router(None).await;
+        let started_before = router.request_metrics.requests_started_total().get();
+        let metadata = BTreeMap::from([("policy-class".to_string(), "interactive".to_string())]);
+        let mut request = Context::with_id_and_metadata(
+            request(),
+            "conditional-admission-failure".to_string(),
+            metadata.clone(),
+        );
+        request.routing_mut().decode_worker_id = Some(99);
+        request.routing_mut().dp_rank = Some(0);
+        request
+            .annotations
+            .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
+        request.insert_unique("conditional-sentinel", "preserved".to_string());
+        let original_context = request.context();
+
+        let error = router.generate(request).await.unwrap_err();
+        let admission_error = error
+            .downcast::<ConditionalDisaggAdmissionError>()
+            .expect("marked pre-dispatch admission failure must return the request");
+        let (mut recovered, source) = admission_error.into_parts();
+        let recovered_context = recovered.context();
+
+        assert!(Arc::ptr_eq(&original_context, &recovered_context));
+        assert_eq!(recovered.id(), "conditional-admission-failure");
+        assert_eq!(recovered.metadata(), &metadata);
+        assert_eq!(
+            recovered
+                .take_unique::<String>("conditional-sentinel")
+                .unwrap(),
+            "preserved"
+        );
+        assert!(source.to_string().contains("not eligible"));
+        assert_eq!(
+            router.request_metrics.requests_started_total().get(),
+            started_before
+        );
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn conditional_disagg_cancellation_is_not_recoverable() {
+        let (router, runtime) = router(None).await;
+        let controller = Controller::new("conditional-cancellation".to_string());
+        controller.stop();
+        let mut request = Context::with_controller(request(), controller);
+        request
+            .annotations
+            .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
+
+        let error = router.generate(request).await.unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<ConditionalDisaggAdmissionError>()
+                .is_none()
+        );
+        assert!(match_error_chain(
+            error.as_ref(),
+            &[ErrorType::Cancelled],
+            &[]
+        ));
+
+        drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn conditional_disagg_dispatch_failure_is_not_recoverable() {
+        let (router, runtime) = router(None).await;
+        let mut request = Context::new(request());
+        request.routing_mut().decode_worker_id = Some(7);
+        request.routing_mut().dp_rank = Some(0);
+        request
+            .annotations
+            .push(BYPASS_REMOTE_PREFILL_ANNOTATION.to_string());
+
+        let error = router.generate(request).await.unwrap_err();
+        assert!(
+            error
+                .downcast_ref::<ConditionalDisaggAdmissionError>()
+                .is_none()
+        );
 
         drop(router);
         runtime.shutdown();

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -42,15 +42,19 @@ use selection::{RoutingRequestParts, SelectionOptions, WorkerSelection};
 const OUTPUT_REPLAY_ID_ANNOTATION_KEY: &str = "output_replay_id";
 const OUTPUT_REPLAY_CONSUMER_RUNTIME_KEY: &str = "output_replay_consumer";
 
+/// Returns ownership of a marked conditional-disagg request when selection fails
+/// before request tracking or backend dispatch begins. Do not construct this after
+/// `select_with_affinity` succeeds. Cancellation is deliberately not wrapped because
+/// a stopped request must not be retried through remote prefill.
 #[derive(Debug, thiserror::Error)]
-#[error("conditional-disagg decode admission failed before dispatch: {source}")]
-pub(crate) struct ConditionalDisaggAdmissionError {
+#[error("conditional-disagg decode selection failed before dispatch: {source}")]
+pub(crate) struct ConditionalDisaggSelectionError {
     request: SingleIn<PreprocessedRequest>,
     #[source]
     source: Error,
 }
 
-impl ConditionalDisaggAdmissionError {
+impl ConditionalDisaggSelectionError {
     fn new(request: SingleIn<PreprocessedRequest>, source: Error) -> Self {
         Self { request, source }
     }
@@ -544,7 +548,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         {
             Ok(result) => result,
             Err(error) if conditional_disagg_bypass && !is_cancelled(&error) => {
-                return Err(ConditionalDisaggAdmissionError::new(request, error).into());
+                return Err(ConditionalDisaggSelectionError::new(request, error).into());
             }
             Err(error) => return Err(error),
         };
@@ -843,7 +847,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn conditional_disagg_admission_failure_returns_original_context() {
+    async fn conditional_disagg_selection_failure_returns_original_context() {
         let (router, runtime) = router(None).await;
         let started_before = router.request_metrics.requests_started_total().get();
         let metadata = BTreeMap::from([("policy-class".to_string(), "interactive".to_string())]);
@@ -861,10 +865,10 @@ mod tests {
         let original_context = request.context();
 
         let error = router.generate(request).await.unwrap_err();
-        let admission_error = error
-            .downcast::<ConditionalDisaggAdmissionError>()
-            .expect("marked pre-dispatch admission failure must return the request");
-        let (mut recovered, source) = admission_error.into_parts();
+        let selection_error = error
+            .downcast::<ConditionalDisaggSelectionError>()
+            .expect("marked pre-dispatch selection failure must return the request");
+        let (mut recovered, source) = selection_error.into_parts();
         let recovered_context = recovered.context();
 
         assert!(Arc::ptr_eq(&original_context, &recovered_context));
@@ -899,7 +903,7 @@ mod tests {
         let error = router.generate(request).await.unwrap_err();
         assert!(
             error
-                .downcast_ref::<ConditionalDisaggAdmissionError>()
+                .downcast_ref::<ConditionalDisaggSelectionError>()
                 .is_none()
         );
         assert!(match_error_chain(
@@ -925,7 +929,7 @@ mod tests {
         let error = router.generate(request).await.unwrap_err();
         assert!(
             error
-                .downcast_ref::<ConditionalDisaggAdmissionError>()
+                .downcast_ref::<ConditionalDisaggSelectionError>()
                 .is_none()
         );
 

--- a/lib/runtime/src/pipeline/nodes/sources.rs
+++ b/lib/runtime/src/pipeline/nodes/sources.rs
@@ -7,9 +7,34 @@ use crate::pipeline::{AsyncEngine, PipelineIO};
 mod base;
 mod common;
 
+struct PendingResponse<Out: PipelineIO> {
+    registration: Arc<()>,
+    sender: oneshot::Sender<Out>,
+}
+
+type PendingResponses<Out> = Arc<Mutex<HashMap<String, PendingResponse<Out>>>>;
+
+struct ResponseRegistration<Out: PipelineIO> {
+    request_id: String,
+    registration: Arc<()>,
+    pending: PendingResponses<Out>,
+}
+
+impl<Out: PipelineIO> Drop for ResponseRegistration<Out> {
+    fn drop(&mut self) {
+        let mut pending = self.pending.lock().unwrap();
+        let owns_entry = pending
+            .get(&self.request_id)
+            .is_some_and(|entry| Arc::ptr_eq(&entry.registration, &self.registration));
+        if owns_entry {
+            pending.remove(&self.request_id);
+        }
+    }
+}
+
 pub struct Frontend<In: PipelineIO, Out: PipelineIO> {
     edge: OnceLock<Edge<In>>,
-    sinks: Arc<Mutex<HashMap<String, oneshot::Sender<Out>>>>,
+    sinks: PendingResponses<Out>,
 }
 
 /// A [`ServiceFrontend`] is the interface for an [`AsyncEngine<SingleIn<Context<In>>, ManyOut<Annotated<Out>>, Error>`]

--- a/lib/runtime/src/pipeline/nodes/sources/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/base.rs
@@ -59,11 +59,15 @@ impl<In: PipelineIO, Out: PipelineIO + AsyncEngineContextProvider> Sink<Out> for
 impl<In: PipelineIO + Sync, Out: PipelineIO> AsyncEngine<In, Out, Error> for Frontend<In, Out> {
     async fn generate(&self, request: In) -> Result<Out, Error> {
         let (tx, rx) = oneshot::channel::<Out>();
+        let request_id = request.id().to_string();
         {
             let mut sinks = self.sinks.lock().unwrap();
-            sinks.insert(request.id().to_string(), tx);
+            sinks.insert(request_id.clone(), tx);
         }
-        self.on_next(request, private::Token {}).await?;
+        if let Err(error) = self.on_next(request, private::Token {}).await {
+            self.sinks.lock().unwrap().remove(&request_id);
+            return Err(error);
+        }
         Ok(rx.await.map_err(|_| PipelineError::DetachedStreamSender)?)
     }
 }
@@ -87,6 +91,7 @@ mod tests {
             PipelineError::NoEdge => (),
             _ => panic!("Expected NoEdge error"),
         }
+        assert!(source.sinks.lock().unwrap().is_empty());
 
         let result = source
             .on_next(().into(), private::Token)

--- a/lib/runtime/src/pipeline/nodes/sources/base.rs
+++ b/lib/runtime/src/pipeline/nodes/sources/base.rs
@@ -38,7 +38,7 @@ impl<In: PipelineIO, Out: PipelineIO + AsyncEngineContextProvider> Sink<Out> for
         let ctx = data.context();
 
         let mut sinks = self.sinks.lock().unwrap();
-        let tx = sinks
+        let pending = sinks
             .remove(ctx.id())
             .ok_or(PipelineError::DetachedStreamReceiver)
             .inspect_err(|_| {
@@ -46,7 +46,8 @@ impl<In: PipelineIO, Out: PipelineIO + AsyncEngineContextProvider> Sink<Out> for
             })?;
         drop(sinks);
 
-        Ok(tx
+        Ok(pending
+            .sender
             .send(data)
             .map_err(|_| PipelineError::DetachedStreamReceiver)
             .inspect_err(|_| {
@@ -60,14 +61,26 @@ impl<In: PipelineIO + Sync, Out: PipelineIO> AsyncEngine<In, Out, Error> for Fro
     async fn generate(&self, request: In) -> Result<Out, Error> {
         let (tx, rx) = oneshot::channel::<Out>();
         let request_id = request.id().to_string();
+        let registration = Arc::new(());
         {
             let mut sinks = self.sinks.lock().unwrap();
-            sinks.insert(request_id.clone(), tx);
+            sinks.insert(
+                request_id.clone(),
+                PendingResponse {
+                    registration: registration.clone(),
+                    sender: tx,
+                },
+            );
         }
-        if let Err(error) = self.on_next(request, private::Token {}).await {
-            self.sinks.lock().unwrap().remove(&request_id);
-            return Err(error);
-        }
+        // A response removes this entry in `on_data`. The guard handles every earlier
+        // exit, including a downstream error or cancellation, and its token prevents an
+        // older call from removing a newer registration which reused the same request ID.
+        let _registration = ResponseRegistration {
+            request_id,
+            registration,
+            pending: self.sinks.clone(),
+        };
+        self.on_next(request, private::Token {}).await?;
         Ok(rx.await.map_err(|_| PipelineError::DetachedStreamSender)?)
     }
 }
@@ -104,5 +117,28 @@ mod tests {
             PipelineError::NoEdge => (),
             _ => panic!("Expected NoEdge error"),
         }
+    }
+
+    #[test]
+    fn stale_registration_does_not_remove_replacement() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let old_registration = Arc::new(());
+        let new_registration = Arc::new(());
+        let (sender, _receiver) = oneshot::channel::<ManyOut<()>>();
+        pending.lock().unwrap().insert(
+            "reused-request-id".to_string(),
+            PendingResponse {
+                registration: new_registration,
+                sender,
+            },
+        );
+
+        drop(ResponseRegistration {
+            request_id: "reused-request-id".to_string(),
+            registration: old_registration,
+            pending: pending.clone(),
+        });
+
+        assert!(pending.lock().unwrap().contains_key("reused-request-id"));
     }
 }


### PR DESCRIPTION
This is a proposed implementation of the fallback discussed in #11725 and tracked in DYN-3694.

## What goes wrong today

Conditional disaggregation first chooses a decode worker from the scheduler state without reserving that worker or admitting the request. The chosen worker and rank are then written into the request, and the decode router performs the real selection and admission.

That second operation can fail before request tracking or backend dispatch begins. For example, the worker may no longer be eligible or may no longer have capacity. Today that error ends the request even though the ordinary remote-prefill route is still available.

## How the fallback works

For a request carrying the router-owned conditional-bypass marker, `KvPushRouter` returns the original request when `select_with_affinity` fails with a non-cancellation error. At that point the request has not been recorded by `track_selection`, no `RequestGuard` has been created, and backend dispatch has not begun.

`PrefillRouter` recognizes only that ownership-return error. It restores the complete routing value from before the advisory decode pin, removes the internal bypass marker, and continues through the existing remote-prefill path. Restoring the complete value preserves any original worker pins, constraints, priorities, LoRA information, and the distinction between absent and empty routing hints.

Cancellation is not converted into fallback. Errors after selection succeeds—including request tracking, dispatch, backend, and response-stream errors—also continue to propagate without retry because the request may already have recorded state or reached the backend.

## Why the pipeline frontend changes

`next.generate(...)` registers a response sender before forwarding the request downstream. When downstream returns the ownership-return error, no response arrives to remove that sender. The new registration guard removes the exact pending sender whenever `generate` exits before receiving a response, including immediate errors and cancellation. Its identity token prevents an older call from removing a newer registration which happens to use the same request ID.

## Checks run

Focused tests were added for context preservation, cancellation, the post-selection boundary, routing restoration, and response-registration cleanup. The tests have not been run, so this PR remains a draft.

The checks that were run are:

- `rustfmt --edition 2024 --check` on the four changed files
- `git diff --check`