### PR TITLE
fix(container): reuse pinned protoc in runtime image

### DIFF
--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -74,6 +74,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         build-essential \
         cmake \
         protobuf-compiler \
+        libprotobuf-dev \
         pkg-config \
         clang \
         libclang-dev \

--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -54,6 +54,13 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
     cp -r /tmp/usr/local/src/ffmpeg /usr/local/src/ && \
     ldconfig
 
+# Runtime test images rebuild Rust crates, so carry the same version-matched
+# protoc binary and well-known schemas used by the wheel builder.
+COPY --from=wheel_builder /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=wheel_builder /usr/local/include/google/protobuf/ /usr/local/include/google/protobuf/
+ENV PROTOC=/usr/local/bin/protoc
+RUN protoc --version && test -f /usr/local/include/google/protobuf/struct.proto
+
 {% if target not in ("dev", "local-dev") %}
 # Copy built artifacts (not needed for dev/local-dev; users build from source)
 COPY --chown=dynamo: --from=wheel_builder $CARGO_TARGET_DIR $CARGO_TARGET_DIR
@@ -73,8 +80,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python${PYTHON_VERSION}-venv \
         build-essential \
         cmake \
-        protobuf-compiler \
-        libprotobuf-dev \
         pkg-config \
         clang \
         libclang-dev \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Fix the v1.4.0 RC crate-staging failure where `dynamo-vllm-sidecar` cannot compile `vllm_grpc.proto` because `google/protobuf/struct.proto` is absent from the runtime test image.

## Summary

- Copy the pinned `protoc` 25.3 binary and its matching well-known schemas from `wheel_builder` into the Dynamo runtime image.
- Point runtime rebuilds at `/usr/local/bin/protoc`.
- Remove the older distro `protobuf-compiler` package from the runtime stage instead of mixing it with schemas from another protobuf version.

## Validation

- `python3 container/render.py --framework dynamo --target runtime --device cuda --cuda-version 13.0 --platform linux/amd64`
- Confirmed the rendered Dockerfile creates the 25.3 toolchain in `wheel_builder`, then copies its compiler and `google/protobuf` schema tree into `runtime`.
- Confirmed the runtime stage sets `PROTOC=/usr/local/bin/protoc` and checks for `google/protobuf/struct.proto` during the image build.
- `git diff --check main...HEAD`
- Focused `pre-commit` remains unavailable because the executable is not installed in this environment.

## Details

The wheel-builder stage already downloads `protoc` 25.3 and unpacks the schemas from the same release archive. Runtime test images rebuild Rust crates, but the runtime stage previously installed Ubuntu's older `protobuf-compiler` without its recommended schema package. Reusing the wheel-builder toolchain keeps the compiler and well-known types version-matched.

## Where Should The Reviewer Start?

`container/templates/dynamo_runtime.Dockerfile`

## Related Issues

**This PR is not linked to an issue:**
- [x] Confirmed — no related issue
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbe15-eea7-7c69-9b00-28f06543a7df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbe15-eea7-7c69-9b00-28f06543a7df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by including required Protocol Buffers support in the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->