### PR TITLE
feat(profiler): model prefix-cache discount in AIC disagg planning

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_prefix_cache_discount.py
+++ b/components/src/dynamo/profiler/tests/unit/test_prefix_cache_discount.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the prefix-cache discount in aic_dataframe.
+
+``build_prefill_row`` previously hardcoded ``prefix = 0`` (cold cache). It now
+accepts a ``kv_hit_rate`` (0-1) so disagg planning can model a warm prefix
+cache: ``prefix = round(kv_hit_rate * isl)`` and the prefill is charged only
+for the uncached ``effective_isl = isl - prefix`` tokens.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+try:
+    from dynamo.profiler.utils.aic_dataframe import (
+        build_decode_row,
+        build_disagg_df_from_static,
+        build_prefill_row,
+    )
+except ImportError as e:
+    pytest.skip(f"Skip (missing dependency): {e}", allow_module_level=True)
+
+
+def _prefill(**overrides) -> dict:
+    base = dict(
+        model="test-model",
+        isl=4000,
+        osl=1000,
+        ttft=50.0,
+        tp=1,
+        pp=1,
+        dp=1,
+        moe_tp=1,
+        moe_ep=1,
+        backend="trtllm",
+        system="h200_sxm",
+    )
+    base.update(overrides)
+    return build_prefill_row(**base)
+
+
+def test_default_is_cold_cache() -> None:
+    """Default kv_hit_rate keeps the previous prefix=0 behaviour."""
+    assert _prefill()["prefix"] == 0
+
+
+@pytest.mark.parametrize(
+    "isl,rate,expected",
+    [
+        (4000, 0.0, 0),
+        (4000, 0.5, 2000),
+        (4000, 1.0, 4000),
+        (5424, 0.51, round(0.51 * 5424)),  # silicon agg anchor
+        (1001, 0.5, round(0.5 * 1001)),  # rounding (500 or 501)
+    ],
+)
+def test_prefix_from_hit_rate(isl: int, rate: float, expected: int) -> None:
+    assert _prefill(isl=isl, kv_hit_rate=rate)["prefix"] == expected
+
+
+@pytest.mark.parametrize("bad", [-0.01, 1.01, 2.0, -1.0])
+def test_hit_rate_out_of_range_raises(bad: float) -> None:
+    with pytest.raises(ValueError):
+        _prefill(kv_hit_rate=bad)
+
+
+def test_build_disagg_df_threads_hit_rate() -> None:
+    """kv_hit_rate on build_disagg_df_from_static sets prefix on the disagg row."""
+    prefill_df = pd.DataFrame([_prefill(isl=4000)])  # prefix defaults to 0
+    decode_df = pd.DataFrame(
+        [
+            build_decode_row(
+                tpot=10.0,
+                thpt_per_gpu=100.0,
+                num_request=8,
+                num_gpus=1,
+                osl=1000,
+                tp=1,
+                pp=1,
+                dp=1,
+                moe_tp=1,
+                moe_ep=1,
+            )
+        ]
+    )
+
+    cold = build_disagg_df_from_static(prefill_df, decode_df)
+    assert int(cold.iloc[0]["prefix"]) == 0
+
+    warm = build_disagg_df_from_static(prefill_df, decode_df, kv_hit_rate=0.51)
+    assert int(warm.iloc[0]["prefix"]) == round(0.51 * 4000)
+
+
+def test_build_disagg_df_none_preserves_row_prefix() -> None:
+    """kv_hit_rate=None leaves a prefix already baked into the prefill row."""
+    prefill_df = pd.DataFrame([_prefill(isl=4000, kv_hit_rate=0.25)])
+    decode_df = pd.DataFrame(
+        [
+            build_decode_row(
+                tpot=10.0,
+                thpt_per_gpu=100.0,
+                num_request=8,
+                num_gpus=1,
+                osl=1000,
+                tp=1,
+                pp=1,
+                dp=1,
+                moe_tp=1,
+                moe_ep=1,
+            )
+        ]
+    )
+    out = build_disagg_df_from_static(prefill_df, decode_df)  # kv_hit_rate=None
+    assert int(out.iloc[0]["prefix"]) == round(0.25 * 4000)

--- a/components/src/dynamo/profiler/tests/unit/test_prefix_cache_discount.py
+++ b/components/src/dynamo/profiler/tests/unit/test_prefix_cache_discount.py
@@ -61,7 +61,7 @@ def test_default_is_cold_cache() -> None:
         (4000, 0.5, 2000),
         (4000, 1.0, 4000),
         (5424, 0.51, round(0.51 * 5424)),  # silicon agg anchor
