### PR TITLE
docs(vllm): correct worker-role flags and document --kv-transfer-config

### DIFF
--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -77,7 +77,7 @@ If workers do not publish KV events, configure the frontend with `--no-router-kv
 `--kv-transfer-config` is a native vLLM engine argument rather than a `DynamoVllmConfig` field, so it has no `DYN_VLLM_*` environment variable. It selects the KV connector that moves cache blocks between prefill and decode workers.
 
 <Warning>
-A worker started with `--disaggregation-mode prefill` must be passed `--kv-transfer-config` explicitly. Without it, the worker raises a `ValueError` during argument parsing and never starts. The other modes — `agg`, `decode`, and `encode` — do not enforce this check.
+A worker started with `--disaggregation-mode prefill` must be passed `--kv-transfer-config` explicitly. Without it, the worker raises a `ValueError` during argument parsing and never starts. All non-prefill modes — `agg`, `pd`, `decode`, and `encode` — do not enforce this check.
 </Warning>
 
 The value is a JSON object. For NIXL-based prefill/decode disaggregation:
@@ -91,7 +91,11 @@ python -m dynamo.vllm \
 
 Only the prefill worker is required to set it, but both halves of a NIXL pair must agree on a connector for transfers to succeed. Pass the same `--kv-transfer-config` value to the decode worker, as the [disaggregated vLLM launch script](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/disagg.sh) does.
 
-The earlier `--connector` flag is no longer accepted by the vLLM backend. Setting it — on the command line or through the `DYN_CONNECTOR` environment variable — raises a `ValueError` whose message includes the equivalent `--kv-transfer-config` value to use instead.
+The earlier `--connector` flag is no longer accepted by the vLLM backend. Setting it — on the command line or through the `DYN_CONNECTOR` environment variable — raises a `ValueError` during argument parsing. The message depends on the value:
+
+- An active connector, such as `--connector nixl` or `DYN_CONNECTOR=nixl`, reports the equivalent `--kv-transfer-config` JSON to use instead.
+- `--connector none` or `--connector null` reports that the flag is no longer needed, because no connector is already the default. There is no equivalent value to migrate to, so none is shown.
+- `DYN_CONNECTOR` set to an empty or whitespace-only value reports that the variable is no longer supported, without an equivalent value.
 
 ## Worker role and disaggregation
 

--- a/docs/fern/pages/reference/backends/vllm-configuration.mdx
+++ b/docs/fern/pages/reference/backends/vllm-configuration.mdx
@@ -8,7 +8,7 @@ subtitle: Field reference for the Dynamo-specific CLI flags and environment vari
 `DynamoVllmConfig` holds the Dynamo-specific configuration for the vLLM backend (`python -m dynamo.vllm`). Every field, type, default, and choice on this page comes from the [`DynamoVllmArgGroup` and `DynamoVllmConfig`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/vllm/backend_args.py) definitions. For features and operational details, see the [vLLM Reference Guide](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md).
 
 <Note>
-  These are **only** the Dynamo wrapper flags. The vLLM backend also accepts every native vLLM `EngineArgs` argument (`--model`, `--tensor-parallel-size`, `--max-model-len`, and so on) in the same command, plus the cross-cutting [Dynamo Runtime](../components/runtime-configuration.mdx) flags (`--namespace`, `--endpoint`, and others). Except for the KV event interoperability note below, this page covers neither — only the vLLM-specific `DYN_VLLM_*` surface.
+  These are **only** the Dynamo wrapper flags. The vLLM backend also accepts every native vLLM `EngineArgs` argument (`--model`, `--tensor-parallel-size`, `--max-model-len`, and so on) in the same command, plus the cross-cutting [Dynamo Runtime](../components/runtime-configuration.mdx) flags (`--namespace`, `--endpoint`, and others). Except for the native KV event and KV transfer sections below, this page covers neither — only the vLLM-specific `DYN_VLLM_*` surface.
 </Note>
 
 ## How the config is loaded
@@ -72,12 +72,35 @@ The `endpoint` value is the base ZeroMQ port. vLLM assigns each data-parallel ra
 
 If workers do not publish KV events, configure the frontend with `--no-router-kv-events` for prediction-based KV routing or `--load-aware` for load-only routing.
 
+## Native KV transfer configuration
+
+`--kv-transfer-config` is a native vLLM engine argument rather than a `DynamoVllmConfig` field, so it has no `DYN_VLLM_*` environment variable. It selects the KV connector that moves cache blocks between prefill and decode workers.
+
+<Warning>
+A worker started with `--disaggregation-mode prefill` must be passed `--kv-transfer-config` explicitly. Without it, the worker raises a `ValueError` during argument parsing and never starts. The other modes — `agg`, `decode`, and `encode` — do not enforce this check.
+</Warning>
+
+The value is a JSON object. For NIXL-based prefill/decode disaggregation:
+
+```bash
+python -m dynamo.vllm \
+  --model Qwen/Qwen3-0.6B \
+  --disaggregation-mode prefill \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+```
+
+Only the prefill worker is required to set it, but both halves of a NIXL pair must agree on a connector for transfers to succeed. Pass the same `--kv-transfer-config` value to the decode worker, as the [disaggregated vLLM launch script](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/disagg.sh) does.
+
+The earlier `--connector` flag is no longer accepted by the vLLM backend. Setting it — on the command line or through the `DYN_CONNECTOR` environment variable — raises a `ValueError` whose message includes the equivalent `--kv-transfer-config` value to use instead.
+
 ## Worker role and disaggregation
 
 These flags control which role this worker plays in a disaggregated deployment. The default when no `--disaggregation-mode` is set is aggregated (`agg`).
 
 <ParamField path="--disaggregation-mode" type="string" default="null">
   Worker disaggregation mode. `agg` (default when unset) runs a combined aggregated prefill+decode worker. `pd` is a legacy alias for `agg`. `prefill` and `decode` split the pipeline for prefill/decode disaggregation. `encode` starts a multimodal encode-only worker.
+
+  `prefill` additionally requires the native `--kv-transfer-config` argument — see [Native KV transfer configuration](#native-kv-transfer-configuration).
 
   <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>pd</Badge> <Badge intent="note" minimal>agg</Badge> <Badge intent="note" minimal>prefill</Badge> <Badge intent="note" minimal>decode</Badge> <Badge intent="note" minimal>encode</Badge></span>
 
@@ -204,18 +227,6 @@ These flags control the self-benchmark sweep that runs on startup before the wor
 
 These flags are retained for backward compatibility and will be removed in a future release. Each is mapped to its replacement at startup with a deprecation warning.
 
-<ParamField path="--is-prefill-worker" type="boolean" default="false" deprecated={true}>
-  **Deprecated** — use `--disaggregation-mode=prefill`. Enable prefill functionality for this worker.
-
-  Environment variable: `DYN_VLLM_IS_PREFILL_WORKER`
-</ParamField>
-
-<ParamField path="--is-decode-worker" type="boolean" default="false" deprecated={true}>
-  **Deprecated** — use `--disaggregation-mode=decode`. Mark this as a decode worker that does not publish KV events.
-
-  Environment variable: `DYN_VLLM_IS_DECODE_WORKER`
-</ParamField>
-
 <ParamField path="--model-express-url" type="string" default="null" deprecated={true}>
   **Deprecated** — accepted for compatibility with older ModelExpress manifests only. The vLLM ModelExpress plugin reads its own configuration.
 
@@ -224,8 +235,6 @@ These flags are retained for backward compatibility and will be removed in a fut
 
 ## Validation rules
 
-- `--disaggregation-mode` cannot be combined with `--is-prefill-worker` or `--is-decode-worker`.
-- `--is-prefill-worker` and `--is-decode-worker` cannot both be set at the same time.
 - `--embedding-worker` is only valid with `--disaggregation-mode=agg` (or the default aggregated mode) and cannot be combined with `--enable-multimodal` or `--benchmark-mode`.
 
 ## Related pages


### PR DESCRIPTION
## Overview:

`docs/fern/pages/reference/backends/vllm-configuration.mdx` documented two CLI flags
the vLLM backend no longer registers, and did not document `--kv-transfer-config` at
all. A reader following the page would pass `--is-prefill-worker` or
`--is-decode-worker` and hit `unrecognized arguments` at worker startup, and would
find no guidance on the flag that a `prefill` worker actually requires.

This corrects the page. Documentation only — one `.mdx` file, no code change.

## Details:

**Removed**, both under `## Deprecated` / `## Validation rules`:

