### PR TITLE
fix(snapshot): cherry-pick enter PID namespace for GPU probe (#12227)

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -79,15 +79,17 @@ func GetPodGPUUUIDs(ctx context.Context, podName, podNamespace, containerName st
 }
 
 // GetGPUUUIDsViaNvidiaSmi discovers GPU UUIDs by running nvidia-smi inside the
-// container's mount namespace. This is the fallback path when the kubelet
+// container's mount and PID namespaces. This is the fallback path when the kubelet
 // PodResources API does not report GPU devices (e.g. when GPUs are allocated
 // via DRA instead of the NVIDIA device plugin).
 func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) ([]string, error) {
 	mountPath := fmt.Sprintf("%s/%d/ns/mnt", strings.TrimRight(hostProcPath, "/"), pid)
+	pidPath := fmt.Sprintf("%s/%d/ns/pid", strings.TrimRight(hostProcPath, "/"), pid)
 	cmd := exec.CommandContext(
 		ctx,
 		"nsenter",
 		fmt.Sprintf("--mount=%s", mountPath),
+		fmt.Sprintf("--pid=%s", pidPath),
 		"--",
 		"nvidia-smi", "--query-gpu=gpu_uuid", "--format=csv,noheader",
 	)


### PR DESCRIPTION
## Summary

Cherry-picks merged #12227 (`506a0a50dde9aab5827831b2439b535b886ed514`) onto `release/1.4.0`.

- Enters the PID namespace when probing GPU identity during snapshot restore
- Signed-off cherry-pick for DCO compliance

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12227

## Test plan

- [ ] Release-branch CI passes
- [ ] Confirm no merge dependencies with other cherry-picks
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->