### PR TITLE
perf(frontend): avoid quadratic batch prompt copies

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -974,7 +974,8 @@ async fn completions_batch(
     batch_size: usize,
     n: u8,
 ) -> Result<Response, ErrorResponse> {
-    use crate::protocols::openai::completions::extract_single_prompt;
+    use crate::protocols::openai::completions::into_single_prompts;
+    use dynamo_protocols::types::Prompt;
     use futures::stream::{self, StreamExt};
 
     let request_id = request.id().to_string();
@@ -1014,14 +1015,16 @@ async fn completions_batch(
     // prepare to process any annotations
     let annotations = request.annotations();
 
+    // Keep the request template payload-free so each clone does not copy the entire batch.
+    let batch_prompt = std::mem::replace(&mut request.inner.prompt, Prompt::String(String::new()));
+    let single_prompts = into_single_prompts(batch_prompt);
+    debug_assert_eq!(single_prompts.len(), batch_size);
+
     // Generate streams for each prompt in the batch
-    let mut all_streams = Vec::new();
+    let mut all_streams = Vec::with_capacity(batch_size);
     let mut first_ctx = None;
 
-    for prompt_idx in 0..batch_size {
-        // Extract single prompt at this index
-        let single_prompt = extract_single_prompt(&request.inner.prompt, prompt_idx);
-
+    for (prompt_idx, single_prompt) in single_prompts.into_iter().enumerate() {
         // Create a new request with this single prompt
         let mut single_request = request.content().clone();
         single_request.inner.prompt = single_prompt;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2257,15 +2257,16 @@ impl OpenAIPreprocessor {
                             tokens_out = tokens;
                         }
                         TokenInput::Batch(token_batches) => {
-                            if token_batches.len() == 1 {
-                                token_count = Some(token_batches[0].len());
-                                tokens_out = token_batches[0].clone();
-                            } else {
+                            let batch_size = token_batches.len();
+                            let Ok([tokens]): Result<[Vec<TokenIdType>; 1], _> =
+                                token_batches.try_into()
+                            else {
                                 bail!(
-                                    "Batch token input not supported for more than one token in requests (got {})",
-                                    token_batches.len()
+                                    "Batch token input requires exactly one token vector in requests (got {batch_size})"
                                 );
-                            }
+                            };
+                            token_count = Some(tokens.len());
+                            tokens_out = tokens;
                         }
                     }
                 }

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -124,6 +124,21 @@ pub fn extract_single_prompt(
     }
 }
 
+pub(crate) fn into_single_prompts(
+    prompt: dynamo_protocols::types::Prompt,
+) -> Vec<dynamo_protocols::types::Prompt> {
+    use dynamo_protocols::types::Prompt;
+
+    match prompt {
+        Prompt::String(prompt) => vec![Prompt::String(prompt)],
+        Prompt::IntegerArray(prompt) => vec![Prompt::IntegerArray(prompt)],
+        Prompt::StringArray(prompts) => prompts.into_iter().map(Prompt::String).collect(),
+        Prompt::ArrayOfIntegerArray(prompts) => {
+            prompts.into_iter().map(Prompt::IntegerArray).collect()
+        }
+    }
+}
+
 impl NvExtProvider for NvCreateCompletionRequest {
     fn nvext(&self) -> Option<&NvExt> {
         self.nvext.as_ref()
@@ -502,6 +517,29 @@ mod tests {
     use crate::protocols::common::OutputOptionsProvider;
     use base64::Engine;
     use serde_json::json;
+
+    #[test]
+    fn test_into_single_prompts_preserves_batch_order() {
+        use dynamo_protocols::types::Prompt;
+
+        assert_eq!(
+            into_single_prompts(Prompt::StringArray(vec![
+                "first".to_string(),
+                "second".to_string(),
+            ])),
+            vec![
+                Prompt::String("first".to_string()),
+                Prompt::String("second".to_string()),
+            ]
+        );
+        assert_eq!(
+            into_single_prompts(Prompt::ArrayOfIntegerArray(vec![vec![1, 2], vec![3, 4],])),
+            vec![
+                Prompt::IntegerArray(vec![1, 2]),
+                Prompt::IntegerArray(vec![3, 4]),
+            ]
+        );
+    }
 
     #[test]
     fn test_skip_special_tokens_none() {


### PR DESCRIPTION
## Summary

- Move owned completion batch prompts into per-prompt requests instead of cloning the full batch for every child request.
- Clone a payload-free request template while preserving the existing request and context metadata flow.
- Move the sole owned token batch through preprocessing without an additional token-vector copy.

## Details

For a batch of (B) prompts with (S) total prompt data, request splitting previously cloned the full (S)-sized batch for each child request, in addition to cloning each extracted prompt. For equally sized prompts, that makes prompt copying quadratic in the batch size.

This change removes the batch prompt from the request template before cloning it, then moves each owned string or token vector into its child request. Prompt variants, ordering, choice-index remapping, streaming behavior, annotations, and context metadata are unchanged.

A Criterion benchmark with 1,024 token IDs per prompt measured the request-splitting path as follows (request construction excluded from both measurements):

| Batch size | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 8 | 12.894 µs | 2.284 µs | 5.65x |
| 32 | 179.377 µs | 7.464 µs | 24.03x |
| 128 | 2.805 ms | 22.793 µs | 123.05x |

At batch size 128, the old split copied approximately 64.5 MiB of prompt-token payload for a 512 KiB input batch; the new split moves that payload without copying it.

## Where should the reviewer start?

Start with `completions_batch` in `lib/llm/src/http/service/openai.rs`, followed by the consuming prompt conversion in `lib/llm/src/protocols/openai/completions.rs`.

## Validation

- `cargo test -p dynamo-llm --lib protocols::openai::completions::tests::test_into_single_prompts_preserves_batch_order`
- `cargo test -p dynamo-llm --test openai_completions`
- `cargo test -p dynamo-llm --test http-service`
- `cargo clippy -p dynamo-llm --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `uvx pre-commit run --files lib/llm/src/http/service/openai.rs lib/llm/src/preprocessor.rs lib/llm/src/protocols/openai/completions.rs`

## Related Issues

- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized batch completion request processing for improved efficiency and reduced memory overhead.

* **Tests**
  * Added test coverage for prompt batch conversion functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->