### PR TITLE
chore: update dynamo-protocols to 5.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a387235d4376f740f1deaa6fadcebaabc6e8b032bb7fc9ba7ec3c6be817b3"
+checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.4.0" }
 dynamo-memory = { path = "lib/memory", version = "1.4.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.4.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.4.0" }
-dynamo-protocols = { version = "=5.0.1" }
+dynamo-protocols = { version = "=5.1.0" }
 dynamo-parsers = { version = "7.0.1" }
 
 # Published on crates.io. To see all available versions:

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1813,9 +1813,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a387235d4376f740f1deaa6fadcebaabc6e8b032bb7fc9ba7ec3c6be817b3"
+checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
 dependencies = [
  "async-openai",
  "derive_builder",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2428,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-protocols"
-version = "5.0.1"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a387235d4376f740f1deaa6fadcebaabc6e8b032bb7fc9ba7ec3c6be817b3"
+checksum = "696b6df4c817c16dc0a619d43f6af5ecc4f045a6b6be7ef516bfe502f977764b"
 dependencies = [
  "async-openai",
  "derive_builder",


### PR DESCRIPTION
## Overview:

Bumps the pinned `dynamo-protocols` dependency from 5.0.1 to 5.1.0, which picks up https://github.com/ai-dynamo/frontend-crates/pull/100. That release makes Dynamo accept `reasoning` as an inbound alias for `reasoning_content` on chat messages.

This matters most for multi-turn and agentic traffic. When a client replays a prior assistant message that carries `reasoning`, Dynamo previously discarded it with no error, which degrades KV-cache-correct prompt reconstruction on the next turn.

Usage (no configuration needed, the alias is passive):

```bash
curl -s localhost:8080/v1/chat/completions -d '{
  "model": "deepseek-v3.2",
  "messages": [
    {"role": "user", "content": "weather tomorrow?"},
    {"role": "assistant", "reasoning": "need date first",
     "tool_calls": [ ... ]},
    {"role": "tool", "tool_call_id": "call_1", "content": "..."}
  ]}'
```

Before this bump the `reasoning` key on that assistant message is dropped during request parsing and never reaches the rendered prompt. After it, it normalizes to `reasoning_content` and the prior-turn chain-of-thought is re-rendered into the prompt.

## Details:

Root `Cargo.toml` moves the pin from `=5.0.1` to `=5.1.0`. That is the only pin site in the tree; `lib/llm/Cargo.toml` and `lib/backend-common/Cargo.toml` both inherit it via `workspace = true`.

The three lockfiles are refreshed to match: `Cargo.lock`, `lib/bindings/kvbm/Cargo.lock`, and `lib/bindings/python/Cargo.lock`. Each moves exactly one package with no transitive churn.

No source changes are required. 5.1.0 adds `#[serde(default, alias = "reasoning")]` to three fields and changes no struct shape, so it is source-compatible. For completeness, the entire 5.0.1 to 5.1.0 delta upstream is `protocols/src/types/chat.rs` +17/-2, a CHANGELOG entry, and the version line; frontend-crates#100 is the only functional commit between the two release tags.

Serialization is unchanged. Dynamo still emits `reasoning_content`. A payload carrying both keys is a duplicate-field error rather than a silent preference, which is stricter than vLLM's behavior.

## Test Plan:

- `cargo update -p dynamo-protocols` in all three lockfile roots: exactly one package moved in each (240 / 170 / 150 other deps untouched).
- `cargo check --workspace --all-targets`: passed, exit 0, zero error lines, 1m02s.
- `cargo check -p dynamo-llm --all-targets`: passed, exit 0.
- `cargo fmt --all -- --check`: exit 0 (no-op for a dependency-only diff).
- End-to-end alias behavior verified with a scratch test against the real Dynamo request path: an assistant message carrying `"reasoning"` deserializes into `reasoning_content` through the `#[serde(tag = "role")]` enum dispatch, and `DeepSeekV32Formatter` renders the prior-turn reasoning back into the prompt. Passed. The test was reverted and is not part of this diff.
- Not tested: runtime serving. This is a dependency version change with no behavior change on the emit side.

## Related Issues

Relates to https://github.com/ai-dynamo/dynamo/issues/11203. This is the ingest half of that fix; the outbound field selector is https://github.com/ai-dynamo/dynamo/pull/11464.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the underlying protocol package to version 5.1.0 for improved compatibility and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->