### PR TITLE
build(container): install gcc-12 on aarch64 for torch inductor's armv9-a flags

### DIFF
--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -265,6 +265,30 @@ RUN set -eux; \
     fi; \
     rm -rf /var/lib/apt/lists/*
 
+# aarch64/Grace only: the upstream vllm/vllm-openai arm64 image is Ubuntu 22.04
+# and ships gcc/g++ 11.4, but torch >= 2.13 detects Grace as armv9-a and its
+# inductor CPU backend codegens `-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm`
+# (torch/_inductor/cpu_vec_isa.py: VecSVE.build_arch_flags). GCC only learned
+# `armv9-a` in 12, so gcc-11 rejects torch's OWN generated flags:
+#   cc1plus: error: unknown value 'armv9-a' for '-march'
+# That breaks the smoke guard below AND every runtime inductor/Triton CPU JIT on
+# a Grace host. gcc-12 is in the jammy archive (gcc-12-base is already pulled in
+# as a dependency), so switch the default toolchain to it. amd64 is untouched.
+# `cc`/`c++` are their own update-alternatives masters here, so each link is
+# registered separately rather than as a slave of gcc.
+RUN set -eux; \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        apt-get update; \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gcc-12 g++-12; \
+        for pair in gcc:gcc-12 g++:g++-12 cc:gcc-12 c++:g++-12; do \
+            name="${pair%%:*}"; impl="${pair##*:}"; \
+            update-alternatives --install "/usr/bin/$name" "$name" "/usr/bin/$impl" 120; \
+            update-alternatives --set "$name" "/usr/bin/$impl"; \
+        done; \
+        rm -rf /var/lib/apt/lists/*; \
+        echo 'int main(){return 0;}' | g++ -march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm -msve-vector-bits=128 -x c++ - -c -o /dev/null; \
+    fi
+
 # Regression guard for the codec purge above: torch.inductor/Triton JIT shell
 # out to a host C/C++ compiler at runtime, so a missing toolchain only surfaces
 # on the first compile in production. Reproduce that compile path at build time


### PR DESCRIPTION
> **Context: one of six fixes from bringing up [`thinkingmachines/inkling`](https://huggingface.co/thinkingmachines/inkling) on Dynamo + vLLM** (4×GB200, TP=4, arm64). Sibling PRs from the same bring-up: #12510, #12541, #12511, #12543. This one is a build fix, hit on the aarch64 image build; it is not model-specific and affects any aarch64 vLLM runtime build where torch inductor emits `-march=armv9-a`.

## Problem

On aarch64 the vLLM runtime image derives from the upstream `vllm/vllm-openai` arm64 image, which is Ubuntu 22.04 and ships gcc/g++ **11.4**.

torch >= 2.13 detects Grace as `armv9-a`, and its inductor CPU backend then codegens:

```
-march=armv9-a+sve2+fp16fml+sha3+bf16+i8mm
```

(`torch/_inductor/cpu_vec_isa.py`, `VecSVE.build_arch_flags`). GCC only learned the `armv9-a` value for `-march` in **12**, so gcc-11 rejects torch's *own* generated flags:

```
cc1plus: error: unknown value 'armv9-a' for '-march'
```

This is not just a build-time problem. It breaks:

1. the `validate_torch_compile_smoke.py` regression guard added for the codec purge, and
2. **every runtime inductor / Triton CPU JIT on a Grace host** — which only surfaces on the first compile in production, exactly the failure mode that guard exists to catch.

## Fix

Install `gcc-12`/`g++-12` and make them the default toolchain, **aarch64 only** — amd64 is untouched. gcc-12 is in the jammy archive and `gcc-12-base` is already pulled in as a dependency.

Two details worth noting for review:

- `cc` and `c++` are their own `update-alternatives` masters in this image rather than slaves of `gcc`/`g++`, so each of the four links is registered separately. Registering only `gcc`/`g++` leaves `cc`/`c++` pointing at 11.
- The block ends by compiling a trivial TU with torch's exact flag set, so if the toolchain still cannot handle them the **build** fails rather than the deployment.

## Test

Built the vLLM runtime image for linux/arm64 and confirmed the smoke guard passes and runtime JIT works on a Grace host. amd64 build path is unchanged (the whole block is inside `if [ "$(uname -m)" = "aarch64" ]`).

## Notes

Filed as a **draft** — happy to attach a Linear ID and adjust the branch name to the `<login>/<desc>__<DYN-ID>` convention before this goes up for review.

