### PR TITLE
fix(frontend): translate response_format/guided_* on the vllm chat-processor path

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1104,3 +1104,100 @@ def test_runtime_config_context_length(vllm_processor_module, runtime_config, ex
     mdc = SimpleNamespace(runtime_config=lambda: runtime_config)
 
     assert vllm_processor_module._runtime_config_context_length(mdc) == expected
+
+
+class TestGuidedDecodingTranslation:
+    """response_format / guided_* must reach sampling_options.guided_decoding.
+
+    The Rust OpenAIPreprocessor is bypassed on the vllm chat-processor path, so
+    this file owns the translation the Rust ``get_guided_json`` normally does.
+    The worker feeds the result into vLLM's ``StructuredOutputsParams``, which
+    rejects a constraint set holding zero or more than one constraint — so the
+    key must be absent unless exactly one constraint is present.
+    """
+
+    SCHEMA = {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    }
+
+    def _build(self, request):
+        from dynamo.frontend.vllm_processor import _build_guided_decoding
+
+        return _build_guided_decoding({"model": MODEL, **request})
+
+    @pytest.mark.parametrize(
+        "request_extra, expected",
+        [
+            # OpenAI response_format nesting.
+            (
+                {
+                    "response_format": {
+                        "type": "json_schema",
+                        "json_schema": {"name": "city", "schema": SCHEMA},
+                    }
+                },
+                {"json": SCHEMA},
+            ),
+            # Bare json_object maps to the "any JSON object" schema.
+            (
+                {"response_format": {"type": "json_object"}},
+                {"json": {"type": "object"}},
+            ),
+            # CommonExt spellings.
+            ({"guided_json": SCHEMA}, {"json": SCHEMA}),
+            ({"guided_regex": r"\d{3}-\d{4}"}, {"regex": r"\d{3}-\d{4}"}),
+            (
+                {"guided_grammar": 'root ::= "yes" | "no"'},
+                {"grammar": 'root ::= "yes" | "no"'},
+            ),
+            ({"guided_choice": ["yes", "no"]}, {"choice": ["yes", "no"]}),
+            # guided_json wins over response_format (Rust get_guided_json).
+            (
+                {
+                    "guided_json": SCHEMA,
+                    "response_format": {"type": "json_object"},
+                },
+                {"json": SCHEMA},
+            ),
+            # whitespace_pattern refines a real constraint.
+            (
+                {"guided_json": SCHEMA, "guided_whitespace_pattern": "[ \n]*"},
+                {"json": SCHEMA, "whitespace_pattern": "[ \n]*"},
+            ),
+        ],
+    )
+    def test_constraint_is_translated(self, request_extra, expected):
+        assert self._build(request_extra) == expected
+
+    @pytest.mark.parametrize(
+        "request_extra",
+        [
+            {},  # plain chat request
+            {"response_format": {"type": "text"}},  # the common default
+            {"response_format": None},
+            {"response_format": {"type": "json_schema", "json_schema": {}}},
+            {"guided_choice": []},  # empty choice list is not a constraint
+            {"guided_whitespace_pattern": "[ \n]*"},  # not a constraint by itself
+        ],
+    )
+    def test_no_constraint_emits_nothing(self, request_extra):
+        assert self._build(request_extra) is None
+
+    def test_emitted_dict_holds_exactly_one_constraint(self):
+        guided_decoding = self._build(
+            {
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {"name": "city", "schema": self.SCHEMA},
+                },
+                "guided_whitespace_pattern": "[ \n]*",
+            }
+        )
+        constraints = [
+            key
+            for key in ("json", "regex", "choice", "grammar", "structural_tag")
+            if guided_decoding.get(key) is not None
+        ]
+        assert constraints == ["json"]

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -168,6 +168,57 @@ def _build_reasoning_parser_metadata(
     return reasoning_parser.is_reasoning_end(prompt_token_ids), parser_kwargs
 
 
+def _build_guided_decoding(request: dict[str, Any]) -> dict[str, Any] | None:
+    """Translate the structured-decoding request fields into Dynamo's
+    ``sampling_options.guided_decoding``.
+
+    The Rust ``OpenAIPreprocessor`` is bypassed when a chat processor is set,
+    so the ``response_format`` / ``guided_*`` translation it normally performs
+    has to happen here. Mirrors ``CommonExtProvider::get_guided_json`` in
+    ``lib/llm/src/protocols/openai/chat_completions.rs``: ``guided_json`` wins
+    over ``response_format``, ``json_object`` becomes the "any JSON object"
+    schema, and ``text`` carries no constraint.
+
+    Returns None when the request carries no constraint. The worker feeds this
+    dict straight into vLLM's ``StructuredOutputsParams``, which rejects a
+    constraint set that is empty, so the key must stay absent rather than
+    carry a dict of ``None`` values.
+    """
+    guided_json = request.get("guided_json")
+    if guided_json is None:
+        response_format = request.get("response_format")
+        if isinstance(response_format, dict):
+            response_format_type = response_format.get("type")
+            if response_format_type == "json_object":
+                # Minimal JSON Schema for "any JSON object".
+                guided_json = {"type": "object"}
+            elif response_format_type == "json_schema":
+                json_schema = response_format.get("json_schema")
+                if isinstance(json_schema, dict):
+                    guided_json = json_schema.get("schema")
+
+    guided_decoding = {
+        key: value
+        for key, value in (
+            ("json", guided_json),
+            ("regex", request.get("guided_regex")),
+            ("grammar", request.get("guided_grammar")),
+            # An empty choice list is not a constraint, matching Rust's
+            # GuidedDecodingOptions::from_optional.
+            ("choice", request.get("guided_choice") or None),
+        )
+        if value is not None
+    }
+    if not guided_decoding:
+        return None
+
+    # whitespace_pattern only refines a constraint, it is not one itself.
+    whitespace_pattern = request.get("guided_whitespace_pattern")
+    if whitespace_pattern is not None:
+        guided_decoding["whitespace_pattern"] = whitespace_pattern
+    return guided_decoding
+
+
 def _inject_routing_metadata(
     dynamo_preproc: dict[str, Any],
     target: dict[str, Any],
@@ -592,6 +643,12 @@ class VllmProcessor:
             "annotations": [],
             "routing": request.get("routing"),
         }
+        # The Rust preprocessor is bypassed on this path, so response_format and
+        # the guided_* extensions are translated here. Set the key only when a
+        # constraint is present; the worker turns it into StructuredOutputsParams.
+        guided_decoding = _build_guided_decoding(request)
+        if guided_decoding is not None:
+            dynamo_preproc["sampling_options"]["guided_decoding"] = guided_decoding
         if reasoning_ended is not None:
             dynamo_preproc["reasoning_ended"] = reasoning_ended
         if reasoning_parser_kwargs is not None:


### PR DESCRIPTION
## Problem

Setting a chat processor (`--dyn-chat-processor vllm`) builds a preprocessed pipeline via `build_preprocessed_pipeline`, which has **no preprocessor op in the link chain** — so the Rust `OpenAIPreprocessor` never runs.

That preprocessor is what normally translates `response_format` and the `guided_*` extensions into `sampling_options.guided_decoding`. On this path the translation simply doesn't happen, so **every structured-output request silently loses its constraint**: the worker gets no constraint, the model free-runs, and the client gets unconstrained text back with **HTTP 200**. There is no error anywhere to indicate the request was not honoured.

## Fix

Add `_build_guided_decoding()` and call it when assembling the preprocessed request. It mirrors `CommonExtProvider::get_guided_json` in `lib/llm/src/protocols/openai/chat_completions.rs` so the two paths agree:

| input | result |
|---|---|
| `guided_json` + `response_format` | `guided_json` wins |
| `response_format: json_object` | "any JSON object" schema `{"type": "object"}` |
| `response_format: json_schema` | the inner `schema` |
| `response_format: text` | no constraint |
| `guided_choice: []` | **not** a constraint, matching `GuidedDecodingOptions::from_optional` |
| `guided_whitespace_pattern` alone | **not** a constraint — it only refines one |

### One non-obvious detail

The key is set **only when a constraint is present**, rather than always writing a dict of `None`s. The worker feeds this straight into vLLM's `StructuredOutputsParams`, which rejects a constraint set whose fields are all `None` — so an always-present key would convert "no constraint requested" into a hard error.

## Test

Adds `TestGuidedDecodingTranslation` covering each row above plus the empty-choice and whitespace-only edge cases.

⚠️ I could not execute the full test module locally — `test_vllm_processor_unit.py` imports `dynamo.frontend.prepost`, which imports `vllm`, and I have no local vLLM install. I verified the new function's behaviour by exercising it directly against all 11 cases (all pass). **CI is the real check here** — please treat the test run as unverified by me.

## Notes

Filed as a **draft** — happy to attach a Linear ID and rename the branch to the `<login>/<desc>__<DYN-ID>` convention before review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for guided decoding options, including JSON schemas, JSON objects, regular expressions, grammars, choices, and whitespace patterns.
  * Requests now translate response-format and guided-decoding settings into generation constraints before processing.

* **Bug Fixes**
  * Ensured empty constraints are omitted and conflicting settings follow a consistent precedence.
  * Added validation to emit no more than one guided-decoding constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->