### PR TITLE
feat(request-trace): opt-in media redaction for request_payload records

### DIFF
--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -103,6 +103,9 @@ pub struct RequestTracePolicy {
     pub s3_prefix: Option<String>,
     pub s3_roll_uncompressed_bytes: u64,
     pub s3_flush_interval_ms: u64,
+    /// Redact media request parts before snapshotting (`DYN_REQUEST_TRACE_REDACT_MEDIA`).
+    /// Defaults to `false`: media is recorded verbatim unless explicitly opted in.
+    pub redact_media: bool,
 }
 
 impl RequestTracePolicy {
@@ -223,6 +226,9 @@ fn load_from_env() -> RequestTracePolicy {
             .filter(|value| !value.is_empty())
             .unwrap_or_else(|| DEFAULT_TOOL_EVENTS_TOPIC.to_string())
     });
+    // Off by default: enabling request-trace payload records must not silently change
+    // what those records contain for existing deployments.
+    let redact_media = env_is_truthy(env_request_trace::DYN_REQUEST_TRACE_REDACT_MEDIA);
     let s3_bucket = env_trimmed(env_request_trace::DYN_REQUEST_TRACE_S3_BUCKET);
     let s3_region = env_trimmed(env_request_trace::DYN_REQUEST_TRACE_S3_REGION);
     let s3_prefix = env_trimmed(env_request_trace::DYN_REQUEST_TRACE_S3_PREFIX);
@@ -256,6 +262,7 @@ fn load_from_env() -> RequestTracePolicy {
         s3_prefix,
         s3_roll_uncompressed_bytes,
         s3_flush_interval_ms,
+        redact_media,
     }
 }
 
@@ -442,6 +449,7 @@ mod tests {
         env_request_trace::DYN_REQUEST_TRACE_FILE_FORMAT,
         env_request_trace::DYN_REQUEST_TRACE_CAPACITY,
         env_request_trace::DYN_REQUEST_TRACE_RECORDS,
+        env_request_trace::DYN_REQUEST_TRACE_REDACT_MEDIA,
         env_request_trace::DYN_REQUEST_TRACE_NATS_SUBJECT,
         env_request_trace::DYN_REQUEST_TRACE_OTEL_MAX_PAYLOAD_BYTES,
         env_request_trace::DYN_REQUEST_TRACE_FILE_BUFFER_BYTES,
@@ -510,7 +518,55 @@ mod tests {
                 policy.otel_max_payload_bytes,
                 DEFAULT_OTEL_MAX_PAYLOAD_BYTES
             );
+            assert!(!policy.redact_media);
         });
+    }
+
+    /// Media redaction is opt-in. Turning request tracing on must not, by itself,
+    /// change what the records contain for deployments already consuming them.
+    #[test]
+    #[serial_test::serial]
+    fn media_redaction_is_off_unless_explicitly_enabled() {
+        with_request_trace_env(&[(env_request_trace::DYN_REQUEST_TRACE, "1")], || {
+            assert!(
+                !load_from_env().redact_media,
+                "media redaction must default to off"
+            );
+        });
+        with_request_trace_env(
+            &[
+                (env_request_trace::DYN_REQUEST_TRACE, "1"),
+                (env_request_trace::DYN_REQUEST_TRACE_REDACT_MEDIA, "1"),
+            ],
+            || assert!(load_from_env().redact_media),
+        );
+    }
+
+    /// A falsey value must leave redaction OFF. This is the footgun worth pinning:
+    /// under a presence-only check (`env::var(..).is_ok()`), writing
+    /// `DYN_REQUEST_TRACE_REDACT_MEDIA=0` would turn redaction ON -- the opposite of
+    /// what the operator wrote, and silently so.
+    ///
+    /// The full accepted-spelling matrix belongs to `lib/truthy` (which also carries a
+    /// workspace test forbidding hand-rolled bool parsers); this only pins that this
+    /// flag routes through it rather than testing presence.
+    #[test]
+    #[serial_test::serial]
+    fn media_redaction_stays_off_for_falsey_values() {
+        for value in ["0", "false", "off", "no", ""] {
+            with_request_trace_env(
+                &[
+                    (env_request_trace::DYN_REQUEST_TRACE, "1"),
+                    (env_request_trace::DYN_REQUEST_TRACE_REDACT_MEDIA, value),
+                ],
+                || {
+                    assert!(
+                        !load_from_env().redact_media,
+                        "redaction enabled by falsey value {value:?}"
+                    )
+                },
+            );
+        }
     }
 
     #[test]

