### PR TITLE
fix(snapshot): cherry-pick exit vLLM source without engine teardown (#12184)

### DIFF
--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -3,6 +3,7 @@
 
 import gc
 import logging
+import os
 from collections.abc import Callable
 
 from dynamo.common.snapshot.lifecycle import (
@@ -46,6 +47,7 @@ async def prepare_snapshot_engine(
         pause_args=(None,),
     )
     if not await snapshot_controller.wait_for_restore():
-        raise SystemExit(0)
+        logger.info("vLLM snapshot captured successfully")
+        os._exit(0)
 
     return snapshot_controller


### PR DESCRIPTION
## Summary

Cherry-picks merged #12184 (`be65a2136809dc74985555bc754d03b53d510108`) onto `release/1.4.0`.

- Exits the vLLM snapshot source path without tearing down the engine
- Signed-off cherry-pick for DCO compliance

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12184

## Test plan

- [ ] Release-branch CI passes
- [ ] Confirm no merge dependencies with other cherry-picks
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->