### PR TITLE
fix(vllm): publish KV gauges from prefill workers

### DIFF
--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -24,22 +24,28 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
 
     def __init__(
         self,
-        endpoint: Endpoint,
+        endpoint: Optional[Endpoint] = None,
         dp_rank: int = 0,
         component_gauges: Optional[LLMBackendMetrics] = None,
     ) -> None:
         self.inner = WorkerMetricsPublisher()
-        self._endpoint = endpoint
         self.dp_rank = dp_rank
         self.component_gauges = component_gauges or LLMBackendMetrics()
         self.num_gpu_block = 1
-        # Schedule async endpoint creation
-        self._endpoint_task = asyncio.create_task(self._create_endpoint())
+        self._endpoint_task: Optional[asyncio.Task[None]] = None
+        if endpoint is not None:
+            self.bind_endpoint(endpoint)
 
-    async def _create_endpoint(self) -> None:
+    def bind_endpoint(self, endpoint: Endpoint) -> None:
+        """Attach the runtime endpoint after snapshot restore if necessary."""
+        if self._endpoint_task is not None:
+            raise RuntimeError("vLLM stat logger endpoint is already bound")
+        self._endpoint_task = asyncio.create_task(self._create_endpoint(endpoint))
+
+    async def _create_endpoint(self, endpoint: Endpoint) -> None:
         """Create the NATS endpoint asynchronously."""
         try:
-            await self.inner.create_endpoint(self._endpoint)
+            await self.inner.create_endpoint(endpoint)
             logging.debug("vLLM metrics publisher endpoint created")
         except Exception:
             logging.exception("Failed to create vLLM metrics publisher endpoint")
@@ -134,7 +140,7 @@ class StatLoggerFactory:
 
     def __init__(
         self,
-        endpoint: Endpoint,
+        endpoint: Optional[Endpoint] = None,
         component_gauges: Optional[LLMBackendMetrics] = None,
         embedding_worker: bool = False,
     ) -> None:
@@ -165,6 +171,14 @@ class StatLoggerFactory:
 
     def __call__(self, vllm_config: VllmConfig, dp_rank: int) -> StatLoggerBase:
         return self.create_stat_logger(dp_rank=dp_rank)
+
+    def bind_endpoint(self, endpoint: Endpoint) -> None:
+        """Bind a factory created before the Dynamo runtime was available."""
+        if self.endpoint is not None:
+            raise RuntimeError("vLLM stat logger factory endpoint is already bound")
+        self.endpoint = endpoint
+        if self.created_logger is not None:
+            self.created_logger.bind_endpoint(endpoint)
 
     # TODO Remove once we publish metadata to shared storage
     def set_num_gpu_blocks_all(self, num_blocks: int) -> None:

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -147,7 +147,7 @@ class StatLoggerFactory:
         self.endpoint = endpoint
         self.component_gauges = component_gauges
         self.embedding_worker = embedding_worker
-        self.created_logger: Optional[DynamoStatLoggerPublisher] = None
+        self.created_loggers: list[DynamoStatLoggerPublisher] = []
 
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
         # Embedding workers have no KV cache and no scheduler stats worth
@@ -165,7 +165,7 @@ class StatLoggerFactory:
             dp_rank=dp_rank,
             component_gauges=self.component_gauges,
         )
-        self.created_logger = logger
+        self.created_loggers.append(logger)
 
         return logger
 
@@ -177,14 +177,14 @@ class StatLoggerFactory:
         if self.endpoint is not None:
             raise RuntimeError("vLLM stat logger factory endpoint is already bound")
         self.endpoint = endpoint
-        if self.created_logger is not None:
-            self.created_logger.bind_endpoint(endpoint)
+        for logger in self.created_loggers:
+            logger.bind_endpoint(endpoint)
 
     # TODO Remove once we publish metadata to shared storage
     def set_num_gpu_blocks_all(self, num_blocks: int) -> None:
-        if self.created_logger:
-            self.created_logger.set_num_gpu_block(num_blocks)
+        for logger in self.created_loggers:
+            logger.set_num_gpu_block(num_blocks)
 
     def init_publish(self) -> None:
-        if self.created_logger:
-            self.created_logger.init_publish()
+        for logger in self.created_loggers:
+            logger.init_publish()

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -84,7 +84,7 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
     def init_publish(self) -> None:
         self.inner.publish(self.dp_rank, kv_used_blocks=0)
         dp_rank_str = str(self.dp_rank)
