### PR TITLE
fix(request-trace): emit request_payload records on the chat-processor path

### DIFF
--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1757,11 +1757,14 @@ impl ModelWatcher {
                             self.metrics.clone(),
                         )
                         .context("PreprocessedRouting::build_preprocessed_pipeline")?;
-                    Some(
+                    // This pipeline links no OpenAIPreprocessor, so the request
+                    // payload record is emitted around the engine the factory
+                    // returns. No-op unless request_payload records are selected.
+                    Some(crate::request_trace::wrap_chat_request_payload_engine(
                         factory(mcid.clone(), card.clone(), routed_engine)
                             .await
                             .context("python chat_engine_factory")?,
-                    )
+                    ))
                 } else if let Some(tk) = tokenizer.clone() {
                     let PromptFormatter::OAI(formatter) =
                         prompt_formatter_from_mdc(card).context("prompt_formatter_from_mdc")?;

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -6,6 +6,7 @@ pub mod config;
 mod integration;
 mod otel_sink;
 pub mod payload;
+mod payload_engine;
 pub(crate) mod payload_stream;
 mod record;
 mod replay;
@@ -37,6 +38,7 @@ pub(crate) use integration::{
     build_request_end_trace_state, finish_reason_metadata_handle, wrap_chat_request_end_stream,
     wrap_completion_request_end_stream,
 };
+pub(crate) use payload_engine::wrap_chat_request_payload_engine;
 pub(crate) use record::{publish_tool_record, validate_tool_record};
 pub(crate) use replay::replay_metrics;
 pub use types::{

--- a/lib/llm/src/request_trace/payload_engine.rs
+++ b/lib/llm/src/request_trace/payload_engine.rs
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
+use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn, async_trait};
+use dynamo_runtime::protocols::annotated::Annotated;
+
+use crate::protocols::openai::chat_completions::{
+    NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
+};
+use crate::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine;
+
+/// Publishes the request payload record for chat pipelines that bring their own
+/// pre/post processor (`--dyn-chat-processor vllm|sglang`). Those pipelines come
+/// from `PreprocessedRouting::build_preprocessed_pipeline`, which links no
+/// `OpenAIPreprocessor`, so the capture site in `OpenAIPreprocessor::generate`
+/// never runs for them. This wrapper reuses the same `payload::create_handle` /
+/// `RequestPayloadHandle::emit` pair, so the emitted row is indistinguishable
+/// from the one the preprocessor produces.
+struct RequestPayloadChatEngine {
+    inner: OpenAIChatCompletionsStreamingEngine,
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateChatCompletionRequest>,
+        ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>,
+        Error,
+    > for RequestPayloadChatEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateChatCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        // Mirrors preprocessor.rs: the handle snapshots the pristine request and
+        // its arrival time here, together with the headers the HTTP layer stashed
+        // on the context; the single record is published once at stream
+        // completion (or with an empty response on cancel/timeout).
+        let request_id = request.id().to_string();
+        let payload_http_headers = if super::payload::http_header_capture_active() {
+            request
+                .get_optional::<BTreeMap<String, String>>(super::payload::HTTP_HEADERS_CONTEXT_KEY)
+                .ok()
+                .flatten()
+        } else {
+            None
+        };
+        let payload_handle =
+            super::payload::create_handle(request.content(), &request_id, payload_http_headers);
+        let Some(payload) = payload_handle else {
+            return self.inner.generate(request).await;
+        };
+
+        let response_stream = self.inner.generate(request).await?;
+        let context = response_stream.context();
+
+        // Pass-through aggregation for both streaming and non-streaming: this
+        // pipeline owns no postprocessor, so the chunks the chat processor
+        // produced must reach the client unchanged. (The preprocessor can use
+        // the `fold` variant for `stream=false` because it owns the chunk shape.)
+        let (stream, agg_fut) = super::payload_stream::scan_aggregate_with_future(response_stream);
+
+        // Spawn the payload emit off the request path. `agg_fut` resolves to None
+        // on client cancel / gateway timeout / aggregation failure; we still emit
+        // the payload record with an empty response so those cases remain
+        // inspectable.
+        tokio::spawn(async move {
+            match agg_fut.await {
+                Some(final_resp) => payload.emit(Some(Arc::new(final_resp))),
+                None => {
+                    tracing::debug!(
+                        request_id = %payload.request_id(),
+                        "request payload: response aggregation incomplete (client cancel / timeout); emitting request-only record"
+                    );
+                    payload.emit(None);
+                }
+            }
+        });
+
+        Ok(ResponseStream::new(stream, context))
+    }
+}
+
+/// Wrap a chat engine built by a `--dyn-chat-processor` factory so request
+/// payload records are emitted for it. Returns the engine untouched unless the
+/// policy selects `request_payload`, and is only applied on the factory path, so
+/// `OpenAIPreprocessor` remains the single producer on the default path.
+pub(crate) fn wrap_chat_request_payload_engine(
+    engine: OpenAIChatCompletionsStreamingEngine,
+) -> OpenAIChatCompletionsStreamingEngine {
+    if !super::policy().emit_request_payload_records() {
+        return engine;
+    }
+    Arc::new(RequestPayloadChatEngine { inner: engine })
+}


