### PR TITLE
fix(examples): bump Triton example image to a CUDA-13 tag

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DYNAMO_BASE_IMAGE="dynamo-base:latest"
-ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.01-py3"
+ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.11-py3"
 
 FROM ${TRITON_SERVER_IMAGE} AS triton_source
 


### PR DESCRIPTION
## Overview:

`examples/backends/tritonserver/Dockerfile` copied a CUDA 12 Triton tree into a CUDA 13 Dynamo base, producing an ABI mismatch that `docker build` does not catch. This bumps the pinned Triton image from `25.01-py3` to `25.11-py3` so the copied tree matches the base's CUDA major version.

## Details:

The Dockerfile is two-stage. `FROM ${TRITON_SERVER_IMAGE} AS triton_source` (line 7) supplies the tree that line 11 copies wholesale into `${DYNAMO_BASE_IMAGE}`:

```dockerfile
COPY --from=triton_source /opt/tritonserver /opt/tritonserver
```

`container/context.yaml` pins the Dynamo base at `nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04` — CUDA 13, with no CUDA 12 variant. The old Triton pin `25.01-py3` is a CUDA 12 build, so `tritonserver`, `libtritonserver.so`, and the backend `.so` files all carried a `libcudart.so.12` dependency that does not exist in the base. The copy succeeds and the failure surfaces at load time.

The change is one line:

```diff
-ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.01-py3"
+ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.11-py3"
```

**Why `25.11-py3` specifically.** Triton crosses to CUDA 13 at `25.08`, so `25.08-py3` and later all satisfy the CUDA major requirement. `25.11` was chosen because three constraints line up on it:

- **CUDA minor.** `25.11-py3` is CUDA 13.0, matching the base's `cuda13.0` exactly. `25.12` and later move to CUDA 13.1, which would put the copied tree a CUDA minor ahead of the base toolkit.
- **NGC monthly train.** Base and Triton both land on `25.11`, so they share a driver floor, Ubuntu 24.04, and DCGM generation. This matters because lines 12-13 also copy `/usr/local/dcgm` and `libdcgm*.so*` across the stage boundary.
- **CPython minor.** Line 26 runs `uv pip install /opt/tritonserver/python/triton*.whl` — a compiled extension built for the source image's Python. r25.11 is Python 3.12, matching `python_version: "3.12"` in `container/context.yaml`.

`25.08-py3` is the documented fallback if `25.11-py3` proves unsuitable; it is a one-string swap on the same line and requires no other change.

`examples/backends/tritonserver/Dockerfile:5` is the only place in the repository that names this tag — `grep -rIn 'TRITON_SERVER_IMAGE'` returns only lines 5 and 7, and no README, compatibility matrix, Helm value, or lockfile restates it. The README documents no Triton tag, so no doc edit accompanies this.

**Two related gaps found while investigating, deliberately left out of scope:**

1. `examples/backends/tritonserver/Makefile:29` clones `triton-inference-server/server` with no `--branch` or tag, so the from-source `make all` path tracks upstream `main` — a second, unpinned owner of the effective Triton version. Fixing it requires deciding a source-build policy.
2. No CI job builds this image. `.github/workflows/` has no Triton reference and `.github/filters.yaml` has path filters for `examples/backends/{vllm,sglang,trtllm,sample}` but no `tritonserver` entry, which is why this drift went unnoticed.

Both are worth separate issues.

## Where should the reviewer start?

`examples/backends/tritonserver/Dockerfile:5` — that is the entire diff (1 file, 1 insertion, 1 deletion).

The check that closes this out is a build and a soname inspection, which requires a Docker daemon:

```bash
docker pull nvcr.io/nvidia/tritonserver:25.11-py3
cd examples/backends/tritonserver && docker build -t dynamo-triton:latest .
docker run --rm dynamo-triton:latest ldd /opt/tritonserver/bin/tritonserver | grep -i cudart
```

Expect `libcudart.so.13`, resolved, with no `not found` lines. That build was not run here — no Docker daemon was available in the environment this change was prepared in, and as noted above no CI job builds this image either. The CUDA 13 claim rests on upstream Triton release metadata and on `build.py` at the `r25.01` and `r25.11` branches, where the copied sonames move `libcudart.so.12` → `libcudart.so.13` in lockstep with `libcublas`, `libcupti`, and `libnvJitLink`.

One caution for anyone re-deriving the tag choice: `cuda-dl-base` and `tritonserver` are independent NGC families with different CUDA boundaries. `cuda-dl-base` crosses to CUDA 13 at `25.10`; Triton crosses at `25.08`. Reasoning from the base image's boundary would wrongly reject `25.08-py3`.

`pre-commit run --files examples/backends/tritonserver/Dockerfile --hook-stage manual` passes (codespell, case conflicts, merge conflicts, shebang-executable, mixed line ending, trailing whitespace). The SPDX header is intact. A green linter does not prove runtime compatibility and is not offered as though it did.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<sub>Tracked internally as DYN-3697; no public GitHub issue exists for this.</sub>

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Triton Server example environment to use the newer 25.11 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->