-        self.component_gauges.set_total_blocks(dp_rank_str, 0)
+        self.component_gauges.set_total_blocks(dp_rank_str, self.num_gpu_block)
         self.component_gauges.set_gpu_cache_usage(dp_rank_str, 0.0)
 
     def log_engine_initialized(self) -> None:

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -89,7 +89,7 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
     def init_publish(self) -> None:
         self.inner.publish(self.dp_rank, kv_used_blocks=0)
         dp_rank_str = str(self.dp_rank)
-        self.component_gauges.set_total_blocks(dp_rank_str, 0)
+        self.component_gauges.set_total_blocks(dp_rank_str, self.num_gpu_block)
         self.component_gauges.set_gpu_cache_usage(dp_rank_str, 0.0)
 
     def log_engine_initialized(self) -> None:

--- a/components/src/dynamo/vllm/snapshot.py
+++ b/components/src/dynamo/vllm/snapshot.py
@@ -14,15 +14,16 @@ from dynamo.common.snapshot.lifecycle import (
 
 from .args import Config
 from .handlers import VllmEnginePauseController
-from .worker_factory import EngineSetupResult
+from .publisher import StatLoggerFactory
+from .worker_factory import EngineSetupResult, SnapshotEngineState
 
 logger = logging.getLogger(__name__)
 
 
 async def prepare_snapshot_engine(
     config: Config,
-    setup_vllm_engine: Callable[[Config], EngineSetupResult],
-) -> EngineSnapshotController[EngineSetupResult] | None:
+    setup_vllm_engine: Callable[..., EngineSetupResult],
+) -> EngineSnapshotController[SnapshotEngineState] | None:
     snapshot_config = SnapshotConfig.from_env()
     if snapshot_config is None:
         return None
