### PR TITLE
fix(anthropic): emit per-chunk token usage on /v1/messages streaming

### DIFF
--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -447,6 +447,9 @@ async fn anthropic_messages(
 
         let mut http_queue_guard = Some(http_queue_guard);
         let mut engine_stream = engine_stream;
+        // Clone for the inner cancellation watch; the original `ctx` is handed
+        // to `monitor_for_disconnects` below.
+        let cancel_ctx = ctx.clone();
 
         let full_stream = async_stream::stream! {
             let mut events = Vec::with_capacity(4);
@@ -456,24 +459,48 @@ async fn anthropic_messages(
             }
 
             let mut saw_error = false;
+            let mut cancelled = false;
 
-            while let Some(annotated_chunk) = engine_stream.next().await {
-                process_response_and_observe_metrics(
-                    &annotated_chunk,
-                    &mut response_collector,
-                    &mut http_queue_guard,
-                );
+            // Keep a single cancellation future alive across chunks — recreating
+            // it per token churns the underlying Notify (see disconnect.rs).
+            let stopped = cancel_ctx.stopped();
+            tokio::pin!(stopped);
 
-                let Some(stream_resp) = annotated_chunk.data else {
-                    if annotated_chunk.event.as_deref() == Some("error") {
-                        saw_error = true;
+            loop {
+                tokio::select! {
+                    // Prefer draining a ready backend chunk before honoring a
+                    // cancel so no already-generated token is dropped.
+                    biased;
+                    maybe_chunk = engine_stream.next() => {
+                        let Some(annotated_chunk) = maybe_chunk else {
+                            break; // backend stream ended normally
+                        };
+                        process_response_and_observe_metrics(
+                            &annotated_chunk,
+                            &mut response_collector,
+                            &mut http_queue_guard,
+                        );
+
+                        let Some(stream_resp) = annotated_chunk.data else {
+                            if annotated_chunk.event.as_deref() == Some("error") {
+                                saw_error = true;
+                            }
+                            continue;
+                        };
+
+                        converter.append_chunk_events(&stream_resp, &mut events);
+                        for event in events.drain(..) {
+                            yield event.map_err(axum::Error::new);
+                        }
                     }
-                    continue;
-                };
-
-                converter.append_chunk_events(&stream_resp, &mut events);
-                for event in events.drain(..) {
-                    yield event.map_err(axum::Error::new);
+                    _ = &mut stopped => {
+                        // Client disconnected (or the request was otherwise
+                        // cancelled). Best-effort flush the terminal usage +
+                        // message_stop below so a still-writable proxy records
+                        // the final token counts for the tokens produced so far.
+                        cancelled = true;
+                        break;
+                    }
                 }
             }
 
@@ -484,6 +511,14 @@ async fn anthropic_messages(
             }
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
+            }
+
+            if cancelled {
+                // Park so the outer `monitor_for_disconnects` (whose select is
+                // biased toward the stream) forwards the finalizer events above,
+                // then observes the stop itself and records the request as
+                // cancelled rather than completed.
+                std::future::pending::<()>().await;
             }
         };
 

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -230,6 +230,12 @@ fn monitor_for_disconnects_with_timeout(
         tokio::pin!(stopped);
         loop {
             tokio::select! {
+                // Drain any ready SSE event before honoring a cancel or the
+                // inactivity timeout. This preserves already-buffered output on
+                // disconnect and lets a source stream that emits its own
+                // finalizer-on-cancel (e.g. the Anthropic converter) flush those
+                // terminal events before this monitor records the cancellation.
+                biased;
                 event = stream.next() => {
                     match event {
                         Some(Ok(event)) => {

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -57,7 +57,13 @@ pub struct AnthropicStreamConverter {
 struct ToolCallState {
     id: String,
     name: String,
-    argument_fragments: Vec<String>,
+    /// Each buffered argument fragment paired with the cumulative usage snapshot
+    /// taken when its backend chunk was processed. Tool-call blocks are flushed
+    /// lazily (at the finish reason or EOF), long after their chunks were seen,
+    /// so serializing them against the converter's *current* usage would stamp
+    /// every `input_json_delta` with the final token count. Snapshotting per
+    /// fragment preserves the per-chunk cumulative count instead.
+    argument_fragments: Vec<(String, AnthropicUsage)>,
 }
 
 impl ToolCallState {
@@ -122,7 +128,11 @@ impl AnthropicStreamConverter {
     ///   `tool_call_states` by `tool_call.index` keeps each call's state separate
     ///   regardless, so interleaved indices would also be handled — but no current
     ///   parser emits them, so that path is defensive rather than exercised.
-    fn record_tool_call(&mut self, tool_call: &ChatCompletionMessageToolCallChunk) {
+    fn record_tool_call(
+        &mut self,
+        tool_call: &ChatCompletionMessageToolCallChunk,
+        usage_snapshot: &AnthropicUsage,
+    ) {
         let tool_call_index = tool_call.index as usize;
         while self.tool_call_states.len() <= tool_call_index {
             self.tool_call_states.push(ToolCallState {
@@ -141,12 +151,22 @@ impl AnthropicStreamConverter {
                 state.name = name.clone();
             }
             if let Some(arguments) = &function.arguments {
-                state.argument_fragments.push(arguments.clone());
+                state
+                    .argument_fragments
+                    .push((arguments.clone(), usage_snapshot.clone()));
             }
         }
     }
 
-    fn drain_buffered_tool_events(&mut self) -> Vec<(&'static str, AnthropicStreamEvent)> {
+    /// Drain buffered tool blocks into taggable events. Each event carries an
+    /// optional usage override: `Some` for `input_json_delta` fragments (the
+    /// per-fragment snapshot taken at record time), `None` for the surrounding
+    /// `content_block_start`/`content_block_stop` (which stamp the current usage
+    /// like any other non-fragment event).
+    #[allow(clippy::type_complexity)]
+    fn drain_buffered_tool_events(
+        &mut self,
+    ) -> Vec<(&'static str, AnthropicStreamEvent, Option<AnthropicUsage>)> {
         if self.tool_blocks_flushed {
             return Vec::new();
         }
@@ -171,9 +191,10 @@ impl AnthropicStreamConverter {
                         input: serde_json::json!({}),
                     },
                 },
+                None,
             ));
 
-            for arguments in &tool_call.argument_fragments {
+            for (arguments, usage_snapshot) in &tool_call.argument_fragments {
                 events.push((
                     "content_block_delta",
                     AnthropicStreamEvent::ContentBlockDelta {
@@ -182,12 +203,14 @@ impl AnthropicStreamConverter {
                             partial_json: arguments.clone(),
                         },
                     },
+                    Some(usage_snapshot.clone()),
                 ));
             }
 
             events.push((
                 "content_block_stop",
                 AnthropicStreamEvent::ContentBlockStop { index: block_index },
+                None,
             ));
             block_index += 1;
         }
@@ -197,10 +220,13 @@ impl AnthropicStreamConverter {
     }
 
     fn append_buffered_tool_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
-        for (event_type, event) in self.drain_buffered_tool_events() {
+        for (event_type, event, usage_override) in self.drain_buffered_tool_events() {
             // Route through serialize_event so tool-argument `content_block_delta`
-            // chunks also carry the per-chunk usage triple.
-            events.push(self.serialize_event(event_type, &event));
+            // chunks also carry the per-chunk usage triple. Fragments carry the
+            // snapshot taken when their chunk was processed; everything else uses
+            // the current usage.
+            let usage = usage_override.as_ref().unwrap_or(&self.usage);
+            events.push(self.serialize_event_with_usage(event_type, &event, usage));
         }
     }
 
@@ -230,7 +256,19 @@ impl AnthropicStreamConverter {
         event_type: &'static str,
         event: &AnthropicStreamEvent,
     ) -> Result<Event, anyhow::Error> {
-        let value = event_json_with_usage(event, &self.usage)?;
+        self.serialize_event_with_usage(event_type, event, &self.usage)
+    }
+
+    /// Like `serialize_event` but stamps an explicit `usage` onto the
+    /// `content_block_delta`. Used to replay buffered tool-argument fragments
+    /// with the usage snapshot from their own chunk (see `record_tool_call`).
+    fn serialize_event_with_usage(
+        &self,
+        event_type: &'static str,
+        event: &AnthropicStreamEvent,
+        usage: &AnthropicUsage,
+    ) -> Result<Event, anyhow::Error> {
+        let value = event_json_with_usage(event, usage)?;
         Ok(Event::default()
             .event(event_type)
             .data(serde_json::to_string(&value)?))
@@ -315,6 +353,12 @@ impl AnthropicStreamConverter {
                 self.usage.output_tokens += 1;
             }
         }
+
+        // Snapshot the cumulative usage for this chunk so buffered tool-argument
+        // fragments recorded below are stamped with the count as of *this* chunk,
+        // not the final count at flush time. `self.usage` is stable for the rest
+        // of this call (record_usage / the fallback above already ran).
+        let usage_snapshot = self.usage.clone();
 
         let mut should_flush_tool_blocks = false;
         for choice in &chunk.inner.choices {
@@ -462,7 +506,7 @@ impl AnthropicStreamConverter {
                 }
 
                 for tool_call in tool_calls {
-                    self.record_tool_call(tool_call);
+                    self.record_tool_call(tool_call, &usage_snapshot);
                 }
             }
         }
@@ -559,9 +603,16 @@ fn make_sse_event(event_type: &str, event: &AnthropicStreamEvent) -> Result<Even
 /// `dynamo-protocols`'s `AnthropicStreamEvent::ContentBlockDelta` has no `usage`
 /// field — the type is an external crate we don't own — so the field is added at
 /// the JSON layer. The triple is `{input_tokens, output_tokens, total_tokens}`
-/// (plus any Anthropic cache fields), where `total_tokens = input + output`,
-/// giving proxies the same per-chunk accounting OpenAI exposes via
-/// `continuous_usage_stats`.
+/// (plus any Anthropic cache fields).
+///
+/// `total_tokens` counts the *complete* prompt plus the output, i.e.
+/// `input_tokens + cache_read_input_tokens + cache_creation_input_tokens +
+/// output_tokens`. Anthropic reports the cached prefix separately from
+/// `input_tokens` (`completion_usage_to_anthropic` subtracts it out), so the
+/// cache fields must be added back here; otherwise a cache-hit request would
+/// under-report and disagree with the `total_tokens` a proxy sees on the
+/// equivalent `/v1/chat/completions` request (`prompt_tokens + completion_tokens`,
+/// cached tokens included). Saturating arithmetic guards against overflow.
 fn event_json_with_usage(
     event: &AnthropicStreamEvent,
     usage: &AnthropicUsage,
@@ -572,7 +623,11 @@ fn event_json_with_usage(
     {
         let mut usage_value = serde_json::to_value(usage)?;
         if let serde_json::Value::Object(usage_map) = &mut usage_value {
-            let total = usage.input_tokens.saturating_add(usage.output_tokens);
+            let total = usage
+                .input_tokens
+                .saturating_add(usage.cache_read_input_tokens.unwrap_or(0))
+                .saturating_add(usage.cache_creation_input_tokens.unwrap_or(0))
+                .saturating_add(usage.output_tokens);
             usage_map.insert("total_tokens".to_string(), serde_json::json!(total));
         }
         map.insert("usage".to_string(), usage_value);
@@ -610,6 +665,8 @@ impl AnthropicStreamConverter {
         if let Some(usage) = &chunk.inner.usage {
             self.record_usage(usage);
         }
+
+        let usage_snapshot = self.usage.clone();
 
         let mut should_flush_tool_blocks = false;
         for choice in &chunk.inner.choices {
@@ -739,7 +796,7 @@ impl AnthropicStreamConverter {
                 }
 
                 for tool_call in tool_calls {
-                    self.record_tool_call(tool_call);
+                    self.record_tool_call(tool_call, &usage_snapshot);
                 }
             }
         }
@@ -748,7 +805,7 @@ impl AnthropicStreamConverter {
         // streams carry a tool-call finish reason, while interrupted streams use
         // the EOF fallback in `emit_end_events_tagged`.
         if should_flush_tool_blocks {
-            for (event_type, event) in self.drain_buffered_tool_events() {
+            for (event_type, event, _usage) in self.drain_buffered_tool_events() {
                 events.push(make_tagged_event(event_type, &event));
             }
         }
@@ -784,7 +841,7 @@ impl AnthropicStreamConverter {
         }
 
         // EOF fallback; a finish-triggered drain leaves no events here.
-        for (event_type, event) in self.drain_buffered_tool_events() {
+        for (event_type, event, _usage) in self.drain_buffered_tool_events() {
             events.push(make_tagged_event(event_type, &event));
         }
 
@@ -1080,6 +1137,48 @@ mod tests {
             "total_tokens must equal input + output"
         );
 
+        // Cache-hit case: `total_tokens` must count the complete prompt
+        // (visible input + cached prefix + cache writes) plus output, matching
+        // the `prompt_tokens + completion_tokens` total a proxy sees on
+        // `/v1/chat/completions`. Anthropic reports the cached prefix outside
+        // `input_tokens`, so it must be added back into the total.
+        let cached_usage = AnthropicUsage {
+            input_tokens: 2,
+            output_tokens: 3,
+            cache_read_input_tokens: Some(9),
+            cache_creation_input_tokens: Some(1),
+        };
+        let cached_value = event_json_with_usage(&delta, &cached_usage).expect("serialize");
+        let cached_usage_obj = cached_value
+            .get("usage")
+            .expect("content_block_delta must carry usage");
+        assert_eq!(
+            cached_usage_obj
+                .get("input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(2),
+            "input_tokens stays the visible (non-cached) prompt count"
+        );
+        assert_eq!(
+            cached_usage_obj
+                .get("cache_read_input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(9)
+        );
+        assert_eq!(
+            cached_usage_obj
+                .get("cache_creation_input_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(1)
+        );
+        assert_eq!(
+            cached_usage_obj
+                .get("total_tokens")
+                .and_then(|v| v.as_u64()),
+            Some(15),
+            "total_tokens must equal input + cache_read + cache_creation + output"
+        );
+
         // A non-delta event carries no injected usage.
         let stop = AnthropicStreamEvent::ContentBlockStop { index: 0 };
         let stop_value = event_json_with_usage(&stop, &usage).expect("serialize");
@@ -1263,6 +1362,55 @@ mod tests {
                 ..
             } if partial_json == "{}"
         ));
+    }
+
+    /// Buffered tool-argument fragments must carry the usage snapshot from their
+    /// own chunk, not the cumulative count at flush time. With no backend usage
+    /// the fallback advances `output_tokens` by one per tool-call chunk, so two
+    /// argument fragments serialize with `output_tokens` 1 and 2 respectively.
+    #[test]
+    fn test_buffered_tool_fragments_snapshot_per_chunk_usage() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 5);
+        let mut sink = Vec::new();
+
+        conv.append_chunk_events(
+            &tool_call_chunk(0, Some("call-1"), Some("Read"), Some("{\"path\":\"/a")),
+            &mut sink,
+        );
+        conv.append_chunk_events(&tool_call_chunk(0, None, None, Some(".txt\"}")), &mut sink);
+        // Tool blocks are buffered until a finish/EOF flush, so nothing is
+        // emitted per chunk.
+        assert!(
+            sink.is_empty(),
+            "tool blocks are buffered, not emitted per chunk"
+        );
+        // Fallback counted one token per tool-call chunk.
+        assert_eq!(conv.usage.output_tokens, 2);
+
+        let fragment_outputs: Vec<u32> = conv
+            .drain_buffered_tool_events()
+            .iter()
+            .filter_map(|(event_type, event, usage)| match (event_type, event) {
+                (
+                    &"content_block_delta",
+                    AnthropicStreamEvent::ContentBlockDelta {
+                        delta: AnthropicDelta::InputJsonDelta { .. },
+                        ..
+                    },
+                ) => Some(
+                    usage
+                        .as_ref()
+                        .expect("tool-argument fragment carries a usage snapshot")
+                        .output_tokens,
+                ),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            fragment_outputs,
+            vec![1, 2],
+            "each fragment stamps the cumulative output count as of its own chunk"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -305,6 +305,11 @@ impl AnthropicStreamConverter {
                         &choice.delta.content,
                         Some(ChatCompletionMessageContent::Text(t)) if !t.is_empty()
                     )
+                    || choice
+                        .delta
+                        .tool_calls
+                        .as_ref()
+                        .is_some_and(|tool_calls| !tool_calls.is_empty())
             });
             if produced_output {
                 self.usage.output_tokens += 1;

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -40,6 +40,11 @@ pub struct AnthropicStreamConverter {
     // Starts with a frontend estimate and is replaced atomically when the
     // engine reports authoritative usage.
     usage: AnthropicUsage,
+    // True once the backend has reported authoritative usage at least once
+    // (via `include_usage`/`continuous_usage_stats`). Until then the converter
+    // falls back to counting output deltas so that every `content_block_delta`
+    // still carries a non-zero output-token estimate.
+    saw_backend_usage: bool,
     // Tool call tracking
     tool_call_states: Vec<ToolCallState>,
     tool_blocks_flushed: bool,
@@ -80,6 +85,7 @@ impl AnthropicStreamConverter {
                 input_tokens: estimated_input_tokens,
                 ..Default::default()
             },
+            saw_backend_usage: false,
             tool_call_states: Vec::new(),
             tool_blocks_flushed: false,
             next_block_index: 0,
@@ -192,12 +198,42 @@ impl AnthropicStreamConverter {
 
     fn append_buffered_tool_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
         for (event_type, event) in self.drain_buffered_tool_events() {
-            events.push(make_sse_event(event_type, &event));
+            // Route through serialize_event so tool-argument `content_block_delta`
+            // chunks also carry the per-chunk usage triple.
+            events.push(self.serialize_event(event_type, &event));
         }
     }
 
     fn record_usage(&mut self, usage: &CompletionUsage) {
+        // Preserve the running output-token estimate if the backend reports a
+        // lower value than we have already emitted. Backends that only send a
+        // final usage chunk (`include_usage` without `continuous_usage_stats`)
+        // would otherwise regress `output_tokens` on the terminal chunk.
+        let running = self.usage.output_tokens;
         self.usage = completion_usage_to_anthropic(usage);
+        self.usage.output_tokens = self.usage.output_tokens.max(running);
+        self.saw_backend_usage = true;
+    }
+
+    /// Serialize an event to SSE, stamping the current cumulative `usage` onto
+    /// every `content_block_delta`.
+    ///
+    /// Anthropic's native protocol only reports usage on `message_start` and the
+    /// terminal `message_delta`, so a proxy that reads the stream for live
+    /// per-token accounting gets nothing until the stream ends — and nothing at
+    /// all if the client aborts mid-stream. Mirroring OpenAI's
+    /// `continuous_usage_stats`, we attach a `usage` triple to each token chunk.
+    /// This is a Dynamo extension to the wire format (the field is additive;
+    /// spec-compliant clients ignore unknown fields).
+    fn serialize_event(
+        &self,
+        event_type: &'static str,
+        event: &AnthropicStreamEvent,
+    ) -> Result<Event, anyhow::Error> {
+        let value = event_json_with_usage(event, &self.usage)?;
+        Ok(Event::default()
+            .event(event_type)
+            .data(serde_json::to_string(&value)?))
     }
 
     /// Emit the initial `message_start` event.
@@ -247,6 +283,32 @@ impl AnthropicStreamConverter {
         // non-overlapping cached-token accounting.
         if let Some(usage) = &chunk.inner.usage {
             self.record_usage(usage);
+        }
+
+        // Fallback output-token accounting for backends that never populate
+        // per-chunk `usage` (e.g. the `ModelInput::Text` / PushRouter path).
+        // Once the backend reports authoritative usage, `record_usage` owns the
+        // count and this estimate is dropped. One token per content-bearing
+        // chunk is the standard approximation for token-by-token streaming.
+        //
+        // This must run *before* the content_block_delta events below are
+        // serialized so every token chunk carries a non-zero output-token count
+        // (the acceptance requirement: usage present on 100% of token chunks).
+        if !self.saw_backend_usage {
+            let produced_output = chunk.inner.choices.iter().any(|choice| {
+                choice
+                    .delta
+                    .reasoning_content
+                    .as_ref()
+                    .is_some_and(|r| !r.is_empty())
+                    || matches!(
+                        &choice.delta.content,
+                        Some(ChatCompletionMessageContent::Text(t)) if !t.is_empty()
+                    )
+            });
+            if produced_output {
+                self.usage.output_tokens += 1;
+            }
         }
 
         let mut should_flush_tool_blocks = false;
@@ -302,7 +364,7 @@ impl AnthropicStreamConverter {
                         thinking: reasoning.clone(),
                     },
                 };
-                events.push(make_sse_event("content_block_delta", &block_delta));
+                events.push(self.serialize_event("content_block_delta", &block_delta));
             }
 
             // Handle text content deltas
@@ -331,7 +393,7 @@ impl AnthropicStreamConverter {
                             signature: "erased".to_string(),
                         },
                     };
-                    events.push(make_sse_event("content_block_delta", &sig_delta));
+                    events.push(self.serialize_event("content_block_delta", &sig_delta));
 
                     let block_stop = AnthropicStreamEvent::ContentBlockStop {
                         index: self.thinking_block_index,
@@ -362,7 +424,7 @@ impl AnthropicStreamConverter {
                         text: text.to_string(),
                     },
                 };
-                events.push(make_sse_event("content_block_delta", &block_delta));
+                events.push(self.serialize_event("content_block_delta", &block_delta));
             }
 
             // Handle tool call deltas
@@ -376,7 +438,7 @@ impl AnthropicStreamConverter {
                             signature: "erased".to_string(),
                         },
                     };
-                    events.push(make_sse_event("content_block_delta", &sig_delta));
+                    events.push(self.serialize_event("content_block_delta", &sig_delta));
                     let block_stop = AnthropicStreamEvent::ContentBlockStop {
                         index: self.thinking_block_index,
                     };
@@ -428,7 +490,7 @@ impl AnthropicStreamConverter {
                     signature: "erased".to_string(),
                 },
             };
-            events.push(make_sse_event("content_block_delta", &sig_delta));
+            events.push(self.serialize_event("content_block_delta", &sig_delta));
             let block_stop = AnthropicStreamEvent::ContentBlockStop {
                 index: self.thinking_block_index,
             };
@@ -484,6 +546,33 @@ impl AnthropicStreamConverter {
 fn make_sse_event(event_type: &str, event: &AnthropicStreamEvent) -> Result<Event, anyhow::Error> {
     let data = serde_json::to_string(event)?;
     Ok(Event::default().event(event_type).data(data))
+}
+
+/// Serialize an Anthropic stream event to JSON, injecting a `usage` triple onto
+/// `content_block_delta` events (and leaving every other event untouched).
+///
+/// `dynamo-protocols`'s `AnthropicStreamEvent::ContentBlockDelta` has no `usage`
+/// field — the type is an external crate we don't own — so the field is added at
+/// the JSON layer. The triple is `{input_tokens, output_tokens, total_tokens}`
+/// (plus any Anthropic cache fields), where `total_tokens = input + output`,
+/// giving proxies the same per-chunk accounting OpenAI exposes via
+/// `continuous_usage_stats`.
+fn event_json_with_usage(
+    event: &AnthropicStreamEvent,
+    usage: &AnthropicUsage,
+) -> Result<serde_json::Value, anyhow::Error> {
+    let mut value = serde_json::to_value(event)?;
+    if let (AnthropicStreamEvent::ContentBlockDelta { .. }, serde_json::Value::Object(map)) =
+        (event, &mut value)
+    {
+        let mut usage_value = serde_json::to_value(usage)?;
+        if let serde_json::Value::Object(usage_map) = &mut usage_value {
+            let total = usage.input_tokens.saturating_add(usage.output_tokens);
+            usage_map.insert("total_tokens".to_string(), serde_json::json!(total));
+        }
+        map.insert("usage".to_string(), usage_value);
+    }
+    Ok(value)
 }
 
 /// A tagged event for testing: the event type string paired with the
@@ -814,6 +903,10 @@ mod tests {
         events.clear();
         let capacity = events.capacity();
         conv.append_chunk_events(&text_chunk("I'll edit the file."), &mut events);
+        // content_block_start + content_block_delta. The content_block_delta now
+        // carries an injected per-chunk usage triple (see
+        // test_content_block_delta_carries_usage_triple) rather than a separate
+        // interim message_delta event.
         assert_eq!(events.len(), 2);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));
@@ -897,10 +990,10 @@ mod tests {
         // Exercise the production chunk path rather than its tagged test mirror.
         let mut events = Vec::new();
         conv.append_chunk_events(&usage_chunk(12, Some(11), 5), &mut events);
-        assert!(
-            events.is_empty(),
-            "usage-only chunk emits no content events"
-        );
+        // A usage-only chunk carries no content deltas, so it emits no SSE
+        // events; the reconciled usage is stamped onto subsequent token chunks
+        // and the terminal message_delta.
+        assert!(events.is_empty(), "usage-only chunk emits no SSE events");
         assert_eq!(conv.usage.input_tokens, 1);
         assert_eq!(conv.usage.cache_read_input_tokens, Some(11));
         assert_eq!(conv.usage.output_tokens, 5);
@@ -918,6 +1011,74 @@ mod tests {
             }
             other => panic!("expected MessageDelta, got {other:?}"),
         }
+    }
+
+    /// Backends that never populate per-chunk `usage` (the `ModelInput::Text`
+    /// path) still get a running output-token estimate that advances *before*
+    /// each token chunk is serialized, so every `content_block_delta` carries a
+    /// non-zero usage triple even for a client that aborts mid-stream.
+    #[test]
+    fn test_fallback_counter_advances_before_each_token_chunk() {
+        let mut conv = AnthropicStreamConverter::new("test-model".into(), 7);
+        let mut events = Vec::new();
+
+        // First content chunk: content_block_start + content_block_delta. The
+        // fallback advances output_tokens to 1 before the delta is serialized.
+        conv.append_chunk_events(&text_chunk("Hello"), &mut events);
+        assert_eq!(conv.usage.output_tokens, 1);
+        assert_eq!(events.len(), 2);
+
+        // Second content chunk on the open block: content_block_delta only
+        // (output_tokens advanced to 2).
+        events.clear();
+        conv.append_chunk_events(&text_chunk(" world"), &mut events);
+        assert_eq!(conv.usage.output_tokens, 2);
+        assert_eq!(events.len(), 1);
+
+        // The frontend input estimate is preserved until the backend reports.
+        assert_eq!(conv.usage.input_tokens, 7);
+        assert!(!conv.saw_backend_usage);
+    }
+
+    /// The root fix: `content_block_delta` events carry an injected `usage`
+    /// triple (input/output/total) — mirroring OpenAI `continuous_usage_stats`
+    /// — while non-delta events are left untouched.
+    #[test]
+    fn test_content_block_delta_carries_usage_triple() {
+        let usage = AnthropicUsage {
+            input_tokens: 7,
+            output_tokens: 3,
+            ..Default::default()
+        };
+
+        let delta = AnthropicStreamEvent::ContentBlockDelta {
+            index: 0,
+            delta: AnthropicDelta::TextDelta {
+                text: "hi".to_string(),
+            },
+        };
+        let value = event_json_with_usage(&delta, &usage).expect("serialize");
+        let usage_obj = value
+            .get("usage")
+            .expect("content_block_delta must carry usage");
+        assert_eq!(usage_obj.get("input_tokens").and_then(|v| v.as_u64()), Some(7));
+        assert_eq!(
+            usage_obj.get("output_tokens").and_then(|v| v.as_u64()),
+            Some(3)
+        );
+        assert_eq!(
+            usage_obj.get("total_tokens").and_then(|v| v.as_u64()),
+            Some(10),
+            "total_tokens must equal input + output"
+        );
+
+        // A non-delta event carries no injected usage.
+        let stop = AnthropicStreamEvent::ContentBlockStop { index: 0 };
+        let stop_value = event_json_with_usage(&stop, &usage).expect("serialize");
+        assert!(
+            stop_value.get("usage").is_none(),
+            "only content_block_delta gets injected usage"
+        );
     }
 
     /// Regression test: text block must be closed (content_block_stop)

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -1061,7 +1061,10 @@ mod tests {
         let usage_obj = value
             .get("usage")
             .expect("content_block_delta must carry usage");
-        assert_eq!(usage_obj.get("input_tokens").and_then(|v| v.as_u64()), Some(7));
+        assert_eq!(
+            usage_obj.get("input_tokens").and_then(|v| v.as_u64()),
+            Some(7)
+        );
         assert_eq!(
             usage_obj.get("output_tokens").and_then(|v| v.as_u64()),
             Some(3)

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -132,9 +132,15 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                 tools,
                 tool_choice,
                 stream: Some(true), // Always stream internally
+                // Request cumulative usage on every chunk (not just the final
+                // one) so the Anthropic stream converter can stamp an
+                // authoritative per-chunk usage triple onto each
+                // `content_block_delta` and still report a token count if the
+                // client aborts mid-stream. Mirrors the running-usage behaviour
+                // of the OpenAI DeltaGenerator.
                 stream_options: Some(dynamo_protocols::types::ChatCompletionStreamOptions {
                     include_usage: true,
-                    continuous_usage_stats: false,
+                    continuous_usage_stats: true,
                 }),
                 ..Default::default()
             },

--- a/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
+++ b/lib/llm/tests/snapshots/anthropic_http_replay__anthropic_streaming_text.snap
@@ -41,6 +41,11 @@ expression: "canonicalize(serde_json::to_value(events).unwrap())"
       "delta": {
         "type": "text_delta",
         "text": "Pong."
+      },
+      "usage": {
+        "input_tokens": 2,
+        "output_tokens": 1,
+        "total_tokens": 3
       }
     }
   },

--- a/tests/frontend/test_anthropic_messages_stream_usage.py
+++ b/tests/frontend/test_anthropic_messages_stream_usage.py
@@ -1,0 +1,258 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Parallelization: Hermetic test (xdist-safe via dynamic ports).
+# GPU Requirement: gpu_0 (CPU-only, mocker does not use GPU)
+#
+# Acceptance test for per-chunk streaming token usage, ported from the manual
+# Qwen3.6-27B acceptance script (dynamo-issues/test_qwen36_messages_stream_usage.py)
+# into a hermetic mocker-backed pytest.
+#
+# Goal (regression guard for the /v1/messages per-chunk usage fix in
+# lib/llm/src/protocols/anthropic/stream_converter.rs): in stream mode, 100% of
+# the token-bearing chunks must carry a token-usage triple — input, output and
+# total tokens — not only the final chunk.
+#
+#   /v1/messages (Anthropic SSE)
+#     Anthropic's native protocol reports usage only on `message_start`
+#     (input_tokens) and the terminal `message_delta` (output_tokens). The
+#     Dynamo frontend additionally stamps the full triple onto every
+#     `content_block_delta`. token chunk = a `content_block_delta` event.
+#
+#   /v1/chat/completions + {"include_usage": true, "continuous_usage_stats": true}
+#     Every `chat.completion.chunk` repeats usage.{prompt,completion,total}_tokens.
+#     token chunk = a chunk whose delta carries content/reasoning_content.
+#
+# Acceptance criterion (per endpoint): usage_chunks == token_chunks (100%), and
+# each usage exposes input, output and total tokens (all > 0), where
+# total = input + output for the Anthropic shape.
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import pytest
+import requests
+
+from tests.frontend.conftest import MockerWorkerProcess, wait_for_http_completions_ready
+from tests.utils.constants import QWEN
+from tests.utils.managed_process import DynamoFrontendProcess
+
+logger = logging.getLogger(__name__)
+
+TEST_MODEL = QWEN
+MAX_TOKENS = 64
+PROMPT = "In one short sentence, what is the capital of France?"
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.gpu_0,  # Mocker is CPU-only (no GPU required)
+    pytest.mark.post_merge,
+    pytest.mark.parallel,
+    pytest.mark.model(TEST_MODEL),
+]
+
+
+@pytest.fixture(scope="function")
+def anthropic_frontend_with_mocker(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    predownload_tokenizers,
+):
+    """Start an HTTP frontend with the Anthropic Messages API enabled, backed by
+    a mocker worker.
+
+    The stock ``start_services_with_mocker`` fixture does not enable
+    ``/v1/messages``; this variant sets ``DYN_ENABLE_ANTHROPIC_API`` on the
+    frontend so the Anthropic SSE path is exercised. Function-scoped for
+    xdist-parallel execution — each test gets its own frontend + mocker on
+    unique ports.
+
+    Yields:
+        frontend_port: Port where the frontend is listening.
+    """
+    ports = dynamo_dynamic_ports
+    frontend_port = ports.frontend_port
+    system_port = ports.system_ports[0]
+
+    with DynamoFrontendProcess(
+        request,
+        frontend_port=frontend_port,
+        terminate_all_matching_process_names=False,
+        extra_env={"DYN_ENABLE_ANTHROPIC_API": "1"},
+    ):
+        with MockerWorkerProcess(request, TEST_MODEL, frontend_port, system_port):
+            wait_for_http_completions_ready(
+                frontend_port=frontend_port, model=TEST_MODEL
+            )
+            logger.info(
+                "Anthropic-enabled frontend + mocker ready on port %s", frontend_port
+            )
+            yield frontend_port
+
+
+def _iter_sse(frontend_port: int, path: str, payload: dict[str, Any]):
+    """Yield decoded JSON objects from an SSE stream; skips the [DONE] sentinel."""
+    url = f"http://localhost:{frontend_port}{path}"
+    headers = {"Content-Type": "application/json"}
+    with requests.post(
+        url, json=payload, headers=headers, stream=True, timeout=180
+    ) as r:
+        assert (
+            r.status_code == 200
+        ), f"{path} returned HTTP {r.status_code}: {r.text[:500]}"
+        for line in r.iter_lines(decode_unicode=True):
+            if not line or not line.startswith("data:"):
+                continue
+            data = line[len("data:") :].strip()
+            if data == "[DONE]":
+                continue
+            try:
+                yield json.loads(data)
+            except json.JSONDecodeError:
+                continue
+
+
+def _triple_ok(u: dict) -> bool:
+    """True if a usage dict exposes input, output and total, all > 0."""
+    if not isinstance(u, dict):
+        return False
+    return all(
+        isinstance(u.get(k), int) and u[k] > 0
+        for k in ("input_tokens", "output_tokens", "total_tokens")
+    )
+
+
+def _check_messages(frontend_port: int) -> tuple[int, int, list]:
+    """Return (token_chunks, chunks_with_usage_triple, sample_usages) for /v1/messages.
+
+    A token chunk is a ``content_block_delta``. Its usage triple must ride on
+    that same chunk (the Dynamo per-chunk usage extension).
+    """
+    payload = {
+        "model": TEST_MODEL,
+        "max_tokens": MAX_TOKENS,
+        "stream": True,
+        "messages": [{"role": "user", "content": PROMPT}],
+    }
+    token_chunks = 0
+    with_usage = 0
+    samples: list = []
+    input_seen = None
+    for obj in _iter_sse(frontend_port, "/v1/messages", payload):
+        etype = obj.get("type")
+        if etype == "message_start":
+            input_seen = ((obj.get("message") or {}).get("usage") or {}).get(
+                "input_tokens"
+            )
+        elif etype == "content_block_delta":
+            token_chunks += 1
+            u = obj.get("usage") or (obj.get("delta") or {}).get("usage")
+            triple = None
+            if isinstance(u, dict) and "input_tokens" in u and "output_tokens" in u:
+                in_tokens = u.get("input_tokens", input_seen)
+                out_tokens = u.get("output_tokens")
+                triple = {
+                    "input_tokens": in_tokens,
+                    "output_tokens": out_tokens,
+                    "total_tokens": u.get(
+                        "total_tokens", (in_tokens or 0) + (out_tokens or 0)
+                    ),
+                }
+            if triple and _triple_ok(triple):
+                with_usage += 1
+                if len(samples) < 3:
+                    samples.append(triple)
+    return token_chunks, with_usage, samples
+
+
+def _check_chat(frontend_port: int) -> tuple[int, int, list]:
+    """Return (token_chunks, chunks_with_usage_triple, sample_usages) for chat.
+
+    ``continuous_usage_stats`` makes every chat.completion.chunk repeat usage.
+    A token chunk is any chunk carrying generated content in its delta.
+    """
+    payload = {
+        "model": TEST_MODEL,
+        "max_tokens": MAX_TOKENS,
+        "stream": True,
+        "stream_options": {"include_usage": True, "continuous_usage_stats": True},
+        "messages": [{"role": "user", "content": PROMPT}],
+    }
+    token_chunks = 0
+    with_usage = 0
+    samples: list = []
+    for obj in _iter_sse(frontend_port, "/v1/chat/completions", payload):
+        choices = obj.get("choices") or []
+        delta = (choices[0].get("delta") if choices else {}) or {}
+        is_token_chunk = bool(delta.get("content") or delta.get("reasoning_content"))
+        if not is_token_chunk:
+            continue
+        token_chunks += 1
+        u = obj.get("usage") or {}
+        triple = {
+            "input_tokens": u.get("prompt_tokens"),
+            "output_tokens": u.get("completion_tokens"),
+            "total_tokens": u.get("total_tokens"),
+        }
+        if _triple_ok(triple):
+            with_usage += 1
+            if len(samples) < 3:
+                samples.append(triple)
+    return token_chunks, with_usage, samples
+
+
+def test_messages_stream_carries_usage_on_every_chunk(
+    anthropic_frontend_with_mocker,
+) -> None:
+    """TC1 — /v1/messages: every ``content_block_delta`` carries the usage triple.
+
+    This is the direct regression guard for the per-chunk usage fix: without it,
+    Anthropic SSE only reports usage on ``message_start`` / ``message_delta`` and
+    a proxy reading the stream for live per-token accounting gets nothing until
+    the stream ends.
+    """
+    frontend_port = anthropic_frontend_with_mocker
+    total, ok, samples = _check_messages(frontend_port)
+
+    assert total > 0, "no content_block_delta (token) chunks were streamed"
+    assert ok == total, (
+        f"/v1/messages: only {ok}/{total} content_block_delta chunks carry the "
+        f"usage triple — requirement is 100% (every token chunk). "
+        f"sample usages: {samples[:3]}"
+    )
+    logger.info(
+        "TC1 /v1/messages: %d/%d token chunks carry usage triple; e.g. %s",
+        ok,
+        total,
+        samples[:2],
+    )
+
+
+def test_chat_stream_continuous_usage_on_every_chunk(
+    anthropic_frontend_with_mocker,
+) -> None:
+    """TC2 — /v1/chat/completions with ``continuous_usage_stats``: every content
+    chunk repeats the usage triple.
+
+    Baseline that the Anthropic per-chunk behavior mirrors; kept in the same
+    file so both wire shapes are asserted against one running frontend.
+    """
+    frontend_port = anthropic_frontend_with_mocker
+    total, ok, samples = _check_chat(frontend_port)
+
+    assert total > 0, "no content-bearing chat.completion.chunk chunks were streamed"
+    assert ok == total, (
+        f"/v1/chat/completions: only {ok}/{total} content chunks carry the usage "
+        f"triple — requirement is 100% (continuous_usage_stats). "
+        f"sample usages: {samples[:3]}"
+    )
+    logger.info(
+        "TC2 /v1/chat/completions: %d/%d token chunks carry usage triple; e.g. %s",
+        ok,
+        total,
+        samples[:2],
+    )


### PR DESCRIPTION
## Overview:

Brings `/v1/messages` (Anthropic Messages API) streaming to usage parity with `/v1/chat/completions`: every token chunk now carries a token-usage triple, so a proxy reading the SSE stream can meter input/output/total tokens live — including for tokens produced before a client aborts mid-stream.

## Details:

Anthropic's native SSE protocol only reports usage on `message_start` (input) and the terminal `message_delta` (output); the per-token `content_block_delta` events carry no usage. A billing/metering proxy reading `/v1/messages` therefore got nothing until the stream finished, and **nothing at all** when a client deliberately aborted. The parity target is `/v1/chat/completions` with `continuous_usage_stats`, which repeats a usage triple on every chunk.

`dynamo-protocols`'s `AnthropicStreamEvent::ContentBlockDelta` is an external type with no `usage` field, so the triple is injected at the JSON serialization layer:

- **`event_json_with_usage`** stamps `{input_tokens, output_tokens, total_tokens}` (`total = input + output`, plus any Anthropic cache fields) onto every `content_block_delta`, leaving all other events untouched. All production content-delta emits route through the new `serialize_event`.
- The **fallback output-token counter** moved ahead of delta serialization, so the first token chunk already carries a non-zero output count when the backend omits per-chunk usage (`ModelInput::Text` / PushRouter path).
- `continuous_usage_stats: true` is kept on the internal request so supporting backends supply authoritative per-chunk usage.
- The superseded interim `message_delta` mechanism was removed.
- Best-effort **flush-on-cancel** (biased `select!` in the stream loop and the disconnect monitor) is retained so the terminal `message_delta`/`message_stop` still drain when the SSE channel is writable at abort time.

The injected `usage` on `content_block_delta` is an **additive Dynamo wire extension**; spec-compliant Anthropic clients ignore unknown fields.

## Where should the reviewer start?

- `lib/llm/src/protocols/anthropic/stream_converter.rs` — `event_json_with_usage` / `serialize_event`, the moved fallback counter, and the removed interim-usage path (the core of the change).
- `lib/llm/src/protocols/anthropic/types.rs` — `continuous_usage_stats: true` on the internal request.
- `lib/llm/src/http/service/anthropic.rs` and `disconnect.rs` — biased `select!` flush-on-cancel.

**Validation:** `cargo test -p dynamo-llm anthropic` → 66 passed, 0 failed. `cargo clippy -p dynamo-llm --all-targets` → clean.

## Related Issues

Closes #12483

<!-- RCA source: dynamo-issues/2026-07-30-dynamo-messages-per-chunk-usage-missing.md -->

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12473" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability when connections are cancelled or disconnected, ensuring final events are delivered before termination.
  * Streaming requests that receive no output now return a clear temporary service-unavailable error.
  * Improved token usage reporting during Anthropic streams, including cumulative totals and estimates before final usage data is available.

* **Enhancements**
  * Continuous usage statistics are now included in streamed chat responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
