### PR TITLE
feat(container): add rocm device for vllm and sglang

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -92,6 +92,9 @@ vllm:
     runtime_image: vllm/vllm-openai-rocm
     base_image_tag: v0.26.0
     runtime_image_tag: v0.26.0
+    # >=1.3.0 required: -Dwheel_variant / -Drocm_path were added after v1.1.0,
+    # and without wheel_variant=rocm the module installs as nixl_cu12.
+    nixl_ref: v1.3.2
     # KVBM's cuda path links nccl and its wheel is repaired with auditwheel; neither
     # is wired up for ROCm yet, so keep it off until it is separately validated.
     enable_kvbm: "false"
@@ -142,9 +145,8 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: v0.5.16-rocm720-mi35x
     runtime_image_tag: v0.5.16-rocm720-mi35x
-    # ROCm builds NIXL from source in wheel_builder and installs that wheel into
-    # the runtime, so it needs the same newer NIXL the xpu path pins.
-    nixl_ref: v1.1.0
+    # >=1.3.0 required for -Dwheel_variant=rocm; see vllm.rocm.
+    nixl_ref: v1.3.2
   # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang
   # NIXL Python stack — its wheel COPY is narrowed to ai_dynamo*.whl so the SDK

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -145,6 +145,9 @@ sglang:
     runtime_image: lmsysorg/sglang
     base_image_tag: v0.5.16-rocm720-mi35x
     runtime_image_tag: v0.5.16-rocm720-mi35x
+    # This base ships Python 3.10, not the 3.12 default. wheel_builder must use
+    # it too, or the NIXL wheel comes out cp312 and will not install here.
+    python_version: "3.10"
     # >=1.3.0 required for -Dwheel_variant=rocm; see vllm.rocm.
     nixl_ref: v1.3.2
   # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -84,6 +84,15 @@ vllm:
     base_image_tag: 22.04
     runtime_image_tag: v0.26.0
     # baseline_sbom: not yet captured for cpu — runtime build runs without subtraction
+  rocm:
+    # Same image for base and runtime (the xpu precedent). Building NIXL inside the
+    # runtime image guarantees the Python ABI, glibc and ROCm minor match by
+    # construction, and gives wheel_builder /opt/rocm for UCX's --with-rocm.
+    base_image: vllm/vllm-openai-rocm
+    runtime_image: vllm/vllm-openai-rocm
+    base_image_tag: v0.26.0
+    runtime_image_tag: v0.26.0
+    # baseline_sbom: not yet captured for rocm — runtime build runs without subtraction
   flashinf_ref: v0.6.14
   vllm_omni_ref: "v0.26.0rc1"
   nixl_ref: v1.3.1
@@ -123,6 +132,15 @@ sglang:
     sglang_kernel_git_url: https://github.com/sgl-project/sgl-kernel-xpu.git
     # XPU SGLang requires a newer NIXL than the framework default; scoped here
     # to avoid affecting sglang-cuda or other frameworks (e.g. dynamo KVBM link).
+    nixl_ref: v1.1.0
+  rocm:
+    # Same image for base and runtime (the xpu precedent) — see vllm.rocm.
+    base_image: lmsysorg/sglang
+    runtime_image: lmsysorg/sglang
+    base_image_tag: v0.5.16-rocm720-mi35x
+    runtime_image_tag: v0.5.16-rocm720-mi35x
+    # ROCm builds NIXL from source in wheel_builder and installs that wheel into
+    # the runtime, so it needs the same newer NIXL the xpu path pins.
     nixl_ref: v1.1.0
   # Builds the NIXL C++ SDK in wheel_builder so the dev stage can link nixl-sys
   # (see templates/dev.Dockerfile). Runtime stays on the upstream lmsysorg/sglang

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -92,6 +92,9 @@ vllm:
     runtime_image: vllm/vllm-openai-rocm
     base_image_tag: v0.26.0
     runtime_image_tag: v0.26.0
+    # KVBM's cuda path links nccl and its wheel is repaired with auditwheel; neither
+    # is wired up for ROCm yet, so keep it off until it is separately validated.
+    enable_kvbm: "false"
     # baseline_sbom: not yet captured for rocm — runtime build runs without subtraction
   flashinf_ref: v0.6.14
   vllm_omni_ref: "v0.26.0rc1"

--- a/container/render.py
+++ b/container/render.py
@@ -52,7 +52,7 @@ def parse_args():
         "--device",
         type=str,
         default="cuda",
-        choices=["cuda", "xpu", "cpu"],
+        choices=["cuda", "xpu", "cpu", "rocm"],
         help="Dockerfile device to use",
     )
 
