### PR TITLE
docs: fix snapshot chart README link to relocated snapshot guide

### DIFF
--- a/deploy/helm/charts/snapshot/README.md
+++ b/deploy/helm/charts/snapshot/README.md
@@ -153,7 +153,7 @@ See [values.yaml](./values.yaml) for the full configuration surface.
 Once the chart is installed, use the snapshot guide to create a checkpoint or
 exercise the lower-level `snapshotctl` flow:
 
-- [Snapshot guide](../../../../docs/fern/kubernetes/snapshot.md)
+- [Snapshot guide](../../../../docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md)
 
 ## Uninstall
 


### PR DESCRIPTION
## Summary

[#12373](https://github.com/ai-dynamo/dynamo/pull/12373) relocated `docs/fern/kubernetes/snapshot.md` to `docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/snapshot.md` but left the snapshot Helm chart README (`deploy/helm/charts/snapshot/README.md`) linking the old path. That stale link is currently the only broken markdown link in the repo, so the `Docs link check / Check for broken markdown links` job fails on every PR that re-scans it. This repoints the link at the relocated guide.

## Validation

- `detect_broken_links.py` (the job's checker) scans all markdown files and reported exactly one broken link — this one; the relocated target exists at the new path, so the fix resolves it. The 2 `setup_minio.sh` "suspicious" symlinks it also reports are pre-existing warnings that do not fail the check.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12469" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Snapshot chart README with the new guide link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->