### PR TITLE
refactor(router): extract default worker score and pick

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "fastrand",
  "flume 0.12.0",
  "indexmap 2.14.0",
+ "once_cell",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -21,6 +21,9 @@ try:
     from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
         PickedParallelConfig,
     )
+    from dynamo.profiler.utils.config_modifiers.protocol import (  # noqa: F401
+        BaseConfigModifier,
+    )
     from dynamo.profiler.utils.defaults import (
         DYNAMO_RUN_DEFAULT_PORT,
         EngineType,

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1670,6 +1670,7 @@ dependencies = [
  "fastrand",
  "flume",
  "indexmap 2.14.0",
+ "once_cell",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2270,6 +2270,7 @@ dependencies = [
  "fastrand",
  "flume",
  "indexmap 2.14.0",
+ "once_cell",
  "ordered-float 4.6.0",
  "parking_lot",
  "prometheus",

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -37,6 +37,7 @@ blake3 = { workspace = true }
 dashmap = { workspace = true }
 indexmap = { workspace = true }
 ordered-float = { workspace = true }
+once_cell = "1"
 derive_builder = { workspace = true }
 fastrand = "2"
 prometheus = { workspace = true, optional = true }

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -92,3 +92,7 @@ harness = false
 [[bench]]
 name = "tracking_hash"
 harness = false
+
+[[bench]]
+name = "worker_selection"
+harness = false

--- a/lib/kv-router/benches/worker_selection.rs
+++ b/lib/kv-router/benches/worker_selection.rs
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Default worker-selection scaling benchmark.
+//!
+//! Run with: `cargo bench -p dynamo-kv-router --bench worker_selection`
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dynamo_kv_router::protocols::{
+    RoutingConstraints, WorkerConfigLike, WorkerId, WorkerWithDpRank,
+};
+use dynamo_kv_router::scheduling::{OverlapSignals, ScheduleMode};
+use dynamo_kv_router::{
+    DefaultWorkerSelector, KvRouterConfig, SchedulingRequest, WorkerLoadProjection, WorkerSelector,
+};
+use rustc_hash::FxHashMap;
+
+#[derive(Default)]
+struct BenchWorkerConfig {
+    taints: HashSet<String>,
+}
+
+impl WorkerConfigLike for BenchWorkerConfig {
+    fn data_parallel_start_rank(&self) -> u32 {
+        0
+    }
+
+    fn data_parallel_size(&self) -> u32 {
+        1
+    }
+
+    fn max_num_batched_tokens(&self) -> Option<u64> {
+        None
+    }
+
+    fn total_kv_blocks(&self) -> Option<u64> {
+        Some(131_072)
+    }
+
+    fn taints(&self) -> &HashSet<String> {
+        &self.taints
+    }
+}
+
+fn fixture(worker_count: usize) -> (HashMap<WorkerId, BenchWorkerConfig>, SchedulingRequest) {
+    let mut workers = HashMap::with_capacity(worker_count);
+    let mut effective_overlap_blocks = HashMap::with_capacity(worker_count);
+    let mut effective_cached_tokens = HashMap::with_capacity(worker_count);
+    let mut worker_loads = FxHashMap::with_capacity_and_hasher(worker_count, Default::default());
+
+    for worker_id in 0..worker_count as WorkerId {
+        let worker = WorkerWithDpRank::from_worker_id(worker_id);
+        let cached_tokens = (worker_id as usize % 32) * 64;
+        workers.insert(worker_id, BenchWorkerConfig::default());
+        effective_overlap_blocks.insert(worker, cached_tokens as f64 / 16.0);
+        effective_cached_tokens.insert(worker, cached_tokens);
+        worker_loads.insert(
+            worker,
+            WorkerLoadProjection {
+                active_prefill_tokens: worker_id as usize * 16,
+                active_decode_blocks: worker_id as usize % 127,
+                active_requests: worker_id as usize % 17,
+                ..Default::default()
+            },
+        );
+    }
+
+    let request = SchedulingRequest {
+        mode: ScheduleMode::QueryOnly { request_id: None },
+        token_seq: None,
+        isl_tokens: 2_048,
+        lora_name: None,
+        expected_output_tokens: Some(256),
+        pinned_worker: None,
+        allowed_worker_ids: None,
+        routing_constraints: RoutingConstraints::default(),
+        router_config_override: None,
+        track_prefill_tokens: true,
+        priority_jump: 0.0,
+        strict_priority: 0,
+        policy_class: None,
+        session_id: None,
+        overlap: OverlapSignals {
+            tier_overlap_blocks: Default::default(),
+            effective_overlap_blocks,
+            effective_cached_tokens,
+        },
+        shared_cache_hits: None,
+        worker_loads,
+        resp_tx: None,
+    };
+
+    (workers, request)
+}
+
+fn worker_selection(c: &mut Criterion) {
+    for temperature in [0.0, 0.7] {
+        let mut group = c.benchmark_group(format!(
+            "default_worker_selection/temperature_{temperature}"
+        ));
+        group.warm_up_time(Duration::from_secs(2));
+        group.measurement_time(Duration::from_secs(5));
+        group.sample_size(50);
+
+        for worker_count in [2, 32, 1_024, 10_000] {
+            let (workers, request) = fixture(worker_count);
+            let selector = DefaultWorkerSelector::new(
+                Some(KvRouterConfig {
+                    router_temperature: temperature,
+                    ..Default::default()
+                }),
+                "prefill",
+            );
+            group.throughput(Throughput::Elements(worker_count as u64));
+            group.bench_with_input(
+                BenchmarkId::from_parameter(worker_count),
+                &worker_count,
+                |b, _| {
+                    b.iter(|| {
+                        black_box(
+                            selector
+                                .select_worker(
+                                    black_box(&workers),
+                                    black_box(&request),
+                                    request.eligibility(),
+                                    black_box(16),
+                                )
+                                .unwrap(),
+                        )
+                    })
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, worker_selection);
+criterion_main!(benches);

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -48,7 +48,7 @@ impl<P, C, Sel, RF> LocalScheduler<P, C, Sel, RF>
 where
     P: SequencePublisher + 'static,
     C: WorkerConfigLike + Clone + PartialEq + Send + Sync + 'static,
-    Sel: WorkerSelector<C> + Send + Sync + 'static,
+    Sel: WorkerSelector<C> + Send + 'static,
     RF: OverlapScoresRefresh + 'static,
 {
     fn make_scheduling_request(
@@ -583,7 +583,7 @@ impl<P, C, Sel> LocalScheduler<P, C, Sel, NoopOverlapScoresRefresh>
 where
     P: SequencePublisher + 'static,
     C: WorkerConfigLike + Clone + PartialEq + Send + Sync + 'static,
-    Sel: WorkerSelector<C> + Send + Sync + 'static,
+    Sel: WorkerSelector<C> + Send + 'static,
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new_without_overlap_refresh_with_policy_profile(

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -201,7 +201,7 @@ pub struct SchedulerQueue<
     workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
     queueing_enabled: bool,
     supports_overlap_refresh: bool,
-    _marker: PhantomData<(Sel, RF)>,
+    _marker: PhantomData<fn() -> (Sel, RF)>,
 }
 
 impl<

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -95,6 +95,50 @@ fn softmax_sample_entries(
     *entries.last().unwrap()
 }
 
+struct MinCostPicker {
+    best_worker: Option<WorkerWithDpRank>,
+    best_cost: f64,
+    tie_count: usize,
+}
+
+impl MinCostPicker {
+    fn new() -> Self {
+        Self {
+            best_worker: None,
+            best_cost: f64::INFINITY,
+            tie_count: 0,
+        }
+    }
+
+    fn consider(
+        &mut self,
+        worker: WorkerWithDpRank,
+        cost: f64,
+        choose_tie: impl FnOnce(std::ops::Range<usize>) -> usize,
+    ) {
+        if cost < self.best_cost {
+            self.best_worker = Some(worker);
+            self.best_cost = cost;
+            self.tie_count = 1;
+            return;
+        }
+
+        if cost == self.best_cost {
+            self.tie_count += 1;
+            if choose_tie(0..self.tie_count) == 0 {
+                self.best_worker = Some(worker);
+            }
+        }
+    }
+
+    fn finish(self) -> (WorkerWithDpRank, f64) {
+        (
+            self.best_worker.expect("eligible worker rank non-empty"),
+            self.best_cost,
+        )
+    }
+}
+
 /// Default implementation matching the Python _cost_function.
 #[derive(Debug, Clone)]
 pub struct DefaultWorkerSelector {
@@ -301,6 +345,114 @@ impl DefaultWorkerSelector {
 
         logit
     }
+
+    fn score_worker<C: WorkerConfigLike>(
+        &self,
+        workers: &HashMap<WorkerId, C>,
+        request: &SchedulingRequest,
+        worker: WorkerWithDpRank,
+        block_size: u32,
+        min_active_prefill_tokens: usize,
+        weights: LogitWeights,
+    ) -> f64 {
+        let base_score = self.worker_logit(
+            request,
+            worker,
+            block_size,
+            min_active_prefill_tokens,
+            weights,
+            "Formula",
+        );
+        let Some(config) = workers.get(&worker.worker_id) else {
+            return base_score;
+        };
+        match request
+            .routing_constraints
+            .preferred_taint_multiplier(config.taints())
+        {
+            // NOTE: This multiplicative bias assumes a non-negative score. Negative
+            // overlap scores expose its pre-existing sign sensitivity; keep it for now.
+            Some(multiplier) => base_score * multiplier,
+            None => base_score,
+        }
+    }
+
+    fn pick_worker<C: WorkerConfigLike>(
+        &self,
+        workers: &HashMap<WorkerId, C>,
+        request: &SchedulingRequest,
+        eligibility: RoutingEligibility<'_>,
+        block_size: u32,
+        weights: LogitWeights,
+        temperature: f64,
+    ) -> (WorkerWithDpRank, f64) {
+        let min_active_prefill_tokens =
+            if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
+                let mut minimum = usize::MAX;
+                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+                    minimum = minimum.min(request.worker_load_for(worker).active_prefill_tokens);
+                });
+                debug_assert_ne!(minimum, usize::MAX);
+                minimum
+            } else {
+                0
+            };
+        let get_score = |worker| {
+            self.score_worker(
+                workers,
+                request,
+                worker,
+                block_size,
+                min_active_prefill_tokens,
+                weights,
+            )
+        };
+
+        #[cfg(any(test, feature = "bench"))]
+        let deterministic_choice = self.deterministic_rng.as_ref().map(|rng| {
+            let mut candidates = Vec::new();
+            eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+                candidates.push(worker);
+            });
+            candidates.sort_unstable_by_key(|worker| (worker.worker_id, worker.dp_rank));
+
+            let mut rng = rng.lock();
+            if temperature == 0.0 {
+                let mut picker = MinCostPicker::new();
+                for worker in candidates {
+                    picker.consider(worker, get_score(worker), |range| rng.usize(range));
+                }
+                return picker.finish();
+            }
+
+            let entries = candidates
+                .into_iter()
+                .map(|worker| (worker, get_score(worker)))
+                .collect();
+            softmax_sample_entries(entries, temperature, rng.f64())
+        });
+
+        let random_choice = || {
+            if temperature == 0.0 {
+                let mut picker = MinCostPicker::new();
+                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+                    picker.consider(worker, get_score(worker), fastrand::usize);
+                });
+                return picker.finish();
+            }
+
+            let mut worker_logits = FxHashMap::default();
+            eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+                worker_logits.insert(worker, get_score(worker));
+            });
+            softmax_sample(&worker_logits, temperature)
+        };
+
+        #[cfg(any(test, feature = "bench"))]
+        return deterministic_choice.unwrap_or_else(random_choice);
+        #[cfg(not(any(test, feature = "bench")))]
+        random_choice()
+    }
 }
 
 impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