-        (1001, 0.5, round(0.5 * 1001)),  # rounding (500 or 501)
+        (1003, 0.5, 502),
     ],
 )
 def test_prefix_from_hit_rate(isl: int, rate: float, expected: int) -> None:
@@ -74,35 +74,7 @@ def test_hit_rate_out_of_range_raises(bad: float) -> None:
         _prefill(kv_hit_rate=bad)
 
 
-def test_build_disagg_df_threads_hit_rate() -> None:
-    """kv_hit_rate on build_disagg_df_from_static sets prefix on the disagg row."""
-    prefill_df = pd.DataFrame([_prefill(isl=4000)])  # prefix defaults to 0
-    decode_df = pd.DataFrame(
-        [
-            build_decode_row(
-                tpot=10.0,
-                thpt_per_gpu=100.0,
-                num_request=8,
-                num_gpus=1,
-                osl=1000,
-                tp=1,
-                pp=1,
-                dp=1,
-                moe_tp=1,
-                moe_ep=1,
-            )
-        ]
-    )
-
-    cold = build_disagg_df_from_static(prefill_df, decode_df)
-    assert int(cold.iloc[0]["prefix"]) == 0
-
-    warm = build_disagg_df_from_static(prefill_df, decode_df, kv_hit_rate=0.51)
-    assert int(warm.iloc[0]["prefix"]) == round(0.51 * 4000)
-
-
-def test_build_disagg_df_none_preserves_row_prefix() -> None:
-    """kv_hit_rate=None leaves a prefix already baked into the prefill row."""
+def test_build_disagg_df_preserves_row_prefix() -> None:
     prefill_df = pd.DataFrame([_prefill(isl=4000, kv_hit_rate=0.25)])
     decode_df = pd.DataFrame(
         [

--- a/components/src/dynamo/profiler/utils/aic_dataframe.py
+++ b/components/src/dynamo/profiler/utils/aic_dataframe.py
@@ -172,26 +172,18 @@ def build_decode_row(
 def build_disagg_df_from_static(
     prefill_df: pd.DataFrame,
     decode_df: pd.DataFrame,
-    *,
-    kv_hit_rate: float | None = None,
 ) -> pd.DataFrame:
     """Cross-product prefill x decode into a ColumnsDisagg DataFrame.
 
     Used when calling ``pick_default`` or ``pick_load_match`` from
     THOROUGH-mode benchmark results.
 
-    ``kv_hit_rate`` (0-1) optionally overrides the prefix-cache hit fraction on
-    every prefill row before rate matching, setting ``prefix =
-    round(kv_hit_rate * isl)`` per row. This is a convenience for callers that
-    hold a pre-built ``prefill_df`` and want to apply a hit rate at
-    disagg-assembly time. When ``None`` (default) the ``prefix`` already carried
-    by each prefill row is used unchanged, so existing behaviour is preserved.
+    Prefix-cache discounts must already be reflected in each prefill row's
+    ``prefix`` and measured/predicted ``ttft``.
     """
     combos: list[dict] = []
     for _, p_row in prefill_df.iterrows():
         p_dict = p_row.to_dict()
-        if kv_hit_rate is not None:
-            p_dict["prefix"] = _prefix_len(kv_hit_rate, int(p_dict["isl"]))
         for _, d_row in decode_df.iterrows():
             combo = _build_disagg_summary_dict(
                 prefill_summary_dict=p_dict,

--- a/components/src/dynamo/profiler/utils/aic_dataframe.py
+++ b/components/src/dynamo/profiler/utils/aic_dataframe.py
@@ -47,6 +47,18 @@ def make_parallel_label(tp: int, pp: int, dp: int, moe_tp: int, moe_ep: int) -> 
     return "-".join(parts)
 
 
+def _prefix_len(kv_hit_rate: float, isl: int) -> int:
+    """Cached-prefix length (tokens) implied by a prefix-cache hit rate.
+
+    ``kv_hit_rate`` is the fraction of ISL served from a warm KV/prefix cache
+    (0 = cold, 1 = fully cached). The prefill only pays for the uncached
+    ``effective_isl = isl - prefix`` tokens.
+    """
+    if not 0.0 <= kv_hit_rate <= 1.0:
+        raise ValueError(f"kv_hit_rate must be in [0, 1], got {kv_hit_rate}")
+    return round(kv_hit_rate * isl)
+
+
 def build_prefill_row(
     *,
     model: str,
@@ -60,14 +72,24 @@ def build_prefill_row(
     moe_ep: int,
     backend: str = "",
     system: str = "",
+    kv_hit_rate: float = 0.0,
 ) -> dict:
     """Build a single prefill row dict with the minimal columns needed by AIC picking.
 
     Only columns actually accessed by ``pick_autoscale`` and
     ``_build_disagg_summary_dict`` are populated.
+
+    ``kv_hit_rate`` (0-1, default 0) is the prefix-cache hit fraction: it sets
+    ``prefix = round(kv_hit_rate * isl)`` so downstream cost models charge the
+    prefill only for the uncached ``effective_isl = isl - prefix`` tokens.
+    The caller is responsible for supplying ``ttft`` already measured/predicted
+    over ``effective_isl`` (e.g. ``AicSession.predict_prefill(bs, effective_isl,
+    prefix)``); this helper only records the resulting ``prefix``. The default
+    of 0 keeps the previous cold-cache behaviour (``prefix = 0``).
     """
     num_gpus = tp * pp * dp
     seq_s = 1000.0 / ttft * dp if ttft > 0 else 0.0
+    prefix = _prefix_len(kv_hit_rate, isl)
 
     return {
         "ttft": ttft,
@@ -84,7 +106,7 @@ def build_prefill_row(
         "bs": 1,
         "moe_tp": moe_tp,
         "moe_ep": moe_ep,
-        "prefix": 0,
+        "prefix": prefix,
         "gemm": "",
         "kvcache": "",
         "fmha": "",
@@ -150,17 +172,29 @@ def build_decode_row(
 def build_disagg_df_from_static(
     prefill_df: pd.DataFrame,
     decode_df: pd.DataFrame,
+    *,
+    kv_hit_rate: float | None = None,
 ) -> pd.DataFrame:
     """Cross-product prefill x decode into a ColumnsDisagg DataFrame.
 
     Used when calling ``pick_default`` or ``pick_load_match`` from
     THOROUGH-mode benchmark results.
+
+    ``kv_hit_rate`` (0-1) optionally overrides the prefix-cache hit fraction on
+    every prefill row before rate matching, setting ``prefix =
+    round(kv_hit_rate * isl)`` per row. This is a convenience for callers that
+    hold a pre-built ``prefill_df`` and want to apply a hit rate at
+    disagg-assembly time. When ``None`` (default) the ``prefix`` already carried
+    by each prefill row is used unchanged, so existing behaviour is preserved.
     """
     combos: list[dict] = []
     for _, p_row in prefill_df.iterrows():
+        p_dict = p_row.to_dict()
+        if kv_hit_rate is not None:
+            p_dict["prefix"] = _prefix_len(kv_hit_rate, int(p_dict["isl"]))
         for _, d_row in decode_df.iterrows():
             combo = _build_disagg_summary_dict(
-                prefill_summary_dict=p_row.to_dict(),
+                prefill_summary_dict=p_dict,
                 prefill_num_worker=1,
                 decode_summary_dict=d_row.to_dict(),
                 decode_num_worker=1,


### PR DESCRIPTION
## Summary

`build_prefill_row` hardcoded `prefix = 0`, so the AIC disaggregated planner always priced prefill at the full input sequence length even when a warm prefix/KV cache would serve part of it.

This adds an optional `kv_hit_rate` to `build_prefill_row`:

- `prefix = round(kv_hit_rate * isl)`
- callers supply TTFT measured or predicted for the matching uncached `effective_isl = isl - prefix`
- the default remains `0.0`, preserving cold-cache behavior for every existing caller

Prefix and TTFT stay coupled at prefill-row construction. The disaggregated assembly helper only preserves those inputs; it does not independently override the hit rate.

## Motivation

Prefix reuse materially changes disaggregated planning. On a production-shaped long-context trace, aggregation reused a large shared prefix (measured about 51% on Step-3.7-Flash) while 1P1D disaggregation started cold. Modeling the prefix prevents analytical comparisons from charging cached tokens as prefill work.

## Validation

```text
PYTHONPATH=components/src uv run --no-project --with pytest --with pandas \
  --with 'aiconfigurator>=0.9,<0.10' pytest -c /dev/null \
  components/src/dynamo/profiler/tests/unit/test_prefix_cache_discount.py -q

11 passed
```

Coverage includes cold/warm/full-cache mapping, range validation, rounding versus truncation, and preservation of a prefill row's prefix during disaggregated assembly.

The repository's default `uv run` dependency resolution currently selects incompatible `nixl` pins from the SGLang and vLLM extras, so validation used the minimal profiler dependency set above.

## Notes

KV-cache transfer cost for the prefill-to-decode handoff is a separate term tracked in ai-dynamo/dynamo#10863.

AI assistance was used to prepare and review this change. The submitter reviewed the diff and validation results.
