### PR TITLE
fix(sglang): preserve Kimi K3 media pads

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -818,16 +818,15 @@ def preprocess_chat_request(
             content_format_override="openai" if is_kimi_k3 else None,
         )
         if is_kimi_k3:
-            image_count = sum(
-                1
-                for message in template_messages
-                for part in (
-                    message.get("content")
-                    if isinstance(message.get("content"), list)
-                    else []
-                )
-                if isinstance(part, dict) and part.get("type") == "image"
-            )
+            image_count = 0
+            for message in template_messages:
+                content = message.get("content")
+                if isinstance(content, list):
+                    image_count += sum(
+                        1
+                        for part in content
+                        if isinstance(part, dict) and part.get("type") == "image"
+                    )
             if image_count:
                 # K3's tokenizer otherwise emits its checkpoint-native
                 # <|kimi_image_placeholder|> sequence. SGLang's processor

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -679,7 +679,10 @@ def _normalize_prompt_token_ids(prompt_token_ids: Any) -> list[int]:
 
 
 def _normalize_messages_for_template(
-    messages: list[dict[str, Any]], tokenizer: Any
+    messages: list[dict[str, Any]],
+    tokenizer: Any,
+    *,
+    content_format_override: str | None = None,
 ) -> list[dict[str, Any]]:
     """Normalize OpenAI media chunks (``image_url``/``video_url``/``audio_url``)
     to the simple ``image``/``video``/``audio`` types most VLM chat templates
@@ -690,7 +693,9 @@ def _normalize_messages_for_template(
     step in sglang's own OpenAI server and dynamo's Rust default path.
     """
     chat_template = getattr(tokenizer, "chat_template", None) or ""
-    content_format = detect_jinja_template_content_format(chat_template)
+    content_format = content_format_override or detect_jinja_template_content_format(
+        chat_template
+    )
     # The media-data side outputs are discarded: dynamo's separate
     # ``extract_mm_urls()`` channel is the source of truth for the worker.
     image_sink: list = []
@@ -798,7 +803,37 @@ def preprocess_chat_request(
         if (reasoning_effort := request.get("reasoning_effort")) is not None:
             template_kwargs["reasoning_effort"] = reasoning_effort
 
-        template_messages = _normalize_messages_for_template(messages, tokenizer)
+        model_name = str(request.get("model") or "").lower().replace("_", "-")
+        is_kimi_k3 = (
+            reasoning_parser_name == "kimi_k3"
+            or "kimi-k3" in model_name
+            or (
+                type(tokenizer).__name__ == "TikTokenTokenizer"
+                and type(tokenizer).__module__.endswith(".tokenization_kimi")
+            )
+        )
+        template_messages = _normalize_messages_for_template(
+            messages,
+            tokenizer,
+            content_format_override="openai" if is_kimi_k3 else None,
+        )
+        if is_kimi_k3:
+            image_count = sum(
+                1
+                for message in template_messages
+                for part in (
+                    message.get("content")
+                    if isinstance(message.get("content"), list)
+                    else []
+                )
+                if isinstance(part, dict) and part.get("type") == "image"
+            )
+            if image_count:
+                # K3's tokenizer otherwise emits its checkpoint-native
+                # <|kimi_image_placeholder|> sequence. SGLang's processor
+                # expects one stable structural pad per image and expands it
+                # after the media dimensions are known.
+                template_kwargs["image_prompts"] = ["<|media_pad|>"] * image_count
 
         prompt_token_ids = _normalize_prompt_token_ids(
             tokenizer.apply_chat_template(template_messages, **template_kwargs)

--- a/components/src/dynamo/frontend/tests/test_sglang_multimodal_prepost.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_multimodal_prepost.py
@@ -96,3 +96,41 @@ def test_preprocess_feeds_normalized_chunks_to_template():
 
     assert 42 in result.prompt_token_ids
     assert [c["type"] for c in tok.seen] == ["text", "image"]
+
+
+def test_kimi_k3_custom_template_emits_one_media_pad_per_image():
+    """K3's custom tokenizer has no Jinja template and needs image_prompts."""
+
+    class Tokenizer:
+        chat_template = None
+
+        def apply_chat_template(self, messages, **kwargs):
+            self.seen = messages[0]["content"]
+            self.image_prompts = kwargs.get("image_prompts")
+            return [42 if chunk["type"] == "image" else 1 for chunk in self.seen]
+
+    tok = Tokenizer()
+    request = {
+        "model": "moonshot-ai/Kimi-K3",
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    _url_chunk("image"),
+                    _url_chunk("image"),
+                    {"type": "text", "text": "what is this?"},
+                ],
+            }
+        ],
+    }
+
+    result = preprocess_chat_request(
+        request,
+        tokenizer=tok,
+        tool_call_parser_name=None,
+        reasoning_parser_name=None,
+    )
+
+    assert result.prompt_token_ids == [42, 42, 1]
+    assert [chunk["type"] for chunk in tok.seen] == ["image", "image", "text"]
+    assert tok.image_prompts == ["<|media_pad|>", "<|media_pad|>"]


### PR DESCRIPTION
## Why

Kimi K3's custom tokenizer has no Jinja chat template and emits its checkpoint-native image placeholder. SGLang expects one stable media-pad token per image, but Dynamo normalized the request as string content and supplied no image prompts, causing image chat to fail with `expected 1, found 0 token(s)`. This preserves structured media only for K3 rendering while keeping URL extraction as the worker's media source. A K3-capable SGLang build remains required; the stock v0.5.16 base in the current Dynamo nightly has no K3 model implementation.

## What Change

- Normalize K3 messages as structured OpenAI content.
- Pass one `<|media_pad|>` prompt per image.
- Cover multi-image rendering with a regression test.

## Test Plan

- `test_sglang_multimodal_prepost.py`: six passed.
- 16x GB200 TP16 text/image smoke on K3-capable SGLang 0.5.16: passed.
