### PR TITLE
feat(runtime): encrypt TCP request dispatch (frontend → worker)

### DIFF
--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -100,7 +100,7 @@ python -m dynamo.frontend \
 ## Kubernetes deployment
 
 In Kubernetes, TLS certificates are typically delivered by a certificate
-management system (e.g., cert-manager) and mounted into pods. Set the
+management system and mounted into pods. Set the
 environment variables on each component's pod template in the
 `DynamoGraphDeployment` spec:
 
@@ -153,11 +153,16 @@ When TLS is configured, the following frontend↔worker streams are encrypted:
 
 ## Design notes
 
+- Server certificates hot-reload: the request-plane and response-stream servers
+  serve their leaf cert/key through a resolver that re-reads the files from disk
+  when their contents change (detected by a content hash, so rotations done by
+  an atomic symlink swap are handled too), so certificate rotation
+  takes effect **without a process restart**. The check is rate-limited (at most
+  once every 30s, sooner after a failed reload) and never blocks a handshake; a
+  failed reload keeps serving the last valid certificate. Client trust anchors
+  (the CA) are still loaded once, so rotating the CA itself requires a restart.
 - Client TLS connectors are built once and cached via `OnceCell` on the first
-  outbound connection; the request-plane and response-stream servers build their
-  TLS acceptor eagerly at startup. Because the config is cached, certificate
-  rotation currently requires a process restart — hot-reloading certificates
-  from disk via a rustls certificate resolver is a possible future enhancement.
+  outbound connection.
 - The TLS handshake is spawned per-connection on both the request plane and
   response stream servers so the accept loop is never blocked.
 - Invalid TLS configuration on the request plane (e.g. bad cert path) prevents

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -2,18 +2,22 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: TCP TLS
-subtitle: Encrypt all TCP connections between frontend and workers
+subtitle: Encrypt the TCP request and response streams between frontend and workers
 ---
 