### PR DESCRIPTION
> **Context: one of six fixes from bringing up [`thinkingmachines/inkling`](https://huggingface.co/thinkingmachines/inkling) on Dynamo + vLLM** (4×GB200, TP=4, arm64). Sibling PRs from the same bring-up: #12507, #12510, #12541, #12543. Surfaced because that deployment serves through `--dyn-chat-processor`, where request-payload trace records were never emitted. The gap is general — it affects any model served on the BYO chat-processor path. Pairs with #12543, which redacts media in the same records.

## Problem

The only non-test producer of a `request_payload` row is `request_trace::payload::create_handle`, called from the `Operator` impl for `OpenAIPreprocessor` in `preprocessor.rs`.

When a `chat_engine_factory` is configured (`--dyn-chat-processor vllm|sglang`), the chat engine is built by `PreprocessedRouting::build_preprocessed_pipeline`, whose link chain is `frontend → migration → encoder → prefill → backend` — it links **no `preprocessor_op`**, in contrast to `build_pipeline`.

So the preprocessor never runs, and `DYN_REQUEST_TRACE_RECORDS=request_payload` produces **zero rows** — silently. Init only reads env, so it still logs `Request trace initialized` and `Request trace sinks ready` and you get no indication anything is wrong.

## Fix

Wrap the engine the factory returns. That is the innermost point which still sees `SingleIn<NvCreateChatCompletionRequest>`, so the record shape **matches** the preprocessor path rather than being approximated from the HTTP handler.

Two alternatives were rejected:

- **Emit in the HTTP handler** — the handler holds one request object and would have to reconstruct what the preprocessor sees, so record shape would drift from the existing path.
- **A trace-only operator in `build_preprocessed_pipeline`** — not possible as specified; that pipeline's link chain is typed such that a trace op cannot be inserted without changing the chain.

**Placement detail worth reviewing:** the wrap is inside the `if let Some(ref factory)` arm, *not* after it. Wrapping every `worker_set.chat_engine` assignment would be a tempting single choke point, but it would also wrap the default preprocessor pipeline and **double-emit**.

Naming follows the module's existing `wrap_chat_request_end_stream`. The wrapper is a no-op unless `request_payload` records are selected.

## Test

**Runtime-verified, but not compiled against this base.** Being explicit about what I did and didn't check:

- ✅ This change is baked into a GB200 image and **works end to end** — an OTEL payload-logging functional test passes against it, emitting correctly-shaped `request_payload` rows on the `--dyn-chat-processor vllm` path that previously produced none.
- ✅ Rebased onto current `main` — all three hunks applied cleanly, and I verified every symbol the new file references still exists (`create_handle`, `scan_aggregate_with_future`, `http_header_capture_active`, `HTTP_HEADERS_CONTEXT_KEY`, `policy`/`emit_request_payload_records`, `OpenAIChatCompletionsStreamingEngine`, both protocol types).
- ⚠️ **I could not run `cargo check` on this rebase** — no Rust toolchain on the machine I rebased from. The original verification was against an older commit, so please let CI be the compile gate.

## Notes

The original change also added a paragraph to `docs/fern/reference/observability/request-tracing.mdx`, noting that rows come from the frontend chat pipeline so the `--dyn-chat-processor` selection does not change emission, and that workers tokenizing their own text (`ModelInput::Text`) bypass it and emit no rows. **That file no longer exists on main**, so I dropped the hunk rather than guess — happy to add it wherever those docs now live.

Filed as a **draft** — happy to attach a Linear ID and rename the branch to the `<login>/<desc>__<DYN-ID>` convention before review.

