### PR TITLE
fix(sglang): suppress matched stop markers

### DIFF
--- a/components/src/dynamo/common/utils/engine_response.py
+++ b/components/src/dynamo/common/utils/engine_response.py
@@ -19,3 +19,15 @@ def normalize_finish_reason(finish_reason: str) -> str:
         logging.debug(f"Normalizing finish reason: {finish_reason} to cancelled")
         return "cancelled"
     return finish_reason
+
+
+def trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
+    """Return the longest trailing substring that prefixes a stop string."""
+    if not text or not stop_strings:
+        return 0
+    max_len = min(len(text), max(len(stop) for stop in stop_strings))
+    for suffix_len in range(max_len, 0, -1):
+        suffix = text[-suffix_len:]
+        if any(stop.startswith(suffix) for stop in stop_strings):
+            return suffix_len
+    return 0

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -40,6 +40,17 @@ logger = logging.getLogger(__name__)
 ToolCallParserType: TypeAlias = FunctionCallParser | JsonArrayParser
 
 
+def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
+    if not text or not stop_strings:
+        return 0
+    max_len = min(len(text), max(len(stop) for stop in stop_strings))
+    for suffix_len in range(max_len, 0, -1):
+        suffix = text[-suffix_len:]
+        if any(stop.startswith(suffix) for stop in stop_strings):
+            return suffix_len
+    return 0
+
+
 @dataclass
 class SglangPreprocessResult:
     """Result of SGLang preprocessing."""
@@ -958,6 +969,7 @@ class SglangStreamingPostProcessor:
         tool_call_parser_name: str | None = None,
         eos_token_ids: list[int] | None = None,
         prompt_token_ids: list[int] | None = None,
+        stop_strings: set[str] | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self.tool_call_parser = tool_call_parser
@@ -979,6 +991,8 @@ class SglangStreamingPostProcessor:
             [] if self._is_json_array_parser and reasoning_parser is not None else None
         )
         self._eos_token_ids = set(eos_token_ids or [])
+        self._stop_strings = stop_strings or set()
+        self._pending_stop_text = ""
 
         # Keep a small, known-complete prompt suffix as decode context. Generated
         # tokens are promoted to context only after they decode without a
@@ -1155,6 +1169,46 @@ class SglangStreamingPostProcessor:
         self._pending_logprobs_content = []
         return {"content": content, "refusal": None}
 
+    def _matched_stop_string(self, raw_finish_reason: Any) -> str | None:
+        if not isinstance(raw_finish_reason, dict):
+            return None
+        if raw_finish_reason.get("type") != "stop":
+            return None
+        matched = raw_finish_reason.get("matched")
+        if isinstance(matched, str) and matched in self._stop_strings:
+            return matched
+        return None
+
+    def _strip_stop_string_suffix(
+        self, text: str, matched_stop_string: str | None
+    ) -> str:
+        if not matched_stop_string or not text:
+            return text
+        # Compatibility guard for tokenizer/text paths that surface the matched
+        # stop string after detokenization while special tokens are preserved for
+        # reasoning/tool parsers.
+        if text.endswith(matched_stop_string):
+            return text[: -len(matched_stop_string)]
+        return text
+
+    def _filter_stop_string_delta(
+        self,
+        text: str,
+        finish_reason: str | None,
+        matched_stop_string: str | None,
+    ) -> str:
+        text = self._pending_stop_text + text
+        self._pending_stop_text = ""
+        text = self._strip_stop_string_suffix(text, matched_stop_string)
+        if finish_reason or not text or not self._stop_strings:
+            return text
+
+        pending_len = _trailing_stop_prefix_len(text, self._stop_strings)
+        if pending_len:
+            self._pending_stop_text = text[-pending_len:]
+            return text[:-pending_len]
+        return text
+
     def _parse_reasoning_delta(
         self, delta_text: str, finish_reason: str | None
     ) -> tuple[str | None, str]:
@@ -1216,7 +1270,13 @@ class SglangStreamingPostProcessor:
         """
         raw_ids = engine_response.get("token_ids")
         token_ids = raw_ids if isinstance(raw_ids, list) else list(raw_ids or [])
+        raw_finish_reason = engine_response.get(
+            "raw_finish_reason", engine_response.get("finish_reason")
+        )
         finish_reason = engine_response.get("finish_reason")
+        if isinstance(finish_reason, dict):
+            finish_reason = finish_reason.get("type")
+        matched_stop_string = self._matched_stop_string(raw_finish_reason)
         log_probs = engine_response.get("log_probs")
         top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
@@ -1241,6 +1301,9 @@ class SglangStreamingPostProcessor:
             if openai_logprobs is not None:
                 self._pending_logprobs_content.extend(openai_logprobs["content"])
         self._logprob_context_ids = (self._logprob_context_ids + token_ids)[-4:]
+        delta_text = self._filter_stop_string_delta(
+            delta_text, finish_reason, matched_stop_string
+        )
 
         if self._fast_plain_text:
             if delta_text:

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -28,6 +28,8 @@ from sglang.srt.parser.jinja_template_utils import (
 )
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 
+from dynamo.common.utils.engine_response import trailing_stop_prefix_len
+
 from .thinking import apply_default_thinking_mode_to_template_kwargs
 from .utils import PreprocessError, random_call_id
 
@@ -38,17 +40,6 @@ logger = logging.getLogger(__name__)
 # - JsonArrayParser: direct JSON array parsing under constrained decoding
 #   (tool_choice="required" or named function)
 ToolCallParserType: TypeAlias = FunctionCallParser | JsonArrayParser
-
-
-def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
-    if not text or not stop_strings:
-        return 0
-    max_len = min(len(text), max(len(stop) for stop in stop_strings))
-    for suffix_len in range(max_len, 0, -1):
-        suffix = text[-suffix_len:]
-        if any(stop.startswith(suffix) for stop in stop_strings):
-            return suffix_len
-    return 0
 
 
 @dataclass
@@ -993,6 +984,8 @@ class SglangStreamingPostProcessor:
         self._eos_token_ids = set(eos_token_ids or [])
         self._stop_strings = stop_strings or set()
         self._pending_stop_text = ""
+        self._locally_finished = False
+        self._local_stop_reason: str | None = None
 
         # Keep a small, known-complete prompt suffix as decode context. Generated
         # tokens are promoted to context only after they decode without a
@@ -1201,64 +1194,81 @@ class SglangStreamingPostProcessor:
             return None
         return {"content": content, "refusal": None}
 
-    def _matched_stop_string(self, raw_finish_reason: Any, text: str) -> str | None:
-        if not isinstance(raw_finish_reason, dict):
-            return None
-        if raw_finish_reason.get("type") != "stop":
-            return None
-        matched = raw_finish_reason.get("matched")
-        if isinstance(matched, str) and matched in self._stop_strings:
-            return matched
-        is_matched_token_id = isinstance(matched, int) and not isinstance(matched, bool)
-        is_matched_token_id_sequence = (
-            isinstance(matched, list)
-            and matched
+    @property
+    def locally_finished(self) -> bool:
+        return self._locally_finished
+
+    @property
+    def local_stop_reason(self) -> str | None:
+        return self._local_stop_reason
+
+    @property
+    def has_pending_stop_text(self) -> bool:
+        return bool(self._pending_stop_text)
+
+    def _matched_stop_string(self, stop_reason: Any) -> str | None:
+        if isinstance(stop_reason, str):
+            return stop_reason if stop_reason in self._stop_strings else None
+
+        if isinstance(stop_reason, int) and not isinstance(stop_reason, bool):
+            matched_ids = [stop_reason]
+        elif (
+            isinstance(stop_reason, list)
+            and stop_reason
             and all(
                 isinstance(token_id, int) and not isinstance(token_id, bool)
-                for token_id in matched
+                for token_id in stop_reason
             )
-        )
-        if is_matched_token_id or is_matched_token_id_sequence:
-            return max(
-                (stop for stop in self._stop_strings if text.endswith(stop)),
-                key=len,
-                default=None,
-            )
-        return None
+        ):
+            matched_ids = stop_reason
+        else:
+            return None
 
-    def _strip_stop_string_suffix(
-        self, text: str, matched_stop_string: str | None
-    ) -> str:
-        if not matched_stop_string or not text:
-            return text
-        # Compatibility guard for tokenizer/text paths that surface the matched
-        # stop string after detokenization while special tokens are preserved for
-        # reasoning/tool parsers.
-        if text.endswith(matched_stop_string):
-            suppressed_count = self._trailing_logprobs_count(matched_stop_string)
-            if suppressed_count:
-                del self._pending_logprobs_content[-suppressed_count:]
-            return text[: -len(matched_stop_string)]
-        return text
+        matched = self.tokenizer.decode(matched_ids, skip_special_tokens=False)
+        return matched if matched in self._stop_strings else None
+
+    def _find_stop_string(self, text: str, stop_reason: Any) -> tuple[int, str] | None:
+        matched = self._matched_stop_string(stop_reason)
+        candidates = self._stop_strings
+        if matched is not None:
+            candidates = {matched, *candidates}
+
+        matches = (
+            (index, stop != matched, -len(stop), stop)
+            for stop in candidates
+            if (index := text.find(stop)) >= 0
+        )
+        first = min(matches, default=None)
+        return (first[0], first[3]) if first is not None else None
 
     def _filter_stop_string_delta(
         self,
         text: str,
         finish_reason: str | None,
-        raw_finish_reason: Any,
-    ) -> str:
+        stop_reason: Any,
+    ) -> tuple[str, bool]:
         text = self._pending_stop_text + text
         self._pending_stop_text = ""
-        matched_stop_string = self._matched_stop_string(raw_finish_reason, text)
-        text = self._strip_stop_string_suffix(text, matched_stop_string)
-        if finish_reason or not text or not self._stop_strings:
-            return text
 
-        pending_len = _trailing_stop_prefix_len(text, self._stop_strings)
+        match = self._find_stop_string(text, stop_reason)
+        if match is not None:
+            match_index, matched_stop_string = match
+            suppressed_text = text[match_index:]
+            suppressed_count = self._trailing_logprobs_count(suppressed_text)
+            if suppressed_count:
+                del self._pending_logprobs_content[-suppressed_count:]
+            self._locally_finished = True
+            self._local_stop_reason = matched_stop_string
+            return text[:match_index], True
+
+        if finish_reason or not text or not self._stop_strings:
+            return text, False
+
+        pending_len = trailing_stop_prefix_len(text, self._stop_strings)
         if pending_len:
             self._pending_stop_text = text[-pending_len:]
-            return text[:-pending_len]
-        return text
+            return text[:-pending_len], False
+        return text, False
 
     def _parse_reasoning_delta(
         self, delta_text: str, finish_reason: str | None
@@ -1319,14 +1329,13 @@ class SglangStreamingPostProcessor:
         Returns:
             OpenAI choice dict or ``None`` if nothing to emit yet.
         """
+        if self._locally_finished:
+            return None
+
         raw_ids = engine_response.get("token_ids")
         token_ids = raw_ids if isinstance(raw_ids, list) else list(raw_ids or [])
-        raw_finish_reason = engine_response.get(
-            "raw_finish_reason", engine_response.get("finish_reason")
-        )
         finish_reason = engine_response.get("finish_reason")
-        if isinstance(finish_reason, dict):
-            finish_reason = finish_reason.get("type")
+        stop_reason = engine_response.get("stop_reason")
         log_probs = engine_response.get("log_probs")
         top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
@@ -1351,9 +1360,11 @@ class SglangStreamingPostProcessor:
             if openai_logprobs is not None:
                 self._pending_logprobs_content.extend(openai_logprobs["content"])
         self._logprob_context_ids = (self._logprob_context_ids + token_ids)[-4:]
