### PR TITLE
refactor(gms): migrate SGLang adapter to TMS backend API

### DIFF
--- a/components/src/dynamo/sglang/main.py
+++ b/components/src/dynamo/sglang/main.py
@@ -44,7 +44,9 @@ async def worker(argv: list[str] | None = None):
     if config.server_args.load_format == "gms":
         from gpu_memory_service.integrations.sglang import setup_gms
 
-        config.server_args.load_format = setup_gms(config.server_args)
+        config.server_args.override(
+            source="dynamo-gms", load_format=setup_gms(config.server_args)
+        )
 
     # Snapshot mode: engine must be created before runtime so CRIU captures no
     # NATS/etcd connections.

--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -568,15 +568,14 @@ The integration uses a custom worker class (`GMSWorker`) that:
 python -m dynamo.sglang \
   --model-path <model> \
   --load-format gms \
-  --enable-memory-saver \
   --mem-fraction-static 0.9
 ```
 
-The integration patches `torch_memory_saver` to route both weight and KV-cache operations through GMS:
+The integration registers the public `gms` hook mode/backend with `torch_memory_saver` and routes weights/KV through GMS:
 - Weights (`"weights"`) use the `weights` GMS tag
 - KV cache (`"kv_cache"`) uses a separate RW-only `kv_cache` GMS tag
 - Other tags are not supported in GMS mode
-- The `--enable-memory-saver` flag is required to activate the memory saver pathway
+- `setup_gms` enables the memory saver pathway automatically
 
 ### Shadow Engine Failover (Pause / Resume)
 

--- a/lib/gpu_memory_service/integrations/sglang/__init__.py
+++ b/lib/gpu_memory_service/integrations/sglang/__init__.py
@@ -20,10 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Module-level GMS lock mode + RO reconnect timeout, set by setup_gms() before
-# loader is instantiated. Read by patches.py when creating GMSMemorySaverImpl.
-_gms_lock_mode = None
-_gms_ro_connect_timeout_ms = None
 _gms_initialized = False
 
 
@@ -57,27 +53,13 @@ def setup_gms(server_args) -> Type["GMSModelLoader"]:
             "Cannot use --enable-draft-weights-cpu-backup with --load-format gms."
         )
 
-    server_args.enable_memory_saver = True
-    # Resolve lock mode and RO reconnect timeout from model_loader_extra_config
-    # before patches fire.
-    global _gms_lock_mode
-    global _gms_ro_connect_timeout_ms
-    extra = getattr(server_args, "model_loader_extra_config", None)
-    if isinstance(extra, str):
-        import json
-
-        extra = json.loads(extra) if extra else {}
-    extra = extra or {}
-
-    from gpu_memory_service.integrations.common.utils import (
-        get_gms_lock_mode,
-        get_gms_ro_connect_timeout_ms,
+    server_args.override(
+        source="dynamo-gms",
+        enable_memory_saver=True,
+        memory_saver_hook_mode="gms",
     )
 
-    _gms_lock_mode = get_gms_lock_mode(extra)
-    _gms_ro_connect_timeout_ms = get_gms_ro_connect_timeout_ms(extra)
-
-    # Import triggers patches at module level
+    # Import registers the GMS memory saver and applies SGLang patches.
     from gpu_memory_service.integrations.sglang.model_loader import GMSModelLoader
 
     global _gms_initialized

--- a/lib/gpu_memory_service/integrations/sglang/memory_saver.py
+++ b/lib/gpu_memory_service/integrations/sglang/memory_saver.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 # Published weights must come back RO, while KV cache always resumes in a fresh
 # RW epoch so the restored engine can rebuild mutable cache state.
 _TAG_LOCK_TYPES = {"weights": RequestedLockType.RO, "kv_cache": RequestedLockType.RW}
+_gms_memory_saver_impl: Optional["GMSMemorySaverImpl"] = None
+_gms_hook_mode_registered = False
 
 
 def _pause_resume_tags(tag: Optional[str]) -> tuple[str, ...]:
@@ -51,13 +53,45 @@ def _pause_resume_tags(tag: Optional[str]) -> tuple[str, ...]:
 
 
 def get_gms_memory_saver_impl() -> Optional["GMSMemorySaverImpl"]:
-    """Get the GMS memory saver impl from the torch_memory_saver singleton."""
-    try:
-        import torch_memory_saver
+    """Get the process-local GMS memory saver implementation."""
+    return _gms_memory_saver_impl
 
-        return torch_memory_saver.torch_memory_saver.gms_impl
-    except (ImportError, AttributeError):
-        return None
+
+def _create_gms_memory_saver_impl() -> "GMSMemorySaverImpl":
+    import json
+
+    from gpu_memory_service.integrations.common.utils import (
+        get_gms_lock_mode,
+        get_gms_ro_connect_timeout_ms,
+    )
+    from sglang.srt.runtime_context import get_server_args
+
+    extra = getattr(get_server_args(), "model_loader_extra_config", None)
+    if isinstance(extra, str):
+        extra = json.loads(extra) if extra else {}
+    extra = extra or {}
+
+    impl = GMSMemorySaverImpl(
+        device_index=torch.cuda.current_device(),
+        mode=get_gms_lock_mode(extra),
+        ro_connect_timeout_ms=get_gms_ro_connect_timeout_ms(extra),
+    )
+
+    global _gms_memory_saver_impl
+    _gms_memory_saver_impl = impl
+    return impl
+
+
+def register_gms_hook_mode() -> None:
+    """Register the GMS backend with torch_memory_saver in this process."""
+    global _gms_hook_mode_registered
+    if _gms_hook_mode_registered:
+        return
+
+    from torch_memory_saver import register_hook_mode
+
+    register_hook_mode("gms", _create_gms_memory_saver_impl, uses_preload=False)
+    _gms_hook_mode_registered = True
 
 
 class GMSMemorySaverImpl:

--- a/lib/gpu_memory_service/integrations/sglang/model_loader.py
+++ b/lib/gpu_memory_service/integrations/sglang/model_loader.py
@@ -25,25 +25,25 @@ from gpu_memory_service.integrations.common.utils import (
 )
 from gpu_memory_service.integrations.sglang.memory_saver import (
     get_gms_memory_saver_impl,
+    register_gms_hook_mode,
 )
 from gpu_memory_service.integrations.sglang.patches import (
     patch_model_runner,
     patch_static_state_for_gms,
-    patch_torch_memory_saver,
 )
 
 logger = logging.getLogger(__name__)
 
-# Apply patches at module import time.
+# Register the memory saver and apply patches at module import time.
 # This module is only imported when load_format="gms" is used.
-# Because SGLang scheduler processes use multiprocessing spawn, these patches
-# must run inside the child process.  The import chain that triggers this is:
+# Because SGLang scheduler processes use multiprocessing spawn, this setup must
+# run inside the child process.  The import chain that triggers this is:
 #   child unpickles server_args.load_format -> imports GMSModelLoader -> here.
+register_gms_hook_mode()
 patch_empty_cache()
-patch_torch_memory_saver()
 patch_model_runner()
 patch_static_state_for_gms()
-logger.info("[GMS] Applied patches")
+logger.info("[GMS] Registered memory saver and applied patches")
 
 
 class GMSModelLoader:
@@ -75,7 +75,8 @@ class GMSModelLoader:
         if impl is None:
             raise RuntimeError(
                 "GMS impl not initialized. "
-                "Ensure torch_memory_saver patch was applied before model loading."
+                "Ensure the GMS hook mode was registered and initialized "
+                "before model loading."
             )
 
         mode = impl.allocators["weights"].granted_lock_type

--- a/lib/gpu_memory_service/integrations/sglang/patches.py
+++ b/lib/gpu_memory_service/integrations/sglang/patches.py
@@ -3,7 +3,6 @@
 
 """SGLang-specific patches for GPU Memory Service integration.
 
-- patch_torch_memory_saver: Routes weights and kv_cache to GMS
 - patch_model_runner: Fixes memory accounting with pre-loaded weights
 - patch_static_state_for_gms: No-ops named-buffer export/import (GMS preserves them)
 """
@@ -11,131 +10,15 @@
 from __future__ import annotations
 
 import logging
-from contextlib import contextmanager
-from typing import Optional
 
-import gpu_memory_service.integrations.sglang as gms_sglang
-import torch
 from gpu_memory_service.integrations.sglang.memory_saver import (
-    GMSMemorySaverImpl,
     get_gms_memory_saver_impl,
 )
 
 logger = logging.getLogger(__name__)
 
-_torch_memory_saver_patched = False
 _model_runner_patched = False
 _static_state_patched = False
-
-
-def patch_torch_memory_saver() -> None:
-    """Patch torch_memory_saver to use GPU Memory Service implementation.
-
-    This function is idempotent - calling it multiple times has no effect.
-    This patch is only applied when GMSModelLoader is imported (load_format="gms").
-    """
-    global _torch_memory_saver_patched
-    if _torch_memory_saver_patched:
-        return
-
-    try:
-        import torch_memory_saver
-        import torch_memory_saver.entrypoint as entrypoint_module
-    except ImportError:
-        logger.debug("[GMS] torch_memory_saver not installed, skipping patch")
-        return
-
-    # Store reference to original method
-    original_ensure_initialized = entrypoint_module.TorchMemorySaver._ensure_initialized
-    original_configure_subprocess = torch_memory_saver.configure_subprocess
-
-    def patched_ensure_initialized(self):
-        """Patched _ensure_initialized that uses GPU Memory Service implementation."""
-        # Check if already initialized
-        if self._impl is not None:
-            logger.debug("[GMS] TorchMemorySaver already initialized, skipping")
-            return
-
-        # Check hook_mode - use GMS for None or explicit "gms"
-        hook_mode = self._impl_ctor_kwargs.get("hook_mode")
-        logger.info(f"[GMS] TorchMemorySaver initializing with hook_mode={hook_mode}")
-
-        if hook_mode is None or hook_mode == "gms":
-            # In GMS mode we install only the strict GMS implementation:
-            # weights + kv_cache go through GMS, generic unsupported tags stay
-            # no-ops/warnings, and cuda_graph remains unsupported.
-            # Get device from torch.cuda.current_device() (already set by SGLang)
-            device_index = torch.cuda.current_device()
-
-            # Read lock mode set by setup_gms() (defaults to RW_OR_RO)
-            gms_impl = GMSMemorySaverImpl(
-                device_index=device_index,
-                mode=gms_sglang._gms_lock_mode,
-                ro_connect_timeout_ms=gms_sglang._gms_ro_connect_timeout_ms,
-            )
-
-            # Set _impl directly (accessible via gms_impl property)
-            self._impl = gms_impl
-            logger.info(
-                "[GMS] Using GMS mode (device=%d, mode=%s)",
-                device_index,
-                gms_impl.allocators["weights"].granted_lock_type.name,
-            )
-            del self._impl_ctor_kwargs
-        else:
-            # Fall back to original implementation
-            logger.info("[GMS] Using default torch_memory_saver hook mode")
-            original_ensure_initialized(self)
-
-    entrypoint_module.TorchMemorySaver._ensure_initialized = patched_ensure_initialized
-
-    @contextmanager
-    def patched_configure_subprocess():
-        """Avoid LD_PRELOAD in GMS mode; keep upstream behavior otherwise."""
-        singleton = torch_memory_saver.torch_memory_saver
-        ctor_kwargs = getattr(singleton, "_impl_ctor_kwargs", None) or {}
-        hook_mode = ctor_kwargs.get("hook_mode")
-
-        if hook_mode is None or hook_mode == "gms":
-            logger.info("[GMS] torch_memory_saver.configure_subprocess is a no-op")
-            yield
-            return
-
-        with original_configure_subprocess():
-            yield
-
-    torch_memory_saver.configure_subprocess = patched_configure_subprocess
-
-    # Add property to access GMS impl directly from the singleton
-    @property
-    def gms_impl(self) -> Optional[GMSMemorySaverImpl]:
-        """Get the GMS impl if installed, None otherwise."""
-        if isinstance(self._impl, GMSMemorySaverImpl):
-            return self._impl
-        return None
-
-    entrypoint_module.TorchMemorySaver.gms_impl = gms_impl
-
-    # If the singleton was already initialized before this patch ran (e.g.,
-    # due to import ordering in multiprocessing spawn), reset _impl so the
-    # next call to _ensure_initialized goes through the patched version and
-    # creates GMSMemorySaverImpl instead of the default _TorchMemorySaverImpl.
-    import torch_memory_saver
-
-    singleton = torch_memory_saver.torch_memory_saver
-    if singleton._impl is not None:
-        logger.debug(
-            "[GMS] TorchMemorySaver singleton already initialized, "
-            "resetting to force GMS re-init on next use"
-        )
-        singleton._impl = None
-        # The original _ensure_initialized deletes _impl_ctor_kwargs after
-        # creating _impl.  Restore it so the patched version can read it.
-        if not hasattr(singleton, "_impl_ctor_kwargs"):
-            singleton._impl_ctor_kwargs = {}
-
-    _torch_memory_saver_patched = True
-    logger.debug("[GMS] Patched torch_memory_saver")
 
 
 def patch_model_runner() -> None:


### PR DESCRIPTION
## Summary

This PR is now based directly on `main`; it is independent of GMS V1 and #12011.

It migrates the existing SGLang `--load-format gms` integration from private `torch_memory_saver` monkeypatches to the public hook-mode registry proposed upstream, while preserving existing GMS loader, allocation, pause/resume, and publication behavior.

## Dependencies

| Dependency | Purpose |
|---|---|
| `torch_memory_saver` #79 | Public `register_hook_mode(...)` API and backend-owned preload policy |
| SGLang #32976 | Hook-mode selection across parent, DP-controller, and scheduler processes |

These upstream interfaces are not yet released in the currently installed environment, so merge/runtime qualification remains gated on their availability.

## Details

- Register `gms` with `uses_preload=False` in each process.
- Construct the GMS memory-saver implementation lazily from process-local SGLang configuration.
- Keep model-aware write finalization in `GMSModelLoader`.
- Remove patches of TMS initialization, subprocess configuration, and singleton internals.
- Use SGLang's supported `ServerArgs.override(...)` path.

## Validation

Current head:

```text
00c9b29037e3003af3f94d5085e128fa8c4584d6
```

Validated with:

- exactly one commit on current `main`, six files, `+58/-157`;
- no inherited #12011 commits or overlapping files;
- existing SGLang GMS tests: `14 passed`;
- registration idempotence, lazy factory, preload policy, and `ServerArgs.override` API probes;
- pre-commit, Ruff, compileall, and `git diff --check`; and
- DCO sign-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native GMS hook-mode support for SGLang.
  * Automatically enables the memory-saver pathway when GMS is configured.
  * Improved configuration of memory locking and read-only connection settings.

* **Bug Fixes**
  * Improved model-loading guidance when GMS initialization is incomplete.
  * Updated memory accounting and static-state handling for improved integration reliability.

* **Documentation**
  * Simplified the SGLang launch instructions by removing the need to manually enable memory saver.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->