@@ -38,10 +39,15 @@ async def prepare_snapshot_engine(
     logger.info("Snapshot mode enabled (watcher-driven signals)")
     config.engine_args.enable_sleep_mode = True
 
-    engine = setup_vllm_engine(config)
+    # Install the stat logger before capture so vLLM retains it in the restored
+    # logger manager. Its Dynamo endpoint is bound only after the runtime is
+    # created, keeping the captured process free of runtime connections.
+    stat_logger = StatLoggerFactory(embedding_worker=config.embedding_worker)
+    engine = setup_vllm_engine(config, stat_logger)
+    snapshot_state = SnapshotEngineState(engine=engine, stat_logger=stat_logger)
     gc.collect()
     snapshot_controller = EngineSnapshotController(
-        engine=engine,
+        engine=snapshot_state,
         pause_controller=VllmEnginePauseController(engine[0]),
         snapshot_config=snapshot_config,
         pause_args=(None,),

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -12,7 +12,7 @@ the chat-shaped pipeline.
 """
 
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
@@ -125,3 +125,37 @@ def test_factory_default_is_chat_path(monkeypatch):
     assert constructed[0]["endpoint"] is endpoint
     assert constructed[0]["dp_rank"] == 3
     assert constructed[0]["component_gauges"] is component_gauges
+
+
+@pytest.mark.asyncio
+async def test_snapshot_factory_defers_endpoint_and_publishes_gauges(monkeypatch):
+    inner = Mock(create_endpoint=AsyncMock())
+    monkeypatch.setattr(
+        publisher_mod,
+        "WorkerMetricsPublisher",
+        Mock(return_value=inner),
+    )
+    component_gauges = Mock()
+    factory = StatLoggerFactory(component_gauges=component_gauges)
+
+    logger = factory.create_stat_logger(dp_rank=0)
+    assert isinstance(logger, DynamoStatLoggerPublisher)
+    assert logger._endpoint_task is None
+
+    factory.set_num_gpu_blocks_all(48)
+    factory.init_publish()
+    logger.record(Mock(kv_cache_usage=0.25), None)
+
+    inner.publish.assert_has_calls(
+        [call(0, kv_used_blocks=0), call(0, kv_used_blocks=12)]
+    )
+    component_gauges.set_total_blocks.assert_has_calls([call("0", 0), call("0", 48)])
+    component_gauges.set_gpu_cache_usage.assert_has_calls(
+        [call("0", 0.0), call("0", 0.25)]
+    )
+
+    endpoint = SimpleNamespace()
+    factory.bind_endpoint(endpoint)
+    assert logger._endpoint_task is not None
+    await logger._endpoint_task
+    inner.create_endpoint.assert_awaited_once_with(endpoint)

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -149,7 +149,7 @@ async def test_snapshot_factory_defers_endpoint_and_publishes_gauges(monkeypatch
     inner.publish.assert_has_calls(
         [call(0, kv_used_blocks=0), call(0, kv_used_blocks=12)]
     )
-    component_gauges.set_total_blocks.assert_has_calls([call("0", 0), call("0", 48)])
+    component_gauges.set_total_blocks.assert_has_calls([call("0", 48), call("0", 48)])
     component_gauges.set_gpu_cache_usage.assert_has_calls(
         [call("0", 0.0), call("0", 0.25)]
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -63,7 +63,7 @@ def test_factory_returns_noop_logger_for_embedding_worker(monkeypatch):
     # downstream ``init_publish`` / ``set_num_gpu_blocks_all`` calls in
     # the chat path are safe no-ops if anyone ever wires them on the
     # embedding branch by mistake.
-    assert factory.created_logger is None
+    assert not factory.created_loggers
 
 
 def test_noop_stat_logger_record_is_safe_with_none_stats():
@@ -129,33 +129,45 @@ def test_factory_default_is_chat_path(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_snapshot_factory_defers_endpoint_and_publishes_gauges(monkeypatch):
-    inner = Mock(create_endpoint=AsyncMock())
+    inners = [Mock(create_endpoint=AsyncMock()), Mock(create_endpoint=AsyncMock())]
     monkeypatch.setattr(
         publisher_mod,
         "WorkerMetricsPublisher",
-        Mock(return_value=inner),
+        Mock(side_effect=inners),
     )
     component_gauges = Mock()
     factory = StatLoggerFactory(component_gauges=component_gauges)
 
-    logger = factory.create_stat_logger(dp_rank=0)
-    assert isinstance(logger, DynamoStatLoggerPublisher)
-    assert logger._endpoint_task is None
+    loggers = [
+        factory.create_stat_logger(dp_rank=0),
+        factory.create_stat_logger(dp_rank=1),
+    ]
+    assert all(isinstance(logger, DynamoStatLoggerPublisher) for logger in loggers)
+    assert factory.created_loggers == loggers
+    assert all(logger._endpoint_task is None for logger in loggers)
 
     factory.set_num_gpu_blocks_all(48)
     factory.init_publish()
-    logger.record(Mock(kv_cache_usage=0.25), None)
+    loggers[0].record(Mock(kv_cache_usage=0.25), None)
+    loggers[1].record(Mock(kv_cache_usage=0.5), None)
 
-    inner.publish.assert_has_calls(
+    inners[0].publish.assert_has_calls(
         [call(0, kv_used_blocks=0), call(0, kv_used_blocks=12)]
     )
-    component_gauges.set_total_blocks.assert_has_calls([call("0", 48), call("0", 48)])
+    inners[1].publish.assert_has_calls(
+        [call(1, kv_used_blocks=0), call(1, kv_used_blocks=24)]
+    )
+    component_gauges.set_total_blocks.assert_has_calls(
+        [call("0", 48), call("1", 48), call("0", 48), call("1", 48)]
+    )
     component_gauges.set_gpu_cache_usage.assert_has_calls(
-        [call("0", 0.0), call("0", 0.25)]
+        [call("0", 0.0), call("1", 0.0), call("0", 0.25), call("1", 0.5)]
     )
 
     endpoint = SimpleNamespace()
     factory.bind_endpoint(endpoint)
-    assert logger._endpoint_task is not None
-    await logger._endpoint_task
-    inner.create_endpoint.assert_awaited_once_with(endpoint)
+    assert all(logger._endpoint_task is not None for logger in loggers)
+    await loggers[0]._endpoint_task
+    await loggers[1]._endpoint_task
+    for inner in inners:
+        inner.create_endpoint.assert_awaited_once_with(endpoint)

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -12,11 +12,14 @@ the chat-shaped pipeline.
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
+from prometheus_client import CollectorRegistry
 
 import dynamo.vllm.publisher as publisher_mod
+from dynamo import prometheus_names
+from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.vllm.publisher import (
     DynamoStatLoggerPublisher,
     NoopStatLogger,
@@ -135,16 +138,27 @@ def test_factory_initializes_every_dp_rank_logger(monkeypatch):
     factory = StatLoggerFactory(
         endpoint=SimpleNamespace(), component_gauges=SimpleNamespace()
     )
-    for dp_rank in range(3):
+    dp_ranks = (2, 4, 7)
+    for dp_rank in dp_ranks:
         factory.create_stat_logger(dp_rank=dp_rank)
 
     factory.set_num_gpu_blocks_all(4096)
     factory.init_publish()
 
-    assert factory.created_loggers == dict(enumerate(loggers))
+    assert factory.created_loggers == dict(zip(dp_ranks, loggers, strict=True))
     for logger in loggers:
         logger.set_num_gpu_block.assert_called_once_with(4096)
         logger.init_publish.assert_called_once_with()
+
+
+def test_factory_initialization_without_loggers_is_a_noop():
+    """Disabled vLLM stat logging leaves the factory without loggers."""
+    factory = StatLoggerFactory(endpoint=SimpleNamespace())
+
+    factory.set_num_gpu_blocks_all(4096)
+    factory.init_publish()
+
+    assert factory.created_loggers == {}
 
 
 def test_factory_binds_deferred_endpoint_to_every_dp_rank_logger(monkeypatch):
@@ -177,11 +191,19 @@ async def test_deferred_logger_starts_with_fresh_metrics_state(monkeypatch):
         publisher_mod, "WorkerMetricsPublisher", Mock(side_effect=publishers)
     )
 
+    registry = CollectorRegistry()
+    component_gauges = LLMBackendMetrics(
+        registry=registry,
+        model_name="test-model",
+        component_name="prefill",
+    )
+
     logger = DynamoStatLoggerPublisher(
         endpoint=None,
-        component_gauges=SimpleNamespace(),
+        dp_rank=5,
+        component_gauges=component_gauges,
     )
-    logger.inner.publish(dp_rank=0, kv_used_blocks=7)
+    logger.inner.publish(dp_rank=5, kv_used_blocks=7)
 
     endpoint = SimpleNamespace()
     logger.bind_endpoint(endpoint)
@@ -189,6 +211,38 @@ async def test_deferred_logger_starts_with_fresh_metrics_state(monkeypatch):
 
     assert logger._endpoint_task is not None
     await logger._endpoint_task
-    publishers[0].publish.assert_called_once_with(dp_rank=0, kv_used_blocks=7)
+    publishers[0].publish.assert_called_once_with(dp_rank=5, kv_used_blocks=7)
     publishers[0].create_endpoint.assert_not_called()
     publishers[1].create_endpoint.assert_awaited_once_with(endpoint)
+
+    metric_labels = {
+        prometheus_names.labels.MODEL: "test-model",
+        prometheus_names.labels.COMPONENT: "prefill",
+        prometheus_names.labels.DP_RANK: "5",
+    }
+    total_blocks_name = (
+        f"{prometheus_names.name_prefix.COMPONENT}_"
+        f"{prometheus_names.kvstats.TOTAL_BLOCKS}"
+    )
+    cache_usage_name = (
+        f"{prometheus_names.name_prefix.COMPONENT}_"
+        f"{prometheus_names.kvstats.GPU_CACHE_USAGE_PERCENT}"
+    )
+
+    logger.set_num_gpu_block(400)
+    logger.init_publish()
+    assert registry.get_sample_value(total_blocks_name, metric_labels) == 400
+    assert registry.get_sample_value(cache_usage_name, metric_labels) == 0.0
+
+    logger.record(SimpleNamespace(kv_cache_usage=0.25), None)
+    assert registry.get_sample_value(total_blocks_name, metric_labels) == 400
+    assert registry.get_sample_value(cache_usage_name, metric_labels) == 0.25
+
+    logger.record(SimpleNamespace(kv_cache_usage=0.0), None)
+    assert registry.get_sample_value(total_blocks_name, metric_labels) == 400
+    assert registry.get_sample_value(cache_usage_name, metric_labels) == 0.0
+    assert publishers[1].publish.call_args_list == [
+        call(5, kv_used_blocks=0),
+        call(5, kv_used_blocks=100),
+        call(5, kv_used_blocks=0),
+    ]

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -718,12 +718,15 @@ class TestPrefillRegistrationContract:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("lora_enabled", [True, False])
-async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
+async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
     lora_enabled: bool,
 ) -> None:
     engine_client = Mock()
-    vllm_config = Mock(additional_config={})
+    vllm_config = Mock(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=96),
+    )
     engine_tuple: EngineSetupResult = (
         engine_client,
         vllm_config,
@@ -731,8 +734,9 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
         "/tmp/prom",
         Mock(),
     )
+    setup_vllm_engine = Mock(return_value=engine_tuple)
     factory = WorkerFactory(
-        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_vllm_engine_fn=setup_vllm_engine,
         setup_kv_event_publisher_fn=Mock(return_value=None),
         register_vllm_model_fn=AsyncMock(),
         setup_fpm_relay_fn=Mock(return_value=None),
@@ -758,6 +762,14 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
 
     monkeypatch.setattr(
         "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 2)
+    )
+    stat_logger = Mock()
+    stat_logger_factory = Mock(return_value=stat_logger)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory", stat_logger_factory
     )
 
     endpoints: dict[str, Mock] = {}
@@ -792,6 +804,13 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
         asyncio.Event(),
         shutdown_endpoints,
     )
+
+    stat_logger_factory.assert_called_once_with(
+        endpoint=endpoints["dyn.prefill.generate"]
+    )
+    setup_vllm_engine.assert_called_once_with(config, stat_logger, fpm_worker_id="cid")
+    stat_logger.set_num_gpu_blocks_all.assert_called_once_with(48)
+    stat_logger.init_publish.assert_called_once_with()
 
     lifecycle_names = {
         "dyn.prefill.load_lora",

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -6,6 +6,7 @@
 import asyncio
 import json
 import logging
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -13,8 +14,11 @@ import pytest
 
 from dynamo.llm import ModelInput, ModelType, WorkerType
 from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.publisher import StatLoggerFactory
+from dynamo.vllm.snapshot import prepare_snapshot_engine
 from dynamo.vllm.worker_factory import (
     EngineSetupResult,
+    SnapshotEngineState,
     WorkerFactory,
     _wait_and_load_benchmark,
 )
@@ -49,6 +53,35 @@ def _make_config(**overrides) -> Mock:
     }
     defaults.update(overrides)
     return Mock(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_snapshot_setup_preserves_unbound_stat_logger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot_config = Mock(run_lifecycle=AsyncMock(return_value=True))
+    monkeypatch.setattr(
+        "dynamo.vllm.snapshot.SnapshotConfig.from_env",
+        Mock(return_value=snapshot_config),
+    )
+    monkeypatch.setattr("dynamo.vllm.snapshot.configure_snapshot_capture_env", Mock())
+    engine: EngineSetupResult = (Mock(), Mock(), Mock(), Mock(), Mock())
+    setup_vllm_engine = Mock(return_value=engine)
+    config = _make_config(
+        headless=False,
+        engine_args=SimpleNamespace(enable_sleep_mode=False),
+    )
+
+    controller = await prepare_snapshot_engine(config, setup_vllm_engine)
+
+    assert controller is not None
+    stat_logger = setup_vllm_engine.call_args.args[1]
+    assert isinstance(stat_logger, StatLoggerFactory)
+    assert stat_logger.endpoint is None
+    assert controller.engine == SnapshotEngineState(
+        engine=engine,
+        stat_logger=stat_logger,
+    )
 
 
 def _single_rank_benchmark_payload(
@@ -571,12 +604,15 @@ class TestCreate:
         runtime = Mock()
         shutdown_event = asyncio.Event()
         shutdown_endpoints: list = []
-        snapshot_engine: EngineSetupResult = (
-            Mock(),
-            Mock(),
-            Mock(),
-            "/tmp/prometheus",
-            Mock(),
+        snapshot_engine = SnapshotEngineState(
+            engine=(
+                Mock(),
+                Mock(),
+                Mock(),
+                "/tmp/prometheus",
+                Mock(),
+            ),
+            stat_logger=Mock(),
         )
 
         await factory.create(
@@ -718,11 +754,15 @@ class TestPrefillRegistrationContract:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("lora_enabled", [True, False])
+@pytest.mark.parametrize("snapshot_mode", [True, False])
 async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
     lora_enabled: bool,
+    snapshot_mode: bool,
 ) -> None:
     engine_client = Mock()
+    stat_logger = Mock()
     vllm_config = Mock(
         additional_config={},
         cache_config=SimpleNamespace(num_gpu_blocks=96),
@@ -731,8 +771,13 @@ async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
         engine_client,
         vllm_config,
         Mock(),
-        "/tmp/prom",
+        tmp_path,
         Mock(),
+    )
+    snapshot_engine = (
+        SnapshotEngineState(engine=engine_tuple, stat_logger=stat_logger)
+        if snapshot_mode
+        else None
     )
     setup_vllm_engine = Mock(return_value=engine_tuple)
     factory = WorkerFactory(
@@ -766,7 +811,6 @@ async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
     monkeypatch.setattr(
         "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (0, 2)
     )
-    stat_logger = Mock()
     stat_logger_factory = Mock(return_value=stat_logger)
     monkeypatch.setattr(
         "dynamo.vllm.worker_factory.StatLoggerFactory", stat_logger_factory
@@ -803,12 +847,23 @@ async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
         config,
         asyncio.Event(),
         shutdown_endpoints,
+        snapshot_engine=snapshot_engine,
     )
 
-    stat_logger_factory.assert_called_once_with(
-        endpoint=endpoints["dyn.prefill.generate"]
-    )
-    setup_vllm_engine.assert_called_once_with(config, stat_logger, fpm_worker_id="cid")
+    if snapshot_mode:
+        stat_logger_factory.assert_not_called()
+        setup_vllm_engine.assert_not_called()
+        stat_logger.bind_endpoint.assert_called_once_with(
+            endpoints["dyn.prefill.generate"]
+        )
+    else:
+        stat_logger_factory.assert_called_once_with(
+            endpoint=endpoints["dyn.prefill.generate"]
+        )
+        setup_vllm_engine.assert_called_once_with(
+            config, stat_logger, fpm_worker_id="cid"
+        )
+        stat_logger.bind_endpoint.assert_not_called()
     stat_logger.set_num_gpu_blocks_all.assert_called_once_with(48)
     stat_logger.init_publish.assert_called_once_with()
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -1114,21 +1114,32 @@ class TestPrefillRegistrationContract:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("lora_enabled", [True, False])
-async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
+@pytest.mark.parametrize("snapshot_mode", [True, False])
+async def test_prefill_initializes_metrics_and_serves_lora_lifecycle(
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
     lora_enabled: bool,
+    snapshot_mode: bool,
 ) -> None:
     engine_client = Mock()
-    vllm_config = Mock(additional_config={})
+    vllm_config = Mock(
+        additional_config={},
+        cache_config=SimpleNamespace(num_gpu_blocks=96),
+    )
     engine_tuple: EngineSetupResult = (
         engine_client,
         vllm_config,
         Mock(),
-        "/tmp/prom",
+        str(tmp_path / "prometheus"),
         Mock(),
     )
+    stat_logger = Mock()
+    snapshot_engine: SnapshotEngineSetupResult | None = (
+        (engine_tuple, stat_logger) if snapshot_mode else None
+    )
+    setup_vllm_engine = Mock(return_value=engine_tuple)
     factory = WorkerFactory(
-        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_vllm_engine_fn=setup_vllm_engine,
         setup_kv_event_publisher_fn=Mock(return_value=None),
         register_vllm_model_fn=AsyncMock(),
         setup_fpm_relay_fn=Mock(return_value=None),
@@ -1154,6 +1165,13 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
 
     monkeypatch.setattr(
         "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.get_dp_range_for_worker", lambda _config: (3, 2)
+    )
+    stat_logger_factory = Mock(return_value=stat_logger)
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory", stat_logger_factory
     )
 
     endpoints: dict[str, Mock] = {}
@@ -1187,7 +1205,25 @@ async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
         config,
         asyncio.Event(),
         shutdown_endpoints,
+        snapshot_engine=snapshot_engine,
     )
+
+    if snapshot_mode:
+        stat_logger_factory.assert_not_called()
+        setup_vllm_engine.assert_not_called()
+        stat_logger.bind_endpoint.assert_called_once_with(
+            endpoints["dyn.prefill.generate"]
+        )
+    else:
+        stat_logger_factory.assert_called_once_with(
+            endpoint=endpoints["dyn.prefill.generate"]
+        )
+        setup_vllm_engine.assert_called_once_with(
+            config, stat_logger, fpm_worker_id="cid"
+        )
+        stat_logger.bind_endpoint.assert_not_called()
+    stat_logger.set_num_gpu_blocks_all.assert_called_once_with(48)
+    stat_logger.init_publish.assert_called_once_with()
 
     lifecycle_names = {
         "dyn.prefill.load_lora",

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -11,6 +11,7 @@ import math
 import os
 import time as _time
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -61,6 +62,14 @@ BENCHMARK_SOFT_TIMEOUT_GRACE_SECONDS = 90
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
 # LLMBackendMetrics registration there.
 EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
+
+
+@dataclass(frozen=True)
+class SnapshotEngineState:
+    """Engine state retained across capture, including its stat logger factory."""
+
+    engine: EngineSetupResult
+    stat_logger: StatLoggerFactory
 
 
 def _benchmark_rank_path(base_path: Path, dp_rank: int) -> Path:
@@ -560,7 +569,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_engine: Optional[SnapshotEngineState] = None,
     ) -> None:
         """Create the appropriate multimodal worker based on config flags."""
 
@@ -616,7 +625,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_engine: Optional[SnapshotEngineState] = None,
     ) -> None:
         """Initialize an aggregated vLLM realtime worker."""
         del shutdown_event  # Connection cancellation is carried by Dynamo Context.
@@ -633,13 +642,11 @@ class WorkerFactory:
                 vllm_config,
                 _default_sampling_params,
                 prometheus_temp_dir,
-                component_gauges,
-            ) = snapshot_engine
+                _component_gauges,
+            ) = snapshot_engine.engine
+            factory = snapshot_engine.stat_logger
             os.environ[ENV_FPM_WORKER_ID] = fpm_worker_id
-            factory = StatLoggerFactory(
-                endpoint=generate_endpoint,
-                component_gauges=component_gauges,
-            )
+            factory.bind_endpoint(generate_endpoint)
         else:
             factory = StatLoggerFactory(endpoint=generate_endpoint)
             (
@@ -647,7 +654,7 @@ class WorkerFactory:
                 vllm_config,
                 _default_sampling_params,
                 prometheus_temp_dir,
-                component_gauges,
+                _component_gauges,
             ) = self.setup_vllm_engine(
                 config,
                 factory,
@@ -936,7 +943,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_engine: Optional[SnapshotEngineState] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -994,14 +1001,11 @@ class WorkerFactory:
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
-                component_gauges,
-            ) = snapshot_engine
+                _component_gauges,
+            ) = snapshot_engine.engine
+            factory = snapshot_engine.stat_logger
             os.environ[ENV_FPM_WORKER_ID] = fpm_worker_id
-            # Factory is created after unpack so component_gauges is available
-            factory = StatLoggerFactory(
-                endpoint=generate_endpoint,
-                component_gauges=component_gauges,
-            )
+            factory.bind_endpoint(generate_endpoint)
         else:
             # Factory is created without component_gauges; setup_vllm_engine() will
             # create the gauges after setup_multiprocess_prometheus() and set them
@@ -1014,7 +1018,7 @@ class WorkerFactory:
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
-                component_gauges,
+                _component_gauges,
             ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
 
@@ -1238,7 +1242,7 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,  # mutated in place
-        snapshot_engine: Optional[EngineSetupResult] = None,
+        snapshot_engine: Optional[SnapshotEngineState] = None,
     ) -> None:
         """
         Instantiate and serve
@@ -1279,12 +1283,10 @@ class WorkerFactory:
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
-                component_gauges,
-            ) = snapshot_engine
-            factory = StatLoggerFactory(
-                endpoint=generate_endpoint,
-                component_gauges=component_gauges,
-            )
+                _component_gauges,
+            ) = snapshot_engine.engine
+            factory = snapshot_engine.stat_logger
+            factory.bind_endpoint(generate_endpoint)
             # TODO: The scheduler in the child process still has worker_id=""
             # because the engine was forked before the runtime existed.
             # Propagating the new ID to the child requires shared memory or

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -1279,22 +1279,39 @@ class WorkerFactory:
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
-                _component_gauges,
+                component_gauges,
             ) = snapshot_engine
