### PR TITLE
fix(dgdr): normalize model cache paths

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -27,6 +27,7 @@ from aiconfigurator.sdk.task_v2 import Task
 
 from dynamo.profiler.utils.config import clamp_total_gpus_to_budget
 from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentRequestSpec
+from dynamo.profiler.utils.model_cache_paths import model_cache_path_in_pvc
 from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
     needs_profile_data,
@@ -50,7 +51,10 @@ def _build_k8s_overrides(
         if dgdr.modelCache.pvcMountPath:
             overrides["k8s_pvc_mount_path"] = dgdr.modelCache.pvcMountPath
         if dgdr.modelCache.pvcModelPath:
-            overrides["k8s_model_path_in_pvc"] = dgdr.modelCache.pvcModelPath
+            overrides["k8s_model_path_in_pvc"] = model_cache_path_in_pvc(
+                dgdr.modelCache.pvcMountPath,
+                dgdr.modelCache.pvcModelPath,
+            )
     return overrides
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
@@ -224,6 +224,82 @@ class TestRunNaiveFallback:
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
+    def test_with_pvc_absolute_path_under_mount_passes_relative_generator_path(self):
+        """Already-mounted pvcModelPath values are passed to AIC as PVC-relative."""
+        dgdr = _make_dgdr(
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath="/opt/models",
+                pvcModelPath=(
+                    "/opt/models/hub/models--Qwen--Qwen3-0.6B/"
+                    "snapshots/c1899de289a04d12100db370d81485cdf75e47ca"
+                ),
+            )
+        )
+        captured_params = {}
+
+        def fake_generate(params, backend, use_dynamo_generator=False):
+            captured_params.update(params)
+            return {
+                "k8s_deploy.yaml": "kind: DGD\nmetadata:\n  name: test\nspec:\n  services: {}"
+            }
+
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                return_value=copy.deepcopy(_FAKE_GENERATOR_PARAMS),
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                side_effect=fake_generate,
+            ),
+        ):
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm")
+
+        k8s = captured_params.get("K8sConfig", {})
+        assert k8s.get("k8s_pvc_mount_path") == "/opt/models"
+        assert k8s.get("k8s_model_path_in_pvc") == (
+            "hub/models--Qwen--Qwen3-0.6B/"
+            "snapshots/c1899de289a04d12100db370d81485cdf75e47ca"
+        )
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_with_cache_only_pvc_omits_model_path_override(self):
+        """When pvcModelPath is unset, AIC receives only the cache PVC mount."""
+        dgdr = _make_dgdr(
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath="/opt/model-cache",
+            )
+        )
+        captured_params = {}
+
+        def fake_generate(params, backend, use_dynamo_generator=False):
+            captured_params.update(params)
+            return {
+                "k8s_deploy.yaml": "kind: DGD\nmetadata:\n  name: test\nspec:\n  services: {}"
+            }
+
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                return_value=copy.deepcopy(_FAKE_GENERATOR_PARAMS),
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                side_effect=fake_generate,
+            ),
+        ):
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-0.6B", 4, "a100_pcie", "vllm")
+
+        k8s = captured_params.get("K8sConfig", {})
+        assert k8s.get("k8s_pvc_name") == "model-cache"
+        assert k8s.get("k8s_pvc_mount_path") == "/opt/model-cache"
+        assert "k8s_model_path_in_pvc" not in k8s
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
     def test_without_pvc_has_no_pvc_overrides(self):
         """When no modelCache, PVC keys are absent from generator params."""
         dgdr = _make_dgdr()

