### PR TITLE
refactor(operator): remove identity from checkpoint info

### DIFF
--- a/deploy/operator/internal/checkpoint/checkpoint_test.go
+++ b/deploy/operator/internal/checkpoint/checkpoint_test.go
@@ -35,7 +35,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -587,7 +586,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 
 	t.Run("ready checkpoint enables restore standby mode", func(t *testing.T) {
 		podSpec := testPodSpec()
-		info := &CheckpointInfo{Enabled: true, Ready: true, Identity: ptr.To(testIdentity())}
+		info := &CheckpointInfo{Enabled: true, Ready: true, Hash: testHash}
 		reader := fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build()
 		require.NoError(t, InjectCheckpointIntoPodSpec(context.Background(), reader, testNamespace, podSpec, info, snapshotprotocol.DefaultSeccompLocalhostProfile))
 		assertRestoreStandbyMode(t, &podSpec.Containers[0], []string{"python3"}, []string{"-m", "dynamo.vllm"})
@@ -748,7 +747,7 @@ func TestInjectCheckpointIntoPodSpec(t *testing.T) {
 			reader  client.Reader
 			errMsg  string
 		}{
-			{"hash empty and identity nil", testPodSpec(), &CheckpointInfo{Enabled: true, Ready: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "identity is nil"},
+			{"ready checkpoint without hash", testPodSpec(), &CheckpointInfo{Enabled: true, Ready: true}, fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "checkpoint is ready but hash is not set"},
 			{"no containers", &corev1.PodSpec{}, testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(testSnapshotAgentDaemonSet()).Build(), "restore target container"},
 			{"snapshot daemonset missing", testPodSpec(), testInfo(), fake.NewClientBuilder().WithScheme(testScheme()).Build(), "no snapshot-agent daemonset found"},
 		} {

--- a/deploy/operator/internal/checkpoint/podspec.go
+++ b/deploy/operator/internal/checkpoint/podspec.go
@@ -195,42 +195,30 @@ func ResolvePodSpecRestore(
 	}
 
 	info := *checkpointInfo
-	if info.Hash == "" {
-		if info.CheckpointName == "" {
-			if info.Identity == nil {
-				return nil, fmt.Errorf("checkpoint enabled but identity is nil and hash is not set")
-			}
-
-			hash, err := ComputeIdentityHash(*info.Identity)
-			if err != nil {
-				return nil, fmt.Errorf("failed to compute identity hash: %w", err)
-			}
-			info.Hash = hash
-		} else {
-			ckpt := &nvidiacomv1alpha1.DynamoCheckpoint{}
-			if err := reader.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: info.CheckpointName}, ckpt); err != nil {
-				return nil, fmt.Errorf("failed to get checkpoint %s/%s: %w", namespace, info.CheckpointName, err)
-			}
-			hash, err := CheckpointID(ckpt)
-			if err != nil {
-				return nil, err
-			}
-			info.Hash = hash
-			if info.ArtifactVersion == "" {
-				info.ArtifactVersion = checkpointArtifactVersion(ckpt)
-			}
-			if info.GPUMemoryService == nil {
-				info.GPUMemoryService = ckpt.Spec.GPUMemoryService
-			}
+	if info.Hash == "" && info.CheckpointName != "" {
+		ckpt := &nvidiacomv1alpha1.DynamoCheckpoint{}
+		if err := reader.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: info.CheckpointName}, ckpt); err != nil {
+			return nil, fmt.Errorf("failed to get checkpoint %s/%s: %w", namespace, info.CheckpointName, err)
 		}
+		hash, err := CheckpointID(ckpt)
+		if err != nil {
+			return nil, err
+		}
+		info.Hash = hash
+		if info.ArtifactVersion == "" {
+			info.ArtifactVersion = checkpointArtifactVersion(ckpt)
+		}
+		if info.GPUMemoryService == nil {
+			info.GPUMemoryService = ckpt.Spec.GPUMemoryService
+		}
+	}
+
+	if info.Hash == "" {
+		return nil, fmt.Errorf("checkpoint is ready but hash is not set")
 	}
 
 	if info.ArtifactVersion == "" {
 		info.ArtifactVersion = snapshotprotocol.DefaultCheckpointArtifactVersion
-	}
-
-	if info.Hash == "" {
-		return nil, fmt.Errorf("checkpoint enabled but hash is not set")
 	}
 
 	storage, err := ResolveStorage(

--- a/deploy/operator/internal/checkpoint/resolve.go
+++ b/deploy/operator/internal/checkpoint/resolve.go
@@ -31,7 +31,6 @@ import (
 type CheckpointInfo struct {
 	Enabled          bool
 	Exists           bool
-	Identity         *nvidiacomv1alpha1.DynamoCheckpointIdentity
 	GPUMemoryService *nvidiacomv1alpha1.GPUMemoryServiceSpec
 	Hash             string
 	ArtifactVersion  string
@@ -51,7 +50,6 @@ func checkpointInfoFromObject(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (*Checkp
 	return &CheckpointInfo{
 		Enabled:          true,
 		Exists:           true,
-		Identity:         &ckpt.Spec.Identity,
 		GPUMemoryService: ckpt.Spec.GPUMemoryService,
 		Hash:             hash,
 		ArtifactVersion:  checkpointArtifactVersion(ckpt),
@@ -121,7 +119,6 @@ func ResolveCheckpointForService(
 	if existing == nil {
 		return &CheckpointInfo{
 			Enabled:       true,
-			Identity:      config.Identity,
 			Hash:          hash,
 			StartupPolicy: startupPolicy,
 		}, nil
@@ -134,7 +131,6 @@ func ResolveCheckpointForService(
 	if err := validateResolvedGMSSnapshotGate(info, gate); err != nil {
 		return nil, err
 	}
-	info.Identity = config.Identity
 	if config.TargetContainerName != "" {
 		info.RestoreTargetContainers = []string{config.TargetContainerName}
 	}


### PR DESCRIPTION
## Summary

- Remove the deprecated `DynamoCheckpointIdentity` payload from the internal `CheckpointInfo` resolved-state model.
- Keep legacy identity-based checkpoint lookup at the resolver boundary. `ServiceCheckpointConfig.Identity` is still hashed and used to find an existing checkpoint, but the identity no longer leaks into pod shaping.
- Remove the pod injection fallback that recomputed a checkpoint hash from `CheckpointInfo.Identity`.
- Make the resolved-state invariant explicit: a ready checkpoint must provide either its resolved hash or a checkpoint name from which the hash can be loaded. A ready checkpoint with neither now returns a direct error.
- Update checkpoint tests to construct resolved checkpoint state with `Hash` and to cover the missing-hash error.

### Rationale

Every production resolver path already supplies `Hash` before a ready checkpoint reaches pod injection:

- `checkpointRef` resolution obtains the ID from the referenced `DynamoCheckpoint`.
- Legacy identity lookup computes the hash before searching for a matching checkpoint.
- Admission restore constructs `CheckpointInfo` directly with the resolved checkpoint ID.

Keeping both `Identity` and `Hash` in `CheckpointInfo` therefore created redundant sources of truth and allowed inconsistent states that production resolution does not produce. This change keeps identity compatibility where it belongs, at API resolution, while making downstream restore shaping consume resolved data only.

## Validation

- `go test ./internal/checkpoint`
- Compile-only pass across `./internal/...` using an empty-match `-run` regex
- `git diff --check`

A full `go test ./internal/...` run also completed all ordinary packages successfully. Envtest suites could not start in the isolated Herdr worktree because its untracked `deploy/operator/bin/k8s/1.30.0-darwin-arm64/etcd` test asset was not present; those failures occurred uniformly during environment setup before test execution.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint validation during pod injection.
  * Checkpoints without a required hash or name now return a clear error instead of being inferred from identity information.
  * Updated checkpoint handling to consistently use checkpoint hashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->