+            factory = StatLoggerFactory(
+                endpoint=generate_endpoint,
+                component_gauges=component_gauges,
+            )
             # TODO: The scheduler in the child process still has worker_id=""
             # because the engine was forked before the runtime existed.
             # Propagating the new ID to the child requires shared memory or
             # a restart of the EngineCore process.
             os.environ[ENV_FPM_WORKER_ID] = fpm_worker_id
         else:
+            factory = StatLoggerFactory(endpoint=generate_endpoint)
             (
                 engine_client,
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
                 _component_gauges,
-            ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
+            ) = self.setup_vllm_engine(
+                config,
+                factory,
+                fpm_worker_id=fpm_worker_id,
+            )
         await configure_kv_event_block_size(engine_client, vllm_config)
+
+        _, dp_size = get_dp_range_for_worker(vllm_config)
+        per_rank_num_gpu_blocks = per_rank_kv_blocks(
+            vllm_config.cache_config.num_gpu_blocks,
+            dp_size,
+        )
+        factory.set_num_gpu_blocks_all(per_rank_num_gpu_blocks or 0)
+        factory.init_publish()
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
             runtime, config

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -1557,9 +1557,8 @@ class WorkerFactory:
 
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
-        snapshot_factory: Optional[StatLoggerFactory] = None
         if snapshot_engine is not None:
