### PR TITLE
fix(backend): skip logprob extraction when none were requested

### DIFF
--- a/components/src/dynamo/common/backend/logprobs.py
+++ b/components/src/dynamo/common/backend/logprobs.py
@@ -76,7 +76,11 @@ def extract_from_completion_output(
     by position, so emitting a shorter array would misalign every later
     token. Bail on the whole chunk instead.
     """
-    if getattr(output, "logprobs", None) is None:
+    # An empty list here means the client asked for no logprobs -- TRT-LLM leaves
+    # the field at `[]` rather than None. Testing `is None` would miss that case
+    # and run on to the `token_ids` copy below, which grows with the request and
+    # is discarded a few lines later.
+    if not getattr(output, "logprobs", None):
         return None, None
 
     token_ids = list(getattr(output, "token_ids", None) or [])

--- a/components/src/dynamo/common/backend/tests/test_logprobs.py
+++ b/components/src/dynamo/common/backend/tests/test_logprobs.py
@@ -76,6 +76,37 @@ def test_extract_completion_returns_none_when_logprobs_absent():
     assert extract_from_completion_output(output, 0) == (None, None)
 
 
+class _ExplodingTokenIds:
+    """Stands in for `token_ids` and fails the test if anything reads it.
+
+    Non-empty, so it survives the `or []` fallback and would reach the copy;
+    iterating it, which is what copying does, raises instead.
+    """
+
+    def __len__(self) -> int:
+        return 2
+
+    def __iter__(self):
+        raise AssertionError("token_ids copied though no logprobs were requested")
+
+
+def test_extract_completion_skips_token_ids_when_logprobs_empty():
+    """When no logprobs were requested, return without ever reading `token_ids`.
+
+    TRT-LLM leaves `logprobs` at its `[]` default whenever the client did not ask
+    for logprobs. That is falsy but not None, so the early return has to test
+    truthiness for this case to fire at all.
+
+    Asserting only the return value would not catch a regression, because the
+    older `is None` check returned `(None, None)` too -- it just copied
+    `token_ids` on the way. `token_ids` holds every token the request has emitted
+    so far, so that copy grows as the request runs and is then thrown away.
+    Hence a `token_ids` that raises if anything touches it.
+    """
+    output = SimpleNamespace(token_ids=_ExplodingTokenIds(), logprobs=[])
+    assert extract_from_completion_output(output, 1) == (None, None)
+
+
 def test_extract_completion_returns_none_past_end_of_tokens():
     output = SimpleNamespace(
         token_ids=[7, 8], logprobs=[{7: _logprob(-0.7)}, {8: _logprob(-0.8)}]


### PR DESCRIPTION
## Summary

- `extract_from_completion_output` bails on `logprobs is None`, but TRT-LLM's `CompletionOutput.logprobs` defaults to `[]` and is only appended to when logprobs were actually requested. The guard therefore falls through on every response and reaches `list(output.token_ids)` before returning `(None, None)` anyway.
- `token_ids` accumulates for the life of the request, so that discarded copy costs more the longer the request runs. Both the TRT-LLM handler (`request_handlers/handler_base.py`) and the vLLM handler (`vllm/handlers.py`) call this unconditionally on the per-response path, where it is held under the GIL.
- Test the value's truthiness instead. The fall-through path already returned `(None, None)`, so the change is behaviour-preserving and only removes work whose result was thrown away.

TRT-LLM's `token_ids` are cumulative, so it pays the growth. vLLM passes per-chunk outputs, so there the saving is a smaller constant. SGLang has its own extraction path and is unaffected.

### Measurements

The script at the bottom loads `logprobs.py` from both `origin/main` and this branch and times the real shipped function on each side, with no logprobs requested — neither arm is a hand-rolled imitation. Cost of a single call, by how far into its output the request has got:

| output position | `main` | this PR |
| --- | --- | --- |
| 1 | ~250 ns | ~85 ns |
| 1,024 | ~1.0 us | ~85 ns |
| 4,096 | ~5 us | ~85 ns |
| 16,384 | ~28 us | ~85 ns |

Summed over every call a single request makes, at `stream_interval: 1`:

| output length | `main` | this PR |
| --- | --- | --- |
| 512 | ~0.2 ms | ~0.03 ms |
| 4,096 | ~7.9 ms | ~0.27 ms |
| 32,768 | ~830 ms | ~2.3 ms |

Long-context reasoning workloads pay the most; short outputs barely notice. These are laptop numbers with visible run-to-run jitter, meant to show the shape of the cost rather than to predict any particular deployment.

## Validation

- `pytest components/src/dynamo/common/backend/tests/test_logprobs.py` — 48 passed, 4 skipped (the skipped ones need vllm/trtllm/sglang installed).
- The new test fails against `origin/main`'s `logprobs.py` and passes with the change. It supplies a `token_ids` that raises if anything iterates it, so it catches the wasted copy rather than only asserting the return value — which the old code also satisfied.
- `pre-commit run --files` on both changed files: isort, black, flake8, codespell, ruff and the remaining hooks pass.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

---

<details>
<summary><b>bench_logprobs.py</b> — reproduces both tables above (stdlib only, no GPU)</summary>

```python
#!/usr/bin/env python3
"""Reproduces the numbers in this PR. Stdlib only -- no GPU, no tensorrt_llm.

Loads `logprobs.py` twice, once from `origin/main` and once from the working
tree, and times `extract_from_completion_output` on the case this PR is about:
a response carrying no logprobs. Both arms run the real shipped function, so
nothing here is a hand-rolled imitation of either side.

Run from anywhere inside the repo:  python bench_logprobs.py
"""

import importlib.util
import statistics
import subprocess
import time
from pathlib import Path
from types import SimpleNamespace

REL = "components/src/dynamo/common/backend/logprobs.py"
POSITIONS = (1, 1024, 4096, 16384)
OUTPUT_LENS = (512, 4096, 32768)


def _git(*args: str) -> str:
    return subprocess.check_output(["git", *args], text=True)


def load(name: str, source: str):
    """Import a standalone copy of logprobs.py. Its imports are stdlib-only."""
    path = Path(f"/tmp/_{name}_logprobs.py")
    path.write_text(source)
    spec = importlib.util.spec_from_file_location(f"_{name}_logprobs", path)
    module = importlib.util.module_from_spec(spec)
    spec.loader.exec_module(module)
    return module.extract_from_completion_output


def make_output(num_tokens: int) -> SimpleNamespace:
    """A response from a request that has already emitted `num_tokens` tokens.

    `logprobs=[]` is what TRT-LLM ships when the client asked for none, and
    `token_ids` is cumulative -- it holds every token emitted so far.
    """
    return SimpleNamespace(token_ids=list(range(num_tokens)), logprobs=[])


def median_ns(fn, position: int, reps: int = 2000) -> float:
    """Median cost of the single call made at output position `position`."""
    output = make_output(position)
    fn(output, position - 1)  # warm up
    samples = []
    for _ in range(reps):
        start = time.perf_counter_ns()
        fn(output, position - 1)
        samples.append(time.perf_counter_ns() - start)
    return statistics.median(samples)


def total_ns(fn, output_len: int) -> float:
    """Every call one request makes, growing `token_ids` as the engine does."""
    output = SimpleNamespace(token_ids=[], logprobs=[])
    start = time.perf_counter_ns()
    for position in range(output_len):
        output.token_ids.append(position)
        fn(output, position)
    return time.perf_counter_ns() - start


root = Path(_git("rev-parse", "--show-toplevel").strip())
arms = {
    "main": load("main", _git("show", f"origin/main:{REL}")),
    "this PR": load("pr", (root / REL).read_text()),
}

print("cost of ONE call, by how far into the output the request is")
print(f"{'position':>10} {'main':>12} {'this PR':>12}")
for pos in POSITIONS:
    a, b = (median_ns(arms[k], pos) for k in arms)
    print(f"{pos:>10} {a:>9.0f} ns {b:>9.0f} ns")

print("\ncost of ALL calls one request makes, at stream_interval 1")
print(f"{'output len':>10} {'main':>12} {'this PR':>12}")
for n in OUTPUT_LENS:
    a, b = (total_ns(arms[k], n) for k in arms)
    print(f"{n:>10} {a / 1e6:>9.2f} ms {b / 1e6:>9.2f} ms")
```

</details>
