### PR TITLE
fix(frontend): support max Responses reasoning effort

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2534,7 +2534,7 @@ async fn responses(
         tools: request.inner.tools.clone(),
         tool_choice: request.inner.tool_choice.clone(),
         instructions: request.inner.instructions.clone(),
-        reasoning: request.inner.reasoning.clone(),
+        reasoning: request.reasoning.clone(),
         text: request.inner.text.clone(),
         service_tier: request.inner.service_tier,
         include: request.inner.include.clone(),
@@ -3984,6 +3984,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         }
     }

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -9,7 +9,7 @@ use dynamo_protocols::types::responses::{
     AssistantRole, FunctionCallOutput, FunctionToolCall, IncludeEnum, IncompleteDetails,
     InputContent, InputItem, InputOutputMessageContent, InputParam, InputRole, InputTokenDetails,
     Instructions, Item, MessageItem, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
-    OutputTextContent, OutputTokenDetails, PromptCacheRetention, Reasoning, ReasoningItem,
+    OutputTextContent, OutputTokenDetails, PromptCacheRetention, ReasoningItem, ReasoningSummary,
     Response, ResponseTextParam, ResponseUsage, Role as ResponseRole, ServiceTier, Status,
     SummaryPart, SummaryTextContent, TextResponseFormatConfiguration, Tool, ToolChoiceOptions,
     ToolChoiceParam, Truncation,
@@ -37,6 +37,20 @@ use super::chat_completions::{NvCreateChatCompletionRequest, NvCreateChatComplet
 use super::{OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider};
 use crate::protocols::common::extensions::{NvExt, NvExtProvider};
 
+/// Responses API reasoning controls.
+///
+/// The upstream Responses `Reasoning` type still uses async-openai's effort
+/// enum, which does not accept the model-defined `"max"` value. Dynamo's Chat
+/// protocol enum does, so own this small request field locally and use the same
+/// effort type across both API surfaces.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
+pub struct Reasoning {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ChatReasoningEffort>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ReasoningSummary>,
+}
+
 /// Request body for `POST /v1/responses`. Uses a plain
 /// `#[derive(Deserialize)]` — the relaxed input shapes are handled by
 /// Dynamo-owning the input chain in `dynamo_protocols::types::responses`,
@@ -59,6 +73,12 @@ pub struct NvCreateResponse {
     #[serde(flatten)]
     #[schema(value_type = Object)]
     pub inner: dynamo_protocols::types::responses::CreateResponse,
+
+    /// Shadows `CreateResponse.reasoning` so model-defined efforts such as
+    /// `"max"` do not deserialize through async-openai's narrower enum.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Object)]
+    pub reasoning: Option<Reasoning>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Object)]
@@ -86,13 +106,19 @@ pub struct NvResponse {
     pub frequency_penalty: f32,
     #[serde(default)]
     pub store: bool,
+
+    /// Request reasoning controls echoed on the response. Kept outside the
+    /// upstream `Response` because its effort enum cannot represent `"max"`.
+    #[serde(default)]
+    #[schema(value_type = Object)]
+    pub reasoning: Option<Reasoning>,
 }
 
 /// Patch an already-serialized `Response` JSON object to match the
 /// OpenResponses spec. Applied both to one-shot `NvResponse` serialization
 /// and to every `Response` embedded inside a streaming event payload.
 ///
-/// Reconciles two spec gaps between upstream async-openai's `Response` and
+/// Reconciles three spec gaps between upstream async-openai's `Response` and
 /// the OpenResponses spec:
 ///
 ///  1. Fields the spec requires as `T | null` that upstream marks
@@ -100,6 +126,8 @@ pub struct NvResponse {
 ///     silently dropped when None; the spec wants them present as null.
 ///  2. Fields the spec requires (`presence_penalty`, `frequency_penalty`,
 ///     `store`) that are absent from upstream `Response` entirely.
+///  3. Model-defined reasoning efforts such as `"max"` that upstream's enum
+///     cannot represent.
 ///
 /// Rather than fork the upstream output chain (which would cascade into
 /// `OutputItem`, streaming events, and a long tail of sub-types), we patch
@@ -111,6 +139,7 @@ pub(crate) fn patch_response_for_spec(
     presence_penalty: f32,
     frequency_penalty: f32,
     store: bool,
+    reasoning: serde_json::Value,
 ) {
     for key in dynamo_protocols::types::responses::SPEC_NULLABLE_REQUIRED_RESPONSE_FIELDS {
         obj.entry(*key).or_insert(serde_json::Value::Null);
@@ -125,6 +154,7 @@ pub(crate) fn patch_response_for_spec(
         serde_json::json!(frequency_penalty),
     );
     obj.insert("store".into(), serde_json::json!(store));
+    obj.insert("reasoning".into(), reasoning);
 }
 
 impl Serialize for NvResponse {
@@ -133,12 +163,14 @@ impl Serialize for NvResponse {
         let serde_json::Value::Object(obj) = &mut value else {
             return value.serialize(serializer);
         };
+        let reasoning = serde_json::to_value(&self.reasoning).map_err(serde::ser::Error::custom)?;
 
         patch_response_for_spec(
             obj,
             self.presence_penalty,
             self.frequency_penalty,
             self.store,
+            reasoning,
         );
 
         if let Some(nvext) = &self.nvext {
@@ -763,15 +795,9 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
         // Determine stream setting: respect caller's preference, default to true for aggregation
         let stream = resp.inner.stream.or(Some(true));
 
-        // Map reasoning.effort to reasoning_effort. The upstream responses
-        // `effort` is the same `async_openai` enum the Chat field is built on,
-        // so the local `From` impl converts it directly and exhaustively.
-        let reasoning_effort = resp
-            .inner
-            .reasoning
-            .as_ref()
-            .and_then(|r| r.effort.clone())
-            .map(ChatReasoningEffort::from);
+        // Map Responses reasoning.effort to the equivalent Chat field without
+        // narrowing model-defined values such as `"max"`.
+        let reasoning_effort = resp.reasoning.as_ref().and_then(|r| r.effort.clone());
 
         // Map text.format to response_format
         let response_format = resp.inner.text.as_ref().and_then(convert_text_format);
@@ -1162,7 +1188,10 @@ pub fn chat_completion_to_response(
         prompt: None,
         prompt_cache_key: params.prompt_cache_key.clone(),
         prompt_cache_retention: params.prompt_cache_retention,
-        reasoning: params.reasoning.clone(),
+        // `NvResponse` owns the wire reasoning field because the upstream
+        // response enum cannot represent model-defined efforts such as
+        // `"max"`.
+        reasoning: None,
         safety_identifier: params.safety_identifier.clone(),
         service_tier: Some(params.service_tier.unwrap_or(ServiceTier::Auto)),
         top_logprobs: Some(0),
@@ -1191,6 +1220,7 @@ pub fn chat_completion_to_response(
         presence_penalty: params.presence_penalty.unwrap_or(0.0),
         frequency_penalty: params.frequency_penalty.unwrap_or(0.0),
         store: params.store.unwrap_or(false),
+        reasoning: params.reasoning.clone(),
     })
 }
 
@@ -1221,6 +1251,7 @@ mod tests {
                 top_logprobs: Some(15),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: Some(NvExt {
                 annotations: Some(vec!["debug".into(), "trace".into()]),
                 ..Default::default()
@@ -1310,6 +1341,7 @@ mod tests {
                 instructions: Some("You are a helpful assistant.".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1354,6 +1386,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1433,6 +1466,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1474,6 +1508,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1517,6 +1552,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1565,6 +1601,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1604,6 +1641,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1638,6 +1676,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1680,6 +1719,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1741,6 +1781,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1813,6 +1854,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1870,6 +1912,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1925,6 +1968,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -1972,6 +2016,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -2037,6 +2082,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -2116,6 +2162,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -2189,6 +2236,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2258,6 +2306,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2324,6 +2373,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2381,6 +2431,7 @@ mod tests {
                 model: Some("test-model".into()),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2420,6 +2471,7 @@ mod tests {
                 })]),
                 ..Default::default()
             },
+            reasoning: None,
             nvext: None,
         };
 
@@ -2599,19 +2651,20 @@ thinking
 
     #[test]
     fn test_reasoning_effort_mapped_to_chat_completion() {
-        use dynamo_protocols::types::responses::Reasoning;
+        for (wire_value, expected) in [
+            ("medium", ChatReasoningEffort::Medium),
+            ("max", ChatReasoningEffort::Max),
+        ] {
+            let req: NvCreateResponse = serde_json::from_value(serde_json::json!({
+                "model": "moonshotai/Kimi-K3",
+                "input": "think hard",
+                "reasoning": {"effort": wire_value}
+            }))
+            .unwrap();
 
-        let mut req = make_response_with_input("think hard");
-        req.inner.reasoning = Some(Reasoning {
-            effort: Some(serde_json::from_value(serde_json::json!("medium")).unwrap()),
-            ..Default::default()
-        });
-
-        let chat: NvCreateChatCompletionRequest = req.try_into().unwrap();
-        assert_eq!(
-            chat.inner.reasoning_effort,
-            Some(ChatReasoningEffort::Medium)
-        );
+            let chat: NvCreateChatCompletionRequest = req.try_into().unwrap();
+            assert_eq!(chat.inner.reasoning_effort, Some(expected));
+        }
     }
 
     #[test]
@@ -2705,36 +2758,34 @@ thinking
 
     #[test]
     fn test_response_echoes_reasoning() {
-        use dynamo_protocols::types::responses::Reasoning;
-
-        let params = ResponseParams {
-            reasoning: Some(Reasoning {
-                effort: Some(serde_json::from_value(serde_json::json!("high")).unwrap()),
+        for effort in [ChatReasoningEffort::High, ChatReasoningEffort::Max] {
+            let expected = serde_json::to_value(&effort).unwrap();
+            let params = ResponseParams {
+                reasoning: Some(Reasoning {
+                    effort: Some(effort),
+                    ..Default::default()
+                }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        };
+            };
 
-        let chat_resp = NvCreateChatCompletionResponse {
-            inner: dynamo_protocols::types::CreateChatCompletionResponse {
-                choices: vec![],
-                created: 0,
-                id: "test".into(),
-                model: "m".into(),
-                service_tier: None,
-                system_fingerprint: None,
-                object: "chat.completion".into(),
-                usage: None,
-            },
-            nvext: None,
-        };
+            let chat_resp = NvCreateChatCompletionResponse {
+                inner: dynamo_protocols::types::CreateChatCompletionResponse {
+                    choices: vec![],
+                    created: 0,
+                    id: "test".into(),
+                    model: "m".into(),
+                    service_tier: None,
+                    system_fingerprint: None,
+                    object: "chat.completion".into(),
+                    usage: None,
+                },
+                nvext: None,
+            };
 
-        let resp = chat_completion_to_response(chat_resp, &params, None).unwrap();
-        let reasoning = resp.inner.reasoning.unwrap();
-        assert_eq!(
-            serde_json::to_value(reasoning.effort).unwrap(),
-            serde_json::json!("high")
-        );
+            let resp = chat_completion_to_response(chat_resp, &params, None).unwrap();
+            let wire = serde_json::to_value(resp).unwrap();
+            assert_eq!(wire["reasoning"]["effort"], expected);
+        }
     }
 
     #[test]
@@ -2963,7 +3014,7 @@ thinking
 
     #[test]
     fn test_reasoning_summary_requires_explicit_request() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let unrequested = chat_completion_to_response(
             make_chat_resp_with_reasoning("private reasoning"),
@@ -3148,7 +3199,7 @@ thinking
 
     #[test]
     fn test_length_finish_reason_preserves_completed_reasoning_status() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let mut chat_resp = make_chat_resp_with_reasoning("complete reasoning");
         chat_resp.inner.choices[0].finish_reason =
@@ -3177,7 +3228,7 @@ thinking
 
     #[test]
     fn test_length_finish_reason_marks_terminal_reasoning_incomplete() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let mut chat_resp = make_chat_resp_with_reasoning("partial reasoning");
         chat_resp.inner.choices[0].message.content = None;

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -35,7 +35,7 @@ use uuid::Uuid;
 
 use dynamo_protocols::types::{ChatCompletionMessageContent, FinishReason};
 
-use super::ResponseParams;
+use super::{Reasoning, ResponseParams};
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionStreamResponse;
 use crate::protocols::unified::ResponsesContext;
 
@@ -189,7 +189,9 @@ impl ResponseStreamConverter {
             prompt: None,
             prompt_cache_key: self.params.prompt_cache_key.clone(),
             prompt_cache_retention: self.params.prompt_cache_retention,
-            reasoning: self.params.reasoning.clone(),
+            // Serialized from `ResponseParams.reasoning` by
+            // `ResponseForSpec`; the upstream enum cannot represent `"max"`.
+            reasoning: None,
             safety_identifier: self.params.safety_identifier.clone(),
             service_tier: Some(self.params.service_tier.unwrap_or(ServiceTier::Auto)),
             top_logprobs: Some(0),
@@ -823,6 +825,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             ResponseStreamEvent::ResponseInProgress(event) => {
@@ -831,6 +834,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             ResponseStreamEvent::ResponseCompleted(event) => {
@@ -839,6 +843,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             ResponseStreamEvent::ResponseFailed(event) => {
@@ -847,6 +852,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             ResponseStreamEvent::ResponseIncomplete(event) => {
@@ -855,6 +861,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             ResponseStreamEvent::ResponseQueued(event) => {
@@ -863,6 +870,7 @@ impl ResponseStreamConverter {
                     event.sequence_number,
                     &event.response,
                     spec,
+                    self.params.reasoning.as_ref(),
                 ))
             }
             _ => serde_json::to_string(event),
@@ -882,6 +890,7 @@ struct ResponseEventForSpec<'a> {
     sequence_number: u64,
     response: &'a Response,
     spec: ResponseSpecFields,
+    reasoning: Option<&'a Reasoning>,
 }
 
 impl<'a> ResponseEventForSpec<'a> {
@@ -890,12 +899,14 @@ impl<'a> ResponseEventForSpec<'a> {
         sequence_number: u64,
         response: &'a Response,
         spec: ResponseSpecFields,
+        reasoning: Option<&'a Reasoning>,
     ) -> Self {
         Self {
             event_type,
             sequence_number,
             response,
             spec,
+            reasoning,
         }
     }
 }
@@ -910,6 +921,7 @@ impl Serialize for ResponseEventForSpec<'_> {
             &ResponseForSpec {
                 response: self.response,
                 spec: self.spec,
+                reasoning: self.reasoning,
             },
         )?;
         map.end()
@@ -919,6 +931,7 @@ impl Serialize for ResponseEventForSpec<'_> {
 struct ResponseForSpec<'a> {
     response: &'a Response,
     spec: ResponseSpecFields,
+    reasoning: Option<&'a Reasoning>,
 }
 
 // Mirrors async-openai's `Response` serialization while writing Dynamo's
@@ -952,7 +965,7 @@ impl Serialize for ResponseForSpec<'_> {
         map.serialize_entry("prompt", &response.prompt)?;
         map.serialize_entry("prompt_cache_key", &response.prompt_cache_key)?;
         map.serialize_entry("prompt_cache_retention", &response.prompt_cache_retention)?;
-        map.serialize_entry("reasoning", &response.reasoning)?;
+        map.serialize_entry("reasoning", &self.reasoning)?;
         map.serialize_entry("safety_identifier", &response.safety_identifier)?;
         serialize_optional_entry(&mut map, "service_tier", &response.service_tier)?;
         map.serialize_entry("status", &response.status)?;
@@ -1280,6 +1293,7 @@ mod tests {
                 params.presence_penalty.unwrap_or(0.0),
                 params.frequency_penalty.unwrap_or(0.0),
                 params.store.unwrap_or(false),
+                serde_json::to_value(&params.reasoning).unwrap(),
             );
         }
         value
@@ -1429,7 +1443,7 @@ mod tests {
 
     #[test]
     fn test_length_finish_reason_marks_reasoning_item_incomplete() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1452,7 +1466,7 @@ mod tests {
 
     #[test]
     fn test_completed_reasoning_stays_complete_when_text_is_truncated() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1481,7 +1495,7 @@ mod tests {
 
     #[test]
     fn test_same_chunk_text_and_length_complete_reasoning_only() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1526,7 +1540,7 @@ mod tests {
 
     #[test]
     fn test_same_chunk_tool_call_and_length_complete_reasoning_only() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1564,7 +1578,7 @@ mod tests {
 
     #[test]
     fn test_requested_reasoning_summary_streams_complete_event_sequence() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1624,7 +1638,7 @@ mod tests {
 
     #[test]
     fn test_reasoning_summary_ignores_updates_after_completion() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1654,7 +1668,7 @@ mod tests {
 
     #[test]
     fn test_reasoning_summary_finishes_before_tool_call() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -1684,7 +1698,7 @@ mod tests {
 
     #[test]
     fn test_reasoning_summary_does_not_start_after_visible_output() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+        use dynamo_protocols::types::responses::ReasoningSummary;
 
         let params = ResponseParams {
             reasoning: Some(Reasoning {
@@ -2107,6 +2121,10 @@ mod tests {
             presence_penalty: Some(0.25),
             frequency_penalty: Some(0.5),
             store: Some(true),
+            reasoning: Some(Reasoning {
+                effort: Some(dynamo_protocols::types::ReasoningEffort::Max),
+                summary: None,
+            }),
             ..Default::default()
         };
         let mut conv = ResponseStreamConverter::new("test-model".into(), params.clone());
@@ -2148,6 +2166,7 @@ mod tests {
         assert_eq!(response_json["response"]["presence_penalty"], 0.25);
         assert_eq!(response_json["response"]["frequency_penalty"], 0.5);
         assert_eq!(response_json["response"]["store"], true);
+        assert_eq!(response_json["response"]["reasoning"]["effort"], "max");
         assert!(response_json["response"]["max_tool_calls"].is_null());
     }
 }

--- a/lib/llm/src/protocols/unified.rs
+++ b/lib/llm/src/protocols/unified.rs
@@ -47,10 +47,10 @@ use crate::protocols::openai::{
     OpenAIOutputOptionsProvider, OpenAISamplingOptionsProvider, OpenAIStopConditionsProvider,
 };
 
-use dynamo_protocols::types::responses::{IncludeEnum, Reasoning, Truncation};
+use dynamo_protocols::types::responses::{IncludeEnum, Truncation};
 
 use super::anthropic::types::{AnthropicCreateMessageRequest, ThinkingConfig};
-use super::openai::responses::NvCreateResponse;
+use super::openai::responses::{NvCreateResponse, Reasoning};
 
 /// Identifies which API surface originated the request and carries
 /// fields specific to that API that cannot be represented in the
@@ -198,7 +198,7 @@ impl TryFrom<NvCreateResponse> for UnifiedRequest {
         let responses_ctx = ResponsesContext {
             previous_response_id: req.inner.previous_response_id.clone(),
             truncation: req.inner.truncation,
-            reasoning: req.inner.reasoning.clone(),
+            reasoning: req.reasoning.clone(),
             include: req.inner.include.clone(),
             store: req.inner.store.unwrap_or(false),
         };


### PR DESCRIPTION
## Summary

- accept `reasoning.effort = "max"` on the Responses API using Dynamo's shared reasoning-effort type
- preserve the requested effort through Responses-to-Chat conversion and echo it in unary and streaming Responses output
- keep upstream-compatible response serialization while covering both `high` and `max` with focused regression tests

The upstream Responses reasoning enum currently stops at `xhigh`, so it rejects `max` before model-specific handling. Dynamo's shared Chat reasoning-effort enum already supports `max`; this change uses it at the Responses boundary.

Linear: [DIS-2560](https://linear.app/nvidia/issue/DIS-2560/codex-compatibility-support-reasoning-effort-max-for-kimi-k3-style)

## Validation

- `cargo check -p dynamo-llm --tests`
- `cargo test -p dynamo-llm --lib 'protocols::openai::responses::'` (87 passed)
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- repository pre-commit hooks