### PR TITLE
fix(router): reconcile request-path overload marks [DYN-3849]

### DIFF
--- a/lib/llm/src/discovery/worker_monitor.rs
+++ b/lib/llm/src/discovery/worker_monitor.rs
@@ -147,6 +147,40 @@ fn publish_overloaded_instances(
     }
 }
 
+fn overload_reconciliation_needed(
+    decode_client: &Client,
+    prefill_client_holder: &RwLock<Option<Client>>,
+) -> bool {
+    decode_client.overload_reconciliation_needed()
+        || prefill_client_holder
+            .read()
+            .unwrap()
+            .as_ref()
+            .is_some_and(Client::overload_reconciliation_needed)
+}
+
+fn publish_overloaded_instances_if_needed(
+    decode_client: &Client,
+    prefill_client_holder: &RwLock<Option<Client>>,
+    overloaded_tracker: &OverloadedWorkerTracker,
+    overloaded_changed: bool,
+) -> bool {
+    // NOTE: Recovery still relies on load producers publishing after meaningful capacity or
+    // lifecycle changes. This only prevents the next observation from being suppressed when
+    // request-path backpressure changed Client state outside this monitor's cached set.
+    if !overloaded_changed && !overload_reconciliation_needed(decode_client, prefill_client_holder)
+    {
+        return false;
+    }
+
+    publish_overloaded_instances(
+        decode_client,
+        prefill_client_holder,
+        &overloaded_tracker.ids(),
+    );
+    true
+}
+
 /// Configuration for worker load thresholds used in overload detection.
 ///
 /// All thresholds are opt-in. An unset (`None`) field means the corresponding
@@ -1004,14 +1038,12 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
                             overloaded_tracker.update_worker(worker_id, worker_overloaded)
                         };
 
-                        if overloaded_changed {
-                            let overloaded_instances = overloaded_tracker.ids();
-                            publish_overloaded_instances(
-                                &client,
-                                &prefill_client_holder,
-                                &overloaded_instances,
-                            );
-                        }
+                        publish_overloaded_instances_if_needed(
+                            &client,
+                            &prefill_client_holder,
+                            &overloaded_tracker,
+                            overloaded_changed,
+                        );
                     }
 
                     // Handle decode endpoint instance changes (for ITL and decode metrics cleanup)
