### PR TITLE
fix(profiler): configure rapid mocker without planner

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -30,6 +30,7 @@ from dynamo.profiler.utils.dgdr_v1beta1_types import DynamoGraphDeploymentReques
 from dynamo.profiler.utils.model_cache_paths import model_cache_path_in_pvc
 from dynamo.profiler.utils.profile_common import (
     derive_backend_image,
+    needs_mocker_aic_perf_model,
     needs_profile_data,
     resolve_model_path,
 )
@@ -304,18 +305,19 @@ def _run_default_sim(
         **load_kwargs,
     )
 
-    # When interpolation data is needed (mocker or throughput-scaling), a
-    # disaggregated config is required.  If AIC picked an aggregated config,
-    # override to the best available disaggregated alternative so that
-    # run_interpolation() can run successfully downstream.
-    if chosen == "agg" and needs_profile_data(dgdr):
+    # File-based interpolation and rapid mocker AIC specs both require separate
+    # prefill/decode picks. If AIC picked an aggregated config, override to the
+    # best available disaggregated alternative for the downstream consumer.
+    requires_disagg = needs_profile_data(dgdr) or needs_mocker_aic_perf_model(dgdr)
+    if chosen == "agg" and requires_disagg:
         disagg_key = next(
             (k for k in best_configs if "disagg" in k and not best_configs[k].empty),
             None,
         )
         if disagg_key:
             logger.info(
-                "AIC picked aggregated config but interpolation data is required — "
+                "AIC picked aggregated config but separate prefill/decode picks "
+                "are required — "
                 "overriding to '%s' to support mocker/throughput-scaling.",
                 disagg_key,
             )
@@ -323,7 +325,8 @@ def _run_default_sim(
         else:
             logger.warning(
                 "AIC picked aggregated config and no disaggregated alternative "
-                "is available; interpolation data will be skipped."
+                "is available; separate prefill/decode performance data will "
+                "be unavailable."
             )
 
     best_config_df = best_configs.get(chosen, pd.DataFrame())

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -25,6 +25,7 @@ try:
         FeaturesSpec,
         MockerSpec,
     )
+    from dynamo.profiler.utils.profile_common import needs_profile_data
 except ImportError as e:
     pytest.skip(f"Missing dependency: {e}", allow_module_level=True)
 
@@ -39,6 +40,7 @@ def _dgdr(
     planner: PlannerConfig | None = None,
     model: str = "Qwen/Qwen3-32B",
     mocker_enabled: bool = False,
+    search_strategy: str = "rapid",
 ) -> DynamoGraphDeploymentRequestSpec:
     features = None
     if planner is not None or mocker_enabled:
@@ -46,7 +48,11 @@ def _dgdr(
             planner=planner,
             mocker=MockerSpec(enabled=True) if mocker_enabled else None,
         )
-    return DynamoGraphDeploymentRequestSpec(model=model, features=features)
+    return DynamoGraphDeploymentRequestSpec(
+        model=model,
+        features=features,
+        searchStrategy=search_strategy,
+    )
 
 
 class TestBuildAICInterpolationSpec:
@@ -199,6 +205,46 @@ class TestBuildAICInterpolationSpec:
         )
         assert isinstance(spec, AICInterpolationSpec)
         assert spec.backend == "trtllm"
+
+    def test_mocker_only_rapid_produces_spec(self):
+        """Mocker-only rapid requests use the DGDR search strategy."""
+        dgdr = _dgdr(mocker_enabled=True)
+        pick = PickedParallelConfig(tp=1, dp=8, moe_ep=8)
+
+        spec = build_aic_interpolation_spec(
+            dgdr,
+            best_prefill_pick=pick,
+            best_decode_pick=pick,
+            isl=1000,
+            osl=100,
+            sweep_max_context_length=4096,
+            resolved_backend="trtllm",
+            system="h200_sxm",
+            prefill_interpolation_granularity=8,
+            decode_interpolation_granularity=4,
+        )
+
+        assert isinstance(spec, AICInterpolationSpec)
+
+    def test_mocker_only_thorough_returns_none(self):
+        """Mocker-only thorough requests consume generated NPZ data."""
+        dgdr = _dgdr(mocker_enabled=True, search_strategy="thorough")
+        pick = PickedParallelConfig(tp=1, dp=8, moe_ep=8)
+
+        spec = build_aic_interpolation_spec(
+            dgdr,
+            best_prefill_pick=pick,
+            best_decode_pick=pick,
+            isl=1000,
+            osl=100,
+            sweep_max_context_length=4096,
+            resolved_backend="trtllm",
+            system="h200_sxm",
+            prefill_interpolation_granularity=8,
+            decode_interpolation_granularity=4,
+        )
+
+        assert spec is None
 
 
 class TestInjectMockerAicArgs:
