### PR TITLE
fix(sglang): restore TP non-leader readiness

### DIFF
--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -73,7 +73,7 @@ async def init_llm_diffusion(
     assert publisher is not None, "setup_sgl_metrics returned None on chat path"
 
     if server_args.node_rank >= 1:
-        await handle_non_leader_node(engine, publisher, metrics_task)
+        await handle_non_leader_node(runtime, engine, publisher, metrics_task)
         return
 
     ready_event = asyncio.Event()

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -104,7 +104,7 @@ async def init_decode(
     logging.debug(f"SGLang model load time: {load_time:.2f}s")
 
     if server_args.node_rank >= 1:
-        await handle_non_leader_node(engine, publisher, metrics_task)
+        await handle_non_leader_node(runtime, engine, publisher, metrics_task)
         return
 
     ready_event = asyncio.Event()
@@ -259,7 +259,7 @@ async def init_prefill(
     publisher.component_gauges.set_model_load_time(load_time)
 
     if server_args.node_rank >= 1:
-        await handle_non_leader_node(engine, publisher, metrics_task)
+        await handle_non_leader_node(runtime, engine, publisher, metrics_task)
         return
 
     try:

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -579,8 +579,9 @@ async def handle_non_leader_node(
     native rank-local readiness contract.
     """
     logging.info(
-        f"Non-leader node detected (node_rank={engine.server_args.node_rank}). "
-        "Running rank-local readiness and metrics."
+        "Non-leader node detected (node_rank=%s). "
+        "Running rank-local readiness and metrics.",
+        engine.server_args.node_rank,
     )
 
     runtime.set_health_status(True)
@@ -604,6 +605,7 @@ async def handle_non_leader_node(
                 await metrics_task
             except asyncio.CancelledError:
                 pass
-            publisher.cleanup()
+            finally:
+                publisher.cleanup()
         finally:
             runtime.set_health_status(False)

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -557,6 +557,7 @@ async def setup_sgl_metrics(
 
 
 async def handle_non_leader_node(
+    runtime,
     engine: sgl.Engine,
     publisher: DynamoSglangPublisher,
     metrics_task: asyncio.Task,
@@ -566,15 +567,23 @@ async def handle_non_leader_node(
 
     Non-leader nodes run scheduler processes but don't handle requests directly.
     They still need:
-    - KV event publishing (subscribe to local DP ranks, forward to NATS)
+    - KV event publishing for local DP-attention ranks
     - Metrics collection from local schedulers
     - Prometheus metrics exposure
+
+    Native SGLang starts the non-zero-rank dummy health server only after
+    scheduler initialization reports ready. Dynamo disables that dummy server via
+    ``SGLANG_BLOCK_NONZERO_RANK_CHILDREN=0`` so the Engine constructor can
+    return; reaching this function means that same scheduler-ready barrier has
+    already passed. Mark the Dynamo system health ready here to preserve the
+    native rank-local readiness contract.
     """
     logging.info(
         f"Non-leader node detected (node_rank={engine.server_args.node_rank}). "
-        "Running with metrics and KV event publishing for local DP ranks."
+        "Running rank-local readiness and metrics."
     )
 
+    runtime.set_health_status(True)
     try:
         if publisher.dynamo_args.use_kv_events and publishes_kv_events(
             publisher.server_args
@@ -589,9 +598,12 @@ async def handle_non_leader_node(
 
         await asyncio.Event().wait()
     finally:
-        metrics_task.cancel()
         try:
-            await metrics_task
-        except asyncio.CancelledError:
-            pass
-        publisher.cleanup()
+            metrics_task.cancel()
+            try:
+                await metrics_task
+            except asyncio.CancelledError:
+                pass
+            publisher.cleanup()
+        finally:
+            runtime.set_health_status(False)

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -536,6 +536,50 @@ async def test_handle_non_leader_node_clears_ready_on_error(
         await metrics_task
 
 
+@pytest.mark.asyncio
+async def test_handle_non_leader_node_cleans_up_when_metrics_task_fails_on_cancel():
+    runtime = FakeRuntime()
+    cleanup_called = asyncio.Event()
+
+    async def fail_on_cancel():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            raise RuntimeError("metrics failed during shutdown") from exc
+
+    publisher = SimpleNamespace(
+        generate_endpoint=object(),
+        server_args=SimpleNamespace(
+            nnodes=2,
+            node_rank=1,
+            dp_size=1,
+            enable_dp_attention=False,
+            kv_events_config=None,
+        ),
+        dynamo_args=SimpleNamespace(use_kv_events=True),
+        cleanup=cleanup_called.set,
+    )
+    metrics_task = asyncio.create_task(fail_on_cancel())
+    task = asyncio.create_task(
+        handle_non_leader_node(
+            runtime,
+            SimpleNamespace(server_args=SimpleNamespace(node_rank=1)),
+            publisher,
+            metrics_task,
+        )
+    )
+
+    await asyncio.sleep(0)
+    assert runtime.health_calls == [True]
+
+    task.cancel()
+    with pytest.raises(RuntimeError, match="metrics failed during shutdown"):
+        await task
+
+    assert cleanup_called.is_set()
+    assert runtime.health_calls == [True, False]
+
+
 def test_init_kv_event_publish_uses_worker_id_override(monkeypatch):
     calls = []
 

--- a/components/src/dynamo/sglang/tests/test_sglang_publisher.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_publisher.py
@@ -86,6 +86,14 @@ class FakeNetworkAddress:
         return f"tcp://{self.host}:{self.port}"
 
 
+class FakeRuntime:
+    def __init__(self):
+        self.health_calls = []
+
+    def set_health_status(self, ready):
+        self.health_calls.append(ready)
+
+
 def test_sglang_worker_group_id_matches_across_node_ranks(monkeypatch):
     monkeypatch.setattr(disagg_mod, "_network_address_cls", lambda: FakeNetworkAddress)
     node0_args = SimpleNamespace(nnodes=2, node_rank=0, dist_init_addr="10.0.0.1:2345")
@@ -247,10 +255,10 @@ async def test_handle_non_leader_node_resolves_worker_before_kv_publish(monkeypa
             return FakeClient()
 
     server_args = SimpleNamespace(
-        dp_size=2,
-        enable_dp_attention=True,
         nnodes=2,
         node_rank=1,
+        dp_size=8,
+        enable_dp_attention=True,
         dist_timeout=5,
         kv_events_config='{"endpoint": "tcp://*:5557"}',
     )
@@ -277,6 +285,7 @@ async def test_handle_non_leader_node_resolves_worker_before_kv_publish(monkeypa
     metrics_task = asyncio.create_task(asyncio.Event().wait())
     task = asyncio.create_task(
         handle_non_leader_node(
+            FakeRuntime(),
             SimpleNamespace(server_args=server_args),
             FakePublisher(),
             metrics_task,
@@ -309,6 +318,7 @@ async def test_handle_non_leader_node_skips_tp_only_kv_event_setup(monkeypatch):
         nnodes=2,
         node_rank=1,
     )
+    runtime = FakeRuntime()
     cleanup = Mock()
     publisher = SimpleNamespace(
         server_args=server_args,
@@ -322,6 +332,7 @@ async def test_handle_non_leader_node_skips_tp_only_kv_event_setup(monkeypatch):
     metrics_task = asyncio.create_task(asyncio.Event().wait())
     task = asyncio.create_task(
         handle_non_leader_node(
+            runtime,
             SimpleNamespace(server_args=server_args),
             publisher,
             metrics_task,
@@ -332,6 +343,7 @@ async def test_handle_non_leader_node_skips_tp_only_kv_event_setup(monkeypatch):
 
     resolve_leader.assert_not_awaited()
     kv_event_publisher.assert_not_called()
+    assert runtime.health_calls == [True]
     assert not task.done()
 
     task.cancel()
@@ -339,6 +351,7 @@ async def test_handle_non_leader_node_skips_tp_only_kv_event_setup(monkeypatch):
         await task
     cleanup.assert_called_once_with()
     assert metrics_task.cancelled()
+    assert runtime.health_calls == [True, False]
 
 
 @pytest.mark.asyncio
@@ -355,7 +368,13 @@ async def test_handle_non_leader_node_skips_kv_publish_without_resolved_worker(
 
     class FakePublisher:
         generate_endpoint = object()
-        server_args = SimpleNamespace(kv_events_config='{"endpoint": "tcp://*:5557"}')
+        server_args = SimpleNamespace(
+            nnodes=2,
+            node_rank=1,
+            dp_size=8,
+            enable_dp_attention=True,
+            kv_events_config='{"endpoint": "tcp://*:5557"}',
+        )
         dynamo_args = SimpleNamespace(use_kv_events=True)
         kv_worker_id = None
 
@@ -373,6 +392,7 @@ async def test_handle_non_leader_node_skips_kv_publish_without_resolved_worker(
     metrics_task = asyncio.create_task(asyncio.Event().wait())
     task = asyncio.create_task(
         handle_non_leader_node(
+            FakeRuntime(),
             SimpleNamespace(server_args=SimpleNamespace(node_rank=1)),
             FakePublisher(),
             metrics_task,
@@ -401,7 +421,13 @@ async def test_handle_non_leader_node_cleans_up_when_resolution_fails(monkeypatc
 
     class FakePublisher:
         generate_endpoint = object()
-        server_args = SimpleNamespace(kv_events_config='{"endpoint": "tcp://*:5557"}')
+        server_args = SimpleNamespace(
+            nnodes=2,
+            node_rank=1,
+            dp_size=8,
+            enable_dp_attention=True,
+            kv_events_config='{"endpoint": "tcp://*:5557"}',
+        )
         dynamo_args = SimpleNamespace(use_kv_events=True)
 
         def cleanup(self):
@@ -416,6 +442,7 @@ async def test_handle_non_leader_node_cleans_up_when_resolution_fails(monkeypatc
 
     with pytest.raises(RuntimeError, match="resolution failed"):
         await handle_non_leader_node(
+            FakeRuntime(),
             SimpleNamespace(server_args=SimpleNamespace(node_rank=1)),
             FakePublisher(),
             metrics_task,
@@ -423,6 +450,90 @@ async def test_handle_non_leader_node_cleans_up_when_resolution_fails(monkeypatc
 
     assert cleanup_called.is_set()
     assert metrics_task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_handle_non_leader_node_marks_ready_until_cancel(
+    monkeypatch,
+):
+    entered = asyncio.Event()
+    runtime = FakeRuntime()
+
+    async def wait_forever(generate_endpoint, server_args):
+        entered.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        publisher_mod, "_resolve_multinode_leader_worker_id", wait_forever
+    )
+    metrics_task = asyncio.create_task(asyncio.Event().wait())
+    task = asyncio.create_task(
+        handle_non_leader_node(
+            runtime,
+            SimpleNamespace(server_args=SimpleNamespace(node_rank=1)),
+            SimpleNamespace(
+                generate_endpoint=object(),
+                server_args=SimpleNamespace(
+                    nnodes=2,
+                    node_rank=1,
+                    dp_size=8,
+                    enable_dp_attention=True,
+                    kv_events_config=None,
+                ),
+                dynamo_args=SimpleNamespace(use_kv_events=True),
+                cleanup=lambda: None,
+            ),
+            metrics_task,
+        )
+    )
+
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    assert runtime.health_calls == [True]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert runtime.health_calls == [True, False]
+    metrics_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await metrics_task
+
+
+@pytest.mark.asyncio
+async def test_handle_non_leader_node_clears_ready_on_error(
+    monkeypatch,
+):
+    runtime = FakeRuntime()
+
+    async def fail(generate_endpoint, server_args):
+        raise RuntimeError("non-leader failed")
+
+    monkeypatch.setattr(publisher_mod, "_resolve_multinode_leader_worker_id", fail)
+    metrics_task = asyncio.create_task(asyncio.Event().wait())
+
+    with pytest.raises(RuntimeError, match="non-leader failed"):
+        await handle_non_leader_node(
+            runtime,
+            SimpleNamespace(server_args=SimpleNamespace(node_rank=1)),
+            SimpleNamespace(
+                generate_endpoint=object(),
+                server_args=SimpleNamespace(
+                    nnodes=2,
+                    node_rank=1,
+                    dp_size=8,
+                    enable_dp_attention=True,
+                    kv_events_config=None,
+                ),
+                dynamo_args=SimpleNamespace(use_kv_events=True),
+                cleanup=lambda: None,
+            ),
+            metrics_task,
+        )
+
+    assert runtime.health_calls == [True, False]
+    metrics_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await metrics_task
 
 
 def test_init_kv_event_publish_uses_worker_id_override(monkeypatch):


### PR DESCRIPTION
## Summary

- restore SGLang non-leader rank readiness by marking Dynamo system health ready only after the Engine has passed the scheduler-ready barrier
- keep non-leader SGLang nodes resident for metrics and clear readiness during cleanup/error paths
- avoid KV event publishing from TP-only non-leader nodes by using the existing publishes_kv_events gate

Fixes #12555

## Validation

- `python3 -m py_compile components/src/dynamo/sglang/publisher.py components/src/dynamo/sglang/init_llm.py components/src/dynamo/sglang/init_diffusion.py components/src/dynamo/sglang/tests/test_sglang_publisher.py components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py`
- `python3 -m pytest components/src/dynamo/sglang/tests/test_sglang_publisher.py components/src/dynamo/sglang/tests/test_sglang_local_dp_ranks.py -q` *(not run: local Python environment has no pytest module)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness reporting for distributed inference workers.
  * Worker health is now marked ready only after local scheduler initialization completes.
  * Health status is reliably cleared during shutdown, cancellation, or initialization failures.

* **Tests**
  * Added coverage for readiness transitions during successful, delayed, and failed worker initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->