--- a/lib/llm/src/request_trace/mod.rs
+++ b/lib/llm/src/request_trace/mod.rs
@@ -78,6 +78,7 @@ pub async fn init_from_env_with_shutdown(shutdown: CancellationToken) -> anyhow:
         sinks = ?policy.sink_names(),
         file_format = policy.file_format.as_str(),
         records = ?policy.record_names(),
+        redact_media = policy.redact_media,
         "Request trace initialized"
     );
     Ok(())

--- a/lib/llm/src/request_trace/payload.rs
+++ b/lib/llm/src/request_trace/payload.rs
@@ -94,6 +94,112 @@ impl RequestPayloadHandle {
     }
 }
 
+/// Replace media (image/video/audio) request content with text placeholders so the
+/// request-trace pipeline never records raw media bytes or URLs.
+///
+/// Payload records carry the full inbound request; for multimodal requests that
+/// includes base64 data URIs or media URLs, which must not be persisted to any sink
+/// (size, and privacy — the OTLP sink forwards to a collector).
+///
+/// Applied where the pristine snapshot is taken, so no sink can observe media even
+/// transiently, and both `create_handle` call sites are covered by construction.
+///
+/// Cost: pure-text requests pay only a scan (a borrow); the clone happens only when
+/// at least one media part is present.
+///
+/// Returns `Some(redacted)` if any message carries a media part, `None` for pure text.
+///
+/// NOTE: BOTH `User` and `Tool` messages can carry media parts — `preprocessor.rs`
+/// converts tool media parts to user parts for multimodal processing. Scanning only
+/// user messages would leak media supplied in tool results.
+fn redact_media(req: &NvCreateChatCompletionRequest) -> Option<NvCreateChatCompletionRequest> {
+    use dynamo_protocols::types::{
+        ChatCompletionRequestMessage, ChatCompletionRequestMessageContentPartText,
+        ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
+        ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
+    };
+
+    // `None` => text, keep as-is. `Some(kind)` => media, replace with a placeholder
+    // naming `kind`. The trailing catch-all is unreachable for the enum as defined
+    // today; it is kept as a fail-closed net so a newly added media variant is
+    // redacted as "unknown" rather than leaked.
+    fn user_kind(part: &ChatCompletionRequestUserMessageContentPart) -> Option<&'static str> {
+        #[allow(unreachable_patterns)]
+        match part {
+            ChatCompletionRequestUserMessageContentPart::Text(_) => None,
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => Some("image_url"),
+            ChatCompletionRequestUserMessageContentPart::VideoUrl(_) => Some("video_url"),
+            ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => Some("audio"),
+            _ => Some("unknown"),
+        }
+    }
+    fn tool_kind(part: &ChatCompletionRequestToolMessageContentPart) -> Option<&'static str> {
+        #[allow(unreachable_patterns)]
+        match part {
+            ChatCompletionRequestToolMessageContentPart::Text(_) => None,
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(_) => Some("image_url"),
+            ChatCompletionRequestToolMessageContentPart::VideoUrl(_) => Some("video_url"),
+            ChatCompletionRequestToolMessageContentPart::AudioUrl(_) => Some("audio"),
+            _ => Some("unknown"),
+        }
+    }
+
+    // ---- Phase 1: scan only, no clone. ----
+    let has_media = req.inner.messages.iter().any(|msg| match msg {
+        ChatCompletionRequestMessage::User(u) => match &u.content {
+            ChatCompletionRequestUserMessageContent::Array(parts) => {
+                parts.iter().any(|p| user_kind(p).is_some())
+            }
+            _ => false,
+        },
+        ChatCompletionRequestMessage::Tool(t) => match &t.content {
+            ChatCompletionRequestToolMessageContent::Array(parts) => {
+                parts.iter().any(|p| tool_kind(p).is_some())
+            }
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_media {
+        return None;
+    }
+
+    // ---- Phase 2: media present. Clone once, rewrite in place. ----
+    let mut redacted = req.clone();
+    for msg in redacted.inner.messages.iter_mut() {
+        match msg {
+            ChatCompletionRequestMessage::User(u) => {
+                if let ChatCompletionRequestUserMessageContent::Array(parts) = &mut u.content {
+                    for part in parts.iter_mut() {
+                        if let Some(kind) = user_kind(part) {
+                            *part = ChatCompletionRequestUserMessageContentPart::Text(
+                                ChatCompletionRequestMessageContentPartText {
+                                    text: format!("[{kind} omitted by audit]"),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            ChatCompletionRequestMessage::Tool(t) => {
+                if let ChatCompletionRequestToolMessageContent::Array(parts) = &mut t.content {
+                    for part in parts.iter_mut() {
+                        if let Some(kind) = tool_kind(part) {
+                            *part = ChatCompletionRequestToolMessageContentPart::Text(
+                                ChatCompletionRequestMessageContentPartText {
+                                    text: format!("[{kind} omitted by audit]"),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(redacted)
+}
+
 pub fn create_handle(
     req: &NvCreateChatCompletionRequest,
     request_id: &str,
@@ -108,6 +214,7 @@ pub fn create_handle(
         request_id,
         super::config::capture_enabled(),
         policy.emit_request_payload_records(),
+        policy.redact_media,
         http_request_headers,
     )
 }
@@ -123,6 +230,7 @@ fn create_handle_with_config(
     request_id: &str,
     enabled: bool,
     emit_request_payload: bool,
+    redact_media_enabled: bool,
     http_request_headers: Option<Arc<BTreeMap<String, String>>>,
 ) -> Option<RequestPayloadHandle> {
     if !enabled || !emit_request_payload {
@@ -139,7 +247,15 @@ fn create_handle_with_config(
         // overrides stream/usage) and stamp arrival time on the producing
         // thread, so the record reflects what the client sent and when.
         event_time: SystemTime::now(),
-        request: Arc::new(req.clone()),
+        // When enabled, media is redacted BEFORE the snapshot, so no sink (file,
+        // stderr, otel) can observe raw image/video/audio bytes even transiently --
+        // see `redact_media`. Off by default (`DYN_REQUEST_TRACE_REDACT_MEDIA`), in
+        // which case the inbound request is recorded verbatim as it was before.
+        request: Arc::new(if redact_media_enabled {
+            redact_media(req).unwrap_or_else(|| req.clone())
+        } else {
+            req.clone()
+        }),
         http_request_headers,
     })
 }
@@ -180,7 +296,7 @@ mod tests {
     #[test]
     fn request_payload_records_emit_even_when_store_is_false() {
         let request = create_test_request("test-model", false);
-        let handle = create_handle_with_config(&request, "test-id", true, true, None);
+        let handle = create_handle_with_config(&request, "test-id", true, true, false, None);
 
         assert!(
             handle.is_some(),
@@ -191,7 +307,7 @@ mod tests {
     #[test]
     fn request_payload_records_disabled_skips_store_true_payloads() {
         let request = create_test_request("test-model", true);
-        let handle = create_handle_with_config(&request, "test-id", true, false, None);
+        let handle = create_handle_with_config(&request, "test-id", true, false, false, None);
 
         assert!(
             handle.is_none(),
@@ -349,5 +465,205 @@ mod tests {
         assert_eq!(second_payload.request_id, "payload-test-req-cancel");
         assert!(second_payload.request.is_some());
         assert!(second_payload.response.is_none());
+    }
+    // -------------------------------------------------------------------------
+    // Media redaction (patch F)
+    // -------------------------------------------------------------------------
+
+    fn req_from_json(v: serde_json::Value) -> NvCreateChatCompletionRequest {
+        serde_json::from_value(v).expect("request should deserialize")
+    }
+
+    /// Pure text: no clone, request untouched.
+    #[test]
+    fn redact_media_none_for_text_only() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hello"}]
+        }));
+        assert!(redact_media(&req).is_none());
+    }
+
+    /// Array of only text parts is still pure text.
+    #[test]
+    fn redact_media_none_for_text_parts_array() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        }));
+        assert!(redact_media(&req).is_none());
+    }
+
+    /// image_url in a USER message is replaced; the text sibling survives; the
+    /// ORIGINAL request is not mutated.
+    #[test]
+    fn redact_media_replaces_user_image_url() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,SECRET"}}
+            ]}]
+        }));
+        let out = redact_media(&req).expect("media present");
+        let v = serde_json::to_value(&out).unwrap();
+        let parts = &v["messages"][0]["content"];
+        assert_eq!(parts[0]["text"], "describe");
+        assert_eq!(parts[1]["text"], "[image_url omitted by audit]");
+        assert!(!serde_json::to_string(&v).unwrap().contains("SECRET"));
+        // original untouched
+        let orig = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            orig["messages"][0]["content"][1]["image_url"]["url"],
+            "data:image/png;base64,SECRET"
+        );
+    }
+
+    /// TOOL messages carry media too. The reference implementation this was ported
+    /// from scanned only user messages, which would leak here.
+    #[test]
+    fn redact_media_replaces_tool_media() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "go"},
+                {"role": "tool", "tool_call_id": "c1", "content": [
+                    {"type": "text", "text": "result"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,TOOLSECRET"}}
+                ]}
+            ]
+        }));
+        let out = redact_media(&req).expect("tool media should be detected");
+        let s = serde_json::to_string(&serde_json::to_value(&out).unwrap()).unwrap();
+        assert!(!s.contains("TOOLSECRET"), "tool media leaked: {s}");
+        assert!(s.contains("[image_url omitted by audit]"));
+        assert!(s.contains("result"), "text sibling must survive");
+    }
+
+    /// video_url and audio get their own placeholder kinds. Both are exercised: the
+    /// `AudioUrl` variant maps to the bare kind `audio`, not `audio_url`, so a copy-paste
+    /// of the video arm would not have caught a mislabelled audio placeholder.
+    #[test]
+    fn redact_media_labels_video_and_audio() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,VSECRET"}},
+                {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,ASECRET"}}
+            ]}]
+        }));
+        let out = redact_media(&req).expect("media present");
+        let s = serde_json::to_string(&serde_json::to_value(&out).unwrap()).unwrap();
+        assert!(s.contains("[video_url omitted by audit]"), "got {s}");
+        assert!(s.contains("[audio omitted by audit]"), "got {s}");
+        assert!(!s.contains("VSECRET"));
+        assert!(!s.contains("ASECRET"));
+    }
+
+    /// Every other test here calls `redact_media` directly. This one goes through the
+    /// real ingress hook, so a future bypass at `create_handle_with_config` -- the single
+    /// point where the pristine snapshot is taken -- cannot leave the helper tests green
+    /// while raw media reaches the file/stderr/OTLP sinks.
+    #[test]
+    fn create_handle_stores_redacted_request() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,HOOKSECRET"}}
+            ]}]
+        }));
+
+        let handle = create_handle_with_config(&req, "test-id", true, true, true, None)
+            .expect("payload handle should be created when capture is enabled");
+        let stored = serde_json::to_string(handle.request.as_ref()).unwrap();
+
+        assert!(
+            !stored.contains("HOOKSECRET"),
+            "raw media stored by the snapshot hook: {stored}"
+        );
+        assert!(
+            stored.contains("[image_url omitted by audit]"),
+            "got {stored}"
+        );
+    }
+
+    /// Redaction is OPT-IN (`DYN_REQUEST_TRACE_REDACT_MEDIA`, default off). With the
+    /// flag clear the snapshot must be byte-for-byte what the client sent, so enabling
+    /// request-trace payload records does not silently change record contents for
+    /// deployments that were already consuming them.
+    #[test]
+    fn create_handle_preserves_media_when_redaction_disabled() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,KEEPME"}}
+            ]}]
+        }));
+
+        let handle = create_handle_with_config(&req, "test-id", true, true, false, None)
+            .expect("payload handle should be created when capture is enabled");
+        let stored = serde_json::to_string(handle.request.as_ref()).unwrap();
+
+        assert!(stored.contains("KEEPME"), "media was redacted: {stored}");
+        assert!(
+            !stored.contains("omitted by audit"),
+            "placeholder leaked with redaction off: {stored}"
+        );
+    }
+
+    /// Redaction ON, no media: the overwhelmingly common case. `redact_media` returns
+    /// `None` here (scan only, no clone), so the hook must fall back to the request
+    /// unchanged -- a regression in that fallback would corrupt or drop content on
+    /// effectively all traffic, not just multimodal traffic.
+    #[test]
+    fn create_handle_leaves_text_only_request_intact_when_redaction_enabled() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "just text"}]
+        }));
+
+        let handle = create_handle_with_config(&req, "test-id", true, true, true, None)
+            .expect("payload handle should be created when capture is enabled");
+        let stored = serde_json::to_value(handle.request.as_ref()).unwrap();
+
+        assert_eq!(stored, serde_json::to_value(&req).unwrap());
+    }
+
+    /// A `/v1/responses` request carries media as `{"type": "input_image", ...}` --
+    /// a shape `redact_media` never sees directly. The HTTP handler converts
+    /// `NvCreateResponse` -> `UnifiedRequest` -> `NvCreateChatCompletionRequest`
+    /// (`unified.rs`, delegating to `responses::mod.rs`) BEFORE the preprocessor takes
+    /// the trace snapshot, and that conversion maps `InputContent::InputImage` onto
+    /// `ChatCompletionRequestUserMessageContentPart::ImageUrl`.
+    ///
+    /// So the Responses API is covered only *by construction*, and nothing pinned it.
+    /// If a future direct Responses path skips the chat conversion, or the conversion
+    /// stops producing `ImageUrl`, raw media would reach every sink and no other test
+    /// in this file would notice -- they all start from a chat-shaped request.
+    #[test]
+    fn redact_media_covers_responses_api_input_image() {
+        use crate::protocols::openai::responses::NvCreateResponse;
+
+        let json = serde_json::json!({
+            "model": "m",
+            "input": [{
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "describe"},
+                    {"type": "input_image", "image_url": "data:image/png;base64,RSECRET"}
+                ]
+            }]
+        });
+        let responses_req: NvCreateResponse =
+            serde_json::from_value(json).expect("responses request should deserialize");
+        let chat: NvCreateChatCompletionRequest = responses_req
+            .try_into()
+            .expect("responses -> chat conversion should succeed");
+
+        let out = redact_media(&chat).expect("input_image must be media after conversion");
+        let s = serde_json::to_string(&serde_json::to_value(&out).unwrap()).unwrap();
+        assert!(!s.contains("RSECRET"), "responses-api image leaked: {s}");
+        assert!(s.contains("[image_url omitted by audit]"), "got {s}");
+        assert!(s.contains("describe"), "text sibling must survive: {s}");
     }
 }