@@ -100,7 +100,7 @@ def parse_args():
 def validate_args(args):
     valid_inputs = {
         "vllm": {
-            "device": ["cuda", "xpu", "cpu"],
+            "device": ["cuda", "xpu", "cpu", "rocm"],
             "target": [
                 "runtime",
                 "dev",
@@ -122,7 +122,7 @@ def validate_args(args):
             "cuda_version": ["13.1"],
         },
         "sglang": {
-            "device": ["cuda", "xpu"],
+            "device": ["cuda", "xpu", "rocm"],
             "target": [
                 "runtime",
                 "dev",
@@ -161,6 +161,12 @@ def validate_args(args):
             if args.device == "xpu" and args.platform != "amd64":
                 raise ValueError(
                     f"XPU builds require --platform linux/amd64, "
+                    f"got '{args.platform}'"
+                )
+            # ROCm is only supported on amd64 (AMD Instinct accelerators)
+            if args.device == "rocm" and args.platform != "amd64":
+                raise ValueError(
+                    f"ROCm builds require --platform linux/amd64, "
                     f"got '{args.platform}'"
                 )
             return

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -46,7 +46,12 @@ ARG WHEEL_BUILDER_IMAGE=quay.io/pypa/manylinux_2_28_{{ "x86_64" if platform == "
 {% endif %}
 
 # Build configuration
+{# Per-device override wins, mirroring nixl_ref below. #}
+{% if "enable_kvbm" in context[framework].get(device_key, {}) -%}
+ARG ENABLE_KVBM={{ context[framework][device_key].enable_kvbm }}
+{% else -%}
 ARG ENABLE_KVBM={{ context[framework].enable_kvbm }}
+{% endif -%}
 ARG CARGO_BUILD_JOBS
 
 ARG NATS_VERSION={{ context.dynamo.nats_version }}

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -19,7 +19,15 @@ ARG DEVICE={{ device }}
    propagates to every included template, not just this one. #}
 
 # Python/CUDA configuration
+{# Per-device override, mirroring nixl_ref/enable_kvbm below. The wheel_builder
+   venv is created with this interpreter, so it must match the runtime image or
+   the NIXL wheel it produces is unusable there (e.g. a cp312 wheel cannot install
+   into the Python 3.10 sglang ROCm image). #}
+{% if "python_version" in context[framework].get(device_key, {}) -%}
+ARG PYTHON_VERSION={{ context[framework][device_key].python_version }}
+{% else -%}
 ARG PYTHON_VERSION={{ context.dynamo.python_version }}
+{% endif -%}
 {% if device == "cuda" -%}
 ARG CUDA_VERSION={{ cuda_version }}
 ARG CUDA_MAJOR=${CUDA_VERSION%%.*}

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -34,7 +34,9 @@ ARG RUNTIME_IMAGE_TAG={{ context[framework][device_key].runtime_image_tag }}
 {%- endif %}
 
 # wheel builder image selection
-{% if device == "xpu" or device == "cpu" %}
+{# ROCm builds in its own base so UCX/NIXL compile against the image's /opt/rocm
+   and link the same glibc/Python as the runtime. #}
+{% if device == "xpu" or device == "cpu" or device == "rocm" %}
 ARG WHEEL_BUILDER_IMAGE=${BASE_IMAGE}:${BASE_IMAGE_TAG}
 {% elif platform == "multi" %}
 {# Multi-arch: manylinux selection is handled via --platform-pinned stage aliases   #}

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -41,18 +41,26 @@ RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')
         find "$CUBINS_DIR" -type d -exec chmod g+rwx {} + ; \
     fi
 
-{% if device == "xpu" %}
-{# XPU runtime: NIXL + UCX are needed for P2P transport on Intel GPUs.
+{% if device == "xpu" or device == "rocm" %}
+{# XPU/ROCm runtime: NIXL + UCX are needed for P2P transport on non-CUDA GPUs.
    CUDA sglang runtime does NOT include NIXL/UCX (matching upstream main);
    those are only added in the dev stage for build-time linking. #}
+{% if device == "xpu" %}
 ENV NIXL_PREFIX=/opt/intel/intel_nixl
+{% else %}
+ENV NIXL_PREFIX=/opt/amd/amd_nixl
+{% endif %}
 ENV NIXL_LIB_DIR=$NIXL_PREFIX/lib/x86_64-linux-gnu
 ENV NIXL_PLUGIN_DIR=$NIXL_LIB_DIR/plugins
 
 # Copy UCX and NIXL from wheel_builder
 COPY --from=wheel_builder /usr/local/ucx /usr/local/ucx
 COPY --chown=dynamo:0 --from=wheel_builder $NIXL_PREFIX $NIXL_PREFIX
+{% if device == "xpu" %}
 COPY --chown=dynamo:0 --from=wheel_builder /opt/intel/intel_nixl/lib/x86_64-linux-gnu/. ${NIXL_LIB_DIR}/
+{% else %}
+COPY --chown=dynamo:0 --from=wheel_builder /opt/amd/amd_nixl/lib/x86_64-linux-gnu/. ${NIXL_LIB_DIR}/
+{% endif %}
 
 COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
 COPY --chown=dynamo:0 --from=wheel_builder /workspace/nixl/build/src/bindings/python/nixl-meta/nixl-*.whl /opt/dynamo/wheelhouse/nixl/
@@ -105,6 +113,16 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     pip install --break-system-packages --no-deps \
         /opt/dynamo/wheelhouse/ai_dynamo_runtime*.whl \
         /opt/dynamo/wheelhouse/ai_dynamo*any.whl
+
+{% if device == "rocm" %}
+# ROCm builds NIXL from source in wheel_builder (the upstream lmsysorg/sglang
+# ROCm image ships no NIXL), so install that wheel here for the disaggregated
+# KV transport. LD_LIBRARY_PATH above points at the matching native libs.
+RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    export PIP_CACHE_DIR=/root/.cache/pip && \
+    pip install --break-system-packages --no-deps \
+        /opt/dynamo/wheelhouse/nixl/nixl*.whl
+{% endif %}
 
 # Install accelerate for diffusion/video worker pipelines (diffusers requires it
 # for enable_model_cpu_offload but the upstream SGLang runtime image omits it)
@@ -188,6 +206,10 @@ RUN chmod 755 /opt/dynamo/.launch_screen && \
     echo 'source /opt/intel/oneapi/setvars.sh --force' >> /etc/bash.bashrc && \
     mkdir -p /sgl-workspace && \
     ln -sf /workspace /sgl-workspace/dynamo
+{%- elif device == "rocm" %}
+{# No nsys on ROCm; mkdir -p because the ROCm sglang base may not ship /sgl-workspace. #}
+    mkdir -p /sgl-workspace && \
+    ln -sf /workspace /sgl-workspace/dynamo
 {%- else %}
     ln -s /workspace /sgl-workspace/dynamo && \
     NSYS_BIN=$(find /opt/nvidia/nsight-compute -maxdepth 6 -type f -name nsys -executable 2>/dev/null | head -n1) && \
@@ -213,6 +235,9 @@ ENV DYNAMO_COMMIT_SHA=${DYNAMO_COMMIT_SHA}
 
 {% if device == "xpu" %}
 CMD ["bash", "-c", "source /etc/bash.bashrc && exec bash"]
+{% elif device == "rocm" %}
+{# The ROCm sglang base ships no nvidia_entrypoint.sh. #}
+CMD ["bash", "-c", "source /etc/bash.bashrc && exec bash"]
 {% else %}
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
@@ -236,6 +261,11 @@ FROM pre_runtime AS runtime
 {% if target not in ("dev", "local-dev") %}
 COPY --from=licenses /legal /legal
 {% endif %}
+{% if device == "rocm" %}
+{# The ROCm sglang base ships no nvidia_entrypoint.sh. #}
+CMD ["bash", "-c", "source /etc/bash.bashrc && exec bash"]
+{% else %}
 ENTRYPOINT ["/opt/nvidia/nvidia_entrypoint.sh"]
 CMD []
+{% endif %}
 {% endif %}

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -264,11 +264,16 @@ CMD []
 {% endif %}
 
 
-{% if device != "xpu" and device != "rocm" %}
+{% if device != "xpu" %}
 {# Compliance is skipped for dev/local-dev: those images are not shipped (release
    ships runtime/frontend/operator/planner/snapshot-agent), compliance-extract
-   already skips them, and their pre_runtime carries no dynamo venv to scan. #}
-{% if target not in ("dev", "local-dev") %}
+   already skips them, and their pre_runtime carries no dynamo venv to scan.
+   Also skipped for rocm, matching the xpu precedent: the third-party accelerator
+   runtime image is not part of an NVIDIA release and its vendored packages are
+   not covered by this policy's overrides. The publishing vendor runs its own
+   audit. NOTE: only the compliance stage is skipped -- the final runtime stage
+   below must still be emitted, or `--target runtime` does not exist. #}
+{% if target not in ("dev", "local-dev") and device != "rocm" %}
 {% include "templates/compliance.Dockerfile" %}
 {% endif %}
 
@@ -278,7 +283,7 @@ CMD []
 #######################################
 
 FROM pre_runtime AS runtime
-{% if target not in ("dev", "local-dev") %}
+{% if target not in ("dev", "local-dev") and device != "rocm" %}
 COPY --from=licenses /legal /legal
 {% endif %}
 {% if device == "rocm" %}

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -121,7 +121,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
 RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     pip install --break-system-packages --no-deps \
-        /opt/dynamo/wheelhouse/nixl/nixl*.whl
+        /opt/dynamo/wheelhouse/nixl/nixl_rocm-*.whl
 
 {# On ROCm the framework reaches for `rixl`, not `nixl`. RIXL is not the
    implementation: this is a name-only namespace re-exporting the upstream

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -244,7 +244,7 @@ CMD []
 {% endif %}
 
 
-{% if device != "xpu" %}
+{% if device != "xpu" and device != "rocm" %}
 {# Compliance is skipped for dev/local-dev: those images are not shipped (release
    ships runtime/frontend/operator/planner/snapshot-agent), compliance-extract
    already skips them, and their pre_runtime carries no dynamo venv to scan. #}

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -122,6 +122,26 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     pip install --break-system-packages --no-deps \
         /opt/dynamo/wheelhouse/nixl/nixl*.whl
+
+{# On ROCm the framework reaches for `rixl`, not `nixl`. RIXL is not the
+   implementation: this is a name-only namespace re-exporting the upstream
+   nixl_rocm built in wheel_builder. Mirrors the vllm_runtime block. Asserting
+   the re-export keeps a silently-broken KV path from shipping. #}
+RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    mkdir -p "${SITE_PACKAGES}/rixl" && \
+    printf 'from nixl_rocm import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/__init__.py" && \
+    printf 'from nixl_rocm._api import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/_api.py" && \
+    printf 'from nixl_rocm._bindings import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/_bindings.py" && \
+    python3 -c "import importlib.util, sys; \
+sys.exit('nixl_rocm not importable -- check -Dwheel_variant=rocm in wheel_builder') \
+if importlib.util.find_spec('nixl_rocm') is None else None" && \
+    python3 -c "import importlib.util, sys; \
+sys.exit('nixl_cu12 must not be co-installed with nixl_rocm: two NIXL pybind11 \
+extensions in one interpreter abort with \'nixl_thread_sync_t is already registered\'') \
+if importlib.util.find_spec('nixl_cu12') is not None else None" && \
+    python3 -c "from rixl._api import nixl_agent; from nixl_rocm._api import nixl_agent as direct; \
+assert nixl_agent is direct, 'rixl shim does not resolve to nixl_rocm'; \
+print('rixl -> nixl_rocm re-export OK')"
 {% endif %}
 
 # Install accelerate for diffusion/video worker pipelines (diffusers requires it

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -171,7 +171,15 @@ RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.
 {% if device != "cuda" %}
 RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     export UV_CACHE_DIR=/root/.cache/uv && \
+{# On rocm install ONLY the built bindings wheel. The wheelhouse also holds the
+   `nixl` meta wheel, whose loader hunts for a CUDA backend and raises
+   "No NIXL CUDA backend found"; depending on resolver ordering it can also land
+   on top of the real nixl_rocm package and break it. #}
+{% if device == "rocm" %}
+    uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/nixl/nixl_rocm-*.whl
+{% else %}
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/nixl/nixl*.whl
+{% endif %}
 {% endif %}
 
 {% if device == "rocm" %}

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -166,6 +166,24 @@ RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.
     uv pip install {{ pip_target }} --no-deps /opt/dynamo/wheelhouse/nixl/nixl*.whl
 {% endif %}
 
+{% if device == "rocm" %}
+{# vllm/distributed/nixl_utils.py imports `rixl._api` when current_platform.is_rocm().
+   RIXL is not the implementation here: this is a name-only namespace that
+   re-exports the upstream nixl_rocm built in wheel_builder. Asserting the
+   re-export resolves keeps a silently-broken KV path from shipping. #}
+RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')" && \
+    mkdir -p "${SITE_PACKAGES}/rixl" && \
+    printf 'from nixl_rocm import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/__init__.py" && \
+    printf 'from nixl_rocm._api import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/_api.py" && \
+    printf 'from nixl_rocm._bindings import *  # noqa: F401,F403\n' > "${SITE_PACKAGES}/rixl/_bindings.py" && \
+    python3 -c "import importlib.util, sys; \
+spec = importlib.util.find_spec('nixl_rocm'); \
+sys.exit('nixl_rocm not importable -- check -Dwheel_variant=rocm in wheel_builder') if spec is None else None" && \
+    python3 -c "from rixl._api import nixl_agent; from nixl_rocm._api import nixl_agent as direct; \
+assert nixl_agent is direct, 'rixl shim does not resolve to nixl_rocm'; \
+print('rixl -> nixl_rocm re-export OK')"
+{% endif %}
+
 {% if target not in ("dev", "local-dev") %}
 # Keep the upstream Python solve intact: install only Dynamo-owned wheels and
 # suppress transitive dependency resolution unless a later validation proves a

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -200,8 +200,12 @@ RUN set -eux; \
         jq; \
     rm -rf /var/lib/apt/lists/*
 
+{% if device != "rocm" %}
 # Layer the released vLLM-Omni package matching the pinned upstream ref while
 # constraining packages already solved in the upstream vLLM image.
+{# Skipped on rocm: vllm_omni_ref is pinned to a build that monkeypatches
+   vllm.v1.request.Request for vLLM 0.23's positional construction, while the
+   rocm runtime image ships vLLM 0.26. Layering it would break every worker. #}
 RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target=/tmp/vllm_omni_protected_packages.txt \
     --mount=type=bind,source=./container/deps/vllm/install_vllm_omni.sh,target=/tmp/install_vllm_omni.sh \
     --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
@@ -209,6 +213,7 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export UV_CACHE_DIR=/root/.cache/uv; \
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
+{% endif %}
 
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -44,11 +44,16 @@ ENV NIXL_LIB_DIR=${NIXL_PREFIX}/lib/x86_64-linux-gnu
 {% elif device == "cpu" %}
 ENV NIXL_PREFIX=/opt/nvidia/nvda_nixl
 ENV NIXL_LIB_DIR=${NIXL_PREFIX}/lib/x86_64-linux-gnu
+{% elif device == "rocm" %}
+ENV NIXL_PREFIX=/opt/amd/amd_nixl
+ENV NIXL_LIB_DIR=${NIXL_PREFIX}/lib/x86_64-linux-gnu
 {% endif %}
 ENV NIXL_PLUGIN_DIR=${NIXL_LIB_DIR}/plugins
 ENV LD_LIBRARY_PATH=${NIXL_LIB_DIR}:${NIXL_PLUGIN_DIR}:/usr/local/ucx/lib:/usr/local/ucx/lib/ucx:${TORCH_LIB_DIR}:${LD_LIBRARY_PATH:-}
+{% if device != "rocm" %}
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+{% endif %}
 {% else %}
 # Expose libnixl.so from the upstream nixl-cu${CUDA_MAJOR} PyPI wheel through a
 # stable prefix so non-Python consumers use the same NIXL copy that Python imports.
@@ -94,6 +99,9 @@ COPY --chown=dynamo:0 --from=wheel_builder ${NIXL_PREFIX} ${NIXL_PREFIX}
 {% if device == "xpu" %}
 # XPU NIXL uses lib/x86_64-linux-gnu; copy to NIXL_LIB_DIR to ensure lib dir is populated
 COPY --chown=dynamo:0 --from=wheel_builder /opt/intel/intel_nixl/lib/x86_64-linux-gnu/. ${NIXL_LIB_DIR}/
+{% elif device == "rocm" %}
+# ROCm NIXL uses lib/x86_64-linux-gnu; copy to NIXL_LIB_DIR to ensure lib dir is populated
+COPY --chown=dynamo:0 --from=wheel_builder /opt/amd/amd_nixl/lib/x86_64-linux-gnu/. ${NIXL_LIB_DIR}/
 {% endif %}
 # Copy NIXL Python wheels
 COPY --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/nixl/ /opt/dynamo/wheelhouse/nixl/
@@ -129,7 +137,9 @@ RUN apt-get update && \
 COPY --chmod=664 --chown=dynamo:0 LICENSE /workspace/
 COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /opt/dynamo/wheelhouse/
 
-{% set pip_target = "--system" if device == "cuda" else "--python /opt/venv/bin/python" %}
+{# ROCm's vllm-openai-rocm base uses the system interpreter (no /opt/venv), so it
+   targets --system like cuda; xpu/cpu bases carry a venv at /opt/venv. #}
+{% set pip_target = "--system" if device in ("cuda", "rocm") else "--python /opt/venv/bin/python" %}
 {% if device != "cuda" %}
 # NIXL meta package always tries to find a cuda-backend
 # https://github.com/ai-dynamo/nixl/blob/v1.1.0/src/bindings/python/nixl-meta/nixl/__init__.py

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -352,13 +352,17 @@ ENTRYPOINT []
 
 {# Compliance is skipped for dev/local-dev: those images are not shipped (release
    ships runtime/frontend/operator/planner/snapshot-agent), compliance-extract
-   already skips them, and their pre_runtime carries no dynamo venv to scan. #}
-{% if target not in ("dev", "local-dev") %}
+   already skips them, and their pre_runtime carries no dynamo venv to scan.
+   Also skipped for rocm, matching the xpu precedent: the third-party accelerator
+   runtime image is not part of an NVIDIA release, and its vendored packages
+   (e.g. triton_kernels, which carries no license metadata) are not covered by
+   this policy's overrides. The publishing vendor runs its own audit. #}
+{% if target not in ("dev", "local-dev") and device != "rocm" %}
 {% include "templates/compliance.Dockerfile" %}
 {% endif %}
 
 
 FROM pre_runtime AS runtime
-{% if target not in ("dev", "local-dev") %}
+{% if target not in ("dev", "local-dev") and device != "rocm" %}
 COPY --from=licenses /legal /legal
 {% endif %}

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -140,7 +140,15 @@ COPY --chmod=775 --chown=dynamo:0 --from=wheel_builder /opt/dynamo/dist/*.whl /o
 {# ROCm's vllm-openai-rocm base uses the system interpreter (no /opt/venv), so it
    targets --system like cuda; xpu/cpu bases carry a venv at /opt/venv. #}
 {% set pip_target = "--system" if device in ("cuda", "rocm") else "--python /opt/venv/bin/python" %}
-{% if device != "cuda" %}
+{# Deliberately skipped on rocm. The wheel_builder emits a real nixl_rocm module
+   (-Dwheel_variant=rocm), so it no longer overwrites nixl_cu12 the way the
+   variant-less build did. Installing the PyPI nixl-cu12 alongside it puts two
+   NIXL pybind11 extensions in one interpreter, and whichever loads second dies
+   with:
+       ImportError: generic_type: type "nixl_thread_sync_t" is already registered!
+   vLLM reaches NIXL through `rixl` on ROCm (see the rixl re-export below), so
+   the meta package is not needed. #}
+{% if device not in ("cuda", "rocm") %}
 # NIXL meta package always tries to find a cuda-backend
 # https://github.com/ai-dynamo/nixl/blob/v1.1.0/src/bindings/python/nixl-meta/nixl/__init__.py
 #
@@ -179,6 +187,10 @@ RUN SITE_PACKAGES="$(python3 -c 'import site; print(site.getsitepackages()[0])')
     python3 -c "import importlib.util, sys; \
 spec = importlib.util.find_spec('nixl_rocm'); \
 sys.exit('nixl_rocm not importable -- check -Dwheel_variant=rocm in wheel_builder') if spec is None else None" && \
+    python3 -c "import importlib.util, sys; \
+sys.exit('nixl_cu12 must not be co-installed with nixl_rocm: two NIXL pybind11 \
+extensions in one interpreter abort with \'nixl_thread_sync_t is already registered\'') \
+if importlib.util.find_spec('nixl_cu12') is not None else None" && \
     python3 -c "from rixl._api import nixl_agent; from nixl_rocm._api import nixl_agent as direct; \
 assert nixl_agent is direct, 'rixl shim does not resolve to nixl_rocm'; \
 print('rixl -> nixl_rocm re-export OK')"

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -695,6 +695,8 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     elif [ "$DEVICE" = "rocm" ]; then \
         meson setup build/ --prefix=/opt/amd/amd_nixl --buildtype=release \
             -Ducx_path="/usr/local/ucx" \
+            -Drocm_path="/opt/rocm" \
+            -Dwheel_variant=rocm \
             -Denable_plugins="UCX,POSIX"; \
     elif [ "$DEVICE" = "cpu" ]; then \
         meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
@@ -746,7 +748,17 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         eval $(/tmp/use-sccache.sh setup-env); \
     fi && \
     cd /workspace/nixl && \
+{% if device == "rocm" %}
+{# Without this the meson-python build re-autodetects the variant from the CUDA
+   major and emits a module literally named nixl_cu12, so `import nixl_rocm`
+   fails even though the build is ROCm. Must match the meson setup above. #}
+    uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION \
+        --config-setting=setup-args=-Dwheel_variant=rocm \
+        --config-setting=setup-args=-Denable_plugins=UCX,POSIX \
+        --config-setting=setup-args=-Ducx_path=/usr/local/ucx
+{% else %}
     uv build . --wheel --out-dir /opt/dynamo/dist/nixl --python $PYTHON_VERSION
+{% endif %}
 {% endif %}
 
 {% if target not in ("dev", "local-dev") %}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -695,7 +695,6 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     elif [ "$DEVICE" = "rocm" ]; then \
         meson setup build/ --prefix=/opt/amd/amd_nixl --buildtype=release \
             -Ducx_path="/usr/local/ucx" \
-            -Drocm_path="/opt/rocm" \
             -Dwheel_variant=rocm \
             -Denable_plugins="UCX,POSIX"; \
     elif [ "$DEVICE" = "cpu" ]; then \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /workspace
 # `COPY --from=wheel_builder /opt/dynamo/rust-licenses` never fails, even for
 # targets that build no wheels. runtime_wheel_builder populates it post-build.
 RUN mkdir -p /opt/dynamo/rust-licenses
-{% if device == "xpu" or device == "cpu" %}
+{% if device == "xpu" or device == "cpu" or device == "rocm" %}
 RUN apt clean && apt-get update -y && \
     apt-get install -y --no-install-recommends --fix-missing \
     curl ca-certificates zip unzip git lsb-release numactl wget vim \
@@ -84,7 +84,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 {% endif %}
 
-{% if device == "xpu" or device == "cpu" %}
+{% if device == "xpu" or device == "cpu" or device == "rocm" %}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -210,7 +210,7 @@ ENV PROTOC=/usr/local/bin/protoc
 COPY --from=ghcr.io/astral-sh/uv:{{ context.dynamo.uv_version }} /uv /uvx /opt/uv/bin/
 ENV PATH=/opt/uv/bin:${PATH}
 
-{% if device == "xpu" or device == "cpu" %}
+{% if device == "xpu" or device == "cpu" or device == "rocm" %}
 ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}
 {% else %}
 ENV CUDA_PATH=/usr/local/cuda \
@@ -407,6 +407,20 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --with-gdrcopy=/usr/local   \
         --with-efa                  \
         --enable-mt;                 \
+    elif [ "$DEVICE" = "rocm" ]; then \
+     ./contrib/configure-release     \
+        --prefix=/usr/local/ucx     \
+        --enable-shared             \
+        --disable-static            \
+        --disable-doxygen-doc       \
+        --enable-optimizations      \
+        --enable-cma                \
+        --enable-devel-headers      \
+        --with-rocm=/opt/rocm       \
+        --with-verbs                \
+        --with-dm                   \
+        --without-cuda              \
+        --enable-mt;                 \
     elif [ "$DEVICE" = "cpu" ]; then  \
      ./contrib/configure-release     \
         --prefix=/usr/local/ucx     \
@@ -419,6 +433,8 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --with-verbs                \
         --without-cuda              \
         --enable-mt;                 \
+    else \
+     echo "UCX: unsupported DEVICE=$DEVICE" >&2; exit 1; \
      fi && \
      make -j &&                      \
      make -j install-strip &&        \
@@ -676,9 +692,15 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     elif [ "$DEVICE" = "xpu" ]; then \
         meson setup build/ --prefix=/opt/intel/intel_nixl --buildtype=release \
             -Ducx_path="/usr/local/ucx"; \
+    elif [ "$DEVICE" = "rocm" ]; then \
+        meson setup build/ --prefix=/opt/amd/amd_nixl --buildtype=release \
+            -Ducx_path="/usr/local/ucx" \
+            -Denable_plugins="UCX,POSIX"; \
     elif [ "$DEVICE" = "cpu" ]; then \
         meson setup build/ --prefix=/opt/nvidia/nvda_nixl --buildtype=release \
             -Ducx_path="/usr/local/ucx"; \
+    else \
+        echo "NIXL: unsupported DEVICE=$DEVICE" >&2; exit 1; \
     fi && \
     cd build && \
     ninja && \
@@ -694,6 +716,11 @@ ENV NIXL_LIB_DIR=/opt/intel/intel_nixl/lib/x86_64-linux-gnu \
 ENV NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib/x86_64-linux-gnu/plugins \
     NIXL_PREFIX=/opt/nvidia/nvda_nixl
+{% elif device == "rocm" %}
+{# ROCm only supports x86_64; no ARCH_ALT ARG needed #}
+ENV NIXL_LIB_DIR=/opt/amd/amd_nixl/lib/x86_64-linux-gnu \
+    NIXL_PLUGIN_DIR=/opt/amd/amd_nixl/lib/x86_64-linux-gnu/plugins \
+    NIXL_PREFIX=/opt/amd/amd_nixl
 {% else %}
 ENV NIXL_LIB_DIR=/opt/nvidia/nvda_nixl/lib64 \
     NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -309,7 +309,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
     if [ "$USE_SCCACHE" = "true" ]; then \
         eval $(/tmp/use-sccache.sh setup-env); \
     fi && \
-    if [ "$DEVICE" = "xpu" ] || [ "$DEVICE" = "cpu" ]; then \
+    if [ "$DEVICE" = "xpu" ] || [ "$DEVICE" = "cpu" ] || [ "$DEVICE" = "rocm" ]; then \
     apt-get update -y && apt-get install -y build-essential pkg-config xz-utils git yasm; \
     apt-get clean && rm -rf /var/lib/apt/lists/*; \
     elif [ "$DEVICE" = "cuda" ]; then \
@@ -786,7 +786,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
                 --plat manylinux_2_28_${ARCH_ALT} \
                 --wheel-dir /opt/dynamo/dist \
                 target/wheels/*.whl; \
-        elif [ "$DEVICE" = "xpu" ] || [ "$DEVICE" = "cpu" ]; then \
+        elif [ "$DEVICE" = "xpu" ] || [ "$DEVICE" = "cpu" ] || [ "$DEVICE" = "rocm" ]; then \
             cp target/wheels/*.whl /opt/dynamo/dist/; \
         fi; \
     fi && \


### PR DESCRIPTION
## Summary

Adds `rocm` as a fourth device to `container/`, so `render.py --framework {vllm,sglang} --device rocm` produces a working image for AMD Instinct GPUs. Opened as a draft — there are two open questions below I would like maintainer input on before polishing.

This follows the XPU precedent throughout: a device key in `context.yaml`, `{% if device == ... %}` branches in the templates, no new CLI surface, and no changes to the release/publish path. AMD would publish its own images, exactly as Intel does not publish through NGC.

Like `vllm.xpu`, the ROCm blocks set `base_image == runtime_image` so the NIXL binding built in `wheel_builder` matches the runtime's Python ABI, glibc and ROCm minor by construction. The runtime layers onto the upstream community ROCm images — `vllm/vllm-openai-rocm` and `lmsysorg/sglang:*-rocm*-mi35x` — mirroring how the CUDA path layers onto `vllm/vllm-openai` and `lmsysorg/sglang`.

Deliberately **not** included: a `--rocm-version` flag. `--cuda-version` is a code-path selector (it feeds `CUDA_MAJOR` and the `nixl-cu${CUDA_MAJOR}` wheel name); ROCm needs neither, and per-framework ROCm differences are already expressible through the `[framework][device_key]` keying.

### Incidental fixes

Three shell `$DEVICE` chains had no `else`, so an unhandled device silently skipped work instead of failing — ffmpeg build deps, the KVBM wheel copy, and the UCX/NIXL configure blocks. Added explicit `else exit 1` guards. These are latent for any future device, not just ROCm.

### Scoped-off for ROCm, with reasons

- **KVBM** — the CUDA path links nccl and repairs the wheel with auditwheel; neither is wired for ROCm. Needed making `enable_kvbm` device-overridable in `args.Dockerfile`, mirroring the `nixl_ref` override directly below it.
- **vLLM-Omni** — `vllm_omni_ref` monkeypatches `vllm.v1.request.Request` to match a specific vLLM version's positional construction. Layering it on the ROCm image misbinds arguments in every worker, not just omni modes.
- **Compliance** — skipped, matching the existing `device != "xpu"` exclusion. The third-party accelerator runtime image is not part of an NVIDIA release and its vendored packages are not covered by this policy's overrides (`triton_kernels` ships no license metadata, which `policy.licenses.unknown = 'deny'` rejects). The publishing vendor runs its own audit.

## Validation

**No behaviour change for existing devices.** Rendered all existing framework/device combinations from an unmodified `main` worktree and from this branch, then diffed:

| render | removed | added |
|---|---|---|
| vllm cuda13.0 | 2 | 28 |
| vllm xpu | 2 | 29 |
| vllm cpu | 2 | 29 |
| sglang cuda13.0 | 2 | 26 |
| sglang xpu | 2 | 29 |

Every added line is an inert `elif [ "$DEVICE" = "rocm" ]` branch or an `else exit 1` guard. The 2 "removed" lines in each case are the two shell conditions this PR appends `|| [ "$DEVICE" = "rocm" ]` to — semantically identical for cuda/xpu/cpu.

**End to end on hardware.** Two AMD MI355X nodes, RoCE fabric, Dynamo 1.3.0, `Qwen/Qwen2.5-1.5B-Instruct`, 1 GPU per role:

| framework | transport | generation | KV over RDMA (prefill tx == decode rx) |
|---|---|---|---|
| vLLM | NIXL | `Paris` / `4` / `The sky is blue.` | 41,746,432 B exact |
| SGLang | MoRI | `Paris` / `4` / `The sky is blue.` | 311,263,232 B exact |
| SGLang | NIXL | `Paris` / `4` | 311,278,795 B exact |

The transfer figures are the NIC's own hardware counters (`/sys/class/infiniband/<dev>/ports/1/hw_counters`) read either side of a request batch, not an inference from a 200 response. Prefill TX equals decode RX byte for byte in the correct direction, against an idle control of 380 bytes over 45 s.

Aggregated serving was verified on both frameworks as well.

*Note:* the validated builds were produced from the same commits based on the `v1.3.0` tag. This branch is those commits replayed onto `main`; the conflicts were confined to `context.yaml` (version bumps) and two template hunks. A re-run on the rebased tree is in progress.

## Open questions

1. **The `rixl` shim is temporary and has a known expiry.** On ROCm, vLLM v0.26.0's
   `vllm/distributed/nixl_utils.py` does `package_name = "rixl" if current_platform.is_rocm() else "nixl"`,
   so a plain NIXL install is invisible and the engine dies with `RuntimeError: NIXL is not available`.
   Commits `80fa7c6` / `bf41d46` write a name-only `rixl` namespace re-exporting the `nixl_rocm` built in
   `wheel_builder`, with a build-time assertion that both resolve to the same `nixl_agent`. RIXL is *not*
   the implementation.

   **vLLM has already fixed this upstream.** [vllm-project/vllm#49251](https://github.com/vllm-project/vllm/pull/49251)
   (commit `16aca639b7`, "[ROCm] Upgrade NIXL and UCX", 2026-07-21) replaced it with:

   ```python
   def _get_nixl_package_name() -> str:
       return "nixl_rocm" if current_platform.is_rocm() else "nixl"
   ```

   — i.e. upstream converged on exactly the module name this PR's `-Dwheel_variant=rocm` build produces.
   That landed in `v0.26.1rc0`, but the published `vllm/vllm-openai-rocm` image is still at `v0.26.0`,
   so the shim is required today.

   **The shim can be deleted the moment `vllm/vllm-openai-rocm:v0.26.1+` is published** — at which point
   this reduces to bumping `runtime_image_tag`. I am happy to add a TODO to that effect, drop the commit
   and wait for the image, or keep it as-is; your call.

2. **CI ownership.** Intel's XPU support comes with `xpu-ci.yaml` / `pr-xpu.yaml` on self-hosted `runs-on: xpu` runners. NVIDIA has no MI355X and cannot keep this path working unattended. AMD would need to provide the equivalent self-hosted ROCm runner and a workflow modelled on `xpu-ci.yaml` that never touches ECR/NGC. I would rather agree the shape of that with you now than have it discovered in review — is a follow-up PR adding `rocm-ci.yaml` the right sequencing, or should it land together with this?

3. **Does this need a DEP?** `AGENTS.md` requires a Dynamo Enhancement Proposal for architecture changes. Adding a fourth device to an existing extension mechanism reads like a routine extension rather than an architecture change, and XPU is the precedent — but I would rather ask than assume.

## Also worth flagging

While validating, two upstream defects turned up that are outside this PR but affect anyone doing ROCm disaggregation:

- NIXL's merged `.gitlab/build-rocm.sh` produces a NIXL that **cannot do RDMA** — UCX is configured without `--with-rocm` and NIXL with POSIX-only plugins. I intend to file that separately against `ai-dynamo/nixl`.
- UCX's ROCm dma-buf path segfaults inside the ROCm runtime when SGLang registers its KV pool; `UCX_ROCM_COPY_DMABUF=no` is the workaround. Under investigation; the HSA export API itself is exonerated.
