### PR TITLE
fix: refresh BuildKit builder before the compliance extract

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -565,6 +565,16 @@ jobs:
             --current-run-id "${DIFF_RUN_ID}" \
             >> "$GITHUB_OUTPUT"
 
+      # builder's pinned to specific pods and the pool can scale down mid-job.
+      # re-route first or the extract just dies on buildx's 20s connect timeout.
+      - name: Refresh BuildKit builder
+        if: ${{ (inputs.compliance_only || inputs.inline_compliance) && inputs.target != 'dev' && inputs.target != 'local-dev' }}
+        uses: ./.github/actions/builder-refresher
+        with:
+          builder_name: ${{ inputs.builder_name }}
+          flavor: ${{ steps.calculate-builder-flavor.outputs.builder_flavor }}
+          arch: ${{ inputs.platform }}
+          cuda_version: ${{ matrix.cuda_version }}
       - name: Compliance extract
         if: ${{ (inputs.compliance_only || inputs.inline_compliance) && inputs.target != 'dev' && inputs.target != 'local-dev' }}
         uses: ./.github/actions/compliance-extract


### PR DESCRIPTION
The remote builder pins specific buildkit StatefulSet pods for the life of the job. When the pool scales down between "Build and Push Image" and the compliance extract, the extract dials a pod that no longer answers and fails on buildx's 20s connect deadline with "context deadline exceeded".

builder-refresher already guards against this for "Build and Push Test Image", but ran after the extract. Add the same guard before the extract so a stale builder is re-routed instead of failing the build.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved compliance build processing by refreshing the build environment before compliance extraction.
  * Ensured compliance jobs use the configured builder, platform, flavor, and CUDA settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->