--- a/lib/llm/src/request_trace/payload.rs
+++ b/lib/llm/src/request_trace/payload.rs
@@ -94,6 +94,112 @@ impl RequestPayloadHandle {
     }
 }
 
+/// Replace media (image/video/audio) request content with text placeholders so the
+/// request-trace pipeline never records raw media bytes or URLs.
+///
+/// Payload records carry the full inbound request; for multimodal requests that
+/// includes base64 data URIs or media URLs, which must not be persisted to any sink
+/// (size, and privacy — the OTLP sink forwards to a collector).
+///
+/// Applied where the pristine snapshot is taken, so no sink can observe media even
+/// transiently, and both `create_handle` call sites are covered by construction.
+///
+/// Cost: pure-text requests pay only a scan (a borrow); the clone happens only when
+/// at least one media part is present.
+///
+/// Returns `Some(redacted)` if any message carries a media part, `None` for pure text.
+///
+/// NOTE: BOTH `User` and `Tool` messages can carry media parts — `preprocessor.rs`
+/// converts tool media parts to user parts for multimodal processing. Scanning only
+/// user messages would leak media supplied in tool results.
+fn redact_media(req: &NvCreateChatCompletionRequest) -> Option<NvCreateChatCompletionRequest> {
+    use dynamo_protocols::types::{
+        ChatCompletionRequestMessage, ChatCompletionRequestMessageContentPartText,
+        ChatCompletionRequestToolMessageContent, ChatCompletionRequestToolMessageContentPart,
+        ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
+    };
+
+    // `None` => text, keep as-is. `Some(kind)` => media, replace with a placeholder
+    // naming `kind`. The trailing catch-all is unreachable for the enum as defined
+    // today; it is kept as a fail-closed net so a newly added media variant is
+    // redacted as "unknown" rather than leaked.
+    fn user_kind(part: &ChatCompletionRequestUserMessageContentPart) -> Option<&'static str> {
+        #[allow(unreachable_patterns)]
+        match part {
+            ChatCompletionRequestUserMessageContentPart::Text(_) => None,
+            ChatCompletionRequestUserMessageContentPart::ImageUrl(_) => Some("image_url"),
+            ChatCompletionRequestUserMessageContentPart::VideoUrl(_) => Some("video_url"),
+            ChatCompletionRequestUserMessageContentPart::AudioUrl(_) => Some("audio"),
+            _ => Some("unknown"),
+        }
+    }
+    fn tool_kind(part: &ChatCompletionRequestToolMessageContentPart) -> Option<&'static str> {
+        #[allow(unreachable_patterns)]
+        match part {
+            ChatCompletionRequestToolMessageContentPart::Text(_) => None,
+            ChatCompletionRequestToolMessageContentPart::ImageUrl(_) => Some("image_url"),
+            ChatCompletionRequestToolMessageContentPart::VideoUrl(_) => Some("video_url"),
+            ChatCompletionRequestToolMessageContentPart::AudioUrl(_) => Some("audio"),
+            _ => Some("unknown"),
+        }
+    }
+
+    // ---- Phase 1: scan only, no clone. ----
+    let has_media = req.inner.messages.iter().any(|msg| match msg {
+        ChatCompletionRequestMessage::User(u) => match &u.content {
+            ChatCompletionRequestUserMessageContent::Array(parts) => {
+                parts.iter().any(|p| user_kind(p).is_some())
+            }
+            _ => false,
+        },
+        ChatCompletionRequestMessage::Tool(t) => match &t.content {
+            ChatCompletionRequestToolMessageContent::Array(parts) => {
+                parts.iter().any(|p| tool_kind(p).is_some())
+            }
+            _ => false,
+        },
+        _ => false,
+    });
+    if !has_media {
+        return None;
+    }
+
+    // ---- Phase 2: media present. Clone once, rewrite in place. ----
+    let mut redacted = req.clone();
+    for msg in redacted.inner.messages.iter_mut() {
+        match msg {
+            ChatCompletionRequestMessage::User(u) => {
+                if let ChatCompletionRequestUserMessageContent::Array(parts) = &mut u.content {
+                    for part in parts.iter_mut() {
+                        if let Some(kind) = user_kind(part) {
+                            *part = ChatCompletionRequestUserMessageContentPart::Text(
+                                ChatCompletionRequestMessageContentPartText {
+                                    text: format!("[{kind} omitted by audit]"),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            ChatCompletionRequestMessage::Tool(t) => {
+                if let ChatCompletionRequestToolMessageContent::Array(parts) = &mut t.content {
+                    for part in parts.iter_mut() {
+                        if let Some(kind) = tool_kind(part) {
+                            *part = ChatCompletionRequestToolMessageContentPart::Text(
+                                ChatCompletionRequestMessageContentPartText {
+                                    text: format!("[{kind} omitted by audit]"),
+                                },
+                            );
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Some(redacted)
+}
+
 pub fn create_handle(
     req: &NvCreateChatCompletionRequest,
     request_id: &str,
@@ -139,7 +245,9 @@ fn create_handle_with_config(
         // overrides stream/usage) and stamp arrival time on the producing
         // thread, so the record reflects what the client sent and when.
         event_time: SystemTime::now(),
-        request: Arc::new(req.clone()),
+        // Media is redacted BEFORE the snapshot, so no sink (file, stderr, otel)
+        // can ever observe raw image/video/audio bytes -- see `redact_media`.
+        request: Arc::new(redact_media(req).unwrap_or_else(|| req.clone())),
         http_request_headers,
     })
 }
@@ -350,4 +458,93 @@ mod tests {
         assert!(second_payload.request.is_some());
         assert!(second_payload.response.is_none());
     }
+    // -------------------------------------------------------------------------
+    // Media redaction (patch F)
+    // -------------------------------------------------------------------------
+
+    fn req_from_json(v: serde_json::Value) -> NvCreateChatCompletionRequest {
+        serde_json::from_value(v).expect("request should deserialize")
+    }
+
+    /// Pure text: no clone, request untouched.
+    #[test]
+    fn redact_media_none_for_text_only() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": "hello"}]
+        }));
+        assert!(redact_media(&req).is_none());
+    }
+
+    /// Array of only text parts is still pure text.
+    #[test]
+    fn redact_media_none_for_text_parts_array() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        }));
+        assert!(redact_media(&req).is_none());
+    }
+
+    /// image_url in a USER message is replaced; the text sibling survives; the
+    /// ORIGINAL request is not mutated.
+    #[test]
+    fn redact_media_replaces_user_image_url() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "describe"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,SECRET"}}
+            ]}]
+        }));
+        let out = redact_media(&req).expect("media present");
+        let v = serde_json::to_value(&out).unwrap();
+        let parts = &v["messages"][0]["content"];
+        assert_eq!(parts[0]["text"], "describe");
+        assert_eq!(parts[1]["text"], "[image_url omitted by audit]");
+        assert!(!serde_json::to_string(&v).unwrap().contains("SECRET"));
+        // original untouched
+        let orig = serde_json::to_value(&req).unwrap();
+        assert_eq!(
+            orig["messages"][0]["content"][1]["image_url"]["url"],
+            "data:image/png;base64,SECRET"
+        );
+    }
+
+    /// TOOL messages carry media too. The reference implementation this was ported
+    /// from scanned only user messages, which would leak here.
+    #[test]
+    fn redact_media_replaces_tool_media() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [
+                {"role": "user", "content": "go"},
+                {"role": "tool", "tool_call_id": "c1", "content": [
+                    {"type": "text", "text": "result"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,TOOLSECRET"}}
+                ]}
+            ]
+        }));
+        let out = redact_media(&req).expect("tool media should be detected");
+        let s = serde_json::to_string(&serde_json::to_value(&out).unwrap()).unwrap();
+        assert!(!s.contains("TOOLSECRET"), "tool media leaked: {s}");
+        assert!(s.contains("[image_url omitted by audit]"));
+        assert!(s.contains("result"), "text sibling must survive");
+    }
+
+    /// video_url and audio get their own placeholder kinds.
+    #[test]
+    fn redact_media_labels_video_and_audio() {
+        let req = req_from_json(serde_json::json!({
+            "model": "m",
+            "messages": [{"role": "user", "content": [
+                {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,VSECRET"}}
+            ]}]
+        }));
+        let out = redact_media(&req).expect("media present");
+        let s = serde_json::to_string(&serde_json::to_value(&out).unwrap()).unwrap();
+        assert!(s.contains("[video_url omitted by audit]"), "got {s}");
+        assert!(!s.contains("VSECRET"));
+    }
+
 }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -531,6 +531,18 @@ pub mod llm {
         /// `request_payload`, `tool`.
         pub const DYN_REQUEST_TRACE_RECORDS: &str = "DYN_REQUEST_TRACE_RECORDS";
 
+        /// Redact media (image / video / audio) request content parts to text
+        /// placeholders before the trace snapshot is taken. Truthy enables redaction.
+        ///
+        /// **Off by default**: records otherwise carry inbound media verbatim --
+        /// including multi-MB base64 data URIs -- to every configured sink, and the
+        /// `otel` sink forwards them off-box to a collector. Enable this on
+        /// deployments where raw media must not leave the process.
+        ///
+        /// Only the trace snapshot is rewritten; the request forwarded to the engine
+        /// is untouched either way.
+        pub const DYN_REQUEST_TRACE_REDACT_MEDIA: &str = "DYN_REQUEST_TRACE_REDACT_MEDIA";
+
         /// NATS subject the request trace sink publishes to.
         pub const DYN_REQUEST_TRACE_NATS_SUBJECT: &str = "DYN_REQUEST_TRACE_NATS_SUBJECT";
 


### PR DESCRIPTION
> **Context: one of six fixes from bringing up [`thinkingmachines/inkling`](https://huggingface.co/thinkingmachines/inkling) on Dynamo + vLLM** (4×GB200, TP=4, arm64). Sibling PRs from the same bring-up: #12507, #12510, #12541, #12511. Found while auditing payload traces on a multimodal deployment that exports to OTLP. The leak is general — it affects any deployment with `DYN_REQUEST_TRACE_RECORDS=request_payload` serving image or video input. Pairs with #12511, which emits these records on the BYO chat-processor path.

## Problem

`request_payload` records carry the full inbound request. For multimodal requests that includes base64 data URIs and media URLs, and they are written **verbatim** to every configured sink — file, stderr, and OTLP. On a deployment exporting to an OTLP collector, raw image/video bytes leave the process.

Observed on a multimodal deployment: a 1×1 PNG sent as an `image_url` part appears unredacted in the record.

```json
{"type":"image_url","image_url":{"url":"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA…"}}
```

## Fix

Add an **opt-in** redaction pass, `DYN_REQUEST_TRACE_REDACT_MEDIA` (**off by default**), that replaces media parts with a text placeholder **before the pristine snapshot is taken**:

```
{"type":"image_url","image_url":{...}}  ->  {"type":"text","text":"[image_url omitted by audit]"}
```

### Configuration

| | |
|---|---|
| env var | `DYN_REQUEST_TRACE_REDACT_MEDIA` |
| default | **off** — records carry inbound media verbatim, as they do today |
| when set truthy | media parts become `[<kind> omitted by audit]` before any sink sees them |

Off by default so that enabling request-trace payload records does not silently change
what those records contain for deployments already consuming them, and so multimodal
debugging / replay workflows that need the media keep working. The resolved value is
logged on the existing `Request trace initialized` line next to `records` and `sinks`,
so which mode a deployment is in is readable straight from its startup logs.

⚠️ Worth stating plainly for reviewers: with the default, a deployment exporting
`request_payload` records to an OTLP collector **does** ship raw base64 media off-box.
That is the pre-existing behaviour, not a regression introduced here — this PR adds the
means to stop it, and leaves the choice to the operator.

Placed inside `create_handle_with_config` rather than at the call sites, which means:

- **both producers are covered by construction** — the Rust preprocessor (`preprocessor.rs`) and the chat-processor wrapper;
- **every sink is covered**, because they all serialise the same snapshot;
- no sink can observe media even transiently.

Only the trace snapshot is rewritten — the request forwarded to the engine is untouched.

### Tool messages are scanned, not just user messages

This is the non-obvious part. `ChatCompletionRequestToolMessageContentPart` carries the same `ImageUrl`/`VideoUrl`/`AudioUrl` variants as the user enum, and `preprocessor.rs` converts tool media parts to user parts for multimodal processing. **Scanning only user messages would leak media supplied in tool results.** One of the tests fails specifically on that case.

### Cost

Pure-text requests pay a **scan, not a clone** — the request is cloned only when at least one media part is present. That matches the previous behaviour, which cloned unconditionally, so this is not a regression for text and is one clone (not two) for media.

The match arms are exhaustive for the enums as defined today; the trailing catch-all is kept under `#[allow(unreachable_patterns)]` as a fail-closed net, so a newly added media variant is redacted as `unknown` rather than leaked.

## Test

Eleven unit tests, covering the flag in **both states at both layers**.

**Flag ON/OFF at the snapshot hook** (`create_handle_with_config`, `payload.rs`):

| flag | request | expected |
|---|---|---|
| on | has media | redacted to placeholders |
| off | has media | **preserved verbatim** |
| on | text-only | **byte-identical** to the inbound request |

That last row guards the `redact_media` → `None` fallback: a regression there would
corrupt or drop content on effectively *all* traffic, not just multimodal.

**Flag ON/OFF at config load** (`load_from_env`, `config.rs`):

| env | expected |
|---|---|
| unset | off |
| truthy (`1`) | on |
| falsey (`0`, `false`, `off`, `no`, empty) | **off** |

The falsey row pins that this reads through `lib/truthy` rather than checking presence —
under an `env::var(..).is_ok()` check, writing `DYN_REQUEST_TRACE_REDACT_MEDIA=0` would
silently mean ON. (The full accepted-spelling matrix is owned by `lib/truthy`, which also
carries a workspace test forbidding hand-rolled bool parsers.)

**Redaction helper itself:**

- pure-text (plain string) → `None`, no clone
- text-only parts array → `None`
- user `image_url` → replaced; **text sibling survives**; **original request not mutated**
- **tool-message media → replaced** (fails if only user messages were scanned)
- `video_url` / `audio_url` → distinct `[video_url …]` / `[audio …]` placeholder kinds
- **`/v1/responses` `input_image` → replaced** (see below)

### Responses API coverage

`/v1/responses` carries media as `{"type": "input_image", "image_url": "…"}` — a shape `redact_media` never sees directly. It **is** covered, but only *by construction*: the handler converts `NvCreateResponse` → `UnifiedRequest` (`unified.rs:193`) → `NvCreateChatCompletionRequest` before the preprocessor takes the snapshot, and `responses/mod.rs:278` maps `InputContent::InputImage` onto `ChatCompletionRequestUserMessageContentPart::ImageUrl`.

Nothing pinned that. Every other test here starts from an already chat-shaped request, so a future direct Responses path — or a change to that conversion — could bypass redaction with all of them still passing. The sixth test drives a real `/v1/responses` payload through the conversion to hold that composition in place.

(`InputVideo` / `InputAudio` are not supported on the Responses path at all today — there is an explicit TODO in `responses/mod.rs`, and `InputFile` errors.)

✅ **Rebased onto `main` (`a97a2b8`) and CI is green** — 21 checks pass, 0 fail; `rust-tests (.)` passes in 29m55s with all six `request_trace::payload::tests::redact_media_*` cases green.

The earlier CI red was **not** a test failure: `cargo fmt --check` objected to a single stray blank line before the closing brace of `mod tests`. Worth flagging that the Datadog comment on this PR reports it as *"expected string to contain the video URL placeholder but it contained sensitive information"* — that summary is inaccurate. It was generated from source lines that merely appeared in the fmt diff; no assertion failed and nothing leaked.

## Relationship to earlier drafts

This supersedes the redaction half of #10415, which was written against the old `lib/llm/src/audit/` module before it became `request_trace`, and applied at `AuditHandle::set_request`. Two substantive differences beyond the relocation:

1. #10415 scans only user messages, with the rationale that tool contents are "text/refusal/tool-call shapes only" — that is not true of the current enum, hence the tool coverage here.
2. #10415 matches an `InputAudio` variant that does not exist at this commit; it would not compile as-is.

Happy to close #10415/#10416 in favour of this, or rebase them, whichever maintainers prefer.

## Notes

Filed as a **draft** — happy to attach a Linear ID and rename the branch to the `<login>/<desc>__<DYN-ID>` convention before review.

The placeholder string `[<kind> omitted by audit]` is deliberately kept verbatim from the earlier draft: downstream log filters and verification probes match on `omitted by audit`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added media redaction for request traces, replacing images, audio, and video with descriptive placeholders.
  * Redaction applies to both user and tool messages before request snapshots are stored.

* **Bug Fixes**
  * Preserved the original request content while creating redacted traces.
  * Ensured text-only requests remain unchanged.
  * Added support for image conversion in Responses API traces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