-        delta_text = self._filter_stop_string_delta(
-            delta_text, finish_reason, raw_finish_reason
+        delta_text, locally_finished = self._filter_stop_string_delta(
+            delta_text, finish_reason, stop_reason
         )
+        if locally_finished:
+            finish_reason = "stop"
 
         if self._fast_plain_text:
             if delta_text:

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -1162,14 +1162,46 @@ class SglangStreamingPostProcessor:
 
         return ""
 
+    def _trailing_logprobs_count(self, text: str) -> int:
+        if not text:
+            return 0
+        decoded = ""
+        count = 0
+        for entry in reversed(self._pending_logprobs_content):
+            token = entry.get("token")
+            if not isinstance(token, str):
+                return 0
+            decoded = token + decoded
+            count += 1
+            if len(decoded) >= len(text):
+                if not decoded.endswith(text):
+                    return 0
+                while (
+                    count < len(self._pending_logprobs_content)
+                    and self._pending_logprobs_content[-count - 1].get("token") == ""
+                ):
+                    count += 1
+                return count
+        return 0
+
     def _take_pending_logprobs(self) -> dict[str, Any] | None:
         if not self._pending_logprobs_content:
             return None
-        content = self._pending_logprobs_content
-        self._pending_logprobs_content = []
+
+        pending_count = self._trailing_logprobs_count(self._pending_stop_text)
+        if pending_count:
+            content = self._pending_logprobs_content[:-pending_count]
+            self._pending_logprobs_content = self._pending_logprobs_content[
+                -pending_count:
+            ]
+        else:
+            content = self._pending_logprobs_content
+            self._pending_logprobs_content = []
+        if not content:
+            return None
         return {"content": content, "refusal": None}
 
-    def _matched_stop_string(self, raw_finish_reason: Any) -> str | None:
+    def _matched_stop_string(self, raw_finish_reason: Any, text: str) -> str | None:
         if not isinstance(raw_finish_reason, dict):
             return None
         if raw_finish_reason.get("type") != "stop":
@@ -1177,6 +1209,21 @@ class SglangStreamingPostProcessor:
         matched = raw_finish_reason.get("matched")
         if isinstance(matched, str) and matched in self._stop_strings:
             return matched
+        is_matched_token_id = isinstance(matched, int) and not isinstance(matched, bool)
+        is_matched_token_id_sequence = (
+            isinstance(matched, list)
+            and matched
+            and all(
+                isinstance(token_id, int) and not isinstance(token_id, bool)
+                for token_id in matched
+            )
+        )
+        if is_matched_token_id or is_matched_token_id_sequence:
+            return max(
+                (stop for stop in self._stop_strings if text.endswith(stop)),
+                key=len,
+                default=None,
+            )
         return None
 
     def _strip_stop_string_suffix(
@@ -1188,6 +1235,9 @@ class SglangStreamingPostProcessor:
         # stop string after detokenization while special tokens are preserved for
         # reasoning/tool parsers.
         if text.endswith(matched_stop_string):
+            suppressed_count = self._trailing_logprobs_count(matched_stop_string)
+            if suppressed_count:
+                del self._pending_logprobs_content[-suppressed_count:]
             return text[: -len(matched_stop_string)]
         return text
 
@@ -1195,10 +1245,11 @@ class SglangStreamingPostProcessor:
         self,
         text: str,
         finish_reason: str | None,
-        matched_stop_string: str | None,
+        raw_finish_reason: Any,
     ) -> str:
         text = self._pending_stop_text + text
         self._pending_stop_text = ""
+        matched_stop_string = self._matched_stop_string(raw_finish_reason, text)
         text = self._strip_stop_string_suffix(text, matched_stop_string)
         if finish_reason or not text or not self._stop_strings:
             return text
@@ -1276,7 +1327,6 @@ class SglangStreamingPostProcessor:
         finish_reason = engine_response.get("finish_reason")
         if isinstance(finish_reason, dict):
             finish_reason = finish_reason.get("type")
-        matched_stop_string = self._matched_stop_string(raw_finish_reason)
         log_probs = engine_response.get("log_probs")
         top_logprobs = engine_response.get("top_logprobs")
         if finish_reason is not None:
@@ -1302,7 +1352,7 @@ class SglangStreamingPostProcessor:
                 self._pending_logprobs_content.extend(openai_logprobs["content"])
         self._logprob_context_ids = (self._logprob_context_ids + token_ids)[-4:]
         delta_text = self._filter_stop_string_delta(
-            delta_text, finish_reason, matched_stop_string
+            delta_text, finish_reason, raw_finish_reason
         )
 
         if self._fast_plain_text:

--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -40,6 +40,17 @@ logger = logging.getLogger(__name__)
 ToolCallParserType: TypeAlias = FunctionCallParser | JsonArrayParser
 
 
+def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
+    if not text or not stop_strings:
+        return 0
+    max_len = min(len(text), max(len(stop) for stop in stop_strings))
+    for suffix_len in range(max_len, 0, -1):
+        suffix = text[-suffix_len:]
+        if any(stop.startswith(suffix) for stop in stop_strings):
+            return suffix_len
+    return 0
+
+
 @dataclass
 class SglangPreprocessResult:
     """Result of SGLang preprocessing."""
@@ -951,6 +962,7 @@ class SglangStreamingPostProcessor:
         tool_call_parser_name: str | None = None,
         eos_token_ids: list[int] | None = None,
         prompt_token_ids: list[int] | None = None,
+        stop_strings: set[str] | None = None,
     ) -> None:
         self.tokenizer = tokenizer
         self.tool_call_parser = tool_call_parser
@@ -972,6 +984,8 @@ class SglangStreamingPostProcessor:
             [] if self._is_json_array_parser and reasoning_parser is not None else None
         )
         self._eos_token_ids = set(eos_token_ids or [])
+        self._stop_strings = stop_strings or set()
+        self._pending_stop_text = ""
 
         # Keep a small, known-complete prompt suffix as decode context. Generated
         # tokens are promoted to context only after they decode without a
@@ -1044,6 +1058,30 @@ class SglangStreamingPostProcessor:
         self._pending_decode_ids = []
         return delta_text
 
+    def _strip_stop_string_suffix(self, text: str, finish_reason: str | None) -> str:
+        if finish_reason != "stop" or not text or not self._stop_strings:
+            return text
+        # Compatibility guard for tokenizer/text paths that surface the matched
+        # stop string after detokenization while special tokens are preserved for
+        # reasoning/tool parsers.
+        for stop in sorted(self._stop_strings, key=len, reverse=True):
+            if stop and text.endswith(stop):
+                return text[: -len(stop)]
+        return text
+
+    def _filter_stop_string_delta(self, text: str, finish_reason: str | None) -> str:
+        text = self._pending_stop_text + text
+        self._pending_stop_text = ""
+        text = self._strip_stop_string_suffix(text, finish_reason)
+        if finish_reason or not text or not self._stop_strings:
+            return text
+
+        pending_len = _trailing_stop_prefix_len(text, self._stop_strings)
+        if pending_len:
+            self._pending_stop_text = text[-pending_len:]
+            return text[:-pending_len]
+        return text
+
     def _parse_reasoning_delta(
         self, delta_text: str, finish_reason: str | None
     ) -> tuple[str | None, str]:
@@ -1114,6 +1152,7 @@ class SglangStreamingPostProcessor:
             if token_ids or finish_reason is not None
             else ""
         )
+        delta_text = self._filter_stop_string_delta(delta_text, finish_reason)
 
         if self._fast_plain_text:
             if delta_text:

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -722,7 +722,6 @@ class SglangProcessor:
             def flush_pending(
                 *,
                 finish_reason: str | None,
-                raw_finish_reason: Any | None,
                 stop_reason: Any | None,
                 engine_data: Any | None,
             ) -> dict[str, Any]:
@@ -739,7 +738,7 @@ class SglangProcessor:
                 mapped_response: dict[str, Any] = {
                     "token_ids": pending_token_ids,
                     "finish_reason": finish_reason,
-                    "raw_finish_reason": raw_finish_reason,
+                    "stop_reason": stop_reason,
                 }
                 if pending_log_probs is not None:
                     mapped_response["log_probs"] = pending_log_probs
@@ -768,10 +767,16 @@ class SglangProcessor:
                     if pending_usage:
                         dynamo_out["usage"] = pending_usage
                     response_nvext: dict[str, Any] = {}
-                    if stop_reason is not None and nvext_extra_field_requested(
-                        request, "stop_reason"
+                    effective_stop_reason = (
+                        stop_reason
+                        if stop_reason is not None
+                        else post.local_stop_reason
+                    )
+                    if (
+                        effective_stop_reason is not None
+                        and nvext_extra_field_requested(request, "stop_reason")
                     ):
-                        response_nvext["stop_reason"] = stop_reason
+                        response_nvext["stop_reason"] = effective_stop_reason
                     if engine_data is not None and nvext_extra_field_requested(
                         request, "engine_data"
                     ):
@@ -847,16 +852,12 @@ class SglangProcessor:
                     if pending_logprob_shape != chunk_logprob_shape:
                         yield flush_pending(
                             finish_reason=None,
-                            raw_finish_reason=None,
                             stop_reason=None,
                             engine_data=None,
                         )
 
                 chunk_tokens = len(new_ids)
                 cumulative_output_tokens += chunk_tokens
-                raw_finish = engine_response.get(
-                    "raw_finish_reason", engine_response.get("finish_reason")
-                )
                 finish_reason = _map_finish_reason(engine_response.get("finish_reason"))
                 stop_reason = engine_response.get("stop_reason")
 
@@ -876,14 +877,20 @@ class SglangProcessor:
 
                 # Flush on finish or when we've accumulated enough tokens.
                 # First chunk flushes immediately (si=1) to minimize TTFT.
-                flush_threshold = 1 if first_chunk else stream_interval
+                flush_threshold = (
+                    1 if first_chunk or post.has_pending_stop_text else stream_interval
+                )
                 if finish_reason or len(pending_token_ids) >= flush_threshold:
-                    yield flush_pending(
+                    envelope = flush_pending(
                         finish_reason=finish_reason,
-                        raw_finish_reason=raw_finish,
                         stop_reason=stop_reason,
                         engine_data=engine_data,
                     )
+                    if post.locally_finished and context is not None:
+                        context.stop_generating()
+                    yield envelope
+                    if post.locally_finished:
+                        break
         except Unknown:
             raise
         except Exception as e:

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -137,6 +137,15 @@ def _routing_from_agent_hints(nvext: dict[str, Any]) -> dict[str, Any] | None:
     return routing or None
 
 
+def _request_stop_strings(request: dict[str, Any]) -> set[str]:
+    stop = request.get("stop")
+    if isinstance(stop, str):
+        return {stop}
+    if isinstance(stop, list):
+        return {item for item in stop if isinstance(item, str)}
+    return set()
+
+
 def _tokenizer_eos_token_ids(tokenizer: Any) -> list[int]:
     eos_token_ids = _normalize_eos_token_ids(getattr(tokenizer, "eos_token_ids", None))
     if eos_token_ids:
@@ -599,6 +608,7 @@ class SglangProcessor:
             tool_call_parser_name=self.tool_call_parser_name,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=pre.prompt_token_ids,
+            stop_strings=_request_stop_strings(request),
         )
 
         async for item in self._generate_and_stream(
@@ -657,6 +667,7 @@ class SglangProcessor:
             tool_call_parser_name=self.tool_call_parser_name,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=preproc_result.prompt_token_ids,
+            stop_strings=_request_stop_strings(request),
         )
 
         async for item in self._generate_and_stream(

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -722,6 +722,7 @@ class SglangProcessor:
             def flush_pending(
                 *,
                 finish_reason: str | None,
+                raw_finish_reason: Any | None,
                 stop_reason: Any | None,
                 engine_data: Any | None,
             ) -> dict[str, Any]:
@@ -738,6 +739,7 @@ class SglangProcessor:
                 mapped_response: dict[str, Any] = {
                     "token_ids": pending_token_ids,
                     "finish_reason": finish_reason,
+                    "raw_finish_reason": raw_finish_reason,
                 }
                 if pending_log_probs is not None:
                     mapped_response["log_probs"] = pending_log_probs
@@ -845,6 +847,7 @@ class SglangProcessor:
                     if pending_logprob_shape != chunk_logprob_shape:
                         yield flush_pending(
                             finish_reason=None,
+                            raw_finish_reason=None,
                             stop_reason=None,
                             engine_data=None,
                         )
@@ -875,6 +878,7 @@ class SglangProcessor:
                 if finish_reason or len(pending_token_ids) >= flush_threshold:
                     yield flush_pending(
                         finish_reason=finish_reason,
+                        raw_finish_reason=raw_finish,
                         stop_reason=stop_reason,
                         engine_data=engine_data,
                     )

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -734,7 +734,6 @@ class SglangProcessor:
                 nonlocal token_count
 
                 chunk_token_count = len(pending_token_ids)
-                usage_for_metrics = pending_usage
                 mapped_response: dict[str, Any] = {
                     "token_ids": pending_token_ids,
                     "finish_reason": finish_reason,
@@ -749,6 +748,14 @@ class SglangProcessor:
                     t_pp0 = time.monotonic()
 
                 choice = post.process_output(mapped_response)
+
+                if post.locally_finished and pending_usage is None:
+                    pending_usage = {
+                        "prompt_tokens": input_tokens,
+                        "completion_tokens": cumulative_output_tokens,
+                        "total_tokens": input_tokens + cumulative_output_tokens,
+                    }
+                usage_for_metrics = pending_usage
 
                 if self.debug_perf:
                     t_pp1 = time.monotonic()

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -857,11 +857,14 @@ class SglangProcessor:
                         top_logprobs is not None,
                     )
                     if pending_logprob_shape != chunk_logprob_shape:
-                        yield flush_pending(
+                        envelope = flush_pending(
                             finish_reason=None,
                             stop_reason=None,
                             engine_data=None,
                         )
+                        yield envelope
+                        if post.locally_finished:
+                            break
 
                 chunk_tokens = len(new_ids)
                 cumulative_output_tokens += chunk_tokens
@@ -893,8 +896,6 @@ class SglangProcessor:
                         stop_reason=stop_reason,
                         engine_data=engine_data,
                     )
-                    if post.locally_finished and context is not None:
-                        context.stop_generating()
                     yield envelope
                     if post.locally_finished:
                         break

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -854,8 +854,10 @@ class SglangProcessor:
 
                 chunk_tokens = len(new_ids)
                 cumulative_output_tokens += chunk_tokens
-                raw_finish = engine_response.get("finish_reason")
-                finish_reason = _map_finish_reason(raw_finish)
+                raw_finish = engine_response.get(
+                    "raw_finish_reason", engine_response.get("finish_reason")
+                )
+                finish_reason = _map_finish_reason(engine_response.get("finish_reason"))
                 stop_reason = engine_response.get("stop_reason")
 
                 if usage := engine_response.get("completion_usage"):

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -78,6 +78,15 @@ def _normalize_eos_token_ids(value: Any) -> list[int]:
     return []
 
 
+def _request_stop_strings(request: dict[str, Any]) -> set[str]:
+    stop = request.get("stop")
+    if isinstance(stop, str):
+        return {stop}
+    if isinstance(stop, list):
+        return {item for item in stop if isinstance(item, str)}
+    return set()
+
+
 def _tokenizer_eos_token_ids(tokenizer: Any) -> list[int]:
     eos_token_ids = _normalize_eos_token_ids(getattr(tokenizer, "eos_token_ids", None))
     if eos_token_ids:
@@ -530,6 +539,7 @@ class SglangProcessor:
             tool_call_parser_name=self.tool_call_parser_name,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=pre.prompt_token_ids,
+            stop_strings=_request_stop_strings(request),
         )
 
         async for item in self._generate_and_stream(
@@ -588,6 +598,7 @@ class SglangProcessor:
             tool_call_parser_name=self.tool_call_parser_name,
             eos_token_ids=self.eos_token_ids,
             prompt_token_ids=preproc_result.prompt_token_ids,
+            stop_strings=_request_stop_strings(request),
         )
 
         async for item in self._generate_and_stream(

--- a/components/src/dynamo/frontend/tests/_routed_engine_fakes.py
+++ b/components/src/dynamo/frontend/tests/_routed_engine_fakes.py
@@ -4,9 +4,13 @@
 """Shared fakes for RoutedEngine in processor unit tests."""
 
 
-async def _async_iter(items):
-    for item in items:
-        yield item
+async def _async_iter(items, engine):
+    try:
+        for item in items:
+            engine.yielded += 1
+            yield item
+    finally:
+        engine.stream_released = True
 
 
 class FakeRoutedItem:
@@ -39,8 +43,10 @@ class FakeRoutedEngine:
         self.items = items
         self.requests = []
         self.kwargs = []
+        self.yielded = 0
+        self.stream_released = False
 
     async def generate(self, preprocessed, **kwargs):
         self.requests.append(preprocessed)
         self.kwargs.append(kwargs)
-        return _async_iter(self.items)
+        return _async_iter(self.items, self)

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_metrics_unit.py
@@ -134,6 +134,10 @@ def _install_sglang_stubs(install_module):
 
 
 class _PostProcessor:
+    locally_finished = False
+    has_pending_stop_text = False
+    local_stop_reason = None
+
     def process_output(self, mapped_response):
         return {
             "index": 0,

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3251,6 +3251,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             {
                 "token_ids": tokenizer.encode("<|user|>"),
                 "finish_reason": "stop",
+                "raw_finish_reason": {"type": "stop", "matched": "<|user|>"},
             }
         )
 
@@ -3275,6 +3276,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             {
                 "token_ids": tokenizer.encode("er|>"),
                 "finish_reason": "stop",
+                "raw_finish_reason": {"type": "stop", "matched": "<|user|>"},
             }
         )
 
@@ -3282,6 +3284,26 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert first["delta"]["content"] == "Hello"
         assert final is not None
         assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+
+    def test_stop_suffix_is_preserved_when_eos_matched(self, tokenizer):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"\n\n"},
+        )
+
+        final = post.process_output(
+            {
+                "token_ids": tokenizer.encode("Hello\n\n"),
+                "finish_reason": "stop",
+                "raw_finish_reason": {"type": "eos", "matched": None},
+            }
+        )
+
+        assert final is not None
+        assert final["delta"]["content"] == "Hello\n\n"
         assert final["finish_reason"] == "stop"
 
     def test_empty_token_ids(self, tokenizer):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3360,8 +3360,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert chunks[0]["choices"][0]["delta"]["content"] == "A"
         assert chunks[0]["choices"][0]["finish_reason"] is None
         assert [
-            entry["token"]
-            for entry in chunks[0]["choices"][0]["logprobs"]["content"]
+            entry["token"] for entry in chunks[0]["choices"][0]["logprobs"]["content"]
         ] == ["A"]
         assert "usage" not in chunks[0]
         assert chunks[1]["choices"][0]["delta"] == {}

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3236,6 +3236,30 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert finished is not None
         assert finished["delta"]["content"] == "\ufffd"
 