--- a/components/src/dynamo/profiler/tests/unit/test_model_cache_paths.py
+++ b/components/src/dynamo/profiler/tests/unit/test_model_cache_paths.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.profiler.utils.model_cache_paths import (
+    model_cache_path_in_pvc,
+    normalize_model_cache_path,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+@pytest.mark.parametrize(
+    "mount,model_path,expected",
+    [
+        (
+            "/opt/models",
+            "hub/models--Qwen--Qwen3-32B",
+            "/opt/models/hub/models--Qwen--Qwen3-32B",
+        ),
+        ("/opt/model-cache", "/model/qwen", "/opt/model-cache/model/qwen"),
+        ("/opt/models", "/opt/models", "/opt/models"),
+        (
+            "/opt/models",
+            "/opt/models/hub/models--Qwen--Qwen3-32B/snapshots/abc",
+            "/opt/models/hub/models--Qwen--Qwen3-32B/snapshots/abc",
+        ),
+        ("/opt/models", "/opt/models/checkpoint", "/opt/models/checkpoint"),
+        (
+            "/opt/models",
+            "opt/models/checkpoint",
+            "/opt/models/opt/models/checkpoint",
+        ),
+    ],
+)
+def test_normalize_model_cache_path(mount, model_path, expected):
+    assert normalize_model_cache_path(mount, model_path) == expected
+
+
+@pytest.mark.parametrize(
+    "mount,model_path,expected",
+    [
+        ("/opt/models", "hub/models--Qwen--Qwen3-32B", "hub/models--Qwen--Qwen3-32B"),
+        ("/opt/model-cache", "/model/qwen", "/model/qwen"),
+        ("/opt/models", "/opt/models", "."),
+        (
+            "/opt/models",
+            "/opt/models/hub/models--Qwen--Qwen3-32B/snapshots/abc",
+            "hub/models--Qwen--Qwen3-32B/snapshots/abc",
+        ),
+        ("/opt/models", "/opt/models/checkpoint", "checkpoint"),
+        ("/opt/models", "opt/models/checkpoint", "opt/models/checkpoint"),
+        ("/opt/models", None, None),
+        ("/opt/models", "", None),
+    ],
+)
+def test_model_cache_path_in_pvc(mount, model_path, expected):
+    assert model_cache_path_in_pvc(mount, model_path) == expected

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -711,6 +711,43 @@ def test_build_dgd_config_pvc_with_model_path_uses_pvc_path(backend) -> None:
         assert args[args.index("--served-model-name") + 1] == model_name
 
 
+@pytest.mark.parametrize("backend", ["vllm", "sglang", "trtllm"])
+def test_update_model_from_pvc_absolute_path_inside_mount_is_not_doubled(
+    backend,
+) -> None:
+    """Absolute pvcModelPath values already under pvcMountPath are used as-is."""
+    modifier = CONFIG_MODIFIERS[backend]
+    pvc_name = "model-cache"
+    pvc_mount_path = "/opt/models"
+    model_name = "Qwen/Qwen3-32B"
+    model_path = "/opt/models/hub/models--Qwen--Qwen3-32B/snapshots/abc123"
+    dgd_config = modifier.build_dgd_config(
+        mode="agg",
+        model_name="stale/model",
+        image=f"example/{backend}:test",
+        agg_cli_args=[],
+        agg_replicas=1,
+        agg_gpus=1,
+    )
+
+    result = modifier.update_model_from_pvc(
+        dgd_config,
+        model_name=model_name,
+        pvc_name=pvc_name,
+        pvc_mount_path=pvc_mount_path,
+        pvc_path=model_path,
+    )
+
+    services = result["spec"]["services"]
+    for svc_name, svc in services.items():
+        args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
+        flat_args = " ".join(args) if args else ""
+        assert f"{pvc_mount_path}{pvc_mount_path}" not in flat_args
+        if svc_name in BaseConfigModifier._NON_WORKER_SERVICES:
+            continue
+        assert model_path in flat_args
+
+
 @pytest.mark.parametrize(
     "backend,model_arg",
     [("vllm", "--model"), ("sglang", "--model-path"), ("trtllm", "--model-path")],

--- a/components/src/dynamo/profiler/tests/unit/test_resolve_model_path.py
+++ b/components/src/dynamo/profiler/tests/unit/test_resolve_model_path.py
@@ -145,6 +145,13 @@ class TestResolveModelPath:
         dgdr = _make_dgdr(modelCache=_pvc_model_cache(f"{tmp_path}/", "/model"))
         assert resolve_model_path(dgdr) == str(local_dir)
 
+    def test_absolute_pvc_model_path_inside_mount_is_not_doubled(self, tmp_path):
+        """An already container-visible pvcModelPath should not be joined again."""
+        local_dir = tmp_path / "model"
+        _make_model_dir(local_dir)
+        dgdr = _make_dgdr(modelCache=_pvc_model_cache(str(tmp_path), str(local_dir)))
+        assert resolve_model_path(dgdr) == str(local_dir)
+
     def test_returns_hf_id_when_local_path_is_a_file(self, tmp_path):
         """The resolved path exists but is a file, not a directory -> the HF id."""
         (tmp_path / "model").write_text("not a directory")
@@ -398,6 +405,20 @@ class TestThoroughResolvesModelPath:
 
         assert mock_enumerate.call_args.kwargs["model_path"] == str(local_dir)
 
+    async def test_enumerate_uses_relative_pvc_path_for_absolute_model_path(
+        self, tmp_path
+    ):
+        """run_thorough passes AIC a PVC-relative path for mounted model paths."""
+        pvc_root = tmp_path / "pvc"
+        local_dir = pvc_root / "model"
+        _make_model_dir(local_dir)
+        dgdr = _make_dgdr(modelCache=_pvc_model_cache(str(pvc_root), str(local_dir)))
+
+        mock_enumerate = await self._capture_enumerate(dgdr, tmp_path)
+
+        assert mock_enumerate.call_args.kwargs["model_path"] == str(local_dir)
+        assert mock_enumerate.call_args.kwargs["k8s_model_path_in_pvc"] == "model"
+
     async def test_enumerate_uses_hf_id_when_no_pvc(self, tmp_path):
         """run_thorough -> enumerate_profiling_configs gets the HF id when no PVC."""
         dgdr = _make_dgdr()
@@ -405,6 +426,20 @@ class TestThoroughResolvesModelPath:
         mock_enumerate = await self._capture_enumerate(dgdr, tmp_path)
 
         assert mock_enumerate.call_args.kwargs["model_path"] == _HF_ID
+
+    async def test_enumerate_preserves_unset_pvc_model_path(self, tmp_path):
+        """run_thorough keeps missing pvcModelPath as None for AIC."""
+        dgdr = _make_dgdr(
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath="/opt/model-cache",
+            )
+        )
+
+        mock_enumerate = await self._capture_enumerate(dgdr, tmp_path)
+
+        assert mock_enumerate.call_args.kwargs["model_path"] == _HF_ID
+        assert mock_enumerate.call_args.kwargs["k8s_model_path_in_pvc"] is None
 
     async def test_materializes_each_candidate_once_with_resolved_model_path(
         self, tmp_path

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -48,6 +48,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import (
     ModelCacheSpec,
     ProfilingPhase,
 )
+from dynamo.profiler.utils.model_cache_paths import model_cache_path_in_pvc
 from dynamo.profiler.utils.profile_common import (
     ProfilerOperationalConfig,
     derive_backend_image,
@@ -416,7 +417,10 @@ async def run_thorough(
         total_gpus=total_gpus,
         k8s_pvc_name=model_cache.pvcName,
         k8s_pvc_mount_path=model_cache.pvcMountPath,
-        k8s_model_path_in_pvc=model_cache.pvcModelPath,
+        k8s_model_path_in_pvc=model_cache_path_in_pvc(
+            model_cache.pvcMountPath,
+            model_cache.pvcModelPath,
+        ),
     )
     prefill_candidates, decode_candidates = enumerated[:2]
 

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -32,6 +32,7 @@ from dynamo.profiler.utils.config import (
     update_image,
 )
 from dynamo.profiler.utils.defaults import EngineType
+from dynamo.profiler.utils.model_cache_paths import normalize_model_cache_path
 
 logger = logging.getLogger(__name__)
 
@@ -217,11 +218,8 @@ class BaseConfigModifier:
 
     @classmethod
     def _normalize_model_path(cls, pvc_mount_path: str, pvc_path: str) -> str:
-        mount = (pvc_mount_path or "").rstrip("/")
-        sub = (pvc_path or "").lstrip("/")
-        if not sub:
-            return mount
-        return f"{mount}/{sub}"
+        """Resolve a PVC model-cache path to the mounted container path."""
+        return normalize_model_cache_path(pvc_mount_path, pvc_path)
 
     @classmethod
     def _ensure_spec_pvc(cls, cfg: Config, pvc_name: str) -> None:

--- a/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
+++ b/components/src/dynamo/profiler/utils/dgdr_v1beta1_types.py
@@ -161,7 +161,7 @@ class ModelCacheSpec(BaseModel):
     )
     pvcModelPath: Optional[str] = Field(
         default=None,
-        description='PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8").',
+        description='PVCModelPath is the path to the model checkpoint directory within the PVC (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8"). It may also be a container-visible absolute path already under PVCMountPath. Such an absolute path is interpreted as container-visible; use the relative form without a leading slash to address the same path prefix within the PVC.',
     )
     pvcMountPath: str = Field(
         default="/opt/model-cache",

--- a/components/src/dynamo/profiler/utils/model_cache_paths.py
+++ b/components/src/dynamo/profiler/utils/model_cache_paths.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path helpers for DGDR model-cache PVC configuration."""
+
+
+def normalize_model_cache_path(
+    pvc_mount_path: str | None,
+    pvc_model_path: str | None,
+) -> str:
+    """Resolve a DGDR model-cache path to the container-visible model path.
+
+    ``pvcModelPath`` is normally relative to the PVC. For compatibility, a leading
+    slash is still treated as PVC-relative unless the value begins with the
+    configured mount path, in which case it is an already container-visible path.
+    To address a PVC directory that happens to match the mount-path prefix, use the
+    unambiguous relative form without a leading slash.
+    """
+    mount = (pvc_mount_path or "").rstrip("/")
+    raw_path = (pvc_model_path or "").strip()
+    if not raw_path:
+        return mount
+
+    absolute_path = raw_path.rstrip("/")
+    if mount and (absolute_path == mount or absolute_path.startswith(f"{mount}/")):
+        return absolute_path
+
+    sub_path = raw_path.lstrip("/")
+    if not sub_path:
+        return mount
+    return f"{mount}/{sub_path}"
+
+
+def model_cache_path_in_pvc(
+    pvc_mount_path: str | None,
+    pvc_model_path: str | None,
+) -> str | None:
+    """Return the model path form expected by PVC-relative generators.
+
+    AIC's Kubernetes generator expects ``k8s_model_path_in_pvc`` to be relative
+    to the PVC mount. Preserve existing relative and legacy leading-slash inputs,
+    but strip the mount prefix from already container-visible paths. A path inside
+    the PVC that matches the mount prefix must use the relative form without a
+    leading slash. Return ``None`` when no model path was provided so callers
+    preserve the prior unset-state behavior. Return ``"."`` when the model path
+    explicitly points at the PVC mount root, which keeps AIC from falling back to
+    its HF_HOME default while still resolving under the mount.
+    """
+    mount = (pvc_mount_path or "").rstrip("/")
+    raw_path = (pvc_model_path or "").strip()
+    if not raw_path:
+        return None
+
+    absolute_path = raw_path.rstrip("/")
+    if mount and absolute_path == mount:
+        return "."
+    if mount and absolute_path.startswith(f"{mount}/"):
+        return absolute_path[len(mount) :].lstrip("/")
+    return raw_path

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -30,6 +30,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import (
     DynamoGraphDeploymentRequestSpec,
     ProfilingPhase,
 )
+from dynamo.profiler.utils.model_cache_paths import normalize_model_cache_path
 
 logger = logging.getLogger(__name__)
 
@@ -158,9 +159,10 @@ def resolve_model_path(dgdr: DynamoGraphDeploymentRequestSpec) -> str:
         and dgdr.modelCache.pvcMountPath
         and dgdr.modelCache.pvcModelPath
     ):
-        mount = dgdr.modelCache.pvcMountPath.rstrip("/")
-        sub = dgdr.modelCache.pvcModelPath.strip("/")
-        local_path = f"{mount}/{sub}"
+        local_path = normalize_model_cache_path(
+            dgdr.modelCache.pvcMountPath,
+            dgdr.modelCache.pvcModelPath,
+        )
         if os.path.isfile(os.path.join(local_path, "config.json")):
             return local_path
     return dgdr.model

--- a/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentrequest_types.go
@@ -281,7 +281,10 @@ type ModelCacheSpec struct {
 	PVCName string `json:"pvcName,omitempty"`
 
 	// PVCModelPath is the path to the model checkpoint directory within the PVC
-	// (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8").
+	// (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8"). It may also be a
+	// container-visible absolute path already under PVCMountPath. Such an absolute
+	// path is interpreted as container-visible; use the relative form without a
+	// leading slash to address the same path prefix within the PVC.
 	// +optional
 	PVCModelPath string `json:"pvcModelPath,omitempty"`
 

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentrequests.yaml
@@ -715,7 +715,10 @@ spec:
                     pvcModelPath:
                       description: |-
                         PVCModelPath is the path to the model checkpoint directory within the PVC
-                        (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8").
+                        (e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8"). It may also be a
+                        container-visible absolute path already under PVCMountPath. Such an absolute
+                        path is interpreted as container-visible; use the relative form without a
+                        leading slash to address the same path prefix within the PVC.
                       type: string
                     pvcMountPath:
                       default: /opt/model-cache

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -2701,7 +2701,7 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `pvcName` _string_ | PVCName is the name of the PersistentVolumeClaim containing model weights.<br />The PVC must exist in the same namespace as the DGDR. |  | Optional: \{\} <br /> |
-| `pvcModelPath` _string_ | PVCModelPath is the path to the model checkpoint directory within the PVC<br />(e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8"). |  | Optional: \{\} <br /> |
+| `pvcModelPath` _string_ | PVCModelPath is the path to the model checkpoint directory within the PVC<br />(e.g. "deepseek-r1" or "models/Llama-3.1-405B-FP8"). It may also be a<br />container-visible absolute path already under PVCMountPath. Such an absolute<br />path is interpreted as container-visible; use the relative form without a<br />leading slash to address the same path prefix within the PVC. |  | Optional: \{\} <br /> |
 | `pvcMountPath` _string_ | PVCMountPath is the mount path for the PVC inside the container. | /opt/model-cache | Optional: \{\} <br /> |
 
 


### PR DESCRIPTION
## Overview

Fix DGDR model-cache path handling when `spec.modelCache.pvcModelPath` is already the container-visible path under `spec.modelCache.pvcMountPath`.

Without this normalization, the profiler/AIC path flow can generate DGD args such as `/opt/models/opt/models/...`, which points workloads at a non-existent checkpoint path.

## Details

- Add shared DGDR model-cache path helpers:
  - `normalize_model_cache_path(...)` returns the container-visible model path used by Dynamo config modifiers and local model inspection.
  - `model_cache_path_in_pvc(...)` returns the PVC-relative path expected by AIC generator inputs.
- Use the container-visible helper in `resolve_model_path()` and `BaseConfigModifier._normalize_model_path()`.
- Use the PVC-relative helper before passing `k8s_model_path_in_pvc` into rapid and thorough AIC generator paths.
- Preserve existing relative paths and legacy leading-slash inputs such as `/model/qwen`; only paths already under the configured mount are treated as already container-visible.
- Add regression coverage for the helper behavior, rapid/thorough AIC handoff, and backend config modifier DGD arg generation.

## Where should reviewer start?

Start with `components/src/dynamo/profiler/utils/model_cache_paths.py`, then the two call sites in `rapid.py` and `thorough.py`. The regression tests show the intended behavior for legacy PVC-relative paths and already-mounted absolute paths.

## Related Issues

Addresses the DGDR model-cache path item described in #12016.

## Validation

- Reproduced on AKS with Dynamo Platform 1.3.0 using a throwaway `DynamoGraphDeploymentRequest` with `autoApply: false`, `pvcMountPath: /opt/models`, and an already-mounted `pvcModelPath`. The generated selected config contained:
  - `Frontend --model-path /opt/models/opt/models/...`
  - `VllmDecodeWorker --model /opt/models/opt/models/...`
- Validated the AIC handoff in the AKS `dynamo-planner:1.3.0` image: absolute `k8s_model_path_in_pvc` doubled, while the PVC-relative path produced by this fix generated clean YAML with no `/opt/models/opt/models`.
- `PYTHONPATH=/tmp/dynamo-profiler-testdeps:components/src python -m pytest -q components/src/dynamo/profiler/tests/unit/test_model_cache_paths.py`
- `PYTHONPATH=/tmp/dynamo-profiler-testdeps:components/src python -m py_compile ...` for touched profiler modules/tests
- `git diff --check`

Local higher-level profiler test targets were module-skipped in this lightweight checkout because `aiconfigurator` and the built `dynamo.llm` bindings are not installed locally; the added tests are intended to run in the normal CI environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model paths for profiler workflows using mounted PVC storage.
  * Prevented already-mounted absolute paths from being prefixed twice.
  * Improved handling of relative paths, mount roots, nested paths, trailing slashes, and legacy leading-slash formats.
  * Ensured profiling services receive the correct container and Kubernetes model paths.

* **Tests**
  * Added regression coverage across vLLM, SGLang, TRT-LLM, rapid profiling, and thorough profiling workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->