@@ -405,123 +557,14 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             .as_ref()
             .and_then(|cfg| cfg.router_temperature)
             .unwrap_or(self.kv_router_config.router_temperature);
-        let min_active_prefill_tokens =
-            if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
-                let mut minimum = usize::MAX;
-                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                    minimum = minimum.min(request.worker_load_for(worker).active_prefill_tokens);
-                });
-                debug_assert_ne!(minimum, usize::MAX);
-                minimum
-            } else {
-                0
-            };
-        let get_score = |worker: WorkerWithDpRank| -> f64 {
-            let base_score = self.worker_logit(
-                request,
-                worker,
-                block_size,
-                min_active_prefill_tokens,
-                weights,
-                "Formula",
-            );
-            let Some(config) = workers.get(&worker.worker_id) else {
-                return base_score;
-            };
-            match request
-                .routing_constraints
-                .preferred_taint_multiplier(config.taints())
-            {
-                // NOTE: This multiplicative bias assumes a non-negative score. Negative
-                // overlap scores expose its pre-existing sign sensitivity; keep it for now.
-                Some(multiplier) => base_score * multiplier,
-                None => base_score,
-            }
-        };
-
-        #[cfg(any(test, feature = "bench"))]
-        let deterministic_choice = self.deterministic_rng.as_ref().map(|rng| {
-            let mut candidates = Vec::new();
-            eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                candidates.push(worker);
-            });
-            candidates.sort_unstable_by_key(|worker| (worker.worker_id, worker.dp_rank));
-
-            let mut rng = rng.lock();
-            if temperature == 0.0 {
-                let mut best_worker = None;
-                let mut best_logit = f64::INFINITY;
-                let mut tie_count = 0usize;
-                for worker in candidates {
-                    let score = get_score(worker);
-                    if score < best_logit {
-                        best_worker = Some(worker);
-                        best_logit = score;
-                        tie_count = 1;
-                        continue;
-                    }
-
-                    if score == best_logit {
-                        tie_count += 1;
-                        if rng.usize(0..tie_count) == 0 {
-                            best_worker = Some(worker);
-                        }
-                    }
-                }
-                return (
-                    best_worker.expect("eligible worker rank non-empty"),
-                    best_logit,
-                );
-            }
-
-            let entries = candidates
-                .into_iter()
-                .map(|worker| (worker, get_score(worker)))
-                .collect();
-            softmax_sample_entries(entries, temperature, rng.f64())
-        });
-
-        let random_choice = || {
-            if temperature == 0.0 {
-                let mut best_worker = None;
-                let mut best_logit = f64::INFINITY;
-                let mut tie_count = 0usize;
-                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                    let score = get_score(worker);
-                    if score < best_logit {
-                        best_worker = Some(worker);
-                        best_logit = score;
-                        tie_count = 1;
-                        return;
-                    }
-
-                    if score == best_logit {
-                        tie_count += 1;
-                        // Reservoir sampling keeps tied minima uniform without collecting workers.
-                        if fastrand::usize(0..tie_count) == 0 {
-                            best_worker = Some(worker);
-                        }
-                    }
-                });
-
-                return (
-                    best_worker.expect("eligible worker rank non-empty"),
-                    best_logit,
-                );
-            }
-
-            let mut worker_logits = FxHashMap::default();
-            eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                let score = get_score(worker);
-                worker_logits.insert(worker, score);
-            });
-
-            softmax_sample(&worker_logits, temperature)
-        };
-        #[cfg(any(test, feature = "bench"))]
-        let (best_worker, best_logit) = deterministic_choice.unwrap_or_else(random_choice);
-        #[cfg(not(any(test, feature = "bench")))]
-        let (best_worker, best_logit) = random_choice();
+        let (best_worker, best_logit) = self.pick_worker(
+            workers,
+            request,
+            eligibility,
+            block_size,
+            weights,
+            temperature,
+        );
 
         let best_host_pinned_overlap_blocks = request
             .overlap