+    def test_final_stop_string_suffix_is_not_emitted(self, tokenizer):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"<|user|>"},
+        )
+
+        first = post.process_output(
+            {"token_ids": tokenizer.encode("Hello"), "finish_reason": None}
+        )
+        final = post.process_output(
+            {
+                "token_ids": tokenizer.encode("<|user|>"),
+                "finish_reason": "stop",
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "Hello"
+        assert final is not None
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+
     def test_empty_token_ids(self, tokenizer):
         """Empty token_ids with no finish_reason returns None."""
         post = SglangStreamingPostProcessor(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3335,7 +3335,15 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             return [
                 item["data"]
                 async for item in processor._generate_and_stream(
-                    "req-stop", {"model": "test-model"}, {}, [], post, context
+                    "req-stop",
+                    {
+                        "model": "test-model",
+                        "stream_options": {"include_usage": True},
+                    },
+                    {},
+                    [1, 2],
+                    post,
+                    context,
                 )
                 if "data" in item
             ]
@@ -3344,8 +3352,14 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
 
         assert chunks[0]["choices"][0]["delta"]["content"] == "A"
         assert chunks[0]["choices"][0]["finish_reason"] is None
+        assert "usage" not in chunks[0]
         assert chunks[1]["choices"][0]["delta"] == {}
         assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+        assert chunks[1]["usage"] == {
+            "prompt_tokens": 2,
+            "completion_tokens": 11,
+            "total_tokens": 13,
+        }
         assert context.stopped
         assert len(chunks) == 2
 

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3251,7 +3251,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             {
                 "token_ids": tokenizer.encode("<|user|>"),
                 "finish_reason": "stop",
-                "raw_finish_reason": {"type": "stop", "matched": 128001},
+                "stop_reason": "<|user|>",
             }
         )
 
@@ -3261,7 +3261,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
 
-    def test_processor_preserves_raw_finish_reason_for_stop_filtering(self):
+    def test_processor_passes_typed_stop_reason_to_postprocessor(self):
         processor = SglangProcessor(
             tokenizer=self.ByteTokenizer(),
             routed_engine=FakeRoutedEngine(
@@ -3269,7 +3269,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
                     {
                         "token_ids": list(b"AEND"),
                         "finish_reason": "stop",
-                        "raw_finish_reason": {"type": "stop", "matched": 128001},
+                        "stop_reason": "END",
                     }
                 ]
             ),
@@ -3299,6 +3299,56 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert chunks[0]["choices"][0]["delta"]["content"] == "A"
         assert chunks[0]["choices"][0]["finish_reason"] == "stop"
 
+    def test_processor_stops_generation_on_local_stop_string(self):
+        processor = SglangProcessor(
+            tokenizer=self.ByteTokenizer(),
+            routed_engine=FakeRoutedEngine(
+                items=[
+                    {
+                        "token_ids": list(b"AEN"),
+                        "finish_reason": None,
+                    },
+                    {"token_ids": list(b"Dignored"), "finish_reason": None},
+                ]
+            ),
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+            eos_token_ids=None,
+            stream_interval=20,
+        )
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"END"},
+        )
+
+        class Context:
+            stopped = False
+
+            def stop_generating(self):
+                self.stopped = True
+
+        context = Context()
+
+        async def collect():
+            return [
+                item["data"]
+                async for item in processor._generate_and_stream(
+                    "req-stop", {"model": "test-model"}, {}, [], post, context
+                )
+                if "data" in item
+            ]
+
+        chunks = asyncio.run(collect())
+
+        assert chunks[0]["choices"][0]["delta"]["content"] == "A"
+        assert chunks[0]["choices"][0]["finish_reason"] is None
+        assert chunks[1]["choices"][0]["delta"] == {}
+        assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+        assert context.stopped
+        assert len(chunks) == 2
+
     def test_split_stop_string_suffix_is_not_emitted(self, tokenizer):
         post = SglangStreamingPostProcessor(
             tokenizer=tokenizer,
@@ -3313,8 +3363,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         final = post.process_output(
             {
                 "token_ids": tokenizer.encode("er|>"),
-                "finish_reason": "stop",
-                "raw_finish_reason": {"type": "stop", "matched": "<|user|>"},
+                "finish_reason": None,
             }
         )
 
@@ -3342,8 +3391,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         final = post.process_output(
             {
                 "token_ids": [ord("D")],
-                "finish_reason": "stop",
-                "raw_finish_reason": {"type": "stop", "matched": 128001},
+                "finish_reason": None,
                 "log_probs": [-0.4],
             }
         )
@@ -3375,7 +3423,6 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             {
                 "token_ids": [],
                 "finish_reason": "stop",
-                "raw_finish_reason": {"type": "eos", "matched": None},
             }
         )
 
@@ -3388,7 +3435,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             "N",
         ]
 
-    def test_stop_suffix_is_preserved_when_eos_matched(self, tokenizer):
+    def test_complete_stop_string_is_suppressed_before_backend_finish(self, tokenizer):
         post = SglangStreamingPostProcessor(
             tokenizer=tokenizer,
             tool_call_parser=None,
@@ -3398,14 +3445,13 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
 
         final = post.process_output(
             {
-                "token_ids": tokenizer.encode("Hello\n\n"),
-                "finish_reason": "stop",
-                "raw_finish_reason": {"type": "eos", "matched": None},
+                "token_ids": tokenizer.encode("Hello\n\nignored"),
+                "finish_reason": None,
             }
         )
 
         assert final is not None
-        assert final["delta"]["content"] == "Hello\n\n"
+        assert final["delta"]["content"] == "Hello"
         assert final["finish_reason"] == "stop"
 
     def test_empty_token_ids(self, tokenizer):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3251,7 +3251,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
             {
                 "token_ids": tokenizer.encode("<|user|>"),
                 "finish_reason": "stop",
-                "raw_finish_reason": {"type": "stop", "matched": "<|user|>"},
+                "raw_finish_reason": {"type": "stop", "matched": 128001},
             }
         )
 