- The `ParamField` blocks for `--is-prefill-worker` and `--is-decode-worker`. Neither
  symbol appears in `components/src/dynamo/vllm/backend_args.py` or
  `components/src/dynamo/vllm/args.py`; both were removed from the vLLM backend in
  1.4.0.
- The two `## Validation rules` bullets describing how those flags interacted with
  each other and with `--disaggregation-mode`. The code paths raising those
  `ValueError`s went away with the flags.

The `## Deprecated` heading and its third `ParamField` (`--model-express-url`) are
kept — that flag is still registered and still deprecated. The surviving
`--embedding-worker` validation bullet is untouched.

**Added** a `## Native KV transfer configuration` section covering
`--kv-transfer-config`, placed after the existing `## Native KV event configuration`
section. It is prose plus a `bash` fence rather than a `ParamField`, mirroring how
the page already handles `--kv-events-config`: the page's opening `<Note>` scopes it
to Dynamo wrapper flags and `## How the config is loaded` promises every field is
both a CLI flag and an environment variable, and neither holds for a native
`AsyncEngineArgs` field. Filing it as a peer `ParamField` would have contradicted
both statements and left the only `ParamField` on the page without an
`Environment variable:` line.

Requiredness is scoped to `prefill` alone. The guard at
`components/src/dynamo/vllm/args.py:216-231` tests
`disaggregation_mode == DisaggregationMode.PREFILL` exactly, so `agg`, `decode`, and
`encode` do not enforce it; the new text names those three modes explicitly so the
scope cannot be misread. The example value
`{"kv_connector":"NixlConnector","kv_role":"kv_both"}` is taken from
`examples/backends/vllm/launch/disagg.sh`.