@@ -361,10 +407,18 @@ class TestBuildPlannerConfigEmbedsAicSpec:
 
 
 class TestNeedsProfileDataRapid:
+    def test_mocker_only_rapid_returns_false(self):
+        """Mocker-only rapid uses AIC directly instead of profile files."""
+        dgdr = _dgdr(mocker_enabled=True)
+        assert needs_profile_data(dgdr) is False
+
+    def test_mocker_only_thorough_returns_true(self):
+        """Mocker-only thorough still consumes generated profile files."""
+        dgdr = _dgdr(mocker_enabled=True, search_strategy="thorough")
+        assert needs_profile_data(dgdr) is True
+
     def test_rapid_planner_only_returns_false(self):
         """Planner-only rapid: no files needed; planner will use aic_spec."""
-        from dynamo.profiler.utils.profile_common import needs_profile_data
-
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -376,8 +430,6 @@ class TestNeedsProfileDataRapid:
 
     def test_thorough_planner_returns_true(self):
         """Thorough still needs files."""
-        from dynamo.profiler.utils.profile_common import needs_profile_data
-
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -389,8 +441,6 @@ class TestNeedsProfileDataRapid:
 
     def test_none_planner_only_returns_false(self):
         """Planner-only none mode can warm from native AIC or live FPMs."""
-        from dynamo.profiler.utils.profile_common import needs_profile_data
-
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -402,8 +452,6 @@ class TestNeedsProfileDataRapid:
 
     def test_mocker_rapid_returns_false(self):
         """Mocker + rapid: mocker pulls AIC perf data at runtime; no NPZ files."""
-        from dynamo.profiler.utils.profile_common import needs_profile_data
-
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -415,8 +463,6 @@ class TestNeedsProfileDataRapid:
 
     def test_mocker_thorough_returns_true(self):
         """Mocker + thorough: mocker consumes real-GPU NPZ."""
-        from dynamo.profiler.utils.profile_common import needs_profile_data
-
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -923,15 +923,15 @@ class TestAssembleFinalConfig:
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
-    def test_mocker_only_no_planner_returns_mocker_config(self, tmp_path):
-        """Mocker-only (no planner): generate_mocker_config is called,
-        add_planner_to_config is not, profile data is still attached."""
+    def test_mocker_only_rapid_returns_mocker_config_without_profile_data(
+        self, tmp_path
+    ):
+        """Mocker-only rapid uses AIC data and does not attach profile files."""
         dgdr = _make_dgdr(features=FeaturesSpec(mocker=MockerSpec(enabled=True)))
         ops = _make_ops(tmp_path)
         os.makedirs(ops.output_dir, exist_ok=True)
         dgd_config = {"kind": "DGD"}
         mocker_base = {"kind": "MockerDGD", "spec": {"components": []}}