@@ -3260,6 +3260,44 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert final is not None
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
+
+    def test_processor_preserves_raw_finish_reason_for_stop_filtering(self):
+        processor = SglangProcessor(
+            tokenizer=self.ByteTokenizer(),
+            routed_engine=FakeRoutedEngine(
+                items=[
+                    {
+                        "token_ids": list(b"AEND"),
+                        "finish_reason": "stop",
+                        "raw_finish_reason": {"type": "stop", "matched": 128001},
+                    }
+                ]
+            ),
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+            eos_token_ids=None,
+            stream_interval=20,
+        )
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"END"},
+        )
+
+        async def collect():
+            return [
+                item["data"]
+                async for item in processor._generate_and_stream(
+                    "req-stop", {"model": "test-model"}, {}, [], post
+                )
+                if "data" in item
+            ]
+
+        chunks = asyncio.run(collect())
+
+        assert chunks[0]["choices"][0]["delta"]["content"] == "A"
+        assert chunks[0]["choices"][0]["finish_reason"] == "stop"
 
     def test_split_stop_string_suffix_is_not_emitted(self, tokenizer):
         post = SglangStreamingPostProcessor(
@@ -3285,6 +3323,70 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert final is not None
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
+
+    def test_split_stop_string_logprobs_are_not_emitted(self):
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"END"},
+        )
+
+        first = post.process_output(
+            {
+                "token_ids": list(b"AEN"),
+                "finish_reason": None,
+                "log_probs": [-0.1, -0.2, -0.3],
+            }
+        )
+        final = post.process_output(
+            {
+                "token_ids": [ord("D")],
+                "finish_reason": "stop",
+                "raw_finish_reason": {"type": "stop", "matched": 128001},
+                "log_probs": [-0.4],
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "A"
+        assert [entry["token"] for entry in first["logprobs"]["content"]] == ["A"]
+        assert final is not None
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+        assert final["logprobs"] is None
+
+    def test_pending_stop_logprobs_are_flushed_without_match(self):
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"END"},
+        )
+
+        first = post.process_output(
+            {
+                "token_ids": list(b"AEN"),
+                "finish_reason": None,
+                "log_probs": [-0.1, -0.2, -0.3],
+            }
+        )
+        final = post.process_output(
+            {
+                "token_ids": [],
+                "finish_reason": "stop",
+                "raw_finish_reason": {"type": "eos", "matched": None},
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "A"
+        assert final is not None
+        assert final["delta"]["content"] == "EN"
+        assert [entry["token"] for entry in final["logprobs"]["content"]] == [
+            "E",
+            "N",
+        ]
 
     def test_stop_suffix_is_preserved_when_eos_matched(self, tokenizer):
         post = SglangStreamingPostProcessor(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3299,18 +3299,25 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert chunks[0]["choices"][0]["delta"]["content"] == "A"
         assert chunks[0]["choices"][0]["finish_reason"] == "stop"
 
-    def test_processor_stops_generation_on_local_stop_string(self):
+    def test_processor_finishes_locally_without_stopping_parent_context(self):
+        routed_engine = FakeRoutedEngine(
+            items=[
+                {
+                    "token_ids": list(b"AEN"),
+                    "finish_reason": None,
+                    "log_probs": [-0.1, -0.2, -0.3],
+                },
+                {
+                    "token_ids": list(b"Dignored"),
+                    "finish_reason": None,
+                    "log_probs": [-0.4] * len(b"Dignored"),
+                },
+                {"token_ids": list(b"not-consumed"), "finish_reason": None},
+            ]
+        )
         processor = SglangProcessor(
             tokenizer=self.ByteTokenizer(),
-            routed_engine=FakeRoutedEngine(
-                items=[
-                    {
-                        "token_ids": list(b"AEN"),
-                        "finish_reason": None,
-                    },
-                    {"token_ids": list(b"Dignored"), "finish_reason": None},
-                ]
-            ),
+            routed_engine=routed_engine,
             tool_call_parser_name=None,
             reasoning_parser_name=None,
             eos_token_ids=None,
@@ -3352,15 +3359,90 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
 
         assert chunks[0]["choices"][0]["delta"]["content"] == "A"
         assert chunks[0]["choices"][0]["finish_reason"] is None
+        assert [
+            entry["token"]
+            for entry in chunks[0]["choices"][0]["logprobs"]["content"]
+        ] == ["A"]
         assert "usage" not in chunks[0]
         assert chunks[1]["choices"][0]["delta"] == {}
         assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+        assert chunks[1]["choices"][0]["logprobs"] is None
         assert chunks[1]["usage"] == {
             "prompt_tokens": 2,
             "completion_tokens": 11,
             "total_tokens": 13,
         }
-        assert context.stopped
+        assert not context.stopped
+        assert routed_engine.yielded == 2
+        assert routed_engine.stream_released
+        assert len(chunks) == 2
+
+    def test_logprob_shape_flush_finishes_without_stopping_parent_context(self):
+        routed_engine = FakeRoutedEngine(
+            items=[
+                {"token_ids": list(b"A"), "finish_reason": None},
+                {"token_ids": list(b"END"), "finish_reason": None},
+                {
+                    "token_ids": list(b"x"),
+                    "finish_reason": None,
+                    "log_probs": [-0.1],
+                },
+                {"token_ids": list(b"not-consumed"), "finish_reason": None},
+            ]
+        )
+        processor = SglangProcessor(
+            tokenizer=self.ByteTokenizer(),
+            routed_engine=routed_engine,
+            tool_call_parser_name=None,
+            reasoning_parser_name=None,
+            eos_token_ids=None,
+            stream_interval=20,
+        )
+        post = SglangStreamingPostProcessor(
+            tokenizer=self.ByteTokenizer(),
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"END"},
+        )
+
+        class Context:
+            stopped = False
+
+            def stop_generating(self):
+                self.stopped = True
+
+        context = Context()
+
+        async def collect():
+            return [
+                item["data"]
+                async for item in processor._generate_and_stream(
+                    "req-stop",
+                    {
+                        "model": "test-model",
+                        "stream_options": {"include_usage": True},
+                    },
+                    {},
+                    [1, 2],
+                    post,
+                    context,
+                )
+                if "data" in item
+            ]
+
+        chunks = asyncio.run(collect())
+
+        assert chunks[0]["choices"][0]["delta"]["content"] == "A"
+        assert chunks[1]["choices"][0]["delta"] == {}
+        assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+        assert chunks[1]["usage"] == {
+            "prompt_tokens": 2,
+            "completion_tokens": 4,
+            "total_tokens": 6,
+        }
+        assert not context.stopped
+        assert routed_engine.yielded == 3
+        assert routed_engine.stream_released
         assert len(chunks) == 2
 
     def test_split_stop_string_suffix_is_not_emitted(self, tokenizer):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -3260,6 +3260,30 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
 
+    def test_split_stop_string_suffix_is_not_emitted(self, tokenizer):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"<|user|>"},
+        )
+
+        first = post.process_output(
+            {"token_ids": tokenizer.encode("Hello<|us"), "finish_reason": None}
+        )
+        final = post.process_output(
+            {
+                "token_ids": tokenizer.encode("er|>"),
+                "finish_reason": "stop",
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "Hello"
+        assert final is not None
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+
     def test_empty_token_ids(self, tokenizer):
         """Empty token_ids with no finish_reason returns None."""
         post = SglangStreamingPostProcessor(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2932,6 +2932,30 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert finished is not None
         assert finished["delta"]["content"] == "\ufffd"
 
+    def test_final_stop_string_suffix_is_not_emitted(self, tokenizer):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"<|user|>"},
+        )
+
+        first = post.process_output(
+            {"token_ids": tokenizer.encode("Hello"), "finish_reason": None}
+        )
+        final = post.process_output(
+            {
+                "token_ids": tokenizer.encode("<|user|>"),
+                "finish_reason": "stop",
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "Hello"
+        assert final is not None
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+
     def test_empty_token_ids(self, tokenizer):
         """Empty token_ids with no finish_reason returns None."""
         post = SglangStreamingPostProcessor(

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2956,6 +2956,30 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         assert final["delta"] == {}
         assert final["finish_reason"] == "stop"
 
+    def test_split_stop_string_suffix_is_not_emitted(self, tokenizer):
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer,
+            tool_call_parser=None,
+            reasoning_parser=None,
+            stop_strings={"<|user|>"},
+        )
+
+        first = post.process_output(
+            {"token_ids": tokenizer.encode("Hello<|us"), "finish_reason": None}
+        )
+        final = post.process_output(
+            {
+                "token_ids": tokenizer.encode("er|>"),
+                "finish_reason": "stop",
+            }
+        )
+
+        assert first is not None
+        assert first["delta"]["content"] == "Hello"
+        assert final is not None
+        assert final["delta"] == {}
+        assert final["finish_reason"] == "stop"
+
     def test_empty_token_ids(self, tokenizer):
         """Empty token_ids with no finish_reason returns None."""
         post = SglangStreamingPostProcessor(

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -99,6 +99,64 @@ def _user_stop_token_ids(request: Dict[str, Any]) -> set[int]:
     }
 
 
+def _suppressed_stop_token_ids(request: Dict[str, Any]) -> set[int]:
+    stop_conditions = request.get("stop_conditions") or {}
+    if not isinstance(stop_conditions, dict):
+        return set()
+
+    values = [
+        *(stop_conditions.get("stop_token_ids") or []),
+        *(stop_conditions.get("stop_token_ids_hidden") or []),
+    ]
+    return {
+        token_id
+        for token_id in values
+        if isinstance(token_id, int) and not isinstance(token_id, bool)
+    }
+
+
+def _stop_strings(request: Dict[str, Any]) -> set[str]:
+    stop_conditions = request.get("stop_conditions")
+    stop = (
+        stop_conditions.get("stop")
+        if isinstance(stop_conditions, dict)
+        else request.get("stop")
+    )
+    if isinstance(stop, str):
+        return {stop}
+    if isinstance(stop, list):
+        return {item for item in stop if isinstance(item, str)}
+    return set()
+
+
+def _remove_suppressed_stop_tokens(
+    output_ids: list[int],
+    matched: Any,
+    suppressed_stop_token_ids: set[int] | None,
+) -> list[int]:
+    if not output_ids or not suppressed_stop_token_ids:
+        return output_ids
+
+    if isinstance(matched, int) and not isinstance(matched, bool):
+        matched_ids = [matched]
+    elif isinstance(matched, list) and all(
+        isinstance(item, int) and not isinstance(item, bool) for item in matched
+    ):
+        matched_ids = matched
+    else:
+        return output_ids
+
+    if (
+        matched_ids
+        and all(token_id in suppressed_stop_token_ids for token_id in matched_ids)
+        and len(output_ids) >= len(matched_ids)
+        and output_ids[-len(matched_ids) :] == matched_ids
+    ):
+        return output_ids[: -len(matched_ids)]
+
+    return output_ids
+
+
 def _openai_stop_sampling_params(request: Dict[str, Any]) -> Dict[str, Any]:
     stop = request.get("stop")
     if isinstance(stop, str):
@@ -292,11 +350,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             _plain = stop_conditions.get("stop_token_ids") or []
             _merged = list(set(_hidden).union(_plain))
             stop_token_ids = _merged if _merged else None
+            stop = stop_conditions.get("stop") or None
 
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                "stop": stop,
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),
                 **self._get_guided_decoding_params(
@@ -368,6 +428,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             output_options.get("return_tokens_as_token_ids")
         )
         user_stop_token_ids = _user_stop_token_ids(request)
+        suppressed_stop_token_ids = _suppressed_stop_token_ids(request)
 
         lora_path = self._resolve_lora(request)
         if lora_path:
@@ -424,6 +485,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    suppressed_stop_token_ids=suppressed_stop_token_ids,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -494,6 +556,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    suppressed_stop_token_ids=suppressed_stop_token_ids,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -513,6 +576,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         context: Context,
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
+        suppressed_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
@@ -565,13 +629,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         out["stop_reason"] = stop_reason
 
                 # With stream_output=True, output_ids contains only new tokens (disjoint)
-                output_ids = res.get("output_ids", [])
+                output_ids = list(res.get("output_ids", []))
                 # Empty, non-final chunks can happen during scheduler idle ticks.
                 # Keep waiting for the next chunk unless cancellation was requested.
                 if not output_ids and not finish_reason:
                     if context.is_stopped():
                         break
                     continue
+
+                matched = finish_reason.get("matched") if finish_reason else None
+                output_ids = _remove_suppressed_stop_tokens(
+                    output_ids, matched, suppressed_stop_token_ids
+                )
 
                 # Pass through disjoint token segments directly
                 out["token_ids"] = output_ids
@@ -645,6 +714,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             OpenAI-formatted chat completion chunk dicts.
         """
         request = request or {}
+        stop_strings = _stop_strings(request)
         # SGLang text chunks are cumulative per choice. Keep independent text
         # offsets so interleaved n>1 choices do not compute deltas from each
         # other's previous text.
@@ -680,7 +750,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 )
                 next_count = len(text)
                 count = text_counts_per_choice.get(index, 0)
-                delta = text[count:]
+                visible_text_len = next_count
+                matched = finish_reason.get("matched") if finish_reason else None
+                if (
+                    isinstance(matched, str)
+                    and matched in stop_strings
+                    and text.endswith(matched)
+                ):
+                    visible_text_len = len(text) - len(matched)
+
+                delta = text[count:visible_text_len] if visible_text_len > count else ""
 
                 choice_data = {
                     "index": index,
@@ -718,4 +797,4 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     response["nvext"] = response_nvext
                 if not context.is_stopped():
                     yield response
-                text_counts_per_choice[index] = next_count
+                text_counts_per_choice[index] = visible_text_len

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -161,6 +161,64 @@ def _user_stop_token_ids(request: Dict[str, Any]) -> set[int]:
     }
 
 
+def _suppressed_stop_token_ids(request: Dict[str, Any]) -> set[int]:
+    stop_conditions = request.get("stop_conditions") or {}
+    if not isinstance(stop_conditions, dict):
+        return set()
+
+    values = [
+        *(stop_conditions.get("stop_token_ids") or []),
+        *(stop_conditions.get("stop_token_ids_hidden") or []),
+    ]
+    return {
+        token_id
+        for token_id in values
+        if isinstance(token_id, int) and not isinstance(token_id, bool)
+    }
+
+
+def _stop_strings(request: Dict[str, Any]) -> set[str]:
+    stop_conditions = request.get("stop_conditions")
+    stop = (
+        stop_conditions.get("stop")
+        if isinstance(stop_conditions, dict)
+        else request.get("stop")
+    )
+    if isinstance(stop, str):
+        return {stop}
+    if isinstance(stop, list):
+        return {item for item in stop if isinstance(item, str)}
+    return set()
+
+
+def _remove_suppressed_stop_tokens(
+    output_ids: list[int],
+    matched: Any,
+    suppressed_stop_token_ids: set[int] | None,
+) -> list[int]:
+    if not output_ids or not suppressed_stop_token_ids:
+        return output_ids
+
+    if isinstance(matched, int) and not isinstance(matched, bool):
+        matched_ids = [matched]
+    elif isinstance(matched, list) and all(
+        isinstance(item, int) and not isinstance(item, bool) for item in matched
+    ):
+        matched_ids = matched
+    else:
+        return output_ids
+
+    if (
+        matched_ids
+        and all(token_id in suppressed_stop_token_ids for token_id in matched_ids)
+        and len(output_ids) >= len(matched_ids)
+        and output_ids[-len(matched_ids) :] == matched_ids
+    ):
+        return output_ids[: -len(matched_ids)]
+
+    return output_ids
+
+
 def _openai_stop_sampling_params(request: Dict[str, Any]) -> Dict[str, Any]:
     stop = request.get("stop")
     if isinstance(stop, str):
@@ -359,12 +417,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             _plain = stop_conditions.get("stop_token_ids") or []
             _merged = list(set(_hidden).union(_plain))
             stop_token_ids = _merged if _merged else None
+            stop = stop_conditions.get("stop") or None
 
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                "stop": stop,
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),
                 **self._get_guided_decoding_params(
@@ -493,6 +553,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             output_options.get("return_tokens_as_token_ids")
         )
         user_stop_token_ids = _user_stop_token_ids(request)
+        suppressed_stop_token_ids = _suppressed_stop_token_ids(request)
 
         lora_path = self._resolve_lora(request)
         if lora_path:
@@ -549,6 +610,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    suppressed_stop_token_ids=suppressed_stop_token_ids,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -632,6 +694,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     context,
                     return_tokens_as_token_ids,
                     user_stop_token_ids=user_stop_token_ids,
+                    suppressed_stop_token_ids=suppressed_stop_token_ids,
                     metadata_uploader=metadata_uploader,
                 ):
                     yield out
@@ -675,6 +738,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         context: Context,
         return_tokens_as_token_ids: bool = False,
         user_stop_token_ids: set[int] | None = None,
+        suppressed_stop_token_ids: set[int] | None = None,
         metadata_uploader: MetadataUploader | None = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process token-based stream output.
@@ -723,13 +787,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         out["stop_reason"] = stop_reason
 
                 # With stream_output=True, output_ids contains only new tokens (disjoint)
-                output_ids = res.get("output_ids", [])
+                output_ids = list(res.get("output_ids", []))
                 # Empty, non-final chunks can happen during scheduler idle ticks.
                 # Keep waiting for the next chunk unless cancellation was requested.
                 if not output_ids and not finish_reason:
                     if context.is_stopped():
                         break
                     continue
+
+                matched = finish_reason.get("matched") if finish_reason else None
+                output_ids = _remove_suppressed_stop_tokens(
+                    output_ids, matched, suppressed_stop_token_ids
+                )
 
                 if output_ids and not first_output_seen:
                     first_output_seen = True
@@ -811,6 +880,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             OpenAI-formatted chat completion chunk dicts.
         """
         request = request or {}
+        stop_strings = _stop_strings(request)
         # SGLang text chunks are cumulative per choice. Keep independent text
         # offsets so interleaved n>1 choices do not compute deltas from each
         # other's previous text.
@@ -847,7 +917,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 )
                 next_count = len(text)
                 count = text_counts_per_choice.get(index, 0)
-                delta = text[count:]
+                visible_text_len = next_count
+                matched = finish_reason.get("matched") if finish_reason else None
+                if (
+                    isinstance(matched, str)
+                    and matched in stop_strings
+                    and text.endswith(matched)
+                ):
+                    visible_text_len = len(text) - len(matched)
+
+                delta = text[count:visible_text_len] if visible_text_len > count else ""
                 if res.get("output_ids") and not first_output_seen:
                     first_output_seen = True
                     context.notify_first_token()
@@ -888,4 +967,4 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     response["nvext"] = response_nvext
                 if not context.is_stopped():
                     yield response
-                text_counts_per_choice[index] = next_count
+                text_counts_per_choice[index] = visible_text_len

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -772,6 +772,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         pending_stop_tokens_per_choice: dict[int, list[int]] = {}
         pending_log_probs_per_choice: dict[int, list[Any]] = {}
         pending_top_logprobs_per_choice: dict[int, list[Any]] = {}
+        completion_tokens_per_choice: dict[int, int] = {}
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
@@ -894,10 +895,14 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     if cached_tokens is not None and cached_tokens > 0:
                         prefill_prompt_tokens_details = {"cached_tokens": cached_tokens}
                     if input_tokens is not None and completion_tokens is not None:
+                        completion_tokens_per_choice[output_idx] = completion_tokens
+                        request_completion_tokens = sum(
+                            completion_tokens_per_choice.values()
+                        )
                         completion_usage = {
                             "prompt_tokens": input_tokens,
-                            "completion_tokens": completion_tokens,
-                            "total_tokens": input_tokens + completion_tokens,
+                            "completion_tokens": request_completion_tokens,
+                            "total_tokens": input_tokens + request_completion_tokens,
                         }
                         if prefill_prompt_tokens_details is not None:
                             completion_usage[

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -166,10 +166,7 @@ def _suppressed_stop_token_ids(request: Dict[str, Any]) -> set[int]:
     if not isinstance(stop_conditions, dict):
         return set()
 
-    values = [
-        *(stop_conditions.get("stop_token_ids") or []),
-        *(stop_conditions.get("stop_token_ids_hidden") or []),
-    ]
+    values = stop_conditions.get("stop_token_ids_hidden") or []
     return {
         token_id
         for token_id in values
@@ -191,13 +188,24 @@ def _stop_strings(request: Dict[str, Any]) -> set[str]:
     return set()
 
 
+def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
+    if not text or not stop_strings:
+        return 0
+    max_len = min(len(text), max(len(stop) for stop in stop_strings))
+    for suffix_len in range(max_len, 0, -1):
+        suffix = text[-suffix_len:]
+        if any(stop.startswith(suffix) for stop in stop_strings):
+            return suffix_len
+    return 0
+
+
 def _remove_suppressed_stop_tokens(
     output_ids: list[int],
     matched: Any,
     suppressed_stop_token_ids: set[int] | None,
-) -> list[int]:
+) -> tuple[list[int], int]:
     if not output_ids or not suppressed_stop_token_ids:
-        return output_ids
+        return output_ids, 0
 
     if isinstance(matched, int) and not isinstance(matched, bool):
         matched_ids = [matched]
@@ -206,7 +214,7 @@ def _remove_suppressed_stop_tokens(
     ):
         matched_ids = matched
     else:
-        return output_ids
+        return output_ids, 0
 
     if (
         matched_ids
@@ -214,9 +222,22 @@ def _remove_suppressed_stop_tokens(
         and len(output_ids) >= len(matched_ids)
         and output_ids[-len(matched_ids) :] == matched_ids
     ):
-        return output_ids[: -len(matched_ids)]
+        return output_ids[: -len(matched_ids)], len(matched_ids)
 
-    return output_ids
+    return output_ids, 0
+
+
+def _split_trailing_suppressed_stop_tokens(
+    output_ids: list[int],
+    suppressed_stop_token_ids: set[int] | None,
+) -> tuple[list[int], list[int]]:
+    if not output_ids or not suppressed_stop_token_ids:
+        return output_ids, []
+
+    split_at = len(output_ids)
+    while split_at > 0 and output_ids[split_at - 1] in suppressed_stop_token_ids:
+        split_at -= 1
+    return output_ids[:split_at], output_ids[split_at:]
 
 
 def _openai_stop_sampling_params(request: Dict[str, Any]) -> Dict[str, Any]:
@@ -756,6 +777,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # Use Future pattern for request ID - will be set when first response arrives
         request_id_future: asyncio.Future[str] = asyncio.Future()
         first_output_seen = False
+        pending_stop_tokens_per_choice: dict[int, list[int]] = {}
+        pending_log_probs_per_choice: dict[int, list[Any]] = {}
+        pending_top_logprobs_per_choice: dict[int, list[Any]] = {}
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
@@ -787,7 +811,59 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         out["stop_reason"] = stop_reason
 
                 # With stream_output=True, output_ids contains only new tokens (disjoint)
-                output_ids = list(res.get("output_ids", []))
+                raw_output_ids = list(res.get("output_ids", []))
+                if raw_output_ids and not first_output_seen:
+                    first_output_seen = True
+                    context.notify_first_token()
+                log_probs = None
+                top_logprobs = None
+                if metadata_uploader is None:
+                    # Extract logprobs for new tokens if available.
+                    log_probs, top_logprobs = self._extract_logprobs(
+                        meta_info,
+                        num_output_tokens_in_chunk=len(raw_output_ids),
+                        return_tokens_as_token_ids=return_tokens_as_token_ids,
+                    )
+
+                output_ids = pending_stop_tokens_per_choice.pop(output_idx, [])
+                output_ids.extend(raw_output_ids)
+                if log_probs is not None:
+                    log_probs = pending_log_probs_per_choice.pop(output_idx, []) + list(
+                        log_probs
+                    )
+                if top_logprobs is not None:
+                    top_logprobs = pending_top_logprobs_per_choice.pop(
+                        output_idx, []
+                    ) + list(top_logprobs)
+
+                matched = finish_reason.get("matched") if finish_reason else None
+                output_ids, removed_count = _remove_suppressed_stop_tokens(
+                    output_ids, matched, suppressed_stop_token_ids
+                )
+                if removed_count:
+                    if log_probs is not None:
+                        log_probs = log_probs[:-removed_count]
+                    if top_logprobs is not None:
+                        top_logprobs = top_logprobs[:-removed_count]
+                elif not finish_reason:
+                    output_ids, pending_stop_tokens = (
+                        _split_trailing_suppressed_stop_tokens(
+                            output_ids, suppressed_stop_token_ids
+                        )
+                    )
+                    if pending_stop_tokens:
+                        pending_stop_tokens_per_choice[output_idx] = pending_stop_tokens
+                        if log_probs is not None:
+                            pending_log_probs_per_choice[output_idx] = log_probs[
+                                -len(pending_stop_tokens) :
+                            ]
+                            log_probs = log_probs[: -len(pending_stop_tokens)]
+                        if top_logprobs is not None:
+                            pending_top_logprobs_per_choice[output_idx] = top_logprobs[
+                                -len(pending_stop_tokens) :
+                            ]
+                            top_logprobs = top_logprobs[: -len(pending_stop_tokens)]
+
                 # Empty, non-final chunks can happen during scheduler idle ticks.
                 # Keep waiting for the next chunk unless cancellation was requested.
                 if not output_ids and not finish_reason:
@@ -795,28 +871,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         break
                     continue
 
-                matched = finish_reason.get("matched") if finish_reason else None
-                output_ids = _remove_suppressed_stop_tokens(
-                    output_ids, matched, suppressed_stop_token_ids
-                )
-
-                if output_ids and not first_output_seen:
-                    first_output_seen = True
-                    context.notify_first_token()
-
                 # Pass through disjoint token segments directly
                 out["token_ids"] = output_ids
-                if metadata_uploader is None:
-                    # Extract logprobs for new tokens if available
-                    log_probs, top_logprobs = self._extract_logprobs(
-                        meta_info,
-                        num_output_tokens_in_chunk=len(output_ids),
-                        return_tokens_as_token_ids=return_tokens_as_token_ids,
-                    )
-                    if log_probs is not None:
-                        out["log_probs"] = log_probs
-                    if top_logprobs is not None:
-                        out["top_logprobs"] = top_logprobs
+
+                if log_probs is not None:
+                    out["log_probs"] = log_probs
+                if top_logprobs is not None:
+                    out["top_logprobs"] = top_logprobs
 
                 engine_data: dict[str, Any] = dict(res.get("engine_data") or {})
                 routed_experts = meta_info.get("routed_experts")
@@ -925,6 +986,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     and text.endswith(matched)
                 ):
                     visible_text_len = len(text) - len(matched)
+                elif not finish_reason:
+                    visible_text_len -= _trailing_stop_prefix_len(
+                        text, stop_strings
+                    )
 
                 delta = text[count:visible_text_len] if visible_text_len > count else ""
                 if res.get("output_ids") and not first_output_seen:

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -692,10 +692,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     if top_logprobs is not None:
                         top_logprobs = top_logprobs[:-removed_count]
                 elif not finish_reason:
-                    output_ids, pending_stop_tokens = (
-                        _split_trailing_suppressed_stop_tokens(
-                            output_ids, suppressed_stop_token_ids
-                        )
+                    (
+                        output_ids,
+                        pending_stop_tokens,
+                    ) = _split_trailing_suppressed_stop_tokens(
+                        output_ids, suppressed_stop_token_ids
                     )
                     if pending_stop_tokens:
                         pending_stop_tokens_per_choice[output_idx] = pending_stop_tokens
@@ -822,9 +823,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     visible_text_len = len(text) - len(matched)
                 elif not finish_reason:
-                    visible_text_len -= _trailing_stop_prefix_len(
-                        text, stop_strings
-                    )
+                    visible_text_len -= _trailing_stop_prefix_len(text, stop_strings)
 
                 delta = text[count:visible_text_len] if visible_text_len > count else ""
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -445,6 +445,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
+                # With --skip-tokenizer-init, SGLang may not have a tokenizer
+                # available for stop-string matching; tokenizer-enabled workers
+                # still need the string stop conditions forwarded.
                 "stop": stop,
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -846,10 +846,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     if top_logprobs is not None:
                         top_logprobs = top_logprobs[:-removed_count]
                 elif not finish_reason:
-                    output_ids, pending_stop_tokens = (
-                        _split_trailing_suppressed_stop_tokens(
-                            output_ids, suppressed_stop_token_ids
-                        )
+                    (
+                        output_ids,
+                        pending_stop_tokens,
+                    ) = _split_trailing_suppressed_stop_tokens(
+                        output_ids, suppressed_stop_token_ids
                     )
                     if pending_stop_tokens:
                         pending_stop_tokens_per_choice[output_idx] = pending_stop_tokens
@@ -987,9 +988,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     visible_text_len = len(text) - len(matched)
                 elif not finish_reason:
-                    visible_text_len -= _trailing_stop_prefix_len(
-                        text, stop_strings
-                    )
+                    visible_text_len -= _trailing_stop_prefix_len(text, stop_strings)
 
                 delta = text[count:visible_text_len] if visible_text_len > count else ""
                 if res.get("output_ids") and not first_output_seen:

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -166,7 +166,10 @@ def _suppressed_stop_token_ids(request: Dict[str, Any]) -> set[int]:
     if not isinstance(stop_conditions, dict):
         return set()
 
-    values = stop_conditions.get("stop_token_ids_hidden") or []
+    values = [
+        *(stop_conditions.get("stop_token_ids") or []),
+        *(stop_conditions.get("stop_token_ids_hidden") or []),
+    ]
     return {
         token_id
         for token_id in values
@@ -438,17 +441,11 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             _plain = stop_conditions.get("stop_token_ids") or []
             _merged = list(set(_hidden).union(_plain))
             stop_token_ids = _merged if _merged else None
-            stop = stop_conditions.get("stop") or None
-
             param_mapping = {
                 "n": sampling_opts.get("n"),
                 "max_new_tokens": stop_conditions.get("max_tokens"),
                 "min_new_tokens": stop_conditions.get("min_tokens"),
                 "ignore_eos": stop_conditions.get("ignore_eos"),
-                # With --skip-tokenizer-init, SGLang may not have a tokenizer
-                # available for stop-string matching; tokenizer-enabled workers
-                # still need the string stop conditions forwarded.
-                "stop": stop,
                 "stop_token_ids": stop_token_ids,
                 **_sampling_option_params(sampling_opts),
                 **self._get_guided_decoding_params(
@@ -804,6 +801,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 out: dict[str, Any] = {"index": output_idx}
                 finish_reason = meta_info["finish_reason"]
                 if finish_reason:
+                    out["raw_finish_reason"] = finish_reason
                     out["finish_reason"] = normalize_finish_reason(
                         finish_reason["type"]
                     )

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -104,10 +104,7 @@ def _suppressed_stop_token_ids(request: Dict[str, Any]) -> set[int]:
     if not isinstance(stop_conditions, dict):
         return set()
 
-    values = [
-        *(stop_conditions.get("stop_token_ids") or []),
-        *(stop_conditions.get("stop_token_ids_hidden") or []),
-    ]
+    values = stop_conditions.get("stop_token_ids_hidden") or []
     return {
         token_id
         for token_id in values
@@ -129,13 +126,24 @@ def _stop_strings(request: Dict[str, Any]) -> set[str]:
     return set()
 
 
+def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
+    if not text or not stop_strings:
+        return 0
+    max_len = min(len(text), max(len(stop) for stop in stop_strings))
+    for suffix_len in range(max_len, 0, -1):
+        suffix = text[-suffix_len:]
+        if any(stop.startswith(suffix) for stop in stop_strings):
+            return suffix_len
+    return 0
+
+
 def _remove_suppressed_stop_tokens(
     output_ids: list[int],
     matched: Any,
     suppressed_stop_token_ids: set[int] | None,
-) -> list[int]:
+) -> tuple[list[int], int]:
     if not output_ids or not suppressed_stop_token_ids:
-        return output_ids
+        return output_ids, 0
 
     if isinstance(matched, int) and not isinstance(matched, bool):
         matched_ids = [matched]
@@ -144,7 +152,7 @@ def _remove_suppressed_stop_tokens(
     ):
         matched_ids = matched
     else:
-        return output_ids
+        return output_ids, 0
 
     if (
         matched_ids
@@ -152,9 +160,22 @@ def _remove_suppressed_stop_tokens(
         and len(output_ids) >= len(matched_ids)
         and output_ids[-len(matched_ids) :] == matched_ids
     ):
-        return output_ids[: -len(matched_ids)]
+        return output_ids[: -len(matched_ids)], len(matched_ids)
 
-    return output_ids
+    return output_ids, 0
+
+
+def _split_trailing_suppressed_stop_tokens(
+    output_ids: list[int],
+    suppressed_stop_token_ids: set[int] | None,
+) -> tuple[list[int], list[int]]:
+    if not output_ids or not suppressed_stop_token_ids:
+        return output_ids, []
+
+    split_at = len(output_ids)
+    while split_at > 0 and output_ids[split_at - 1] in suppressed_stop_token_ids:
+        split_at -= 1
+    return output_ids[:split_at], output_ids[split_at:]
 
 
 def _openai_stop_sampling_params(request: Dict[str, Any]) -> Dict[str, Any]:
@@ -598,6 +619,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # With n>1, chunks for different choices are interleaved, so track the
         # cumulative-logprob cursor per choice index instead of globally.
         output_logprobs_per_choice: dict[int, int] = {}
+        pending_stop_tokens_per_choice: dict[int, list[int]] = {}
+        pending_log_probs_per_choice: dict[int, list[Any]] = {}
+        pending_top_logprobs_per_choice: dict[int, list[Any]] = {}
         async with self._cancellation_monitor(request_id_future, context):
             async for res in stream_source:
                 meta_info = res.get("meta_info", {})
@@ -629,22 +653,9 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         out["stop_reason"] = stop_reason
 
                 # With stream_output=True, output_ids contains only new tokens (disjoint)
-                output_ids = list(res.get("output_ids", []))
-                # Empty, non-final chunks can happen during scheduler idle ticks.
-                # Keep waiting for the next chunk unless cancellation was requested.
-                if not output_ids and not finish_reason:
-                    if context.is_stopped():
-                        break
-                    continue
-
-                matched = finish_reason.get("matched") if finish_reason else None
-                output_ids = _remove_suppressed_stop_tokens(
-                    output_ids, matched, suppressed_stop_token_ids
-                )
-
-                # Pass through disjoint token segments directly
-                out["token_ids"] = output_ids
-
+                raw_output_ids = list(res.get("output_ids", []))
+                log_probs = None
+                top_logprobs = None
                 if metadata_uploader is None:
                     # Extract logprobs for new tokens if available
                     (
@@ -656,11 +667,63 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         output_logprobs_per_choice.get(output_idx, 0),
                         return_tokens_as_token_ids=return_tokens_as_token_ids,
                     )
+                    # Advance over SGLang's original segment even if we buffer
+                    # or suppress a hidden stop marker before emitting.
                     output_logprobs_per_choice[output_idx] = next_logprobs_total
+
+                output_ids = pending_stop_tokens_per_choice.pop(output_idx, [])
+                output_ids.extend(raw_output_ids)
+                if log_probs is not None:
+                    log_probs = pending_log_probs_per_choice.pop(output_idx, []) + list(
+                        log_probs
+                    )
+                if top_logprobs is not None:
+                    top_logprobs = pending_top_logprobs_per_choice.pop(
+                        output_idx, []
+                    ) + list(top_logprobs)
+
+                matched = finish_reason.get("matched") if finish_reason else None
+                output_ids, removed_count = _remove_suppressed_stop_tokens(
+                    output_ids, matched, suppressed_stop_token_ids
+                )
+                if removed_count:
                     if log_probs is not None:
-                        out["log_probs"] = log_probs
+                        log_probs = log_probs[:-removed_count]
                     if top_logprobs is not None:
-                        out["top_logprobs"] = top_logprobs
+                        top_logprobs = top_logprobs[:-removed_count]
+                elif not finish_reason:
+                    output_ids, pending_stop_tokens = (
+                        _split_trailing_suppressed_stop_tokens(
+                            output_ids, suppressed_stop_token_ids
+                        )
+                    )
+                    if pending_stop_tokens:
+                        pending_stop_tokens_per_choice[output_idx] = pending_stop_tokens
+                        if log_probs is not None:
+                            pending_log_probs_per_choice[output_idx] = log_probs[
+                                -len(pending_stop_tokens) :
+                            ]
+                            log_probs = log_probs[: -len(pending_stop_tokens)]
+                        if top_logprobs is not None:
+                            pending_top_logprobs_per_choice[output_idx] = top_logprobs[
+                                -len(pending_stop_tokens) :
+                            ]
+                            top_logprobs = top_logprobs[: -len(pending_stop_tokens)]
+
+                # Empty, non-final chunks can happen during scheduler idle ticks.
+                # Keep waiting for the next chunk unless cancellation was requested.
+                if not output_ids and not finish_reason:
+                    if context.is_stopped():
+                        break
+                    continue
+
+                # Pass through disjoint token segments directly
+                out["token_ids"] = output_ids
+
+                if log_probs is not None:
+                    out["log_probs"] = log_probs
+                if top_logprobs is not None:
+                    out["top_logprobs"] = top_logprobs
 
                 routed_experts = meta_info.get("routed_experts")
                 if routed_experts is not None and metadata_uploader is None:
@@ -758,6 +821,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     and text.endswith(matched)
                 ):
                     visible_text_len = len(text) - len(matched)
+                elif not finish_reason:
+                    visible_text_len -= _trailing_stop_prefix_len(
+                        text, stop_strings
+                    )
 
                 delta = text[count:visible_text_len] if visible_text_len > count else ""
 

--- a/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/decode_handler.py
@@ -18,7 +18,10 @@ from dynamo.common.constants import DisaggregationMode
 from dynamo.common.metadata_upload import MetadataUploader
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.common.multimodal.video_loader import VideoLoader
-from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.common.utils.engine_response import (
+    normalize_finish_reason,
+    trailing_stop_prefix_len,
+)
 from dynamo.llm import HttpError
 from dynamo.sglang._compat import (
     filter_supported_async_generate_kwargs,
@@ -189,17 +192,6 @@ def _stop_strings(request: Dict[str, Any]) -> set[str]:
     if isinstance(stop, list):
         return {item for item in stop if isinstance(item, str)}
     return set()
-
-
-def _trailing_stop_prefix_len(text: str, stop_strings: set[str]) -> int:
-    if not text or not stop_strings:
-        return 0
-    max_len = min(len(text), max(len(stop) for stop in stop_strings))
-    for suffix_len in range(max_len, 0, -1):
-        suffix = text[-suffix_len:]
-        if any(stop.startswith(suffix) for stop in stop_strings):
-            return suffix_len
-    return 0
 
 
 def _remove_suppressed_stop_tokens(
@@ -801,7 +793,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 out: dict[str, Any] = {"index": output_idx}
                 finish_reason = meta_info["finish_reason"]
                 if finish_reason:
-                    out["raw_finish_reason"] = finish_reason
                     out["finish_reason"] = normalize_finish_reason(
                         finish_reason["type"]
                     )
@@ -989,7 +980,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 ):
                     visible_text_len = len(text) - len(matched)
                 elif not finish_reason:
-                    visible_text_len -= _trailing_stop_prefix_len(text, stop_strings)
+                    visible_text_len -= trailing_stop_prefix_len(text, stop_strings)
 
                 delta = text[count:visible_text_len] if visible_text_len > count else ""
                 if res.get("output_ids") and not first_output_seen:

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -186,6 +186,7 @@ def test_user_stop_token_ids_ignores_hidden_ids():
             "stop_conditions": {
                 "stop_token_ids": [576],
                 "stop_token_ids_hidden": [128001],
+                "stop_token_ids_visible": [128009],
             }
         }
     ) == {576}
@@ -204,15 +205,16 @@ def test_user_stop_token_ids_treats_token_id_display_as_string_stop():
     assert _user_stop_token_ids({"stop": ["token_id:576"]}) == set()
 
 
-def test_suppressed_stop_token_ids_ignores_plain_stop_token_ids():
+def test_suppressed_stop_token_ids_includes_plain_and_hidden_stop_token_ids():
     assert _suppressed_stop_token_ids(
         {
             "stop_conditions": {
                 "stop_token_ids": [576],
                 "stop_token_ids_hidden": [128001],
+                "stop_token_ids_visible": [128009],
             }
         }
-    ) == {128001}
+    ) == {576, 128001}
 
 
 def test_remove_suppressed_stop_tokens_removes_matched_tail_sequence():
@@ -628,7 +630,7 @@ def test_build_sampling_params_passes_n_for_token_requests():
     assert sampling_params["max_new_tokens"] == 8
 
 
-def test_build_sampling_params_forwards_string_stop_for_token_requests():
+def test_build_sampling_params_omits_string_stop_for_token_requests():
     handler = _new_decode_handler(use_sglang_tokenizer=False)
 
     sampling_params = handler._build_sampling_params(
@@ -642,7 +644,7 @@ def test_build_sampling_params_forwards_string_stop_for_token_requests():
         }
     )
 
-    assert sampling_params["stop"] == ["<|user|>"]
+    assert "stop" not in sampling_params
     assert sampling_params["stop_token_ids"] == [128001]
 
 
@@ -1092,9 +1094,15 @@ async def test_process_token_stream_treats_completion_usage_as_optional():
     )
 
     assert chunks == [
-        {"index": 0, "finish_reason": "stop", "token_ids": []},
+        {
+            "index": 0,
+            "raw_finish_reason": {"type": "stop"},
+            "finish_reason": "stop",
+            "token_ids": [],
+        },
         {
             "index": 1,
+            "raw_finish_reason": {"type": "stop"},
             "finish_reason": "stop",
             "token_ids": [],
             "completion_usage": {
@@ -1633,7 +1641,49 @@ async def test_process_token_stream_removes_matched_hidden_stop_token():
         )
     )
 
-    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+    assert chunks == [
+        {
+            "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 128001},
+            "finish_reason": "stop",
+            "token_ids": [101],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_removes_plain_stop_token_and_keeps_reason():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 576],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 576},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={576},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 576},
+            "finish_reason": "stop",
+            "stop_reason": 576,
+            "token_ids": [101],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1663,7 +1713,17 @@ async def test_process_token_stream_removes_matched_hidden_stop_token_sequence()
         )
     )
 
-    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+    assert chunks == [
+        {
+            "index": 0,
+            "raw_finish_reason": {
+                "type": "stop",
+                "matched": [128001, 128009],
+            },
+            "finish_reason": "stop",
+            "token_ids": [101],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1700,7 +1760,15 @@ async def test_process_token_stream_buffers_split_hidden_stop_token_sequence():
 
     assert chunks == [
         {"index": 0, "token_ids": [101]},
-        {"index": 0, "finish_reason": "stop", "token_ids": []},
+        {
+            "index": 0,
+            "raw_finish_reason": {
+                "type": "stop",
+                "matched": [128001, 128009],
+            },
+            "finish_reason": "stop",
+            "token_ids": [],
+        },
     ]
 
 
@@ -1739,6 +1807,7 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
     assert chunks == [
         {
             "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
@@ -1773,7 +1842,14 @@ async def test_process_token_stream_keeps_final_stop_when_hidden_token_removed_t
         )
     )
 
-    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": []}]
+    assert chunks == [
+        {
+            "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 128001},
+            "finish_reason": "stop",
+            "token_ids": [],
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1802,6 +1878,7 @@ async def test_process_token_stream_keeps_visible_stop_token():
     assert chunks == [
         {
             "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "stop_reason": 128001,
             "token_ids": [101, 128001],
@@ -1836,6 +1913,7 @@ async def test_process_token_stream_keeps_hidden_stop_token_when_match_is_not_ta
     assert chunks == [
         {
             "index": 0,
+            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [128001, 101],
         }

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1096,13 +1096,11 @@ async def test_process_token_stream_treats_completion_usage_as_optional():
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop"},
             "finish_reason": "stop",
             "token_ids": [],
         },
         {
             "index": 1,
-            "raw_finish_reason": {"type": "stop"},
             "finish_reason": "stop",
             "token_ids": [],
             "completion_usage": {
@@ -1644,7 +1642,6 @@ async def test_process_token_stream_removes_matched_hidden_stop_token():
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [101],
         }
@@ -1678,7 +1675,6 @@ async def test_process_token_stream_removes_plain_stop_token_and_keeps_reason():
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 576},
             "finish_reason": "stop",
             "stop_reason": 576,
             "token_ids": [101],
@@ -1716,10 +1712,6 @@ async def test_process_token_stream_removes_matched_hidden_stop_token_sequence()
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {
-                "type": "stop",
-                "matched": [128001, 128009],
-            },
             "finish_reason": "stop",
             "token_ids": [101],
         }
@@ -1762,10 +1754,6 @@ async def test_process_token_stream_buffers_split_hidden_stop_token_sequence():
         {"index": 0, "token_ids": [101]},
         {
             "index": 0,
-            "raw_finish_reason": {
-                "type": "stop",
-                "matched": [128001, 128009],
-            },
             "finish_reason": "stop",
             "token_ids": [],
         },
@@ -1807,7 +1795,6 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
@@ -1845,7 +1832,6 @@ async def test_process_token_stream_keeps_final_stop_when_hidden_token_removed_t
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [],
         }
@@ -1878,7 +1864,6 @@ async def test_process_token_stream_keeps_visible_stop_token():
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "stop_reason": 128001,
             "token_ids": [101, 128001],
@@ -1913,7 +1898,6 @@ async def test_process_token_stream_keeps_hidden_stop_token_when_match_is_not_ta
     assert chunks == [
         {
             "index": 0,
-            "raw_finish_reason": {"type": "stop", "matched": 128001},
             "finish_reason": "stop",
             "token_ids": [128001, 101],
         }

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -25,6 +25,7 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _nvext_extra_field_requested,
     _openai_stop_sampling_params,
     _remove_suppressed_stop_tokens,
+    _suppressed_stop_token_ids,
     _user_stop_token_ids,
 )
 from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
@@ -203,19 +204,30 @@ def test_user_stop_token_ids_treats_token_id_display_as_string_stop():
     assert _user_stop_token_ids({"stop": ["token_id:576"]}) == set()
 
 
+def test_suppressed_stop_token_ids_ignores_plain_stop_token_ids():
+    assert _suppressed_stop_token_ids(
+        {
+            "stop_conditions": {
+                "stop_token_ids": [576],
+                "stop_token_ids_hidden": [128001],
+            }
+        }
+    ) == {128001}
+
+
 def test_remove_suppressed_stop_tokens_removes_matched_tail_sequence():
     assert _remove_suppressed_stop_tokens(
         [101, 128001, 128009], [128001, 128009], {128001, 128009}
-    ) == [101]
+    ) == ([101], 2)
 
 
 def test_remove_suppressed_stop_tokens_keeps_visible_or_non_tail_matches():
     assert _remove_suppressed_stop_tokens(
         [101, 128001, 128009], [128001, 128009], {128001}
-    ) == [101, 128001, 128009]
+    ) == ([101, 128001, 128009], 0)
     assert _remove_suppressed_stop_tokens(
         [128001, 128009, 101], [128001, 128009], {128001, 128009}
-    ) == [128001, 128009, 101]
+    ) == ([128001, 128009, 101], 0)
 
 
 def test_openai_stop_sampling_params_preserves_string_stops():
@@ -1406,6 +1418,44 @@ async def test_process_text_stream_stop_reason_uses_response_nvext():
 
 
 @pytest.mark.asyncio
+async def test_process_text_stream_buffers_split_stop_string_suffix():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello<|us",
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "text": "Hello<|user|>",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": "<|user|>",
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            request={"stop": ["<|user|>"]},
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hello",
+        "",
+    ]
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
 async def test_process_text_stream_removes_matched_stop_string_suffix():
     handler = _new_decode_handler()
 
@@ -1614,6 +1664,87 @@ async def test_process_token_stream_removes_matched_hidden_stop_token_sequence()
     )
 
     assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_buffers_split_hidden_stop_token_sequence():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [128009],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": [128001, 128009],
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001, 128009},
+        )
+    )
+
+    assert chunks == [
+        {"index": 0, "token_ids": [101]},
+        {"index": 0, "finish_reason": "stop", "token_ids": []},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                            "output_token_logprobs": [
+                                (-0.1, 101, "a"),
+                                (-0.2, 128001, "<|user|>"),
+                            ],
+                            "output_top_logprobs": [
+                                [(-0.1, 101, "a")],
+                                [(-0.2, 128001, "<|user|>")],
+                            ],
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [101],
+            "log_probs": [-0.1],
+            "top_logprobs": [[{"rank": 1, "token": "a", "logprob": -0.1}]],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1742,7 +1742,9 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
-            "top_logprobs": [[{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]],
+            "top_logprobs": [
+                [{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]
+            ],
         }
     ]
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -23,6 +24,7 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _extract_sglang_stop_reason,
     _nvext_extra_field_requested,
     _openai_stop_sampling_params,
+    _remove_suppressed_stop_tokens,
     _user_stop_token_ids,
 )
 from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
