### PR TITLE
fix(container): repair broken dev/local-dev images for docker run and uv

### DIFF
--- a/.github/FILTERS.md
+++ b/.github/FILTERS.md
@@ -9,6 +9,7 @@ When you open a PR, CI checks which files changed and runs only relevant jobs:
 | Filter | Triggers |
 |--------|----------|
 | `core` | Main test suite (vLLM, SGLang, TRT-LLM containers) |
+| `dev_images` | dev / local-dev image builds only (no runtime or GPU jobs) |
 | `operator` | Kubernetes operator tests |
 | `snapshot` | Snapshot Agent + all-framework DynamoCheckpoint deploy tests |
 | `snapshot_vllm` / `snapshot_sglang` / `snapshot_trtllm` | That framework's DynamoCheckpoint deploy suite |

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -169,7 +169,8 @@ runs:
         echo "=== Files Matching Each Filter ==="
         echo "docs: ${{ steps.filter.outputs.docs_all_modified_files }}"
         echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
-        echo "core: ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.dev_images_all_modified_files }}"
+        echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
+        echo "dev_images: ${{ steps.filter.outputs.dev_images_all_modified_files }}"
         echo "operator: ${{ steps.filter.outputs.operator_all_modified_files }}"
         echo "snapshot: ${{ steps.filter.outputs.snapshot_all_modified_files }}"
         echo "snapshot_vllm: ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }}"
@@ -192,7 +193,7 @@ runs:
       shell: bash
       run: |
         # Combine all filter-specific files into one list
