### PR TITLE
perf(kv-router): remove router hint ownership scan [DYN-3849]

### DIFF
--- a/lib/kv-router/CLAUDE.md
+++ b/lib/kv-router/CLAUDE.md
@@ -18,3 +18,13 @@ when one exists.
   paths.
 - Do not use `FxHashMap` / `FxHashSet` for text keys or externally controlled
   values such as `request_id`; use the standard hash collections there.
+
+## Engine Hash Invariant
+
+- Within one indexer/hash domain, engine-published local block hashes and
+  external sequence hashes are deterministic and consistent across workers: a
+  unique local block chain maps to one unique external sequence-hash chain, and
+  vice versa.
+- Treat a violation as a producer, configuration, or protocol error. Do not
+  revalidate this invariant by scanning per-worker external-hash ownership on
+  request lookup or scheduling hot paths.

--- a/lib/kv-router/src/indexer/radix_tree.rs
+++ b/lib/kv-router/src/indexer/radix_tree.rs
@@ -216,18 +216,7 @@ impl RadixTree {
         }
 
         if let Some(block_hashes) = router_hint_root_chain {
-            details.retain_router_hint_root_candidates_with_filter(
-                block_hashes,
-                |worker, blocks, hashes| {
-                    self.lookup.get(&worker).map_or(0, |lookup| {
-                        hashes
-                            .iter()
-                            .take(blocks)
-                            .take_while(|hash| lookup.contains_key(hash))
-                            .count()
-                    })
-                },
-            );
+            details.retain_router_hint_root_candidates(block_hashes);
         }
 
         details
@@ -812,10 +801,7 @@ mod tests {
 
     use super::*;
     use crate::indexer::WorkerKvQueryResponse;
-    use crate::test_utils::{
-        create_store_event, make_store_event, router_event, snapshot_events,
-        stored_blocks_with_sequence_hashes,
-    };
+    use crate::test_utils::{create_store_event, make_store_event, snapshot_events};
 
     #[test]
     fn rejects_self_referencing_store() {
@@ -882,65 +868,6 @@ mod tests {
                 (WorkerWithDpRank::new(7, 0), 2),
                 (WorkerWithDpRank::new(8, 0), 3),
             ]
-        );
-    }
-
-    #[test]
-    fn router_hint_candidates_exclude_divergent_external_hash_owner() {
-        let mut tree = RadixTree::new();
-        tree.apply_event(router_event(
-            7,
-            0,
-            0,
-            KvCacheEventData::Stored(KvCacheStoreData {
-                parent_hash: None,
-                start_position: None,
-                blocks: stored_blocks_with_sequence_hashes(
-                    &[LocalBlockHash(11), LocalBlockHash(12)],
-                    &[101, 102],
-                ),
-            }),
-        ))
-        .unwrap();
-        tree.apply_event(router_event(
-            8,
-            1,
-            0,
-            KvCacheEventData::Stored(KvCacheStoreData {
-                parent_hash: None,
-                start_position: None,
-                blocks: stored_blocks_with_sequence_hashes(
-                    &[LocalBlockHash(11), LocalBlockHash(12)],
-                    &[201, 202],
-                ),
-            }),
-        ))
-        .unwrap();
-
-        let details = tree.find_match_details_with_options(
-            vec![LocalBlockHash(11), LocalBlockHash(12)],
-            false,
-            true,
-        );
-
-        assert_eq!(
-            details.overlap_scores.scores,
-            FxHashMap::from_iter([
-                (WorkerWithDpRank::new(7, 0), 2),
-                (WorkerWithDpRank::new(8, 0), 2),
-            ])
-        );
-        let candidates = details.router_hint_root_candidates.unwrap();
-        assert_eq!(
-            candidates.block_hashes,
-            vec![
-                ExternalSequenceBlockHash(101),
-                ExternalSequenceBlockHash(102)
-            ]
-        );
-        assert_eq!(
-            candidates.owner_prefix_blocks,
-            vec![(WorkerWithDpRank::new(7, 0), 2)]
         );
     }
 

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -371,30 +371,15 @@ impl MatchDetails {
 
     pub fn retain_router_hint_root_candidates(
         &mut self,
-        block_hashes: Vec<ExternalSequenceBlockHash>,
-    ) {
-        self.retain_router_hint_root_candidates_with_filter(block_hashes, |_, blocks, _| blocks);
-    }
-
-    pub fn retain_router_hint_root_candidates_with_filter<F>(
-        &mut self,
         mut block_hashes: Vec<ExternalSequenceBlockHash>,
-        mut compatible_prefix_blocks: F,
-    ) where
-        F: FnMut(WorkerWithDpRank, usize, &[ExternalSequenceBlockHash]) -> usize,
-    {
+    ) {
         let mut owner_prefix_blocks: Vec<_> = self
             .overlap_scores
             .scores
             .iter()
             .filter_map(|(worker, blocks)| {
-                let blocks = usize::try_from(*blocks).ok()?.min(block_hashes.len());
-                if blocks == 0 {
-                    return None;
-                }
-                let compatible_blocks =
-                    compatible_prefix_blocks(*worker, blocks, &block_hashes[..blocks]).min(blocks);
-                (compatible_blocks > 0).then_some((*worker, compatible_blocks))
+                let blocks = usize::try_from(*blocks).ok()?;
+                (blocks > 0 && blocks <= block_hashes.len()).then_some((*worker, blocks))
             })
             .collect();
         if block_hashes.is_empty() || owner_prefix_blocks.is_empty() {

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -87,6 +87,10 @@ impl Indexer {
                 approx: None,
                 primary_records_routing_decisions: false,
                 ..
+            } | Self::Concurrent {
+                approx: None,
+                primary_records_routing_decisions: false,
+                ..
             }
         )
     }
@@ -488,7 +492,7 @@ mod tests {
     #[test]
     fn router_hint_chain_retention_requires_event_driven_primary() {
         assert!(make_test_indexer().supports_router_hint_chain_retention());
-        assert!(!make_test_concurrent_indexer().supports_router_hint_chain_retention());
+        assert!(make_test_concurrent_indexer().supports_router_hint_chain_retention());
         assert!(!make_test_concurrent_approx_indexer().supports_router_hint_chain_retention());
         assert!(!Indexer::None.supports_router_hint_chain_retention());
     }


### PR DESCRIPTION
## Summary

- Remove the single-threaded radix indexer's per-request scan of every router-hint candidate owner's external-hash table. The scan treated an engine hash invariant violation as a normal routing state and added `O(candidate owners × matched prefix)` hash probes to the lookup hot path.
- Restore router-hint chain retention for the concurrent indexer, which does not need that validation either.
- Document that, within an indexer/hash domain, engine-published local block chains and external sequence-hash chains have a deterministic one-to-one mapping. Producer, configuration, or protocol violations must not be revalidated on request lookup or scheduling paths.

This is a narrow stacked change against #11695. It does not add a replacement runtime validation path.

## Validation

- `cargo test -p dynamo-kv-router find_match_details_can_retain_router_hint_root_candidates`
- `cargo test -p dynamo-llm --no-default-features router_hint_chain_retention_requires_event_driven_primary`
- `cargo fmt --all -- --check`
- Commit hooks, including codespell and repository hygiene checks
