### PR TITLE
fix(frontend): apply multimodal processor overrides during rendering

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -185,6 +185,11 @@ def _prepare_request(
     chat_params = ChatParams(
         chat_template=request_for_sampling.chat_template,
         chat_template_content_format="auto",
+        # Multimodal processor overrides must be present during rendering. The
+        # renderer fetches and preprocesses media here, so attaching these only
+        # to the later EngineInput leaves the already-rendered image placeholders
+        # at the model default (for example Gemma 4 stays at 280 soft tokens).
+        mm_processor_kwargs=request_for_sampling.mm_processor_kwargs,
         # Renderer-managed keys last so a nested duplicate can't raise TypeError.
         chat_template_kwargs={
             **chat_template_kwargs,

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1104,3 +1104,19 @@ def test_runtime_config_context_length(vllm_processor_module, runtime_config, ex
     mdc = SimpleNamespace(runtime_config=lambda: runtime_config)
 
     assert vllm_processor_module._runtime_config_context_length(mdc) == expected
+
+
+@pytest.mark.core
+class TestMmProcessorKwargsForwarding:
+    def test_mm_processor_kwargs_forwarded_to_renderer(self, tokenizer):
+        """Per-request multimodal overrides are applied during media rendering."""
+        _, _, _, _, chat_params = _prepare_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "mm_processor_kwargs": {"max_soft_tokens": 1120},
+            },
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+        )
+        assert chat_params.mm_processor_kwargs == {"max_soft_tokens": 1120}


### PR DESCRIPTION
## Summary

- pass per-request `mm_processor_kwargs` into `ChatParams` before multimodal rendering
- prevent render-time image placeholders from being fixed at the model default before processor overrides are attached
- add regression coverage for a Gemma-style `max_soft_tokens: 1120` override

## Validation

- `python -m py_compile components/src/dynamo/frontend/prepost.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py`
- `uvx ruff check --ignore SIM102,I001 components/src/dynamo/frontend/prepost.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py`
- `git diff --check`

The focused pytest requires the vLLM test container, which is not installed on the development host.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal request processing by ensuring per-request media processor settings are applied during chat rendering.
  * Preserved custom media processing options throughout request preparation for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->