### PR TITLE
fix(kv-router): keep output block load local [DYN-3849]

### DIFF
--- a/lib/kv-router/src/sequences/CLAUDE.md
+++ b/lib/kv-router/src/sequences/CLAUDE.md
@@ -26,3 +26,43 @@ boundaries.
 - Do not expose new public routing/projection APIs from lower-level structures
   unless there is an in-tree production caller and the ownership boundary is
   documented.
+
+## Replica synchronization and load publication
+
+- Treat replica synchronization as best-effort and advisory. The locally
+  owning frontend's `ActiveSequences` is authoritative; peer state may be
+  delayed, dropped, duplicated, or temporarily reordered.
+- Keep lifecycle replica sync separate from shared load publication. Replica
+  sync carries `AddRequest`, `MarkPrefillCompleted`, and `Free` events, while
+  `ActiveLoad` is a whole-worker snapshot rather than a delta.
+- Output-block mutations are replica-local because they are high-frequency and
+  each frontend has only a partial view of worker output activity.
+- `add_output_block` must update local `ActiveSequences`, `PromptRegistry`, and
+  Prometheus observations, but must not itself enqueue an
+  `ActiveSequenceEvent` or trigger shared `ActiveLoad` publication.
+- Do not assume output blocks can never appear in shared load. A later lifecycle
+  publication currently carries a full local snapshot, which can include
+  locally tracked output blocks.
+- Avoid publishing a full shared snapshot directly from an output-block
+  boundary. Its partial, replica-local state can overwrite a newer shared view,
+  especially when the snapshot races with the final `Free` publication.
+- Output-block production is not a heartbeat for time-decayed prefill load.
+  Prefill lifecycle changes publish through their own operations. Implement any
+  required periodic shared refresh explicitly and coalesce it.
+
+## Lifecycle ordering tolerance
+
+- The intended lifecycle is
+  `AddRequest -> MarkPrefillCompleted? -> Free`, but replica consumers must not
+  require strict global temporal ordering.
+- Keep duplicate and missing-request operations idempotent where possible:
+  duplicate adds are ignored, mark/free for an unknown request are no-ops, and
+  `Free` also performs prefill cleanup.
+- Do not treat reversed events as harmless. For example, `Free` before
+  `AddRequest` makes the free a no-op and the later add temporarily stale.
+  Configured request expiry is the final convergence mechanism for peer state
+  left stale by dropped or reordered events.
+- Temporary peer-state errors may affect routing quality, but must not corrupt
+  locally authoritative request ownership or block membership.
+- Normal spacing between add, prefill completion, and free reduces race
+  likelihood; it is not a correctness guarantee.

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -838,7 +838,9 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     /// This is used during generation to track output blocks as they are created.
     /// The decay_fraction represents how "temporary" the block is based on generation progress.
     // NOTE: Output blocks remain local and are intentionally not replicated because their
-    // frequency would consume disproportionate replica-sync network bandwidth.
+    // frequency would consume disproportionate replica-sync network bandwidth. Keep their load
+    // observation local too: a full snapshot containing replica-local output state must not
+    // overwrite shared worker load reported by another router.
     pub fn add_output_block(
         &self,
         request_id: &RequestId,
@@ -867,7 +869,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             load
         };
 
-        self.publish_worker_load_snapshot(worker, load, Instant::now());
+        let _ = self.observe_worker_load_snapshot(worker, load, Instant::now());
 
         Ok(())
     }
@@ -1811,6 +1813,28 @@ mod tests {
         sequences.free(&request_id, Instant::now()).unwrap();
 
         assert!(state.events.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn output_block_observes_load_without_publishing_or_replication() {
+        let (sequences, state) = make_recording_sequences(HashMap::from([(1_u64, (0_u32, 1_u32))]));
+        let worker = WorkerWithDpRank::new(1, 0);
+        let request_id = "output".to_string();
+
+        sequences
+            .add_request(local_sequence_request(&request_id, worker), Instant::now())
+            .unwrap();
+        state.clear();
+
+        sequences.add_output_block(&request_id, None).unwrap();
+
+        assert!(state.events.lock().unwrap().is_empty());
+        assert!(state.single_loads.lock().unwrap().is_empty());
+        let observations = state.observations.lock().unwrap();
+        assert_eq!(observations.len(), 1);
+        assert_eq!(observations[0].0, worker);
+        assert_eq!(observations[0].1, 4);
+        assert_eq!(sequences.active_blocks().get(&worker), Some(&4));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep output-block mutations in the local active-sequence and prompt-registry state
- continue recording the local Prometheus load observation
- stop publishing replica-local output-block totals as shared `ActiveLoad` snapshots
- add a regression test covering local accounting, observation, and absence of shared publication/replication

## Rationale

Output blocks are intentionally not replica-synchronized, but each output-block mutation currently publishes a full worker load snapshot to the shared load channel. With multiple frontend replicas, those snapshots contain different replica-local output state and can overwrite shared worker load with a value assembled from only one router's output state.

The scheduler should continue using locally tracked output blocks, but a replica-local output mutation should not publish a full shared snapshot. Backend-reported KV utilization remains the physical-occupancy signal, and add/prefill/free lifecycle events continue to publish and replica-sync as before.

## Validation

- `cargo test -p dynamo-kv-router output_block_observes_load_without_publishing_or_replication`
- `cargo fmt --all -- --check`
- commit hooks
- full presubmit CI

### Adversarial campaign

- four live vLLM-mode mock workers and two KV frontend replicas
- replica sync, output-block tracking, FCFS, token-capacity admission, and 16-token blocks enabled
- exact output-block boundary: 72 frontend-accounted input tokens plus OSL 9, crossing the 80-token edge on the final output token
- decode threshold `1.1`; a run-only compatibility shim relaxed newer startup validation without changing overload comparison semantics and is not part of this PR
- 50 waves per revision, 512 requests per wave at concurrency 512, followed by 20 post-drain probes per wave
- baseline: 15,129 HTTP 200 and 10,471 load-time HTTP 529; candidate: 15,118 HTTP 200 and 10,482 load-time HTTP 529
- both revisions recovered all 1,000 post-drain probes, ended with all scheduler gauges at zero, and received terminal worker-load zeros
- shared scheduler-load events per frontend fell from 79,409 to 64,041 (19.4%); worker-source events remained effectively unchanged (1,602 vs. 1,603)

The campaign validates the intended ownership boundary and removes one shared load publication per completed output-block boundary without a measurable throughput or recovery regression. It did not reproduce a persistent overload latch when the worker source reliably published its terminal low sample, so this result does not claim to cover stale worker-source failure modes.