@@ -31,7 +33,10 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     raise_if_unextracted_multimodal,
 )
 from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
-from dynamo.sglang.request_handlers.multimodal.worker_handler import SglangUtils
+from dynamo.sglang.request_handlers.multimodal.worker_handler import (
+    SglangUtils,
+    StreamProcessor,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -196,6 +201,21 @@ def test_user_stop_token_ids_accepts_stop_token_id_array():
 
 def test_user_stop_token_ids_treats_token_id_display_as_string_stop():
     assert _user_stop_token_ids({"stop": ["token_id:576"]}) == set()
+
+
+def test_remove_suppressed_stop_tokens_removes_matched_tail_sequence():
+    assert _remove_suppressed_stop_tokens(
+        [101, 128001, 128009], [128001, 128009], {128001, 128009}
+    ) == [101]
+
+
+def test_remove_suppressed_stop_tokens_keeps_visible_or_non_tail_matches():
+    assert _remove_suppressed_stop_tokens(
+        [101, 128001, 128009], [128001, 128009], {128001}
+    ) == [101, 128001, 128009]
+    assert _remove_suppressed_stop_tokens(
+        [128001, 128009, 101], [128001, 128009], {128001, 128009}
+    ) == [128001, 128009, 101]
 
 
 def test_openai_stop_sampling_params_preserves_string_stops():
@@ -594,6 +614,24 @@ def test_build_sampling_params_passes_n_for_token_requests():
     assert sampling_params["n"] == 3
     assert sampling_params["temperature"] == 0.2
     assert sampling_params["max_new_tokens"] == 8
+
+
+def test_build_sampling_params_forwards_string_stop_for_token_requests():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {},
+            "stop_conditions": {
+                "max_tokens": 8,
+                "stop": ["<|user|>"],
+                "stop_token_ids_hidden": [128001],
+            },
+        }
+    )
+
+    assert sampling_params["stop"] == ["<|user|>"]
+    assert sampling_params["stop_token_ids"] == [128001]
 
 
 def test_build_sampling_params_forwards_repetition_controls_for_token_requests():