-        profile_cm = {"kind": "ConfigMap", "metadata": {"name": "profile-cm"}}
 
         with (
             patch(
@@ -943,7 +943,6 @@ class TestAssembleFinalConfig:
             ) as mock_planner,
             patch(
                 f"{_DGD_GEN}.add_profile_data_to_config",
-                return_value=profile_cm,
             ) as mock_profile,
         ):
             result = assemble_final_config(
@@ -956,8 +955,8 @@ class TestAssembleFinalConfig:
 
         mock_mocker.assert_called_once()
         mock_planner.assert_not_called()
-        mock_profile.assert_called_once()
-        assert result == [profile_cm, mocker_base]
+        mock_profile.assert_not_called()
+        assert result is mocker_base
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
@@ -477,14 +477,14 @@ class TestRunDefaultSim:
 
 
 # ---------------------------------------------------------------------------
-# Force-disagg when interpolation data is needed
+# Force-disagg when a downstream consumer needs separate worker picks
 # ---------------------------------------------------------------------------
 
 
 class TestRunDefaultSimForceDisagg:
-    """When AIC picks an aggregated config but the DGDR requires interpolation
-    data (mocker or throughput-scaling), _run_default_sim must override the
-    selection to the best available disaggregated config."""
+    """When AIC picks an aggregated config but a downstream consumer needs
+    separate prefill/decode picks, _run_default_sim must select the best
+    available disaggregated config."""
 
     def _call_default_sim(self, dgdr, execute_return_value):
         with (
@@ -534,7 +534,7 @@ class TestRunDefaultSimForceDisagg:
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
     def test_no_profile_data_needed_agg_pick_preserved(self):
-        """When no interpolation data is needed, an agg pick is kept as-is."""
+        """When no downstream consumer needs disagg picks, agg is preserved."""
         dgdr = _make_dgdr()  # no mocker, no throughput scaling
         result = self._call_default_sim(dgdr, self._both_configs(chosen="agg"))
         assert result["chosen_exp"] == "agg"

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -853,13 +853,14 @@ def test_update_model_from_pvc_absolute_path_inside_mount_is_not_doubled(
         pvc_path=model_path,
     )
 
-    services = result["spec"]["services"]
-    for svc_name, svc in services.items():
-        args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
+    for component in result["spec"]["components"]:
+        args = _main_container(component).get("args", [])
         flat_args = " ".join(args) if args else ""
         assert f"{pvc_mount_path}{pvc_mount_path}" not in flat_args
-        if svc_name in BaseConfigModifier._NON_WORKER_SERVICES:
-            continue
+
+    for component in _worker_components(result):
+        args = _main_container(component).get("args", [])
+        flat_args = " ".join(args) if args else ""
         assert model_path in flat_args
 
 

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -50,6 +50,7 @@ from dynamo.profiler.utils.profile_common import (
     derive_planner_image,
     is_mocker_enabled,
     is_planner_enabled,
+    needs_mocker_aic_perf_model,
     needs_profile_data,
 )
 
@@ -733,9 +734,8 @@ def build_aic_interpolation_spec(
     the mocker (via ``--aic-perf-model`` flags injected into worker args).
     Returns ``None`` when any of the following hold:
 
-    * no AIC consumer needs it — planner is disabled or has
-      ``enable_throughput_scaling=False``, **and** mocker is disabled
-    * ``pre_deployment_sweeping_mode`` is not ``Rapid``
+    * neither a throughput-scaling Planner with a rapid sweep nor a mocker in
+      rapid mode needs it
     * picks are missing
     * ``resolved_backend`` is not one AIC supports
 
@@ -757,16 +757,14 @@ def build_aic_interpolation_spec(
         if dgdr.features is not None and dgdr.features.planner is not None
         else None
     )
-    mocker_enabled = is_mocker_enabled(dgdr)
+    mocker_needs_aic = needs_mocker_aic_perf_model(dgdr)
     planner_needs_aic = (
         is_planner_enabled(dgdr)
         and planner is not None
         and planner.enable_throughput_scaling
+        and planner.pre_deployment_sweeping_mode == PlannerPreDeploymentSweepMode.Rapid
     )
-    if not planner_needs_aic and not mocker_enabled:
-        return None
-    sweep_mode = planner.pre_deployment_sweeping_mode if planner is not None else None
-    if sweep_mode != PlannerPreDeploymentSweepMode.Rapid:
+    if not planner_needs_aic and not mocker_needs_aic:
         return None
     if best_prefill_pick is None or best_decode_pick is None:
         logger.info(

--- a/components/src/dynamo/profiler/utils/profile_common.py
+++ b/components/src/dynamo/profiler/utils/profile_common.py
@@ -29,6 +29,7 @@ from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
 from dynamo.profiler.utils.dgdr_v1beta1_types import (
     DynamoGraphDeploymentRequestSpec,
     ProfilingPhase,
+    SearchStrategy,
 )
 from dynamo.profiler.utils.model_cache_paths import normalize_model_cache_path
 
@@ -201,28 +202,46 @@ def is_mocker_enabled(dgdr: DynamoGraphDeploymentRequestSpec) -> bool:
     )
 
 
+def needs_mocker_aic_perf_model(dgdr: DynamoGraphDeploymentRequestSpec) -> bool:
+    """True when mocker workers should load performance data from AIC.
+
+    Requests with Planner configuration use its pre-deployment sweep mode. For
+    mocker-only requests there is no Planner mode, so the DGDR search strategy
+    determines whether the profiler uses rapid AIC data or thorough NPZ data.
+    """
+    if not is_mocker_enabled(dgdr):
+        return False
+    if dgdr.features is not None and dgdr.features.planner is not None:
+        return (
+            dgdr.features.planner.pre_deployment_sweeping_mode
+            == PlannerPreDeploymentSweepMode.Rapid
+        )
+    return dgdr.searchStrategy == SearchStrategy.Rapid
+
+
 def needs_profile_data(dgdr: DynamoGraphDeploymentRequestSpec) -> bool:
     """True when the DGDR requires profiling interpolation data *at this stage*.
 
     Profile data (NPZ/JSON on disk) is consumed by:
 
-    * **Mocker workers** for latency simulation — required for thorough
-      mode. In rapid mode the mocker pulls latency data directly from the
-      AIConfigurator SDK via ``--aic-perf-model`` flags injected by the
-      profiler, so no NPZ is emitted.
+    * **Mocker workers** for latency simulation — required for thorough mode.
+      Requests with Planner configuration use its sweep mode; mocker-only
+      requests use the DGDR search strategy. In rapid mode the mocker pulls
+      latency data directly from the AIConfigurator SDK via
+      ``--aic-perf-model`` flags injected by the profiler, so no NPZ is
+      emitted.
     * **Planner** when thorough-mode bootstrap data is requested. In rapid
       mode the planner receives ``aic_perf_model`` and can also run AIC
       interpolation in-process at bootstrap; in none mode it starts from
       native AIC or live FPM regression warmup.
     """
+    if is_mocker_enabled(dgdr):
+        return not needs_mocker_aic_perf_model(dgdr)
     sweep_mode = (
         dgdr.features.planner.pre_deployment_sweeping_mode
         if dgdr.features is not None and dgdr.features.planner is not None
         else None
     )
-    is_rapid = sweep_mode == PlannerPreDeploymentSweepMode.Rapid
-    if is_mocker_enabled(dgdr):
-        return not is_rapid
     if (
         dgdr.features is not None
         and dgdr.features.planner is not None

--- a/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/deployment/output.yaml
@@ -28,10 +28,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - decode
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -56,10 +69,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - prefill
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -98,10 +124,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - decode
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m
@@ -157,10 +196,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - decode
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m
@@ -427,10 +479,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m
@@ -585,10 +650,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m

--- a/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/grove/output.yaml
@@ -30,10 +30,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - decode
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -59,10 +72,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - prefill
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -203,10 +229,23 @@ spec:
                   - Qwen/Qwen3-0.6B
                   - --speedup-ratio
                   - "1.0"
-                  - --planner-profile-data
-                  - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                   - --disaggregation-mode
                   - decode
+                  - --aic-perf-model
+                  - --aic-backend
+                  - vllm
+                  - --aic-system
+                  - h100_sxm
+                  - --aic-tp-size
+                  - "1"
+                  - --aic-moe-tp-size
+                  - "1"
+                  - --aic-moe-ep-size
+                  - "1"
+                  - --aic-attention-dp-size
+                  - "1"
+                  - --engine-type
+                  - vllm
                 command:
                   - python3
                   - -m
@@ -325,10 +364,23 @@ spec:
                   - Qwen/Qwen3-0.6B
                   - --speedup-ratio
                   - "1.0"
-                  - --planner-profile-data
-                  - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                   - --disaggregation-mode
                   - prefill
+                  - --aic-perf-model
+                  - --aic-backend
+                  - vllm
+                  - --aic-system
+                  - h100_sxm
+                  - --aic-tp-size
+                  - "1"
+                  - --aic-moe-tp-size
+                  - "1"
+                  - --aic-moe-ep-size
+                  - "1"
+                  - --aic-attention-dp-size
+                  - "1"
+                  - --engine-type
+                  - vllm
                 command:
                   - python3
                   - -m

--- a/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
+++ b/deploy/operator/internal/controller/testdata/dgdr/lws/output.yaml
@@ -30,10 +30,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - decode
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -58,10 +71,23 @@ spec:
                 - Qwen/Qwen3-0.6B
                 - --speedup-ratio
                 - "1.0"
-                - --planner-profile-data
-                - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
                 - --disaggregation-mode
                 - prefill
+                - --aic-perf-model
+                - --aic-backend
+                - vllm
+                - --aic-system
+                - h100_sxm
+                - --aic-tp-size
+                - "1"
+                - --aic-moe-tp-size
+                - "1"
+                - --aic-moe-ep-size
+                - "1"
+                - --aic-attention-dp-size
+                - "1"
+                - --engine-type
+                - vllm
               command:
                 - python3
                 - -m
@@ -102,10 +128,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - decode
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m
@@ -267,10 +306,23 @@ spec:
               - Qwen/Qwen3-0.6B
               - --speedup-ratio
               - "1.0"
-              - --planner-profile-data
-              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
               - --disaggregation-mode
               - decode
+              - --aic-perf-model
+              - --aic-backend
+              - vllm
+              - --aic-system
+              - h100_sxm
+              - --aic-tp-size
+              - "1"
+              - --aic-moe-tp-size
+              - "1"
+              - --aic-moe-ep-size
+              - "1"
+              - --aic-attention-dp-size
+              - "1"
+              - --engine-type
+              - vllm
             command:
               - python3
               - -m
@@ -388,10 +440,23 @@ spec:
               - Qwen/Qwen3-0.6B
               - --speedup-ratio
               - "1.0"
-              - --planner-profile-data
-              - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
               - --disaggregation-mode
               - decode
+              - --aic-perf-model
+              - --aic-backend
+              - vllm
+              - --aic-system
+              - h100_sxm
+              - --aic-tp-size
+              - "1"
+              - --aic-moe-tp-size
+              - "1"
+              - --aic-moe-ep-size
+              - "1"
+              - --aic-attention-dp-size
+              - "1"
+              - --engine-type
+              - vllm
             command:
               - python3
               - -m
@@ -535,10 +600,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m
@@ -693,10 +771,23 @@ spec:
             - Qwen/Qwen3-0.6B
             - --speedup-ratio
             - "1.0"
-            - --planner-profile-data
-            - /workspace/components/src/dynamo/planner/tests/data/profiling_results/H200_TP1P_TP1D
             - --disaggregation-mode
             - prefill
+            - --aic-perf-model
+            - --aic-backend
+            - vllm
+            - --aic-system
+            - h100_sxm
+            - --aic-tp-size
+            - "1"
+            - --aic-moe-tp-size
+            - "1"
+            - --aic-moe-ep-size
+            - "1"
+            - --aic-attention-dp-size
+            - "1"
+            - --engine-type
+            - vllm
           command:
             - python3
             - -m


### PR DESCRIPTION
## Summary

- Make mocker-only DGDRs use `spec.searchStrategy` to select rapid AIC data or thorough NPZ profile data when no Planner configuration is present.
- Build and inject the AIC performance-model arguments required by rapid mocker workers.
- Preserve disaggregated selection when rapid mocker workers need separate prefill and decode picks.
- Update the Deployment, Grove, and LeaderWorkerSet operator goldens to remove stale `--planner-profile-data` arguments and include the generated AIC arguments.
- Correct the PVC-path regression test inherited from #12493 to use the v1beta1 `spec.components` shape and existing worker-component helper.
- Align the mocker-only assembly test with rapid mode's intentional AIC-only output.

## Root Cause

#12506 stopped emitting file-based profile data for rapid-mode mocker deployments, but two profiler gates still derived rapid mode exclusively from the Planner's `pre_deployment_sweeping_mode`. Mocker-only DGDRs do not have a Planner configuration, so `needs_profile_data()` incorrectly returned true while `build_aic_interpolation_spec()` returned `None`.

The existing goldens appeared correct only because no interpolation NPZ was produced during the integration scenario. The generated mocker workers consequently had neither a profile-data path nor an AIC performance model. This change centralizes the mocker AIC decision and uses the DGDR-level search strategy when Planner is absent.

Rebasing onto current `main` also inherited a test from #12493 that referenced the removed v1alpha1 `spec.services` shape and an undefined `BaseConfigModifier._NON_WORKER_SERVICES` member. The test now validates the same PVC-path behavior through the v1beta1 component helpers.

The existing mocker-only assembly test also still expected rapid mode to attach file-based profile data. It now verifies that rapid mode returns the generated mocker deployment without calling `add_profile_data_to_config()`.

## Validation

- 118 focused profiler unit tests passed, including the complete profiler-protocol module and `TestAssembleFinalConfig`.
- Seven rapid/thorough consumer combinations passed the profiler mode matrix.
- `pre-commit run --show-diff-on-failure --all-files`
- Parsed all three updated golden files as YAML.
- Verified all 17 generated mocker containers have the complete AIC argument set and no stale `--planner-profile-data` argument.
- `git diff --check origin/main..HEAD`
- Rebased directly onto current `origin/main`.

The full operator cluster integration test requires CI-built profiler and operator images in a Kind cluster and is therefore left to CI.

## Related Issues

Relates to #12506 and unblocks #12375.