Two smaller edits follow from the new section: a cross-reference from the
`--disaggregation-mode` `ParamField` body to the new anchor for `prefill` readers,
and a widened carve-out in the intro `<Note>` so its exception covers both native
sections rather than only the KV event one.

## Where should the reviewer start?

`docs/fern/pages/reference/backends/vllm-configuration.mdx` is the only changed file.
Start at the new `## Native KV transfer configuration` section and check its scoping
claim against `components/src/dynamo/vllm/args.py:216-231`; that is the one sentence
in the diff where a factual error would matter. The deletions are mechanical — a
grep for `is_prefill_worker` / `is_decode_worker` under `components/src/dynamo/vllm/`
returns nothing.

## Validation

- `pre-commit run --files docs/fern/pages/reference/backends/vllm-configuration.mdx
  --hook-stage manual` — passed. `codespell`, case/merge-conflict checks, mixed line
  ending, and trailing whitespace all pass; Python/Rust/JSON hooks skip with no files
  to check. No hook modified the file.
- `pytest components/src/dynamo/vllm/tests/test_vllm_unit.py -k "kv_transfer_config
  or prefill_worker"` — `2 passed, 120 deselected`. Corroboration, not new coverage:
  this diff changes no code, so there is no regression to demonstrate. The runs show
  that the behavior the new prose describes is true of `main` today —
  `test_prefill_worker_without_kv_transfer_config_raises` asserts
  `pytest.raises(ValueError, match="--kv-transfer-config")` for
  `--disaggregation-mode prefill` with the flag absent.
- Static inspection: no body `# H1` (Fern frontmatter intact), SPDX header unchanged,
  language-tagged fence, "vLLM" casing, and the diff reverse-applies cleanly onto
  `main`.

No new test is added. A docs-only diff admits no behavioral test that is not either a
mirror of the file's literal text or a duplicate of `test_vllm_unit.py:282`, which
already covers the single claim the new text makes.

`docs/fern/scripts/check_reference.sh` was deliberately not run: it needs the `fern`
CLI, which is absent here, and its broken-links step self-skips with a warning when
the CLI is missing — running it would have produced a misleading green rather than
evidence. CI owns that gate.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring native KV transfer in vLLM, including prefill worker requirements and NIXL examples.
  * Documented connector consistency requirements and the removal of the legacy connector option.
  * Updated disaggregation-mode guidance and clarified supported KV event and transfer configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->