@@ -1368,6 +1406,44 @@ async def test_process_text_stream_stop_reason_uses_response_nvext():
 
 
 @pytest.mark.asyncio
+async def test_process_text_stream_removes_matched_stop_string_suffix():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello",
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "text": "Hello<|user|>",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": "<|user|>",
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            request={"stop": ["<|user|>"]},
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hello",
+        "",
+    ]
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
 async def test_process_text_stream_stop_reason_requires_nvext_extra_field():
     handler = _new_decode_handler()
 
@@ -1481,6 +1557,203 @@ async def test_process_token_stream_suppresses_hidden_stop_token_reason():
     )
 
     assert "stop_reason" not in chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_removes_matched_hidden_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_removes_matched_hidden_stop_token_sequence():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001, 128009],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": [128001, 128009],
+                            },
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001, 128009},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_final_stop_when_hidden_token_removed_to_empty():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": []}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_visible_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            suppressed_stop_token_ids=set(),
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "stop_reason": 128001,
+            "token_ids": [101, 128001],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_hidden_stop_token_when_match_is_not_tail():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [128001, 101],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [128001, 101],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multimodal_stream_keeps_reading_after_one_choice_finishes():
+    chunks = await _collect(
+        StreamProcessor.process_sglang_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101],
+                        "text": "a",
+                        "meta_info": {"finish_reason": None},
+                    },
+                    {
+                        "index": 1,
+                        "output_ids": [201],
+                        "text": "b",
+                        "meta_info": {"finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [],
+                        "text": "a",
+                        "meta_info": {"finish_reason": {"type": "stop"}},
+                    },
+                    {
+                        "index": 1,
+                        "output_ids": [],
+                        "text": "b",
+                        "meta_info": {"finish_reason": {"type": "stop"}},
+                    },
+                ]
+            )
+        )
+    )
+
+    outputs = [json.loads(chunk) for chunk in chunks]
+
+    assert [output["index"] for output in outputs] == [0, 1, 0, 1]
+    assert [output["finished"] for output in outputs] == [False, False, True, True]
+    assert [output.get("finish_reason") for output in outputs] == [
+        None,
+        None,
+        "stop",
+        "stop",
+    ]
 
 
 async def _collect(stream):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1113,6 +1113,48 @@ async def test_process_token_stream_treats_completion_usage_as_optional():
 
 
 @pytest.mark.asyncio
