### PR TITLE
chore(container): bump vLLM and SGLang base images to kimi-k3 tag

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -61,7 +61,7 @@ vllm:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: vllm/vllm-openai
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.25.1-ubuntu2404
+    runtime_image_tag: kimi-k3
     # Baseline is vllm-openai's TRUE base, nvidia/cuda:13.0.2-base-ubuntu24.04
     # (Docker Hub), NOT a self-baseline of the third-party vllm/vllm-openai image.
     # vllm-openai is built FROM nvidia/cuda, so this attributes everything vLLM
@@ -99,7 +99,7 @@ sglang:
     base_image: nvcr.io/nvidia/cuda-dl-base
     runtime_image: lmsysorg/sglang
     base_image_tag: 25.11-cuda13.0-devel-ubuntu24.04
-    runtime_image_tag: v0.5.15-cu130-runtime
+    runtime_image_tag: kimi-k3
     # Baseline is the TRUE base of the third-party lmsysorg/sglang image,
     # nvidia/cuda:13.0.1-cudnn-devel-ubuntu24.04 (Docker Hub; CUDA_VERSION=13.0.1,
     # cuDNN 9.13.0.50, ubuntu24.04), NOT a self-baseline of lmsysorg/sglang.


### PR DESCRIPTION
## Summary

Updates `container/context.yaml` to use the official Kimi-K3 base images released by vLLM and SGLang teams.

### Changes

- `vllm.cuda13.0.runtime_image_tag`: `v0.25.1-ubuntu2404` → `kimi-k3`
  - Image: `vllm/vllm-openai:kimi-k3`
- `sglang.cuda13.0.runtime_image_tag`: `v0.5.15-cu130-runtime` → `kimi-k3`
  - Image: `lmsysorg/sglang:kimi-k3`

### Motivation

Refreshing Kimi-K3 recipes with spec-dec support requires Dynamo containers built on the official `kimi-k3`-tagged framework images. Opening as a draft to trigger the build pipeline per instructions in #dynamo-goldenprairie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)