@@ -850,7 +893,20 @@ mod tests {
     fn seeded_selector_is_stable_for_ties_and_temperature_sampling() {
         use crate::test_utils::SimpleWorkerConfig;
 
-        for temperature in [0.0, 0.7] {
+        for (temperature, expected_prefix) in [
+            (
+                0.0,
+                [
+                    10, 30, 10, 10, 30, 20, 10, 10, 10, 20, 10, 20, 30, 10, 20, 20,
+                ],
+            ),
+            (
+                0.7,
+                [
+                    30, 20, 30, 10, 20, 20, 30, 20, 30, 10, 10, 30, 30, 20, 30, 30,
+                ],
+            ),
+        ] {
             let config = KvRouterConfig {
                 router_temperature: temperature,
                 ..Default::default()
@@ -887,6 +943,14 @@ mod tests {
                 .collect::<Vec<_>>();
 
             assert_eq!(first_sequence, second_sequence);
+            assert_eq!(
+                first_sequence
+                    .iter()
+                    .take(expected_prefix.len())
+                    .map(|worker| worker.worker_id)
+                    .collect::<Vec<_>>(),
+                expected_prefix,
+            );
         }
     }
 

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -95,50 +95,6 @@ fn softmax_sample_entries(
     *entries.last().unwrap()
 }
 
-struct MinCostPicker {
-    best_worker: Option<WorkerWithDpRank>,
-    best_cost: f64,
-    tie_count: usize,
-}
-
-impl MinCostPicker {
-    fn new() -> Self {
-        Self {
-            best_worker: None,
-            best_cost: f64::INFINITY,
-            tie_count: 0,
-        }
-    }
-
-    fn consider(
-        &mut self,
-        worker: WorkerWithDpRank,
-        cost: f64,
-        choose_tie: impl FnOnce(std::ops::Range<usize>) -> usize,
-    ) {
-        if cost < self.best_cost {
-            self.best_worker = Some(worker);
-            self.best_cost = cost;
-            self.tie_count = 1;
-            return;
-        }
-
-        if cost == self.best_cost {
-            self.tie_count += 1;
-            if choose_tie(0..self.tie_count) == 0 {
-                self.best_worker = Some(worker);
-            }
-        }
-    }
-
-    fn finish(self) -> (WorkerWithDpRank, f64) {
-        (
-            self.best_worker.expect("eligible worker rank non-empty"),
-            self.best_cost,
-        )
-    }
-}
-
 /// Default implementation matching the Python _cost_function.
 #[derive(Debug, Clone)]
 pub struct DefaultWorkerSelector {
@@ -418,11 +374,29 @@ impl DefaultWorkerSelector {
 
             let mut rng = rng.lock();
             if temperature == 0.0 {
-                let mut picker = MinCostPicker::new();
+                let mut best_worker = None;
+                let mut best_logit = f64::INFINITY;
+                let mut tie_count = 0usize;
                 for worker in candidates {
-                    picker.consider(worker, get_score(worker), |range| rng.usize(range));
+                    let score = get_score(worker);
+                    if score < best_logit {
+                        best_worker = Some(worker);
+                        best_logit = score;
+                        tie_count = 1;
+                        continue;
+                    }
+
+                    if score == best_logit {
+                        tie_count += 1;
+                        if rng.usize(0..tie_count) == 0 {
+                            best_worker = Some(worker);
+                        }
+                    }
                 }
-                return picker.finish();
+                return (
+                    best_worker.expect("eligible worker rank non-empty"),
+                    best_logit,
+                );
             }
 
             let entries = candidates
@@ -434,11 +408,31 @@ impl DefaultWorkerSelector {
 
         let random_choice = || {
             if temperature == 0.0 {
-                let mut picker = MinCostPicker::new();
+                let mut best_worker = None;
+                let mut best_logit = f64::INFINITY;
+                let mut tie_count = 0usize;
                 eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                    picker.consider(worker, get_score(worker), fastrand::usize);
+                    let score = get_score(worker);
+                    if score < best_logit {
+                        best_worker = Some(worker);
+                        best_logit = score;
+                        tie_count = 1;
+                        return;
+                    }
+
+                    if score == best_logit {
+                        tie_count += 1;
+                        // Reservoir sampling keeps tied minima uniform without collecting workers.
+                        if fastrand::usize(0..tie_count) == 0 {
+                            best_worker = Some(worker);
+                        }
+                    }
                 });
-                return picker.finish();
+
+                return (
+                    best_worker.expect("eligible worker rank non-empty"),
+                    best_logit,
+                );
             }
 
             let mut worker_logits = FxHashMap::default();

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 #[cfg(any(test, feature = "bench"))]
 use std::sync::Arc;
 
@@ -112,6 +114,55 @@ struct LogitWeights {
     shared_cache_multiplier: f64,
 }
 
+struct WorkerSelectionInput<'a, C> {
+    workers: &'a HashMap<WorkerId, C>,
+    request: &'a SchedulingRequest,
+    eligibility: RoutingEligibility<'a>,
+    context: WorkerSelectionContext<'a>,
+}
+
+struct WorkerSelectionContext<'a> {
+    request_id: &'a str,
+    request_blocks: u64,
+    block_size: u32,
+    track_prefill_tokens: bool,
+    weights: LogitWeights,
+    min_active_prefill_tokens: usize,
+}
+
+struct WorkerSelectionRow {
+    worker: WorkerWithDpRank,
+    effective_overlap_blocks: f64,
+    device_overlap_blocks: f64,
+    host_overlap_blocks: f64,
+    disk_overlap_blocks: f64,
+    shared_beyond: u32,
+    raw_prefill_blocks: f64,
+    active_prefill_tokens: usize,
+    decode_cost_blocks: f64,
+    active_requests: usize,
+    preferred_taint_multiplier: Option<f64>,
+}
+
+trait WorkerScorer {
+    fn score(&self, context: &WorkerSelectionContext<'_>, row: &WorkerSelectionRow) -> f64;
+}
+
+trait WorkerPicker<C: WorkerConfigLike, S: WorkerScorer> {
+    fn pick(&self, scorer: &S, input: &WorkerSelectionInput<'_, C>) -> (WorkerWithDpRank, f64);
+}
+
+struct DefaultWorkerScorer<C> {
+    kv_router_config: C,
+    worker_type: &'static str,
+}
+
+struct DefaultWorkerPicker<'a> {
+    default_temperature: f64,
+    #[cfg(any(test, feature = "bench"))]
+    deterministic_rng: Option<&'a Arc<Mutex<fastrand::Rng>>>,
+    selector_lifetime: PhantomData<&'a DefaultWorkerSelector>,
+}
 impl DefaultWorkerSelector {
     pub fn new(kv_router_config: Option<KvRouterConfig>, worker_type: &'static str) -> Self {
         Self {
@@ -134,113 +185,82 @@ impl DefaultWorkerSelector {
             deterministic_rng: Some(Arc::new(Mutex::new(fastrand::Rng::with_seed(seed)))),
         }
     }
+}
+
+impl<'a> DefaultWorkerScorer<&'a KvRouterConfig> {
+    fn from_selector(selector: &'a DefaultWorkerSelector) -> Self {
+        Self {
+            kv_router_config: &selector.kv_router_config,
+            worker_type: selector.worker_type,
+        }
+    }
+}
+
+impl<C: Borrow<KvRouterConfig>> DefaultWorkerScorer<C> {
+    fn selection_weights(&self, request: &SchedulingRequest) -> LogitWeights {
+        let kv_router_config = self.kv_router_config.borrow();
+        LogitWeights {
+            overlap_score_credit: request
+                .router_config_override
+                .as_ref()
+                .and_then(|cfg| cfg.overlap_score_credit)
+                .unwrap_or(kv_router_config.overlap_score_credit),
+            overlap_score_credit_decay: kv_router_config.overlap_score_credit_decay,
+            prefill_load_scale: request
+                .router_config_override
+                .as_ref()
+                .and_then(|cfg| cfg.prefill_load_scale)
+                .unwrap_or(kv_router_config.prefill_load_scale),
+            shared_cache_multiplier: request
+                .router_config_override
+                .as_ref()
+                .and_then(|cfg| cfg.shared_cache_multiplier)
+                .unwrap_or(kv_router_config.shared_cache_multiplier),
+        }
+    }
 
     fn worker_logit(
         &self,
-        request: &SchedulingRequest,
-        worker: WorkerWithDpRank,
-        block_size: u32,
-        min_active_prefill_tokens: usize,
-        weights: LogitWeights,
+        context: &WorkerSelectionContext<'_>,
+        row: &WorkerSelectionRow,
         formula_name: &'static str,
     ) -> f64 {
-        let block_size_f64 = block_size as f64;
-        let effective_overlap_blocks = request.effective_overlap_blocks_for(worker);
-        let has_tier_overlap_blocks = !request.overlap.tier_overlap_blocks.device.is_empty()
-            || !request.overlap.tier_overlap_blocks.host_pinned.is_empty()
-            || !request.overlap.tier_overlap_blocks.disk.is_empty();
-        let device_overlap_blocks = request
-            .overlap
-            .tier_overlap_blocks
-            .device
-            .get(&worker)
-            .copied()
-            .map(|blocks| blocks as f64)
-            .unwrap_or_else(|| {
-                if has_tier_overlap_blocks {
-                    0.0
-                } else {
-                    effective_overlap_blocks
-                }
-            });
-        // `shared_cache_hits::hits_beyond` expects an integer block count, so
-        // use the unweighted device prefix depth for this comparison.
-        let device_overlap_blocks_u32 = device_overlap_blocks.round().max(0.0) as u32;
-        let worker_load = request.worker_loads.get(&worker).copied();
-        let raw_prefill_tokens = if request.track_prefill_tokens {
-            match worker_load {
-                Some(load) => {
-                    let cached_tokens = request.effective_cached_tokens_for(worker);
-                    // Preserve the legacy operation order when overlap exceeds the prompt.
-                    let uncached_tokens = super::prefill_load::effective_prefill_tokens(
-                        request.isl_tokens,
-                        cached_tokens,
-                    );
-                    let projected_tokens = load.active_prefill_tokens + uncached_tokens;
-                    projected_tokens.saturating_add(cached_tokens)
-                }
-                None => request.isl_tokens,
-            }
-        } else {
-            0
-        } as f64;
-
-        let host_overlap_blocks = request
-            .overlap
-            .tier_overlap_blocks
-            .host_pinned
-            .get(&worker)
-            .copied()
-            .unwrap_or(0) as f64;
-        let disk_overlap_blocks = request
-            .overlap
-            .tier_overlap_blocks
-            .disk
-            .get(&worker)
-            .copied()
-            .unwrap_or(0) as f64;
-
-        // Credit shared cache hits beyond this worker's device prefix.
-        let (shared_overlap_blocks, shared_beyond) =
-            if let Some(ref shared_hits) = request.shared_cache_hits {
-                let beyond = shared_hits.hits_beyond(device_overlap_blocks_u32);
-                (weights.shared_cache_multiplier * (beyond as f64), beyond)
-            } else {
-                (0.0, 0)
-            };
-
-        let raw_prefill_blocks = raw_prefill_tokens / block_size_f64;
+        let kv_router_config = self.kv_router_config.borrow();
+        let weights = context.weights;
+        let worker = row.worker;
+        let effective_overlap_blocks = row.effective_overlap_blocks;
+        let shared_overlap_blocks = weights.shared_cache_multiplier * row.shared_beyond as f64;
         // Normalize backlog above the least-loaded eligible worker by this request's
         // size. The rational decay softly trades cache locality for prefill balance,
         // while leaving workers at the load floor with their full device credit.
-        let overlap_credit_decay =
-            if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
-                let active_prefill_tokens = worker_load.unwrap_or_default().active_prefill_tokens;
-                let excess_active_prefill_blocks =
-                    active_prefill_tokens.saturating_sub(min_active_prefill_tokens) as f64
-                        / block_size_f64;
-                let normalized_prefill_load =
-                    excess_active_prefill_blocks / request.request_blocks(block_size) as f64;
-                1.0 / (1.0 + weights.overlap_score_credit_decay * normalized_prefill_load)
-            } else {
-                1.0
-            };
+        let overlap_credit_decay = if context.track_prefill_tokens
+            && weights.overlap_score_credit_decay > 0.0
+        {
+            let excess_active_prefill_blocks =
+                row.active_prefill_tokens
+                    .saturating_sub(context.min_active_prefill_tokens) as f64
+                    / context.block_size as f64;
+            let normalized_prefill_load =
+                excess_active_prefill_blocks / context.request_blocks as f64;
+            1.0 / (1.0 + weights.overlap_score_credit_decay * normalized_prefill_load)
+        } else {
+            1.0
+        };
         let effective_overlap_score_credit = weights.overlap_score_credit * overlap_credit_decay;
-        let overlap_credit_blocks = effective_overlap_score_credit * device_overlap_blocks
-            + self.kv_router_config.host_cache_hit_weight * host_overlap_blocks
-            + self.kv_router_config.disk_cache_hit_weight * disk_overlap_blocks
+        let overlap_credit_blocks = effective_overlap_score_credit * row.device_overlap_blocks
+            + kv_router_config.host_cache_hit_weight * row.host_overlap_blocks
+            + kv_router_config.disk_cache_hit_weight * row.disk_overlap_blocks
             + shared_overlap_blocks;
-        let worker_load = worker_load.unwrap_or_default();
-        let decode_cost_blocks = worker_load.potential_decode_blocks() as f64;
+        let decode_cost_blocks = row.decode_cost_blocks;
         let active_request_cost_blocks =
-            self.kv_router_config.decode_active_request_weight * worker_load.active_requests as f64;
+            kv_router_config.decode_active_request_weight * row.active_requests as f64;
 
         // Decode routers normally force `overlap_score_credit=0` through the
         // per-request override, which preserves load-only disagg routing. When
         // conditional disagg leaves a positive overlap credit in place, prefer
         // cache-hot decode workers while still charging decode backlog.
         if self.worker_type == "decode"
-            && !request.track_prefill_tokens
+            && !context.track_prefill_tokens
             && weights.overlap_score_credit > 0.0
         {
             // Clamp at zero because downstream taint multipliers assume non-negative scores.
@@ -259,7 +279,7 @@ impl DefaultWorkerSelector {
             return logit;
         }
 
-        let adjusted_prefill_blocks = (raw_prefill_blocks - overlap_credit_blocks).max(0.0);
+        let adjusted_prefill_blocks = (row.raw_prefill_blocks - overlap_credit_blocks).max(0.0);
         let prefill_cost_blocks = weights.prefill_load_scale * adjusted_prefill_blocks;
         let logit = prefill_cost_blocks + decode_cost_blocks + active_request_cost_blocks;
 
@@ -269,76 +289,62 @@ impl DefaultWorkerSelector {
         // `request_id` is the same value `[ROUTING] Best` logs, and `worker_type` separates the
         // prefill-pool and decode-pool decisions that interleave into one log. Both are evaluated
         // inside the macro so they cost nothing when DEBUG is disabled.
-        if shared_beyond > 0 {
+        if row.shared_beyond > 0 {
             tracing::debug!(
-                request_id = request.mode.request_id().unwrap_or("-"),
+                request_id = context.request_id,
                 worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks, \
-                 {shared_beyond} shared blocks beyond device (multiplier={shared_cache_multiplier:.2}): {logit:.3} \
+                 {} shared blocks beyond device (multiplier={shared_cache_multiplier:.2}): {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks + active_request_cost_blocks \
                  = {prefill_load_scale:.3} * {adjusted_prefill_blocks:.3} + {decode_cost_blocks:.3} + {active_request_cost_blocks:.3} \
-                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
+                 (raw_prefill_blocks: {:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
                  overlap_credit_decay: {overlap_credit_decay:.3})",
                 worker.worker_id,
                 worker.dp_rank,
+                row.shared_beyond,
+                row.raw_prefill_blocks,
                 shared_cache_multiplier = weights.shared_cache_multiplier,
                 prefill_load_scale = weights.prefill_load_scale
             );
         } else {
             tracing::debug!(
-                request_id = request.mode.request_id().unwrap_or("-"),
+                request_id = context.request_id,
                 worker_type = self.worker_type,
                 "{formula_name} for worker_id={} dp_rank={:?} with {effective_overlap_blocks:.2} effective cached blocks: {logit:.3} \
                  = prefill_load_scale * adjusted_prefill_blocks + decode_blocks + active_request_cost_blocks \
                  = {prefill_load_scale:.3} * {adjusted_prefill_blocks:.3} + {decode_cost_blocks:.3} + {active_request_cost_blocks:.3} \
-                 (raw_prefill_blocks: {raw_prefill_blocks:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
+                 (raw_prefill_blocks: {:.3}, overlap_credit_blocks: {overlap_credit_blocks:.3}, \
                  overlap_credit_decay: {overlap_credit_decay:.3})",
                 worker.worker_id,
                 worker.dp_rank,
+                row.raw_prefill_blocks,
                 prefill_load_scale = weights.prefill_load_scale
             );
         }
 
         logit
     }
+}
 
-    fn score_worker<C: WorkerConfigLike>(
-        &self,
-        config: &C,
-        request: &SchedulingRequest,
-        worker: WorkerWithDpRank,
-        block_size: u32,
-        min_active_prefill_tokens: usize,
-        weights: LogitWeights,
-    ) -> f64 {
-        let base_score = self.worker_logit(
-            request,
-            worker,
-            block_size,
-            min_active_prefill_tokens,
-            weights,
-            "Formula",
-        );
-        match request
-            .routing_constraints
-            .preferred_taint_multiplier(config.taints())
-        {
-            // NOTE: This multiplicative bias assumes a non-negative score. Negative
-            // overlap scores expose its pre-existing sign sensitivity; keep it for now.
-            Some(multiplier) => base_score * multiplier,
-            None => base_score,
+impl<'a> DefaultWorkerPicker<'a> {
+    fn from_selector(selector: &'a DefaultWorkerSelector) -> Self {
+        Self {
+            default_temperature: selector.kv_router_config.router_temperature,
+            #[cfg(any(test, feature = "bench"))]
+            deterministic_rng: selector.deterministic_rng.as_ref(),
+            selector_lifetime: PhantomData,
         }
     }
+}
 
-    fn pick_worker<C: WorkerConfigLike>(
-        &self,
-        workers: &HashMap<WorkerId, C>,
-        request: &SchedulingRequest,
-        eligibility: RoutingEligibility<'_>,
+impl<'a, C: WorkerConfigLike> WorkerSelectionInput<'a, C> {
+    fn new(
+        workers: &'a HashMap<WorkerId, C>,
+        request: &'a SchedulingRequest,
+        eligibility: RoutingEligibility<'a>,
         block_size: u32,
         weights: LogitWeights,
-        temperature: f64,
-    ) -> (WorkerWithDpRank, f64) {
+    ) -> Self {
         let min_active_prefill_tokens =
             if request.track_prefill_tokens && weights.overlap_score_credit_decay > 0.0 {
                 let mut minimum = usize::MAX;
@@ -350,14 +356,138 @@ impl DefaultWorkerSelector {
             } else {
                 0
             };
-        let get_score = |worker, config: &C| {
-            self.score_worker(
-                config,
-                request,
-                worker,
+        Self {
+            workers,
+            request,
+            eligibility,
+            context: WorkerSelectionContext {
+                request_id: request.mode.request_id().unwrap_or("-"),
+                request_blocks: request.request_blocks(block_size),
                 block_size,
-                min_active_prefill_tokens,
+                track_prefill_tokens: request.track_prefill_tokens,
                 weights,
+                min_active_prefill_tokens,
+            },
+        }
+    }
+
+    fn row(
+        &self,
+        worker: WorkerWithDpRank,
+        preferred_taint_multiplier: Option<f64>,
+    ) -> WorkerSelectionRow {
+        let effective_overlap_blocks = self.request.effective_overlap_blocks_for(worker);
+        let has_tier_overlap_blocks = !self.request.overlap.tier_overlap_blocks.device.is_empty()
+            || !self
+                .request
+                .overlap
+                .tier_overlap_blocks
+                .host_pinned
+                .is_empty()
+            || !self.request.overlap.tier_overlap_blocks.disk.is_empty();
+        let device_overlap_blocks = self
+            .request
+            .overlap
+            .tier_overlap_blocks
+            .device
+            .get(&worker)
+            .copied()
+            .map(|blocks| blocks as f64)
+            .unwrap_or_else(|| {
+                if has_tier_overlap_blocks {
+                    0.0
+                } else {
+                    effective_overlap_blocks
+                }
+            });
+        let worker_load = self.request.worker_loads.get(&worker).copied();
+        let cached_tokens = self.request.effective_cached_tokens_for(worker);
+        let raw_prefill_tokens = if self.request.track_prefill_tokens {
+            match worker_load {
+                Some(load) => {
+                    // Preserve the legacy operation order when overlap exceeds the prompt.
+                    let uncached_tokens = super::prefill_load::effective_prefill_tokens(
+                        self.request.isl_tokens,
+                        cached_tokens,
+                    );
+                    let projected_tokens = load.active_prefill_tokens + uncached_tokens;
+                    projected_tokens.saturating_add(cached_tokens)
+                }
+                None => self.request.isl_tokens,
+            }
+        } else {
+            0
+        } as f64;
+        let worker_load = worker_load.unwrap_or_default();
+        let shared_beyond = self.request.shared_cache_hits.as_ref().map_or(0, |hits| {
+            // `hits_beyond` expects the unweighted device prefix depth.
+            hits.hits_beyond(device_overlap_blocks.round().max(0.0) as u32)
+        });
+
+        WorkerSelectionRow {
+            worker,
+            effective_overlap_blocks,
+            device_overlap_blocks,
+            host_overlap_blocks: self
+                .request
+                .overlap
+                .tier_overlap_blocks
+                .host_pinned
+                .get(&worker)
+                .copied()
+                .unwrap_or(0) as f64,
+            disk_overlap_blocks: self
+                .request
+                .overlap
+                .tier_overlap_blocks
+                .disk
+                .get(&worker)
+                .copied()
+                .unwrap_or(0) as f64,
+            shared_beyond,
+            raw_prefill_blocks: raw_prefill_tokens / self.context.block_size as f64,
+            active_prefill_tokens: worker_load.active_prefill_tokens,
+            decode_cost_blocks: worker_load.potential_decode_blocks() as f64,
+            active_requests: worker_load.active_requests,
+            preferred_taint_multiplier,
+        }
+    }
+}
+
+impl<C: Borrow<KvRouterConfig>> WorkerScorer for DefaultWorkerScorer<C> {
+    fn score(&self, context: &WorkerSelectionContext<'_>, row: &WorkerSelectionRow) -> f64 {
+        let base_score = self.worker_logit(context, row, "Formula");
+        match row.preferred_taint_multiplier {
+            // NOTE: This multiplicative bias assumes a non-negative score. Negative
+            // overlap scores expose its pre-existing sign sensitivity; keep it for now.
+            Some(multiplier) => base_score * multiplier,
+            None => base_score,
+        }
+    }
+}
+
+impl<C, S> WorkerPicker<C, S> for DefaultWorkerPicker<'_>
+where
+    C: WorkerConfigLike,
+    S: WorkerScorer,
+{
+    fn pick(&self, scorer: &S, input: &WorkerSelectionInput<'_, C>) -> (WorkerWithDpRank, f64) {
+        let workers = input.workers;
+        let request = input.request;
+        let eligibility = input.eligibility;
+        let temperature = request
+            .router_config_override
+            .as_ref()
+            .and_then(|cfg| cfg.router_temperature)
+            .unwrap_or(self.default_temperature);
+        let get_score = |worker, config: &C| {
+            let preferred_taint_multiplier = input
+                .request
+                .routing_constraints
+                .preferred_taint_multiplier(config.taints());
+            scorer.score(
+                &input.context,
+                &input.row(worker, preferred_taint_multiplier),
             )
         };
 
@@ -482,24 +612,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
         // Borrowed, never allocated; bridges the winner row to `[ROUTING] Best`.
         let request_id = request.mode.request_id().unwrap_or("-");
 
-        let weights = LogitWeights {
-            overlap_score_credit: request
-                .router_config_override
-                .as_ref()
-                .and_then(|cfg| cfg.overlap_score_credit)
-                .unwrap_or(self.kv_router_config.overlap_score_credit),
-            overlap_score_credit_decay: self.kv_router_config.overlap_score_credit_decay,
-            prefill_load_scale: request
-                .router_config_override
-                .as_ref()
-                .and_then(|cfg| cfg.prefill_load_scale)
-                .unwrap_or(self.kv_router_config.prefill_load_scale),
-            shared_cache_multiplier: request
-                .router_config_override
-                .as_ref()
-                .and_then(|cfg| cfg.shared_cache_multiplier)
-                .unwrap_or(self.kv_router_config.shared_cache_multiplier),
-        };
+        let scorer = DefaultWorkerScorer::from_selector(self);
+        let weights = scorer.selection_weights(request);
 
         if let Some(worker) = pinned_worker {
             match eligibility.validate_worker_rank(workers, worker) {
@@ -512,15 +626,10 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 Err(_) => return Err(KvSchedulerError::NoEndpoints),
             }
 
-            let min_active_prefill_tokens = request.worker_load_for(worker).active_prefill_tokens;
-            let logit = self.worker_logit(
-                request,
-                worker,
-                block_size,
-                min_active_prefill_tokens,
-                weights,
-                "Pinned formula",
-            );
+            let input =
+                WorkerSelectionInput::new(workers, request, eligibility, block_size, weights);
+            let row = input.row(worker, None);
+            let logit = scorer.worker_logit(&input.context, &row, "Pinned formula");
             let effective_overlap_blocks = request.effective_overlap_blocks_for(worker);
             let cached_tokens = request.effective_cached_tokens_for(worker);
 
@@ -544,19 +653,9 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             });
         }
 
-        let temperature = request
-            .router_config_override
-            .as_ref()
-            .and_then(|cfg| cfg.router_temperature)
-            .unwrap_or(self.kv_router_config.router_temperature);
-        let (best_worker, best_logit) = self.pick_worker(
-            workers,
-            request,
-            eligibility,
-            block_size,
-            weights,
-            temperature,
-        );
+        let input = WorkerSelectionInput::new(workers, request, eligibility, block_size, weights);
+        let picker = DefaultWorkerPicker::from_selector(self);
+        let (best_worker, best_logit) = picker.pick(&scorer, &input);
 
         let best_host_pinned_overlap_blocks = request
             .overlap
@@ -635,6 +734,7 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
+    use crate::config::RouterConfigOverride;
     use crate::protocols::{SharedCacheHits, WorkerConfigLike};
     use crate::scheduling::{OverlapSignals, ScheduleMode};
 
@@ -692,6 +792,28 @@ mod tests {
             shared_cache_hits: None,
             resp_tx: None,
         }
+    }
+
+    fn worker_logit(
+        selector: &DefaultWorkerSelector,
+        request: &SchedulingRequest,
+        worker: WorkerWithDpRank,
+        block_size: u32,
+        weights: LogitWeights,
+    ) -> f64 {
+        let workers = HashMap::from([(worker.worker_id, TaintedWorkerConfig::default())]);
+        let input = WorkerSelectionInput::new(
+            &workers,
+            request,
+            request.eligibility(),
+            block_size,
+            weights,
+        );
+        DefaultWorkerScorer::from_selector(selector).worker_logit(
+            &input.context,
+            &input.row(worker, None),
+            "test",
+        )
     }
 
     fn worker_loads_with_active_decode(
@@ -943,6 +1065,88 @@ mod tests {
                     .collect::<Vec<_>>(),
                 expected_prefix,
             );
+        }
+    }
+
+    #[test]
+    fn per_request_overrides_change_selection() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let warm_worker = WorkerWithDpRank::from_worker_id(0);
+        let cold_worker = WorkerWithDpRank::from_worker_id(1);
+        let workers = HashMap::from([
+            (warm_worker.worker_id, SimpleWorkerConfig::default()),
+            (cold_worker.worker_id, SimpleWorkerConfig::default()),
+        ]);
+        let mut request = base_request(4);
+        request
+            .overlap
+            .tier_overlap_blocks
+            .device
+            .insert(warm_worker, 2);
+        request
+            .overlap
+            .effective_cached_tokens
+            .insert(warm_worker, 2);
+        request.worker_loads.insert(
+            warm_worker,
+            crate::sequences::WorkerLoadProjection {
+                active_decode_blocks: 1,
+                ..Default::default()
+            },
+        );
+        #[allow(clippy::single_range_in_vec_init)]
+        let shared_cache_hits = SharedCacheHits::from_ranges(vec![0..4]);
+        request.shared_cache_hits = Some(shared_cache_hits);
+
+        let config = KvRouterConfig {
+            overlap_score_credit: 1.0,
+            prefill_load_scale: 1.0,
+            shared_cache_multiplier: 0.0,
+            router_temperature: 0.0,
+            ..Default::default()
+        };
+        let select = |request: &SchedulingRequest| {
+            DefaultWorkerSelector::new_seeded(Some(config.clone()), "test", 42)
+                .select_worker(&workers, request, request.eligibility(), 1)
+                .unwrap()
+                .worker
+        };
+
+        assert_eq!(select(&request), warm_worker);
+
+        for (name, config_override) in [
+            (
+                "overlap_score_credit",
+                RouterConfigOverride {
+                    overlap_score_credit: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "prefill_load_scale",
+                RouterConfigOverride {
+                    prefill_load_scale: Some(0.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "shared_cache_multiplier",
+                RouterConfigOverride {
+                    shared_cache_multiplier: Some(1.0),
+                    ..Default::default()
+                },
+            ),
+            (
+                "router_temperature",
+                RouterConfigOverride {
+                    router_temperature: Some(1.0),
+                    ..Default::default()
+                },
+            ),
+        ] {
+            request.router_config_override = Some(config_override);
+            assert_eq!(select(&request), cold_worker, "{name} override was ignored");
         }
     }
 
@@ -1563,16 +1767,10 @@ mod tests {
             shared_cache_multiplier: 0.0,
         };
 
-        assert_eq!(
-            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
-            7.0
-        );
+        assert_eq!(worker_logit(&selector, &request, worker, 16, weights), 7.0);
 
         request.track_prefill_tokens = false;
-        assert_eq!(
-            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
-            5.0
-        );
+        assert_eq!(worker_logit(&selector, &request, worker, 16, weights), 5.0);
     }
 
     #[test]
@@ -1602,12 +1800,9 @@ mod tests {
             "test",
         );
 
+        assert_eq!(worker_logit(&default, &request, worker, 16, weights), 100.0);
         assert_eq!(
-            default.worker_logit(&request, worker, 16, 0, weights, "test"),
-            100.0
-        );
-        assert_eq!(
-            weighted.worker_logit(&request, worker, 16, 0, weights, "test"),
+            worker_logit(&weighted, &request, worker, 16, weights),
             228.0
         );
     }
@@ -1633,10 +1828,7 @@ mod tests {
             shared_cache_multiplier: 0.0,
         };
 
-        assert_eq!(
-            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
-            7.0
-        );
+        assert_eq!(worker_logit(&selector, &request, worker, 16, weights), 7.0);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -304,7 +304,7 @@ impl DefaultWorkerSelector {
 
     fn score_worker<C: WorkerConfigLike>(
         &self,
-        workers: &HashMap<WorkerId, C>,
+        config: &C,
         request: &SchedulingRequest,
         worker: WorkerWithDpRank,
         block_size: u32,
@@ -319,9 +319,6 @@ impl DefaultWorkerSelector {
             weights,
             "Formula",
         );
-        let Some(config) = workers.get(&worker.worker_id) else {
-            return base_score;
-        };
         match request
             .routing_constraints
             .preferred_taint_multiplier(config.taints())
@@ -353,9 +350,9 @@ impl DefaultWorkerSelector {
             } else {
                 0
             };
-        let get_score = |worker| {
+        let get_score = |worker, config: &C| {
             self.score_worker(
-                workers,
+                config,
                 request,
                 worker,
                 block_size,
@@ -373,12 +370,13 @@ impl DefaultWorkerSelector {
             candidates.sort_unstable_by_key(|worker| (worker.worker_id, worker.dp_rank));
 
             let mut rng = rng.lock();
+            let get_candidate_score = |worker| get_score(worker, &workers[&worker.worker_id]);
             if temperature == 0.0 {
                 let mut best_worker = None;
                 let mut best_logit = f64::INFINITY;
                 let mut tie_count = 0usize;
                 for worker in candidates {
-                    let score = get_score(worker);
+                    let score = get_candidate_score(worker);
                     if score < best_logit {
                         best_worker = Some(worker);
                         best_logit = score;
@@ -401,7 +399,7 @@ impl DefaultWorkerSelector {
 
             let entries = candidates
                 .into_iter()
-                .map(|worker| (worker, get_score(worker)))
+                .map(|worker| (worker, get_candidate_score(worker)))
                 .collect();
             softmax_sample_entries(entries, temperature, rng.f64())
         });
@@ -411,8 +409,8 @@ impl DefaultWorkerSelector {
                 let mut best_worker = None;
                 let mut best_logit = f64::INFINITY;
                 let mut tie_count = 0usize;
-                eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                    let score = get_score(worker);
+                eligibility.for_each_eligible_worker_rank(workers, |worker, config| {
+                    let score = get_score(worker, config);
                     if score < best_logit {
                         best_worker = Some(worker);
                         best_logit = score;
@@ -436,8 +434,8 @@ impl DefaultWorkerSelector {
             }
 
             let mut worker_logits = FxHashMap::default();
-            eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
-                worker_logits.insert(worker, get_score(worker));
+            eligibility.for_each_eligible_worker_rank(workers, |worker, config| {
+                worker_logits.insert(worker, get_score(worker, config));
             });
             softmax_sample(&worker_logits, temperature)
         };

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use dynamo_tokens::SequenceHash;
+use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
@@ -17,10 +18,10 @@ use crate::protocols::{
     WorkerWithDpRank,
 };
 use crate::scheduling::config::RouterConfigOverride;
-use crate::scheduling::selector::DefaultWorkerSelector;
+use crate::scheduling::selector::{DefaultWorkerSelector, WorkerSelector};
 use crate::scheduling::{
     KvSchedulerError, LocalScheduler, OverlapAnalysis, OverlapSignals, PotentialLoad, ScheduleMode,
-    ScheduleRequest, TieredOverlapRefresher, effective_prefill_tokens,
+    ScheduleRequest, TieredOverlapRefresher, WorkerEligibilityError, effective_prefill_tokens,
     prefill_load_hint_from_effective_tokens,
 };
 use crate::sequences::{
@@ -46,10 +47,86 @@ use super::types::{
     WorkerPatchRequest, WorkerRequest,
 };
 
+pub(crate) type SelectionWorkerSelectorFactory = Box<
+    dyn Fn() -> Box<dyn WorkerSelector<SelectionWorkerConfig> + Send + 'static>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+// Keep the default selector inline so the default path does not add an allocation.
+#[allow(clippy::large_enum_variant)]
+enum SelectionWorkerSelector {
+    Default(DefaultWorkerSelector),
+    Custom(Box<dyn WorkerSelector<SelectionWorkerConfig> + Send + 'static>),
+}
+
+impl WorkerSelector<SelectionWorkerConfig> for SelectionWorkerSelector {
+    fn select_worker(
+        &self,
+        workers: &HashMap<WorkerId, SelectionWorkerConfig>,
+        request: &crate::scheduling::SchedulingRequest,
+        eligibility: crate::scheduling::RoutingEligibility<'_>,
+        block_size: u32,
+    ) -> Result<crate::protocols::WorkerSelectionResult, KvSchedulerError> {
+        match self {
+            Self::Default(selector) => {
+                selector.select_worker(workers, request, eligibility, block_size)
+            }
+            Self::Custom(selector) => {
+                eligibility.validate_pinned_worker_allowed()?;
+                if let Some(pinned_worker) = eligibility.pinned_worker() {
+                    match eligibility.validate_worker_rank(workers, pinned_worker) {
+                        Ok(_) => {}
+                        Err(WorkerEligibilityError::WorkerOverloaded { .. }) => {
+                            return Err(KvSchedulerError::PinnedWorkerOverloaded {
+                                worker_id: pinned_worker.worker_id,
+                            });
+                        }
+                        Err(_) => return Err(KvSchedulerError::NoEndpoints),
+                    }
+                } else if !eligibility.has_eligible_worker(
+                    workers
+                        .iter()
+                        .map(|(&worker_id, config)| (worker_id, config)),
+                ) {
+                    if eligibility.has_eligible_worker_ignoring_overload(
+                        workers
+                            .iter()
+                            .map(|(&worker_id, config)| (worker_id, config)),
+                    ) {
+                        return Err(KvSchedulerError::AllEligibleWorkersOverloaded);
+                    }
+                    return Err(KvSchedulerError::NoEndpoints);
+                }
+
+                let worker = selector
+                    .select_worker(workers, request, eligibility, block_size)?
+                    .worker;
+                if eligibility
+                    .pinned_worker()
+                    .is_some_and(|pinned| pinned != worker)
+                    || eligibility.validate_worker_rank(workers, worker).is_err()
+                {
+                    return Err(KvSchedulerError::NoEndpoints);
+                }
+                Ok(crate::protocols::WorkerSelectionResult {
+                    worker,
+                    required_blocks: request.request_blocks(block_size),
+                    effective_overlap_blocks: request.effective_overlap_blocks_for(worker),
+                    cached_tokens: request.effective_cached_tokens_for(worker),
+                    potential_decode_blocks: request
+                        .potential_decode_blocks_after_admission(worker, block_size),
+                })
+            }
+        }
+    }
+}
+
 type SelectionScheduler = LocalScheduler<
     ScopedSequencePublisher,
     SelectionWorkerConfig,
-    DefaultWorkerSelector,
+    SelectionWorkerSelector,
     TieredOverlapRefresher<Indexer>,
 >;
 
@@ -111,9 +188,10 @@ pub struct SelectionServiceConfig {
 
 pub struct SelectionCore {
     catalog: WorkerCatalog,
-    entries: RwLock<HashMap<RoutingPartitionId, Arc<SelectionEntry>>>,
+    entries: RwLock<HashMap<RoutingPartitionId, Arc<OnceCell<Arc<SelectionEntry>>>>>,
     indexer_registry: Arc<WorkerRegistry>,
     kv_router_config: crate::config::KvRouterConfig,
+    worker_selector_factory: Option<SelectionWorkerSelectorFactory>,
     cancel_token: CancellationToken,
     replica_config: Option<ReplicaSyncConfig>,
     /// Booking inputs captured by `select`, keyed by `selection_id`, so a later
@@ -123,6 +201,21 @@ pub struct SelectionCore {
 }
 
 impl SelectionCore {
+    fn entry(&self, key: &RoutingPartitionId) -> Option<Arc<SelectionEntry>> {
+        self.entries
+            .read()
+            .get(key)
+            .and_then(|entry| entry.get().cloned())
+    }
+
+    fn initialized_entries(&self) -> Vec<Arc<SelectionEntry>> {
+        self.entries
+            .read()
+            .values()
+            .filter_map(|entry| entry.get().cloned())
+            .collect()
+    }
+
     /// Create an intentionally local selector without replica synchronization
     /// or startup recovery.
     ///
@@ -161,6 +254,7 @@ impl SelectionCore {
             indexer_threads,
             cancel_token,
             None,
+            None,
             true,
             cache_config,
             tracking_hash,
@@ -172,6 +266,7 @@ impl SelectionCore {
         indexer_threads: usize,
         cancel_token: CancellationToken,
         replica_config: Option<ReplicaSyncConfig>,
+        worker_selector_factory: Option<SelectionWorkerSelectorFactory>,
         cache_config: SelectionCacheConfig,
         tracking_hash: Arc<TrackingHashContext>,
     ) -> Self {
@@ -180,17 +275,20 @@ impl SelectionCore {
             indexer_threads,
             cancel_token,
             replica_config,
+            worker_selector_factory,
             false,
             cache_config,
             tracking_hash,
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_inner(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,
         cancel_token: CancellationToken,
         replica_config: Option<ReplicaSyncConfig>,
+        worker_selector_factory: Option<SelectionWorkerSelectorFactory>,
         signal_indexer_ready: bool,
         cache_config: SelectionCacheConfig,
         tracking_hash: Arc<TrackingHashContext>,
@@ -208,6 +306,7 @@ impl SelectionCore {
             entries: RwLock::new(HashMap::new()),
             indexer_registry,
             kv_router_config,
+            worker_selector_factory,
             cancel_token,
             replica_config,
             selection_cache: SelectionCache::new(&cache_config),
@@ -259,7 +358,7 @@ impl SelectionCore {
             return;
         }
 
-        let Some(entry) = self.entries.read().get(&key).cloned() else {
+        let Some(entry) = self.entry(&key) else {
             tracing::trace!(%key, "Dropping replica event for unknown selector entry");
             return;
         };
@@ -433,95 +532,95 @@ impl SelectionCore {
         let is_eagle = record.is_eagle.unwrap_or(false);
         let key = record.key();
 
-        if let Some(entry) = self.entries.read().get(&key).cloned() {
-            if entry.block_size != block_size {
-                return Err(SelectionError::Conflict(format!(
-                    "block_size mismatch for {key}: existing={} requested={block_size}",
-                    entry.block_size
-                )));
-            }
-            if entry.is_eagle != is_eagle {
-                return Err(SelectionError::Conflict(format!(
-                    "is_eagle mismatch for {key}: existing={} requested={is_eagle}",
-                    entry.is_eagle
-                )));
-            }
-            return Ok(entry);
-        }
-
-        let mut entries = self.entries.write();
-        if let Some(entry) = entries.get(&key).cloned() {
-            if entry.block_size != block_size {
-                return Err(SelectionError::Conflict(format!(
-                    "block_size mismatch for {key}: existing={} requested={block_size}",
-                    entry.block_size
-                )));
-            }
-            if entry.is_eagle != is_eagle {
-                return Err(SelectionError::Conflict(format!(
-                    "is_eagle mismatch for {key}: existing={} requested={is_eagle}",
-                    entry.is_eagle
-                )));
-            }
-            return Ok(entry);
-        }
-
-        let (workers_tx, workers_rx) = watch::channel(HashMap::new());
-        let scoped_replica_sync =
-            setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
-        let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
-            scoped_replica_sync.publisher,
-            block_size as usize,
-            HashMap::new(),
-            scoped_replica_sync.enabled,
-            scoped_replica_sync.process_id,
-            WORKER_TYPE,
-            ReplicaWorkerPolicy::RequireRegistered,
-        ));
-        let replica_tx = scoped_replica_sync.channel.map(|(replica_tx, subscriber)| {
-            slots.start_replica_sync(subscriber, self.cancel_token.child_token());
-            replica_tx
+        let entry_cell = { self.entries.read().get(&key).cloned() };
+        let entry_cell = entry_cell.unwrap_or_else(|| {
+            self.entries
+                .write()
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
         });
-        slots.start_periodic_force_expiry_across_all_workers(self.cancel_token.child_token());
+        let entry = entry_cell
+            .get_or_try_init(|| -> Result<Arc<SelectionEntry>, SelectionError> {
+                let (workers_tx, workers_rx) = watch::channel(HashMap::new());
+                let scoped_replica_sync =
+                    setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
+                let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
+                    scoped_replica_sync.publisher,
+                    block_size as usize,
+                    HashMap::new(),
+                    scoped_replica_sync.enabled,
+                    scoped_replica_sync.process_id,
+                    WORKER_TYPE,
+                    ReplicaWorkerPolicy::RequireRegistered,
+                ));
+                let replica_tx = scoped_replica_sync.channel.map(|(replica_tx, subscriber)| {
+                    slots.start_replica_sync(subscriber, self.cancel_token.child_token());
+                    replica_tx
+                });
+                slots.start_periodic_force_expiry_across_all_workers(
+                    self.cancel_token.child_token(),
+                );
 
-        let indexer = self
-            .indexer_registry
-            .get_or_create_indexer(key.clone(), block_size);
-        let overlap_refresh = Arc::new(TieredOverlapRefresher::new(
-            indexer.clone(),
-            self.kv_router_config.clone(),
-            block_size,
-        ));
-        let selector = DefaultWorkerSelector::new(Some(self.kv_router_config.clone()), WORKER_TYPE);
-        let profile = self
-            .kv_router_config
-            .policy_profile(Some(&key.model_name))
-            .map_err(|error| SelectionError::BadRequest(error.to_string()))?;
-        let scheduler = LocalScheduler::new_with_policy_profile(
-            slots,
-            workers_rx,
-            profile,
-            block_size,
-            selector,
-            None,
-            Some(overlap_refresh),
-            None,
-            self.kv_router_config.router_queue_recheck_interval(),
-            self.kv_router_config.router_track_prefill_tokens,
-            self.cancel_token.child_token(),
-            WORKER_TYPE,
-            true,
-        )?;
-        let entry = Arc::new(SelectionEntry {
-            key: key.clone(),
-            block_size,
-            is_eagle,
-            indexer,
-            workers_tx,
-            scheduler,
-            replica_tx,
-        });
-        entries.insert(key, entry.clone());
+                let indexer = self
+                    .indexer_registry
+                    .get_or_create_indexer(key.clone(), block_size);
+                let overlap_refresh = Arc::new(TieredOverlapRefresher::new(
+                    indexer.clone(),
+                    self.kv_router_config.clone(),
+                    block_size,
+                ));
+                let selector = self.worker_selector_factory.as_ref().map_or_else(
+                    || {
+                        SelectionWorkerSelector::Default(DefaultWorkerSelector::new(
+                            Some(self.kv_router_config.clone()),
+                            WORKER_TYPE,
+                        ))
+                    },
+                    |factory| SelectionWorkerSelector::Custom(factory()),
+                );
+                let profile = self
+                    .kv_router_config
+                    .policy_profile(Some(&key.model_name))
+                    .map_err(|error| SelectionError::BadRequest(error.to_string()))?;
+                let scheduler = LocalScheduler::new_with_policy_profile(
+                    slots,
+                    workers_rx,
+                    profile,
+                    block_size,
+                    selector,
+                    None,
+                    Some(overlap_refresh),
+                    None,
+                    self.kv_router_config.router_queue_recheck_interval(),
+                    self.kv_router_config.router_track_prefill_tokens,
+                    self.cancel_token.child_token(),
+                    WORKER_TYPE,
+                    true,
+                )?;
+                Ok(Arc::new(SelectionEntry {
+                    key: key.clone(),
+                    block_size,
+                    is_eagle,
+                    indexer,
+                    workers_tx,
+                    scheduler,
+                    replica_tx,
+                }))
+            })?
+            .clone();
+        if entry.block_size != block_size {
+            return Err(SelectionError::Conflict(format!(
+                "block_size mismatch for {key}: existing={} requested={block_size}",
+                entry.block_size
+            )));
+        }
+        if entry.is_eagle != is_eagle {
+            return Err(SelectionError::Conflict(format!(
+                "is_eagle mismatch for {key}: existing={} requested={is_eagle}",
+                entry.is_eagle
+            )));
+        }
         Ok(entry)
     }
 
@@ -594,7 +693,7 @@ impl SelectionCore {
     }
 
     fn publish_scheduler_config(&self, key: &RoutingPartitionId) -> Result<(), SelectionError> {
-        let Some(entry) = self.entries.read().get(key).cloned() else {
+        let Some(entry) = self.entry(key) else {
             return Ok(());
         };
         let workers = self.catalog.scheduler_configs_for_key(key);
@@ -610,7 +709,7 @@ impl SelectionCore {
             ));
         }
 
-        let Some(entry) = self.entries.read().get(key).cloned() else {
+        let Some(entry) = self.entry(key) else {
             return Err(SelectionError::NotReady(format!(
                 "no schedulable workers for {key}"
             )));
@@ -1027,7 +1126,7 @@ impl SelectionCore {
     }
 
     pub async fn prefill_complete(&self, selection_id: &str) -> Result<(), SelectionError> {
-        let entries = { self.entries.read().values().cloned().collect::<Vec<_>>() };
+        let entries = self.initialized_entries();
         for entry in entries {
             match entry.scheduler.mark_prefill_completed(selection_id).await {
                 Ok(()) => return Ok(()),
@@ -1041,7 +1140,7 @@ impl SelectionCore {
     }
 
     pub async fn free_reservation(&self, selection_id: &str) -> Result<(), SelectionError> {
-        let entries = { self.entries.read().values().cloned().collect::<Vec<_>>() };
+        let entries = self.initialized_entries();
         for entry in entries {
             match entry.scheduler.free(selection_id).await {
                 Ok(()) => return Ok(()),
@@ -1067,7 +1166,7 @@ impl SelectionCore {
             ));
         }
 
-        let entries = { self.entries.read().values().cloned().collect::<Vec<_>>() };
+        let entries = self.initialized_entries();
         for entry in entries {
             match entry
                 .scheduler
@@ -1088,7 +1187,7 @@ impl SelectionCore {
         model_name: Option<&str>,
         routing_group: Option<&str>,
     ) -> Vec<ModelLoadResponse> {
-        let entries: Vec<_> = self.entries.read().values().cloned().collect();
+        let entries = self.initialized_entries();
         let mut loads = Vec::new();
         for entry in entries {
             if model_name.is_some_and(|model_name| entry.key.model_name != model_name)
@@ -1567,7 +1666,7 @@ mod tests {
             core.upsert_worker(request).await.expect("worker upsert");
         }
         let key = RoutingPartitionId::new("model", "default");
-        let entry = core.entries.read().get(&key).cloned().expect("entry");
+        let entry = core.entry(&key).expect("entry");
         entry
             .indexer
             .apply_event_routed(store_event(1, 0, 1, &[], &[11], StorageTier::Device))

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -13,7 +13,7 @@ use crate::services::common::replica_sync::{
 };
 use crate::tracking_hash::TrackingHashContext;
 
-use super::core::{SelectionCore, SelectionServiceConfig};
+use super::core::{SelectionCore, SelectionServiceConfig, SelectionWorkerSelectorFactory};
 use super::error::SelectionError;
 use super::pending::SelectionCacheConfig;
 use super::types::{
@@ -29,6 +29,7 @@ pub struct SelectionServiceBuilder {
     replica_sync_port: Option<u16>,
     replica_sync_peers: Vec<String>,
     selection_cache: SelectionCacheConfig,
+    worker_selector_factory: Option<SelectionWorkerSelectorFactory>,
 }
 
 impl SelectionServiceBuilder {
@@ -40,6 +41,7 @@ impl SelectionServiceBuilder {
             replica_sync_port: None,
             replica_sync_peers: Vec::new(),
             selection_cache: SelectionCacheConfig::default(),
+            worker_selector_factory: None,
         }
     }
 
@@ -61,6 +63,15 @@ impl SelectionServiceBuilder {
 
     pub fn selection_cache(mut self, config: SelectionCacheConfig) -> Self {
         self.selection_cache = config;
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn worker_selector_factory(
+        mut self,
+        factory: SelectionWorkerSelectorFactory,
+    ) -> Self {
+        self.worker_selector_factory = Some(factory);
         self
     }
 
@@ -89,6 +100,7 @@ impl SelectionServiceBuilder {
             self.indexer_threads,
             cancel_token.clone(),
             replica_config,
+            self.worker_selector_factory,
             self.selection_cache,
             tracking_hash,
         ));

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -5,9 +5,12 @@ use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode, header};
 use axum::response::Response;
+use std::collections::HashMap;
 use std::io::Write;
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::time::Duration;
 use tower::ServiceExt;
 
@@ -17,11 +20,14 @@ use super::*;
 use crate::identity::RoutingPartitionRef;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
 use crate::protocols::{
-    BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier,
-    WorkerWithDpRank, compute_block_hash_for_seq, compute_seq_hash_for_block,
+    BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier, WorkerId,
+    WorkerSelectionResult, WorkerWithDpRank, compute_block_hash_for_seq,
+    compute_seq_hash_for_block,
 };
 use crate::scheduling::config::RouterConfigOverride;
 use crate::scheduling::overlap::build_overlap_scores_response;
+use crate::scheduling::selector::WorkerSelector;
+use crate::scheduling::{KvSchedulerError, RoutingEligibility, SchedulingRequest};
 use crate::{TrackingHashContext, TrackingHashScope};
 use tempfile::NamedTempFile;
 
@@ -36,6 +42,44 @@ fn test_config() -> crate::config::KvRouterConfig {
 fn app() -> Router {
     let service = Arc::new(SelectionService::new_local_for_test(test_config(), 1));
     create_router(Arc::new(AppState { service }))
+}
+
+struct HighestWorkerSelector {
+    calls: Arc<AtomicUsize>,
+    invalid_first: bool,
+}
+
+impl WorkerSelector<SelectionWorkerConfig> for HighestWorkerSelector {
+    fn select_worker(
+        &self,
+        workers: &HashMap<WorkerId, SelectionWorkerConfig>,
+        _request: &SchedulingRequest,
+        eligibility: RoutingEligibility<'_>,
+        _block_size: u32,
+    ) -> Result<WorkerSelectionResult, KvSchedulerError> {
+        let call = self.calls.fetch_add(1, Ordering::Relaxed);
+        if self.invalid_first && call == 0 {
+            return Ok(WorkerSelectionResult {
+                worker: WorkerWithDpRank::from_worker_id(WorkerId::MAX),
+                required_blocks: u64::MAX,
+                effective_overlap_blocks: f64::NAN,
+                cached_tokens: usize::MAX,
+                potential_decode_blocks: usize::MAX,
+            });
+        }
+        let mut selected = None;
+        eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+            selected = selected.max(Some(worker));
+        });
+        let worker = selected.ok_or(KvSchedulerError::NoEndpoints)?;
+        Ok(WorkerSelectionResult {
+            worker,
+            required_blocks: u64::MAX,
+            effective_overlap_blocks: f64::NAN,
+            cached_tokens: usize::MAX,
+            potential_decode_blocks: usize::MAX,
+        })
+    }
 }
 
 fn normalize_prompt(request: &PromptRequest) -> super::input::NormalizedPrompt {
@@ -128,6 +172,152 @@ async fn register_worker_id(app: Router, worker_id: u64, max_tokens: Option<u64>
         body["max_num_batched_tokens"] = serde_json::json!(max_tokens);
     }
     post(app, "/workers", &body.to_string()).await
+}
+
+#[derive(Default)]
+struct FactoryRendezvous {
+    arrivals: Mutex<usize>,
+    ready: Condvar,
+}
+
+impl FactoryRendezvous {
+    fn wait_for_peer(&self) {
+        let mut arrivals = self.arrivals.lock().unwrap();
+        *arrivals += 1;
+        if *arrivals == 2 {
+            self.ready.notify_all();
+            return;
+        }
+
+        let (arrivals, _) = self
+            .ready
+            .wait_timeout_while(arrivals, Duration::from_secs(2), |arrivals| *arrivals < 2)
+            .unwrap();
+        assert_eq!(*arrivals, 2, "selector factories did not run concurrently");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn worker_selector_factory_is_per_partition_and_books_selected_worker() {
+    let factory_calls = Arc::new(AtomicUsize::new(0));
+    let factory_rendezvous = Arc::new(FactoryRendezvous::default());
+    let selector_calls = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::clone(&factory_calls);
+    let rendezvous = Arc::clone(&factory_rendezvous);
+    let selections = Arc::clone(&selector_calls);
+    let service = SelectionServiceBuilder::new(test_config())
+        .indexer_threads(1)
+        .worker_selector_factory(Box::new(move || {
+            calls.fetch_add(1, Ordering::Relaxed);
+            rendezvous.wait_for_peer();
+            Box::new(HighestWorkerSelector {
+                calls: Arc::clone(&selections),
+                invalid_first: false,
+            }) as Box<dyn WorkerSelector<SelectionWorkerConfig> + Send>
+        }))
+        .build()
+        .await
+        .expect("build selection service");
+    let app = create_router(Arc::new(AppState {
+        service: Arc::new(service),
+    }));
+
+    let model_registration = tokio::spawn(register_worker_id(app.clone(), 1, None));
+    let other_app = app.clone();
+    let other_registration = tokio::spawn(async move {
+        let body = serde_json::json!({
+            "worker_id": 3,
+            "model_name": "other-model",
+            "endpoint": "http://worker-3:8000",
+            "block_size": 4
+        });
+        post(other_app, "/workers", &body.to_string()).await
+    });
+    assert_eq!(
+        model_registration.await.unwrap().status(),
+        StatusCode::CREATED
+    );
+    assert_eq!(
+        other_registration.await.unwrap().status(),
+        StatusCode::CREATED
+    );
+    assert_eq!(
+        register_worker_id(app.clone(), 2, None).await.status(),
+        StatusCode::CREATED
+    );
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 2);
+
+    let reserved = post(
+        app.clone(),
+        "/select_and_reserve",
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"custom-selector"}"#,
+    )
+    .await;
+    assert_eq!(reserved.status(), StatusCode::OK);
+    let reserved = response_json(reserved).await;
+    assert_eq!(reserved["worker_id"], 2);
+    assert_eq!(reserved["effective_prefill_tokens"], 4);
+    assert_eq!(selector_calls.load(Ordering::Relaxed), 1);
+
+    let loads = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/loads?model_name=model")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let loads = response_json(loads).await;
+    let selected = loads[0]["loads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|load| load["worker_id"] == 2)
+        .unwrap();
+    assert_eq!(selected["active_requests"], 1);
+
+    assert_eq!(factory_calls.load(Ordering::Relaxed), 2);
+}
+
+#[tokio::test]
+async fn invalid_custom_selection_does_not_stop_partition() {
+    let selector_calls = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::clone(&selector_calls);
+    let service = SelectionServiceBuilder::new(test_config())
+        .indexer_threads(1)
+        .worker_selector_factory(Box::new(move || {
+            Box::new(HighestWorkerSelector {
+                calls: Arc::clone(&calls),
+                invalid_first: true,
+            }) as Box<dyn WorkerSelector<SelectionWorkerConfig> + Send>
+        }))
+        .build()
+        .await
+        .expect("build selection service");
+    let app = create_router(Arc::new(AppState {
+        service: Arc::new(service),
+    }));
+    assert_eq!(
+        register_worker(app.clone(), None).await.status(),
+        StatusCode::CREATED
+    );
+
+    let disallowed_pin = r#"{"model_name":"model","token_ids":[1,2,3,4],"pinned_worker":{"worker_id":1,"dp_rank":0},"allowed_worker_ids":[2]}"#;
+    assert_eq!(
+        post(app.clone(), "/select", disallowed_pin).await.status(),
+        StatusCode::BAD_REQUEST
+    );
+    assert_eq!(selector_calls.load(Ordering::Relaxed), 0);
+
+    let body = r#"{"model_name":"model","token_ids":[1,2,3,4]}"#;
+    assert_eq!(
+        post(app.clone(), "/select", body).await.status(),
+        StatusCode::SERVICE_UNAVAILABLE
+    );
+    assert_eq!(post(app, "/select", body).await.status(), StatusCode::OK);
+    assert_eq!(selector_calls.load(Ordering::Relaxed), 2);
 }
 
 #[test]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Builds Dynamo's internal native worker-selection foundation by extracting the default score and pick behavior, expressing it through scorer and picker contracts, and adding an opt-in `SelectionService` selector factory. This preserves the concrete allocation-free default path while letting the native-policy follow-up reuse Dynamo's scheduler, eligibility, validation, accounting, reservations, and metrics.

CLOSES: DYN-3709
CLOSES: DYN-3710
CLOSES: DYN-3711

### How This Was Implemented

- Moves the existing cost formula into `DefaultWorkerScorer` and the existing tie handling and temperature sampling into `DefaultWorkerPicker`.
- Uses borrowed request context and stack-built worker rows; the default path retains static dispatch and creates no candidate vector.
- Threads an optional crate-private selector factory through `SelectionServiceBuilder` and `SelectionCore`, invoking it once per routing partition rather than once per request.
- Keeps the default selector inline; only the opt-in custom branch uses dynamic dispatch and actor-local policy state.
- Validates custom selections against host eligibility and reconstructs accounting fields from the request before existing scheduling and reservation logic runs.

<details>
<summary>Walkthrough</summary>

#### Mental model

The default routing algorithm is unchanged. The refactor gives its scoring and picking stages explicit contracts, then adds the narrow internal construction seam required for a later linked native policy.

```mermaid
flowchart LR
    B["SelectionServiceBuilder"] --> C["SelectionCore"]
    C -->|"once per routing partition"| S{"Selector"}
    S -->|"default"| D["Concrete DefaultWorkerSelector"]
    D --> E["RoutingEligibility"]
    E --> R["Borrowed worker row"]
    R --> DS["DefaultWorkerScorer"]
    DS --> DP["DefaultWorkerPicker"]
    S -->|"opt-in internal seam"| H["Host eligibility preflight"]
    H --> X["Injected WorkerSelector"]
    X --> V["Host rank validation and accounting reconstruction"]
    DP --> A["Existing scheduler, accounting, and reservation"]
    V --> A
```

#### Scoring and ordering

Lower costs remain better. At zero temperature, the picker keeps the existing streaming minimum and uniform reservoir tie-breaking; at nonzero temperature, it keeps the existing softmax sampling behavior. Pinned workers, overload handling, routing constraints, taint multipliers, cache credit, prefill load, and decode load retain their existing precedence and formulas.

#### State and request lifecycle

`SelectionCore` initializes each partition through its existing per-key cell without holding the global entries-map lock during construction. The optional factory runs once for that `SelectionEntry`, so custom selector state is actor-local and reused across requests; the normal scheduler queues, worker registry, and reservation lifecycle remain host-owned.

For an injected selector, the host first rejects invalid pinned or empty-eligibility cases, calls the selector with `RoutingEligibility`, validates the returned worker rank, and rebuilds `WorkerSelectionResult` accounting from the request. Invalid output therefore cannot book arbitrary accounting values or bypass worker eligibility.

#### Boundaries and limitations

The factory is crate-private and is not the customer API. This PR adds no filters, runtime loading, C ABI, registry, configuration graph, EPP changes, or public policy adapter; public native scorer and picker composition remains in #12526.

</details>

### Validation

- `cargo test -p dynamo-kv-router --features standalone-selection` — 909 passed, 2 ignored; 6 standalone HTTP tests passed.
- `cargo clippy -p dynamo-kv-router --features standalone-selection --all-targets -- -D warnings -A dead-code`
- `cargo fmt --all -- --check`
- Full GitHub pre-merge and `PR` pipelines passed at `f4a3e08469`.

### Benchmark Results

Criterion A/B and B/A runs cover 2, 32, 1,024, and 10,000 workers at zero and nonzero temperature. Deltas are the combined concrete scorer/picker path versus the pre-refactor selector; no regression repeats across ordering.

| Workers | Temperature | A/B delta | B/A delta |
|---:|---:|---:|---:|
| 2 | 0.0 | -1.03% | -0.37% |
| 32 | 0.0 | +0.13% | +0.16% |
| 1,024 | 0.0 | -2.43% | +0.60% |
| 10,000 | 0.0 | -1.67% | -0.86% |
| 2 | 0.7 | -1.40% | -1.32% |
| 32 | 0.7 | +0.33% | +0.93% |
| 1,024 | 0.7 | +0.81% | +0.42% |
| 10,000 | 0.7 | -0.32% | -0.76% |
<!-- codex-pr-description:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added benchmarks for worker selection across varying worker counts and router temperature settings.

* **Reliability**
  * Preserved deterministic seeded selection and temperature-based sampling behavior.
  * Improved coverage for consistent worker-selection results through expanded tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