@@ -1164,7 +1196,8 @@ impl WorkerLoadMonitor for KvWorkerMonitor {
 mod tests {
     use super::{
         LoadMembership, LoadThresholdConfig, OverloadedWorkerTracker, WorkerLoadState,
-        classify_load_membership, compute_overloaded_instances, publish_overloaded_instances,
+        classify_load_membership, compute_overloaded_instances, overload_reconciliation_needed,
+        publish_overloaded_instances, publish_overloaded_instances_if_needed,
     };
     use dynamo_kv_router::protocols::ActiveLoad;
     use std::collections::HashSet;
@@ -1594,6 +1627,53 @@ mod tests {
             .into_iter()
             .collect();
         assert_eq!(overloaded, HashSet::from([1]));
+    }
+
+    #[tokio::test]
+    async fn unchanged_low_metric_reconciles_request_path_overload() {
+        use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
+        use std::sync::RwLock;
+
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let client = drt
+            .namespace("test_request_path_overload_reconciliation".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("decode".to_string())
+            .client()
+            .await
+            .unwrap();
+        let prefill_client_holder = RwLock::new(None);
+        let mut tracker = OverloadedWorkerTracker::default();
+
+        assert!(!tracker.update_worker(7, false));
+        client.mark_overloaded_immediate(7);
+        assert_eq!(client.overloaded_instance_ids(), Some(HashSet::from([7])));
+
+        let overloaded_changed = tracker.update_worker(7, false);
+        assert!(
+            !overloaded_changed,
+            "the monitor's cached set remains empty"
+        );
+        assert!(overload_reconciliation_needed(
+            &client,
+            &prefill_client_holder
+        ));
+
+        assert!(publish_overloaded_instances_if_needed(
+            &client,
+            &prefill_client_holder,
+            &tracker,
+            overloaded_changed,
+        ));
+
+        assert_eq!(client.overloaded_instance_ids(), None);
+        assert!(!client.overload_reconciliation_needed());
+        rt.shutdown();
     }
 
     /// Regression: the overloaded set must reach the prefill

--- a/lib/runtime/src/component/client.rs
+++ b/lib/runtime/src/component/client.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, LazyLock, Mutex as StdMutex},
@@ -359,6 +359,7 @@ impl RoutingInstances {
 struct RoutingInstancesState {
     snapshot: ArcSwap<RoutingInstances>,
     update_lock: StdMutex<()>,
+    overload_reconciliation_needed: AtomicBool,
     instance_avail_tx: tokio::sync::watch::Sender<Vec<u64>>,
     instance_avail_rx: tokio::sync::watch::Receiver<Vec<u64>>,
 }
@@ -371,6 +372,7 @@ impl RoutingInstancesState {
         Self {
             snapshot: ArcSwap::from_pointee(snapshot),
             update_lock: StdMutex::new(()),
+            overload_reconciliation_needed: AtomicBool::new(false),
             instance_avail_tx,
             instance_avail_rx,
         }
@@ -431,6 +433,8 @@ impl RoutingInstancesState {
             .copied()
             .collect::<HashSet<_>>();
         let _guard = self.update_lock.lock().unwrap();
+        self.overload_reconciliation_needed
+            .store(false, Ordering::Release);
         let current = self.snapshot.load();
         if current.overloaded_ids == overloaded_ids {
             return false;
@@ -442,12 +446,16 @@ impl RoutingInstancesState {
     }
 
     fn mark_overloaded_immediate(&self, instance_id: u64) {
-        self.update(
-            move |current| current.mark_overloaded(instance_id),
-            // Routable set is unchanged — only the derived free set shrinks —
-            // so there's no need to republish routable_ids.
-            false,
-        );
+        let _guard = self.update_lock.lock().unwrap();
+        let current = self.snapshot.load();
+        let next = Arc::new(current.mark_overloaded(instance_id));
+        self.snapshot.store(next);
+        self.overload_reconciliation_needed
+            .store(true, Ordering::Release);
+    }
+
+    fn overload_reconciliation_needed(&self) -> bool {
+        self.overload_reconciliation_needed.load(Ordering::Acquire)
     }
 
     fn clear_overloaded_for_removed(&self, removed_instance_ids: &[u64]) {
@@ -618,6 +626,12 @@ impl Client {
     pub fn set_overloaded_instances(&self, overloaded_instance_ids: &[u64]) -> bool {
         self.routing_instances
             .set_overloaded_instances(overloaded_instance_ids)
+    }
+
+    /// Whether request-path backpressure changed overload state after the monitor's
+    /// most recent metric publication.
+    pub fn overload_reconciliation_needed(&self) -> bool {
+        self.routing_instances.overload_reconciliation_needed()
     }
 
     /// Mark an instance overloaded immediately. A worker returning


### PR DESCRIPTION
## Summary

`ResourceExhausted` marks a worker overloaded directly in the routing `Client`, outside `KvWorkerMonitor`'s cached metric set. When that cached set remains empty, the next healthy load observation also computes an empty set and the monitor suppresses publication, leaving the request-path mark stuck indefinitely.

Track whether request-path backpressure changed Client overload state, and allow the next load observation to republish the monitor's authoritative set even when its cached membership did not change. Normal load processing remains change-only; routing reads are unchanged.

This intentionally preserves the existing recovery contract: load producers must publish after meaningful capacity or lifecycle changes. It does not add a heartbeat, timeout, cooldown, or new backpressure state model.

Credit to [#12138](https://github.com/ai-dynamo/dynamo/pull/12138) for identifying the same lost-update path and demonstrating an every-load-frame reconciliation. This PR uses a dirty-triggered reconciliation instead, avoiding a full overloaded-set publication on every unchanged load sample.

## Validation

- Added the exact regression: monitor cache `{}` -> request-path mark `{W}` -> unchanged healthy metric `{}` -> Client returns to `{}`.
- `cargo test -p dynamo-llm --no-default-features unchanged_low_metric_reconciles_request_path_overload -- --nocapture` (`1 passed`, `0 failed`).
- Scoped Clippy and formatting passed for `lib/runtime` and `lib/llm` with `--no-default-features` and warnings denied.
- A two-frontend/two-worker CPU Mocker baseline reproduced the permanent post-drain 529 state with worker load gauges at zero.
- E2E Mocker validation passed at exact PR commit `ec2ef2d9`: three saturation/drain cycles with KV routing, replica sync, FCFS, output-block tracking, and active load thresholds. The load phase produced 57 expected worker-capacity 529s; after all exported decode gauges reached zero, 60/60 probes returned HTTP 200 and 0/60 returned HTTP 529. Frontend logs captured `ResourceExhausted`, immediate request-path overload marks, and subsequent empty-set metric reconciliation.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12540" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overload monitoring to detect and reconcile immediate request-path overload changes, even when load metrics remain unchanged.
  * Fixed recovery handling when workers are externally marked as overloaded.
  * Improved synchronization of overload state updates to ensure monitoring reflects the latest status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