-Dynamo supports opt-in TLS encryption on all TCP transports between frontends
-and workers. When enabled, both the **request plane** (frontend → worker
-inference requests) and the **response stream** (worker → frontend inference
-output) are encrypted using [rustls](https://github.com/rustls/rustls) with the
-`ring` cryptographic provider. When no TLS configuration is provided, all
-transports operate in plaintext exactly as before.
+Dynamo supports opt-in TLS encryption on the TCP request and response streams
+between frontends and workers. When enabled, both the **request plane**
+(frontend → worker inference requests) and the **response stream** (worker →
+frontend inference output) are encrypted using
+[rustls](https://github.com/rustls/rustls) with the `ring` cryptographic
+provider. When no TLS configuration is provided, these streams operate in
+plaintext exactly as before.
 
 The same `DYN_TCP_TLS_*` environment variables apply to both transports — a
-single set of certificates encrypts all TCP traffic between Dynamo components.
+single set of certificates encrypts the frontend↔worker TCP request and
+response streams. This does **not** cover the KV event plane, which is carried
+over ZMQ or NATS Core depending on setup and is a separate transport; those
+paths are not encrypted by this configuration.
 
 ## Environment variables
 
@@ -139,8 +143,7 @@ server and client depending on the stream direction.
 
 ## Encrypted paths
 
-When TLS is configured, all TCP communication between frontend and worker is
-encrypted:
+When TLS is configured, the following frontend↔worker streams are encrypted:
 
 | Path | Direction | Data | Transport |
 |---|---|---|---|
@@ -152,8 +155,9 @@ encrypted:
 
 - Client TLS connectors are built once and cached via `OnceCell` on the first
   outbound connection; the request-plane and response-stream servers build their
-  TLS acceptor eagerly at startup. Either way, certificate rotation requires a
-  process restart.
+  TLS acceptor eagerly at startup. Because the config is cached, certificate
+  rotation currently requires a process restart — hot-reloading certificates
+  from disk via a rustls certificate resolver is a possible future enhancement.
 - The TLS handshake is spawned per-connection on both the request plane and
   response stream servers so the accept loop is never blocked.
 - Invalid TLS configuration on the request plane (e.g. bad cert path) prevents

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -2,16 +2,18 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: TCP TLS
-subtitle: Encrypt TCP streaming connections between frontend and workers
+subtitle: Encrypt all TCP connections between frontend and workers
 ---
 
-Dynamo supports opt-in TLS encryption on the TCP call-home streaming transport
-(implemented by `TcpStreamServer` and `TcpClient`, handling both response
-streams and request streams between frontends and workers). When enabled, all TCP
-connections on this path are upgraded to TLS using
-[rustls](https://github.com/rustls/rustls) with the `ring` cryptographic
-provider. When no TLS configuration is provided, the transport operates in
-plaintext exactly as before.
+Dynamo supports opt-in TLS encryption on all TCP transports between frontends
+and workers. When enabled, both the **request plane** (frontend → worker
+inference requests) and the **response stream** (worker → frontend inference
+output) are encrypted using [rustls](https://github.com/rustls/rustls) with the
+`ring` cryptographic provider. When no TLS configuration is provided, all
+transports operate in plaintext exactly as before.
+
+The same `DYN_TCP_TLS_*` environment variables apply to both transports — a
+single set of certificates encrypts all TCP traffic between Dynamo components.
 
 ## Environment variables
 
@@ -135,12 +137,25 @@ server and client depending on the stream direction.
 > allowing TLS to be configured once at the platform level and auto-injected
 > into all DGD pods without per-component env var setup.
 
+## Encrypted paths
+
+When TLS is configured, all TCP communication between frontend and worker is
+encrypted:
+
+| Path | Direction | Data | Transport |
+|---|---|---|---|
+| Request plane | Frontend → Worker | User prompts, request metadata | `egress/tcp_client` → `ingress/shared_tcp_endpoint` |
+| Response stream | Worker → Frontend | Inference output tokens | `tcp/client` → `tcp/server` |
+| Request stream | Frontend → Worker | Streaming input (bidirectional) | `tcp/client` → `tcp/server` |
+
 ## Design notes
 
-- TLS configuration is cached after the first TCP connection via `OnceCell`.
+- TLS configuration is cached after the first connection via `OnceCell`.
   Certificate rotation requires a process restart.
-- The TLS handshake is spawned per-connection on the server side so the accept
-  loop is never blocked by a slow handshake.
+- The TLS handshake is spawned per-connection on both the request plane and
+  response stream servers so the accept loop is never blocked.
+- Invalid TLS configuration on the request plane (e.g. bad cert path) prevents
+  server startup rather than silently falling back to plaintext.
 - When server and client TLS configurations are mismatched (e.g., server has TLS
   but client does not), a warning is logged at startup.
 - An empty CA certificate file is detected at load time and rejected with a

--- a/docs/fern/pages/reference/components/tls-configuration.mdx
+++ b/docs/fern/pages/reference/components/tls-configuration.mdx
@@ -150,8 +150,10 @@ encrypted:
 
 ## Design notes
 
-- TLS configuration is cached after the first connection via `OnceCell`.
-  Certificate rotation requires a process restart.
+- Client TLS connectors are built once and cached via `OnceCell` on the first
+  outbound connection; the request-plane and response-stream servers build their
+  TLS acceptor eagerly at startup. Either way, certificate rotation requires a
+  process restart.
 - The TLS handshake is spawned per-connection on both the request plane and
   response stream servers so the accept loop is never blocked.
 - Invalid TLS configuration on the request plane (e.g. bad cert path) prevents

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -385,25 +385,50 @@ static REQUEST_PLANE_TLS_CONNECTOR: once_cell::sync::OnceCell<Option<TlsConnecto
     once_cell::sync::OnceCell::new();
 
 fn get_request_plane_tls_connector() -> anyhow::Result<&'static Option<TlsConnector>> {
-    REQUEST_PLANE_TLS_CONNECTOR.get_or_try_init(|| {
-        use crate::config::environment_names::tcp_response_stream::tls as env;
-        let ca_cert_path = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).ok();
-        let insecure = crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
-        let tls_requested = ca_cert_path.is_some() || insecure;
-        if !tls_requested {
-            return Ok(None);
-        }
-        let tls_config = crate::tls_utils::client_tls_config(
-            ca_cert_path.as_deref().map(std::path::Path::new),
-            insecure,
-        )?;
-        Ok(Some(TlsConnector::from(std::sync::Arc::new(tls_config))))
-    })
+    REQUEST_PLANE_TLS_CONNECTOR.get_or_try_init(build_request_plane_tls_connector_from_env)
+}
+
+/// Build the request-plane client TLS connector from the `DYN_TCP_TLS_*`
+/// environment. Returns `None` when no TLS is requested (no CA and not
+/// insecure). Split out from the `OnceCell` init so the env parsing can be
+/// unit-tested directly.
+fn build_request_plane_tls_connector_from_env() -> anyhow::Result<Option<TlsConnector>> {
+    use crate::config::environment_names::tcp_response_stream::tls as env;
+    let ca_cert_path = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).ok();
+    let insecure = crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+    let tls_requested = ca_cert_path.is_some() || insecure;
+    if !tls_requested {
+        return Ok(None);
+    }
+    let tls_config = crate::tls_utils::client_tls_config(
+        ca_cert_path.as_deref().map(std::path::Path::new),
+        insecure,
+    )?;
+    Ok(Some(TlsConnector::from(std::sync::Arc::new(tls_config))))
 }
 
 impl TcpConnection {
     /// Create a new connection with lock-free submit and batched write/read tasks
     async fn connect(addr: SocketAddr, timeout: Duration, channel_buffer: usize) -> Result<Self> {
+        Self::connect_with_connector(
+            addr,
+            timeout,
+            channel_buffer,
+            get_request_plane_tls_connector()?.as_ref(),
+        )
+        .await
+    }
+
+    /// Like [`TcpConnection::connect`], but with an explicitly supplied TLS
+    /// connector instead of the process-global `REQUEST_PLANE_TLS_CONNECTOR`.
+    /// This lets tests drive the real connect/handshake/reader/writer path with a
+    /// per-test connector, without initializing (and poisoning) the cached one.
+    async fn connect_with_connector(
+        addr: SocketAddr,
+        timeout: Duration,
+        channel_buffer: usize,
+        connector: Option<&TlsConnector>,
+    ) -> Result<Self> {
         let stream = tokio::time::timeout(timeout, TcpStream::connect(addr))
             .await
             .map_err(|_| anyhow::anyhow!("TCP connect timeout to {}", addr))??;
@@ -411,9 +436,7 @@ impl TcpConnection {
         // Configure socket for lower latency
         Self::configure_socket(&stream)?;
 
-        let (read_half, write_half): (BoxRead, BoxWrite) = if let Some(connector) =
-            get_request_plane_tls_connector()?
-        {
+        let (read_half, write_half): (BoxRead, BoxWrite) = if let Some(connector) = connector {
             use crate::config::environment_names::tcp_response_stream::tls as env;
             let server_name = match std::env::var(env::DYN_TCP_TLS_SERVER_NAME) {
                 Ok(name) => rustls::pki_types::ServerName::try_from(name)
@@ -1651,6 +1674,22 @@ mod tests {
     use tokio::io::{AsyncReadExt, AsyncWrite};
     use tokio::net::TcpListener;
 
+    fn make_cert_files() -> (tempfile::NamedTempFile, tempfile::NamedTempFile) {
+        use std::io::Write as _;
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .unwrap()
+            .self_signed(&key_pair)
+            .unwrap();
+        let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+        cert_file.write_all(cert.pem().as_bytes()).unwrap();
+        let mut key_file = tempfile::NamedTempFile::new().unwrap();
+        key_file
+            .write_all(key_pair.serialize_pem().as_bytes())
+            .unwrap();
+        (cert_file, key_file)
+    }
+
     #[test]
     fn test_tcp_config_default() {
         let config = TcpRequestConfig::default();
@@ -1774,64 +1813,125 @@ mod tests {
         (addr, conn_count)
     }
 
-    /// Full request-plane TLS handshake + encrypted round-trip using the real
-    /// `tls_utils` config builders (the same ones egress/ingress use). Generates
-    /// a self-signed cert, trusts it as the CA, and drives a verified handshake
-    /// with SNI `localhost` (mirroring `connector.connect(server_name, stream)`
-    /// in `TcpConnection::connect`), then echoes bytes over the encrypted stream.
+    /// Env parsing for the request-plane client connector (independent of the
+    /// process-global `OnceCell`): no TLS env → no connector; CA or insecure →
+    /// connector built.
+    #[test]
+    fn request_plane_tls_connector_from_env_parses() {
+        let (cert, _key) = make_cert_files();
+        temp_env::with_vars_unset(["DYN_TCP_TLS_CA_CERT_PATH", "DYN_TCP_TLS_INSECURE"], || {
+            assert!(
+                build_request_plane_tls_connector_from_env()
+                    .unwrap()
+                    .is_none()
+            );
+        });
+        temp_env::with_vars(
+            [
+                (
+                    "DYN_TCP_TLS_CA_CERT_PATH",
+                    Some(cert.path().to_str().unwrap()),
+                ),
+                ("DYN_TCP_TLS_INSECURE", None),
+            ],
+            || {
+                assert!(
+                    build_request_plane_tls_connector_from_env()
+                        .unwrap()
+                        .is_some()
+                );
+            },
+        );
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CA_CERT_PATH", None),
+                ("DYN_TCP_TLS_INSECURE", Some("1")),
+            ],
+            || {
+                assert!(
+                    build_request_plane_tls_connector_from_env()
+                        .unwrap()
+                        .is_some()
+                );
+            },
+        );
+    }
+
+    /// End-to-end encrypted request through the **real** request-plane client
+    /// path: `TcpConnection::connect_with_connector` performs the TLS handshake
+    /// (SNI from `DYN_TCP_TLS_SERVER_NAME`), spawns the reader/writer tasks over
+    /// boxed TLS I/O, and `send_request` frames a request that a TLS-wrapped echo
+    /// server (built from the production `server_tls_config`) reads and replies
+    /// to. This exercises handshake + SNI + boxed I/O + reader/writer + framing,
+    /// not just a `tls_utils` round-trip.
     #[tokio::test]
-    async fn request_plane_tls_handshake_roundtrip() {
-        use std::io::Write as _;
+    async fn request_plane_tls_end_to_end() {
+        use crate::pipeline::network::codec::TcpResponseMessage;
         use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
-        // Self-signed cert with SAN=localhost; also used as the trusted CA.
-        let key_pair = rcgen::KeyPair::generate().unwrap();
-        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
-            .unwrap()
-            .self_signed(&key_pair)
-            .unwrap();
-        let mut cert_file = tempfile::NamedTempFile::new().unwrap();
-        cert_file.write_all(cert.pem().as_bytes()).unwrap();
-        let mut key_file = tempfile::NamedTempFile::new().unwrap();
-        key_file
-            .write_all(key_pair.serialize_pem().as_bytes())
-            .unwrap();
-
-        // Server acceptor + client connector via the real builders.
-        let server_config =
-            crate::tls_utils::server_tls_config(cert_file.path(), key_file.path()).unwrap();
+        // Self-signed cert (SAN=localhost), trusted as the CA by the client.
+        let (cert, key) = make_cert_files();
+        let server_config = crate::tls_utils::server_tls_config(cert.path(), key.path()).unwrap();
         let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
-        let client_config =
-            crate::tls_utils::client_tls_config(Some(cert_file.path()), false).unwrap();
+        let client_config = crate::tls_utils::client_tls_config(Some(cert.path()), false).unwrap();
         let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
 
-        // TLS echo server on loopback.
+        // TLS-wrapped echo server speaking the request-plane wire framing.
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let server = tokio::spawn(async move {
+        tokio::spawn(async move {
             let (tcp, _) = listener.accept().await.unwrap();
-            let mut tls = acceptor.accept(tcp).await.expect("server TLS handshake");
-            let mut buf = [0u8; 5];
-            tls.read_exact(&mut buf).await.unwrap();
-            tls.write_all(&buf).await.unwrap();
-            tls.flush().await.unwrap();
+            let tls = acceptor.accept(tcp).await.expect("server TLS handshake");
+            let (mut r, mut w) = tokio::io::split(tls);
+            // path
+            let mut l2 = [0u8; 2];
+            r.read_exact(&mut l2).await.unwrap();
+            let mut path = vec![0u8; u16::from_be_bytes(l2) as usize];
+            r.read_exact(&mut path).await.unwrap();
+            // headers
+            let mut hl = [0u8; 2];
+            r.read_exact(&mut hl).await.unwrap();
+            let mut headers = vec![0u8; u16::from_be_bytes(hl) as usize];
+            r.read_exact(&mut headers).await.unwrap();
+            // payload
+            let mut l4 = [0u8; 4];
+            r.read_exact(&mut l4).await.unwrap();
+            let mut payload = vec![0u8; u32::from_be_bytes(l4) as usize];
+            r.read_exact(&mut payload).await.unwrap();
+            // echo the payload back as a response frame
+            let resp = TcpResponseMessage::new(Bytes::from(payload));
+            w.write_all(&resp.encode().unwrap()).await.unwrap();
+            w.flush().await.unwrap();
         });
 
-        // Client: TCP connect + verified TLS handshake with SNI (mirrors egress).
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
-        let mut tls = connector
-            .connect(server_name, tcp)
-            .await
-            .expect("client TLS handshake (CA verification + SNI)");
+        // Drive the real client path with an explicit connector (no OnceCell) and
+        // SNI supplied via env so it matches the cert's `localhost` SAN.
+        let payload = Bytes::from_static(b"encrypted-request-plane-payload");
+        let expected = payload.clone();
+        let response = temp_env::async_with_vars(
+            [("DYN_TCP_TLS_SERVER_NAME", Some("localhost"))],
+            async move {
+                let conn = TcpConnection::connect_with_connector(
+                    addr,
+                    Duration::from_secs(5),
+                    10,
+                    Some(&connector),
+                )
+                .await
+                .expect("client connect + TLS handshake");
+                let mut headers = Headers::new();
+                headers.insert("x-endpoint-path".to_string(), "test".to_string());
+                conn.send_request(payload, &headers)
+                    .await
+                    .expect("send_request over TLS")
+            },
+        )
+        .await;
 
-        tls.write_all(b"hello").await.unwrap();
-        tls.flush().await.unwrap();
-        let mut resp = [0u8; 5];
-        tls.read_exact(&mut resp).await.unwrap();
-        assert_eq!(&resp, b"hello", "bytes should round-trip over TLS");
-
-        server.await.unwrap();
+        assert_eq!(
+            response, expected,
+            "payload should round-trip through the encrypted request plane"
+        );
     }
 
     struct RecordingWriter {

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -678,11 +678,26 @@ impl TcpConnection {
                     }
                     return Err(e.into());
                 }
+                // Flush after the batch write. `write_half` may be a tokio-rustls
+                // TLS stream, whose `poll_write` copies plaintext into the session
+                // buffer and can return Ready(Ok(n)) with encrypted records still
+                // buffered when the socket would block; without this flush the batch
+                // can stall under write back-pressure until the next request is
+                // written, hanging its callers until the request timeout. For a
+                // plaintext TCP write half this is a no-op.
+                if let Err(e) = write_half.flush().await {
+                    write_buf.clear();
+                    let err_msg = format!("Flush failed: {}", e);
+                    for tx in response_batch.drain(..) {
+                        let _ = tx.send(Err(anyhow::anyhow!("{}", err_msg)));
+                    }
+                    return Err(e.into());
+                }
                 TCP_BYTES_SENT_TOTAL.inc_by(bytes_to_write as f64);
                 debug_assert!(write_buf.is_empty());
 
-                // Phase 3: write_all succeeded — data is committed to the wire.
-                // NOW push response_txs to response_queue so the reader can
+                // Phase 3: write_all + flush succeeded — data is committed to the
+                // wire. NOW push response_txs to response_queue so the reader can
                 // match them with incoming responses.
                 for tx in response_batch.drain(..) {
                     response_queue.push(tx);

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -31,8 +31,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+
+type BoxRead = Box<dyn AsyncRead + Unpin + Send>;
+type BoxWrite = Box<dyn AsyncWrite + Unpin + Send>;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_util::codec::FramedRead;
@@ -376,6 +380,27 @@ struct TcpConnection {
     post_enqueue_barrier: Option<Arc<tokio::sync::Barrier>>,
 }
 
+/// Cached TLS connector for the request plane. Built once from env vars.
+static REQUEST_PLANE_TLS_CONNECTOR: once_cell::sync::OnceCell<Option<TlsConnector>> =
+    once_cell::sync::OnceCell::new();
+
+fn get_request_plane_tls_connector() -> anyhow::Result<&'static Option<TlsConnector>> {
+    REQUEST_PLANE_TLS_CONNECTOR.get_or_try_init(|| {
+        use crate::config::environment_names::tcp_response_stream::tls as env;
+        let ca_cert_path = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).ok();
+        let insecure = crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+        let tls_requested = ca_cert_path.is_some() || insecure;
+        if !tls_requested {
+            return Ok(None);
+        }
+        let tls_config = crate::tls_utils::client_tls_config(
+            ca_cert_path.as_deref().map(std::path::Path::new),
+            insecure,
+        )?;
+        Ok(Some(TlsConnector::from(std::sync::Arc::new(tls_config))))
+    })
+}
+
 impl TcpConnection {
     /// Create a new connection with lock-free submit and batched write/read tasks
     async fn connect(addr: SocketAddr, timeout: Duration, channel_buffer: usize) -> Result<Self> {
@@ -386,7 +411,28 @@ impl TcpConnection {
         // Configure socket for lower latency
         Self::configure_socket(&stream)?;
 
-        let (read_half, write_half) = tokio::io::split(stream);
+        let (read_half, write_half): (BoxRead, BoxWrite) = if let Some(connector) =
+            get_request_plane_tls_connector()?
+        {
+            use crate::config::environment_names::tcp_response_stream::tls as env;
+            let server_name = match std::env::var(env::DYN_TCP_TLS_SERVER_NAME) {
+                Ok(name) => rustls::pki_types::ServerName::try_from(name)
+                    .map_err(|e| anyhow::anyhow!("invalid TLS server name: {e}"))?,
+                Err(_) => rustls::pki_types::ServerName::IpAddress(addr.ip().into()),
+            };
+            let tls_stream = tokio::time::timeout(
+                crate::tls_utils::handshake_timeout(),
+                connector.connect(server_name, stream),
+            )
+            .await
+            .map_err(|_| anyhow::anyhow!("Request plane TLS handshake timed out to {}", addr))?
+            .map_err(|e| anyhow::anyhow!("Request plane TLS handshake failed to {}: {e}", addr))?;
+            let (r, w) = tokio::io::split(tls_stream);
+            (Box::new(r), Box::new(w))
+        } else {
+            let (r, w) = tokio::io::split(stream);
+            (Box::new(r), Box::new(w))
+        };
 
         let submit_queue = Arc::new(SegQueue::new());
         let response_queue = Arc::new(SegQueue::new());
@@ -557,7 +603,7 @@ impl TcpConnection {
     /// - If a response races back before waiters are queued, the reader's
     ///   existing spin-wait covers that small handoff window
     async fn writer_task(
-        mut write_half: tokio::io::WriteHalf<TcpStream>,
+        mut write_half: BoxWrite,
         submit_queue: Arc<SegQueue<PendingRequest>>,
         response_queue: Arc<SegQueue<oneshot::Sender<Result<Bytes>>>>,
         notify: Arc<tokio::sync::Notify>,
@@ -698,7 +744,7 @@ impl TcpConnection {
     /// On exit (clean close or error), sets `healthy=false` and wakes the writer
     /// via `writer_notify` so it can detect reader death and drain pending callers.
     async fn reader_task(
-        read_half: tokio::io::ReadHalf<TcpStream>,
+        read_half: BoxRead,
         response_queue: Arc<SegQueue<oneshot::Sender<Result<Bytes>>>>,
         healthy: Arc<AtomicBool>,
         writer_notify: Arc<tokio::sync::Notify>,

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1774,6 +1774,66 @@ mod tests {
         (addr, conn_count)
     }
 
+    /// Full request-plane TLS handshake + encrypted round-trip using the real
+    /// `tls_utils` config builders (the same ones egress/ingress use). Generates
+    /// a self-signed cert, trusts it as the CA, and drives a verified handshake
+    /// with SNI `localhost` (mirroring `connector.connect(server_name, stream)`
+    /// in `TcpConnection::connect`), then echoes bytes over the encrypted stream.
+    #[tokio::test]
+    async fn request_plane_tls_handshake_roundtrip() {
+        use std::io::Write as _;
+        use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+
+        // Self-signed cert with SAN=localhost; also used as the trusted CA.
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .unwrap()
+            .self_signed(&key_pair)
+            .unwrap();
+        let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+        cert_file.write_all(cert.pem().as_bytes()).unwrap();
+        let mut key_file = tempfile::NamedTempFile::new().unwrap();
+        key_file
+            .write_all(key_pair.serialize_pem().as_bytes())
+            .unwrap();
+
+        // Server acceptor + client connector via the real builders.
+        let server_config =
+            crate::tls_utils::server_tls_config(cert_file.path(), key_file.path()).unwrap();
+        let acceptor = tokio_rustls::TlsAcceptor::from(std::sync::Arc::new(server_config));
+        let client_config =
+            crate::tls_utils::client_tls_config(Some(cert_file.path()), false).unwrap();
+        let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(client_config));
+
+        // TLS echo server on loopback.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (tcp, _) = listener.accept().await.unwrap();
+            let mut tls = acceptor.accept(tcp).await.expect("server TLS handshake");
+            let mut buf = [0u8; 5];
+            tls.read_exact(&mut buf).await.unwrap();
+            tls.write_all(&buf).await.unwrap();
+            tls.flush().await.unwrap();
+        });
+
+        // Client: TCP connect + verified TLS handshake with SNI (mirrors egress).
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let server_name = rustls::pki_types::ServerName::try_from("localhost").unwrap();
+        let mut tls = connector
+            .connect(server_name, tcp)
+            .await
+            .expect("client TLS handshake (CA verification + SNI)");
+
+        tls.write_all(b"hello").await.unwrap();
+        tls.flush().await.unwrap();
+        let mut resp = [0u8; 5];
+        tls.read_exact(&mut resp).await.unwrap();
+        assert_eq!(&resp, b"hello", "bytes should round-trip over TLS");
+
+        server.await.unwrap();
+    }
+
     struct RecordingWriter {
         written: Vec<u8>,
         max_per_write: Option<usize>,

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -155,7 +155,7 @@ pub struct SharedTcpServer {
     /// the queue is empty for the FIFO direct-dispatch rule.
     queue_capacity: usize,
     /// Optional TLS acceptor for encrypting request plane connections.
-    tls_acceptor: Option<Arc<TlsAcceptor>>,
+    tls_acceptor: Option<TlsAcceptor>,
 }
 
 struct EndpointHandler {
@@ -231,7 +231,7 @@ impl SharedTcpServer {
                             env::DYN_TCP_TLS_KEY_PATH,
                         );
                     }
-                    Some(Arc::new(TlsAcceptor::from(Arc::new(config))))
+                    Some(TlsAcceptor::from(Arc::new(config)))
                 }
                 (Some(_), None) | (None, Some(_)) => {
                     anyhow::bail!(
@@ -474,13 +474,16 @@ impl SharedTcpServer {
                                             }
                                             Ok(Err(e)) => {
                                                 tracing::warn!(
-                                                    "Request plane TLS handshake failed from {peer_addr}: {e}"
+                                                    peer_addr = %peer_addr,
+                                                    error = %e,
+                                                    "Request-plane TLS handshake failed"
                                                 );
                                                 return;
                                             }
                                             Err(_) => {
                                                 tracing::warn!(
-                                                    "Request plane TLS handshake timed out from {peer_addr}"
+                                                    peer_addr = %peer_addr,
+                                                    "Request-plane TLS handshake timed out"
                                                 );
                                                 return;
                                             }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -22,8 +22,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::TlsAcceptor;
+
+type BoxRead = Box<dyn AsyncRead + Unpin + Send>;
+type BoxWrite = Box<dyn AsyncWrite + Unpin + Send>;
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tokio_util::bytes::BytesMut;
 use tokio_util::sync::CancellationToken;
@@ -150,6 +154,8 @@ pub struct SharedTcpServer {
     /// Overflow-queue capacity; `read_loop` compares against it to tell whether
     /// the queue is empty for the FIFO direct-dispatch rule.
     queue_capacity: usize,
+    /// Optional TLS acceptor for encrypting request plane connections.
+    tls_acceptor: Option<Arc<TlsAcceptor>>,
 }
 
 struct EndpointHandler {
@@ -195,16 +201,40 @@ impl SharedTcpServer {
         // Dispatcher drains the overflow queue.
         Self::start_worker_pool(engine_sem.clone(), work_rx, cancellation_token.clone());
 
+        // Build TLS acceptor from the same env vars as the call-home transport.
+        let tls_acceptor = {
+            use crate::config::environment_names::tcp_response_stream::tls as env;
+            let cert = std::env::var(env::DYN_TCP_TLS_CERT_PATH).ok();
+            let key = std::env::var(env::DYN_TCP_TLS_KEY_PATH).ok();
+            match (cert, key) {
+                (Some(c), Some(k)) => {
+                    let config = crate::tls_utils::server_tls_config(c.as_ref(), k.as_ref())
+                        .expect(
+                            "Failed to build TCP request plane TLS config — check cert/key paths",
+                        );
+                    tracing::info!("TCP request plane: TLS enabled");
+                    Some(Arc::new(TlsAcceptor::from(Arc::new(config))))
+                }
+                (Some(_), None) | (None, Some(_)) => {
+                    panic!(
+                        "Both {} and {} must be set to enable TCP request plane TLS",
+                        env::DYN_TCP_TLS_CERT_PATH,
+                        env::DYN_TCP_TLS_KEY_PATH,
+                    );
+                }
+                (None, None) => None,
+            }
+        };
+
         Arc::new(Self {
             handlers: Arc::new(DashMap::new()),
-            // address we requested to bind to.
             bind_addr,
-            // actual address after free port assignment (if DYN_TCP_RPC_PORT is not specified)
             actual_addr: RwLock::new(None),
             cancellation_token,
             work_tx,
             engine_sem,
             queue_capacity: work_queue_size,
+            tls_acceptor,
         })
     }
 
@@ -395,8 +425,38 @@ impl SharedTcpServer {
                             let work_tx = self.work_tx.clone();
                             let engine_sem = self.engine_sem.clone();
                             let queue_capacity = self.queue_capacity;
+                            let tls_acceptor = self.tls_acceptor.clone();
                             tokio::spawn(async move {
-                                if let Err(e) = Self::handle_connection(stream, handlers, work_tx, engine_sem, queue_capacity).await {
+                                let (reader, writer): (BoxRead, BoxWrite) =
+                                    if let Some(ref tls) = tls_acceptor {
+                                        match tokio::time::timeout(
+                                            crate::tls_utils::handshake_timeout(),
+                                            tls.accept(stream),
+                                        )
+                                        .await
+                                        {
+                                            Ok(Ok(tls_stream)) => {
+                                                let (r, w) = tokio::io::split(tls_stream);
+                                                (Box::new(r), Box::new(w))
+                                            }
+                                            Ok(Err(e)) => {
+                                                tracing::warn!(
+                                                    "Request plane TLS handshake failed from {peer_addr}: {e}"
+                                                );
+                                                return;
+                                            }
+                                            Err(_) => {
+                                                tracing::warn!(
+                                                    "Request plane TLS handshake timed out from {peer_addr}"
+                                                );
+                                                return;
+                                            }
+                                        }
+                                    } else {
+                                        let (r, w) = tokio::io::split(stream);
+                                        (Box::new(r), Box::new(w))
+                                    };
+                                if let Err(e) = Self::handle_connection(reader, writer, handlers, work_tx, engine_sem, queue_capacity).await {
                                     tracing::error!("TCP connection error: {e}");
                                 }
                             });
@@ -486,16 +546,14 @@ impl SharedTcpServer {
     }
 
     async fn handle_connection(
-        stream: TcpStream,
+        read_half: BoxRead,
+        write_half: BoxWrite,
         handlers: Arc<DashMap<String, Arc<EndpointHandler>>>,
         work_tx: tokio::sync::mpsc::Sender<WorkItem>,
         engine_sem: Arc<Semaphore>,
         queue_capacity: usize,
     ) -> Result<()> {
         use crate::pipeline::network::codec::{TcpRequestMessage, TcpResponseMessage};
-
-        // Split stream into read and write halves for concurrent operations
-        let (read_half, write_half) = tokio::io::split(stream);
 
         // Channel for sending responses to the write task (zero-copy Bytes)
         let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
@@ -522,7 +580,7 @@ impl SharedTcpServer {
 
     #[allow(clippy::too_many_arguments)]
     async fn read_loop(
-        mut read_half: tokio::io::ReadHalf<TcpStream>,
+        mut read_half: BoxRead,
         handlers: Arc<DashMap<String, Arc<EndpointHandler>>>,
         response_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
         work_tx: tokio::sync::mpsc::Sender<WorkItem>,
@@ -688,7 +746,7 @@ impl SharedTcpServer {
     }
 
     async fn write_loop(
-        mut write_half: tokio::io::WriteHalf<TcpStream>,
+        mut write_half: BoxWrite,
         mut response_rx: tokio::sync::mpsc::UnboundedReceiver<Bytes>,
     ) -> Result<()> {
         while let Some(response) = response_rx.recv().await {

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -216,6 +216,21 @@ impl SharedTcpServer {
                             "Failed to build TCP request plane TLS config — check cert/key paths",
                         )?;
                     tracing::info!("TCP request plane: TLS enabled");
+                    // Warn if the client side is not configured for TLS — peers
+                    // dialing this server without a CA (or insecure) will fail the
+                    // handshake with no obvious diagnostic.
+                    let client_tls_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
+                        || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+                    if !client_tls_set {
+                        tracing::warn!(
+                            "TCP request plane server has TLS enabled but client TLS env vars are \
+                             not set. Set {} (or {}) so clients can connect, or unset {}/{}.",
+                            env::DYN_TCP_TLS_CA_CERT_PATH,
+                            env::DYN_TCP_TLS_INSECURE,
+                            env::DYN_TCP_TLS_CERT_PATH,
+                            env::DYN_TCP_TLS_KEY_PATH,
+                        );
+                    }
                     Some(Arc::new(TlsAcceptor::from(Arc::new(config))))
                 }
                 (Some(_), None) | (None, Some(_)) => {
@@ -225,7 +240,22 @@ impl SharedTcpServer {
                         env::DYN_TCP_TLS_KEY_PATH,
                     );
                 }
-                (None, None) => None,
+                (None, None) => {
+                    // Warn on the reverse mismatch: server plaintext but client TLS
+                    // env is set (mirrors the call-home server warning).
+                    let client_tls_set = std::env::var(env::DYN_TCP_TLS_CA_CERT_PATH).is_ok()
+                        || crate::config::env_is_truthy(env::DYN_TCP_TLS_INSECURE);
+                    if client_tls_set {
+                        tracing::warn!(
+                            "TCP request plane server is running in plaintext mode but client TLS \
+                             env vars are set. Set {} and {} to enable server-side TLS, or unset \
+                             client TLS vars.",
+                            env::DYN_TCP_TLS_CERT_PATH,
+                            env::DYN_TCP_TLS_KEY_PATH,
+                        );
+                    }
+                    None
+                }
             }
         };
 

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -1260,4 +1260,82 @@ mod tests {
         );
         cancellation_token.cancel();
     }
+
+    fn make_cert_files() -> (tempfile::NamedTempFile, tempfile::NamedTempFile) {
+        use std::io::Write;
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .unwrap()
+            .self_signed(&key_pair)
+            .unwrap();
+        let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+        cert_file.write_all(cert.pem().as_bytes()).unwrap();
+        let mut key_file = tempfile::NamedTempFile::new().unwrap();
+        key_file
+            .write_all(key_pair.serialize_pem().as_bytes())
+            .unwrap();
+        (cert_file, key_file)
+    }
+
+    #[tokio::test]
+    async fn new_no_tls_env_is_plaintext() {
+        let token = CancellationToken::new();
+        temp_env::with_vars_unset(["DYN_TCP_TLS_CERT_PATH", "DYN_TCP_TLS_KEY_PATH"], || {
+            let server =
+                SharedTcpServer::new("127.0.0.1:0".parse().unwrap(), token.clone()).unwrap();
+            assert!(server.tls_acceptor.is_none());
+        });
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn new_partial_tls_config_errors() {
+        let (cert, key) = make_cert_files();
+        let cert_str = cert.path().to_str().unwrap();
+        let key_str = key.path().to_str().unwrap();
+        let token = CancellationToken::new();
+        // only cert set -> returns Err (must not panic)
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CERT_PATH", Some(cert_str)),
+                ("DYN_TCP_TLS_KEY_PATH", None),
+            ],
+            || {
+                assert!(
+                    SharedTcpServer::new("127.0.0.1:0".parse().unwrap(), token.clone()).is_err()
+                );
+            },
+        );
+        // only key set -> returns Err
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CERT_PATH", None),
+                ("DYN_TCP_TLS_KEY_PATH", Some(key_str)),
+            ],
+            || {
+                assert!(
+                    SharedTcpServer::new("127.0.0.1:0".parse().unwrap(), token.clone()).is_err()
+                );
+            },
+        );
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn new_both_paths_enables_tls() {
+        let (cert, key) = make_cert_files();
+        let token = CancellationToken::new();
+        temp_env::with_vars(
+            [
+                ("DYN_TCP_TLS_CERT_PATH", Some(cert.path().to_str().unwrap())),
+                ("DYN_TCP_TLS_KEY_PATH", Some(key.path().to_str().unwrap())),
+            ],
+            || {
+                let server =
+                    SharedTcpServer::new("127.0.0.1:0".parse().unwrap(), token.clone()).unwrap();
+                assert!(server.tls_acceptor.is_some());
+            },
+        );
+        token.cancel();
+    }
 }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -14,7 +14,7 @@ use crate::metrics::work_handler_pool::{
     WORK_HANDLER_QUEUE_DEPTH,
 };
 use crate::pipeline::network::PushWorkHandler;
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bytes::Bytes;
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
@@ -170,7 +170,10 @@ struct EndpointHandler {
 }
 
 impl SharedTcpServer {
-    pub fn new(bind_addr: SocketAddr, cancellation_token: CancellationToken) -> Arc<Self> {
+    pub fn new(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+    ) -> anyhow::Result<Arc<Self>> {
         let SizingConfig {
             pool_size: worker_pool_size,
             queue_size: work_queue_size,
@@ -209,14 +212,14 @@ impl SharedTcpServer {
             match (cert, key) {
                 (Some(c), Some(k)) => {
                     let config = crate::tls_utils::server_tls_config(c.as_ref(), k.as_ref())
-                        .expect(
+                        .context(
                             "Failed to build TCP request plane TLS config — check cert/key paths",
-                        );
+                        )?;
                     tracing::info!("TCP request plane: TLS enabled");
                     Some(Arc::new(TlsAcceptor::from(Arc::new(config))))
                 }
                 (Some(_), None) | (None, Some(_)) => {
-                    panic!(
+                    anyhow::bail!(
                         "Both {} and {} must be set to enable TCP request plane TLS",
                         env::DYN_TCP_TLS_CERT_PATH,
                         env::DYN_TCP_TLS_KEY_PATH,
@@ -226,7 +229,7 @@ impl SharedTcpServer {
             }
         };
 
-        Arc::new(Self {
+        Ok(Arc::new(Self {
             handlers: Arc::new(DashMap::new()),
             bind_addr,
             actual_addr: RwLock::new(None),
@@ -235,7 +238,7 @@ impl SharedTcpServer {
             engine_sem,
             queue_capacity: work_queue_size,
             tls_acceptor,
-        })
+        }))
     }
 
     /// Start the worker pool dispatcher that processes requests with bounded concurrency
@@ -894,7 +897,7 @@ mod tests {
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         // Create SharedTcpServer
-        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone()).unwrap();
 
         // Create a handler that takes 1s to process requests
         let handler = Arc::new(SlowMockHandler::new(Duration::from_secs(1)));
@@ -1245,7 +1248,7 @@ mod tests {
         // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone()).unwrap();
 
         assert!(
             WORK_HANDLER_POOL_CAPACITY.get() > 0,

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -277,7 +277,7 @@ impl NetworkManager {
                     "Creating TCP request plane server"
                 );
 
-                let server = SharedTcpServer::new(bind_addr, GLOBAL_TCP_SERVER_TOKEN.clone());
+                let server = SharedTcpServer::new(bind_addr, GLOBAL_TCP_SERVER_TOKEN.clone())?;
 
                 // Bind and start server, getting the actual bound address
                 let actual_addr = server.clone().bind_and_start().await?;

--- a/lib/runtime/src/tls_utils.rs
+++ b/lib/runtime/src/tls_utils.rs
@@ -6,10 +6,18 @@
 //! Provides helpers for loading PEM certificates and building rustls
 //! `ServerConfig` / `ClientConfig` objects for transport-layer security.
 
-use std::{path::Path, sync::Arc};
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, TryLockError},
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, Result};
-use rustls::{ClientConfig, RootCertStore, ServerConfig};
+use arc_swap::ArcSwap;
+use rustls::server::{ClientHello, ResolvesServerCert};
+use rustls::sign::CertifiedKey;
+use rustls::{ClientConfig, RootCertStore, ServerConfig, SignatureScheme};
 use rustls_pemfile::{certs, private_key};
 
 /// TLS handshake timeout, configurable via `DYN_TCP_TLS_HANDSHAKE_TIMEOUT_SECS` (default: 3s).
@@ -23,27 +31,21 @@ pub fn handshake_timeout() -> std::time::Duration {
 }
 
 /// Build a rustls `ServerConfig` from PEM certificate and key files.
+///
+/// The certificate is served through a [`ReloadingCertifiedKey`], so a rotated
+/// cert/key on disk (in-place rewrite or an atomic symlink swap) is picked up
+/// automatically on the next handshake without restarting the process. The
+/// initial load is validated eagerly: an invalid cert/key path
+/// fails here rather than starting a server that cannot serve TLS.
 pub fn server_tls_config(cert_path: &Path, key_path: &Path) -> Result<ServerConfig> {
-    let cert_pem = std::fs::read(cert_path)
-        .with_context(|| format!("reading cert: {}", cert_path.display()))?;
-    let key_pem =
-        std::fs::read(key_path).with_context(|| format!("reading key: {}", key_path.display()))?;
-
-    let cert_chain = certs(&mut cert_pem.as_slice())
-        .collect::<Result<Vec<_>, _>>()
-        .context("parsing certificate PEM")?;
-
-    let key = private_key(&mut key_pem.as_slice())
-        .context("parsing private key PEM")?
-        .context("no private key found in PEM")?;
+    let resolver = Arc::new(ReloadingCertifiedKey::new(cert_path, key_path)?);
 
     let provider = Arc::new(rustls::crypto::ring::default_provider());
     let config = ServerConfig::builder_with_provider(provider)
         .with_safe_default_protocol_versions()
         .context("configuring TLS protocol versions")?
         .with_no_client_auth()
-        .with_single_cert(cert_chain, key)
-        .context("building ServerConfig")?;
+        .with_cert_resolver(resolver);
 
     Ok(config)
 }
@@ -99,6 +101,198 @@ pub fn client_tls_config(ca_cert_path: Option<&Path>, insecure: bool) -> Result<
         .with_no_client_auth();
 
     Ok(config)
+}
+
+/// Load a leaf certificate chain + private key from PEM bytes into a rustls
+/// [`CertifiedKey`], validating that the certificate and key match.
+fn load_certified_key(cert_pem: &[u8], key_pem: &[u8]) -> Result<CertifiedKey> {
+    let mut cert_reader = cert_pem;
+    let cert_chain = certs(&mut cert_reader)
+        .collect::<Result<Vec<_>, _>>()
+        .context("parsing certificate PEM")?;
+    if cert_chain.is_empty() {
+        anyhow::bail!("no certificates found in PEM");
+    }
+
+    let mut key_reader = key_pem;
+    let key = private_key(&mut key_reader)
+        .context("parsing private key PEM")?
+        .context("no private key found in PEM")?;
+    let signing_key =
+        rustls::crypto::ring::sign::any_supported_type(&key).context("loading TLS private key")?;
+
+    let certified_key = CertifiedKey::new(cert_chain, signing_key);
+    certified_key
+        .keys_match()
+        .context("TLS certificate and private key do not match")?;
+    Ok(certified_key)
+}
+
+/// Content fingerprint of a loaded identity. Change is detected by hashing the
+/// file *contents* (blake3) rather than mtime, so atomic symlink swaps (where a
+/// mounted directory of certs is rotated by relinking) are handled reliably.
+#[derive(Debug, Eq, PartialEq)]
+struct IdentityFingerprint {
+    content_hash: [u8; 32],
+}
+
+impl IdentityFingerprint {
+    fn from_loaded(cert_pem: &[u8], key_pem: &[u8]) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(cert_pem);
+        hasher.update(&[0]); // domain separator between cert and key
+        hasher.update(key_pem);
+        Self {
+            content_hash: *hasher.finalize().as_bytes(),
+        }
+    }
+}
+
+struct LoadedIdentity {
+    fingerprint: IdentityFingerprint,
+    certified_key: Arc<CertifiedKey>,
+}
+
+struct ReloadState {
+    /// Fingerprint of the last successfully loaded identity.
+    fingerprint: IdentityFingerprint,
+    last_checked: Instant,
+    /// Minimum time between filesystem checks: the full interval after a
+    /// successful check, a short backoff after a failed one so an in-progress
+    /// rotation is picked up promptly.
+    min_check_interval: Duration,
+}
+
+/// A rustls certificate resolver that reloads the leaf certificate and private
+/// key from disk when their contents change, so certificate rotation takes
+/// effect without a process restart.
+///
+/// Handshakes read the current identity from an [`ArcSwap`] without locking.
+/// One caller at a time performs the rate-limited filesystem check (`try_lock`);
+/// others keep serving the current identity, so a reload never blocks a
+/// handshake. A failed reload keeps the last valid identity and retries soon.
+///
+/// The same type serves as both a [`ResolvesServerCert`] (server leaf cert) and
+/// a [`rustls::client::ResolvesClientCert`] (mTLS client identity).
+pub(crate) struct ReloadingCertifiedKey {
+    cert_path: PathBuf,
+    key_path: PathBuf,
+    current: ArcSwap<CertifiedKey>,
+    reload_state: Mutex<ReloadState>,
+}
+
+impl fmt::Debug for ReloadingCertifiedKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReloadingCertifiedKey")
+            .field("cert_path", &self.cert_path)
+            .field("key_path", &self.key_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReloadingCertifiedKey {
+    const RELOAD_CHECK_INTERVAL: Duration = Duration::from_secs(30);
+    const FAILURE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+    fn new(cert_path: &Path, key_path: &Path) -> Result<Self> {
+        let cert_path = cert_path.to_path_buf();
+        let key_path = key_path.to_path_buf();
+        let loaded = Self::load(&cert_path, &key_path)?;
+        Ok(Self {
+            cert_path,
+            key_path,
+            current: ArcSwap::from(loaded.certified_key),
+            reload_state: Mutex::new(ReloadState {
+                fingerprint: loaded.fingerprint,
+                last_checked: Instant::now(),
+                min_check_interval: Self::RELOAD_CHECK_INTERVAL,
+            }),
+        })
+    }
+
+    fn load(cert_path: &Path, key_path: &Path) -> Result<LoadedIdentity> {
+        let cert_pem = std::fs::read(cert_path)
+            .with_context(|| format!("reading cert: {}", cert_path.display()))?;
+        let key_pem = std::fs::read(key_path)
+            .with_context(|| format!("reading key: {}", key_path.display()))?;
+        let certified_key = load_certified_key(&cert_pem, &key_pem)?;
+        let fingerprint = IdentityFingerprint::from_loaded(&cert_pem, &key_pem);
+        Ok(LoadedIdentity {
+            fingerprint,
+            certified_key: Arc::new(certified_key),
+        })
+    }
+
+    fn resolve_key(&self) -> Arc<CertifiedKey> {
+        // Never make a handshake wait on another handshake's filesystem check;
+        // the current identity stays available via ArcSwap while one caller
+        // performs the rate-limited reload.
+        let mut state = match self.reload_state.try_lock() {
+            Ok(state) => state,
+            Err(TryLockError::WouldBlock) => return self.current.load_full(),
+            Err(TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
+        };
+        if state.last_checked.elapsed() < state.min_check_interval {
+            return self.current.load_full();
+        }
+
+        match Self::load(&self.cert_path, &self.key_path) {
+            Ok(reloaded) => {
+                if state.fingerprint != reloaded.fingerprint {
+                    let cert_count = reloaded.certified_key.cert.len();
+                    self.current.store(reloaded.certified_key);
+                    tracing::info!(
+                        cert_path = %self.cert_path.display(),
+                        cert_count,
+                        "Reloaded rotated TLS certificate and key from disk"
+                    );
+                }
+                state.fingerprint = reloaded.fingerprint;
+                state.last_checked = Instant::now();
+                state.min_check_interval = Self::RELOAD_CHECK_INTERVAL;
+            }
+            Err(error) => {
+                state.last_checked = Instant::now();
+                state.min_check_interval = Self::FAILURE_RETRY_INTERVAL;
+                tracing::warn!(
+                    cert_path = %self.cert_path.display(),
+                    error = %format!("{error:#}"),
+                    "Failed to reload rotated TLS certificate; keeping the last valid identity"
+                );
+            }
+        }
+        self.current.load_full()
+    }
+
+    #[cfg(test)]
+    fn mark_reload_due(&self) {
+        let mut state = self
+            .reload_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.min_check_interval = Duration::ZERO;
+        state.last_checked = Instant::now() - Duration::from_secs(1);
+    }
+}
+
+impl ResolvesServerCert for ReloadingCertifiedKey {
+    fn resolve(&self, _client_hello: ClientHello<'_>) -> Option<Arc<CertifiedKey>> {
+        Some(self.resolve_key())
+    }
+}
+
+impl rustls::client::ResolvesClientCert for ReloadingCertifiedKey {
+    fn resolve(
+        &self,
+        _root_hint_subjects: &[&[u8]],
+        _sigschemes: &[SignatureScheme],
+    ) -> Option<Arc<CertifiedKey>> {
+        Some(self.resolve_key())
+    }
+
+    fn has_certs(&self) -> bool {
+        true
+    }
 }
 
 /// Certificate verifier that accepts any certificate.
@@ -185,6 +379,108 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("reading key")
+        );
+    }
+
+    fn make_cert_pem() -> (String, String) {
+        let key_pair = rcgen::KeyPair::generate().unwrap();
+        let cert = rcgen::CertificateParams::new(vec!["localhost".to_string()])
+            .unwrap()
+            .self_signed(&key_pair)
+            .unwrap();
+        (cert.pem(), key_pair.serialize_pem())
+    }
+
+    #[test]
+    fn certified_key_reloads_rotated_files() {
+        let (cert1, key1) = make_cert_pem();
+        let cert_file = NamedTempFile::new().unwrap();
+        let key_file = NamedTempFile::new().unwrap();
+        std::fs::write(cert_file.path(), &cert1).unwrap();
+        std::fs::write(key_file.path(), &key1).unwrap();
+
+        let resolver = ReloadingCertifiedKey::new(cert_file.path(), key_file.path()).unwrap();
+        let before = resolver.resolve_key().cert[0].clone();
+
+        // Rotate the file contents in place and force a re-check.
+        let (cert2, key2) = make_cert_pem();
+        std::fs::write(cert_file.path(), &cert2).unwrap();
+        std::fs::write(key_file.path(), &key2).unwrap();
+        resolver.mark_reload_due();
+
+        let after = resolver.resolve_key().cert[0].clone();
+        assert_ne!(
+            before, after,
+            "resolver should serve the rotated certificate after the contents change"
+        );
+    }
+
+    #[test]
+    fn certified_key_reloads_symlinked_generation() {
+        use std::os::unix::fs::symlink;
+
+        // Mimic a symlink-based cert rotation: the mounted paths are symlinks
+        // into a per-generation directory, rotated by an atomic rename over the
+        // link.
+        let dir = tempfile::tempdir().unwrap();
+        let (c1, k1) = make_cert_pem();
+        let gen1 = dir.path().join("gen1");
+        std::fs::create_dir(&gen1).unwrap();
+        std::fs::write(gen1.join("tls.crt"), &c1).unwrap();
+        std::fs::write(gen1.join("tls.key"), &k1).unwrap();
+
+        let cert_link = dir.path().join("tls.crt");
+        let key_link = dir.path().join("tls.key");
+        symlink(gen1.join("tls.crt"), &cert_link).unwrap();
+        symlink(gen1.join("tls.key"), &key_link).unwrap();
+
+        let resolver = ReloadingCertifiedKey::new(&cert_link, &key_link).unwrap();
+        let before = resolver.resolve_key().cert[0].clone();
+
+        let (c2, k2) = make_cert_pem();
+        let gen2 = dir.path().join("gen2");
+        std::fs::create_dir(&gen2).unwrap();
+        std::fs::write(gen2.join("tls.crt"), &c2).unwrap();
+        std::fs::write(gen2.join("tls.key"), &k2).unwrap();
+        // Atomic symlink swap: create new links then rename over the live ones.
+        let cert_tmp = dir.path().join("tls.crt.tmp");
+        let key_tmp = dir.path().join("tls.key.tmp");
+        symlink(gen2.join("tls.crt"), &cert_tmp).unwrap();
+        symlink(gen2.join("tls.key"), &key_tmp).unwrap();
+        std::fs::rename(&cert_tmp, &cert_link).unwrap();
+        std::fs::rename(&key_tmp, &key_link).unwrap();
+        resolver.mark_reload_due();
+
+        let after = resolver.resolve_key().cert[0].clone();
+        assert_ne!(
+            before, after,
+            "resolver should follow the swapped symlink to the new generation"
+        );
+    }
+
+    #[test]
+    fn certified_key_keeps_previous_on_corrupt_reload() {
+        let (c1, k1) = make_cert_pem();
+        let cert_file = NamedTempFile::new().unwrap();
+        let key_file = NamedTempFile::new().unwrap();
+        std::fs::write(cert_file.path(), &c1).unwrap();
+        std::fs::write(key_file.path(), &k1).unwrap();
+        let resolver = ReloadingCertifiedKey::new(cert_file.path(), key_file.path()).unwrap();
+        let before = resolver.resolve_key().cert[0].clone();
+
+        // Simulate a partial write mid-rotation.
+        std::fs::write(cert_file.path(), b"not a valid pem").unwrap();
+        resolver.mark_reload_due();
+
+        let after = resolver.resolve_key().cert[0].clone();
+        assert_eq!(
+            before, after,
+            "a failed reload must keep serving the previously loaded certificate"
+        );
+        assert_eq!(
+            resolver.reload_state.lock().unwrap().min_check_interval,
+            ReloadingCertifiedKey::FAILURE_RETRY_INTERVAL,
+            "a failed reload should schedule a short retry"
         );
     }
 


### PR DESCRIPTION
## Overview

Extends TLS encryption to the TCP request plane (`egress/tcp_client` / `ingress/shared_tcp_endpoint`), which carries user prompts from frontend to worker. This closes the security gap where inference request payloads were transmitted in plaintext while only the response stream was encrypted (#10921).

## Details

**Server side** (`ingress/shared_tcp_endpoint.rs`):
- Builds `TlsAcceptor` from `DYN_TCP_TLS_CERT_PATH`/`KEY_PATH` at startup
- Per-connection TLS handshake with configurable timeout
- Panics on invalid TLS config (fail-closed, not silent fallback)
- `BoxRead`/`BoxWrite` unify TLS and plaintext through `read_loop`/`write_loop`

**Client side** (`egress/tcp_client.rs`):
- `OnceLock`-cached `TlsConnector` from `DYN_TCP_TLS_CA_CERT_PATH`/`INSECURE`
- Honors `DYN_TCP_TLS_SERVER_NAME` for SNI override
- TLS handshake with timeout on each pooled connection
- `BoxRead`/`BoxWrite` through `writer_task`/`reader_task`

Reuses the same `DYN_TCP_TLS_*` environment variables as the call-home transport (#10921). No new env vars needed.

## Where should the reviewer start?

1. `lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs` - TLS acceptor in `new()` + `accept_loop()`
2. `lib/runtime/src/pipeline/network/egress/tcp_client.rs` - TLS connector in `connect()` + `get_request_plane_tls_connector()`

## Related Issues

- Depends on #10921 (TCP call-home TLS)
- Relates to #10809 (TLS contribution request)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional TLS encryption for TCP request and response traffic.
  - Supports configurable certificates, CA validation, server names, insecure mode, and handshake timeouts.
  - TLS connections are securely established per connection.

- **Bug Fixes**
  - Invalid or incomplete TLS settings now prevent startup with clear configuration errors.
  - Failed or timed-out TLS handshakes are safely closed.

- **Documentation**
  - Expanded TLS guidance with supported traffic flows and configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->