### PR TITLE
fix(responses): preserve chat_template_args during Responses to Chat Completions conversion

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3985,6 +3985,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         }
     }
 

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -63,6 +63,16 @@ pub struct NvCreateResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schema(value_type = Object)]
     pub nvext: Option<NvExt>,
+
+    /// Extra args to pass to the chat template rendering context, forwarded
+    /// to the generated Chat Completions request during conversion.
+    /// Also accepts "chat_template_kwargs" as an alias for compatibility.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        alias = "chat_template_kwargs"
+    )]
+    pub chat_template_args: Option<HashMap<String, serde_json::Value>>,
 }
 
 #[derive(ToSchema, Deserialize, Validate, Debug, Clone)]
@@ -803,7 +813,7 @@ impl TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest {
             },
             common: Default::default(),
             nvext: resp.nvext,
-            chat_template_args: None,
+            chat_template_args: resp.chat_template_args,
             thinking: None,
             media_io_kwargs: None,
             return_tokens_as_token_ids: None,
@@ -1225,7 +1235,40 @@ mod tests {
                 annotations: Some(vec!["debug".into(), "trace".into()]),
                 ..Default::default()
             }),
+            chat_template_args: None,
         }
+    }
+
+    #[test]
+    fn test_responses_chat_template_args_forwarded() {
+        // Issue #12284: chat_template_args on a Responses request must survive
+        // conversion into the generated Chat Completions request.
+        let json = serde_json::json!({
+            "model": "dummy-model",
+            "input": "hello",
+            "chat_template_args": {
+                "enable_thinking": true
+            }
+        });
+        let req: NvCreateResponse = serde_json::from_value(json).unwrap();
+        let chat: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        assert_eq!(
+            chat.chat_template_args
+                .as_ref()
+                .and_then(|m| m.get("enable_thinking")),
+            Some(&serde_json::json!(true))
+        );
+    }
+
+    #[test]
+    fn test_responses_chat_template_args_absent() {
+        let json = serde_json::json!({
+            "model": "dummy-model",
+            "input": "hello"
+        });
+        let req: NvCreateResponse = serde_json::from_value(json).unwrap();
+        let chat: NvCreateChatCompletionRequest = req.try_into().unwrap();
+        assert!(chat.chat_template_args.is_none());
     }
 
     #[test]
@@ -1311,6 +1354,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1355,6 +1399,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1434,6 +1479,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1475,6 +1521,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1518,6 +1565,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1566,6 +1614,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1605,6 +1654,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1639,6 +1689,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1681,6 +1732,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1742,6 +1794,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1814,6 +1867,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1871,6 +1925,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1926,6 +1981,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -1973,6 +2029,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2038,6 +2095,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2117,6 +2175,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
@@ -2190,6 +2249,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2259,6 +2319,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2325,6 +2386,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2382,6 +2444,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
         let messages = &chat_req.inner.messages;
@@ -2421,6 +2484,7 @@ mod tests {
                 ..Default::default()
             },
             nvext: None,
+            chat_template_args: None,
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();


### PR DESCRIPTION
## Summary

- Fixes #12284
- `NvCreateResponse` now accepts an optional top-level `chat_template_args`
  field (with the `chat_template_kwargs` alias, matching the Chat
  Completions request surface).
- `TryFrom<NvCreateResponse> for NvCreateChatCompletionRequest` forwards it
  into the generated Chat Completions request instead of initializing it to
  `None`, so chat-template arguments (e.g. `enable_thinking`) survive the
  `/v1/responses` → Chat Completions conversion. The `UnifiedRequest`
  responses path funnels through the same `TryFrom`, so it is covered too.

## Test plan

- New unit tests in `protocols::openai::responses` cover the issue's repro
  shape: a synthetic responses request with
  `chat_template_args.enable_thinking == true` still has it after
  conversion, and a request without the field still yields `None`.
- `cargo test -p dynamo-llm --no-default-features --lib protocols::openai::responses`: 89 passed, 0 failed.
- `cargo clippy -p dynamo-llm --no-default-features --lib -- -D warnings`: clean.

## Notes

- Linear: TODO (no Linear access from the authoring session; DIS ticket to
  be created and linked).