-            engine_setup, snapshot_factory = snapshot_engine
+            engine_setup, factory = snapshot_engine
             (
                 engine_client,
                 vllm_config,
@@ -1567,30 +1566,30 @@ class WorkerFactory:
                 prometheus_temp_dir,
                 _component_gauges,
             ) = engine_setup
-            snapshot_factory.bind_endpoint(generate_endpoint)
+            factory.bind_endpoint(generate_endpoint)
             # TODO: The scheduler in the child process still has worker_id=""
             # because the engine was forked before the runtime existed.
             # Propagating the new ID to the child requires shared memory or
             # a restart of the EngineCore process.
             os.environ[ENV_FPM_WORKER_ID] = fpm_worker_id
         else:
+            factory = StatLoggerFactory(endpoint=generate_endpoint)
             (
                 engine_client,
                 vllm_config,
                 default_sampling_params,
                 prometheus_temp_dir,
                 _component_gauges,
-            ) = self.setup_vllm_engine(config, fpm_worker_id=fpm_worker_id)
+            ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
         await configure_kv_event_block_size(engine_client, vllm_config)
 
-        if snapshot_factory is not None:
-            _, dp_size = get_dp_range_for_worker(vllm_config)
-            per_rank_num_gpu_blocks = per_rank_kv_blocks(
-                vllm_config.cache_config.num_gpu_blocks,
-                dp_size,
-            )
-            snapshot_factory.set_num_gpu_blocks_all(per_rank_num_gpu_blocks or 0)
-            snapshot_factory.init_publish()
+        _, dp_size = get_dp_range_for_worker(vllm_config)
+        per_rank_num_gpu_blocks = per_rank_kv_blocks(
+            vllm_config.cache_config.num_gpu_blocks,
+            dp_size,
+        )
+        factory.set_num_gpu_blocks_all(per_rank_num_gpu_blocks or 0)
+        factory.init_publish()
 
         encode_worker_client = await self._maybe_get_encode_worker_client(
             runtime, config

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -364,7 +364,8 @@ vllm_configs = {
             pytest.mark.core,
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
-        ],  # TODO: profile to get max_vram and timeout
+            pytest.mark.timeout(330),  # 3x measured 109s runtime
+        ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             chat_payload_default(),

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -369,6 +369,11 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            metric_payload_default(
+                min_num_requests=1,
+                backend="vllm",
+                port=DefaultPort.SYSTEM2.value,
+            ),
         ],
     ),
     "disaggregated_same_gpu": VLLMConfig(

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -365,11 +365,17 @@ vllm_configs = {
             pytest.mark.core,
             pytest.mark.gpu_2,
             pytest.mark.pre_merge,
-        ],  # TODO: profile to get max_vram and timeout
+            pytest.mark.timeout(720),  # 3x ~240s local runtime
+        ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            metric_payload_default(
+                min_num_requests=1,
+                backend="vllm",
+                port=DefaultPort.SYSTEM2.value,
+            ),
         ],
     ),
     "disaggregated_same_gpu": VLLMConfig(


### PR DESCRIPTION
## Overview

Fix missing `dynamo_component_total_blocks` and `dynamo_component_gpu_cache_usage_percent` samples on ordinary disaggregated vLLM prefill workers.

This consolidates the remaining fix for #11919 on current `main` while preserving the retained per-rank snapshot logger lifecycle merged in #14258.

## Details

- Create and pass a `StatLoggerFactory` during ordinary prefill engine setup.
- Share per-rank KV capacity initialization and initial publication between ordinary and restored prefill workers.
- Publish configured total capacity at startup while keeping used blocks and cache utilization at zero until requests arrive.
- Add deterministic nonzero-DP-rank assertions for post-bind startup, active, and idle publication, including fresh publisher state and the disabled-stat no-op path.
- Extend the two-GPU disaggregated serve scenario to scrape the prefill `SYSTEM2` metrics endpoint.

No snapshot state format or restored scheduler/FPM identity plumbing is changed.

## Where should the reviewer start?

Start with `components/src/dynamo/vllm/worker_factory.py`, then `components/src/dynamo/vllm/publisher.py`. The focused regression coverage is in their adjacent test files.

## Validation

- `python -m pytest -q components/src/dynamo/vllm/tests/test_vllm_worker_factory.py components/src/dynamo/vllm/tests/test_vllm_publisher.py components/src/dynamo/vllm/tests/test_vllm_snapshot.py`
  - 65 passed with vLLM 0.28.0 and PyTorch 2.13.0+cu130.
- `python -m pytest -xvv -s 'tests/serve/test_vllm.py::test_serve_deployment[disaggregated-2]'`
  - 1 passed in 240.40 seconds on two NVIDIA H20 GPUs.
  - The prefill scrape reported `dynamo_component_total_blocks = 49888` and `dynamo_component_gpu_cache_usage_percent = 0.0` after successful chat and completion requests through prefill, NIXL transfer, and decode.
- `python3 -m pre_commit run --files <changed files>`
  - All hooks passed.
- `git diff --check`
  - Passed.

## Related issues

Closes #11919