+async def test_process_token_stream_reports_request_total_completion_usage():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop"},
+                            "prompt_tokens": 2,
+                            "completion_tokens": 1,
+                        },
+                    },
+                    {
+                        "index": 1,
+                        "output_ids": [],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop"},
+                            "prompt_tokens": 2,
+                            "completion_tokens": 2,
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+        )
+    )
+
+    assert chunks[0]["completion_usage"]["completion_tokens"] == 1
+    assert chunks[1]["completion_usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+    }
+
+
+@pytest.mark.asyncio
 async def test_process_token_stream_accepts_incremental_logprob_arrays():
     handler = _new_decode_handler()
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1742,7 +1742,7 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
-            "top_logprobs": [[{"rank": 1, "token": "a", "logprob": -0.1}]],
+            "top_logprobs": [[{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]],
         }
     ]
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1215,7 +1215,7 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
-            "top_logprobs": [[{"rank": 1, "token": "a", "logprob": -0.1}]],
+            "top_logprobs": [[{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]],
         }
     ]
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1215,7 +1215,9 @@ async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
             "finish_reason": "stop",
             "token_ids": [101],
             "log_probs": [-0.1],
-            "top_logprobs": [[{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]],
+            "top_logprobs": [
+                [{"rank": 1, "token_id": 101, "token": "a", "logprob": -0.1}]
+            ],
         }
     ]
 

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 
@@ -12,6 +13,7 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _extract_sglang_stop_reason,
     _nvext_extra_field_requested,
     _openai_stop_sampling_params,
+    _remove_suppressed_stop_tokens,
     _user_stop_token_ids,
 )
 from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
@@ -20,6 +22,7 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     raise_if_unextracted_multimodal,
 )
 from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
+from dynamo.sglang.request_handlers.multimodal.worker_handler import StreamProcessor
 
 pytestmark = [
     pytest.mark.unit,
@@ -186,6 +189,21 @@ def test_user_stop_token_ids_treats_token_id_display_as_string_stop():
     assert _user_stop_token_ids({"stop": ["token_id:576"]}) == set()
 
 
+def test_remove_suppressed_stop_tokens_removes_matched_tail_sequence():
+    assert _remove_suppressed_stop_tokens(
+        [101, 128001, 128009], [128001, 128009], {128001, 128009}
+    ) == [101]
+
+
+def test_remove_suppressed_stop_tokens_keeps_visible_or_non_tail_matches():
+    assert _remove_suppressed_stop_tokens(
+        [101, 128001, 128009], [128001, 128009], {128001}
+    ) == [101, 128001, 128009]
+    assert _remove_suppressed_stop_tokens(
+        [128001, 128009, 101], [128001, 128009], {128001, 128009}
+    ) == [128001, 128009, 101]
+
+
 def test_openai_stop_sampling_params_preserves_string_stops():
     assert _openai_stop_sampling_params({"stop": "END"}) == {"stop": "END"}
     assert _openai_stop_sampling_params({"stop": ["END"]}) == {"stop": ["END"]}
@@ -242,6 +260,24 @@ def test_build_sampling_params_passes_n_for_token_requests():
     assert sampling_params["n"] == 3
     assert sampling_params["temperature"] == 0.2
     assert sampling_params["max_new_tokens"] == 8
+
+
+def test_build_sampling_params_forwards_string_stop_for_token_requests():
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    sampling_params = handler._build_sampling_params(
+        {
+            "sampling_options": {},
+            "stop_conditions": {
+                "max_tokens": 8,
+                "stop": ["<|user|>"],
+                "stop_token_ids_hidden": [128001],
+            },
+        }
+    )
+
+    assert sampling_params["stop"] == ["<|user|>"]
+    assert sampling_params["stop_token_ids"] == [128001]
 
 
 def test_build_sampling_params_forwards_repetition_controls_for_token_requests():
@@ -870,6 +906,44 @@ async def test_process_text_stream_stop_reason_uses_response_nvext():
 
 
 @pytest.mark.asyncio
+async def test_process_text_stream_removes_matched_stop_string_suffix():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello",
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "text": "Hello<|user|>",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": "<|user|>",
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            request={"stop": ["<|user|>"]},
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hello",
+        "",
+    ]
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
 async def test_process_text_stream_stop_reason_requires_nvext_extra_field():
     handler = _new_decode_handler()
 
@@ -956,6 +1030,203 @@ async def test_process_token_stream_suppresses_hidden_stop_token_reason():
     )
 
     assert "stop_reason" not in chunks[0]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_removes_matched_hidden_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_removes_matched_hidden_stop_token_sequence():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001, 128009],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": [128001, 128009],
+                            },
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001, 128009},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_final_stop_when_hidden_token_removed_to_empty():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": []}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_visible_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            suppressed_stop_token_ids=set(),
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "stop_reason": 128001,
+            "token_ids": [101, 128001],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_keeps_hidden_stop_token_when_match_is_not_tail():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [128001, 101],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [128001, 101],
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multimodal_stream_keeps_reading_after_one_choice_finishes():
+    chunks = await _collect(
+        StreamProcessor.process_sglang_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101],
+                        "text": "a",
+                        "meta_info": {"finish_reason": None},
+                    },
+                    {
+                        "index": 1,
+                        "output_ids": [201],
+                        "text": "b",
+                        "meta_info": {"finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [],
+                        "text": "a",
+                        "meta_info": {"finish_reason": {"type": "stop"}},
+                    },
+                    {
+                        "index": 1,
+                        "output_ids": [],
+                        "text": "b",
+                        "meta_info": {"finish_reason": {"type": "stop"}},
+                    },
+                ]
+            )
+        )
+    )
+
+    outputs = [json.loads(chunk) for chunk in chunks]
+
+    assert [output["index"] for output in outputs] == [0, 1, 0, 1]
+    assert [output["finished"] for output in outputs] == [False, False, True, True]
+    assert [output.get("finish_reason") for output in outputs] == [
+        None,
+        None,
+        "stop",
+        "stop",
+    ]
 
 
 async def _collect(stream):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -14,6 +14,7 @@ from dynamo.sglang.request_handlers.llm.decode_handler import (
     _nvext_extra_field_requested,
     _openai_stop_sampling_params,
     _remove_suppressed_stop_tokens,
+    _suppressed_stop_token_ids,
     _user_stop_token_ids,
 )
 from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
@@ -189,19 +190,30 @@ def test_user_stop_token_ids_treats_token_id_display_as_string_stop():
     assert _user_stop_token_ids({"stop": ["token_id:576"]}) == set()
 
 
+def test_suppressed_stop_token_ids_ignores_plain_stop_token_ids():
+    assert _suppressed_stop_token_ids(
+        {
+            "stop_conditions": {
+                "stop_token_ids": [576],
+                "stop_token_ids_hidden": [128001],
+            }
+        }
+    ) == {128001}
+
+
 def test_remove_suppressed_stop_tokens_removes_matched_tail_sequence():
     assert _remove_suppressed_stop_tokens(
         [101, 128001, 128009], [128001, 128009], {128001, 128009}
-    ) == [101]
+    ) == ([101], 2)
 
 
 def test_remove_suppressed_stop_tokens_keeps_visible_or_non_tail_matches():
     assert _remove_suppressed_stop_tokens(
         [101, 128001, 128009], [128001, 128009], {128001}
-    ) == [101, 128001, 128009]
+    ) == ([101, 128001, 128009], 0)
     assert _remove_suppressed_stop_tokens(
         [128001, 128009, 101], [128001, 128009], {128001, 128009}
-    ) == [128001, 128009, 101]
+    ) == ([128001, 128009, 101], 0)
 
 
 def test_openai_stop_sampling_params_preserves_string_stops():
@@ -906,6 +918,44 @@ async def test_process_text_stream_stop_reason_uses_response_nvext():
 
 
 @pytest.mark.asyncio
+async def test_process_text_stream_buffers_split_stop_string_suffix():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_text_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "text": "Hello<|us",
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "text": "Hello<|user|>",
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": "<|user|>",
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            request={"stop": ["<|user|>"]},
+        )
+    )
+
+    assert [chunk["choices"][0]["delta"]["content"] for chunk in chunks] == [
+        "Hello",
+        "",
+    ]
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+
+
+@pytest.mark.asyncio
 async def test_process_text_stream_removes_matched_stop_string_suffix():
     handler = _new_decode_handler()
 