-        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.sidecar_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
+        COVERED_FILES=$(echo "${{ steps.filter.outputs.docs_all_modified_files }} ${{ steps.filter.outputs.examples_all_modified_files }} ${{ steps.filter.outputs.ignore_all_modified_files }} ${{ steps.filter.outputs.ci_all_modified_files }} ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.dev_images_all_modified_files }} ${{ steps.filter.outputs.operator_all_modified_files }} ${{ steps.filter.outputs.snapshot_all_modified_files }} ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }} ${{ steps.filter.outputs.snapshot_sglang_all_modified_files }} ${{ steps.filter.outputs.snapshot_trtllm_all_modified_files }} ${{ steps.filter.outputs.power_agent_all_modified_files }} ${{ steps.filter.outputs.deploy_all_modified_files }} ${{ steps.filter.outputs.planner_all_modified_files }} ${{ steps.filter.outputs.sidecar_all_modified_files }} ${{ steps.filter.outputs.vllm_all_modified_files }} ${{ steps.filter.outputs.sglang_all_modified_files }} ${{ steps.filter.outputs.trtllm_all_modified_files }} ${{ steps.filter.outputs.sample_all_modified_files }} ${{ steps.filter.outputs.frontend_all_modified_files }} ${{ steps.filter.outputs.benchmarks_all_modified_files }} ${{ steps.filter.outputs.efa_all_modified_files }} ${{ steps.filter.outputs.rust_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)
 
         # Get all modified files
         ALL_FILES=$(echo "${{ steps.filter.outputs.all_all_modified_files }}" | tr ' ' '\n' | grep -v '^$' | sort -u)

--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -10,6 +10,9 @@ outputs:
   core:
     description: 'Whether core files changed'
     value: ${{ steps.filter.outputs.core_any_modified }}
+  dev_images:
+    description: 'Whether dev/local-dev image templates changed'
+    value: ${{ steps.filter.outputs.dev_images_any_modified }}
   operator:
     description: 'Whether operator files changed'
     value: ${{ steps.filter.outputs.operator_any_modified }}
@@ -144,6 +147,7 @@ runs:
         echo "docs: ${{ steps.filter.outputs.docs_any_modified }}"
         echo "ci: ${{ steps.filter.outputs.ci_any_modified }}"
         echo "core: ${{ steps.filter.outputs.core_any_modified }}"
+        echo "dev_images: ${{ steps.filter.outputs.dev_images_any_modified }}"
         echo "operator: ${{ steps.filter.outputs.operator_any_modified }}"
         echo "snapshot: ${{ steps.filter.outputs.snapshot_any_modified }}"
         echo "snapshot_vllm: ${{ steps.filter.outputs.snapshot_vllm_any_modified }}"
@@ -165,7 +169,7 @@ runs:
         echo "=== Files Matching Each Filter ==="
         echo "docs: ${{ steps.filter.outputs.docs_all_modified_files }}"
         echo "ci: ${{ steps.filter.outputs.ci_all_modified_files }}"
-        echo "core: ${{ steps.filter.outputs.core_all_modified_files }}"
+        echo "core: ${{ steps.filter.outputs.core_all_modified_files }} ${{ steps.filter.outputs.dev_images_all_modified_files }}"
         echo "operator: ${{ steps.filter.outputs.operator_all_modified_files }}"
         echo "snapshot: ${{ steps.filter.outputs.snapshot_all_modified_files }}"
         echo "snapshot_vllm: ${{ steps.filter.outputs.snapshot_vllm_all_modified_files }}"

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -78,8 +78,6 @@ ignore:
   - 'container/run.sh'
   - 'container/use-sccache.sh'
   - 'container/dev/**'
-  - 'container/templates/local_dev.Dockerfile'
-  - 'container/templates/dev.Dockerfile'
   # Removed by trtllm upstream-base migration; claim here so changed-files
   # validation passes on the deletion diff without triggering trtllm CI.
   - 'container/build_trtllm_wheel.sh'
@@ -107,6 +105,14 @@ core:
   - 'container/templates/dynamo_*'
   - 'container/templates/wheel_builder.Dockerfile'
   - 'container/templates/compliance.Dockerfile'
+  # dev/local-dev are built for EVERY framework -- dev.Dockerfile is `FROM runtime`
+  # and local_dev.Dockerfile is `FROM dev` -- so a change here has an all-framework
+  # blast radius, exactly like wheel_builder above. These two used to sit in
+  # `ignore`, which meant the templates defining every developer's image were never
+  # built by CI: both the missing libprotobuf-dev (#12443) and the vLLM dev image
+  # whose ENTRYPOINT pointed at a script it does not ship (#12515) shipped that way.
+  - 'container/templates/dev.Dockerfile'
+  - 'container/templates/local_dev.Dockerfile'
   - '.dockerignore'
   - 'container/deps/*'
   - 'container/compliance/**'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -105,14 +105,6 @@ core:
   - 'container/templates/dynamo_*'
   - 'container/templates/wheel_builder.Dockerfile'
   - 'container/templates/compliance.Dockerfile'
-  # dev/local-dev are built for EVERY framework -- dev.Dockerfile is `FROM runtime`
-  # and local_dev.Dockerfile is `FROM dev` -- so a change here has an all-framework
-  # blast radius, exactly like wheel_builder above. These two used to sit in
-  # `ignore`, which meant the templates defining every developer's image were never
-  # built by CI: both the missing libprotobuf-dev (#12443) and the vLLM dev image
-  # whose ENTRYPOINT pointed at a script it does not ship (#12515) shipped that way.
-  - 'container/templates/dev.Dockerfile'
-  - 'container/templates/local_dev.Dockerfile'
   - '.dockerignore'
   - 'container/deps/*'
   - 'container/compliance/**'
@@ -145,6 +137,18 @@ core:
   - '!**/*.md'
   - '!**/*.rst'
   - '!**/*.txt'
+
+# dev/local-dev image templates. These are NOT in `core`: dev.Dockerfile is `FROM
+# runtime` and local_dev.Dockerfile is `FROM dev`, so neither can change a runtime
+# artifact or a runtime test result -- gating them on `core` would run all three
+# runtime builds plus the GPU test matrix for a change that cannot affect them.
+# They were previously in `ignore`, which meant the templates defining every
+# developer's image were never built by CI at all: both the missing libprotobuf-dev
+# (#12443) and the vLLM dev image whose ENTRYPOINT pointed at a script it does not
+# ship (#12515) shipped that way. Gate only the dev/local-dev build jobs on this.
+dev_images:
+  - 'container/templates/dev.Dockerfile'
+  - 'container/templates/local_dev.Dockerfile'
 
 operator:
   - *ci

--- a/.github/scripts/test-filters.js
+++ b/.github/scripts/test-filters.js
@@ -59,6 +59,19 @@ function checkFilter(file, patterns) {
 // Test cases: [file, expectations, description]
 // expectations: { filterName: expectedValue, ... }
 const testCases = [
+  // dev/local-dev templates build only the dev images -- they must NOT pull in
+  // `core` (all runtime builds + the GPU test matrix), and must not be silently
+  // uncovered the way they were when they sat in `ignore`.
+  {
+    file: 'container/templates/dev.Dockerfile',
+    expect: { dev_images: true, core: false },
+    desc: 'dev.Dockerfile triggers dev image builds only'
+  },
+  {
+    file: 'container/templates/local_dev.Dockerfile',
+    expect: { dev_images: true, core: false },
+    desc: 'local_dev.Dockerfile triggers dev image builds only'
+  },
   // Backend-specific files should only trigger their backend
   {
     file: 'examples/backends/vllm/launch/dsr1_dep.sh',

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       core: ${{ steps.changes.outputs.core }}
+      dev_images: ${{ steps.changes.outputs.dev_images }}
       planner: ${{ steps.changes.outputs.planner }}
       operator: ${{ steps.changes.outputs.operator }}
       snapshot: ${{ steps.changes.outputs.snapshot }}
@@ -69,6 +70,9 @@ jobs:
       - snapshot-placeholder-trtllm
       - power-agent
       - vllm-build
+      - vllm-local-dev-build
+      - sglang-local-dev-build
+      - trtllm-local-dev-build
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
@@ -356,7 +360,7 @@ jobs:
   vllm-dev-build:
     name: vllm-dev
     needs: [changed-files]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true'
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.vllm == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: vllm
@@ -366,6 +370,25 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
       build_timeout_minutes: 60
+    secrets: inherit
+
+  vllm-local-dev-build:
+    name: vllm-local-dev
+    needs: [changed-files]
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.vllm == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: vllm
+      target: local-dev
+      cuda_version: '["13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+      # local-dev remaps to the host user; ARG USER_UID/USER_GID have no defaults.
+      extra_build_args: |
+        USER_UID=1000
+        USER_GID=1000
     secrets: inherit
 
   sglang-build:
@@ -408,7 +431,7 @@ jobs:
   sglang-dev-build:
     name: sglang-dev
     needs: [changed-files]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.sglang == 'true'
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.sglang == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: sglang
@@ -418,6 +441,25 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
       build_timeout_minutes: 60
+    secrets: inherit
+
+  sglang-local-dev-build:
+    name: sglang-local-dev
+    needs: [changed-files]
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.sglang == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: sglang
+      target: local-dev
+      cuda_version: '["13.0"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+      # local-dev remaps to the host user; ARG USER_UID/USER_GID have no defaults.
+      extra_build_args: |
+        USER_UID=1000
+        USER_GID=1000
     secrets: inherit
 
   trtllm-build:
@@ -460,7 +502,7 @@ jobs:
   trtllm-dev-build:
     name: trtllm-dev
     needs: [changed-files]
-    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.trtllm == 'true'
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.trtllm == 'true'
     uses: ./.github/workflows/shared-build-image.yml
     with:
       framework: trtllm
@@ -470,6 +512,25 @@ jobs:
       builder_name: ${{ needs.changed-files.outputs.builder_name }}
       push_image: false
       build_timeout_minutes: 60
+    secrets: inherit
+
+  trtllm-local-dev-build:
+    name: trtllm-local-dev
+    needs: [changed-files]
+    if: needs.changed-files.outputs.dev_images == 'true' || needs.changed-files.outputs.trtllm == 'true'
+    uses: ./.github/workflows/shared-build-image.yml
+    with:
+      framework: trtllm
+      target: local-dev
+      cuda_version: '["13.1"]'
+      platform: 'linux/amd64,linux/arm64'
+      builder_name: ${{ needs.changed-files.outputs.builder_name }}
+      push_image: false
+      build_timeout_minutes: 60
+      # local-dev remaps to the host user; ARG USER_UID/USER_GID have no defaults.
+      extra_build_args: |
+        USER_UID=1000
+        USER_GID=1000
     secrets: inherit
 
   vllm-efa-build:

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -611,7 +611,7 @@ jobs:
           # RC promotions inherit the source archive.
           archive_sources: ${{ inputs.archive_sources }}
       - name: Refresh BuildKit builder
-        if: ${{ inputs.target != 'dev' && inputs.target != 'frontend' }}
+        if: ${{ inputs.target != 'dev' && inputs.target != 'local-dev' && inputs.target != 'frontend' }}
         uses: ./.github/actions/builder-refresher
         with:
           builder_name: ${{ inputs.builder_name }}
@@ -619,7 +619,7 @@ jobs:
           arch: ${{ inputs.platform }}
           cuda_version: ${{ matrix.cuda_version }}
       - name: Build and Push Test Image
-        if: ${{ !inputs.compliance_only && inputs.target != 'dev' && inputs.target != 'frontend' }}
+        if: ${{ !inputs.compliance_only && inputs.target != 'dev' && inputs.target != 'local-dev' && inputs.target != 'frontend' }}
         shell: bash
         run: |
           PUSH_ARGS=""

--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -486,6 +486,16 @@ RUN --mount=type=bind,source=./container/launch_message/dev.txt,target=/opt/dyna
 {% if device == "xpu" or device == "cpu" %}
 SHELL ["bash", "-c"]
 CMD ["bash", "-c", "source /root/.bashrc && exec bash"]
+{% elif framework == "vllm" %}
+# The upstream vllm/vllm-openai base does not ship /opt/nvidia/nvidia_entrypoint.sh,
+# so setting it here makes every `docker run` of the vLLM dev image fail with
+# "stat /opt/nvidia/nvidia_entrypoint.sh: no such file or directory".
+# vllm_runtime.Dockerfile already resets ENTRYPOINT for that reason — keep dev
+# aligned with it instead of clobbering it back. (local_dev.Dockerfile does the same.)
+# CMD must be non-empty here: with both ENTRYPOINT and CMD empty, a bare
+# `docker run <image>` fails with "no command specified".
+ENTRYPOINT []
+CMD ["/bin/bash"]
 {% else %}
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []

--- a/container/templates/local_dev.Dockerfile
+++ b/container/templates/local_dev.Dockerfile
@@ -81,10 +81,32 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
     && touch $HOME/.commandhistory/.bash_history \
     && echo "$SNIPPET" >> "$HOME/.bashrc"
 
-RUN mkdir -p /home/$USERNAME/.cache/ \
-    && mkdir -p /home/$USERNAME/.cache/pre-commit \
-    && chmod g+w /home/$USERNAME/.cache/ \
-    && chmod g+w /home/$USERNAME/.cache/pre-commit
+# Framework runtime bases bake their own uv cache location into the image env
+# (vllm/vllm-openai sets UV_CACHE_DIR=/opt/uv/cache), and its entries are root-owned
+# 0755. That works while the image runs as root, but this stage remaps to a non-root
+# user, so afterwards every uv call dies with:
+#   error: Failed to initialize cache at `/opt/uv/cache`
+#   Caused by: failed to open file `/opt/uv/cache/sdists-v9/.git`: Permission denied
+# which breaks the two commands the dev docs tell you to run (`maturin develop --uv`
+# and `uv pip install --no-deps -e /workspace`).
+#
+# Point the cache at the user's own cache dir — the same /home/dynamo/.cache/uv path
+# the runtime, frontend and planner stages already use. `chmod -R g+w /opt/uv/cache`
+# would also work but copies a ~780MB tree into a new layer, which the permissions
+# memo above rules out.
+ENV UV_CACHE_DIR=/home/${USERNAME}/.cache/uv
+
+# `usermod -u` above re-chowns only files owned by the OLD uid, so anything under
+# /home/$USERNAME that the base image left root-owned survives the remap — and `chmod`
+# on it then fails with EPERM because we are no longer root. The trtllm dev image ships
+# /home/dynamo/.cache/uv exactly this way. Group-write is what we actually need, so set
+# it where we own the directory and assert the result either way.
+RUN set -eux; \
+    for d in /home/$USERNAME/.cache /home/$USERNAME/.cache/pre-commit /home/$USERNAME/.cache/uv; do \
+        mkdir -p "$d"; \
+        if [ "$(stat -c %u "$d")" = "$(id -u)" ]; then chmod g+w "$d"; fi; \
+        test -w "$d"; \
+    done
 
 {% if device == "xpu" or device == "cpu" %}
 SHELL ["bash", "-c"]

--- a/container/templates/local_dev.Dockerfile
+++ b/container/templates/local_dev.Dockerfile
@@ -94,19 +94,23 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
 # the runtime, frontend and planner stages already use. `chmod -R g+w /opt/uv/cache`
 # would also work but copies a ~780MB tree into a new layer, which the permissions
 # memo above rules out.
-ENV UV_CACHE_DIR=/home/${USERNAME}/.cache/uv
+# Use a cache path this stage owns outright rather than an inherited one. uv does not
+# only create new entries — it OPENS existing cache metadata on init, which is the exact
+# original failure (`failed to open file .../sdists-v9/.git: Permission denied`). So a
+# shallow chown of the cache root is not enough: any root-owned file nested inside an
+# inherited cache re-breaks it. trtllm already ships ~27MB of root-owned content under
+# /home/dynamo/.cache/uv, group-writable today but not guaranteed to stay that way.
+# Recursively chmod-ing instead would copy a 781MB tree into a new layer, which the
+# permissions memo above rules out.
+ENV UV_CACHE_DIR=/home/${USERNAME}/.cache/uv-local-dev
 
-# Prepare the cache dirs while we are still root. `usermod -u` above re-chowns only
-# files owned by the OLD uid, so whatever the base image left root-owned survives the
-# remap: the trtllm dev image ships /home/dynamo/.cache/uv as root:0 because its runtime
-# template chowns /home/dynamo/.cache but not the uv dir beneath it. As the remapped user
-# we could neither chmod that dir nor mkdir inside a root-owned parent, so doing this
-# after the USER switch turns any base that ships 0755 into a hard build failure.
-# Shallow chown only — the permissions memo above rules out -R, and a root-owned entry
-# already inside the cache stays as it is; uv only needs to create new entries.
+# Prepare the dirs while we are still root. `usermod -u` above re-chowns only files owned
+# by the OLD uid, so whatever the base left root-owned survives the remap; as the remapped
+# user we could neither chmod such a dir nor mkdir inside a root-owned parent, which turns
+# any base that ships 0755 into a hard build failure.
 USER root
 RUN set -eux; \
-    for d in /home/$USERNAME/.cache /home/$USERNAME/.cache/pre-commit /home/$USERNAME/.cache/uv; do \
+    for d in /home/$USERNAME/.cache /home/$USERNAME/.cache/pre-commit "$UV_CACHE_DIR"; do \
         mkdir -p "$d"; \
         chown "$USERNAME:$USER_GID" "$d"; \
         chmod g+rwx "$d"; \

--- a/container/templates/local_dev.Dockerfile
+++ b/container/templates/local_dev.Dockerfile
@@ -96,17 +96,22 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=$HOME/.comman
 # memo above rules out.
 ENV UV_CACHE_DIR=/home/${USERNAME}/.cache/uv
 
-# `usermod -u` above re-chowns only files owned by the OLD uid, so anything under
-# /home/$USERNAME that the base image left root-owned survives the remap — and `chmod`
-# on it then fails with EPERM because we are no longer root. The trtllm dev image ships
-# /home/dynamo/.cache/uv exactly this way. Group-write is what we actually need, so set
-# it where we own the directory and assert the result either way.
+# Prepare the cache dirs while we are still root. `usermod -u` above re-chowns only
+# files owned by the OLD uid, so whatever the base image left root-owned survives the
+# remap: the trtllm dev image ships /home/dynamo/.cache/uv as root:0 because its runtime
+# template chowns /home/dynamo/.cache but not the uv dir beneath it. As the remapped user
+# we could neither chmod that dir nor mkdir inside a root-owned parent, so doing this
+# after the USER switch turns any base that ships 0755 into a hard build failure.
+# Shallow chown only — the permissions memo above rules out -R, and a root-owned entry
+# already inside the cache stays as it is; uv only needs to create new entries.
+USER root
 RUN set -eux; \
     for d in /home/$USERNAME/.cache /home/$USERNAME/.cache/pre-commit /home/$USERNAME/.cache/uv; do \
         mkdir -p "$d"; \
-        if [ "$(stat -c %u "$d")" = "$(id -u)" ]; then chmod g+w "$d"; fi; \
-        test -w "$d"; \
+        chown "$USERNAME:$USER_GID" "$d"; \
+        chmod g+rwx "$d"; \
     done
+USER $USERNAME
 
 {% if device == "xpu" or device == "cpu" %}
 SHELL ["bash", "-c"]


### PR DESCRIPTION
#### Overview:

This PR repairs the vLLM `dev` and `local-dev` container images so the build commands our own dev docs prescribe work on a freshly launched container with no manual `apt-get` and no `UV_CACHE_DIR` override, and puts both image templates under CI so this class of bug cannot ship unnoticed again. ENTRYPOINT changes affect the vLLM CUDA images only; the uv-cache change affects every CUDA `local-dev` image (vLLM, SGLang, TensorRT-LLM).

#### Example (before → after):

Input: launch a `local-dev` container and run the three documented commands.

```
before:  docker run <vllm-dev|vllm-local-dev> ...
           -> exec: "/opt/nvidia/nvidia_entrypoint.sh": no such file or directory
         maturin develop --uv  /  uv pip install --no-deps -e /workspace
           -> error: Failed to initialize cache at `/opt/uv/cache`
              Caused by: failed to open `/opt/uv/cache/sdists-v9/.git`: Permission denied
after:   docker run <vllm-dev|vllm-local-dev> ...   -> starts a shell
         cargo build / maturin develop / uv pip install   -> all exit 0
```

#### Details:

- `dev.Dockerfile`: stop clobbering the `ENTRYPOINT []` that `vllm_runtime.Dockerfile` deliberately sets — `vllm/vllm-openai` does not ship `/opt/nvidia/nvidia_entrypoint.sh`, so pointing at it made every `docker run` of the vLLM dev image fail. CMD is set non-empty because empty ENTRYPOINT + empty CMD fails with "no command specified".
- `local_dev.Dockerfile`: point `UV_CACHE_DIR` at `/home/dynamo/.cache/uv-local-dev`, a path this stage creates and owns, and prepare it (plus the other cache dirs) as root before dropping back to the remapped user. Repairing an inherited cache is not enough — uv *opens* existing cache metadata on init, which is the original `sdists-v9/.git: Permission denied` failure, and TRT-LLM ships root-owned content under `/home/dynamo/.cache/uv`. Recursive `chmod` is ruled out by the stage's own permissions memo (the vLLM cache is 781MB).
- `.github/filters.yaml` + `pr.yaml`: both templates were on the `ignore` list, so no dev image was ever built by CI — that is how the missing `libprotobuf-dev` (#12443) and the broken ENTRYPOINT both shipped. They now live in a dedicated `dev_images` filter rather than `core`: `dev.Dockerfile` is `FROM runtime` and `local_dev.Dockerfile` is `FROM dev`, so neither can affect a runtime artifact, and `core` would have run all three runtime builds plus the GPU matrix. **New `*-local-dev` build jobs were added** — the existing `*-dev` jobs pass `target: dev`, and `Dockerfile.template` only includes `local_dev.Dockerfile` at `target: local-dev`, so that file was still never parsed by CI.

#### Verification:

Built `local-dev` for vLLM, SGLang and TensorRT-LLM off current CI dev images. In a freshly launched container for each, `cargo build --features dynamo-llm/block-manager`, `maturin develop --uv --features mm-routing` and `uv pip install --no-deps -e /workspace` all exit 0 with no manual `apt-get` and no `UV_CACHE_DIR` override, bare `docker run` succeeds, and each container served an end-to-end `/v1/chat/completions` request through `dynamo.frontend` + `dynamo.mocker` (HTTP 200). The cache fix was verified adversarially by poisoning the inherited path (`.cache/uv/sdists-v9/.git` as root:root 0644): uv against the new path reports "Would make no changes" while the same uv against the poisoned path reproduces the original error. `test-filters.js` passes 34/34, including new cases asserting `dev_images: true, core: false` for both templates.

#### Where should the reviewer start?

`container/templates/local_dev.Dockerfile`, then `container/templates/dev.Dockerfile`, then `.github/filters.yaml` and `.github/workflows/pr.yaml`

/coderabbit profile chill