@@ -1087,6 +1137,87 @@ async def test_process_token_stream_removes_matched_hidden_stop_token_sequence()
     )
 
     assert chunks == [{"index": 0, "finish_reason": "stop", "token_ids": [101]}]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_buffers_split_hidden_stop_token_sequence():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {"id": "request-1", "finish_reason": None},
+                    },
+                    {
+                        "index": 0,
+                        "output_ids": [128009],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {
+                                "type": "stop",
+                                "matched": [128001, 128009],
+                            },
+                        },
+                    },
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001, 128009},
+        )
+    )
+
+    assert chunks == [
+        {"index": 0, "token_ids": [101]},
+        {"index": 0, "finish_reason": "stop", "token_ids": []},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_process_token_stream_trims_logprobs_for_suppressed_stop_token():
+    handler = _new_decode_handler()
+
+    chunks = await _collect(
+        handler._process_token_stream(
+            _stream(
+                [
+                    {
+                        "index": 0,
+                        "output_ids": [101, 128001],
+                        "meta_info": {
+                            "id": "request-1",
+                            "finish_reason": {"type": "stop", "matched": 128001},
+                            "output_token_logprobs": [
+                                (-0.1, 101, "a"),
+                                (-0.2, 128001, "<|user|>"),
+                            ],
+                            "output_top_logprobs": [
+                                [(-0.1, 101, "a")],
+                                [(-0.2, 128001, "<|user|>")],
+                            ],
+                        },
+                    }
+                ]
+            ),
+            _Context(),
+            user_stop_token_ids={576},
+            suppressed_stop_token_ids={128001},
+        )
+    )
+
+    assert chunks == [
+        {
+            "index": 0,
+            "finish_reason": "stop",
+            "token_ids": [101],
+            "log_probs": [-0.1],
+            "top_logprobs": [[{"rank": 1, "token": "a", "logprob": -0.1}]],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -262,6 +262,10 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateChatCompletionStreamRes
         if let Some(completion_usage) = delta.completion_usage.as_ref() {
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
+            self.usage.completion_tokens = self
+                .usage
+                .completion_tokens
+                .max(completion_usage.completion_tokens);
 
             // Propagate prompt token details if provided
             if let Some(prompt_details) = completion_usage.prompt_tokens_details.as_ref() {
@@ -545,6 +549,56 @@ mod tests {
         );
         assert_eq!(second_choice_zero.inner.choices[0].delta.role, None);
         assert_eq!(second_choice_one.inner.choices[0].delta.role, None);
+    }
+
+    #[test]
+    fn test_completion_tokens_use_backend_usage_when_higher() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.token_ids.clear();
+        backend_output.tokens.clear();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-zero-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 0,
+            total_tokens: 5,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -545,6 +545,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_completion_tokens_use_backend_usage_when_higher() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.token_ids.clear();
+        backend_output.tokens.clear();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-zero-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 0,
+            total_tokens: 5,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
+    }
+
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {
         let messages = vec![ChatCompletionRequestMessage::User(
             ChatCompletionRequestUserMessage {

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -572,6 +572,35 @@ mod tests {
     }
 
     #[test]
+    fn test_completion_tokens_treat_backend_usage_as_request_total() {
+        let mut request = create_test_request();
+        request.inner.n = Some(2);
+        let mut generator = request.response_generator("req-multi-choice-usage".to_string());
+
+        for index in 0..2 {
+            let mut backend_output = final_backend_output();
+            backend_output.index = Some(index);
+            backend_output.token_ids.clear();
+            backend_output.tokens.clear();
+            backend_output.completion_usage = Some(CompletionUsage {
+                prompt_tokens: 5,
+                completion_tokens: 5,
+                total_tokens: 10,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            });
+            generator
+                .choice_from_postprocessor(backend_output)
+                .expect("choice generation");
+        }
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.total_tokens, 10);
+    }
+
+    #[test]
     fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-backend-zero-usage".to_string());

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -298,7 +298,7 @@ mod tests {
     use super::*;
     use crate::protocols::common::{self, llm_backend::BackendOutput, timing::WORKER_TYPE_PREFILL};
     use crate::protocols::openai::DeltaGeneratorExt;
-    use dynamo_protocols::types::{CreateCompletionRequestArgs, Prompt};
+    use dynamo_protocols::types::{CompletionUsage, CreateCompletionRequestArgs, Prompt};
 
     fn create_test_request() -> NvCreateCompletionRequest {
         let inner = CreateCompletionRequestArgs::default()
@@ -358,6 +358,32 @@ mod tests {
         assert_eq!(response.inner.id, "cmpl-request-id");
         assert_eq!(response.inner.object, "text_completion");
         assert_eq!(response.inner.model, "test-model");
+    }
+
+    #[test]
+    fn test_completion_tokens_are_authoritative_from_backend_usage() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.token_ids.clear();
+        backend_output.tokens.clear();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateCompletionRequest {

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -387,6 +387,35 @@ mod tests {
     }
 
     #[test]
+    fn test_completion_tokens_treat_backend_usage_as_request_total() {
+        let mut request = create_test_request();
+        request.inner.n = Some(2);
+        let mut generator = request.response_generator("req-multi-choice-usage".to_string());
+
+        for index in 0..2 {
+            let mut backend_output = final_backend_output();
+            backend_output.index = Some(index);
+            backend_output.token_ids.clear();
+            backend_output.tokens.clear();
+            backend_output.completion_usage = Some(CompletionUsage {
+                prompt_tokens: 5,
+                completion_tokens: 5,
+                total_tokens: 10,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            });
+            generator
+                .choice_from_postprocessor(backend_output)
+                .expect("choice generation");
+        }
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 5);
+        assert_eq!(usage.total_tokens, 10);
+    }
+
+    #[test]
     fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-backend-zero-usage".to_string());

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -219,6 +219,7 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         if let Some(completion_usage) = delta.completion_usage.as_ref() {
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
+            self.usage.completion_tokens = completion_usage.completion_tokens;
 
             // Propagate completion token details if provided
             if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {
@@ -327,7 +328,7 @@ mod tests {
     use super::*;
     use crate::protocols::common::{self, llm_backend::BackendOutput, timing::WORKER_TYPE_PREFILL};
     use crate::protocols::openai::DeltaGeneratorExt;
-    use dynamo_protocols::types::{CreateCompletionRequestArgs, Prompt};
+    use dynamo_protocols::types::{CompletionUsage, CreateCompletionRequestArgs, Prompt};
 
     fn create_test_request() -> NvCreateCompletionRequest {
         let inner = CreateCompletionRequestArgs::default()
@@ -375,6 +376,32 @@ mod tests {
             encoder_result: None,
             routing_data: None,
         }
+    }
+
+    #[test]
+    fn test_completion_tokens_are_authoritative_from_backend_usage() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.token_ids.clear();
+        backend_output.tokens.clear();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 1,
+            total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateCompletionRequest {

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -361,7 +361,7 @@ mod tests {
     }
 
     #[test]
-    fn test_completion_tokens_are_authoritative_from_backend_usage() {
+    fn test_completion_tokens_use_backend_usage_when_higher() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-backend-usage".to_string());
 
@@ -372,6 +372,30 @@ mod tests {
             prompt_tokens: 5,
             completion_tokens: 1,
             total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-zero-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 0,
+            total_tokens: 5,
             prompt_tokens_details: None,
             completion_tokens_details: None,
         });

--- a/lib/llm/src/protocols/openai/completions/delta.rs
+++ b/lib/llm/src/protocols/openai/completions/delta.rs
@@ -219,7 +219,10 @@ impl crate::protocols::openai::DeltaGeneratorExt<NvCreateCompletionResponse> for
         if let Some(completion_usage) = delta.completion_usage.as_ref() {
             // Update prompt_tokens from worker if provided (e.g., for embeddings)
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
-            self.usage.completion_tokens = completion_usage.completion_tokens;
+            self.usage.completion_tokens = self
+                .usage
+                .completion_tokens
+                .max(completion_usage.completion_tokens);
 
             // Propagate completion token details if provided
             if let Some(completion_details) = completion_usage.completion_tokens_details.as_ref() {
@@ -379,7 +382,7 @@ mod tests {
     }
 
     #[test]
-    fn test_completion_tokens_are_authoritative_from_backend_usage() {
+    fn test_completion_tokens_use_backend_usage_when_higher() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-backend-usage".to_string());
 
@@ -390,6 +393,30 @@ mod tests {
             prompt_tokens: 5,
             completion_tokens: 1,
             total_tokens: 6,
+            prompt_tokens_details: None,
+            completion_tokens_details: None,
+        });
+
+        generator
+            .choice_from_postprocessor(backend_output)
+            .expect("choice generation");
+
+        let usage = generator.get_usage();
+        assert_eq!(usage.prompt_tokens, 5);
+        assert_eq!(usage.completion_tokens, 1);
+        assert_eq!(usage.total_tokens, 6);
+    }
+
+    #[test]
+    fn test_completion_tokens_keep_aggregated_count_when_backend_usage_is_zero() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-backend-zero-usage".to_string());
+
+        let mut backend_output = final_backend_output();
+        backend_output.completion_usage = Some(CompletionUsage {
+            prompt_tokens: 5,
+            completion_tokens: 0,
+            total_tokens: 5,
             prompt_tokens_details: None,
             completion_tokens_details: None,
         });

--- a/lib/llm/src/protocols/openai/delta_common.rs
+++ b/lib/llm/src/protocols/openai/delta_common.rs
@@ -152,6 +152,10 @@ impl DeltaGeneratorState {
         // the embedding sequence length computed by the worker.
         if let Some(completion_usage) = output.completion_usage.as_ref() {
             self.usage.prompt_tokens = completion_usage.prompt_tokens;
+            self.usage.completion_tokens = self
+                .usage
+                .completion_tokens
+                .max(completion_usage.completion_tokens);
 
             if let Some(prompt_details) = completion_usage.prompt_tokens_details.as_ref() {
                 self.usage.prompt_tokens_details = Some(prompt_details.clone());


### PR DESCRIPTION
## Overview:

Fixes a SGLang stop-marker leak where matched stop tokens or stop strings could appear in user-visible output, especially when special tokens are preserved for reasoning/tool-call parsing.

Changes:
- Avoid forwarding string `stop` conditions to tokenizer-disabled SGLang workers; suppress matched stop strings in the frontend instead.
- Suppress matched hidden/plain stop token IDs from backend token streams.
- Support both single-token and multi-token matched stop sequences.
- Preserve visible stop tokens.
- Add a frontend postprocessor compatibility guard for matched stop string suffixes surfaced after detokenization.
- Keep final stop chunks even when the suppressed stop marker leaves no visible content.

## Detail

``` json
data: {"id":"befc21f33e205cc9","choices":[{"index":0,"delta":{"content":"?","role":"assistant"},"finish_reason":null,"logprobs":null}],"created":1785745305,"model":"zai-org/GLM-5.2-FP8","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":null}
data: {"id":"befc21f33e205cc9","choices":[{"index":0,"delta":{"content":"<|user|>","role":"assistant"},"finish_reason":"stop","logprobs":null}],"created":1785745305,"model":"zai-org/GLM-5.2-FP8","service_tier":null,"system_fingerprint":null,"object":"chat.completion.chunk","usage":{"prompt_tokens":15,"completion_tokens":287,"total_tokens":302}}
data: [DONE]
```

```json
{
    "id": "99a8545bd312424d",
    "choices": [
        {
            "index": 0,
            "message": {
                "content": "I'm GLM, a large language model developed by Z.ai. I've been trained on diverse text data to understand and generate human-like responses across various topics. I can help answer questions, provide information, and assist with writing tasks, all while maintaining a conversational approach.\n\nIs there something specific you'd like to know about my capabilities or how I can assist you today?<|user|>",
                "role": "assistant",
                "reasoning_content": "Let me consider how to approach this question about identity. The user is asking a straightforward question that deserves a clear and honest response. I should focus on explaining my role as a language model while maintaining transparency about my capabilities and limitations.\n\nFirst, I'll establish my identity as GLM, a large language model developed by Z.ai. This is the fundamental truth about who I am. However, I should be careful not to overstate my abilities or create misconceptions about artificial consciousness.\n\nThe key aspects to cover are my basic identity, my purpose, and how I work. I should explain that I'm designed for natural language processing and communication tasks, while being honest about not having human-like experiences or emotions.\n\nI need to structure this information clearly, starting with the most important point - my identity - and then expanding into my capabilities and limitations. The tone should be professional yet approachable, making it easy for users to understand what I am and how I can help them.\n\nLet me also consider what not to include - I shouldn't mention details about my training process, specific technical specifications, or make claims about having consciousness or emotions. The focus should be on practical utility and clear communication of my role.\n\nThis response should set appropriate expectations while encouraging further engagement. I'll end with an invitation for more specific questions, as that naturally leads to productive interactions."
            },
            "finish_reason": "stop",
            "logprobs": null
        }
    ],
    "created": 1785745604,
    "model": "zai-org/GLM-5.2-FP8",
    "service_tier": null,
    "system_fingerprint": null,
    "object": "chat.completion",
    "usage": {
        "prompt_tokens": 15,
        "completion_tokens": 348,
        "total_tokens": 363
    }
}
```


## Validation

- `PYTHONPYCACHEPREFIX=/tmp/dynamo-mycode-pycache python3 -m compileall components/src/dynamo/frontend/sglang_processor.py components/src/dynamo/frontend/sglang_prepost.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py components/src/dynamo/sglang/request_handlers/llm/decode_handler.py components/src/dynamo/sglang/tests/test_sglang_decode_handler.py`

Manual validation with GLM-5.2-FP8:
- `stream=true` no longer emits `<|user|>` in the final stop chunk.
- `stream=false` no longer includes `<|user|>` in `message.content`.
- Explicit `"stop": ["<|user|>"]` still returns `finish_reason="stop"` without leaking the stop marker.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of configured stop strings during streaming responses.
  * Prevented matched stop strings and suppressed stop tokens from appearing in visible text or token output.
  * Preserved completion status and stop reasons, including when a response contains no remaining content.
  * Applied consistent stop behavior across inline and worker-based streaming paths.

* **Tests**
  * Added coverage for text and token streaming, stop-string handling, suppressed tokens, and completion metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
