### PR TITLE
feat(llm): stream guided tool calls by default and route Qwen3 to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2828,9 +2828,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500b56f141d7c5e5f81011abe15ef1c4611c5495f68e4c24d2adf853c1ff5a1"
+checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2851,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279943c1ed1d4354ca80a16fdd276a2f504bae6efb8f0332a197cdcaa1d01b40"
+checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1561,7 +1561,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2736,9 +2736,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
+version = "0.1.25"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkeiven-qwen-unified-fix#6e26f04eb6339df6f33612ecfe1efb7132a95b1b"
 dependencies = [
  "anyhow",
  "num-traits",
@@ -3196,7 +3195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4176,7 +4175,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -4503,7 +4502,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5821,7 +5820,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6946,8 +6945,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -6966,8 +6965,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -6988,7 +6987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7001,7 +7000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -7128,7 +7127,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.40",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7165,9 +7164,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7823,7 +7822,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8790,7 +8789,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10439,7 +10438,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,12 +69,12 @@ dynamo-memory = { path = "lib/memory", version = "1.5.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.5.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.5.0" }
 dynamo-protocols = { version = "=5.3.1" }
-dynamo-parsers = { version = "8.0.0" }
+dynamo-parsers = { version = "8.1.0" }
 
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions
 #   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.3.1" }
+dynamo-parsers-v2 = { version = "0.3.2" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.5.0" }
 dynamo-sidecar-common = { path = "lib/sidecar/common", version = "1.5.0" }
 fastokens = { version = "0.2.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,17 @@ dynamo-kv-router = { path = "lib/kv-router", version = "1.4.0" }
 dynamo-protocols = { version = "=5.0.1" }
 dynamo-parsers = { version = "7.0.1" }
 
+# TEMPORARY TESTING PIN — MUST become a published version bump before this merges.
+# frontend-crates PR #163 adds `UnifiedParserPrefill`, `UnifiedToolOutputMode` and the
+# `unified_registry!` macro on top of the base unified API published in 0.1.25. Nothing
+# on crates.io carries them yet, so the unified wiring below builds against the branch.
+# Replace with `dynamo-parsers-v2 = { version = "0.1.26" }` (or whatever #163 releases as)
+# once it is published; a git pin cannot ship in a released Dynamo.
+#
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions
 #   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.1.23" }
+dynamo-parsers-v2 = { git = "https://github.com/ai-dynamo/frontend-crates.git", branch = "rmccormick/keiven-qwen-unified-fix" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.4.0" }
 dynamo-sidecar-common = { path = "lib/sidecar/common", version = "1.4.0" }
 fastokens = { version = "0.2.0" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500b56f141d7c5e5f81011abe15ef1c4611c5495f68e4c24d2adf853c1ff5a1"
+checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1870,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279943c1ed1d4354ca80a16fdd276a2f504bae6efb8f0332a197cdcaa1d01b40"
+checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1796,9 +1796,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
+version = "0.1.25"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkeiven-qwen-unified-fix#09d1fe056aec0555087a9bdf0646bce319f96df8"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "8.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500b56f141d7c5e5f81011abe15ef1c4611c5495f68e4c24d2adf853c1ff5a1"
+checksum = "e78ad3396a91e388a6ab6e4e9f66236238793076b5d0b80c37671134f54bcfa5"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1937,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279943c1ed1d4354ca80a16fdd276a2f504bae6efb8f0332a197cdcaa1d01b40"
+checksum = "3e2277648c57af9f41943c1c6abf573ed42ddbad9d05f2e4053e9d66e9a41182"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2411,9 +2411,8 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948332d4646bf6eb14796f70fa99a640baec53db5b786119be994f84317274f4"
+version = "0.1.25"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?branch=rmccormick%2Fkeiven-qwen-unified-fix#bf98a57ec5851f3a241d72260635817273862801"
 dependencies = [
  "anyhow",
  "num-traits",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -62,7 +62,7 @@ request-trace-s3 = ["dynamo-llm/request-trace-s3"]
 aiconfigurator-core = { version = "=0.11.0-dev20260728", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "8.0.0" }
+dynamo-parsers = { version = "8.1.0" }
 dynamo-backend-common = { path = "../../backend-common" }
 dynamo-sglang-sidecar = { path = "../../sidecar/sglang" }
 

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -341,10 +341,18 @@ impl WorkerSet {
 
     /// Build ParsingOptions from this WorkerSet's card configuration.
     pub fn parsing_options(&self) -> crate::protocols::openai::ParsingOptions {
-        crate::protocols::openai::ParsingOptions::new(
-            self.card.runtime_config.tool_call_parser.clone(),
-            self.card.runtime_config.reasoning_parser.clone(),
-        )
+        crate::protocols::openai::ParsingOptions {
+            structural_tag_mode: self.card.runtime_config.structural_tag_mode,
+            structural_tag_scope: self.card.runtime_config.structural_tag_scope,
+            exclude_tools_when_tool_choice_none: self
+                .card
+                .runtime_config
+                .exclude_tools_when_tool_choice_none,
+            ..crate::protocols::openai::ParsingOptions::new(
+                self.card.runtime_config.tool_call_parser.clone(),
+                self.card.runtime_config.reasoning_parser.clone(),
+            )
+        }
     }
 
     /// Number of active workers in this set, derived from the Client's discovery watcher.

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -81,7 +81,8 @@ fn apply_request_tool_call_parsing_options(
     )?;
     Ok(parsing_options
         .with_guided_tool_constraint(guided_tool_constraint)
-        .with_tool_call_parsing_enabled(tool_call_parsing_enabled))
+        .with_tool_call_parsing_enabled(tool_call_parsing_enabled)
+        .with_tools(converted_tools))
 }
 
 #[cfg(test)]

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -43,23 +43,447 @@ pub use metrics::Metrics;
 
 use crate::{
     preprocessor::OpenAIPreprocessor,
-    protocols::openai::{
-        ParsingOptions, chat_completions::NvCreateChatCompletionRequest,
-        chat_completions::tool_parser_v2::batch_tool_choice_eligible,
-    },
+    protocols::openai::{ParsingOptions, chat_completions::NvCreateChatCompletionRequest},
 };
+
+use dynamo_protocols::types::ChatCompletionToolChoiceOption;
+use dynamo_runtime::error::DynamoError;
 
 /// Apply the request-level tool-call gates shared by the HTTP protocol handlers.
 fn apply_request_tool_call_parsing_options(
     parsing_options: ParsingOptions,
     request: &NvCreateChatCompletionRequest,
-) -> ParsingOptions {
+) -> Result<ParsingOptions, DynamoError> {
     let tool_call_parsing_enabled = OpenAIPreprocessor::tool_call_parsing_enabled(request);
-    parsing_options
-        .with_experimental_v2_batch_eligible(batch_tool_choice_eligible(
-            request.inner.tool_choice.as_ref(),
-        ))
-        .with_tool_call_parsing_enabled(tool_call_parsing_enabled)
+    let tool_choice = request
+        .inner
+        .tool_choice
+        .as_ref()
+        .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
+    let converted_tool_choice = crate::preprocessor::tool_choice::convert_tool_choice(tool_choice);
+    let tools = request.inner.tools.as_deref().unwrap_or(&[]);
+    let converted_tools = crate::preprocessor::tool_choice::convert_tools(tools);
+    let uses_structural_tag = crate::preprocessor::structural_tag::structural_tag_decision(
+        parsing_options.tool_call_parser.as_deref(),
+        &converted_tool_choice,
+        &converted_tools,
+        request.inner.parallel_tool_calls,
+        parsing_options.structural_tag_mode,
+        parsing_options.structural_tag_scope,
+        parsing_options.exclude_tools_when_tool_choice_none,
+    )?
+    .is_required();
+    let guided_tool_constraint = crate::preprocessor::tool_choice::guided_tool_constraint(
+        request,
+        parsing_options.tool_call_parser.as_deref(),
+        parsing_options.reasoning_parser.as_deref(),
+        uses_structural_tag,
+    )?;
+    Ok(parsing_options
+        .with_guided_tool_constraint(guided_tool_constraint)
+        .with_tool_call_parsing_enabled(tool_call_parsing_enabled))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::GuidedToolConstraint;
+    use serde_json::{Value, json};
+
+    fn request(tool_choice: Value) -> NvCreateChatCompletionRequest {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": tool_choice,
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                }
+            }]
+        });
+        serde_json::from_value(value).expect("request must deserialize")
+    }
+
+    // A Kimi K2 pair with a forced/named tool_choice must resolve to the real
+    // structural-tag decision computed by the single shared owner,
+    // `structural_tag::structural_tag_decision`, not to a second, independently
+    // reconstructed decision. `apply_tool_choice_structural_tag` is the in-process
+    // preprocessing owner that consults the same shared function; this HTTP-layer
+    // helper must agree with it, including when the parser registry does or does not
+    // actually have a builder for the parser (see `structural_tag_decision`'s own
+    // doc comment for why eligibility and registry-availability are bundled into one
+    // value rather than checked independently).
+    #[test]
+    fn kimi_k2_required_resolves_to_the_real_structural_tag_decision() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k2".to_string()),
+            ..Default::default()
+        };
+        let result =
+            apply_request_tool_call_parsing_options(parsing_options, &request(json!("required")))
+                .expect("kimi_k2 + required must resolve a constraint");
+        assert_eq!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::StructuralTag,
+            "kimi_k2 + required must use the intrinsic structural tag, not a reconstructed JSON schema"
+        );
+    }
+
+    #[test]
+    fn kimi_k2_named_resolves_to_the_real_structural_tag_decision() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k2".to_string()),
+            ..Default::default()
+        };
+        let named = json!({"type": "function", "function": {"name": "get_weather"}});
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request(named))
+            .expect("kimi_k2 + named must resolve a constraint");
+        assert_eq!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::StructuralTag,
+            "kimi_k2 + a named tool choice must use the intrinsic structural tag, not a reconstructed JSON schema"
+        );
+    }
+
+    // Non-structural-tag parsers must be unaffected by this fix: they still get a
+    // reconstructed JSON-schema constraint for a forced tool_choice.
+    #[test]
+    fn non_structural_tag_parser_still_gets_guided_json_required() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("hermes".to_string()),
+            ..Default::default()
+        };
+        let result =
+            apply_request_tool_call_parsing_options(parsing_options, &request(json!("required")))
+                .expect("hermes + required must resolve a constraint");
+        assert_eq!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::GuidedJsonRequired
+        );
+    }
+
+    // The registry-builder gap this test suite exists to close: a non-Kimi parser
+    // (qwen3_coder, which the parser registry does register a structural-tag builder
+    // for) with a forced tool_choice must still resolve to `StructuralTag` once the
+    // operator has globally enabled structural-tag mode — matching the real
+    // preprocessing path (`apply_tool_choice_structural_tag`'s
+    // `structural_tag_mode != Off` branch), not the narrower Kimi-only reconstruction
+    // this helper used before this fix.
+    #[test]
+    fn operator_enabled_mode_resolves_structural_tag_for_a_non_kimi_parser() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("qwen3_coder".to_string()),
+            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            ..Default::default()
+        };
+        let result =
+            apply_request_tool_call_parsing_options(parsing_options, &request(json!("required")))
+                .expect("qwen3_coder + required must resolve a constraint");
+        assert_eq!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::StructuralTag,
+            "an operator-enabled structural_tag_mode must apply to any registry-supported \
+             parser, not only the Kimi-intrinsic case"
+        );
+    }
+
+    // With the operator default (`structural_tag_mode = Off`), the same non-Kimi
+    // parser must NOT get a structural tag — confirms the mode gate above is real,
+    // not a permanently-on regression.
+    #[test]
+    fn operator_default_mode_off_does_not_resolve_structural_tag_for_a_non_kimi_parser() {
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("qwen3_coder".to_string()),
+            ..Default::default()
+        };
+        let result =
+            apply_request_tool_call_parsing_options(parsing_options, &request(json!("required")))
+                .expect("qwen3_coder + required (mode off) must resolve a constraint");
+        assert_ne!(
+            result.guided_tool_constraint,
+            GuidedToolConstraint::StructuralTag
+        );
+    }
+
+    // `tool_choice: none` must never leave the client able to observe a tool call or
+    // a tool-call finish reason, regardless of the operator's structural-tag mode or
+    // exclusion setting. The real preprocessing path may install a ban tag at
+    // generation time for `none` (which is a request-time generation constraint on
+    // the engine, tracked separately from this field), but that must not surface as
+    // a guided-tool-output-parsing constraint here: `with_tool_call_parsing_enabled`
+    // (called unconditionally by this function, below) always suppresses tool-call
+    // output and resets `guided_tool_constraint` to `None` whenever tool-call parsing
+    // is disabled, which `tool_choice: none` always is. Covering both the ban-enabled
+    // and default-exclusion configurations proves this safety invariant holds either
+    // way, not just in the configuration that happens not to trigger the ban path.
+    #[test]
+    fn tool_choice_none_never_exposes_tool_calls_regardless_of_ban_tag_configuration() {
+        for exclude_tools_when_tool_choice_none in [true, false] {
+            let parsing_options = ParsingOptions {
+                tool_call_parser: Some("qwen3_coder".to_string()),
+                structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+                exclude_tools_when_tool_choice_none,
+                ..Default::default()
+            };
+            let result =
+                apply_request_tool_call_parsing_options(parsing_options, &request(json!("none")))
+                    .expect("tool_choice=none must resolve a constraint");
+            assert_eq!(
+                result.guided_tool_constraint,
+                GuidedToolConstraint::None,
+                "tool_choice=none must never report a guided-tool-output constraint \
+                 (exclude_tools_when_tool_choice_none={exclude_tools_when_tool_choice_none})"
+            );
+            assert!(
+                result.suppress_tool_calls,
+                "tool_choice=none must suppress tool calls \
+                 (exclude_tools_when_tool_choice_none={exclude_tools_when_tool_choice_none})"
+            );
+        }
+    }
+
+    // `guided_tool_constraint` must validate the forced choice against the real
+    // `tools` list via `get_json_schema_from_tools` (the same function
+    // `apply_tool_choice_guided_decoding` calls at request-preprocessing time)
+    // instead of unconditionally installing a JSON-schema constraint. A
+    // `tool_choice: "required"` request with an empty `tools` list has nothing to
+    // constrain against and must be rejected, not silently resolved to
+    // `GuidedJsonRequired`.
+    #[test]
+    fn required_tool_choice_with_empty_tools_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": "required",
+            "tools": []
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("hermes".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "tool_choice=required with no tools must not resolve to a bogus GuidedJsonRequired"
+        );
+    }
+
+    // A named tool_choice that references a tool absent from `tools` is equally
+    // unvalidatable and must also be rejected rather than resolved to a
+    // constraint for a tool the request never declared.
+    #[test]
+    fn named_tool_choice_for_absent_tool_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": {"type": "function", "function": {"name": "does_not_exist"}},
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                }
+            }]
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("hermes".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "a named tool_choice for a tool absent from `tools` must not resolve to a \
+             bogus constraint"
+        );
+    }
+
+    // Regression for the CodeRabbit finding on PR #12576 (review comment 3836534587,
+    // filed against this file): `structural_tag_decision` returned `Required`
+    // without checking `tools`, so `guided_tool_constraint` skipped
+    // `get_json_schema_from_tools` entirely for the STRUCTURAL-TAG branch (it
+    // short-circuits to `Ok(StructuralTag)` whenever `uses_structural_tag` is true,
+    // without building or validating anything). The two `hermes` tests above only
+    // ever exercised the non-structural-tag JSON-schema fallback, which already
+    // validated correctly — they never covered the actual bug. Kimi K2 is the
+    // structural-tag-intrinsic parser, so this reproduces the real gap.
+    #[test]
+    fn kimi_k2_required_with_empty_tools_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": "required",
+            "tools": []
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k2".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "kimi_k2 + required with no tools must not resolve to StructuralTag"
+        );
+    }
+
+    #[test]
+    fn kimi_k2_named_tool_choice_for_absent_tool_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": {"type": "function", "function": {"name": "does_not_exist"}},
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                }
+            }]
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k2".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "kimi_k2 + a named tool_choice for a tool absent from `tools` must not \
+             resolve to StructuralTag"
+        );
+    }
+
+    #[test]
+    fn kimi_k3_named_tool_choice_for_absent_tool_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": {"type": "function", "function": {"name": "does_not_exist"}},
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                }
+            }]
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k3".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "kimi_k3 + a named tool_choice for a tool absent from `tools` must not \
+             resolve to StructuralTag"
+        );
+    }
+
+    #[test]
+    fn kimi_k3_required_with_empty_tools_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": "required",
+            "tools": []
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("kimi_k3".to_string()),
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "kimi_k3 + required with no tools must be rejected before the XTML path"
+        );
+    }
+
+    // Same gap, operator-enabled path: qwen3_coder only gets a structural tag when
+    // `structural_tag_mode = On` (it is not Kimi-intrinsic). Confirms the fix isn't
+    // narrowly scoped to the two Kimi-intrinsic parsers.
+    #[test]
+    fn operator_enabled_qwen3_coder_required_with_empty_tools_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": "required",
+            "tools": []
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("qwen3_coder".to_string()),
+            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "operator-enabled qwen3_coder + required with no tools must not resolve \
+             to StructuralTag"
+        );
+    }
+
+    #[test]
+    fn operator_enabled_qwen3_coder_named_tool_choice_for_absent_tool_is_rejected() {
+        let value = json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "test"}],
+            "tool_choice": {"type": "function", "function": {"name": "does_not_exist"}},
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"location": {"type": "string"}},
+                        "required": ["location"]
+                    }
+                }
+            }]
+        });
+        let request: NvCreateChatCompletionRequest =
+            serde_json::from_value(value).expect("request must deserialize");
+        let parsing_options = ParsingOptions {
+            tool_call_parser: Some("qwen3_coder".to_string()),
+            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::On,
+            ..Default::default()
+        };
+        let result = apply_request_tool_call_parsing_options(parsing_options, &request);
+        assert!(
+            result.is_err(),
+            "operator-enabled qwen3_coder + a named tool_choice for a tool absent from \
+             `tools` must not resolve to StructuralTag"
+        );
+    }
 }
 
 /// Documentation for a route

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -518,7 +518,15 @@ async fn anthropic_messages(
     // Anthropic requests are converted to the same chat request contract. Keep
     // parser activation identical to the OpenAI Chat Completions and Responses
     // entry points so content-only turns cannot be reclassified as tool calls.
-    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request);
+    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request)
+        .map_err(|e| {
+            inflight_guard.mark_error(ErrorType::Validation);
+            anthropic_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request_error",
+                &format!("Invalid tool_choice: {}", e.message()),
+            )
+        })?;
 
     // Same backstop as the chat handler, so the two aggregation entry points
     // cannot drift. See `wants_reasoning_as_content_when_empty`.
@@ -533,6 +541,7 @@ async fn anthropic_messages(
     // withhold every data frame needs forced keep-alive frames.
     let stream_can_defer_all_output =
         crate::preprocessor::OpenAIPreprocessor::stream_can_defer_all_output(
+            parsing_options.tool_call_parser.as_deref(),
             parsing_options.reasoning_parser.as_deref(),
             request.chat_template_args.as_ref(),
         );

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -61,6 +61,7 @@ use crate::protocols::common::input_trigger::{
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::{
+    ParsingOptions,
     audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest},
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
@@ -2849,7 +2850,12 @@ async fn chat_completions(
     // Request policy controls whether parser-produced tool calls may be exposed.
     // Assistant response/guided constraints are handled separately during
     // preprocessing and do not revoke an auto request's tool-call permission.
-    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request);
+    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request)
+        .map_err(|e| {
+            let err_response = ErrorMessage::from_anyhow(e.into(), "Invalid tool_choice");
+            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
 
     // When parallel_tool_calls is false, limit the response to a single tool call.
     let parsing_options =
@@ -2868,10 +2874,7 @@ async fn chat_completions(
     // Computed before `request` moves into `generate`. Only a stream that can
     // withhold every data frame needs forced keep-alive frames.
     let stream_can_defer_all_output =
-        crate::preprocessor::OpenAIPreprocessor::stream_can_defer_all_output(
-            parsing_options.reasoning_parser.as_deref(),
-            request.chat_template_args.as_ref(),
-        );
+        request_stream_can_defer_all_output(&parsing_options, request.chat_template_args.as_ref());
 
     let mut response_collector = state
         .metrics_clone()
@@ -3131,6 +3134,17 @@ fn normalize_chat_reasoning_template_args(
             message: VALIDATION_PREFIX.to_string() + &e.to_string(),
         })
     })
+}
+
+fn request_stream_can_defer_all_output(
+    parsing_options: &ParsingOptions,
+    chat_template_args: Option<&HashMap<String, serde_json::Value>>,
+) -> bool {
+    crate::preprocessor::OpenAIPreprocessor::stream_can_defer_all_output(
+        parsing_options.tool_call_parser.as_deref(),
+        parsing_options.reasoning_parser.as_deref(),
+        chat_template_args,
+    )
 }
 
 /// Validates that required fields are present and valid in the chat completion request
@@ -3451,7 +3465,12 @@ async fn responses(
 
     // The Responses API is converted to the same chat request contract. Narrow
     // the model parser before unary aggregation just as the streaming path does.
-    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request);
+    let parsing_options = apply_request_tool_call_parsing_options(parsing_options, &request)
+        .map_err(|e| {
+            let err_response = ErrorMessage::from_anyhow(e.into(), "Invalid tool_choice");
+            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
 
     // Responses requests share the chat-completions aggregator for the unary
     // path. Thread this option through so its post-parse fallback also caps a
@@ -3478,6 +3497,12 @@ async fn responses(
         );
     let parsing_options = parsing_options
         .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
+
+    // Computed before `request` moves into `generate`. Responses streams use
+    // the same force-nonempty deferral as chat completions and therefore need
+    // the same fallback keep-alive when every data frame may be withheld.
+    let stream_can_defer_all_output =
+        request_stream_can_defer_all_output(&parsing_options, request.chat_template_args.as_ref());
 
     let mut response_collector = state
         .metrics_clone()
@@ -3580,7 +3605,7 @@ async fn responses(
         let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
 
         let mut sse_stream = Sse::new(stream);
-        if let Some(keep_alive) = state.sse_keep_alive() {
+        if let Some(keep_alive) = state.sse_keep_alive_for_response(stream_can_defer_all_output) {
             sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
         }
 
@@ -5103,6 +5128,38 @@ mod tests {
             nvext: None,
             chat_template_args: None,
         }
+    }
+
+    #[test]
+    fn responses_force_nonempty_request_requires_fallback_keep_alive() {
+        let parsing_options = ParsingOptions::new(Some("qwen3_coder".into()), Some("qwen3".into()));
+        let mut chat_template_args = HashMap::new();
+
+        assert!(!request_stream_can_defer_all_output(&parsing_options, None));
+
+        chat_template_args.insert(
+            "force_nonempty_content".to_string(),
+            serde_json::Value::Bool(false),
+        );
+        assert!(!request_stream_can_defer_all_output(
+            &parsing_options,
+            Some(&chat_template_args)
+        ));
+
+        chat_template_args.insert(
+            "force_nonempty_content".to_string(),
+            serde_json::Value::Bool(true),
+        );
+        assert!(request_stream_can_defer_all_output(
+            &parsing_options,
+            Some(&chat_template_args)
+        ));
+
+        let muse_tool_parser_only = ParsingOptions::new(Some("muse_glimmer".into()), None);
+        assert!(request_stream_can_defer_all_output(
+            &muse_tool_parser_only,
+            Some(&chat_template_args)
+        ));
     }
 
     #[test]

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -336,7 +336,7 @@ const fn default_local_indexer() -> bool {
     true
 }
 
-const fn default_exclude_tools_when_tool_choice_none() -> bool {
+pub(crate) const fn default_exclude_tools_when_tool_choice_none() -> bool {
     true
 }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -3298,6 +3298,17 @@ impl OpenAIPreprocessor {
         let uses_tool_call_structural_tag = guided_tool_constraint.uses_structural_tag();
         let defer_reasoning_for_nonempty_content =
             Self::wants_reasoning_as_content_when_empty(request.chat_template_args.as_ref());
+        // Two different streaming paths can release a grammar-constrained tool call
+        // before its payload closes: the unified (v2) adapter below and the jail near
+        // the end of this function. Both must obey the same rollback lever, so
+        // `DYN_ENABLE_GUIDED_TOOL_STREAMING` is read ONCE, here, and the single decision
+        // is handed to whichever path runs. Reading it again at either site would be a
+        // second predicate that can drift; a site with no read at all makes the lever
+        // silently inert for every request routed through it.
+        let guided_tool_streaming = Self::guided_tool_streaming_release(
+            guided_tool_constraint.installs_guided_json(),
+            env_is_falsey(env_llm::DYN_ENABLE_GUIDED_TOOL_STREAMING),
+        );
 
         // Two independent families each own ONE unified parser (ordered reasoning +
         // content + tool calls) that replaces the v1 reasoning stage AND the tool
@@ -3369,6 +3380,7 @@ impl OpenAIPreprocessor {
                     guided_tool_constraint,
                     unified_parser::stream_prefill(family, prompt_injected_reasoning),
                     family,
+                    guided_tool_streaming,
                 ));
             return Ok(Self::apply_unified_response_policies(
                 unified,
@@ -3542,8 +3554,8 @@ impl OpenAIPreprocessor {
         // argument object itself, and a required choice's is an array of
         // `{name, parameters}`. Routing comes from the SHARED constraint predicate, not
         // from `tool_choice`, because a Kimi K3 forced request is indistinguishable
-        // there yet installs no JSON schema at all.
-        let guided = guided_tool_constraint;
+        // there yet installs no JSON schema at all. That predicate is read once at the
+        // top of this function, into `guided_tool_streaming`.
 
         let parser_name = effective_tool_call_parser.as_deref();
         let use_parsers_v2 = tool_parser_v2::enabled()
@@ -3569,16 +3581,13 @@ impl OpenAIPreprocessor {
                 // calls as they arrive instead of buffering to the closing brace. The
                 // jail keeps its own native fallback, so a backend that ignores the
                 // grammar (MiniMax M2 emits XML under `required`) still parses normally.
-                let incremental_release = Self::guided_tool_streaming_release(
-                    guided.installs_guided_json(),
-                    env_is_falsey(env_llm::DYN_ENABLE_GUIDED_TOOL_STREAMING),
-                );
+                // Same request-scoped decision the unified path above was given.
                 Box::pin(Self::apply_tool_calling_jail(
                     effective_tool_call_parser,
                     request.inner.tool_choice.clone(),
                     tool_definitions,
                     uses_tool_call_structural_tag,
-                    incremental_release,
+                    guided_tool_streaming,
                     stream,
                 ))
             } else {
@@ -4075,13 +4084,22 @@ impl OpenAIPreprocessor {
     }
 
     /// Whether a forced tool_choice's installed JSON grammar should release
-    /// jailed calls incrementally, or fall back to buffer-to-completion.
+    /// calls incrementally, or fall back to buffer-to-completion.
+    ///
+    /// The SINGLE owner of that decision, for BOTH streaming paths that can act on
+    /// it: the tool-calling jail (`apply_tool_calling_jail`'s `guided_streaming`)
+    /// and the unified v2 adapter (`unified_parser::apply_stream_with_constraint`'s
+    /// `guided_streaming`, which becomes `StreamBestEffort` vs `RecoverAsText`).
+    /// `postprocessor_parsing_stream_with_constraint` calls this once per request
+    /// and hands the answer to whichever path runs; neither site re-reads the env
+    /// var, because two reads are two predicates that can drift.
     ///
     /// Rollback lever: the grammar-constrained decoding itself lives in the
-    /// published `dynamo-parsers` dependency, not in this repo, so a backend
-    /// that misbehaves under guided decoding in production has no same-release
-    /// fix other than `DYN_ENABLE_GUIDED_TOOL_STREAMING`. On by default; set it
-    /// to a falsy value (`0`/`false`) to fall back to buffer-to-completion.
+    /// published `dynamo-parsers` / `dynamo-parsers-v2` dependencies, not in this
+    /// repo, so a backend that misbehaves under guided decoding in production has
+    /// no same-release fix other than `DYN_ENABLE_GUIDED_TOOL_STREAMING`. On by
+    /// default; set it to a falsy value (`0`/`false`) to fall back to
+    /// buffer-to-completion.
     fn guided_tool_streaming_release(installs_guided_json: bool, rollback_disabled: bool) -> bool {
         installs_guided_json && !rollback_disabled
     }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -29,7 +29,9 @@ use dynamo_protocols::types::{
     ChatCompletionToolChoiceOption, EncodingFormat,
 };
 use dynamo_renderer::{OAIPromptFormatter, PromptRenderError, RenderedPrompt};
-use dynamo_runtime::config::{is_truthy, parse_bool_opt};
+use dynamo_runtime::config::{
+    env_is_falsey, environment_names::llm as env_llm, is_truthy, parse_bool_opt,
+};
 use dynamo_runtime::error::{DynamoError, ErrorType};
 use either::Either;
 use futures::Stream;
@@ -3567,12 +3569,16 @@ impl OpenAIPreprocessor {
                 // calls as they arrive instead of buffering to the closing brace. The
                 // jail keeps its own native fallback, so a backend that ignores the
                 // grammar (MiniMax M2 emits XML under `required`) still parses normally.
+                let incremental_release = Self::guided_tool_streaming_release(
+                    guided.installs_guided_json(),
+                    env_is_falsey(env_llm::DYN_ENABLE_GUIDED_TOOL_STREAMING),
+                );
                 Box::pin(Self::apply_tool_calling_jail(
                     effective_tool_call_parser,
                     request.inner.tool_choice.clone(),
                     tool_definitions,
                     uses_tool_call_structural_tag,
-                    guided.installs_guided_json(),
+                    incremental_release,
                     stream,
                 ))
             } else {
@@ -4068,6 +4074,18 @@ impl OpenAIPreprocessor {
         }
     }
 
+    /// Whether a forced tool_choice's installed JSON grammar should release
+    /// jailed calls incrementally, or fall back to buffer-to-completion.
+    ///
+    /// Rollback lever: the grammar-constrained decoding itself lives in the
+    /// published `dynamo-parsers` dependency, not in this repo, so a backend
+    /// that misbehaves under guided decoding in production has no same-release
+    /// fix other than `DYN_ENABLE_GUIDED_TOOL_STREAMING`. On by default; set it
+    /// to a falsy value (`0`/`false`) to fall back to buffer-to-completion.
+    fn guided_tool_streaming_release(installs_guided_json: bool, rollback_disabled: bool) -> bool {
+        installs_guided_json && !rollback_disabled
+    }
+
     /// Apply tool calling jail to the stream if needed.
     ///
     /// The jail itself now lives in `dynamo-parsers`
@@ -4148,6 +4166,34 @@ impl OpenAIPreprocessor {
         let choice_recovery_in = Arc::clone(&choice_recovery);
         let glm47_start_jail = glm47_start.clone();
 
+        // The jail's own (vendored, out-of-scope) finalize logic cannot tell an
+        // error-terminated input stream from one that genuinely completed — it
+        // sees a plain EOF either way — so on a natural EOF it can synthesize a
+        // `tool_calls` finish chunk from whatever partial arguments it had
+        // buffered, even though the request actually failed upstream. Both
+        // unified adapters (`unified_parser::apply_stream_with_constraint`,
+        // `tool_parser_v2::apply_stream`/`apply_unified_stream`) already give a
+        // terminal upstream error this exact contract: `yield response; return;`,
+        // dropping everything after. Give the jail wrapper the same contract:
+        // `terminal_error` latches the first error `Annotated` observed on the
+        // way in, `take_while` below stops it from ever reaching the jail (so
+        // the jail's finalize never runs on an error-caused EOF at all), and the
+        // matching `take_while`/`chain` on the way out (below) drops anything
+        // the jail still emits after that point and substitutes the error
+        // instead — never letting a synthesized completion reach the caller.
+        let terminal_error: Arc<Mutex<Option<Annotated<NvCreateChatCompletionStreamResponse>>>> =
+            Arc::new(Mutex::new(None));
+        let terminal_error_in = Arc::clone(&terminal_error);
+        let stream = stream.take_while(move |a| {
+            let is_error = a.is_error();
+            if is_error {
+                *terminal_error_in
+                    .lock()
+                    .expect("jail terminal error poisoned") = Some(a.clone());
+            }
+            std::future::ready(!is_error)
+        });
+
         // dynamo `Annotated<Nv>` -> jail `Annotated<Create>` (buffer llm_metrics)
         let jail_input = stream.map(move |mut a| {
             if let Some(metrics) = a.data.as_mut().and_then(|nv| nv.llm_metrics.take()) {
@@ -4224,168 +4270,196 @@ impl OpenAIPreprocessor {
                 jail_input,
             ))
         };
-        jailed.flat_map(move |a| {
-            // Stamp the accumulated metrics onto the next emitted data chunk;
-            // data-less/synthesized chunks carry it forward (or `None`).
-            let llm_metrics = a.data.as_ref().and_then(|_| {
-                let mut p = pending.lock().expect("jail metrics buffer poisoned");
-                let chunk_tokens = p.chunk_tokens;
-                p.chunk_tokens = 0;
-                p.template.take().map(|mut metrics| {
-                    metrics.chunk_tokens = chunk_tokens;
-                    metrics
-                })
-            });
-            let mut nv_chunk = Annotated {
-                data: a.data.map(|inner| NvCreateChatCompletionStreamResponse {
-                    inner,
-                    nvext: None,
-                    llm_metrics,
-                }),
-                id: a.id,
-                event: a.event,
-                comment: a.comment,
-                error: a.error.map(DynamoError::msg),
-            };
-
-            // glm47: on finish_reason=length, recover the last incomplete
-            // <tool_call> block. rfind skips complete blocks so earlier parsed
-            // calls are never duplicated. Recovered content WILL contain raw
-            // markup — callers that require "no tool tags in content" must
-            // filter on finish_reason=length.
-            //
-            // TODO: this recovery runs inside apply_tool_calling_jail, which
-            // the v2 path bypasses (use_parsers_v2 branch above). Adding
-            // "glm47" to V2_FAMILIES in tool_parser_v2.rs silently disables
-            // streaming recovery while aggregator.rs keeps running. At that
-            // point hoist this above the jail/v2 branch — it only needs
-            // buffered input text + finish_reason, both available there.
-            // Pass 1 (immutable): compute the recovery tail per choice and
-            // whether the jail already released it as content on this chunk.
-            // We collect into a Vec so we can release the immutable borrow on
-            // nv_chunk before mutating it in pass 2.
-            let recoveries: Vec<PendingRecovery> = if is_glm47 {
-                let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
-                nv_chunk
-                    .data
-                    .iter()
-                    .flat_map(|data| data.inner.choices.iter())
-                    .filter_map(|choice| {
-                        let state = cr.entry(choice.index).or_default();
-                        if !state.recovered
-                            && let Some(ChatCompletionMessageContent::Text(t)) =
-                                &choice.delta.content
-                        {
-                            state.emitted_text.push_str(t);
-                            // Bound like input_text: retain only the suffix from
-                            // the last marker onward — all the contains(&tail)
-                            // check needs.
-                            let mut keep_from = match state.emitted_text.rfind(glm47_start.as_str())
-                            {
-                                Some(pos) => pos,
-                                None => state
-                                    .emitted_text
-                                    .len()
-                                    .saturating_sub(glm47_start.len() - 1),
-                            };
-                            while keep_from > 0 && !state.emitted_text.is_char_boundary(keep_from) {
-                                keep_from -= 1;
-                            }
-                            state.emitted_text.drain(..keep_from);
-                        }
-                        if state.recovered
-                            || !matches!(
-                                choice.finish_reason,
-                                Some(dynamo_protocols::types::FinishReason::Length)
-                            )
-                        {
-                            return None;
-                        }
-                        let tail =
-                            state
-                                .input_text
-                                .rfind(glm47_start.as_str())
-                                .and_then(|pos| {
-                                    let t = &state.input_text[pos..];
-                                    if !t.contains(glm47_end.as_str()) {
-                                        Some(t.to_string())
-                                    } else {
-                                        None
-                                    }
-                                })?;
-                        let tail_already_emitted = state.emitted_text.contains(&tail);
-                        state.recovered = true;
-                        Some(PendingRecovery {
-                            choice_idx: choice.index,
-                            tail,
-                            tail_already_emitted,
-                        })
+        let terminal_error_out = Arc::clone(&terminal_error);
+        jailed
+            .flat_map(move |a| {
+                // Stamp the accumulated metrics onto the next emitted data chunk;
+                // data-less/synthesized chunks carry it forward (or `None`).
+                let llm_metrics = a.data.as_ref().and_then(|_| {
+                    let mut p = pending.lock().expect("jail metrics buffer poisoned");
+                    let chunk_tokens = p.chunk_tokens;
+                    p.chunk_tokens = 0;
+                    p.template.take().map(|mut metrics| {
+                        metrics.chunk_tokens = chunk_tokens;
+                        metrics
                     })
-                    .collect()
-            } else {
-                vec![]
-            };
+                });
+                let mut nv_chunk = Annotated {
+                    data: a.data.map(|inner| NvCreateChatCompletionStreamResponse {
+                        inner,
+                        nvext: None,
+                        llm_metrics,
+                    }),
+                    id: a.id,
+                    event: a.event,
+                    comment: a.comment,
+                    error: a.error.map(DynamoError::msg),
+                };
 
-            // Pass 2 (mutable): when the jail already released the tail verbatim,
-            // suppress the finish chunk's content entirely. The recovery chunk
-            // carries just the marker-onwards tail, matching the non-streaming
-            // path (rfind result only, no post-call prose).
-            for pr in &recoveries {
-                if !pr.tail_already_emitted {
-                    continue;
-                }
-                if let Some(ref mut data) = nv_chunk.data {
-                    for rc in data
-                        .inner
-                        .choices
-                        .iter_mut()
-                        .filter(|c| c.index == pr.choice_idx)
-                    {
-                        // The jail released the truncated block verbatim as content
-                        // on this chunk, potentially preceded by post-call prose.
-                        // glm47's parser drops post-call prose deliberately, so
-                        // suppress the whole content here and let the recovery
-                        // chunk carry just the marker-onwards tail — matching batch.
-                        rc.delta.content = None;
+                // glm47: on finish_reason=length, recover the last incomplete
+                // <tool_call> block. rfind skips complete blocks so earlier parsed
+                // calls are never duplicated. Recovered content WILL contain raw
+                // markup — callers that require "no tool tags in content" must
+                // filter on finish_reason=length.
+                //
+                // TODO: this recovery runs inside apply_tool_calling_jail, which
+                // the v2 path bypasses (use_parsers_v2 branch above). Adding
+                // "glm47" to V2_FAMILIES in tool_parser_v2.rs silently disables
+                // streaming recovery while aggregator.rs keeps running. At that
+                // point hoist this above the jail/v2 branch — it only needs
+                // buffered input text + finish_reason, both available there.
+                // Pass 1 (immutable): compute the recovery tail per choice and
+                // whether the jail already released it as content on this chunk.
+                // We collect into a Vec so we can release the immutable borrow on
+                // nv_chunk before mutating it in pass 2.
+                let recoveries: Vec<PendingRecovery> =
+                    if is_glm47 {
+                        let mut cr = choice_recovery.lock().expect("choice recovery poisoned");
+                        nv_chunk
+                            .data
+                            .iter()
+                            .flat_map(|data| data.inner.choices.iter())
+                            .filter_map(|choice| {
+                                let state = cr.entry(choice.index).or_default();
+                                if !state.recovered
+                                    && let Some(ChatCompletionMessageContent::Text(t)) =
+                                        &choice.delta.content
+                                {
+                                    state.emitted_text.push_str(t);
+                                    // Bound like input_text: retain only the suffix from
+                                    // the last marker onward — all the contains(&tail)
+                                    // check needs.
+                                    let mut keep_from =
+                                        match state.emitted_text.rfind(glm47_start.as_str()) {
+                                            Some(pos) => pos,
+                                            None => state
+                                                .emitted_text
+                                                .len()
+                                                .saturating_sub(glm47_start.len() - 1),
+                                        };
+                                    while keep_from > 0
+                                        && !state.emitted_text.is_char_boundary(keep_from)
+                                    {
+                                        keep_from -= 1;
+                                    }
+                                    state.emitted_text.drain(..keep_from);
+                                }
+                                if state.recovered
+                                    || !matches!(
+                                        choice.finish_reason,
+                                        Some(dynamo_protocols::types::FinishReason::Length)
+                                    )
+                                {
+                                    return None;
+                                }
+                                let tail = state.input_text.rfind(glm47_start.as_str()).and_then(
+                                    |pos| {
+                                        let t = &state.input_text[pos..];
+                                        if !t.contains(glm47_end.as_str()) {
+                                            Some(t.to_string())
+                                        } else {
+                                            None
+                                        }
+                                    },
+                                )?;
+                                let tail_already_emitted = state.emitted_text.contains(&tail);
+                                state.recovered = true;
+                                Some(PendingRecovery {
+                                    choice_idx: choice.index,
+                                    tail,
+                                    tail_already_emitted,
+                                })
+                            })
+                            .collect()
+                    } else {
+                        vec![]
+                    };
+
+                // Pass 2 (mutable): when the jail already released the tail verbatim,
+                // suppress the finish chunk's content entirely. The recovery chunk
+                // carries just the marker-onwards tail, matching the non-streaming
+                // path (rfind result only, no post-call prose).
+                for pr in &recoveries {
+                    if !pr.tail_already_emitted {
+                        continue;
+                    }
+                    if let Some(ref mut data) = nv_chunk.data {
+                        for rc in data
+                            .inner
+                            .choices
+                            .iter_mut()
+                            .filter(|c| c.index == pr.choice_idx)
+                        {
+                            // The jail released the truncated block verbatim as content
+                            // on this chunk, potentially preceded by post-call prose.
+                            // glm47's parser drops post-call prose deliberately, so
+                            // suppress the whole content here and let the recovery
+                            // chunk carry just the marker-onwards tail — matching batch.
+                            rc.delta.content = None;
+                        }
                     }
                 }
-            }
 
-            // Pass 3: emit a recovery chunk per affected choice carrying just
-            // the truncated tail (marker onwards, no post-call prose).
-            let recovery_chunks: Vec<_> = recoveries
-                .into_iter()
-                .filter_map(|pr| {
-                    let PendingRecovery {
-                        choice_idx, tail, ..
-                    } = pr;
-                    tracing::warn!(
-                        choice_index = choice_idx,
-                        recovered_bytes = tail.len(),
-                        "glm47 streaming: partial <tool_call> emitted as content \
+                // Pass 3: emit a recovery chunk per affected choice carrying just
+                // the truncated tail (marker onwards, no post-call prose).
+                let recovery_chunks: Vec<_> = recoveries
+                    .into_iter()
+                    .filter_map(|pr| {
+                        let PendingRecovery {
+                            choice_idx, tail, ..
+                        } = pr;
+                        tracing::warn!(
+                            choice_index = choice_idx,
+                            recovered_bytes = tail.len(),
+                            "glm47 streaming: partial <tool_call> emitted as content \
                          on length finish"
-                    );
-                    let mut rec = nv_chunk.clone();
-                    rec.id = None;
-                    rec.event = None;
-                    rec.comment = None;
-                    rec.error = None;
-                    let rd = rec.data.as_mut()?;
-                    rd.inner.usage = None;
-                    rd.llm_metrics = None;
-                    rd.inner.choices.retain(|c| c.index == choice_idx);
-                    for rc in &mut rd.inner.choices {
-                        rc.delta.content = Some(ChatCompletionMessageContent::Text(tail.clone()));
-                        rc.delta.tool_calls = None;
-                        rc.finish_reason = None;
-                        rc.logprobs = None;
-                    }
-                    Some(rec)
-                })
-                .collect();
+                        );
+                        let mut rec = nv_chunk.clone();
+                        rec.id = None;
+                        rec.event = None;
+                        rec.comment = None;
+                        rec.error = None;
+                        let rd = rec.data.as_mut()?;
+                        rd.inner.usage = None;
+                        rd.llm_metrics = None;
+                        rd.inner.choices.retain(|c| c.index == choice_idx);
+                        for rc in &mut rd.inner.choices {
+                            rc.delta.content =
+                                Some(ChatCompletionMessageContent::Text(tail.clone()));
+                            rc.delta.tool_calls = None;
+                            rc.finish_reason = None;
+                            rc.logprobs = None;
+                        }
+                        Some(rec)
+                    })
+                    .collect();
 
-            futures::stream::iter(recovery_chunks.into_iter().chain(std::iter::once(nv_chunk)))
-        })
+                futures::stream::iter(recovery_chunks.into_iter().chain(std::iter::once(nv_chunk)))
+            })
+            // See the `terminal_error` comment above: once the upstream error was
+            // latched, `take_while` drops everything the jail still emits from that
+            // point on (its finalize output has no way to know the request already
+            // failed), and `chain` substitutes the latched error as the stream's
+            // final and only item from there. When no error occurred, `terminal_error`
+            // is never populated, `take_while` never stops early, and `chain`'s
+            // `filter_map` drops the `None` it reads back — this stage is then a
+            // no-op passthrough.
+            .take_while(move |_| {
+                let stop = terminal_error_out
+                    .lock()
+                    .expect("jail terminal error poisoned")
+                    .is_some();
+                std::future::ready(!stop)
+            })
+            .chain(
+                stream::once(async move {
+                    terminal_error
+                        .lock()
+                        .expect("jail terminal error poisoned")
+                        .take()
+                })
+                .filter_map(std::future::ready),
+            )
     }
 
     /// Whether the selected tool-call or reasoning parser depends on the
@@ -5915,6 +5989,27 @@ mod tests {
         ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
         FinishReason, Role,
     };
+
+    #[test]
+    fn guided_tool_streaming_release_only_when_guided_json_and_not_rolled_back() {
+        assert!(
+            OpenAIPreprocessor::guided_tool_streaming_release(true, false),
+            "a forced tool_choice with an installed grammar releases incrementally by default"
+        );
+        assert!(
+            !OpenAIPreprocessor::guided_tool_streaming_release(true, true),
+            "DYN_ENABLE_GUIDED_TOOL_STREAMING=false must fall back to buffer-to-completion \
+             even when guided JSON is installed"
+        );
+        assert!(
+            !OpenAIPreprocessor::guided_tool_streaming_release(false, false),
+            "no installed grammar means nothing to release incrementally, rollback or not"
+        );
+        assert!(
+            !OpenAIPreprocessor::guided_tool_streaming_release(false, true),
+            "no installed grammar means nothing to release incrementally, rollback or not"
+        );
+    }
 
     fn chat_stream_chunk(
         index: u32,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -16,8 +16,8 @@ pub mod lightseek_mm;
 pub mod media;
 pub mod prompt;
 pub mod speculative_prefill;
-mod structural_tag;
-mod tool_choice;
+pub(crate) mod structural_tag;
+pub(crate) mod tool_choice;
 pub mod tools;
 use anyhow::Context;
 use anyhow::{Result, bail};
@@ -583,6 +583,42 @@ struct ReasoningState {
     // error and keep consuming (`saw_error = true; continue;`), so without this
     // latch they emit the synthetic content chunk and only then report failure.
     saw_terminal_error: bool,
+}
+
+#[derive(Default)]
+struct DeferredUnifiedChoice {
+    pending_reasoning: String,
+    pending_content: String,
+    saw_visible_output: bool,
+    drained: bool,
+}
+
+impl DeferredUnifiedChoice {
+    fn release_split(&mut self) -> (Option<String>, Option<String>) {
+        let content = std::mem::take(&mut self.pending_content);
+        let reasoning = std::mem::take(&mut self.pending_reasoning);
+        (
+            (!content.is_empty()).then_some(content),
+            (!reasoning.is_empty()).then_some(reasoning),
+        )
+    }
+
+    fn drain(&mut self) -> (Option<String>, Option<String>) {
+        if self.drained {
+            return (None, None);
+        }
+        self.drained = true;
+        if self.saw_visible_output {
+            return self.release_split();
+        }
+        let reasoning = std::mem::take(&mut self.pending_reasoning);
+        let content = std::mem::take(&mut self.pending_content);
+        if !reasoning.trim().is_empty() {
+            (Some(reasoning), None)
+        } else {
+            ((!content.is_empty()).then_some(content), None)
+        }
+    }
 }
 
 /// Per-image routing payload accumulated by `gather_multi_modal_data` and
@@ -3187,6 +3223,37 @@ impl OpenAIPreprocessor {
         Ok((builder.build()?, annotations))
     }
 
+    fn apply_unified_response_policies<S>(
+        stream: S,
+        emit_tool_calls: bool,
+        defer_reasoning_for_nonempty_content: bool,
+    ) -> Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>
+    where
+        S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = Box::pin(
+            Self::apply_tool_call_response_policy(stream, emit_tool_calls),
+        );
+        // Observe parser classification before force_nonempty deferral removes the
+        // reasoning delta. The annotated usage trailer can still be held below until
+        // every deferred recovery chunk has been emitted.
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> =
+            Box::pin(annotate_reasoning_usage(stream));
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if defer_reasoning_for_nonempty_content
+        {
+            Box::pin(Self::defer_unified_reasoning_for_nonempty_content(stream))
+        } else {
+            stream
+        };
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if defer_reasoning_for_nonempty_content
+        {
+            Box::pin(Self::hold_usage_until_stream_end(stream))
+        } else {
+            stream
+        };
+        stream
+    }
+
     pub fn postprocessor_parsing_stream<S>(
         &self,
         stream: S,
@@ -3199,25 +3266,56 @@ impl OpenAIPreprocessor {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
-        // Muse serves through ONE unified parser (ordered reasoning + content +
-        // tool calls), default-on. Bypass the v1 reasoning stage — its muse parser
-        // is gone, so it falls back to `Basic`, which cannot read the
-        // `to=self<|message|>` grammar — and the tool jail. auto/none only; a forced
-        // tool_choice keeps the guided-decode + jail path (that emits guided JSON,
-        // not the native markup the unified parser reads), and a structural-tag
-        // request is excluded for the SAME reason by a different flag. `none` routes
-        // here so the markers are still stripped, but its calls are suppressed below.
-        // Runs regardless of has_tools: muse owns reasoning and strips its markers
-        // even with zero tools.
+        let guided_tool_constraint = crate::preprocessor::tool_choice::guided_tool_constraint(
+            request,
+            self.tool_call_parser.as_deref(),
+            self.runtime_config.reasoning_parser.as_deref(),
+            uses_tool_call_structural_tag,
+        )?;
+        self.postprocessor_parsing_stream_with_constraint(
+            stream,
+            request,
+            prompt_injected_reasoning,
+            guided_tool_constraint,
+        )
+    }
+
+    fn postprocessor_parsing_stream_with_constraint<S>(
+        &self,
+        stream: S,
+        request: &NvCreateChatCompletionRequest,
+        prompt_injected_reasoning: bool,
+        guided_tool_constraint: crate::protocols::openai::GuidedToolConstraint,
+    ) -> anyhow::Result<
+        impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    >
+    where
+        S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        use crate::protocols::openai::chat_completions::unified_parser;
+        let uses_tool_call_structural_tag = guided_tool_constraint.uses_structural_tag();
+        let defer_reasoning_for_nonempty_content =
+            Self::wants_reasoning_as_content_when_empty(request.chat_template_args.as_ref());
+
+        // Two independent families each own ONE unified parser (ordered reasoning +
+        // content + tool calls) that replaces the v1 reasoning stage AND the tool
+        // jail outright: muse (`tool_parser_v2`, default-on — its v1 reasoning
+        // parser is gone, so `get_reasoning_parser_from_name` falls back to
+        // `Basic`, which cannot read the `to=self<|message|>` grammar) and Qwen3
+        // (`unified_parser`, gated on `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`). Both
+        // run regardless of has_tools — they own reasoning and strip its markers
+        // even with zero tools — and both route their output through the SAME
+        // shared response policy below, which is what suppresses `tool_calls` for
+        // a no-tools or `tool_choice: none` request, exactly as it does for every
+        // other family's jail output.
         //
-        // KNOWN GAP: this returns before `defer_reasoning_for_nonempty_content` is
-        // computed, so a `force_nonempty_content=true` request whose turn produced only
-        // reasoning streams empty `content` while the aggregator surfaces the reasoning
-        // AS content for the identical request. Closing it needs the per-choice
-        // buffering + EOF flush that `parse_reasoning_content_from_stream_inner` has;
-        // it is a follow-up, not a guard tweak. `stream_can_defer_all_output` already
-        // reports false for muse so nothing claims a deferral that does not happen.
-        // (`tool_parser_v2` is imported below; a `use` is in scope for the whole body.)
+        // A forced/structural-tag `tool_choice` still excludes muse: its
+        // `apply_unified_stream` only reads native markup, so a guided-JSON or
+        // structural-tag request would misparse the grammar it does not speak. The
+        // newer Qwen3 `apply_stream` handles every `tool_choice` itself (guided
+        // JSON for named/required, native markup for auto/none/structural-tag), so
+        // it does not need the same entry gate.
+        //
         if let Some(family) = tool_parser_v2::unified_family(
             self.tool_call_parser.as_deref(),
             self.runtime_config.reasoning_parser.as_deref(),
@@ -3238,21 +3336,43 @@ impl OpenAIPreprocessor {
                     })
                     .collect()
             });
-            // `none` routes here for the split and the stripping, but a caller that
-            // disabled tools must not get `tool_calls` back — every other family
-            // reaches that via `should_apply_tool_jail` returning false.
-            let emit_tool_calls = !matches!(
-                request.inner.tool_choice.as_ref(),
-                Some(ChatCompletionToolChoiceOption::None)
+            let unified: Pin<Box<dyn Stream<Item = _> + Send>> = Box::pin(
+                tool_parser_v2::apply_unified_stream(stream, tool_definitions, family, true),
             );
+            return Ok(Self::apply_unified_response_policies(
+                unified,
+                Self::tool_call_parsing_enabled(request),
+                defer_reasoning_for_nonempty_content,
+            ));
+        }
+
+        if let Some(family) = unified_parser::selected_family(
+            self.tool_call_parser.as_deref(),
+            self.runtime_config.reasoning_parser.as_deref(),
+        ) {
+            let tool_definitions = request.inner.tools.as_ref().map(|tools| {
+                tools
+                    .iter()
+                    .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
+                        name: tool.function.name.clone(),
+                        parameters: tool.function.parameters.clone(),
+                        strict: tool.function.strict,
+                    })
+                    .collect()
+            });
             let unified: Pin<Box<dyn Stream<Item = _> + Send>> =
-                Box::pin(tool_parser_v2::apply_unified_stream(
+                Box::pin(unified_parser::apply_stream_with_constraint(
                     stream,
                     tool_definitions,
+                    guided_tool_constraint,
+                    unified_parser::stream_prefill(family, prompt_injected_reasoning),
                     family,
-                    emit_tool_calls,
                 ));
-            return Ok(unified);
+            return Ok(Self::apply_unified_response_policies(
+                unified,
+                Self::tool_call_parsing_enabled(request),
+                defer_reasoning_for_nonempty_content,
+            ));
         }
 
         // Guided output may be bare JSON or `reasoning</think>JSON`. Supported
@@ -3332,8 +3452,6 @@ impl OpenAIPreprocessor {
         // per-token clone and the finish_reasoning_stream() flush off every
         // other request's path. Same predicate the aggregator uses, so the
         // streaming and non-streaming paths cannot disagree.
-        let defer_reasoning_for_nonempty_content =
-            Self::wants_reasoning_as_content_when_empty(request.chat_template_args.as_ref());
         let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if should_parse_reasoning {
             Box::pin(Self::parse_reasoning_content_from_stream_inner(
                 stream,
@@ -3416,6 +3534,15 @@ impl OpenAIPreprocessor {
         // Immediate mode, since those rely on guided-decoded JSON rather than the
         // native markup the v2 parser reads. See tool_parser_v2::apply_stream.
         use crate::protocols::openai::chat_completions::tool_parser_v2;
+
+        // Guided JSON does NOT go to the jail. We installed the grammar that produced
+        // this output, so the shape is already known: a named choice's payload is the
+        // argument object itself, and a required choice's is an array of
+        // `{name, parameters}`. Routing comes from the SHARED constraint predicate, not
+        // from `tool_choice`, because a Kimi K3 forced request is indistinguishable
+        // there yet installs no JSON schema at all.
+        let guided = guided_tool_constraint;
+
         let parser_name = effective_tool_call_parser.as_deref();
         let use_parsers_v2 = tool_parser_v2::enabled()
             && parser_name.is_some_and(tool_parser_v2::supports_family)
@@ -3436,11 +3563,16 @@ impl OpenAIPreprocessor {
                         .to_string(),
                 ))
             } else if should_jail {
+                // A forced tool_choice installed a JSON grammar, so the jail may release
+                // calls as they arrive instead of buffering to the closing brace. The
+                // jail keeps its own native fallback, so a backend that ignores the
+                // grammar (MiniMax M2 emits XML under `required`) still parses normally.
                 Box::pin(Self::apply_tool_calling_jail(
                     effective_tool_call_parser,
                     request.inner.tool_choice.clone(),
                     tool_definitions,
                     uses_tool_call_structural_tag,
+                    guided.installs_guided_json(),
                     stream,
                 ))
             } else {
@@ -3955,13 +4087,15 @@ impl OpenAIPreprocessor {
         tool_choice: Option<dynamo_protocols::types::ChatCompletionToolChoiceOption>,
         tool_definitions: Option<Vec<dynamo_parsers::tool_calling::ToolDefinition>>,
         uses_tool_call_structural_tag: bool,
+        guided_streaming: bool,
         stream: S,
     ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
         use dynamo_parsers::tool_calling::jail::{
-            Annotated as JailAnnotated, apply_tool_calling_jail as jail_apply,
+            Annotated as JailAnnotated, apply_tool_calling_jail,
+            apply_tool_calling_jail_with_guided_streaming,
         };
         use std::sync::{Arc, Mutex};
 
@@ -4062,14 +4196,35 @@ impl OpenAIPreprocessor {
         });
 
         // jail `Annotated<Create>` -> dynamo `Annotated<Nv>` (re-attach llm_metrics)
-        jail_apply(
-            tool_call_parser,
-            tool_choice,
-            tool_definitions,
-            uses_tool_call_structural_tag,
-            jail_input,
-        )
-        .flat_map(move |a| {
+        // The crate encodes the opt-in in WHICH entry point you call, so pick here and
+        // box both arms to one type. `apply_tool_calling_jail` keeps the published
+        // five-argument signature for everyone else.
+        let jailed: Pin<
+            Box<
+                dyn Stream<
+                        Item = JailAnnotated<
+                            dynamo_protocols::types::CreateChatCompletionStreamResponse,
+                        >,
+                    > + Send,
+            >,
+        > = if guided_streaming {
+            Box::pin(apply_tool_calling_jail_with_guided_streaming(
+                tool_call_parser,
+                tool_choice,
+                tool_definitions,
+                uses_tool_call_structural_tag,
+                jail_input,
+            ))
+        } else {
+            Box::pin(apply_tool_calling_jail(
+                tool_call_parser,
+                tool_choice,
+                tool_definitions,
+                uses_tool_call_structural_tag,
+                jail_input,
+            ))
+        };
+        jailed.flat_map(move |a| {
             // Stamp the accumulated metrics onto the next emitted data chunk;
             // data-less/synthesized chunks carry it forward (or `None`).
             let llm_metrics = a.data.as_ref().and_then(|_| {
@@ -4376,21 +4531,20 @@ impl OpenAIPreprocessor {
     /// frames on an opt-in path rather than a silent stream — and closing it
     /// needs the guided-output derivation lifted out of the stream builder.
     pub(crate) fn stream_can_defer_all_output(
+        tool_call_parser: Option<&str>,
         reasoning_parser: Option<&str>,
         chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
     ) -> bool {
-        // Muse streams through the unified parser, which withholds nothing, so a
-        // muse request never defers all output. Claiming otherwise switched SSE
-        // keep-alive frames on for a stream that has no buffering to cover.
-        if crate::protocols::openai::chat_completions::tool_parser_v2::unified_family(
-            None,
-            reasoning_parser,
-        )
-        .is_some()
-        {
-            return false;
-        }
-        reasoning_parser.is_some()
+        // Unified Qwen and Muse now use the same force-nonempty deferral as the v1
+        // reasoning path, so their reasoning-only turns can withhold every meaningful
+        // output delta until the terminal decision too.
+        let has_reasoning_decoder = reasoning_parser.is_some()
+            || crate::protocols::openai::chat_completions::tool_parser_v2::unified_family(
+                tool_call_parser,
+                reasoning_parser,
+            )
+            .is_some();
+        has_reasoning_decoder
             && Self::wants_reasoning_as_content_when_empty(chat_template_args)
             && !Self::is_reasoning_disabled_by_request(reasoning_parser, chat_template_args)
     }
@@ -4900,6 +5054,198 @@ impl OpenAIPreprocessor {
         .fuse()
     }
 
+    /// Apply the request-level non-empty-content contract after a unified parser has
+    /// already split reasoning, content, and tool calls.
+    fn defer_unified_reasoning_for_nonempty_content<S>(
+        stream_in: S,
+    ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+    where
+        S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        async_stream::stream! {
+            let mut states: HashMap<u32, DeferredUnifiedChoice> = HashMap::new();
+            let mut last_response: Option<Annotated<NvCreateChatCompletionStreamResponse>> = None;
+            tokio::pin!(stream_in);
+
+            while let Some(mut response) = stream_in.next().await {
+                if response.is_error() {
+                    yield response;
+                    return;
+                }
+                let Some(data) = response.data.as_mut() else {
+                    yield response;
+                    continue;
+                };
+                let mut prefix_choices = Vec::new();
+
+                for choice in &mut data.inner.choices {
+                    let state = states.entry(choice.index).or_default();
+                    if choice.delta.content.is_some()
+                        || choice.delta.reasoning_content.is_some()
+                        || choice.delta.tool_calls.is_some()
+                    {
+                        state.drained = false;
+                    }
+
+                    if !state.saw_visible_output
+                        && let Some(reasoning) = choice.delta.reasoning_content.take()
+                    {
+                        state.pending_reasoning.push_str(&reasoning);
+                    }
+
+                    let carries_parts = matches!(
+                        choice.delta.content,
+                        Some(ChatCompletionMessageContent::Parts(_))
+                    );
+                    match choice.delta.content.take() {
+                        Some(ChatCompletionMessageContent::Text(text)) => {
+                            if !state.saw_visible_output && text.trim().is_empty() {
+                                state.pending_content.push_str(&text);
+                            } else {
+                                if !text.trim().is_empty() {
+                                    state.saw_visible_output = true;
+                                }
+                                let mut content = std::mem::take(&mut state.pending_content);
+                                content.push_str(&text);
+                                choice.delta.content =
+                                    Some(ChatCompletionMessageContent::Text(content));
+                            }
+                        }
+                        Some(parts @ ChatCompletionMessageContent::Parts(_)) => {
+                            choice.delta.content = Some(parts);
+                        }
+                        None => {}
+                    }
+
+                    let has_tool_calls = choice
+                        .delta
+                        .tool_calls
+                        .as_ref()
+                        .is_some_and(|calls| !calls.is_empty());
+                    if carries_parts || has_tool_calls {
+                        state.saw_visible_output = true;
+                    }
+                    if carries_parts {
+                        state.pending_content.clear();
+                    }
+
+                    if state.saw_visible_output {
+                        let (content, reasoning) = state.release_split();
+                        if let Some(reasoning) = reasoning {
+                            let mut prefix = choice.clone();
+                            prefix.delta.role = None;
+                            prefix.delta.content = None;
+                            prefix.delta.tool_calls = None;
+                            prefix.delta.function_call = None;
+                            prefix.delta.refusal = None;
+                            prefix.delta.reasoning_content = Some(reasoning);
+                            prefix.finish_reason = None;
+                            prefix.logprobs = None;
+                            prefix_choices.push(prefix);
+                        }
+                        if let Some(content) = content {
+                            match choice.delta.content.as_mut() {
+                                Some(ChatCompletionMessageContent::Text(existing)) => {
+                                    existing.insert_str(0, &content);
+                                }
+                                Some(ChatCompletionMessageContent::Parts(_)) | None => {
+                                    let mut prefix = choice.clone();
+                                    prefix.delta.role = None;
+                                    prefix.delta.content =
+                                        Some(ChatCompletionMessageContent::Text(content));
+                                    prefix.delta.tool_calls = None;
+                                    prefix.delta.function_call = None;
+                                    prefix.delta.refusal = None;
+                                    prefix.delta.reasoning_content = None;
+                                    prefix.finish_reason = None;
+                                    prefix.logprobs = None;
+                                    prefix_choices.push(prefix);
+                                }
+                            }
+                        }
+                    }
+
+                    if choice.finish_reason.is_some() {
+                        let (content, reasoning) = state.drain();
+                        if let Some(content) = content {
+                            match choice.delta.content.as_mut() {
+                                Some(ChatCompletionMessageContent::Text(existing)) => {
+                                    existing.push_str(&content);
+                                }
+                                Some(ChatCompletionMessageContent::Parts(_)) => {}
+                                None => {
+                                    choice.delta.content =
+                                        Some(ChatCompletionMessageContent::Text(content));
+                                }
+                            }
+                        }
+                        if let Some(reasoning) = reasoning {
+                            choice
+                                .delta
+                                .reasoning_content
+                                .get_or_insert_default()
+                                .push_str(&reasoning);
+                        }
+                    }
+                }
+
+                if !data.inner.choices.is_empty() {
+                    last_response = Some(response.clone());
+                }
+                for prefix_choice in prefix_choices {
+                    let mut prefix_response = response.clone();
+                    if let Some(prefix_data) = prefix_response.data.as_mut() {
+                        prefix_data.inner.choices = vec![prefix_choice];
+                        prefix_data.inner.usage = None;
+                        prefix_data.nvext = None;
+                        prefix_data.llm_metrics = None;
+                    }
+                    prefix_response.id = None;
+                    prefix_response.event = None;
+                    prefix_response.comment = None;
+                    prefix_response.error = None;
+                    yield prefix_response;
+                }
+                yield response;
+            }
+
+            let mut indices: Vec<_> = states.keys().copied().collect();
+            indices.sort_unstable();
+            let flushed: Vec<_> = indices
+                .into_iter()
+                .filter_map(|index| {
+                    let (content, reasoning) = states.get_mut(&index)?.drain();
+                    (content.is_some() || reasoning.is_some())
+                        .then_some((index, content, reasoning))
+                })
+                .collect();
+            if !flushed.is_empty()
+                && let Some(mut response) = last_response
+                && scrub_synthetic_chunk_metadata(&mut response).is_some()
+                && let Some(data) = response.data.as_mut()
+                && let Some(template) = data.inner.choices.first().cloned()
+            {
+                data.inner.choices = flushed
+                    .into_iter()
+                    .map(|(index, content, reasoning)| {
+                        let mut choice = template.clone();
+                        choice.index = index;
+                        choice.delta.role = None;
+                        choice.delta.content = content.map(ChatCompletionMessageContent::Text);
+                        choice.delta.tool_calls = None;
+                        choice.delta.function_call = None;
+                        choice.delta.refusal = None;
+                        choice.delta.reasoning_content = reasoning;
+                        choice.finish_reason = None;
+                        choice.logprobs = None;
+                        choice
+                    })
+                    .collect();
+                yield response;
+            }
+        }
+    }
+
     /// Hold the trailing usage-only chunk until every parser recovery chunk has
     /// been emitted. A truncated upstream stream can end without
     /// `finish_reason`, so reasoning recovery happens at EOF; forwarding usage
@@ -5185,7 +5531,7 @@ impl
             .await?;
         attach_agent_context_from_context(&mut common_request, &context);
 
-        let uses_tool_call_structural_tag = self.apply_tool_choice_guided_decoding(
+        let guided_tool_constraint = self.apply_tool_choice_guided_decoding(
             &request,
             &mut common_request,
             prompt_injected_reasoning,
@@ -5243,11 +5589,11 @@ impl
             image_tokens,
         );
 
-        let transformed_stream = self.postprocessor_parsing_stream(
+        let transformed_stream = self.postprocessor_parsing_stream_with_constraint(
             stream,
             &request,
             prompt_injected_reasoning,
-            uses_tool_call_structural_tag,
+            guided_tool_constraint,
         )?;
         let transformed_stream = Self::normalize_chat_stream_roles(transformed_stream);
 
@@ -5724,6 +6070,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn force_nonempty_deferral_preserves_reasoning_usage() {
+        let reasoning = reasoning_usage_chunk(Some("deferred thought"), None, 3);
+        let mut terminal = chat_stream_chunk(0, None);
+        let terminal_choice = &mut terminal.data.as_mut().unwrap().inner.choices[0];
+        terminal_choice.delta.content = None;
+        terminal_choice.finish_reason = Some(FinishReason::Stop);
+
+        let output = OpenAIPreprocessor::apply_unified_response_policies(
+            stream::iter(vec![reasoning, terminal, reasoning_usage_trailer(3, None)]),
+            true,
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let usage = output
+            .last()
+            .and_then(|response| response.data.as_ref())
+            .and_then(|chunk| chunk.inner.usage.as_ref())
+            .expect("held usage trailer");
+
+        assert_eq!(
+            usage
+                .completion_tokens_details
+                .as_ref()
+                .and_then(|details| details.reasoning_tokens),
+            Some(3),
+            "deferral must not erase the parser's reasoning classification"
+        );
+        assert_eq!(
+            output
+                .iter()
+                .filter_map(|response| response.data.as_ref())
+                .filter(|chunk| chunk.llm_metrics.is_some())
+                .count(),
+            2,
+            "one source metric and one usage-trailer metric must survive"
+        );
+    }
+
+    #[tokio::test]
     async fn test_normalize_chat_stream_roles_recovers_missing_first_role_per_choice() {
         let input = stream::iter(vec![
             // Mirrors a parser releasing buffered content without the role that
@@ -5779,6 +6165,8 @@ mod tests {
             Some("kimi_k3".to_string()),
             request.inner.tool_choice.clone(),
             None,
+            false,
+            // No tools and no forced choice, so no JSON grammar was installed.
             false,
             stream::iter(vec![
                 kimi_k3_reasoning_chunk(leaked_reasoning),
@@ -8426,6 +8814,21 @@ mod tests {
         // The force_nonempty_content=true → NOT disabled behavior is what lets a
         // reasoning-only non-streaming turn surface reasoning as content; verify
         // the aggregator half in test_move_reasoning_to_content_when_empty.
+    }
+
+    #[test]
+    fn muse_force_nonempty_stream_reports_that_it_can_defer_all_output() {
+        let mut args = std::collections::HashMap::new();
+        args.insert(
+            "force_nonempty_content".to_string(),
+            serde_json::Value::Bool(true),
+        );
+
+        assert!(OpenAIPreprocessor::stream_can_defer_all_output(
+            None,
+            Some("muse_glimmer"),
+            Some(&args),
+        ));
     }
 
     /// Different query strings must produce different hashes. `?v=1` and

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2532,6 +2532,40 @@ impl OpenAIPreprocessor {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
+        use crate::protocols::openai::chat_completions::unified_parser;
+
+        // When a request's parser pair has a unified parser and it is switched on, ONE
+        // state machine owns reasoning + text + tool calls for the whole stream. It
+        // replaces everything below — the reasoning-parser stage AND the tool-call jail
+        // — because the ordering it recovers is exactly what is lost at the seam
+        // between those two stages.
+        if let Some(family) = unified_parser::selected_family(
+            self.tool_call_parser.as_deref(),
+            self.runtime_config.reasoning_parser.as_deref(),
+        ) {
+            let tool_definitions = request.inner.tools.as_ref().map(|tools| {
+                tools
+                    .iter()
+                    .map(|tool| dynamo_parsers::tool_calling::ToolDefinition {
+                        name: tool.function.name.clone(),
+                        parameters: tool.function.parameters.clone(),
+                        strict: tool.function.strict,
+                    })
+                    .collect()
+            });
+            return Ok(Box::pin(unified_parser::apply_stream(
+                stream,
+                tool_definitions,
+                request.inner.tool_choice.clone(),
+                uses_tool_call_structural_tag,
+                unified_parser::stream_prefill(family, prompt_injected_reasoning),
+                family,
+            ))
+                as Pin<
+                    Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>,
+                >);
+        }
+
         // Guided output may be bare JSON or `reasoning</think>JSON`. Supported
         // parsers inspect the stream shape before deciding whether to parse it.
         let is_guided_tool_choice = matches!(

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -7,9 +7,34 @@ use crate::local_model::runtime_config::{
     StructuralTagMode, StructuralTagScope, TOOL_CALL_STRUCTURAL_TAG_EXCLUDES_REASONING_RUNTIME_KEY,
 };
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use crate::protocols::openai::tools::{ToolChoiceValidation, validate_tool_choice_against_names};
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
 use dynamo_runtime::error::{DynamoError, ErrorType};
+
+/// Validate a forced `tool_choice` against the request's actual `tools` list.
+///
+/// `Required` with no tools, and a `Named` choice for a tool absent from `tools`,
+/// have nothing valid to constrain against. The rule itself lives in
+/// `validate_tool_choice_against_names`, which is also used by the OpenAI-wire
+/// schema builder; this adapter only maps the parser-facing types and error.
+fn validate_forced_tool_choice(
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
+) -> Result<(), DynamoError> {
+    let tool_choice = match tool_choice {
+        ToolChoice::Required => ToolChoiceValidation::Required,
+        ToolChoice::Named(name) => ToolChoiceValidation::Named(name),
+        ToolChoice::None | ToolChoice::Auto => ToolChoiceValidation::Unforced,
+    };
+    validate_tool_choice_against_names(tool_choice, tools.iter().map(|tool| tool.name.as_str()))
+        .map_err(|error| {
+            DynamoError::builder()
+                .error_type(ErrorType::InvalidArgument)
+                .message(error.to_string())
+                .build()
+        })
+}
 
 fn is_kimi_k3_parser(parser_name: Option<&str>) -> bool {
     parser_name.is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"))
@@ -35,6 +60,100 @@ fn should_skip_tool_call_ban(exclude_tools_when_none: bool, tool_choice: &ToolCh
     exclude_tools_when_none && matches!(tool_choice, ToolChoice::None)
 }
 
+/// Whether a request is entitled to use a structural tag, bundled with proof the
+/// parser registry can actually build one.
+///
+/// This is the single owner of "is a structural tag applicable and available" —
+/// covering model-family/tool-choice intrinsic eligibility, the operator's global
+/// `structural_tag_mode`/`structural_tag_scope`, the `tool_choice=None` ban-tag
+/// exclusion, and real parser-registry builder availability. A caller can only
+/// reach `Required` by way of a real, registered
+/// [`dynamo_parsers::tool_calling::StructuralTagBuilder`] — it cannot ask for the
+/// eligibility half of this decision without also getting the registry-availability
+/// proof in the same value. Both the real preprocessing path
+/// (`apply_tool_choice_structural_tag`) and the HTTP-layer reconstruction
+/// (`http::service::apply_request_tool_call_parsing_options`) must consult this
+/// function; neither may re-derive eligibility, mode, scope, or registry
+/// availability independently.
+pub(crate) enum StructuralTagDecision {
+    Required(&'static dynamo_parsers::tool_calling::StructuralTagBuilder),
+    NotApplicable,
+}
+
+impl StructuralTagDecision {
+    pub(crate) fn is_required(&self) -> bool {
+        matches!(self, Self::Required(_))
+    }
+}
+
+/// Decide whether a structural tag applies to this request. See
+/// [`StructuralTagDecision`] for why this is the single shared owner.
+///
+/// Returns `Err` when `tool_choice` is a forced choice (`Required` or `Named`)
+/// that is not valid against the request's `tools` — e.g. `required` with no
+/// tools, or a named tool absent from `tools`. Both the real preprocessing path
+/// (`apply_tool_choice_structural_tag`) and the HTTP-layer reconstruction
+/// (`http::service::apply_request_tool_call_parsing_options`) must propagate
+/// this error rather than falling back to `NotApplicable`, or an invalid forced
+/// choice would silently install a structural tag anyway.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn structural_tag_decision(
+    parser_name: Option<&str>,
+    tool_choice: &ToolChoice,
+    tools: &[ToolDefinition],
+    parallel_tool_calls: Option<bool>,
+    mode: StructuralTagMode,
+    scope: StructuralTagScope,
+    exclude_tools_when_tool_choice_none: bool,
+) -> Result<StructuralTagDecision, DynamoError> {
+    // Validate before any mode or family gate. Kimi K3 required requests use a
+    // prompt-level XTML path, but they still need an actual tool to require.
+    validate_forced_tool_choice(tool_choice, tools)?;
+
+    if mode == StructuralTagMode::Off
+        && !requires_intrinsic_structural_tag(parser_name, tool_choice)
+    {
+        return Ok(StructuralTagDecision::NotApplicable);
+    }
+
+    if should_skip_tool_call_ban(exclude_tools_when_tool_choice_none, tool_choice) {
+        // The prompt formatter already omits tools for this request. Avoid
+        // sending a redundant AnyTokens structural tag: vLLM cannot
+        // validate token-string exclusions without tokenizer metadata.
+        return Ok(StructuralTagDecision::NotApplicable);
+    }
+
+    let Some(parser_name) = parser_name else {
+        tracing::warn!(
+            "Structural tag is enabled but --dyn-tool-call-parser is not set; \
+             structural tags will not be applied"
+        );
+        return Ok(StructuralTagDecision::NotApplicable);
+    };
+
+    let Some(builder) = OpenAIPreprocessor::structural_tag_builder_for_parser(parser_name) else {
+        return Ok(StructuralTagDecision::NotApplicable);
+    };
+
+    if matches!(tool_choice, ToolChoice::None) {
+        if tools.is_empty() {
+            return Ok(StructuralTagDecision::NotApplicable);
+        }
+        return Ok(StructuralTagDecision::Required(builder));
+    }
+
+    if !OpenAIPreprocessor::should_apply_tool_call_format(
+        scope,
+        tool_choice,
+        tools,
+        parallel_tool_calls,
+    ) {
+        return Ok(StructuralTagDecision::NotApplicable);
+    }
+
+    Ok(StructuralTagDecision::Required(builder))
+}
+
 impl OpenAIPreprocessor {
     /// Apply structural tag guided decoding when enabled for this request.
     pub(super) fn apply_tool_choice_structural_tag(
@@ -46,50 +165,29 @@ impl OpenAIPreprocessor {
         preprocessed_request: &mut PreprocessedRequest,
     ) -> Result<bool, DynamoError> {
         let parser_name = self.tool_call_parser.as_deref();
-        if self.runtime_config.structural_tag_mode == StructuralTagMode::Off
-            && !requires_intrinsic_structural_tag(parser_name, tool_choice)
-        {
-            return Ok(false);
-        }
-
-        if should_skip_tool_call_ban(
-            self.runtime_config.exclude_tools_when_tool_choice_none,
-            tool_choice,
-        ) {
-            // The prompt formatter already omits tools for this request. Avoid
-            // sending a redundant AnyTokens structural tag: vLLM cannot
-            // validate token-string exclusions without tokenizer metadata.
-            return Ok(false);
-        }
-
-        let Some(parser_name) = parser_name else {
-            tracing::warn!(
-                "Structural tag is enabled but --dyn-tool-call-parser is not set; \
-                 structural tags will not be applied"
-            );
-            return Ok(false);
-        };
-
-        let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
-            return Ok(false);
-        };
-
-        if matches!(tool_choice, ToolChoice::None) {
-            if tools.is_empty() {
-                return Ok(false);
-            }
-            return Self::apply_tool_call_ban(builder, preprocessed_request);
-        }
-
-        if !Self::should_apply_tool_call_format(
-            self.runtime_config.structural_tag_scope,
+        let StructuralTagDecision::Required(builder) = structural_tag_decision(
+            parser_name,
             tool_choice,
             tools,
             parallel_tool_calls,
-        ) {
+            self.runtime_config.structural_tag_mode,
+            self.runtime_config.structural_tag_scope,
+            self.runtime_config.exclude_tools_when_tool_choice_none,
+        )?
+        else {
             return Ok(false);
+        };
+        // `structural_tag_decision` only returns `Required` once `parser_name` is
+        // confirmed `Some` (it is the source of the registry lookup that produced
+        // `builder`), so this is a real value, not a placeholder.
+        let parser_name = parser_name.expect("Required decision implies a parser name");
+
+        if matches!(tool_choice, ToolChoice::None) {
+            return Self::apply_tool_call_ban(builder, preprocessed_request);
         }
 
+        // `structural_tag_decision` already confirmed `should_apply_tool_call_format`
+        // for this non-None tool_choice before returning `Required`.
         let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
             tool_choice,
             tools,
@@ -269,6 +367,15 @@ mod tests {
         OpenAIPreprocessor::new(mdc).unwrap()
     }
 
+    fn kimi_k3_preprocessor() -> Arc<OpenAIPreprocessor> {
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        mdc.runtime_config.structural_tag_mode = StructuralTagMode::Off;
+        mdc.runtime_config.tool_call_parser = Some("kimi_k3".to_string());
+        OpenAIPreprocessor::new(mdc).unwrap()
+    }
+
     fn kimi_k2_required_format(excludes_reasoning: Option<bool>) -> serde_json::Value {
         let preprocessor = kimi_k2_preprocessor(excludes_reasoning);
         let tools = [ToolDefinition {
@@ -334,6 +441,36 @@ mod tests {
             Some("kimi_k2"),
             &ToolChoice::Named("get_weather".to_string())
         ));
+    }
+
+    // Durable registry-parity property: every parser/tool_choice combination the
+    // intrinsic predicate recognizes must have a real, registered
+    // `StructuralTagBuilder` in the parser registry. If a future edit registers a
+    // new intrinsic-family alias, or de-registers an existing one, without keeping
+    // both in lockstep, `structural_tag_decision` would otherwise report `Required`
+    // with no way to actually build the tag — this is the exact gap the shared
+    // decision owner exists to close. No global-state mutation, no scratch worktree,
+    // runs against the real production registry.
+    #[test]
+    fn every_intrinsic_parser_choice_has_a_registered_structural_tag_builder() {
+        let cases: &[(&str, ToolChoice)] = &[
+            ("kimi_k2", ToolChoice::Required),
+            ("kimi_k2", ToolChoice::Named("get_weather".to_string())),
+            ("kimi_k3", ToolChoice::Named("get_weather".to_string())),
+            ("kimi-k3", ToolChoice::Named("get_weather".to_string())),
+        ];
+        for (parser, choice) in cases {
+            assert!(
+                requires_intrinsic_structural_tag(Some(parser), choice),
+                "test fixture drifted: '{parser}' + {choice:?} is no longer intrinsic"
+            );
+            assert!(
+                OpenAIPreprocessor::structural_tag_builder_for_parser(parser).is_some(),
+                "'{parser}' is intrinsic per the predicate but the parser registry has \
+                 no structural-tag builder for it — the predicate and the registry have \
+                 drifted apart"
+            );
+        }
     }
 
     #[test]
@@ -406,12 +543,7 @@ mod tests {
 
     #[test]
     fn kimi_k3_required_stays_non_structural_when_global_mode_is_off() {
-        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
-        let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
-        mdc.runtime_config.structural_tag_mode = StructuralTagMode::Off;
-        mdc.runtime_config.tool_call_parser = Some("kimi_k3".to_string());
-        let preprocessor = OpenAIPreprocessor::new(mdc).unwrap();
+        let preprocessor = kimi_k3_preprocessor();
         let tools = [ToolDefinition {
             name: "get_weather".to_string(),
             parameters: None,
@@ -431,6 +563,127 @@ mod tests {
 
         assert!(!applied);
         assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    // Regression for the CodeRabbit finding on PR #12576 (structural_tag.rs is the
+    // real root cause; the finding was filed against http/service.rs lines 66-81):
+    // `should_apply_tool_call_format` returned `true` for `Required`/`Named`
+    // unconditionally, so `structural_tag_decision` built a structural tag for a
+    // forced tool_choice that `get_json_schema_from_tools` would have rejected on
+    // the non-structural-tag path. This must be rejected on the REAL preprocessing
+    // path (`apply_tool_choice_structural_tag`), not just the HTTP compatibility
+    // helper.
+    #[test]
+    fn kimi_k2_required_with_empty_tools_is_rejected() {
+        let preprocessor = kimi_k2_preprocessor(None);
+        let mut request = preprocessed_request();
+
+        let err = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .expect_err(
+                "kimi_k2 + required with no tools must be rejected, not silently \
+                 resolved to a structural tag",
+            );
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    #[test]
+    fn kimi_k3_required_with_empty_tools_is_rejected_before_the_mode_gate() {
+        let preprocessor = kimi_k3_preprocessor();
+        let mut request = preprocessed_request();
+
+        let err = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .expect_err("required with no tools must be rejected before Kimi K3's XTML path");
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    #[test]
+    fn kimi_k2_named_tool_absent_from_tools_is_rejected() {
+        let preprocessor = kimi_k2_preprocessor(None);
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+        let mut request = preprocessed_request();
+
+        let err = preprocessor
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Named("does_not_exist".to_string()),
+                &tools,
+                None,
+                false,
+                &mut request,
+            )
+            .expect_err(
+                "a named tool_choice for a tool absent from `tools` must be rejected, \
+                 not silently resolved to a structural tag",
+            );
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    #[test]
+    fn operator_enabled_qwen3_coder_required_with_empty_tools_is_rejected() {
+        let preprocessor = structural_tag_preprocessor(false);
+        let mut request = preprocessed_request();
+
+        let err = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::Required, &[], None, false, &mut request)
+            .expect_err(
+                "operator-enabled structural_tag_mode must not let required-with-no-tools \
+                 through for a non-Kimi registry-supported parser either",
+            );
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    #[test]
+    fn operator_enabled_qwen3_coder_named_tool_absent_from_tools_is_rejected() {
+        let preprocessor = structural_tag_preprocessor(false);
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+        let mut request = preprocessed_request();
+
+        let err = preprocessor
+            .apply_tool_choice_structural_tag(
+                &ToolChoice::Named("does_not_exist".to_string()),
+                &tools,
+                None,
+                false,
+                &mut request,
+            )
+            .expect_err(
+                "operator-enabled structural tags must reject a named tool_choice \
+                 that is absent from `tools`",
+            );
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        assert!(request.sampling_options.guided_decoding.is_none());
+    }
+
+    // `None`/`Auto` are not forced choices; the new validation must not affect them
+    // even when `tools` is empty.
+    #[test]
+    fn none_and_auto_are_unaffected_by_forced_choice_validation_with_empty_tools() {
+        let preprocessor = kimi_k2_preprocessor(None);
+
+        let mut request = preprocessed_request();
+        let applied = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::None, &[], None, false, &mut request)
+            .unwrap();
+        assert!(!applied);
+
+        let mut request = preprocessed_request();
+        let applied = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::Auto, &[], None, false, &mut request)
+            .unwrap();
+        assert!(!applied);
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/tool_choice.rs
+++ b/lib/llm/src/preprocessor/tool_choice.rs
@@ -4,8 +4,9 @@
 //! Tool-choice guided decoding policy for OpenAI chat requests.
 
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
+use crate::protocols::openai::GuidedToolConstraint;
 use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
-use crate::protocols::openai::tools::get_json_schema_from_tools;
+use crate::protocols::openai::tools::{get_json_schema_from_tools, validate_openai_tool_choice};
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
 use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolChoiceOption, ResponseFormat};
@@ -58,7 +59,7 @@ impl OpenAIPreprocessor {
         request: &NvCreateChatCompletionRequest,
         common_request: &mut PreprocessedRequest,
         prompt_injected_reasoning: bool,
-    ) -> Result<bool, DynamoError> {
+    ) -> Result<GuidedToolConstraint, DynamoError> {
         let tool_choice = request
             .inner
             .tool_choice
@@ -84,7 +85,7 @@ impl OpenAIPreprocessor {
         let has_assistant_constraint =
             has_explicit_guided_decoding || has_response_format_constraint;
         if !is_forced_tool_choice && has_assistant_constraint {
-            return Ok(false);
+            return Ok(GuidedToolConstraint::None);
         }
 
         if is_forced_tool_choice
@@ -102,18 +103,13 @@ impl OpenAIPreprocessor {
             prompt_injected_reasoning,
             common_request,
         )? {
-            return Ok(true);
+            return Ok(GuidedToolConstraint::StructuralTag);
         }
 
-        let uses_kimi_k3_parser = self
-            .tool_call_parser
-            .as_deref()
-            .is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"))
-            || self
-                .runtime_config
-                .reasoning_parser
-                .as_deref()
-                .is_some_and(|parser| matches!(parser, "kimi_k3" | "kimi-k3"));
+        let uses_kimi_k3_parser = uses_kimi_k3_parser(
+            self.tool_call_parser.as_deref(),
+            self.runtime_config.reasoning_parser.as_deref(),
+        );
         if is_forced_tool_choice && uses_kimi_k3_parser {
             if matches!(tool_choice, ChatCompletionToolChoiceOption::Named(_)) {
                 return Err(invalid_argument(
@@ -124,17 +120,27 @@ impl OpenAIPreprocessor {
 
             // K3's prompt-level required instruction produces an XTML `tools`
             // channel. Generic JSON guided decoding would constrain the wrong
-            // wire format and prevent the Rust K3 parser from seeing it.
-            return Ok(false);
+            // wire format and prevent the Rust K3 parser from seeing it. No JSON
+            // schema is installed, so this is NOT a guided-JSON request.
+            return Ok(GuidedToolConstraint::None);
         }
 
-        match get_json_schema_from_tools(Some(tool_choice), Some(tools)) {
+        match get_json_schema_from_tools(
+            Some(tool_choice),
+            Some(tools),
+            request.inner.parallel_tool_calls,
+        ) {
             Ok(Some(schema)) => {
                 let gd = common_request
                     .sampling_options
                     .guided_decoding
                     .get_or_insert_default();
                 gd.json = Some(schema);
+
+                // Report the shape that was installed, not the tool_choice that
+                // asked for it. Only these two arms produce a JSON schema, so only
+                // they may be streamed as guided JSON.
+                return Ok(installed_json_constraint(tool_choice));
             }
             Ok(None) => {}
             Err(err) => {
@@ -144,7 +150,7 @@ impl OpenAIPreprocessor {
 
         // Auto/None requests can reach here when neither structural tags nor a
         // tool-choice JSON fallback were needed.
-        Ok(false)
+        Ok(GuidedToolConstraint::None)
     }
 }
 
@@ -167,7 +173,7 @@ fn has_response_format_constraint(request: &NvCreateChatCompletionRequest) -> bo
         .is_some_and(|format| !matches!(format, ResponseFormat::Text))
 }
 
-fn convert_tool_choice(tool_choice: &ChatCompletionToolChoiceOption) -> ToolChoice {
+pub(crate) fn convert_tool_choice(tool_choice: &ChatCompletionToolChoiceOption) -> ToolChoice {
     match tool_choice {
         ChatCompletionToolChoiceOption::None => ToolChoice::None,
         ChatCompletionToolChoiceOption::Auto => ToolChoice::Auto,
@@ -178,7 +184,7 @@ fn convert_tool_choice(tool_choice: &ChatCompletionToolChoiceOption) -> ToolChoi
     }
 }
 
-fn convert_tools(tools: &[ChatCompletionTool]) -> Vec<ToolDefinition> {
+pub(crate) fn convert_tools(tools: &[ChatCompletionTool]) -> Vec<ToolDefinition> {
     tools
         .iter()
         .map(|tool| ToolDefinition {
@@ -189,9 +195,94 @@ fn convert_tools(tools: &[ChatCompletionTool]) -> Vec<ToolDefinition> {
         .collect()
 }
 
+/// The guided-tool constraint a request implies, given what the structural-tag stage
+/// already decided.
+///
+/// Direct postprocessor callers and remote frontends use this compatibility helper
+/// when they did not run request preprocessing. The worker streaming path carries the
+/// enum returned by `apply_tool_choice_guided_decoding`; topology-B aggregation may
+/// reconstruct a structural-tag request as guided JSON, so its complete-output parser
+/// also checks the generated wire shape.
+pub(crate) fn guided_tool_constraint(
+    request: &NvCreateChatCompletionRequest,
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+    uses_structural_tag: bool,
+) -> Result<GuidedToolConstraint, DynamoError> {
+    if uses_structural_tag {
+        return Ok(GuidedToolConstraint::StructuralTag);
+    }
+    let tool_choice = request
+        .inner
+        .tool_choice
+        .as_ref()
+        .unwrap_or(&ChatCompletionToolChoiceOption::Auto);
+    validate_openai_tool_choice(Some(tool_choice), request.inner.tools.as_deref())
+        .map_err(|error| invalid_argument(error.to_string()))?;
+    let is_forced_tool_choice = matches!(
+        tool_choice,
+        ChatCompletionToolChoiceOption::Required | ChatCompletionToolChoiceOption::Named(_)
+    );
+    // Only a forced choice installs a tool-level JSON schema. Auto/None leave any
+    // JSON constraint to `response_format`, which governs assistant CONTENT.
+    if !is_forced_tool_choice {
+        return Ok(GuidedToolConstraint::None);
+    }
+    // Forced + explicit guided decoding is rejected at request time, so reaching here
+    // with both means the request never ran.
+    if has_explicit_guided_decoding(request) {
+        return Ok(GuidedToolConstraint::None);
+    }
+    // K3 forced requests are served by a prompt-level XTML instruction; no JSON schema.
+    if uses_kimi_k3_parser(tool_call_parser, reasoning_parser) {
+        return Ok(GuidedToolConstraint::None);
+    }
+    // Validate the forced choice against the actual tools the same way
+    // `apply_tool_choice_guided_decoding` does, instead of blindly installing a
+    // constraint for a `tool_choice` that names a tool absent from `tools` (or an
+    // empty `tools` list under `tool_choice: "required"`).
+    let tools = request.inner.tools.as_deref().unwrap_or(&[]);
+    match get_json_schema_from_tools(
+        Some(tool_choice),
+        Some(tools),
+        request.inner.parallel_tool_calls,
+    ) {
+        Ok(Some(_)) => Ok(installed_json_constraint(tool_choice)),
+        Ok(None) => Ok(GuidedToolConstraint::None),
+        Err(e) => Err(invalid_argument(e.to_string())),
+    }
+}
+
+/// True when either configured parser is Kimi K3.
+///
+/// K3 forced requests are served by a prompt-level XTML instruction, so they must
+/// NOT be reported as guided JSON even though their `tool_choice` is forced.
+fn uses_kimi_k3_parser(tool_call_parser: Option<&str>, reasoning_parser: Option<&str>) -> bool {
+    let is_k3 = |parser: &str| matches!(parser, "kimi_k3" | "kimi-k3");
+    tool_call_parser.is_some_and(is_k3) || reasoning_parser.is_some_and(is_k3)
+}
+
+/// Map a forced `tool_choice` onto the JSON shape its schema constrains output to.
+///
+/// Only reachable once `get_json_schema_from_tools` actually produced a schema, and
+/// that function returns `None` for `Auto`/`None`, so those arms are unreachable in
+/// practice and report [`GuidedToolConstraint::None`] rather than guessing.
+fn installed_json_constraint(tool_choice: &ChatCompletionToolChoiceOption) -> GuidedToolConstraint {
+    match tool_choice {
+        ChatCompletionToolChoiceOption::Named(named) => GuidedToolConstraint::GuidedJsonNamed {
+            tool_name: named.function.name.clone(),
+        },
+        ChatCompletionToolChoiceOption::Required => GuidedToolConstraint::GuidedJsonRequired,
+        ChatCompletionToolChoiceOption::Auto | ChatCompletionToolChoiceOption::None => {
+            GuidedToolConstraint::None
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_protocols::types::{ChatCompletionNamedToolChoice, FunctionName};
     use serde_json::{Value, json};
 
     fn request(extra: Value) -> NvCreateChatCompletionRequest {
@@ -301,5 +392,87 @@ mod tests {
                 "response_format": {"type": "text"}
             })
         )));
+    }
+
+    fn named(name: &str) -> ChatCompletionToolChoiceOption {
+        ChatCompletionToolChoiceOption::Named(ChatCompletionNamedToolChoice {
+            r#type: dynamo_protocols::types::ChatCompletionToolType::Function,
+            function: FunctionName {
+                name: name.to_string(),
+            },
+        })
+    }
+
+    #[test]
+    fn only_structural_tag_reports_a_structural_tag() {
+        assert!(GuidedToolConstraint::StructuralTag.uses_structural_tag());
+        assert!(!GuidedToolConstraint::None.uses_structural_tag());
+        assert!(!GuidedToolConstraint::GuidedJsonRequired.uses_structural_tag());
+        assert!(
+            !GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            }
+            .uses_structural_tag()
+        );
+    }
+
+    #[test]
+    fn required_reports_the_array_shape() {
+        assert_eq!(
+            installed_json_constraint(&ChatCompletionToolChoiceOption::Required),
+            GuidedToolConstraint::GuidedJsonRequired
+        );
+    }
+
+    #[test]
+    fn named_carries_the_tool_name_from_the_request() {
+        assert_eq!(
+            installed_json_constraint(&named("get_weather")),
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn unforced_choices_install_no_tool_constraint() {
+        assert_eq!(
+            installed_json_constraint(&ChatCompletionToolChoiceOption::Auto),
+            GuidedToolConstraint::None
+        );
+        assert_eq!(
+            installed_json_constraint(&ChatCompletionToolChoiceOption::None),
+            GuidedToolConstraint::None
+        );
+    }
+
+    #[test]
+    fn kimi_k3_is_detected_from_either_parser_slot() {
+        assert!(uses_kimi_k3_parser(Some("kimi_k3"), None));
+        assert!(uses_kimi_k3_parser(Some("kimi-k3"), None));
+        assert!(uses_kimi_k3_parser(None, Some("kimi_k3")));
+        assert!(uses_kimi_k3_parser(None, Some("kimi-k3")));
+    }
+
+    #[test]
+    fn non_k3_parsers_are_not_mistaken_for_k3() {
+        assert!(!uses_kimi_k3_parser(None, None));
+        assert!(!uses_kimi_k3_parser(Some("kimi_k2"), Some("qwen3")));
+        assert!(!uses_kimi_k3_parser(Some("qwen3_coder"), None));
+    }
+
+    #[test]
+    fn kimi_k3_required_without_tools_is_rejected_before_the_xtml_return() {
+        for extra in [
+            json!({"tool_choice": "required"}),
+            json!({"tool_choice": "required", "tools": []}),
+        ] {
+            let request = request(extra);
+            let result = guided_tool_constraint(&request, Some("kimi_k3"), None, false);
+            assert!(
+                result.is_err(),
+                "Kimi K3 required must reject both missing and empty tools"
+            );
+        }
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -335,7 +335,39 @@ pub trait DeltaGeneratorExt<ResponseType: Send + 'static + std::fmt::Debug>:
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+/// The tool-output grammar installed for one request.
+///
+/// Batch and streaming consumers carry this decision forward instead of deriving it
+/// again from `tool_choice`, which cannot distinguish JSON guidance from a native
+/// structural tag or a family-specific prompt constraint.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GuidedToolConstraint {
+    /// No tool-choice generation constraint was installed.
+    #[default]
+    None,
+    /// Generation was pinned to the model family's native tool-call markup.
+    StructuralTag,
+    /// The model emits only the named tool's argument object.
+    GuidedJsonNamed { tool_name: String },
+    /// The model emits one call object or an array of `{name, parameters}` objects.
+    GuidedJsonRequired,
+}
+
+impl GuidedToolConstraint {
+    pub(crate) fn installs_guided_json(&self) -> bool {
+        matches!(
+            self,
+            Self::GuidedJsonNamed { .. } | Self::GuidedJsonRequired
+        )
+    }
+
+    pub(crate) fn uses_structural_tag(&self) -> bool {
+        matches!(self, Self::StructuralTag)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ParsingOptions {
     pub tool_call_parser: Option<String>,
 
@@ -349,14 +381,9 @@ pub struct ParsingOptions {
     #[serde(default)]
     pub suppress_tool_calls: bool,
 
-    /// Request-side gate for routing the batch tool-call finalize through
-    /// `dynamo-parsers-v2` (see
-    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`). Defaults `false`
-    /// so any path that does not explicitly opt in stays on the v1 finalize path; the
-    /// chat HTTP handlers set it from the request's tool_choice. The env flag and family
-    /// support are checked separately in the aggregator.
+    /// Exact tool-output grammar installed while preprocessing this request.
     #[serde(default)]
-    pub experimental_v2_batch_eligible: bool,
+    pub guided_tool_constraint: GuidedToolConstraint,
 
     /// The request's `parallel_tool_calls`. When `Some(false)`, the aggregator
     /// caps each choice to a single tool call as a post-parse fallback for
@@ -374,6 +401,28 @@ pub struct ParsingOptions {
     /// generated, reasoning stays in `reasoning_content`.
     #[serde(default)]
     pub move_reasoning_to_content_when_empty: bool,
+
+    /// The worker's operator-configured structural-tag policy. Carried through so
+    /// the HTTP-layer tool-call-gate reconstruction
+    /// (`http::service::apply_request_tool_call_parsing_options`) can consult the
+    /// same structural-tag contract the real preprocessing path uses, instead of
+    /// only recognizing intrinsically-forced model families.
+    #[serde(default)]
+    pub structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode,
+
+    #[serde(default)]
+    pub structural_tag_scope: crate::local_model::runtime_config::StructuralTagScope,
+
+    #[serde(
+        default = "crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none"
+    )]
+    pub exclude_tools_when_tool_choice_none: bool,
+}
+
+impl Default for ParsingOptions {
+    fn default() -> Self {
+        Self::new(None, None)
+    }
 }
 
 impl ParsingOptions {
@@ -382,37 +431,48 @@ impl ParsingOptions {
             tool_call_parser,
             reasoning_parser,
             suppress_tool_calls: false,
-            experimental_v2_batch_eligible: false,
+            guided_tool_constraint: GuidedToolConstraint::None,
             parallel_tool_calls: None,
             move_reasoning_to_content_when_empty: false,
+            structural_tag_mode: crate::local_model::runtime_config::StructuralTagMode::default(),
+            structural_tag_scope: crate::local_model::runtime_config::StructuralTagScope::default(),
+            exclude_tools_when_tool_choice_none:
+                crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none(),
         }
     }
 
-    /// Set whether this request is eligible for the experimental v2 batch parser
-    /// (request-side tool_choice gate). See
-    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`.
-    pub fn with_experimental_v2_batch_eligible(mut self, eligible: bool) -> Self {
-        self.experimental_v2_batch_eligible = eligible;
+    pub fn with_guided_tool_constraint(mut self, constraint: GuidedToolConstraint) -> Self {
+        self.guided_tool_constraint = constraint;
         self
     }
 
     /// Enforce request-level tool-call permission while preserving independent
     /// reasoning parsing and any parser needed for whole-response decoding.
     /// `tool_call_parser` originates in model configuration, so HTTP handlers
-    /// must narrow it to requests that actually permit tool calls. Harmony and
-    /// Kimi K3 are retained because their aggregate parsers also remove internal
-    /// channel markup from ordinary content; `suppress_tool_calls` remains the
-    /// output policy boundary for those cases.
+    /// must narrow it to requests that actually permit tool calls. Whole-response
+    /// decoders are retained because they also remove internal channel markup from
+    /// ordinary content; `suppress_tool_calls` remains the output policy boundary.
     pub fn with_tool_call_parsing_enabled(mut self, enabled: bool) -> Self {
         if !enabled {
             self.suppress_tool_calls = true;
-            if !matches!(
+            let whole_response_decoder = matches!(
                 self.tool_call_parser.as_deref(),
                 Some("harmony" | "kimi_k3" | "kimi-k3")
-            ) {
+            )
+                || chat_completions::unified_parser::selected_batch_family(
+                    self.tool_call_parser.as_deref(),
+                    self.reasoning_parser.as_deref(),
+                )
+                .is_some()
+                || chat_completions::tool_parser_v2::unified_family(
+                    self.tool_call_parser.as_deref(),
+                    self.reasoning_parser.as_deref(),
+                )
+                .is_some();
+            if !whole_response_decoder {
                 self.tool_call_parser = None;
             }
-            self.experimental_v2_batch_eligible = false;
+            self.guided_tool_constraint = GuidedToolConstraint::None;
         }
         self
     }
@@ -441,25 +501,21 @@ mod parsing_options_tests {
     #[test]
     fn disabling_tool_parsing_preserves_reasoning_parser() {
         let options = ParsingOptions::new(Some("hermes".to_string()), Some("qwen3".to_string()))
-            .with_experimental_v2_batch_eligible(true)
             .with_tool_call_parsing_enabled(false);
 
         assert_eq!(options.tool_call_parser, None);
         assert_eq!(options.reasoning_parser.as_deref(), Some("qwen3"));
         assert!(options.suppress_tool_calls);
-        assert!(!options.experimental_v2_batch_eligible);
     }
 
     #[test]
     fn disabling_tool_calls_retains_harmony_for_content_decoding() {
         let options = ParsingOptions::new(Some("harmony".to_string()), Some("gpt_oss".to_string()))
-            .with_experimental_v2_batch_eligible(true)
             .with_tool_call_parsing_enabled(false);
 
         assert_eq!(options.tool_call_parser.as_deref(), Some("harmony"));
         assert_eq!(options.reasoning_parser.as_deref(), Some("gpt_oss"));
         assert!(options.suppress_tool_calls);
-        assert!(!options.experimental_v2_batch_eligible);
     }
 
     #[test]
@@ -467,13 +523,38 @@ mod parsing_options_tests {
         for parser in ["kimi_k3", "kimi-k3"] {
             let options =
                 ParsingOptions::new(Some(parser.to_string()), Some("kimi_k3".to_string()))
-                    .with_experimental_v2_batch_eligible(true)
                     .with_tool_call_parsing_enabled(false);
 
             assert_eq!(options.tool_call_parser.as_deref(), Some(parser));
             assert_eq!(options.reasoning_parser.as_deref(), Some("kimi_k3"));
             assert!(options.suppress_tool_calls);
-            assert!(!options.experimental_v2_batch_eligible);
         }
+    }
+
+    #[test]
+    fn disabling_tool_calls_retains_muse_for_content_decoding() {
+        for parser in ["muse_glimmer", "muse"] {
+            let options = ParsingOptions::new(Some(parser.to_string()), None)
+                .with_tool_call_parsing_enabled(false);
+
+            assert_eq!(options.tool_call_parser.as_deref(), Some(parser));
+            assert_eq!(options.reasoning_parser, None);
+            assert!(options.suppress_tool_calls);
+        }
+    }
+
+    #[test]
+    fn disabling_tool_calls_retains_exact_qwen_unified_pair() {
+        let options =
+            ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+                .with_tool_call_parsing_enabled(false);
+
+        assert_eq!(
+            options.tool_call_parser.as_deref(),
+            crate::protocols::openai::chat_completions::tool_parser_v2::enabled()
+                .then_some("qwen3_coder")
+        );
+        assert_eq!(options.reasoning_parser.as_deref(), Some("qwen3"));
+        assert!(options.suppress_tool_calls);
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use dynamo_parsers::tool_calling::ToolDefinition;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -417,6 +418,17 @@ pub struct ParsingOptions {
         default = "crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none"
     )]
     pub exclude_tools_when_tool_choice_none: bool,
+
+    /// The request's declared tool schemas. Threaded through so batch-path
+    /// argument parsing (`unified_parser::parse_complete`) can type-coerce
+    /// arguments against the same schema the streaming path already uses via
+    /// `apply_stream_with_constraint`'s `tool_definitions`. Empty for requests
+    /// that declare no tools, matching prior (correct) behavior for those.
+    /// `ToolDefinition` does not implement `Serialize`/`Deserialize`, and this
+    /// field is always populated fresh from the live request rather than
+    /// round-tripped, so it is skipped rather than wired into the wire format.
+    #[serde(skip)]
+    pub tools: Vec<ToolDefinition>,
 }
 
 impl Default for ParsingOptions {
@@ -438,11 +450,19 @@ impl ParsingOptions {
             structural_tag_scope: crate::local_model::runtime_config::StructuralTagScope::default(),
             exclude_tools_when_tool_choice_none:
                 crate::local_model::runtime_config::default_exclude_tools_when_tool_choice_none(),
+            tools: Vec::new(),
         }
     }
 
     pub fn with_guided_tool_constraint(mut self, constraint: GuidedToolConstraint) -> Self {
         self.guided_tool_constraint = constraint;
+        self
+    }
+
+    /// Thread the request's declared tool schemas through for batch-path
+    /// argument type coercion. See the `tools` field doc comment.
+    pub fn with_tools(mut self, tools: Vec<ToolDefinition>) -> Self {
+        self.tools = tools;
         self
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -23,6 +23,7 @@ use crate::protocols::common::extensions::{
 pub mod aggregator;
 mod delta;
 pub mod tool_parser_v2;
+pub(crate) mod unified_parser;
 
 pub use aggregator::DeltaAggregator;
 pub use delta::DeltaGenerator;

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -31,6 +31,62 @@ fn contains_harmony_protocol(text: &str) -> bool {
     text.contains("<|channel|>")
 }
 
+/// Quote/escape-aware replacement for `dynamo_parsers::tool_calling::detect_tool_call_start`,
+/// which does a naive substring search and false-positives on a marker token that only
+/// appears as a quoted JSON string value (e.g. a tool argument literally containing the
+/// text `<tool_call>`). Looks up the real per-family marker tokens for `parser` from
+/// `dynamo_parsers`' own parser map (falling back to its "default" key exactly as
+/// `detect_tool_call_start` does for `None`/empty), then checks each with
+/// `unified_parser::contains_unquoted_marker` so a marker embedded inside a quoted string
+/// is not misread as native tool-call markup.
+fn contains_native_tool_call_marker(content: &str, parser: &str) -> bool {
+    let parser_key = if parser.is_empty() { "default" } else { parser };
+    let Some(config) = dynamo_parsers::tool_calling::parsers::get_tool_parser_map().get(parser_key)
+    else {
+        return false;
+    };
+    config
+        .parser_config
+        .tool_call_start_tokens()
+        .iter()
+        .any(|marker| {
+            !marker.is_empty() && super::unified_parser::contains_unquoted_marker(content, marker)
+        })
+}
+
+async fn parse_complete_tool_output(
+    content: &str,
+    parser: &str,
+    constraint: &crate::protocols::openai::GuidedToolConstraint,
+) -> anyhow::Result<(
+    Vec<dynamo_parsers::tool_calling::ToolCallResponse>,
+    Option<String>,
+)> {
+    if constraint.installs_guided_json() {
+        match super::tool_parser_v2::parse_complete_guided_json(content, constraint) {
+            Ok(calls) => return Ok((calls, Some(String::new()))),
+            Err(guided_error) => {
+                if !contains_native_tool_call_marker(content, parser) {
+                    return Err(guided_error);
+                }
+                tracing::warn!(
+                    parser,
+                    why = "guided_json_reconstructed_but_native_markup_observed",
+                    recovered_bytes = content.len(),
+                    "falling back to the configured native tool parser"
+                );
+            }
+        }
+    }
+
+    if super::tool_parser_v2::enabled() && super::tool_parser_v2::supports_family(parser) {
+        super::tool_parser_v2::parse_complete(content, None, parser)
+            .map(|(calls, normal)| (calls, Some(normal)))
+    } else {
+        try_tool_call_parse_aggregate_finalize(content, Some(parser), None).await
+    }
+}
+
 /// Aggregates a stream of [`NvCreateChatCompletionStreamResponse`]s into a single
 /// [`NvCreateChatCompletionResponse`]. This struct accumulates incremental responses
 /// from a streaming OpenAI API call into a complete final response.
@@ -377,18 +433,82 @@ impl DeltaAggregator {
             }
         }
 
+        // Two independent families each own ONE unified parser (topology B: raw
+        // model text reaches the frontend un-split) that replaces the split
+        // reasoning/tool-call finalize below outright: Qwen3 (`unified_parser`,
+        // gated on DYN_ENABLE_EXPERIMENTAL_PARSERS_V2) and muse (`tool_parser_v2`,
+        // default-on). This is the safety net for output that reached the
+        // aggregator unparsed; a request the worker already streamed through the
+        // matching `apply_stream`/`apply_unified_stream` arrives with `tool_calls`
+        // populated and is skipped by each guard below.
+        let qwen3_unified_family = super::unified_parser::selected_batch_family(
+            parsing_options.tool_call_parser.as_deref(),
+            parsing_options.reasoning_parser.as_deref(),
+        );
+        if let Some(family) = qwen3_unified_family {
+            for choice in aggregator.choices.values_mut() {
+                if choice.text.is_empty()
+                    || choice
+                        .tool_calls
+                        .as_ref()
+                        .is_some_and(|calls| !calls.is_empty())
+                {
+                    continue;
+                }
+                match super::unified_parser::parse_complete(
+                    family,
+                    &choice.text,
+                    &parsing_options.guided_tool_constraint,
+                ) {
+                    Ok(parsed) => {
+                        choice.text = parsed.text;
+                        if !parsed.reasoning.is_empty() {
+                            choice
+                                .reasoning_content
+                                .get_or_insert_with(String::new)
+                                .push_str(&parsed.reasoning);
+                        }
+                        if !parsed.tool_calls.is_empty() && !parsing_options.suppress_tool_calls {
+                            choice.tool_calls = Some(parsed.tool_calls);
+                            // OpenAI contract: a message carrying tool calls finishes
+                            // with `ToolCalls`, not `Stop`.
+                            if choice.finish_reason
+                                == Some(dynamo_protocols::types::FinishReason::Stop)
+                            {
+                                choice.finish_reason =
+                                    Some(dynamo_protocols::types::FinishReason::ToolCalls);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        // Best-effort: the aggregated text is served as-is rather than
+                        // failing a request the model already answered.
+                        tracing::warn!(
+                            error = %error,
+                            family,
+                            "failed to parse aggregated unified output; serving it unparsed"
+                        );
+                    }
+                }
+            }
+        }
+
         // Muse finalizes through the UNIFIED parser (topology B: raw model text
         // reaches the frontend un-split). Keyed on EITHER parser name to match the
         // streaming guard, so a reasoning-only card (`--dyn-reasoning-parser
         // muse_glimmer`, no tool-call parser) splits its markup here too. Default-on,
         // so muse never falls into the v1 aggregate-finalize below. The gate is wider
         // than main's `tool_call_parser.is_some()` for that reason; `parser` is bound
-        // inside the loop, after the muse branch has taken its `continue`.
+        // inside the loop, after the muse branch has taken its `continue`. Excluded
+        // when Qwen3 already claimed the request above, since Qwen3 also configures a
+        // `tool_call_parser` and would otherwise fall through into this block too.
         let unified_family = super::tool_parser_v2::unified_family(
             parsing_options.tool_call_parser.as_deref(),
             parsing_options.reasoning_parser.as_deref(),
         );
-        if unified_family.is_some() || parsing_options.tool_call_parser.is_some() {
+        if qwen3_unified_family.is_none()
+            && (unified_family.is_some() || parsing_options.tool_call_parser.is_some())
+        {
             for choice in aggregator.choices.values_mut() {
                 if choice
                     .tool_calls
@@ -400,16 +520,64 @@ impl DeltaAggregator {
                 }
 
                 if let Some(family) = unified_family.as_deref() {
-                    match super::tool_parser_v2::parse_complete_unified(&choice.text, None, family)
+                    // Only the guided-JSON success arm below returns a synthetic
+                    // empty `content` placeholder (there is no separate message
+                    // text distinct from the tool-call JSON itself). Every other
+                    // arm — the native-fallback-after-guided-error reconstruction,
+                    // and the plain non-guided `else` branch — returns REAL
+                    // stripped content from `parse_complete_unified` that must
+                    // always replace `choice.text`, matching the sibling Qwen3
+                    // block's unconditional assignment, regardless of whether any
+                    // tool calls were found.
+                    let mut content_is_guided_placeholder = false;
+                    let parse_result = if parsing_options
+                        .guided_tool_constraint
+                        .installs_guided_json()
                     {
+                        match super::tool_parser_v2::parse_complete_guided_json(
+                            &choice.text,
+                            &parsing_options.guided_tool_constraint,
+                        ) {
+                            Ok(calls) => {
+                                content_is_guided_placeholder = true;
+                                Ok((calls, String::new(), String::new()))
+                            }
+                            Err(guided_error) => {
+                                match super::tool_parser_v2::parse_complete_unified(
+                                    &choice.text,
+                                    None,
+                                    family,
+                                ) {
+                                    Ok((calls, reasoning, content))
+                                        if !calls.is_empty()
+                                            || !reasoning.is_empty()
+                                            || content != choice.text =>
+                                    {
+                                        tracing::warn!(
+                                            family,
+                                            why = "guided_json_reconstructed_but_native_markup_observed",
+                                            recovered_bytes = choice.text.len(),
+                                            "falling back to the configured unified parser"
+                                        );
+                                        Ok((calls, reasoning, content))
+                                    }
+                                    Ok(_) => Err(guided_error),
+                                    Err(native_error) => Err(native_error.context(format!(
+                                        "guided JSON parse also failed: {guided_error:#}"
+                                    ))),
+                                }
+                            }
+                        }
+                    } else {
+                        super::tool_parser_v2::parse_complete_unified(&choice.text, None, family)
+                    };
+                    match parse_result {
                         Ok((calls, reasoning, content)) => {
+                            let calls_is_empty = calls.is_empty();
                             // Same rule the streaming path applies: `none` still gets the
                             // reasoning/content split and the marker stripping, but a
                             // caller that disabled tools must not receive `tool_calls`.
-                            // `experimental_v2_batch_eligible` is set from the request's
-                            // tool_choice by `batch_tool_choice_eligible`, which admits
-                            // unset/auto only, so it is exactly that gate.
-                            if !calls.is_empty() && parsing_options.experimental_v2_batch_eligible {
+                            if !calls_is_empty && !parsing_options.suppress_tool_calls {
                                 choice.tool_calls = Some(
                                     calls
                                         .into_iter()
@@ -417,10 +585,22 @@ impl DeltaAggregator {
                                         .collect(),
                                 );
                             }
-                            if choice.reasoning_content.is_none() && !reasoning.is_empty() {
-                                choice.reasoning_content = Some(reasoning);
+                            if !reasoning.is_empty() {
+                                choice
+                                    .reasoning_content
+                                    .get_or_insert_with(String::new)
+                                    .push_str(&reasoning);
                             }
-                            choice.text = content;
+                            if !calls_is_empty || !content_is_guided_placeholder {
+                                choice.text = content;
+                            } else {
+                                tracing::warn!(
+                                    family,
+                                    why = "guided_json_produced_zero_calls_under_tool_choice_required",
+                                    original_bytes = choice.text.len(),
+                                    "guided-JSON parse returned zero tool calls; preserving original text"
+                                );
+                            }
                         }
                         Err(error) => {
                             tracing::debug!(error = %error, family, "muse unified batch parse failed");
@@ -437,10 +617,8 @@ impl DeltaAggregator {
                 // With DYN_ENABLE_EXPERIMENTAL_PARSERS_V2, supported families use the
                 // v2 parser for batch too (no jail / no aggregate-finalize):
                 // parse_complete drops a value truncated at EOF instead of guessing it.
-                // Other families, the flag off, and guided-decoded requests
-                // (tool_choice=required/named or structural-tag, gated by
-                // experimental_v2_batch_eligible — see tool_parser_v2::batch_tool_choice_eligible)
-                // keep the v1 finalize path.
+                // Other families and the flag-off path keep the v1 finalize path.
+                // Guided JSON is handled above from the exact carried constraint.
                 // Extract the truncated tail BEFORE parsing so a second <tool_call>
                 // truncated after a complete first one is not silently dropped.
                 // Token strings come from the parser config so this stays in sync
@@ -466,15 +644,12 @@ impl DeltaAggregator {
                     None
                 };
 
-                let parse_result = if super::tool_parser_v2::enabled()
-                    && super::tool_parser_v2::supports_family(parser)
-                    && parsing_options.experimental_v2_batch_eligible
-                {
-                    super::tool_parser_v2::parse_complete(&choice.text, None, parser)
-                        .map(|(calls, normal)| (calls, Some(normal)))
-                } else {
-                    try_tool_call_parse_aggregate_finalize(&choice.text, Some(parser), None).await
-                };
+                let parse_result = parse_complete_tool_output(
+                    &choice.text,
+                    parser,
+                    &parsing_options.guided_tool_constraint,
+                )
+                .await;
                 let (tool_calls, content) = match parse_result {
                     Ok(result) => result,
                     Err(error) => {

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -54,6 +54,33 @@ fn contains_native_tool_call_marker(content: &str, parser: &str) -> bool {
         })
 }
 
+/// Drops any recovered native-fallback calls that don't match the forced
+/// `tool_name` from a `GuidedJsonNamed` constraint. Guided-JSON failure only
+/// tells us the *shape* was wrong; it says nothing about which tool the
+/// native markup named, so a malformed guided output that happens to embed
+/// native markup for a different tool must never be handed back to a client
+/// that pinned `tool_choice` to one specific function.
+fn filter_calls_to_forced_tool_name(
+    calls: Vec<dynamo_parsers::tool_calling::ToolCallResponse>,
+    constraint: &crate::protocols::openai::GuidedToolConstraint,
+) -> Vec<dynamo_parsers::tool_calling::ToolCallResponse> {
+    let crate::protocols::openai::GuidedToolConstraint::GuidedJsonNamed { tool_name } = constraint
+    else {
+        return calls;
+    };
+    let (matched, dropped): (Vec<_>, Vec<_>) = calls
+        .into_iter()
+        .partition(|call| &call.function.name == tool_name);
+    if !dropped.is_empty() {
+        tracing::warn!(
+            tool_name,
+            dropped = dropped.len(),
+            "dropped native-fallback tool call(s) whose name did not match the tool_choice-forced tool_name"
+        );
+    }
+    matched
+}
+
 async fn parse_complete_tool_output(
     content: &str,
     parser: &str,
@@ -79,12 +106,31 @@ async fn parse_complete_tool_output(
         }
     }
 
-    if super::tool_parser_v2::enabled() && super::tool_parser_v2::supports_family(parser) {
-        super::tool_parser_v2::parse_complete(content, None, parser)
-            .map(|(calls, normal)| (calls, Some(normal)))
-    } else {
-        try_tool_call_parse_aggregate_finalize(content, Some(parser), None).await
-    }
+    let result =
+        if super::tool_parser_v2::enabled() && super::tool_parser_v2::supports_family(parser) {
+            super::tool_parser_v2::parse_complete(content, None, parser)
+                .map(|(calls, normal)| (calls, Some(normal)))
+        } else {
+            try_tool_call_parse_aggregate_finalize(content, Some(parser), None).await
+        };
+
+    result.and_then(|(calls, normal)| {
+        let filtered = filter_calls_to_forced_tool_name(calls, constraint);
+        if filtered.is_empty()
+            && matches!(
+                constraint,
+                crate::protocols::openai::GuidedToolConstraint::GuidedJsonNamed { .. }
+            )
+        {
+            // Mirror the "no native markup found" behavior above: a fallback
+            // that recovered nothing usable for the forced tool is treated
+            // the same as a fallback that found nothing at all.
+            return Err(anyhow::anyhow!(
+                "native tool-call fallback recovered no call matching the tool_choice-forced tool name"
+            ));
+        }
+        Ok((filtered, normal))
+    })
 }
 
 /// Aggregates a stream of [`NvCreateChatCompletionStreamResponse`]s into a single
@@ -459,6 +505,7 @@ impl DeltaAggregator {
                     family,
                     &choice.text,
                     &parsing_options.guided_tool_constraint,
+                    &parsing_options.tools,
                 ) {
                     Ok(parsed) => {
                         choice.text = parsed.text;
@@ -548,20 +595,31 @@ impl DeltaAggregator {
                                     None,
                                     family,
                                 ) {
-                                    Ok((calls, reasoning, content))
+                                    Ok((calls, reasoning, content)) => {
+                                        // A GuidedJsonNamed constraint pins one tool
+                                        // name; the native fallback must never hand
+                                        // back a call for a different tool just
+                                        // because it happened to find markup naming
+                                        // one in the malformed guided output.
+                                        let calls = filter_calls_to_forced_tool_name(
+                                            calls,
+                                            &parsing_options.guided_tool_constraint,
+                                        );
                                         if !calls.is_empty()
                                             || !reasoning.is_empty()
-                                            || content != choice.text =>
-                                    {
-                                        tracing::warn!(
-                                            family,
-                                            why = "guided_json_reconstructed_but_native_markup_observed",
-                                            recovered_bytes = choice.text.len(),
-                                            "falling back to the configured unified parser"
-                                        );
-                                        Ok((calls, reasoning, content))
+                                            || content != choice.text
+                                        {
+                                            tracing::warn!(
+                                                family,
+                                                why = "guided_json_reconstructed_but_native_markup_observed",
+                                                recovered_bytes = choice.text.len(),
+                                                "falling back to the configured unified parser"
+                                            );
+                                            Ok((calls, reasoning, content))
+                                        } else {
+                                            Err(guided_error)
+                                        }
                                     }
-                                    Ok(_) => Err(guided_error),
                                     Err(native_error) => Err(native_error.context(format!(
                                         "guided JSON parse also failed: {guided_error:#}"
                                     ))),

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -370,7 +370,63 @@ impl DeltaAggregator {
             }
         }
 
-        if let Some(parser) = parsing_options.tool_call_parser.as_deref() {
+        // When the request's parser pair has a unified parser and it is switched on, ONE
+        // state machine owns reasoning + text + tool calls, so it replaces the split
+        // reasoning/tool-call finalize below rather than running alongside it. This is
+        // the safety net for output that reached the aggregator unparsed; a request the
+        // worker already streamed through `unified_parser::apply_stream` arrives with
+        // `tool_calls` populated and is skipped by the guard.
+        let unified_family = super::unified_parser::selected_family(
+            parsing_options.tool_call_parser.as_deref(),
+            parsing_options.reasoning_parser.as_deref(),
+        );
+        if let Some(family) = unified_family {
+            for choice in aggregator.choices.values_mut() {
+                if choice.text.is_empty()
+                    || choice
+                        .tool_calls
+                        .as_ref()
+                        .is_some_and(|calls| !calls.is_empty())
+                {
+                    continue;
+                }
+                match super::unified_parser::parse_complete(family, &choice.text) {
+                    Ok(parsed) => {
+                        choice.text = parsed.text;
+                        if !parsed.reasoning.is_empty() {
+                            choice
+                                .reasoning_content
+                                .get_or_insert_with(String::new)
+                                .push_str(&parsed.reasoning);
+                        }
+                        if !parsed.tool_calls.is_empty() {
+                            choice.tool_calls = Some(parsed.tool_calls);
+                            // OpenAI contract: a message carrying tool calls finishes
+                            // with `ToolCalls`, not `Stop`.
+                            if choice.finish_reason
+                                == Some(dynamo_protocols::types::FinishReason::Stop)
+                            {
+                                choice.finish_reason =
+                                    Some(dynamo_protocols::types::FinishReason::ToolCalls);
+                            }
+                        }
+                    }
+                    Err(error) => {
+                        // Best-effort: the aggregated text is served as-is rather than
+                        // failing a request the model already answered.
+                        tracing::warn!(
+                            error = %error,
+                            family,
+                            "failed to parse aggregated unified output; serving it unparsed"
+                        );
+                    }
+                }
+            }
+        }
+
+        if unified_family.is_none()
+            && let Some(parser) = parsing_options.tool_call_parser.as_deref()
+        {
             for choice in aggregator.choices.values_mut() {
                 if choice
                     .tool_calls

--- a/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/tool_parser_v2.rs
@@ -20,8 +20,8 @@ use std::sync::LazyLock;
 
 use async_stream::stream;
 use dynamo_protocols::types::{
-    ChatCompletionMessageContent, ChatCompletionMessageToolCallChunk,
-    ChatCompletionToolChoiceOption, FinishReason, FunctionCallStream, FunctionType,
+    ChatCompletionMessageContent, ChatCompletionMessageToolCallChunk, FinishReason,
+    FunctionCallStream, FunctionType,
 };
 use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
 use dynamo_runtime::protocols::annotated::Annotated;
@@ -32,9 +32,11 @@ use dynamo_parsers::tool_calling::{
     CalledFunction, ToolCallResponse, ToolCallType, ToolDefinition,
 };
 use dynamo_parsers_v2::{
-    Tool as ToolV2, ToolCallDelta, ToolParser, UnifiedEvent, UnifiedParser, UnifiedParserEvent,
-    UnifiedParserExt, create_tool_parser_for_family, create_unified_parser_for_family,
+    Tool as ToolV2, ToolCallDelta, ToolParser, UnifiedEvent, UnifiedParserEvent, UnifiedParserExt,
+    create_tool_parser_for_family, create_unified_parser_for_family,
 };
+
+use crate::protocols::openai::GuidedToolConstraint;
 
 use super::{NvCreateChatCompletionStreamResponse, stream_choice_chunk_from_template};
 
@@ -96,26 +98,6 @@ pub(crate) fn unified_family(
 ) -> Option<String> {
     let is_muse = |p: Option<&str>| UNIFIED_FAMILIES.contains(&p.unwrap_or_default());
     (is_muse(tool_call_parser) || is_muse(reasoning_parser)).then(|| "muse_glimmer".to_string())
-}
-
-/// Request-side gate for routing the **batch** finalize through v2, mirroring the
-/// streaming gate's tool_choice clause (see `preprocessor.rs`): only an unset or `auto`
-/// tool_choice is eligible. `tool_choice=required`/named and structural-tag mode are
-/// guided-decoded JSON, not the native markup the v2 parser reads, so they stay on the
-/// v1 finalize path.
-///
-/// The streaming gate's `!uses_tool_call_structural_tag` clause is intentionally not
-/// re-checked here. That flag is computed in the worker preprocessor and isn't visible
-/// to the frontend aggregator; but any request that gets structural-tag/guided decoding
-/// is parsed upstream (the worker jails it and emits `tool_calls`), so it never reaches
-/// the batch finalize with raw text. The request's tool_choice is the reachable guard.
-pub(crate) fn batch_tool_choice_eligible(
-    tool_choice: Option<&ChatCompletionToolChoiceOption>,
-) -> bool {
-    matches!(
-        tool_choice,
-        None | Some(ChatCompletionToolChoiceOption::Auto)
-    )
 }
 
 /// Map dynamo's v1 `ToolDefinition`s onto the v2 parser's `Tool` shape.
@@ -198,6 +180,68 @@ pub(crate) fn parse_complete_unified(
     Ok((tool_calls, reasoning, text))
 }
 
+/// Convert the two guided-JSON response shapes into parser-native tool calls.
+///
+/// Named guidance emits only the selected tool's argument object. Required guidance
+/// emits one call envelope or an array of envelopes. This conversion is family-neutral:
+/// Muse has no guided mode in its unified parser, while Qwen's unified parser consumes
+/// the same constraint directly so it can also recover a preceding reasoning span.
+pub(crate) fn parse_complete_guided_json(
+    content: &str,
+    constraint: &GuidedToolConstraint,
+) -> anyhow::Result<Vec<ToolCallResponse>> {
+    fn response(name: String, arguments: &serde_json::Value) -> anyhow::Result<ToolCallResponse> {
+        Ok(ToolCallResponse {
+            id: format!("call-{}", Uuid::new_v4()),
+            tp: ToolCallType::Function,
+            function: CalledFunction {
+                name,
+                arguments: serde_json::to_string(arguments)?,
+            },
+        })
+    }
+
+    let payload: serde_json::Value = serde_json::from_str(content.trim())?;
+    match constraint {
+        GuidedToolConstraint::GuidedJsonNamed { tool_name } => {
+            anyhow::ensure!(
+                payload.is_object(),
+                "named guided payload must be an object"
+            );
+            Ok(vec![response(tool_name.clone(), &payload)?])
+        }
+        GuidedToolConstraint::GuidedJsonRequired => {
+            let envelopes = match &payload {
+                serde_json::Value::Array(envelopes) => envelopes.as_slice(),
+                serde_json::Value::Object(_) => std::slice::from_ref(&payload),
+                _ => anyhow::bail!("required guided payload must be an object or array"),
+            };
+            envelopes
+                .iter()
+                .map(|envelope| {
+                    let object = envelope
+                        .as_object()
+                        .ok_or_else(|| anyhow::anyhow!("guided call envelope must be an object"))?;
+                    let name = object
+                        .get("name")
+                        .and_then(serde_json::Value::as_str)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!("guided call envelope has no string name")
+                        })?;
+                    let arguments = object
+                        .get("parameters")
+                        .or_else(|| object.get("arguments"))
+                        .ok_or_else(|| anyhow::anyhow!("guided call envelope has no arguments"))?;
+                    response(name.to_string(), arguments)
+                })
+                .collect()
+        }
+        GuidedToolConstraint::None | GuidedToolConstraint::StructuralTag => {
+            anyhow::bail!("request did not install guided JSON")
+        }
+    }
+}
+
 /// Map v2 per-chunk tool deltas onto OpenAI streaming tool-call chunks. The first
 /// delta for a given tool index carries the minted id, type and function name;
 /// later deltas for that index carry only argument fragments (`id`/`type`/`name`
@@ -228,24 +272,6 @@ fn emit_tool_chunks(
     Some(chunks)
 }
 
-/// Split one push/finish batch of unified deltas into the three OpenAI delta
-/// channels. Each channel is a single concatenated string on the wire, so
-/// collapsing one batch is lossless w.r.t. the schema while still emitting
-/// reasoning WHERE it occurred rather than hoisting it ahead of a call.
-fn fold_unified_deltas(deltas: Vec<UnifiedParserEvent>) -> (String, String, Vec<ToolCallDelta>) {
-    let mut reasoning = String::new();
-    let mut text = String::new();
-    let mut calls = Vec::new();
-    for delta in deltas {
-        match delta {
-            UnifiedParserEvent::Reasoning(t) => reasoning.push_str(&t),
-            UnifiedParserEvent::Text(t) => text.push_str(&t),
-            UnifiedParserEvent::ToolCall(call) => calls.push(call),
-        }
-    }
-    (reasoning, text, calls)
-}
-
 /// Per-choice streaming state: one parser plus the set of tool indices whose
 /// opening delta (id + type + function name) has already been emitted.
 struct ChoiceState {
@@ -270,29 +296,7 @@ impl ChoiceState {
     }
 }
 
-/// Per-choice UNIFIED streaming state: one unified parser plus the same
-/// tool-index opened-set as [`ChoiceState`], so the id-minting contract is
-/// shared verbatim.
-struct UnifiedChoiceState {
-    parser: Box<dyn UnifiedParser>,
-    opened: HashSet<usize>,
-}
-
-impl UnifiedChoiceState {
-    fn new(family: &str, tools: &[ToolV2]) -> anyhow::Result<Self> {
-        Ok(Self {
-            parser: create_unified_parser_for_family(family, tools)?,
-            opened: HashSet::new(),
-        })
-    }
-
-    fn emit_chunks(
-        &mut self,
-        calls: Vec<ToolCallDelta>,
-    ) -> Option<Vec<ChatCompletionMessageToolCallChunk>> {
-        emit_tool_chunks(&mut self.opened, calls)
-    }
-}
+type UnifiedChoiceState = super::unified_parser::ChoiceState;
 
 /// Finish every choice that has not received an upstream finish reason. This is
 /// called before a usage-only chunk when one exists, with EOF as a fallback.
@@ -357,8 +361,8 @@ fn finish_unterminated_choices(
 fn finish_unterminated_choices_unified(
     states: &mut HashMap<u32, UnifiedChoiceState>,
     finished: &mut HashSet<u32>,
-    tool_emitted: &mut HashSet<u32>,
     template: &NvCreateChatCompletionStreamResponse,
+    emit_tool_calls: bool,
 ) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
     let mut indices: Vec<_> = states
         .keys()
@@ -373,42 +377,36 @@ fn finish_unterminated_choices_unified(
         let state = states
             .get_mut(&index)
             .expect("choice index came from parser state map");
-        let deltas = match state.parser.finish() {
-            Ok(output) => output.events,
-            Err(error) => {
-                tracing::warn!(error = %error, choice_index = index, "muse unified stream finish failed");
-                Vec::new()
-            }
-        };
-        let (reasoning, text, calls) = fold_unified_deltas(deltas);
-        let tool_calls = state.emit_chunks(calls);
-        if tool_calls.is_some() {
-            tool_emitted.insert(index);
+        let deltas = state.finish();
+        let prior_finish_reason = state.unterminated_finish_reason();
+        let mut choices = state.choices_for(
+            &super::unified_parser::empty_choice(index),
+            deltas,
+            emit_tool_calls,
+            prior_finish_reason,
+        );
+        if let Some(last) = choices.last_mut() {
+            last.finish_reason = state.unterminated_finish_reason();
         }
-        let finish_reason = if tool_emitted.contains(&index) {
-            Some(FinishReason::ToolCalls)
-        } else {
-            None
-        };
-        let content = (!text.is_empty()).then_some(ChatCompletionMessageContent::Text(text));
-        let reasoning_content = (!reasoning.is_empty()).then_some(reasoning);
-        if content.is_none()
-            && reasoning_content.is_none()
-            && tool_calls.is_none()
-            && finish_reason.is_none()
-        {
-            continue;
-        }
-        responses.push(stream_choice_chunk_from_template(
-            template,
-            index,
-            content,
-            reasoning_content,
-            tool_calls,
-            finish_reason,
-        ));
+        responses.extend(
+            choices
+                .into_iter()
+                .map(|choice| response_with_choice(template, choice)),
+        );
     }
     responses
+}
+
+fn response_with_choice(
+    template: &NvCreateChatCompletionStreamResponse,
+    choice: dynamo_protocols::types::ChatChoiceStream,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    let mut data = template.clone();
+    data.inner.choices = vec![choice];
+    data.inner.usage = None;
+    data.nvext = None;
+    data.llm_metrics = None;
+    Annotated::from_data(data)
 }
 
 /// Streaming path: replace the jail with the `family` v2 parser. Each upstream text
@@ -442,6 +440,13 @@ where
         let mut finished: HashSet<u32> = HashSet::new();
         // Choice indices that have emitted at least one tool-call chunk; used to flip a
         // `Stop` terminating reason to `ToolCalls` (OpenAI contract — see below).
+        //
+        // This path never receives an already-parsed chunk for a choice already in
+        // `states` (no already_parsed() detour here, unlike unified_parser.rs's
+        // apply_stream_with_constraint), so a `ChoiceState` here is never dropped
+        // mid-stream and this flag never needs to survive a gap the way
+        // unified_parser.rs's stream-scoped `tool_history` does. Do not merge the two:
+        // they track the same fact for architecturally different streams.
         let mut tool_emitted: HashSet<u32> = HashSet::new();
         // Last data response, kept (with choices cleared) as a template for the
         // end-of-stream flush when no finish_reason chunk arrived.
@@ -450,6 +455,10 @@ where
         tokio::pin!(stream_in);
 
         while let Some(mut response) = stream_in.next().await {
+            if response.is_error() {
+                yield response;
+                return;
+            }
             let Some(chat_response) = response.data.as_mut() else {
                 // Non-data annotations (errors, comments) pass through untouched.
                 yield response;
@@ -605,9 +614,6 @@ where
         let mut states: HashMap<u32, UnifiedChoiceState> = HashMap::new();
         // Choice indices whose finish() has already run (terminating chunk seen).
         let mut finished: HashSet<u32> = HashSet::new();
-        // Choice indices that have emitted at least one tool-call chunk; used to flip
-        // a `Stop` terminating reason to `ToolCalls` (OpenAI contract).
-        let mut tool_emitted: HashSet<u32> = HashSet::new();
         // Last data response, kept (with choices cleared) as a template for the
         // end-of-stream flush when no finish_reason chunk arrived.
         let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
@@ -615,6 +621,10 @@ where
         tokio::pin!(stream_in);
 
         while let Some(mut response) = stream_in.next().await {
+            if response.is_error() {
+                yield response;
+                return;
+            }
             let Some(chat_response) = response.data.as_mut() else {
                 // Non-data annotations (errors, comments) pass through untouched.
                 yield response;
@@ -628,15 +638,32 @@ where
             }
             let is_empty_choices = chat_response.inner.choices.is_empty();
 
-            for choice in chat_response.inner.choices.iter_mut() {
-                let state = states.entry(choice.index).or_insert_with(|| {
+            if is_empty_choices {
+                if let Some(template) = &template {
+                    for terminal in finish_unterminated_choices_unified(
+                        &mut states,
+                        &mut finished,
+                        template,
+                        emit_tool_calls,
+                    ) {
+                        yield terminal;
+                    }
+                }
+                yield response;
+                continue;
+            }
+
+            let originals = std::mem::take(&mut chat_response.inner.choices);
+            let mut emitted = Vec::new();
+            for original in originals {
+                let state = states.entry(original.index).or_insert_with(|| {
                     // Family validated above; construction is deterministic in-process.
-                    UnifiedChoiceState::new(&family, &v2_tools)
+                    UnifiedChoiceState::new_default(&family, &v2_tools)
                         .expect("dynamo-parsers-v2 unified parser construction validated above")
                 });
 
                 // Only text content feeds the parser; multimodal parts pass through.
-                let text = match choice.delta.content.as_ref() {
+                let text = match original.delta.content.as_ref() {
                     Some(ChatCompletionMessageContent::Text(t)) => Some(t.clone()),
                     _ => None,
                 };
@@ -644,82 +671,57 @@ where
                 let mut deltas: Vec<UnifiedParserEvent> = Vec::new();
                 let mut parsed_any = false;
                 if let Some(text) = text.as_deref() {
-                    match state.parser.push(text) {
-                        Ok(mut pushed) => {
-                            deltas.append(&mut pushed);
-                            parsed_any = true;
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, family = %family, "muse unified push failed; passing chunk through");
-                        }
-                    }
+                    deltas.extend(state.push(text));
+                    parsed_any = true;
                 }
                 // Flush on the terminating chunk so a value truncated at EOF is dropped
                 // and open reasoning is promoted.
-                if choice.finish_reason.is_some() && finished.insert(choice.index) {
-                    match state.parser.finish() {
-                        Ok(mut flushed) => {
-                            deltas.append(&mut flushed.events);
-                            parsed_any = true;
-                        }
-                        Err(e) => {
-                            tracing::warn!(error = %e, family = %family, "muse unified finish failed");
-                        }
-                    }
+                if original.finish_reason.is_some() && finished.insert(original.index) {
+                    deltas.extend(state.finish());
+                    parsed_any = true;
                 }
 
                 if parsed_any {
-                    let (reasoning, out_text, calls) = fold_unified_deltas(deltas);
-                    // Dropped BEFORE `emit_chunks` so the index state never advances on a
-                    // call the client will not see, and so `tool_emitted` stays empty and
-                    // the finish_reason is not flipped to `ToolCalls`.
-                    let calls = if emit_tool_calls { calls } else { Vec::new() };
-                    let tool_calls = state.emit_chunks(calls);
-                    if tool_calls.is_some() {
-                        tool_emitted.insert(choice.index);
+                    let mut parsed = state.choices_for(
+                        &original,
+                        deltas,
+                        emit_tool_calls,
+                        original.finish_reason,
+                    );
+                    if parsed.is_empty() {
+                        parsed.push(super::unified_parser::empty_choice(original.index));
                     }
-                    // The parser consumed the text input, so replace every channel
-                    // from its output — raw markup must never reach the client. Role
-                    // and logprobs are preserved as-is.
-                    //
-                    // Reasoning is the exception: only FILL it, never clear it. A
-                    // topology-A worker splits the markup itself and sends
-                    // `reasoning_content` already populated, and this pass sees only
-                    // `Text` events for that chunk. Assigning unconditionally replaced
-                    // the worker's reasoning with `None` and lost the channel. The
-                    // batch path in `aggregator.rs` guards it the same way.
-                    if !reasoning.is_empty() {
-                        choice.delta.reasoning_content = Some(reasoning);
-                    }
-                    choice.delta.content = (!out_text.is_empty())
-                        .then_some(ChatCompletionMessageContent::Text(out_text));
-                    choice.delta.tool_calls = tool_calls;
-                }
-
-                // OpenAI streaming contract: once a choice has emitted tool calls, a
-                // `Stop` terminating reason must be reported as `ToolCalls`.
-                if choice.finish_reason == Some(FinishReason::Stop)
-                    && tool_emitted.contains(&choice.index)
-                {
-                    choice.finish_reason = Some(FinishReason::ToolCalls);
+                    emitted.extend(parsed);
+                } else {
+                    emitted.push(original);
                 }
             }
 
-            // OpenAI stream ordering requires a terminal finish_reason before the
-            // usage-only chunk. Finish every unterminated choice before yielding an
-            // empty-choices response; EOF below remains the fallback.
-            if is_empty_choices && let Some(template) = &template {
-                for terminal in finish_unterminated_choices_unified(
-                    &mut states,
-                    &mut finished,
-                    &mut tool_emitted,
-                    template,
-                ) {
-                    yield terminal;
+            let last = emitted.len() - 1;
+            let Some(llm_metrics_position) =
+                super::unified_parser::fanout_llm_metrics_position(&emitted)
+            else {
+                continue;
+            };
+            for (position, choice) in emitted.into_iter().enumerate() {
+                let is_last = position == last;
+                let mut data = chat_response.clone();
+                data.inner.choices = vec![choice];
+                if !is_last {
+                    data.inner.usage = None;
+                    data.nvext = None;
                 }
+                if position != llm_metrics_position {
+                    data.llm_metrics = None;
+                }
+                yield Annotated {
+                    data: Some(data),
+                    id: if is_last { response.id.take() } else { None },
+                    event: if is_last { response.event.take() } else { None },
+                    comment: if is_last { response.comment.take() } else { None },
+                    error: if is_last { response.error.take() } else { None },
+                };
             }
-
-            yield response;
         }
 
         // Backstop: the stream ended without a finish_reason for some choice.
@@ -727,8 +729,8 @@ where
             for terminal in finish_unterminated_choices_unified(
                 &mut states,
                 &mut finished,
-                &mut tool_emitted,
                 template,
+                emit_tool_calls,
             ) {
                 yield terminal;
             }
@@ -949,6 +951,26 @@ mod tests {
             final_finish_reason(&out),
             Some(FinishReason::Stop),
             "no tool calls emitted -> finish_reason stays Stop"
+        );
+    }
+
+    #[tokio::test]
+    async fn qwen3_terminal_error_suppresses_eof_recovery() {
+        let out = apply_stream(
+            stream::iter([
+                chunk("hello <tool_c", false),
+                Annotated::from_error("backend exploded"),
+            ]),
+            None,
+            "qwen3_coder".to_string(),
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let error_position = out.iter().position(Annotated::is_error).unwrap();
+        assert!(
+            out[error_position + 1..]
+                .iter()
+                .all(|response| response.data.is_none())
         );
     }
 
@@ -1216,6 +1238,27 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn muse_terminal_error_suppresses_eof_recovery() {
+        let out = apply_unified_stream(
+            stream::iter([
+                chunk("<|start|>assistant to=self<|mess", false),
+                Annotated::from_error("backend exploded"),
+            ]),
+            None,
+            "muse_glimmer".to_string(),
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let error_position = out.iter().position(Annotated::is_error).unwrap();
+        assert!(
+            out[error_position + 1..]
+                .iter()
+                .all(|response| response.data.is_none())
+        );
+    }
+
     // Missing-finish-reason backstop: the stream ends with a usage-only chunk and
     // no terminating finish_reason. The end-of-stream flush must synthesize
     // `ToolCalls` before the usage chunk so a strict client does not hang.
@@ -1370,33 +1413,41 @@ mod tests {
         assert_eq!(args["location"], "Paris");
     }
 
-    // A single push carrying reasoning, a tool call and text folds each onto its own
-    // channel (no cross-leak), and empty-string deltas stay empty (dropped downstream
-    // by `then_some`).
-    #[test]
-    fn fold_unified_deltas_routes_each_channel_and_drops_empties() {
-        let deltas = vec![
-            UnifiedParserEvent::Reasoning("think".into()),
-            UnifiedParserEvent::ToolCall(ToolCallDelta {
-                tool_index: 0,
-                name: Some("f".into()),
-                arguments: "{}".into(),
-            }),
-            UnifiedParserEvent::Text("ans".into()),
-        ];
-        let (r, t, c) = fold_unified_deltas(deltas);
-        assert_eq!(
-            r, "think",
-            "Reasoning must land on the reasoning channel only"
+    #[tokio::test]
+    async fn muse_unified_preserves_event_order_within_one_push() {
+        let turn = concat!(
+            "<|start|>assistant to=self<|message|>Look it up.<|eom|>",
+            "<|start|>assistant to=get_weather<|message|><atem:invoke name=\"get_weather\"><atem:parameter name=\"location\">Paris</atem:parameter></atem:invoke><|eom|>",
+            "<|start|>assistant to=self<|message|>Verify it.<|eom|>",
+            "<|start|>assistant to=user<|message|>It's 18C.<|eot|>"
         );
-        assert_eq!(t, "ans", "Text must land on the content channel only");
-        assert_eq!(c.len(), 1, "ToolCall must land on the calls channel only");
-        // Empty-string deltas accumulate to empty strings (dropped by then_some).
-        let (r2, t2, c2) = fold_unified_deltas(vec![
-            UnifiedParserEvent::Reasoning(String::new()),
-            UnifiedParserEvent::Text(String::new()),
-        ]);
-        assert!(r2.is_empty() && t2.is_empty() && c2.is_empty());
+        let out = apply_unified_stream(
+            stream::iter([chunk(turn, true)]),
+            None,
+            "muse_glimmer".to_string(),
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let mut kinds = Vec::new();
+        for choice in out
+            .iter()
+            .filter_map(|response| response.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+        {
+            if choice.delta.reasoning_content.is_some() {
+                kinds.push("reasoning");
+            }
+            if choice.delta.tool_calls.is_some() {
+                kinds.push("tool");
+            }
+            if choice.delta.content.is_some() {
+                kinds.push("text");
+            }
+        }
+        kinds.dedup();
+        assert_eq!(kinds, ["reasoning", "tool", "reasoning", "text"]);
     }
 
     // Topology A: the worker already stripped markers, then the frontend aggregator
@@ -1502,5 +1553,42 @@ mod tests {
             "choice1 must NOT inherit choice0's call: {n1:?}"
         );
         assert_eq!(f1, Some(FinishReason::Stop), "choice1 stays Stop (no flip)");
+    }
+
+    #[tokio::test]
+    async fn muse_packed_choice_fanout_keeps_source_metrics_on_reasoning() {
+        let choice0 = format!("{MUSE_REASONING}{MUSE_ANSWER}");
+        let mut source = two_choice_chunk(&choice0, MUSE_ANSWER, false);
+        source.data.as_mut().unwrap().llm_metrics =
+            Some(crate::protocols::common::metrics::LLMMetricAnnotation {
+                chunk_tokens: 6,
+                ..Default::default()
+            });
+
+        let out = apply_unified_stream(
+            stream::iter([source]),
+            None,
+            "muse_glimmer".to_string(),
+            true,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let metric_choices: Vec<_> = out
+            .iter()
+            .filter_map(|response| response.data.as_ref())
+            .filter(|data| data.llm_metrics.is_some())
+            .flat_map(|data| data.inner.choices.iter())
+            .collect();
+
+        assert_eq!(
+            metric_choices.len(),
+            1,
+            "source metrics must be emitted once"
+        );
+        assert_eq!(metric_choices[0].index, 0);
+        assert!(
+            metric_choices[0].delta.reasoning_content.is_some(),
+            "packed choice order must not move metrics onto the later visible choice"
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -393,6 +393,26 @@ fn tool_output_mode(constraint: &GuidedToolConstraint) -> UnifiedToolOutputMode 
     }
 }
 
+/// The malformed-guided-payload contract for one request, selected by the
+/// guided tool-call streaming rollback lever.
+///
+/// Only [`InvalidGuidedPayloadPolicy::StreamBestEffort`] may emit a call before its
+/// payload closes; the other two contracts buffer to completion (see the policy's
+/// own doc table). So this IS the streaming decision on the unified path, the same
+/// way `guided_streaming` is on the jail path — the caller passes down one already-
+/// made decision rather than re-deriving it here.
+///
+/// Rolling back picks `RecoverAsText`, not `Reject`: the lever exists to stop early
+/// emission, not to convert a malformed payload from recovered text into a typed
+/// error, which would be a second, louder behaviour change riding along with it.
+fn invalid_guided_payload_policy(guided_streaming: bool) -> InvalidGuidedPayloadPolicy {
+    if guided_streaming {
+        InvalidGuidedPayloadPolicy::StreamBestEffort
+    } else {
+        InvalidGuidedPayloadPolicy::RecoverAsText
+    }
+}
+
 /// Select the complete-output grammar from the bytes that actually arrived.
 ///
 /// A remote frontend can reconstruct a forced request as guided JSON without seeing
@@ -488,6 +508,7 @@ impl ChoiceState {
         tools: &[Tool],
         prefill: UnifiedParserStartingState,
         tool_output_mode: UnifiedToolOutputMode,
+        guided_streaming: bool,
     ) -> anyhow::Result<Self> {
         let mut parser = create_unified_parser_for_family(family, tools)?;
         // `prompt_token_ids` stays empty: this path establishes the starting state from
@@ -496,12 +517,17 @@ impl ChoiceState {
         //
         // Streaming guided calls commit per call once the name and argument object opener
         // are unambiguous. A committed fragment cannot later be rejected or recovered as
-        // text, so this path opts into that contract explicitly.
+        // text, so this path opts into that contract explicitly — unless the request
+        // rolled guided tool streaming back, in which case it buffers to completion.
+        // `guided_streaming` is decided once per request by
+        // `OpenAIPreprocessor::guided_tool_streaming_release` and threaded down here;
+        // it is inert in `UnifiedToolOutputMode::Native`, where the parser builds no
+        // guided state at all.
         parser.initialize_request(UnifiedParserInit {
             prompt_token_ids: Vec::new(),
             starting_state: prefill,
             tool_output_mode,
-            invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
+            invalid_guided_payload: invalid_guided_payload_policy(guided_streaming),
         })?;
         Ok(Self {
             family: family.to_string(),
@@ -963,15 +989,25 @@ where
         guided_tool_constraint,
         prefill,
         family,
+        // Streaming released, matching the production default when the rollback lever
+        // is unset. Tests that exercise the rolled-back contract call
+        // `apply_stream_with_constraint` directly with `false`.
+        true,
     )
 }
 
+/// `guided_streaming` is the request's already-made guided tool-call streaming
+/// decision (`OpenAIPreprocessor::guided_tool_streaming_release`), not a second
+/// derivation of it: `true` releases each call as soon as its name and argument
+/// object opener are unambiguous, `false` buffers every call to completion. It is
+/// inert unless `guided_tool_constraint` installed guided JSON.
 pub(crate) fn apply_stream_with_constraint<S>(
     stream_in: S,
     tool_definitions: Option<Vec<ToolDefinition>>,
     guided_tool_constraint: GuidedToolConstraint,
     prefill: UnifiedParserStartingState,
     family: &'static str,
+    guided_streaming: bool,
 ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
 where
     S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
@@ -1115,7 +1151,7 @@ where
                         } else {
                             prefill
                         };
-                        match ChoiceState::new(family, &tools, choice_prefill, mode) {
+                        match ChoiceState::new(family, &tools, choice_prefill, mode, guided_streaming) {
                             Ok(mut state) => {
                                 // A raw run resuming after an already-parsed detour
                                 // gets a brand-new parser instance; seed it with any
@@ -1658,6 +1694,7 @@ mod tests {
             &[],
             UnifiedParserStartingState::None,
             UnifiedToolOutputMode::Native,
+            true,
         )
         .expect("qwen3 unified parser")
     }
@@ -2118,6 +2155,99 @@ mod tests {
                 .as_ref()
                 .and_then(|function| function.name.as_deref()),
             Some("get_weather")
+        );
+    }
+
+    /// Drive one guided-`required` stream whose payload closes only in the LAST
+    /// upstream chunk, and report how many emitted responses carried a tool-call
+    /// delta plus the assembled logical events.
+    ///
+    /// Anything counted above one is an argument fragment that went out before the
+    /// payload closed, which is exactly the difference the guided tool-call
+    /// streaming rollback lever is supposed to make. Nothing here touches process
+    /// env, so it is safe under the default parallel test runner.
+    async fn guided_required_tool_chunk_count(
+        guided_streaming: bool,
+    ) -> (usize, Vec<LogicalEvent>) {
+        let head = r#"reason</think>[{"name":"get_weather","arguments":{"city":"Tok"#;
+        let tail = r#"yo"}}]"#;
+        let responses = apply_stream_with_constraint(
+            stream::iter([chunk(head, false), chunk(tail, true)]),
+            Some(weather_tools()),
+            GuidedToolConstraint::GuidedJsonRequired,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+            guided_streaming,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let tool_chunks = responses
+            .iter()
+            .filter(|response| {
+                response.data.as_ref().is_some_and(|data| {
+                    data.inner.choices.iter().any(|choice| {
+                        choice
+                            .delta
+                            .tool_calls
+                            .as_ref()
+                            .is_some_and(|calls| !calls.is_empty())
+                    })
+                })
+            })
+            .count();
+        (tool_chunks, logical_events(&responses))
+    }
+
+    #[tokio::test]
+    async fn guided_streaming_rollback_buffers_the_call_to_completion() {
+        let expected_call = LogicalEvent::Tool {
+            index: 0,
+            name: Some("get_weather".to_string()),
+            arguments: r#"{"city":"Tokyo"}"#.to_string(),
+        };
+
+        // Released (production default when DYN_ENABLE_GUIDED_TOOL_STREAMING is unset):
+        // the call goes out in pieces as the argument object streams in.
+        let (released_chunks, released_events) = guided_required_tool_chunk_count(true).await;
+        assert!(
+            released_chunks > 1,
+            "guided streaming must emit argument fragments before the payload closes, \
+             got {released_chunks} tool-call chunk(s)"
+        );
+
+        // Rolled back (DYN_ENABLE_GUIDED_TOOL_STREAMING=0): nothing may go out until the
+        // payload closes, so the whole call arrives as one chunk.
+        let (rolled_back_chunks, rolled_back_events) =
+            guided_required_tool_chunk_count(false).await;
+        assert_eq!(
+            rolled_back_chunks, 1,
+            "DYN_ENABLE_GUIDED_TOOL_STREAMING=0 must buffer the guided call to completion \
+             on the unified path, but {rolled_back_chunks} tool-call chunk(s) went out"
+        );
+
+        // The lever changes WHEN the call is emitted, never WHAT is emitted.
+        assert!(
+            released_events.contains(&expected_call),
+            "released events lost the call: {released_events:?}"
+        );
+        assert!(
+            rolled_back_events.contains(&expected_call),
+            "rolled-back events lost the call: {rolled_back_events:?}"
+        );
+    }
+
+    #[test]
+    fn only_stream_best_effort_may_emit_before_the_payload_closes() {
+        // The two buffering contracts are interchangeable for WHEN, but not for WHAT a
+        // malformed payload becomes, so the rollback must pick `RecoverAsText` (text)
+        // and not `Reject` (typed error).
+        assert_eq!(
+            invalid_guided_payload_policy(true),
+            InvalidGuidedPayloadPolicy::StreamBestEffort
+        );
+        assert_eq!(
+            invalid_guided_payload_policy(false),
+            InvalidGuidedPayloadPolicy::RecoverAsText
         );
     }
 

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -182,6 +182,47 @@ pub(crate) fn stream_prefill(
     }
 }
 
+/// Resolve a `Reasoning`-prefill choice's ACTUAL starting state when guided JSON is
+/// installed, from the shape of that choice's first content-bearing chunk.
+///
+/// Guided decoding forbids the model from emitting the reasoning closer, so a request
+/// whose rendered prompt already opened reasoning (`prompt_injected_reasoning`) would,
+/// if started unconditionally at `Reasoning`, have its ENTIRE guided JSON payload
+/// swallowed as `reasoning_content` with zero tool calls ever extracted — the parser
+/// waits forever for a closer guided decoding will never produce. But committing to
+/// `None` unconditionally instead is equally wrong: a turn that genuinely reasons before
+/// its guided JSON (`reasoning</think>JSON`) would then be misread as pure content, and
+/// the legitimate `reasoning_content`/`content` split would be lost.
+///
+/// Mirrors `bypass_bare_guided_json`'s shape check in
+/// `Preprocessor::parse_reasoning_content_from_stream_inner` (preprocessor.rs), which
+/// makes the identical call for the non-unified reasoning-parser path: a payload whose
+/// first non-whitespace byte is `[` or `{` is bare guided JSON with no reasoning to
+/// split out (start at `None`, so the whole payload reaches the tool/response path
+/// untouched); anything else is ordinary text, meaning this really is a reasoning block
+/// that will close normally (start at `Reasoning`).
+///
+/// An empty or whitespace-only first chunk (e.g. a role-only opening delta) is
+/// inconclusive by this single-chunk check — unlike the legacy path, which re-evaluates
+/// per subsequent chunk, the unified parser commits to a starting state once at
+/// `ChoiceState` creation, so an inconclusive first chunk conservatively keeps the
+/// `Reasoning` default rather than risking a genuine reasoning turn being misclassified.
+fn bare_guided_json_prefill(
+    first_content: Option<&ChatCompletionMessageContent>,
+) -> UnifiedParserStartingState {
+    let Some(ChatCompletionMessageContent::Text(text)) = first_content else {
+        return UnifiedParserStartingState::Reasoning;
+    };
+    let trimmed = text.trim_start();
+    if trimmed.is_empty() {
+        return UnifiedParserStartingState::Reasoning;
+    }
+    match trimmed.as_bytes()[0] {
+        b'[' | b'{' => UnifiedParserStartingState::None,
+        _ => UnifiedParserStartingState::Reasoning,
+    }
+}
+
 /// Which channel the prompt opened, inferred from complete output text.
 ///
 /// The batch path has no prompt in hand, only what the model produced, so the channel
@@ -190,19 +231,41 @@ pub(crate) fn stream_prefill(
 /// neither marker means reasoning never ran for this turn.
 fn detect_prefill(family: &str, content: &str) -> anyhow::Result<UnifiedParserStartingState> {
     match family {
-        QWEN3_UNIFIED_FAMILY => Ok(if contains_unquoted_marker(content, "<think>") {
-            UnifiedParserStartingState::None
-        } else if contains_unquoted_marker(content, "</think>") {
-            UnifiedParserStartingState::Reasoning
-        } else {
-            UnifiedParserStartingState::Response
-        }),
+        QWEN3_UNIFIED_FAMILY => {
+            // Compare FIRST-occurrence positions, not mere presence: a prompt that
+            // pre-opened reasoning produces a leading `</think>` with no opener before
+            // it, but a later `<think>...</think>` pair from the model can still follow
+            // in the same output (e.g. after a tool-call gap). Testing "does an opener
+            // exist anywhere" before "does a closer exist anywhere" would misclassify
+            // that case as `None` instead of `Reasoning`.
+            let opener = first_unquoted_marker_position(content, "<think>");
+            let closer = first_unquoted_marker_position(content, "</think>");
+            Ok(match (opener, closer) {
+                // No opener before it (or no opener at all): the prompt opened reasoning.
+                (None, Some(_)) => UnifiedParserStartingState::Reasoning,
+                (Some(open_at), Some(close_at)) if close_at < open_at => {
+                    UnifiedParserStartingState::Reasoning
+                }
+                // An opener exists (and any closer does not precede it): the model will
+                // open reasoning itself later, currently visible as ordinary text.
+                (Some(_), _) => UnifiedParserStartingState::None,
+                (None, None) => UnifiedParserStartingState::Response,
+            })
+        }
         other => anyhow::bail!("no prefill detector for unified parser family '{other}'"),
     }
 }
 
 /// Marker-looking text quoted as prose is visible content, not parser control syntax.
 pub(crate) fn contains_unquoted_marker(content: &str, marker: &str) -> bool {
+    first_unquoted_marker_position(content, marker).is_some()
+}
+
+/// The byte offset of the first unquoted occurrence of `marker` in `content`, or `None`
+/// if it never appears outside a quoted span. Shared scanner behind
+/// [`contains_unquoted_marker`] and [`detect_prefill`], which needs the position (not
+/// just presence) to compare two markers' first occurrences.
+fn first_unquoted_marker_position(content: &str, marker: &str) -> Option<usize> {
     let chars: Vec<(usize, char)> = content.char_indices().collect();
     // Whether an unescaped `"`, `'`, or `` ` `` appears anywhere at or after each
     // position, precomputed once in O(n) so the scan below doesn't rescan the
@@ -223,15 +286,21 @@ pub(crate) fn contains_unquoted_marker(content: &str, marker: &str) -> bool {
             }
             continue;
         }
+        // A contraction/possessive apostrophe is exempt from quote-opening whenever
+        // EITHER side is alphanumeric (`James'`, `isn't`, `'twas`) — only an apostrophe
+        // with non-alphanumeric on both sides (`' quoted text '`) is a real quote-open.
+        // Requiring alphanumeric on both sides would treat a word-final possessive like
+        // `James'` as opening a quote, and a later contraction's apostrophe would then
+        // wrongly close that phantom span, hiding every real marker in between.
         let apostrophe = character == '\''
-            && content[..offset]
+            && (content[..offset]
                 .chars()
                 .next_back()
                 .is_some_and(char::is_alphanumeric)
-            && content[offset + character.len_utf8()..]
-                .chars()
-                .next()
-                .is_some_and(char::is_alphanumeric);
+                || content[offset + character.len_utf8()..]
+                    .chars()
+                    .next()
+                    .is_some_and(char::is_alphanumeric));
         // A quote that never closes before end-of-string was never really quoting
         // anything; treating it as an open span would blind the rest of the scan to
         // a real marker that follows (e.g. a stray `"` before a genuine `</think>`).
@@ -243,10 +312,10 @@ pub(crate) fn contains_unquoted_marker(content: &str, marker: &str) -> bool {
             continue;
         }
         if content[offset..].starts_with(marker) {
-            return true;
+            return Some(offset);
         }
     }
-    false
+    None
 }
 
 /// Index into the fixed-size "which quote characters close later" arrays used by
@@ -683,14 +752,29 @@ pub(crate) fn parse_complete(
     family: &str,
     content: &str,
     guided_tool_constraint: &GuidedToolConstraint,
+    tool_definitions: &[ToolDefinition],
 ) -> anyhow::Result<CompleteOutput> {
-    let mut parser = create_unified_parser_for_family(family, &[])?;
+    let tools = to_v2_tools(Some(tool_definitions));
+    let mut parser = create_unified_parser_for_family(family, &tools)?;
     // Batch replays already-generated output. Prefer its observable native marker when
     // topology B could not carry the worker's installed structural tag to the frontend;
     // otherwise use the reconstructed guided-JSON constraint.
+    let effective_mode = batch_tool_output_mode(content, guided_tool_constraint);
+    // `batch_tool_output_mode` drops to `Native` on observed markup even when the
+    // constraint reconstructed a `GuidedJsonNamed` pin. That native fallback recovers
+    // whatever tool name the markup happens to contain, so it must be checked against
+    // the forced name below instead of trusted unfiltered — a malformed guided output
+    // that embeds a *different* tool's markup must not be handed back as the pinned
+    // tool's call.
+    let forced_tool_name = match (guided_tool_constraint, &effective_mode) {
+        (GuidedToolConstraint::GuidedJsonNamed { tool_name }, UnifiedToolOutputMode::Native) => {
+            Some(tool_name.as_str())
+        }
+        _ => None,
+    };
     parser.initialize_request(UnifiedParserInit {
         starting_state: detect_prefill(family, content)?,
-        tool_output_mode: batch_tool_output_mode(content, guided_tool_constraint),
+        tool_output_mode: effective_mode,
         ..UnifiedParserInit::default()
     })?;
 
@@ -702,6 +786,14 @@ pub(crate) fn parse_complete(
             UnifiedEvent::Text { text: chunk } => text.push_str(&chunk),
             UnifiedEvent::Reasoning { text: chunk } => reasoning.push_str(&chunk),
             UnifiedEvent::ToolCall { name, arguments } => {
+                if forced_tool_name.is_some_and(|forced| forced != name) {
+                    tracing::warn!(
+                        forced_tool_name = forced_tool_name,
+                        recovered_tool_name = %name,
+                        "dropped native-fallback tool call whose name did not match the tool_choice-forced tool_name"
+                    );
+                    continue;
+                }
                 tool_calls.push(ChatCompletionMessageToolCall {
                     id: format!("call-{}", Uuid::new_v4()),
                     r#type: FunctionType::Function,
@@ -732,6 +824,15 @@ pub(crate) fn parse_complete(
 struct ChoiceRecord {
     tool_emitted: bool,
     finished: bool,
+    /// Whether an already-parsed chunk has EVER interrupted this choice. An
+    /// already-parsed chunk implies the model has already emitted structured output
+    /// (reasoning_content / tool_calls / function_call / `Parts` content), which per
+    /// `already_parsed`'s own trigger set only happens after any reasoning phase would
+    /// have concluded. So a raw run resuming after such a detour must rebuild its
+    /// `ChoiceState` starting at `Response`, never at the outer request-level `prefill`
+    /// (which only describes what the PROMPT opened, before this choice ever ran) — see
+    /// the `Vacant` arm in the main loop below.
+    detoured: bool,
 }
 
 /// Finish every choice that never received a terminating chunk, in index order.
@@ -933,6 +1034,10 @@ where
                     // built for it (e.g. its first-ever chunk is already-parsed),
                     // so it is not invisible to `finish_unterminated_choices`.
                     let record = records.entry(original.index).or_default();
+                    // Any raw run resuming this choice after this point must rebuild
+                    // starting at `Response`, not the outer request-level `prefill` —
+                    // see the `Vacant` arm below and the field doc on `ChoiceRecord`.
+                    record.detoured = true;
                     // An already-parsed chunk carries its tool calls verbatim in its
                     // own delta rather than through a `ChoiceState`, so that history
                     // has to be observed here directly — a state may never exist for
@@ -991,7 +1096,26 @@ where
                     std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
                     std::collections::hash_map::Entry::Vacant(entry) => {
                         let mode = tool_output_mode(&guided_tool_constraint);
-                        match ChoiceState::new(family, &tools, prefill, mode) {
+                        // `Vacant` covers both a brand-new choice AND one whose
+                        // `ChoiceState` was just dropped by an already-parsed detour.
+                        // Only the former may start at the request-level `prefill`
+                        // (what the PROMPT opened); a choice that has already been
+                        // through a detour has, by definition, already emitted
+                        // structured output, so its reasoning phase (if any) already
+                        // concluded and a resumed raw run must start at `Response`.
+                        let choice_prefill = if records
+                            .get(&original.index)
+                            .is_some_and(|record| record.detoured)
+                        {
+                            UnifiedParserStartingState::Response
+                        } else if prefill == UnifiedParserStartingState::Reasoning
+                            && guided_tool_constraint.installs_guided_json()
+                        {
+                            bare_guided_json_prefill(original.delta.content.as_ref())
+                        } else {
+                            prefill
+                        };
+                        match ChoiceState::new(family, &tools, choice_prefill, mode) {
                             Ok(mut state) => {
                                 // A raw run resuming after an already-parsed detour
                                 // gets a brand-new parser instance; seed it with any
@@ -1475,6 +1599,49 @@ mod tests {
         assert!(detect_prefill("kimi_k3", "answer").is_err());
     }
 
+    #[test]
+    fn detect_prefill_compares_first_marker_positions_not_mere_presence() {
+        // A prompt-opened reasoning span that the model closes, followed by the model
+        // opening (and closing) a SECOND thought later in the same output. The leading
+        // `</think>` has no opener before it, so the prompt pre-opened reasoning: this
+        // must return `Reasoning`, not `None`. Presence-only testing ("does <think>
+        // exist anywhere") wrongly answers `None` because a `<think>` exists somewhere
+        // in the string, even though it comes AFTER the first `</think>`.
+        assert_eq!(
+            detect_prefill(
+                QWEN3_UNIFIED_FAMILY,
+                "secret</think>answer<think>second thought</think>tail"
+            )
+            .unwrap(),
+            UnifiedParserStartingState::Reasoning,
+            "a leading closer with no prior opener means the prompt pre-opened reasoning, \
+             regardless of a later model-opened thought"
+        );
+    }
+
+    #[test]
+    fn apostrophe_exemption_needs_only_one_alphanumeric_side() {
+        // A possessive apostrophe that ends a word (`James'`) has non-alphanumeric on
+        // the RIGHT. Requiring alphanumeric on both sides treats it as a real
+        // quote-open, and the later contraction apostrophe in `isn't` then closes that
+        // phantom span, hiding the real `</think>` marker in between.
+        assert_eq!(
+            detect_prefill(
+                QWEN3_UNIFIED_FAMILY,
+                "James' secret </think>answer isn't final"
+            )
+            .unwrap(),
+            UnifiedParserStartingState::Reasoning,
+            "a trailing possessive apostrophe must not be treated as a real quote-open"
+        );
+        // Mirror case: a leading contraction (`'twas`) has non-alphanumeric on the LEFT
+        // and alphanumeric only on the right — the OR-based fix must exempt this too.
+        assert!(
+            contains_unquoted_marker("'twas </think> hidden", "</think>"),
+            "a leading-apostrophe contraction must not be treated as a real quote-open"
+        );
+    }
+
     // --- delta -> chunk conversion -----------------------------------------------
 
     fn call_delta(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedParserEvent {
@@ -1828,6 +1995,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bare_guided_json_under_prompt_injected_reasoning_still_becomes_a_tool_call() {
+        // Regression for the guided-JSON-swallowed-as-reasoning bug: a Qwen3-Thinking
+        // style template appends `<think>` to the generation prompt
+        // (`prompt_injected_reasoning`, modeled here by starting the parser at
+        // `Reasoning`), and guided decoding forbids the model from ever emitting
+        // `</think>`. Unconditionally honoring the `Reasoning` prefill would make the
+        // parser wait forever for a closer that will never arrive, classifying the
+        // ENTIRE guided JSON payload as `reasoning_content` with zero tool calls
+        // extracted. The payload here has no `reason</think>` prefix at all — its first
+        // byte is `[` — so `bare_guided_json_prefill` must reclassify this choice's
+        // starting state to `None` and let the array parse as a tool call instead.
+        let responses = apply_stream(
+            stream::iter([chunk(
+                r#"[{"name":"get_weather","parameters":{"city":"Paris"}}]"#,
+                true,
+            )]),
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            false,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert!(
+            choices.iter().all(|c| c.delta.reasoning_content.is_none()),
+            "a bare guided JSON payload with no reasoning prefix must not be classified \
+             as reasoning_content: {choices:?}"
+        );
+        let calls: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .collect();
+        assert_eq!(
+            calls
+                .iter()
+                .find_map(|call| call.function.as_ref()?.name.as_deref()),
+            Some("get_weather"),
+            "the guided JSON payload must still be recovered as a tool call: {choices:?}"
+        );
+        let arguments: String = calls
+            .iter()
+            .filter_map(|call| call.function.as_ref()?.arguments.as_deref())
+            .collect();
+        assert_eq!(arguments, r#"{"city":"Paris"}"#);
+    }
+
+    #[tokio::test]
     async fn required_guided_json_becomes_a_tool_call() {
         let responses = apply_stream(
             stream::iter([chunk(
@@ -2155,6 +2373,54 @@ mod tests {
                 ("content", " after"),
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn raw_preparsed_raw_resumes_at_response_not_original_prefill() {
+        // Request-level prefill is `Reasoning` (prompt-injected reasoning): the first
+        // raw run closes reasoning mid-run. An already-parsed chunk then detours the
+        // choice, dropping its live `ChoiceState`. The next raw chunk must NOT rebuild
+        // starting at `Reasoning` again — an already-parsed chunk implies the model has
+        // already emitted structured output, which only happens after any reasoning
+        // phase concluded, so the resumed run's text belongs to `content`.
+        let mut pre_parsed = chunk("", false);
+        let choice = &mut pre_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+
+        let responses = apply_stream(
+            stream::iter([
+                chunk("secret</think>visible-before-gap ", false),
+                pre_parsed,
+                chunk("visible-after-gap", true),
+            ]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        let reasoning: String = choices
+            .iter()
+            .filter_map(|choice| choice.delta.reasoning_content.as_deref())
+            .collect();
+        let visible: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            visible, "visible-before-gap visible-after-gap",
+            "text after the already-parsed gap must resume as content, not reasoning"
+        );
+        assert_eq!(reasoning, "secretalready parsed");
     }
 
     #[tokio::test]
@@ -2979,6 +3245,7 @@ mod tests {
                 "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
             ),
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
 
@@ -2999,6 +3266,7 @@ mod tests {
             QWEN3_UNIFIED_FAMILY,
             "hidden</think>visible",
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
         assert_eq!(parsed.reasoning, "hidden");
@@ -3012,6 +3280,7 @@ mod tests {
             QWEN3_UNIFIED_FAMILY,
             r#"hidden "unfinished</think>visible"#,
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
 
@@ -3027,6 +3296,7 @@ mod tests {
             QWEN3_UNIFIED_FAMILY,
             "hidden 'unfinished</think>visible",
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
 
@@ -3040,6 +3310,7 @@ mod tests {
             QWEN3_UNIFIED_FAMILY,
             "hidden `unfinished</think>visible",
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
 
@@ -3071,14 +3342,24 @@ mod tests {
     #[test]
     fn marker_looking_visible_text_stays_visible_in_batch() {
         let literal = "The literal \"</think>\" closes reasoning.";
-        let parsed =
-            parse_complete(QWEN3_UNIFIED_FAMILY, literal, &GuidedToolConstraint::None).unwrap();
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            literal,
+            &GuidedToolConstraint::None,
+            &[],
+        )
+        .unwrap();
         assert_eq!(parsed.text, literal);
         assert!(parsed.reasoning.is_empty());
 
         let embedded = "The string \"a </think> token\" stays visible.";
-        let parsed =
-            parse_complete(QWEN3_UNIFIED_FAMILY, embedded, &GuidedToolConstraint::None).unwrap();
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            embedded,
+            &GuidedToolConstraint::None,
+            &[],
+        )
+        .unwrap();
         assert_eq!(parsed.text, embedded);
         assert!(parsed.reasoning.is_empty());
     }
@@ -3089,10 +3370,48 @@ mod tests {
             QWEN3_UNIFIED_FAMILY,
             "just an answer",
             &GuidedToolConstraint::None,
+            &[],
         )
         .unwrap();
         assert_eq!(parsed.text, "just an answer");
         assert!(parsed.reasoning.is_empty());
         assert!(parsed.tool_calls.is_empty());
+    }
+
+    // Regression for a batch/streaming argument-type divergence: `parse_complete`
+    // used to hardcode an empty tool slice, so it had no schema to type-coerce
+    // arguments against and always emitted them as JSON strings. The streaming
+    // path (`apply_stream_with_constraint`) builds its parser from the request's
+    // real `tool_definitions` and correctly coerces `count` to an integer for the
+    // same input. Passing the real tool schema through here must match that.
+    #[test]
+    fn batch_path_coerces_argument_types_from_the_real_tool_schema() {
+        let tool_definitions = vec![ToolDefinition {
+            name: "set_count".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {"count": {"type": "integer"}},
+                "required": ["count"],
+            })),
+            strict: None,
+        }];
+
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            concat!(
+                "<tool_call>\n<function=set_count>\n",
+                "<parameter=count>42</parameter>\n</function>\n</tool_call>"
+            ),
+            &GuidedToolConstraint::None,
+            &tool_definitions,
+        )
+        .unwrap();
+
+        assert_eq!(
+            parsed.tool_calls[0].function.arguments, r#"{"count":42}"#,
+            "batch path must type-coerce `count` to an integer using the real tool \
+             schema, matching what the streaming path already produces for the same \
+             input"
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -1,0 +1,3098 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Opt-in ordered reasoning, text, and tool-call parsing through one state machine.
+//!
+//! Gated behind
+//! [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](dynamo_runtime::config::environment_names::llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2).
+//!
+//! # What this replaces
+//!
+//! Dynamo serves a Qwen3 turn today by chaining two independent parsers: the reasoning
+//! parser strips `<think>...</think>` across the whole stream into one assembled
+//! `reasoning_content`, and the tool-call jail then scans whatever is left. That chain
+//! cannot represent WHERE a thought happened. Given
+//!
+//! ```text
+//! <think>Look it up.</think><tool_call>…</tool_call><think>Now answer.</think>It's 18C.
+//! ```
+//!
+//! it serves `reasoning("Look it up.Now answer.")`, then the call, then `text("It's 18C.")`:
+//! the second thought moved ahead of the call it followed and fused with the first. A
+//! client rendering thoughts inline puts them in the wrong place, and a client counting
+//! reasoning turns sees one where there were two.
+//!
+//! Ordering is not a field the split can add — it is lost at the seam between the two
+//! parsers. So when this path is enabled, ONE [`UnifiedParser`] owns the whole grammar
+//! and emits deltas in the order the model produced them, and this module maps those
+//! deltas onto the OpenAI streaming/batch wire shapes.
+//!
+//! # Why one chunk per delta
+//!
+//! [`ChatCompletionStreamResponseDelta`] carries `content`, `reasoning_content` and
+//! `tool_calls` side by side with no way to say which came first. Packing a whole
+//! `push` into one delta object would throw away exactly the ordering this path exists
+//! to preserve, so every [`UnifiedParserEvent`] becomes its own chunk.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use async_stream::stream;
+use dynamo_parsers::tool_calling::ToolDefinition;
+use dynamo_parsers_v2::{
+    InvalidGuidedPayloadPolicy, Tool, UnifiedEvent, UnifiedParser, UnifiedParserEvent,
+    UnifiedParserExt, UnifiedParserInit, UnifiedParserOutput, UnifiedParserStartingState,
+    UnifiedToolOutputMode, create_unified_parser_for_family,
+};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta, FinishReason,
+    FunctionCall, FunctionCallStream, FunctionType,
+};
+use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
+use dynamo_runtime::protocols::annotated::Annotated;
+use futures::{Stream, StreamExt};
+use uuid::Uuid;
+
+use crate::protocols::openai::GuidedToolConstraint;
+
+use super::NvCreateChatCompletionStreamResponse;
+
+#[cfg(test)]
+use dynamo_protocols::types::ChatCompletionToolChoiceOption;
+
+/// The `dynamo-parsers-v2` unified family that serves Qwen3.
+///
+/// `REGISTERED_UNIFIED_FAMILIES` accepts both `qwen3` and the `qwen3_coder` alias for
+/// the same XML grammar; `qwen3` is the canonical registry name and the one the
+/// conformance corpus uses, so it is what this module passes and logs.
+pub(crate) const QWEN3_UNIFIED_FAMILY: &str = "qwen3";
+
+/// Dynamo's `--dyn-tool-call-parser` name that pairs into [`QWEN3_UNIFIED_FAMILY`].
+const QWEN3_TOOL_CALL_PARSER: &str = "qwen3_coder";
+
+/// Dynamo's `--dyn-reasoning-parser` name that pairs into [`QWEN3_UNIFIED_FAMILY`].
+const QWEN3_REASONING_PARSER: &str = "qwen3";
+
+/// Whether the experimental v2 parser path is enabled. Read once — env vars are fixed
+/// for the process lifetime, so re-reading per request would only add syscalls.
+///
+/// This reuses `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` rather than adding a second switch.
+/// That flag already means "route this family through `dynamo-parsers-v2` instead of the
+/// v1 jail, for BOTH the batch and the streaming path". The unified parser is the same
+/// intent carried one step further: it also takes over reasoning, so the family stops
+/// needing a separate reasoning parser at all. Two flags would have to define what
+/// setting only one of them means for a family that has both, and the answer is not
+/// interesting — so there is one flag, and the parser PAIR decides which v2 shape a
+/// request gets (see `configured_family`).
+fn experimental_parsers_v2_enabled() -> bool {
+    static ENABLED: LazyLock<bool> =
+        LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2));
+    *ENABLED
+}
+
+/// The unified family this parser pair names, ignoring whether it is switched on.
+///
+/// Both halves must be set and must agree: a unified parser owns reasoning AND tool
+/// calls, so taking over a request configured with only one of them, or with a
+/// reasoning parser from a different family, would silently change what the operator
+/// asked for. Split out from [`selected_family`] so the pairing rule can be tested
+/// without the process-wide env flag.
+pub(crate) fn configured_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    match (tool_call_parser, reasoning_parser) {
+        (Some(QWEN3_TOOL_CALL_PARSER), Some(QWEN3_REASONING_PARSER)) => Some(QWEN3_UNIFIED_FAMILY),
+        _ => None,
+    }
+}
+
+/// The unified family to actually use for this parser pair, or `None` to keep the
+/// existing split reasoning-parser + tool-call-jail path.
+pub(crate) fn selected_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    // A request that silently fell back to the split path is otherwise
+    // indistinguishable from one the unified parser handled — the two produce the
+    // same shape of response. One INFO line per stream lets an operator answer
+    // "did v2 actually run?" from the log instead of inferring it from a build
+    // pin, which is exactly the ambiguity that cost real debugging time here.
+    let configured = configured_family(tool_call_parser, reasoning_parser);
+    tracing::info!(
+        target: "dynamo_unified",
+        ?tool_call_parser,
+        ?reasoning_parser,
+        ?configured,
+        flag_on = experimental_parsers_v2_enabled(),
+        "unified parser path decision"
+    );
+    configured.filter(|family| match *family {
+        QWEN3_UNIFIED_FAMILY => experimental_parsers_v2_enabled(),
+        // A family with no opt-in flag stays off; adding one here is what turns it on.
+        _ => false,
+    })
+}
+
+/// The configured family eligible to own raw aggregate text.
+///
+/// Every request for the configured pair opts into the v2 batch parser. Requests that
+/// suppress calls still need the unified decoder to strip native markup before the
+/// calls are discarded, while named/required raw text is decoded using the installed
+/// constraint plus the observed native-marker fallback in [`batch_tool_output_mode`].
+pub(crate) fn configured_batch_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    configured_family(tool_call_parser, reasoning_parser)
+}
+
+pub(crate) fn selected_batch_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    configured_batch_family(tool_call_parser, reasoning_parser).filter(|family| match *family {
+        QWEN3_UNIFIED_FAMILY => experimental_parsers_v2_enabled(),
+        _ => false,
+    })
+}
+
+/// Which channel the rendered generation prompt already opened, for the streaming path.
+///
+/// `prompt_injected_reasoning` is the per-request fact the preprocessor already
+/// computes: the rendered prompt ended with the family's reasoning opener, so generated
+/// output starts inside a thought the model will close without ever emitting the
+/// opener. Absent that, the answer is per family.
+pub(crate) fn stream_prefill(
+    family: &str,
+    prompt_injected_reasoning: bool,
+) -> UnifiedParserStartingState {
+    if prompt_injected_reasoning {
+        return UnifiedParserStartingState::Reasoning;
+    }
+    match family {
+        // Qwen3's generation prompt ends at the assistant header with no channel open,
+        // so the model emits `<think>` itself when it thinks.
+        QWEN3_UNIFIED_FAMILY => UnifiedParserStartingState::None,
+        // A family whose non-thinking prompt ends INSIDE the visible response channel
+        // would return `Response` here. None exists yet; an unknown family gets the
+        // conservative answer, which is to assume the model opens its own channels.
+        _ => UnifiedParserStartingState::None,
+    }
+}
+
+/// Which channel the prompt opened, inferred from complete output text.
+///
+/// The batch path has no prompt in hand, only what the model produced, so the channel
+/// state is read back off the text: a `<think>` opener means the model opened reasoning
+/// itself; a bare `</think>` with no opener means the prompt had already opened it; and
+/// neither marker means reasoning never ran for this turn.
+fn detect_prefill(family: &str, content: &str) -> anyhow::Result<UnifiedParserStartingState> {
+    match family {
+        QWEN3_UNIFIED_FAMILY => Ok(if contains_unquoted_marker(content, "<think>") {
+            UnifiedParserStartingState::None
+        } else if contains_unquoted_marker(content, "</think>") {
+            UnifiedParserStartingState::Reasoning
+        } else {
+            UnifiedParserStartingState::Response
+        }),
+        other => anyhow::bail!("no prefill detector for unified parser family '{other}'"),
+    }
+}
+
+/// Marker-looking text quoted as prose is visible content, not parser control syntax.
+pub(crate) fn contains_unquoted_marker(content: &str, marker: &str) -> bool {
+    let chars: Vec<(usize, char)> = content.char_indices().collect();
+    // Whether an unescaped `"`, `'`, or `` ` `` appears anywhere at or after each
+    // position, precomputed once in O(n) so the scan below doesn't rescan the
+    // remainder of the string for every candidate quote character (which would be
+    // O(n^2) on adversarial text with many non-closing quote-like characters).
+    let closes_later = later_unescaped_quote_closes(&chars);
+
+    let mut quote = None;
+    let mut escaped = false;
+    for (position, &(offset, character)) in chars.iter().enumerate() {
+        if let Some(active_quote) = quote {
+            if escaped {
+                escaped = false;
+            } else if character == '\\' {
+                escaped = true;
+            } else if character == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+        let apostrophe = character == '\''
+            && content[..offset]
+                .chars()
+                .next_back()
+                .is_some_and(char::is_alphanumeric)
+            && content[offset + character.len_utf8()..]
+                .chars()
+                .next()
+                .is_some_and(char::is_alphanumeric);
+        // A quote that never closes before end-of-string was never really quoting
+        // anything; treating it as an open span would blind the rest of the scan to
+        // a real marker that follows (e.g. a stray `"` before a genuine `</think>`).
+        if let Some(slot) = quote_slot(character)
+            && !apostrophe
+            && closes_later[position + 1][slot]
+        {
+            quote = Some(character);
+            continue;
+        }
+        if content[offset..].starts_with(marker) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Index into the fixed-size "which quote characters close later" arrays used by
+/// [`later_unescaped_quote_closes`].
+fn quote_slot(character: char) -> Option<usize> {
+    match character {
+        '"' => Some(0),
+        '\'' => Some(1),
+        '`' => Some(2),
+        _ => None,
+    }
+}
+
+/// For each position in `chars`, whether an unescaped `"`, `'`, or `` ` `` appears
+/// anywhere later in the string — `result[i][quote_slot(c)]` answers "does an
+/// unescaped `c` exist in `chars[i..]`". Built in one right-to-left O(n) pass: the
+/// answer at `i` depends only on `chars[i]` and the answer at `i + 1` (or `i + 2` for
+/// a backslash, which escapes exactly the next character), so this is an exact
+/// backward re-expression of the left-to-right escaped-flag scan that used to be
+/// re-run from scratch for every candidate quote character.
+fn later_unescaped_quote_closes(chars: &[(usize, char)]) -> Vec<[bool; 3]> {
+    let n = chars.len();
+    let mut closes = vec![[false; 3]; n + 1];
+    let mut i = n;
+    while i > 0 {
+        i -= 1;
+        let character = chars[i].1;
+        closes[i] = if character == '\\' {
+            closes.get(i + 2).copied().unwrap_or([false; 3])
+        } else {
+            let mut next = closes[i + 1];
+            if let Some(slot) = quote_slot(character) {
+                next[slot] = true;
+            }
+            next
+        };
+    }
+    closes
+}
+
+/// Map dynamo's v1 [`ToolDefinition`]s onto the v2 parser's [`Tool`] shape.
+fn to_v2_tools(tools: Option<&[ToolDefinition]>) -> Vec<Tool> {
+    tools
+        .unwrap_or(&[])
+        .iter()
+        .map(|tool| Tool {
+            name: tool.name.clone(),
+            description: None,
+            parameters: tool.parameters.clone().unwrap_or(serde_json::Value::Null),
+            strict: tool.strict,
+        })
+        .collect()
+}
+
+/// Map the request's `tool_choice` onto the wire format the backend will produce.
+///
+/// A named or `required` choice is served by guided decoding, which constrains the
+/// model to bare JSON instead of Qwen's native `<tool_call>` XML: a named choice to
+/// that one tool's argument object, `required` to a call object or an array of them.
+/// Unset / `auto` / `none` leave the model in native markup.
+///
+/// Callers must not consult this when a structural tag is active — see
+/// [`apply_stream`]'s `uses_tool_call_structural_tag`.
+fn tool_output_mode(constraint: &GuidedToolConstraint) -> UnifiedToolOutputMode {
+    match constraint {
+        GuidedToolConstraint::GuidedJsonNamed { tool_name } => UnifiedToolOutputMode::GuidedJson {
+            named_tool: Some(tool_name.clone()),
+        },
+        GuidedToolConstraint::GuidedJsonRequired => {
+            UnifiedToolOutputMode::GuidedJson { named_tool: None }
+        }
+        GuidedToolConstraint::None | GuidedToolConstraint::StructuralTag => {
+            UnifiedToolOutputMode::Native
+        }
+    }
+}
+
+/// Select the complete-output grammar from the bytes that actually arrived.
+///
+/// A remote frontend can reconstruct a forced request as guided JSON without seeing
+/// that the worker installed a structural tag. Native Qwen markup is unambiguous once
+/// generated, so prefer that observed shape over the reconstructed request policy.
+fn batch_tool_output_mode(
+    content: &str,
+    constraint: &GuidedToolConstraint,
+) -> UnifiedToolOutputMode {
+    if constraint.installs_guided_json() && contains_unquoted_marker(content, "<tool_call>") {
+        UnifiedToolOutputMode::Native
+    } else {
+        tool_output_mode(constraint)
+    }
+}
+
+/// Merge adjacent same-kind text/reasoning deltas so one `push` does not become three
+/// chunks that say the same thing.
+///
+/// Tool-call deltas never merge: two fragments belonging to different `tool_index`es
+/// would fuse into one call, and even two fragments of the SAME call must keep their
+/// `name`-carrying first delta distinct from later argument-only ones.
+fn coalesce(deltas: Vec<UnifiedParserEvent>) -> Vec<UnifiedParserEvent> {
+    let mut out: Vec<UnifiedParserEvent> = Vec::with_capacity(deltas.len());
+    for delta in deltas {
+        match (out.last_mut(), delta) {
+            (Some(UnifiedParserEvent::Text(prev)), UnifiedParserEvent::Text(text)) => {
+                prev.push_str(&text)
+            }
+            (Some(UnifiedParserEvent::Reasoning(prev)), UnifiedParserEvent::Reasoning(text)) => {
+                prev.push_str(&text)
+            }
+            (_, delta) => out.push(delta),
+        }
+    }
+    out
+}
+
+/// Pick the one fanout child that keeps the source chunk's token metrics.
+///
+/// The reasoning-usage estimator runs after unified parsing and attributes the source
+/// chunk's tokens to reasoning when any emitted child carries `reasoning_content`.
+/// Keeping metrics on the last child unconditionally loses that classification whenever
+/// reasoning is followed by visible text, a tool call, or a later response choice.
+pub(crate) fn fanout_llm_metrics_position(choices: &[ChatChoiceStream]) -> Option<usize> {
+    choices
+        .iter()
+        .position(|choice| choice.delta.reasoning_content.is_some())
+        .or_else(|| choices.len().checked_sub(1))
+}
+
+/// An empty streaming choice for `index`, used as the base every emitted chunk is
+/// filled in from.
+///
+/// `logprobs` is dropped on purpose: once parsing rewrites a choice, the emitted text
+/// no longer lines up token-for-token with the backend's raw stream, so per-token
+/// logprobs would be attached to the wrong characters.
+pub(crate) fn empty_choice(index: u32) -> ChatChoiceStream {
+    #[allow(deprecated)]
+    ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role: None,
+            content: None,
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        logprobs: None,
+    }
+}
+
+/// Per-choice streaming state: one parser instance plus the bookkeeping the OpenAI
+/// streaming tool-call contract needs. One instance parses exactly one choice of one
+/// request, which is what gives per-stream isolation by construction.
+pub(crate) struct ChoiceState {
+    family: String,
+    parser: Box<dyn UnifiedParser>,
+    /// Tool indices whose opening chunk (id + type + name) has already gone out.
+    opened_calls: HashSet<usize>,
+    /// Whether any tool-call chunk was emitted; flips a terminal `Stop` to `ToolCalls`.
+    tool_emitted: bool,
+    /// The parser errored. Later chunks pass through as plain text instead of failing
+    /// the request — a parser bug must not turn a served answer into a 500.
+    failed: bool,
+}
+
+impl ChoiceState {
+    pub(crate) fn new(
+        family: &str,
+        tools: &[Tool],
+        prefill: UnifiedParserStartingState,
+        tool_output_mode: UnifiedToolOutputMode,
+    ) -> anyhow::Result<Self> {
+        let mut parser = create_unified_parser_for_family(family, tools)?;
+        // `prompt_token_ids` stays empty: this path establishes the starting state from
+        // the rendered prompt text (see `stream_prefill` / `detect_prefill`), not from
+        // token IDs, which the preprocessor has already consumed by this point.
+        //
+        // Streaming guided calls commit per call once the name and argument object opener
+        // are unambiguous. A committed fragment cannot later be rejected or recovered as
+        // text, so this path opts into that contract explicitly.
+        parser.initialize_request(UnifiedParserInit {
+            prompt_token_ids: Vec::new(),
+            starting_state: prefill,
+            tool_output_mode,
+            invalid_guided_payload: InvalidGuidedPayloadPolicy::StreamBestEffort,
+        })?;
+        Ok(Self {
+            family: family.to_string(),
+            parser,
+            opened_calls: HashSet::new(),
+            tool_emitted: false,
+            failed: false,
+        })
+    }
+
+    pub(crate) fn new_default(family: &str, tools: &[Tool]) -> anyhow::Result<Self> {
+        Ok(Self {
+            family: family.to_string(),
+            parser: create_unified_parser_for_family(family, tools)?,
+            opened_calls: HashSet::new(),
+            tool_emitted: false,
+            failed: false,
+        })
+    }
+
+    /// Feed one decoded text delta through the parser.
+    pub(crate) fn push(&mut self, text: &str) -> Vec<UnifiedParserEvent> {
+        if self.failed {
+            return text_delta(text.to_string());
+        }
+        let mut output = UnifiedParserOutput::default();
+        match self.parser.parse_into(text, &mut output) {
+            Ok(()) => output.events,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    family = self.family,
+                    "unified parser push failed; falling back to plain text for this choice"
+                );
+                output.events.extend(self.give_up(text));
+                output.events
+            }
+        }
+    }
+
+    /// Flush buffered partial state at end of stream.
+    pub(crate) fn finish(&mut self) -> Vec<UnifiedParserEvent> {
+        if self.failed {
+            return Vec::new();
+        }
+        match self.parser.finish() {
+            // `finish` now hands back the whole `UnifiedParserOutput`; this path only ever
+            // wants the ordered events out of it.
+            Ok(output) => output.events,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    family = self.family,
+                    "unified parser finish failed; recovering buffered text"
+                );
+                self.give_up("")
+            }
+        }
+    }
+
+    /// Stop using the parser and surface whatever it was holding.
+    ///
+    /// `reset()` hands back the bytes the parser had buffered but not yet emitted.
+    /// Dropping them would silently delete model output — the caller would see a
+    /// truncated answer with no indication anything was lost — so they go out as
+    /// visible text. When the parser had nothing buffered, the chunk that broke it
+    /// does instead, so that chunk is not lost either.
+    fn give_up(&mut self, fallback: &str) -> Vec<UnifiedParserEvent> {
+        self.failed = true;
+        let recovered = self.parser.reset();
+        if recovered.is_empty() {
+            text_delta(fallback.to_string())
+        } else {
+            text_delta(recovered)
+        }
+    }
+
+    /// Convert one ordered delta into a streaming choice for `index`.
+    fn delta_to_choice(&mut self, index: u32, delta: UnifiedParserEvent) -> ChatChoiceStream {
+        let mut choice = empty_choice(index);
+        match delta {
+            UnifiedParserEvent::Text(text) => {
+                choice.delta.content = Some(ChatCompletionMessageContent::Text(text));
+            }
+            UnifiedParserEvent::Reasoning(text) => {
+                choice.delta.reasoning_content = Some(text);
+            }
+            UnifiedParserEvent::ToolCall(call) => {
+                self.tool_emitted = true;
+                // The OpenAI streaming tool-call contract: the FIRST chunk for a tool
+                // index carries id + type + name, later chunks carry only argument
+                // fragments. `dynamo-parsers-v2` mints no ids (serving layers own them),
+                // so one is minted here per call, exactly once.
+                let first = self.opened_calls.insert(call.tool_index);
+                choice.delta.tool_calls = Some(vec![ChatCompletionMessageToolCallChunk {
+                    index: call.tool_index as u32,
+                    id: first.then(|| format!("call-{}", Uuid::new_v4())),
+                    r#type: first.then_some(FunctionType::Function),
+                    function: Some(FunctionCallStream {
+                        name: first.then_some(call.name).flatten(),
+                        arguments: Some(call.arguments),
+                    }),
+                }]);
+            }
+        }
+        choice
+    }
+
+    /// Convert an ordered delta run into the streaming choices it becomes.
+    ///
+    /// `role` / `refusal` ride on the first emitted choice and the terminating
+    /// `finish_reason` on the last, so a client that reassembles the stream sees the
+    /// same envelope it would have without this path.
+    pub(crate) fn choices_for(
+        &mut self,
+        original: &ChatChoiceStream,
+        deltas: Vec<UnifiedParserEvent>,
+        emit_tool_calls: bool,
+        finish_reason: Option<FinishReason>,
+    ) -> Vec<ChatChoiceStream> {
+        let deltas = coalesce(
+            deltas
+                .into_iter()
+                .filter(|delta| {
+                    emit_tool_calls || !matches!(delta, UnifiedParserEvent::ToolCall(_))
+                })
+                .collect(),
+        );
+        let index = original.index;
+        let count = deltas.len();
+        let mut choices = Vec::with_capacity(count.max(1));
+
+        for (position, delta) in deltas.into_iter().enumerate() {
+            let mut choice = self.delta_to_choice(index, delta);
+            if position == 0 {
+                choice.delta.role = original.delta.role;
+                choice.delta.refusal = original.delta.refusal.clone();
+                choice.delta.function_call = original.delta.function_call.clone();
+                if let Some(reasoning) = original.delta.reasoning_content.as_deref() {
+                    choice
+                        .delta
+                        .reasoning_content
+                        .get_or_insert_default()
+                        .insert_str(0, reasoning);
+                }
+                if let Some(mut original_calls) = original.delta.tool_calls.clone() {
+                    if !original_calls.is_empty() {
+                        self.tool_emitted = true;
+                    }
+                    if let Some(parsed_calls) = choice.delta.tool_calls.take() {
+                        original_calls.extend(parsed_calls);
+                    }
+                    choice.delta.tool_calls = Some(original_calls);
+                }
+            }
+            if position + 1 == count {
+                choice.finish_reason = self.normalize_finish_reason(finish_reason);
+            }
+            choices.push(choice);
+        }
+
+        // The parser produced nothing, but the chunk still carried envelope state that
+        // has to reach the client (the opening role chunk, a refusal, or the terminal
+        // finish_reason).
+        if choices.is_empty()
+            && (original.delta.role.is_some()
+                || original.delta.refusal.is_some()
+                || original.delta.reasoning_content.is_some()
+                || original.delta.tool_calls.is_some()
+                || original.delta.function_call.is_some()
+                || finish_reason.is_some())
+        {
+            let mut choice = empty_choice(index);
+            choice.delta.role = original.delta.role;
+            choice.delta.refusal = original.delta.refusal.clone();
+            choice.delta.reasoning_content = original.delta.reasoning_content.clone();
+            choice.delta.tool_calls = original.delta.tool_calls.clone();
+            choice.delta.function_call = original.delta.function_call.clone();
+            if choice
+                .delta
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| !calls.is_empty())
+            {
+                self.tool_emitted = true;
+            }
+            choice.finish_reason = self.normalize_finish_reason(finish_reason);
+            choices.push(choice);
+        }
+
+        choices
+    }
+
+    pub(crate) fn unterminated_finish_reason(&self) -> Option<FinishReason> {
+        self.tool_emitted.then_some(FinishReason::ToolCalls)
+    }
+
+    /// Whether this choice has emitted a tool call so far.
+    pub(crate) fn tool_emitted(&self) -> bool {
+        self.tool_emitted
+    }
+
+    /// Seed tool-call history from before an already-parsed detour into a freshly
+    /// constructed parser instance for the same choice index.
+    pub(crate) fn mark_tool_emitted(&mut self) {
+        self.tool_emitted = true;
+    }
+
+    /// OpenAI streaming contract: once a choice has emitted tool calls, a `Stop`
+    /// terminating reason must be reported as `ToolCalls`. `Length` / `ContentFilter`
+    /// describe why generation stopped and are preserved as-is.
+    fn normalize_finish_reason(&self, finish_reason: Option<FinishReason>) -> Option<FinishReason> {
+        if finish_reason == Some(FinishReason::Stop) && self.tool_emitted {
+            Some(FinishReason::ToolCalls)
+        } else {
+            finish_reason
+        }
+    }
+}
+
+/// One text delta, or nothing at all when the text is empty — an empty content chunk
+/// carries no information and clients render it as a stray empty string.
+fn text_delta(text: String) -> Vec<UnifiedParserEvent> {
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        vec![UnifiedParserEvent::Text(text)]
+    }
+}
+
+/// The aggregated result of parsing one complete (non-streaming) output.
+pub(crate) struct CompleteOutput {
+    pub text: String,
+    pub reasoning: String,
+    pub tool_calls: Vec<ChatCompletionMessageToolCall>,
+}
+
+/// Batch (non-streaming) path: run the whole output through the same parser lifecycle
+/// and fold the assembled events into the final message.
+///
+/// Routing batch through `push`/`finish` is what makes stream/batch parity structural
+/// rather than a property two code paths have to agree on.
+///
+/// Reasoning spans are concatenated because the non-streaming message schema has ONE
+/// `reasoning_content` string — the ordering the unified parser recovered survives only
+/// on the streaming path, which is where a client can act on it.
+pub(crate) fn parse_complete(
+    family: &str,
+    content: &str,
+    guided_tool_constraint: &GuidedToolConstraint,
+) -> anyhow::Result<CompleteOutput> {
+    let mut parser = create_unified_parser_for_family(family, &[])?;
+    // Batch replays already-generated output. Prefer its observable native marker when
+    // topology B could not carry the worker's installed structural tag to the frontend;
+    // otherwise use the reconstructed guided-JSON constraint.
+    parser.initialize_request(UnifiedParserInit {
+        starting_state: detect_prefill(family, content)?,
+        tool_output_mode: batch_tool_output_mode(content, guided_tool_constraint),
+        ..UnifiedParserInit::default()
+    })?;
+
+    let mut text = String::new();
+    let mut reasoning = String::new();
+    let mut tool_calls = Vec::new();
+    for event in parser.parse_complete(content)? {
+        match event {
+            UnifiedEvent::Text { text: chunk } => text.push_str(&chunk),
+            UnifiedEvent::Reasoning { text: chunk } => reasoning.push_str(&chunk),
+            UnifiedEvent::ToolCall { name, arguments } => {
+                tool_calls.push(ChatCompletionMessageToolCall {
+                    id: format!("call-{}", Uuid::new_v4()),
+                    r#type: FunctionType::Function,
+                    // `assemble` already parsed the argument fragments into a typed
+                    // object, so this re-serializes rather than passing the model's
+                    // bytes through. Formatting is normalized as a result.
+                    function: FunctionCall {
+                        name,
+                        arguments: serde_json::to_string(&arguments)?,
+                    },
+                });
+            }
+        }
+    }
+
+    Ok(CompleteOutput {
+        text,
+        reasoning,
+        tool_calls,
+    })
+}
+
+/// Per-choice bookkeeping that outlives any single `ChoiceState` instance for that
+/// index: whether it has ever emitted a tool call, and whether its terminal chunk has
+/// already been sent. See the field comment at its use site in
+/// `apply_stream_with_constraint` for why this can't just live inside `ChoiceState`.
+#[derive(Default)]
+struct ChoiceRecord {
+    tool_emitted: bool,
+    finished: bool,
+}
+
+/// Finish every choice that never received a terminating chunk, in index order.
+///
+/// A choice can reach this point two ways: still holding a live `ChoiceState` (the
+/// common case — nothing special happened, it just never got an explicit terminal),
+/// or "history-only" — its `ChoiceState` was removed by an already-parsed detour and
+/// never rebuilt, so all that remains is its `ChoiceRecord`. The second case has
+/// nothing left to flush, but a tool-emitting choice still needs a synthesized
+/// `ToolCalls` terminal so a strict client doesn't hang waiting for one; a choice that
+/// never called a tool gets no synthetic chunk at all, matching the no-signal,
+/// text-only contract a live `ChoiceState` already has via `tool_emitted` above.
+fn finish_unterminated_choices(
+    states: &mut HashMap<u32, ChoiceState>,
+    records: &mut HashMap<u32, ChoiceRecord>,
+) -> Vec<ChatChoiceStream> {
+    let mut indices: Vec<u32> = states
+        .keys()
+        .copied()
+        .chain(records.keys().copied())
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+
+    let mut choices = Vec::new();
+    for index in indices {
+        if records.get(&index).is_some_and(|record| record.finished) {
+            continue;
+        }
+        records.entry(index).or_default().finished = true;
+        let base = empty_choice(index);
+        match states.get_mut(&index) {
+            Some(state) => {
+                let deltas = state.finish();
+                // A choice that emitted tool calls must terminate with `ToolCalls`
+                // even when the backend never sent a finish_reason: a strict client
+                // waits for a non-null one before considering the call complete, and
+                // would otherwise hang.
+                let finish_reason = state.tool_emitted().then_some(FinishReason::ToolCalls);
+                choices.extend(state.choices_for(&base, deltas, true, finish_reason));
+            }
+            None => {
+                if records
+                    .get(&index)
+                    .is_some_and(|record| record.tool_emitted)
+                {
+                    let mut choice = base;
+                    choice.finish_reason = Some(FinishReason::ToolCalls);
+                    choices.push(choice);
+                }
+            }
+        }
+    }
+    choices
+}
+
+/// Wrap one rewritten choice in a response built from `template`.
+///
+/// Usage, nvext and metrics are cleared: they belong to the chunk that carried them,
+/// and repeating them on a synthesized chunk would double-count.
+fn response_with_choice(
+    template: &NvCreateChatCompletionStreamResponse,
+    choice: ChatChoiceStream,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    let mut data = template.clone();
+    data.inner.choices = vec![choice];
+    data.inner.usage = None;
+    data.nvext = None;
+    data.llm_metrics = None;
+    Annotated::from_data(data)
+}
+
+/// Whether a choice arrived already parsed by something upstream and must be passed
+/// through untouched rather than re-parsed.
+fn already_parsed(choice: &ChatChoiceStream) -> bool {
+    let has_raw_text = matches!(
+        choice.delta.content,
+        Some(ChatCompletionMessageContent::Text(_))
+    );
+    matches!(
+        choice.delta.content,
+        Some(ChatCompletionMessageContent::Parts(_))
+    ) || (!has_raw_text
+        && (choice.delta.tool_calls.is_some()
+            || choice.delta.function_call.is_some()
+            || choice.delta.reasoning_content.is_some()))
+}
+
+/// Streaming path: one unified parser per response choice, replacing both the reasoning
+/// parser and the tool-call jail for this request.
+///
+/// `uses_tool_call_structural_tag` reports that the backend was given a structural tag
+/// constraining generation to the family's NATIVE grammar. When it is set the output is
+/// native markup no matter what `tool_choice` says, so `tool_choice` is not consulted;
+/// this path only parses guided JSON, it never builds the grammar that produces it.
+#[cfg(test)]
+pub(crate) fn apply_stream<S>(
+    stream_in: S,
+    tool_definitions: Option<Vec<ToolDefinition>>,
+    tool_choice: Option<ChatCompletionToolChoiceOption>,
+    uses_tool_call_structural_tag: bool,
+    prefill: UnifiedParserStartingState,
+    family: &'static str,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    let guided_tool_constraint = if uses_tool_call_structural_tag {
+        GuidedToolConstraint::StructuralTag
+    } else {
+        match tool_choice {
+            Some(ChatCompletionToolChoiceOption::Named(named)) => {
+                GuidedToolConstraint::GuidedJsonNamed {
+                    tool_name: named.function.name,
+                }
+            }
+            Some(ChatCompletionToolChoiceOption::Required) => {
+                GuidedToolConstraint::GuidedJsonRequired
+            }
+            None
+            | Some(ChatCompletionToolChoiceOption::Auto)
+            | Some(ChatCompletionToolChoiceOption::None) => GuidedToolConstraint::None,
+        }
+    };
+    apply_stream_with_constraint(
+        stream_in,
+        tool_definitions,
+        guided_tool_constraint,
+        prefill,
+        family,
+    )
+}
+
+pub(crate) fn apply_stream_with_constraint<S>(
+    stream_in: S,
+    tool_definitions: Option<Vec<ToolDefinition>>,
+    guided_tool_constraint: GuidedToolConstraint,
+    prefill: UnifiedParserStartingState,
+    family: &'static str,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    let tools = to_v2_tools(tool_definitions.as_deref());
+    stream! {
+        let mut states: HashMap<u32, ChoiceState> = HashMap::new();
+        // Per-choice bookkeeping that must outlive a single `ChoiceState`: a
+        // `ChoiceState` is dropped whenever an already-parsed chunk interrupts a
+        // choice (its buffered parser state would be wrong to keep across the
+        // detour), but whether that choice ever called a tool and whether its
+        // terminal has already gone out must still be known afterward — by a
+        // resumed raw run, an already-parsed terminal, or the EOF backstop below,
+        // even when no `ChoiceState` for that index exists any more (or never did:
+        // an index whose first-ever chunk is already-parsed never gets one either).
+        let mut records: HashMap<u32, ChoiceRecord> = HashMap::new();
+        // Last data response with its choices cleared, so an end-of-stream flush has an
+        // envelope (id, model, created) to attach synthesized chunks to.
+        let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
+
+        tokio::pin!(stream_in);
+
+        while let Some(mut response) = stream_in.next().await {
+            if response.is_error() {
+                yield response;
+                return;
+            }
+            let Some(chat) = response.data.as_mut() else {
+                // Non-data annotations (errors, comments) pass through untouched.
+                yield response;
+                continue;
+            };
+
+            {
+                let mut next = chat.clone();
+                next.inner.choices.clear();
+                next.inner.usage = None;
+                next.nvext = None;
+                next.llm_metrics = None;
+                template = Some(next);
+            }
+
+            if chat.inner.choices.is_empty() {
+                // A usage-only chunk. OpenAI stream ordering requires every choice's
+                // terminal finish_reason to precede it, so flush first.
+                if let Some(template) = &template {
+                    for choice in finish_unterminated_choices(&mut states, &mut records) {
+                        yield response_with_choice(template, choice);
+                    }
+                }
+                yield response;
+                continue;
+            }
+
+            let originals = std::mem::take(&mut chat.inner.choices);
+            let mut emitted: Vec<ChatChoiceStream> = Vec::new();
+            for mut original in originals {
+                if already_parsed(&original) {
+                    // Record this index exists even if no `ChoiceState` is ever
+                    // built for it (e.g. its first-ever chunk is already-parsed),
+                    // so it is not invisible to `finish_unterminated_choices`.
+                    let record = records.entry(original.index).or_default();
+                    // An already-parsed chunk carries its tool calls verbatim in its
+                    // own delta rather than through a `ChoiceState`, so that history
+                    // has to be observed here directly — a state may never exist for
+                    // this index at all (its very first chunk can be already-parsed).
+                    if original
+                        .delta
+                        .tool_calls
+                        .as_ref()
+                        .is_some_and(|calls| !calls.is_empty())
+                    {
+                        record.tool_emitted = true;
+                    }
+                    if let Some(mut state) = states.remove(&original.index) {
+                        // A prior raw chunk on this choice may have emitted a tool
+                        // call before this already-parsed terminal replaced it; that
+                        // history lives only in the state being discarded here, so
+                        // fold it into the record before it's gone (also needed by a
+                        // later chunk or the EOF backstop after this `ChoiceState` is
+                        // gone). Normalize against `record.tool_emitted`, not the
+                        // state's own flag: this chunk's own `delta.tool_calls` (set
+                        // into `record` above) can carry a tool call the state itself
+                        // never saw, e.g. an already-parsed terminal chunk that is
+                        // itself the first and only tool-call signal for this choice.
+                        if state.tool_emitted() {
+                            record.tool_emitted = true;
+                        }
+                        original.finish_reason =
+                            if original.finish_reason == Some(FinishReason::Stop) && record.tool_emitted {
+                                Some(FinishReason::ToolCalls)
+                            } else {
+                                original.finish_reason
+                            };
+                        let deltas = state.finish();
+                        emitted.extend(state.choices_for(
+                            &empty_choice(original.index),
+                            deltas,
+                            true,
+                            None,
+                        ));
+                    } else if record.tool_emitted
+                        && original.finish_reason == Some(FinishReason::Stop)
+                    {
+                        // No live state for this chunk (an earlier already-parsed
+                        // chunk already discarded it), but this choice emitted a
+                        // tool call before that gap.
+                        original.finish_reason = Some(FinishReason::ToolCalls);
+                    }
+                    if original.finish_reason.is_some() {
+                        record.finished = true;
+                    }
+                    emitted.push(original);
+                    continue;
+                }
+
+                let state = match states.entry(original.index) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        let mode = tool_output_mode(&guided_tool_constraint);
+                        match ChoiceState::new(family, &tools, prefill, mode) {
+                            Ok(mut state) => {
+                                // A raw run resuming after an already-parsed detour
+                                // gets a brand-new parser instance; seed it with any
+                                // tool-call history from before the gap so a Stop at
+                                // the end of this run still normalizes correctly.
+                                if records.get(&original.index).is_some_and(|record| record.tool_emitted) {
+                                    state.mark_tool_emitted();
+                                }
+                                entry.insert(state)
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    family,
+                                    choice = original.index,
+                                    "unified parser construction failed; passing choice through"
+                                );
+                                emitted.push(original);
+                                continue;
+                            }
+                        }
+                    }
+                };
+
+                let mut deltas = Vec::new();
+                if let Some(ChatCompletionMessageContent::Text(text)) =
+                    original.delta.content.as_ref()
+                {
+                    deltas.extend(state.push(text));
+                }
+                let terminal = original.finish_reason;
+                let already_finished = records
+                    .get(&original.index)
+                    .is_some_and(|record| record.finished);
+                if terminal.is_some() {
+                    if !already_finished {
+                        deltas.extend(state.finish());
+                    }
+                    records.entry(original.index).or_default().finished = true;
+                }
+
+                let mut parsed = state.choices_for(&original, deltas, true, terminal);
+                if parsed.is_empty() {
+                    // A marker-only chunk produced no deltas. Keep it as an empty
+                    // choice so the typed llm_metrics and annotation metadata it
+                    // carries still reach the client.
+                    parsed.push(empty_choice(original.index));
+                }
+                emitted.extend(parsed);
+            }
+
+            if emitted.is_empty() {
+                continue;
+            }
+
+            // One upstream chunk can fan out into several. Usage, nvext and annotation
+            // fields stay on the last child. Token metrics stay on one reasoning child
+            // when present so the downstream reasoning-usage estimator preserves the
+            // source chunk's classification without counting it twice.
+            let last = emitted.len() - 1;
+            let Some(llm_metrics_position) = fanout_llm_metrics_position(&emitted) else {
+                continue;
+            };
+            for (position, choice) in emitted.into_iter().enumerate() {
+                let is_last = position == last;
+                let mut data = chat.clone();
+                data.inner.choices = vec![choice];
+                if !is_last {
+                    data.inner.usage = None;
+                    data.nvext = None;
+                }
+                if position != llm_metrics_position {
+                    data.llm_metrics = None;
+                }
+                yield Annotated {
+                    data: Some(data),
+                    id: if is_last { response.id.take() } else { None },
+                    event: if is_last { response.event.take() } else { None },
+                    comment: if is_last { response.comment.take() } else { None },
+                    error: if is_last { response.error.take() } else { None },
+                };
+            }
+        }
+
+        // Backstop: the stream ended without a terminating chunk for some choice.
+        if let Some(template) = &template {
+            for choice in finish_unterminated_choices(&mut states, &mut records) {
+                yield response_with_choice(template, choice);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_parsers_v2::ToolCallDelta;
+    use dynamo_protocols::types::{
+        ChatCompletionStreamResponseDeltaFunctionCall, CreateChatCompletionStreamResponse, Role,
+    };
+    use futures::stream;
+
+    struct PartialCommitParser {
+        recovered: String,
+    }
+
+    impl UnifiedParser for PartialCommitParser {
+        fn parse_into(
+            &mut self,
+            _delta: &str,
+            output: &mut UnifiedParserOutput,
+        ) -> anyhow::Result<()> {
+            output
+                .events
+                .push(UnifiedParserEvent::Text("committed".to_string()));
+            anyhow::bail!("intentional failure after a committed event")
+        }
+
+        fn finish(&mut self) -> anyhow::Result<UnifiedParserOutput> {
+            Ok(UnifiedParserOutput::default())
+        }
+
+        fn reset(&mut self) -> String {
+            std::mem::take(&mut self.recovered)
+        }
+    }
+
+    fn chunk(text: &str, finish: bool) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let response = NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![ChatChoiceStream {
+                    index: 0,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: finish.then_some(FinishReason::Stop),
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "qwen3".to_string(),
+                system_fingerprint: None,
+                service_tier: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        Annotated::from_data(response)
+    }
+
+    fn weather_tools() -> Vec<ToolDefinition> {
+        vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            })),
+            strict: None,
+        }]
+    }
+
+    fn collect_choices(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<&ChatChoiceStream> {
+        responses
+            .iter()
+            .filter_map(|response| response.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+            .collect()
+    }
+
+    fn named_choice(name: &str) -> ChatCompletionToolChoiceOption {
+        serde_json::from_value(serde_json::json!({
+            "type": "function",
+            "function": {"name": name}
+        }))
+        .expect("named tool choice")
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum LogicalEvent {
+        Reasoning(String),
+        Text(String),
+        Tool {
+            index: u32,
+            name: Option<String>,
+            arguments: String,
+        },
+    }
+
+    fn logical_events(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<LogicalEvent> {
+        let mut events = Vec::new();
+        for choice in collect_choices(responses) {
+            if let Some(reasoning) = &choice.delta.reasoning_content {
+                match events.last_mut() {
+                    Some(LogicalEvent::Reasoning(existing)) => existing.push_str(reasoning),
+                    _ => events.push(LogicalEvent::Reasoning(reasoning.clone())),
+                }
+            }
+            if let Some(ChatCompletionMessageContent::Text(text)) = &choice.delta.content {
+                match events.last_mut() {
+                    Some(LogicalEvent::Text(existing)) => existing.push_str(text),
+                    _ => events.push(LogicalEvent::Text(text.clone())),
+                }
+            }
+            for call in choice.delta.tool_calls.iter().flatten() {
+                let name = call.function.as_ref().and_then(|f| f.name.clone());
+                let arguments = call
+                    .function
+                    .as_ref()
+                    .and_then(|f| f.arguments.clone())
+                    .unwrap_or_default();
+                match events.last_mut() {
+                    Some(LogicalEvent::Tool {
+                        index,
+                        name: existing_name,
+                        arguments: existing_arguments,
+                    }) if *index == call.index => {
+                        if existing_name.is_none() {
+                            *existing_name = name;
+                        }
+                        existing_arguments.push_str(&arguments);
+                    }
+                    _ => events.push(LogicalEvent::Tool {
+                        index: call.index,
+                        name,
+                        arguments,
+                    }),
+                }
+            }
+        }
+        events
+    }
+
+    async fn parse_at_split(
+        input: &str,
+        split: usize,
+        tool_choice: Option<ChatCompletionToolChoiceOption>,
+    ) -> Vec<LogicalEvent> {
+        let (first, second) = input.split_at(split);
+        let responses = apply_stream(
+            stream::iter([chunk(first, false), chunk(second, true)]),
+            Some(weather_tools()),
+            tool_choice,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        logical_events(&responses)
+    }
+
+    // --- selected_family / configured_family -------------------------------------
+
+    #[test]
+    fn pairs_only_qwen3_coder_with_qwen3() {
+        assert_eq!(
+            configured_family(Some("qwen3_coder"), Some("qwen3")),
+            Some(QWEN3_UNIFIED_FAMILY)
+        );
+        // A unified parser owns BOTH halves, so half a pair must not opt in.
+        assert_eq!(configured_family(Some("qwen3_coder"), None), None);
+        assert_eq!(configured_family(None, Some("qwen3")), None);
+        assert_eq!(configured_family(None, None), None);
+        // Right tool parser, wrong reasoning family.
+        assert_eq!(
+            configured_family(Some("qwen3_coder"), Some("deepseek_r1")),
+            None
+        );
+        // Right reasoning parser, wrong tool family.
+        assert_eq!(configured_family(Some("kimi_k2"), Some("qwen3")), None);
+        // The pairing is on dynamo's parser names, not the unified family name.
+        assert_eq!(configured_family(Some("qwen3"), Some("qwen3")), None);
+    }
+
+    #[test]
+    fn selected_family_needs_the_env_flag() {
+        // The env flag is process-wide and read once, so this asserts the relationship
+        // between the two functions rather than mutating the environment: whatever the
+        // flag says, `selected_family` never selects a pair `configured_family` rejects,
+        // and it agrees with `configured_family` exactly when the flag is on.
+        let pair = (Some("qwen3_coder"), Some("qwen3"));
+        assert_eq!(
+            configured_family(pair.0, pair.1),
+            Some(QWEN3_UNIFIED_FAMILY)
+        );
+        if experimental_parsers_v2_enabled() {
+            assert_eq!(
+                selected_family(pair.0, pair.1),
+                Some(QWEN3_UNIFIED_FAMILY),
+                "flag on: the configured pair must be selected"
+            );
+        } else {
+            assert_eq!(
+                selected_family(pair.0, pair.1),
+                None,
+                "flag off: the configured pair must NOT be selected"
+            );
+        }
+        // Never selected regardless of the flag.
+        assert_eq!(selected_family(Some("qwen3_coder"), None), None);
+        assert_eq!(selected_family(None, Some("qwen3")), None);
+    }
+
+    #[test]
+    fn batch_routing_uses_the_configured_pair_for_every_output_mode() {
+        let pair = (Some("qwen3_coder"), Some("qwen3"));
+        assert_eq!(
+            configured_batch_family(pair.0, pair.1),
+            Some(QWEN3_UNIFIED_FAMILY),
+            "the carried constraint selects native versus guided parsing after routing"
+        );
+    }
+
+    // --- tool_choice -> UnifiedToolOutputMode ------------------------------------
+
+    #[test]
+    fn maps_tool_choice_onto_the_output_mode() {
+        assert_eq!(
+            tool_output_mode(&GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            }),
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather".to_string())
+            }
+        );
+        assert_eq!(
+            tool_output_mode(&GuidedToolConstraint::GuidedJsonRequired),
+            UnifiedToolOutputMode::GuidedJson { named_tool: None }
+        );
+        for native in [
+            GuidedToolConstraint::None,
+            GuidedToolConstraint::StructuralTag,
+        ] {
+            assert_eq!(
+                tool_output_mode(&native),
+                UnifiedToolOutputMode::Native,
+                "{native:?} must stay on native markup"
+            );
+        }
+    }
+
+    #[test]
+    fn batch_native_marker_overrides_a_reconstructed_guided_constraint() {
+        for constraint in [
+            GuidedToolConstraint::GuidedJsonRequired,
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            },
+        ] {
+            assert_eq!(
+                batch_tool_output_mode(
+                    "<tool_call>\n<function=get_weather>\n</function>\n</tool_call>",
+                    &constraint,
+                ),
+                UnifiedToolOutputMode::Native,
+            );
+        }
+        assert_eq!(
+            batch_tool_output_mode(
+                r#"[{"name":"get_weather","parameters":{"literal":"<tool_call>"}}]"#,
+                &GuidedToolConstraint::GuidedJsonRequired,
+            ),
+            UnifiedToolOutputMode::GuidedJson { named_tool: None },
+            "a marker inside JSON arguments remains payload data",
+        );
+    }
+
+    #[tokio::test]
+    async fn every_valid_utf8_split_matches_whole_input_across_output_modes() {
+        let cases = [
+            (
+                concat!(
+                    "<think>理由は東京です。</think>",
+                    "<tool_call>\n<function=get_weather>\n",
+                    "<parameter=city>東京</parameter>\n</function>\n</tool_call>"
+                ),
+                Some(ChatCompletionToolChoiceOption::Auto),
+            ),
+            (
+                r#"{"city":"東</think>京"}"#,
+                Some(named_choice("get_weather")),
+            ),
+            (
+                r#"[{"name":"get_weather","parameters":{"city":"東京"}}]"#,
+                Some(ChatCompletionToolChoiceOption::Required),
+            ),
+        ];
+
+        for (input, tool_choice) in cases {
+            let expected = parse_at_split(input, 0, tool_choice.clone()).await;
+            for split in (0..=input.len()).filter(|split| input.is_char_boundary(*split)) {
+                assert_eq!(
+                    parse_at_split(input, split, tool_choice.clone()).await,
+                    expected,
+                    "output changed at UTF-8 split {split} for {input:?}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn structural_tag_keeps_required_on_native_markup() {
+        // A structural tag constrains generation to Qwen's XML, so `required` must NOT
+        // put the parser into guided-JSON mode; doing so would surface the whole call
+        // as text.
+        let output = concat!(
+            "<think>reason</think>",
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let responses = apply_stream(
+            stream::iter([chunk(output, true)]),
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            true,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let call = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .next()
+            .expect("a native tool call");
+        let function = call.function.as_ref().expect("function");
+        assert_eq!(function.name.as_deref(), Some("get_weather"));
+        assert_eq!(function.arguments.as_deref(), Some(r#"{"city":"Tokyo"}"#));
+    }
+
+    // --- prefill -----------------------------------------------------------------
+
+    #[test]
+    fn prompt_injected_reasoning_selects_the_reasoning_prefill() {
+        assert_eq!(
+            stream_prefill(QWEN3_UNIFIED_FAMILY, true),
+            UnifiedParserStartingState::Reasoning
+        );
+        // Qwen3's template pre-opens no channel, so the model emits `<think>` itself.
+        assert_eq!(
+            stream_prefill(QWEN3_UNIFIED_FAMILY, false),
+            UnifiedParserStartingState::None
+        );
+    }
+
+    #[test]
+    fn detects_batch_prefill_from_complete_output() {
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "<think>reason</think>answer").unwrap(),
+            UnifiedParserStartingState::None
+        );
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "reason</think>answer").unwrap(),
+            UnifiedParserStartingState::Reasoning
+        );
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "answer").unwrap(),
+            UnifiedParserStartingState::Response
+        );
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "It's hidden</think>visible").unwrap(),
+            UnifiedParserStartingState::Reasoning,
+            "an apostrophe in prose must not hide a later control marker"
+        );
+        assert!(detect_prefill("kimi_k3", "answer").is_err());
+    }
+
+    // --- delta -> chunk conversion -----------------------------------------------
+
+    fn call_delta(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedParserEvent {
+        UnifiedParserEvent::ToolCall(ToolCallDelta {
+            tool_index,
+            name: name.map(str::to_string),
+            arguments: arguments.to_string(),
+        })
+    }
+
+    fn test_state() -> ChoiceState {
+        ChoiceState::new(
+            QWEN3_UNIFIED_FAMILY,
+            &[],
+            UnifiedParserStartingState::None,
+            UnifiedToolOutputMode::Native,
+        )
+        .expect("qwen3 unified parser")
+    }
+
+    #[test]
+    fn each_delta_becomes_its_own_chunk_in_order() {
+        // The whole point of this path: a thought that followed a call stays after it.
+        let mut state = test_state();
+        let base = empty_choice(0);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                UnifiedParserEvent::Reasoning("look it up".into()),
+                call_delta(0, Some("get_weather"), r#"{"city":"Tokyo"}"#),
+                UnifiedParserEvent::Reasoning("now answer".into()),
+                UnifiedParserEvent::Text("It's 18C.".into()),
+            ],
+            true,
+            Some(FinishReason::Stop),
+        );
+
+        assert_eq!(choices.len(), 4, "one chunk per delta: {choices:?}");
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("look it up")
+        );
+        assert!(choices[1].delta.tool_calls.is_some());
+        assert_eq!(
+            choices[2].delta.reasoning_content.as_deref(),
+            Some("now answer"),
+            "the second thought must stay AFTER the call, not fuse with the first"
+        );
+        assert_eq!(
+            choices[3].delta.content,
+            Some(ChatCompletionMessageContent::Text("It's 18C.".into()))
+        );
+        // Only the last chunk terminates, and Stop became ToolCalls.
+        assert_eq!(choices[3].finish_reason, Some(FinishReason::ToolCalls));
+        assert!(choices[..3].iter().all(|c| c.finish_reason.is_none()));
+    }
+
+    #[test]
+    fn first_tool_chunk_opens_the_call_and_later_ones_only_add_arguments() {
+        let mut state = test_state();
+        let base = empty_choice(7);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                call_delta(0, Some("get_weather"), r#"{"city":"#),
+                call_delta(0, None, r#""Tokyo"}"#),
+            ],
+            true,
+            None,
+        );
+
+        assert_eq!(choices.len(), 2);
+        let first = &choices[0].delta.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(choices[0].index, 7, "the choice index is preserved");
+        assert_eq!(first.index, 0, "the tool index is preserved");
+        assert!(first.id.is_some(), "the opening chunk mints an id");
+        assert_eq!(first.r#type, Some(FunctionType::Function));
+        assert_eq!(
+            first.function.as_ref().unwrap().name.as_deref(),
+            Some("get_weather")
+        );
+
+        let second = &choices[1].delta.tool_calls.as_ref().unwrap()[0];
+        assert!(second.id.is_none(), "only the first chunk carries an id");
+        assert!(second.r#type.is_none());
+        assert!(second.function.as_ref().unwrap().name.is_none());
+        assert_eq!(
+            second.function.as_ref().unwrap().arguments.as_deref(),
+            Some(r#""Tokyo"}"#)
+        );
+    }
+
+    #[test]
+    fn two_calls_get_distinct_ids_and_keep_their_indices() {
+        let mut state = test_state();
+        let base = empty_choice(0);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                call_delta(0, Some("a"), "{}"),
+                call_delta(1, Some("b"), "{}"),
+            ],
+            true,
+            None,
+        );
+
+        let ids: Vec<_> = choices
+            .iter()
+            .map(|choice| {
+                let call = &choice.delta.tool_calls.as_ref().unwrap()[0];
+                (call.index, call.id.clone().expect("id"))
+            })
+            .collect();
+        assert_eq!(ids[0].0, 0);
+        assert_eq!(ids[1].0, 1);
+        assert_ne!(ids[0].1, ids[1].1, "each call gets its own id");
+    }
+
+    #[test]
+    fn adjacent_same_kind_deltas_coalesce_but_calls_never_do() {
+        let merged = coalesce(vec![
+            UnifiedParserEvent::Text("he".into()),
+            UnifiedParserEvent::Text("llo".into()),
+            call_delta(0, Some("f"), "{"),
+            call_delta(0, None, "}"),
+            UnifiedParserEvent::Reasoning("a".into()),
+            UnifiedParserEvent::Reasoning("b".into()),
+        ]);
+        assert_eq!(merged.len(), 4);
+        assert_eq!(merged[0], UnifiedParserEvent::Text("hello".into()));
+        assert_eq!(merged[1], call_delta(0, Some("f"), "{"));
+        assert_eq!(merged[2], call_delta(0, None, "}"));
+        assert_eq!(merged[3], UnifiedParserEvent::Reasoning("ab".into()));
+    }
+
+    #[test]
+    fn role_rides_the_first_chunk_and_finish_reason_the_last() {
+        let mut state = test_state();
+        let mut base = empty_choice(0);
+        base.delta.role = Some(Role::Assistant);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                UnifiedParserEvent::Text("a".into()),
+                call_delta(0, Some("f"), "{}"),
+            ],
+            true,
+            Some(FinishReason::Stop),
+        );
+
+        assert_eq!(choices[0].delta.role, Some(Role::Assistant));
+        assert!(choices[1].delta.role.is_none());
+        assert!(choices[0].finish_reason.is_none());
+        assert_eq!(choices[1].finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[test]
+    fn an_empty_run_still_carries_the_terminating_envelope() {
+        let mut state = test_state();
+        let mut base = empty_choice(0);
+        base.delta.role = Some(Role::Assistant);
+        let choices = state.choices_for(&base, Vec::new(), true, Some(FinishReason::Length));
+
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].delta.role, Some(Role::Assistant));
+        assert_eq!(
+            choices[0].finish_reason,
+            Some(FinishReason::Length),
+            "Length is not rewritten"
+        );
+    }
+
+    #[test]
+    fn an_empty_run_with_no_envelope_emits_nothing() {
+        let mut state = test_state();
+        let base = empty_choice(0);
+        assert!(state.choices_for(&base, Vec::new(), true, None).is_empty());
+    }
+
+    // --- end-to-end streaming ----------------------------------------------------
+
+    #[tokio::test]
+    async fn streams_ordered_reasoning_text_and_tool_calls() {
+        let output = concat!(
+            "<think>reason</think>answer ",
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        // Split into small chunks so markers straddle push() boundaries.
+        let mut chunks: Vec<_> = output
+            .as_bytes()
+            .chunks(7)
+            .map(|bytes| chunk(std::str::from_utf8(bytes).unwrap(), false))
+            .collect();
+        chunks.push(chunk("", true));
+
+        let responses = apply_stream(
+            stream::iter(chunks),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let reasoning: String = choices
+            .iter()
+            .filter_map(|choice| choice.delta.reasoning_content.as_deref())
+            .collect();
+        let content: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        let arguments: String = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .filter_map(|call| call.function.as_ref()?.arguments.as_deref())
+            .collect();
+
+        assert_eq!(reasoning, "reason");
+        assert_eq!(content, "answer ");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&arguments).unwrap()["city"],
+            "Tokyo"
+        );
+        for marker in ["<think>", "<tool_call>", "<function=", "<parameter="] {
+            assert!(
+                !content.contains(marker),
+                "raw markup {marker:?} leaked into content: {content:?}"
+            );
+        }
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .next_back(),
+            Some(FinishReason::ToolCalls)
+        );
+    }
+
+    #[tokio::test]
+    async fn qwen_fanout_keeps_source_metrics_on_reasoning() {
+        let mut source = chunk("<think>reason</think>answer", false);
+        source.data.as_mut().unwrap().llm_metrics =
+            Some(crate::protocols::common::metrics::LLMMetricAnnotation {
+                chunk_tokens: 4,
+                ..Default::default()
+            });
+
+        let responses = apply_stream(
+            stream::iter([source]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let metric_choices: Vec<_> = responses
+            .iter()
+            .filter_map(|response| response.data.as_ref())
+            .filter(|data| data.llm_metrics.is_some())
+            .flat_map(|data| data.inner.choices.iter())
+            .collect();
+
+        assert_eq!(
+            metric_choices.len(),
+            1,
+            "source metrics must be emitted once"
+        );
+        assert_eq!(
+            metric_choices[0].delta.reasoning_content.as_deref(),
+            Some("reason"),
+            "the metrics owner must retain the source chunk's reasoning classification"
+        );
+    }
+
+    #[tokio::test]
+    async fn named_guided_json_becomes_a_tool_call() {
+        let responses = apply_stream(
+            stream::iter([
+                chunk("reason</think>{\"city\": ", false),
+                chunk("\"Tokyo\"}", true),
+            ]),
+            Some(weather_tools()),
+            Some(named_choice("get_weather")),
+            false,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("reason")
+        );
+        // A named choice now STREAMS: the name rides the first delta and the argument
+        // bytes follow, so collect across deltas exactly as the required case does.
+        let calls: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .collect();
+        assert_eq!(
+            calls
+                .iter()
+                .find_map(|call| call.function.as_ref()?.name.as_deref()),
+            Some("get_weather")
+        );
+        let arguments: String = calls
+            .iter()
+            .filter_map(|call| call.function.as_ref()?.arguments.as_deref())
+            .collect();
+        assert_eq!(
+            arguments, "{\"city\": \"Tokyo\"}",
+            "a named choice passes the model's argument bytes through verbatim"
+        );
+        // The argument bytes must arrive as they are generated, not in one terminal
+        // burst: the caller split the payload across two chunks, so a client that
+        // renders each delta sees the call grow instead of waiting for the whole
+        // object. One frame here means the wiring buffered what the parser streamed.
+        let frames = calls
+            .iter()
+            .filter(|call| {
+                call.function
+                    .as_ref()
+                    .and_then(|f| f.arguments.as_deref())
+                    .is_some_and(|a| !a.is_empty())
+            })
+            .count();
+        assert!(
+            frames >= 2,
+            "arguments arrived in {frames} frame(s) - that is a burst, not a stream"
+        );
+        assert!(
+            choices
+                .iter()
+                .any(|c| c.finish_reason == Some(FinishReason::ToolCalls)),
+            "the stream must terminate with ToolCalls"
+        );
+    }
+
+    #[tokio::test]
+    async fn required_guided_json_becomes_a_tool_call() {
+        let responses = apply_stream(
+            stream::iter([chunk(
+                r#"reason</think>[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#,
+                true,
+            )]),
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            false,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let calls: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .collect();
+        assert_eq!(
+            calls
+                .iter()
+                .find_map(|call| call.function.as_ref()?.name.as_deref()),
+            Some("get_weather")
+        );
+        let arguments: String = calls
+            .iter()
+            .filter_map(|call| call.function.as_ref()?.arguments.as_deref())
+            .collect();
+        assert_eq!(arguments, r#"{"city":"Tokyo"}"#);
+    }
+
+    #[tokio::test]
+    async fn required_guided_emits_name_before_polling_call_completion() {
+        let prefix = r#"reason</think>[{"name":"get_weather","arguments":{"#;
+        let upstream = stream::iter([chunk(prefix, false)]).chain(stream::poll_fn(|_| {
+            panic!("apply_stream polled for call-completing bytes before emitting the tool name")
+        }));
+        let responses = apply_stream(
+            upstream,
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            false,
+            UnifiedParserStartingState::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        );
+        tokio::pin!(responses);
+
+        let reasoning = responses.next().await.expect("reasoning delta");
+        assert_eq!(
+            collect_choices(&[reasoning])[0]
+                .delta
+                .reasoning_content
+                .as_deref(),
+            Some("reason")
+        );
+
+        let tool = responses.next().await.expect("tool-name delta");
+        let tool_responses = [tool];
+        let tool_choices = collect_choices(&tool_responses);
+        let call = &tool_choices[0]
+            .delta
+            .tool_calls
+            .as_ref()
+            .expect("tool call before completion")[0];
+        assert_eq!(
+            call.function
+                .as_ref()
+                .and_then(|function| function.name.as_deref()),
+            Some("get_weather")
+        );
+    }
+
+    #[tokio::test]
+    async fn already_parsed_choices_pass_through_untouched() {
+        // A chunk that already carries reasoning_content was parsed upstream; running
+        // it through the parser again would double it.
+        let mut pre_parsed = chunk("", false);
+        let choice = &mut pre_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already".to_string());
+
+        let responses = apply_stream(
+            stream::iter([pre_parsed]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(choices.len(), 1);
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("already")
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_preparsed_reasoning_still_parses_raw_content() {
+        let output = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut mixed = chunk(output, true);
+        mixed.data.as_mut().unwrap().inner.choices[0]
+            .delta
+            .reasoning_content = Some("already parsed".to_string());
+
+        let responses = apply_stream(
+            stream::iter([mixed]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+        let visible: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.delta.reasoning_content.as_deref())
+                .collect::<String>(),
+            "already parsed"
+        );
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "raw native tool markup must still become a structured call"
+        );
+        assert!(
+            !visible.contains("<tool_call>"),
+            "raw markup leaked: {visible:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_preparsed_tool_call_still_parses_raw_content() {
+        let output = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut mixed = chunk(output, true);
+        let choice = &mut mixed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.tool_calls = Some(vec![ChatCompletionMessageToolCallChunk {
+            index: 7,
+            id: Some("existing-call".to_string()),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: Some("already_parsed".to_string()),
+                arguments: Some("{}".to_string()),
+            }),
+        }]);
+
+        let responses = apply_stream(
+            stream::iter([mixed]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+        let visible: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        let names: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .filter_map(|call| call.function.as_ref()?.name.as_deref())
+            .collect();
+
+        assert!(names.contains(&"already_parsed"));
+        assert!(names.contains(&"get_weather"));
+        assert!(
+            !visible.contains("<tool_call>"),
+            "raw markup leaked: {visible:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preparsed_terminal_choice_does_not_drop_buffered_bytes() {
+        let mut terminal = chunk("", true);
+        let choice = &mut terminal.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already".to_string());
+
+        let responses = apply_stream(
+            stream::iter([chunk("hello <tool_c", false), terminal]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+        let visible: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(visible, "hello <tool_c");
+        let terminal_position = choices
+            .iter()
+            .position(|choice| choice.finish_reason.is_some())
+            .expect("terminal choice");
+        assert!(
+            choices[terminal_position + 1..]
+                .iter()
+                .all(|choice| choice.delta.content.is_none()),
+            "buffered content appeared after the terminal choice"
+        );
+    }
+
+    #[tokio::test]
+    async fn preparsed_terminal_normalizes_stop_after_prior_raw_tool_call() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut terminal = chunk("", true);
+        let choice = &mut terminal.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+
+        let responses = apply_stream(
+            stream::iter([chunk(tool_call, false), terminal]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "the raw first chunk must emit a tool call"
+        );
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .next_back(),
+            Some(FinishReason::ToolCalls),
+            "an already-parsed terminal Stop must retain the earlier tool-call state"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_preparsed_raw_sequence_preserves_order_and_buffered_bytes() {
+        let mut pre_parsed = chunk("", false);
+        let choice = &mut pre_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("middle".to_string());
+
+        let responses = apply_stream(
+            stream::iter([
+                chunk("before <tool_c", false),
+                pre_parsed,
+                chunk(" after", true),
+            ]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+        let ordered: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| {
+                if let Some(ChatCompletionMessageContent::Text(text)) = &choice.delta.content {
+                    Some(("content", text.as_str()))
+                } else {
+                    choice
+                        .delta
+                        .reasoning_content
+                        .as_deref()
+                        .map(|reasoning| ("reasoning", reasoning))
+                }
+            })
+            .collect();
+
+        assert_eq!(
+            ordered,
+            vec![
+                ("content", "before "),
+                ("content", "<tool_c"),
+                ("reasoning", "middle"),
+                ("content", " after"),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_preparsed_raw_terminal_normalizes_stop_after_tool_call_before_gap() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut pre_parsed = chunk("", false);
+        let choice = &mut pre_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+
+        let responses = apply_stream(
+            stream::iter([
+                chunk(tool_call, false),
+                pre_parsed,
+                chunk(" trailing text", true),
+            ]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "the raw first chunk must emit a tool call"
+        );
+        let finish_reasons: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.finish_reason)
+            .collect();
+        assert_eq!(
+            finish_reasons,
+            vec![FinishReason::ToolCalls],
+            "a fresh parser instance for the resumed raw run must not lose the \
+             tool-call history from before the already-parsed gap, and exactly \
+             one terminal must be emitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn two_consecutive_already_parsed_chunks_after_tool_call_normalize_once() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let already_parsed_chunk = |reasoning: &str, finish: bool| {
+            let mut c = chunk("", finish);
+            let choice = &mut c.data.as_mut().unwrap().inner.choices[0];
+            choice.delta.content = None;
+            choice.delta.reasoning_content = Some(reasoning.to_string());
+            c
+        };
+
+        let responses = apply_stream(
+            stream::iter([
+                chunk(tool_call, false),
+                already_parsed_chunk("first already-parsed", false),
+                already_parsed_chunk("second already-parsed", false),
+                already_parsed_chunk("third already-parsed (terminal)", true),
+            ]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "the raw first chunk must emit a tool call"
+        );
+        let finish_reasons: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.finish_reason)
+            .collect();
+        assert_eq!(
+            finish_reasons,
+            vec![FinishReason::ToolCalls],
+            "two already-parsed chunks in a row after the tool call (the second \
+             with no live ChoiceState left to remove) must still normalize to \
+             exactly one ToolCalls terminal, not Stop and not more than one terminal"
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_history_is_isolated_per_choice_index() {
+        fn two_choice_response(
+            index0: (&str, bool),
+            index1: (&str, bool),
+        ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+            let make = |index: u32, text: &str, finish: bool| ChatChoiceStream {
+                index,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: Some(Role::Assistant),
+                    content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                    tool_calls: None,
+                    function_call: None,
+                    refusal: None,
+                    reasoning_content: None,
+                },
+                finish_reason: finish.then_some(FinishReason::Stop),
+                logprobs: None,
+            };
+            #[allow(deprecated)]
+            let response = NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "test".to_string(),
+                    choices: vec![make(0, index0.0, index0.1), make(1, index1.0, index1.1)],
+                    created: 0,
+                    model: "qwen3".to_string(),
+                    system_fingerprint: None,
+                    service_tier: None,
+                    object: "chat.completion.chunk".to_string(),
+                    usage: None,
+                },
+                nvext: None,
+                llm_metrics: None,
+            };
+            Annotated::from_data(response)
+        }
+        let already_parsed_pair = || {
+            let mut response = two_choice_response(("", false), ("", false));
+            for choice in &mut response.data.as_mut().unwrap().inner.choices {
+                choice.delta.content = None;
+                choice.delta.reasoning_content = Some("already parsed".to_string());
+            }
+            response
+        };
+
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let responses = apply_stream(
+            stream::iter([
+                two_choice_response((tool_call, false), ("hello", false)),
+                already_parsed_pair(),
+                two_choice_response((" trailing0", true), (" trailing1", true)),
+            ]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        let finish_for = |index: u32| {
+            choices
+                .iter()
+                .filter(|choice| choice.index == index)
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            finish_for(0),
+            vec![FinishReason::ToolCalls],
+            "choice 0 emitted a tool call before the gap and must normalize to ToolCalls"
+        );
+        assert_eq!(
+            finish_for(1),
+            vec![FinishReason::Stop],
+            "choice 1 never emitted a tool call and must not be contaminated by \
+             choice 0's tool history"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn legacy_function_call_passes_through_untouched() {
+        let mut legacy = chunk("", true);
+        let choice = &mut legacy.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.function_call = Some(ChatCompletionStreamResponseDeltaFunctionCall {
+            name: Some("get_weather".to_string()),
+            arguments: Some(r#"{"city":"Tokyo"}"#.to_string()),
+        });
+
+        let responses = apply_stream(
+            stream::iter([legacy]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert_eq!(choices.len(), 1);
+        assert_eq!(
+            choices[0]
+                .delta
+                .function_call
+                .as_ref()
+                .and_then(|call| call.name.as_deref()),
+            Some("get_weather")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stream_without_a_finish_reason_still_terminates_a_tool_call() {
+        let output = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        // No terminating chunk at all — the stream just ends.
+        let responses = apply_stream(
+            stream::iter([chunk(output, false)]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .next_back(),
+            Some(FinishReason::ToolCalls),
+            "the backstop must synthesize a terminal reason or a strict client hangs"
+        );
+    }
+
+    #[tokio::test]
+    async fn already_parsed_gap_then_immediate_eof_still_terminates_a_tool_call() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut already_parsed = chunk("", false);
+        let choice = &mut already_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+
+        // Raw tool call, then an already-parsed chunk that removes the live
+        // ChoiceState (no finish_reason on it), then the stream just ends — no
+        // further chunks, no usage-only chunk, no explicit terminal at all.
+        let responses = apply_stream(
+            stream::iter([chunk(tool_call, false), already_parsed]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices
+                .iter()
+                .any(|choice| choice.delta.tool_calls.is_some()),
+            "the raw first chunk must emit a tool call"
+        );
+        let finish_reasons: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| choice.finish_reason)
+            .collect();
+        assert_eq!(
+            finish_reasons,
+            vec![FinishReason::ToolCalls],
+            "a choice whose live state was removed by an already-parsed gap must \
+             still get exactly one terminal at end-of-stream, not zero — the EOF \
+             backstop must not silently drop it"
+        );
+    }
+
+    #[tokio::test]
+    async fn already_parsed_gap_terminal_precedes_a_usage_only_chunk() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let mut already_parsed = chunk("", false);
+        let choice = &mut already_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+        let mut usage_only = chunk("unused", false);
+        usage_only.data.as_mut().unwrap().inner.choices.clear();
+
+        let responses = apply_stream(
+            stream::iter([chunk(tool_call, false), already_parsed, usage_only]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let usage_position = responses
+            .iter()
+            .position(|response| {
+                response
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| data.inner.choices.is_empty())
+            })
+            .expect("the usage-only chunk must still be forwarded");
+        let terminal_position = responses
+            .iter()
+            .position(|response| {
+                response.data.as_ref().is_some_and(|data| {
+                    data.inner
+                        .choices
+                        .iter()
+                        .any(|choice| choice.finish_reason == Some(FinishReason::ToolCalls))
+                })
+            })
+            .expect("a history-only choice must still get exactly one ToolCalls terminal");
+        assert!(
+            terminal_position < usage_position,
+            "the terminal must precede the usage-only chunk, per OpenAI stream ordering"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_tool_choice_gets_no_synthetic_terminal_after_a_gap() {
+        let mut already_parsed = chunk("", false);
+        let choice = &mut already_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already parsed".to_string());
+
+        // No tool call anywhere: raw plain text, then a gap, then immediate EOF.
+        let responses = apply_stream(
+            stream::iter([chunk("plain text, no tool call", false), already_parsed]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices.iter().all(|choice| choice.finish_reason.is_none()),
+            "a choice that never called a tool must not get a synthesized terminal \
+             after a gap, matching the text-only, no-signal contract a live \
+             ChoiceState already has"
+        );
+    }
+
+    #[tokio::test]
+    #[allow(deprecated)]
+    async fn legacy_function_call_choice_gets_no_synthetic_terminal_after_a_gap() {
+        // The legacy `function_call` field is a distinct signal from `tool_calls`
+        // (it has its own `FinishReason::FunctionCall`, never `ToolCalls`) and, like
+        // plain text, is never treated as `tool_emitted` anywhere in this file (only
+        // actual parsed tool-call events and non-empty `delta.tool_calls` are). An
+        // already-parsed chunk that only carries `function_call` must therefore get
+        // the same "no synthetic terminal" treatment after a gap as plain text does,
+        // matching the pre-existing live-`ChoiceState` precedent, not a new gap.
+        let mut already_parsed = chunk("", false);
+        let choice = &mut already_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.function_call = Some(ChatCompletionStreamResponseDeltaFunctionCall {
+            name: Some("get_weather".to_string()),
+            arguments: Some(r#"{"city": "Tokyo"}"#.to_string()),
+        });
+
+        let responses = apply_stream(
+            stream::iter([chunk("plain text, no tool call", false), already_parsed]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert!(
+            choices.iter().all(|choice| choice.finish_reason.is_none()),
+            "a choice whose only already-parsed signal is the legacy function_call \
+             field must not get a synthesized ToolCalls terminal after a gap"
+        );
+    }
+
+    #[tokio::test]
+    async fn already_parsed_terminal_carrying_its_own_tool_call_normalizes_stop() {
+        // The live ChoiceState never emits a tool call itself (raw reasoning-only
+        // content), but the already-parsed TERMINAL chunk that follows carries its
+        // own `delta.tool_calls` together with `finish_reason: Stop` in the same
+        // chunk. The state's own `tool_emitted()` is false, but the record must still
+        // pick up this chunk's own tool call and normalize Stop -> ToolCalls.
+        let mut terminal = chunk("", true);
+        let choice = &mut terminal.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.tool_calls = Some(vec![ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: Some("call-terminal".to_string()),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: Some("get_weather".to_string()),
+                arguments: Some("{}".to_string()),
+            }),
+        }]);
+
+        let responses = apply_stream(
+            stream::iter([chunk("reasoning only, no tool call", false), terminal]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>(),
+            vec![FinishReason::ToolCalls],
+            "an already-parsed terminal chunk that itself carries a tool call must \
+             normalize Stop to ToolCalls even when the live state never saw one"
+        );
+    }
+
+    #[tokio::test]
+    async fn already_parsed_first_chunk_with_no_prior_raw_still_terminates_correctly() {
+        let mut already_parsed = chunk("", false);
+        let choice = &mut already_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.tool_calls = Some(vec![ChatCompletionMessageToolCallChunk {
+            index: 0,
+            id: Some("call-preexisting".to_string()),
+            r#type: Some(FunctionType::Function),
+            function: Some(FunctionCallStream {
+                name: Some("get_weather".to_string()),
+                arguments: Some("{}".to_string()),
+            }),
+        }]);
+
+        // This choice index never has a raw chunk at all — no ChoiceState is ever
+        // constructed for it — then the stream ends immediately.
+        let responses = apply_stream(
+            stream::iter([already_parsed]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>(),
+            vec![FinishReason::ToolCalls],
+            "a choice whose only-ever chunk was already-parsed and carried a tool \
+             call must still get exactly one ToolCalls terminal at EOF"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_choice_interleave_finishes_each_unfinished_index_once() {
+        fn choice(index: u32, text: &str, finish: bool) -> ChatChoiceStream {
+            ChatChoiceStream {
+                index,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: Some(Role::Assistant),
+                    content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                    tool_calls: None,
+                    function_call: None,
+                    refusal: None,
+                    reasoning_content: None,
+                },
+                finish_reason: finish.then_some(FinishReason::Stop),
+                logprobs: None,
+            }
+        }
+        fn response(
+            choices: Vec<ChatChoiceStream>,
+        ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+            #[allow(deprecated)]
+            let response = NvCreateChatCompletionStreamResponse {
+                inner: CreateChatCompletionStreamResponse {
+                    id: "test".to_string(),
+                    choices,
+                    created: 0,
+                    model: "qwen3".to_string(),
+                    system_fingerprint: None,
+                    service_tier: None,
+                    object: "chat.completion.chunk".to_string(),
+                    usage: None,
+                },
+                nvext: None,
+                llm_metrics: None,
+            };
+            Annotated::from_data(response)
+        }
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        // Index 0: live the whole time, never removed, never explicitly finished —
+        // the ordinary backstop case. Index 1: raw tool call, then a gap that removes
+        // its state and is never touched again — history-only at EOF. Index 2: raw
+        // tool call, explicitly finished right away, never touched again.
+        let first = response(vec![
+            choice(0, tool_call, false),
+            choice(1, tool_call, false),
+            choice(2, tool_call, false),
+        ]);
+        let mut second = response(vec![choice(0, " more", false), choice(2, " done", true)]);
+        {
+            let mut gap = choice(1, "", false);
+            gap.delta.content = None;
+            gap.delta.reasoning_content = Some("already parsed".to_string());
+            second.data.as_mut().unwrap().inner.choices.push(gap);
+        }
+        // Index 1 gets no further chunks after this — it must stay history-only
+        // through to EOF for this to actually exercise the bug.
+
+        let responses = apply_stream(
+            stream::iter([first, second]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        let finish_for = |index: u32| {
+            choices
+                .iter()
+                .filter(|choice| choice.index == index)
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            finish_for(0),
+            vec![FinishReason::ToolCalls],
+            "the ordinary live choice must get exactly one terminal via the backstop"
+        );
+        assert_eq!(
+            finish_for(1),
+            vec![FinishReason::ToolCalls],
+            "the history-only choice must get exactly one terminal, not zero"
+        );
+        assert_eq!(
+            finish_for(2),
+            vec![FinishReason::ToolCalls],
+            "the already-explicitly-finished choice must not be finished a second \
+             time by the EOF backstop"
+        );
+    }
+
+    #[tokio::test]
+    async fn three_consecutive_already_parsed_gaps_then_eof_finishes_once() {
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let already_parsed_chunk = |reasoning: &str| {
+            let mut c = chunk("", false);
+            let choice = &mut c.data.as_mut().unwrap().inner.choices[0];
+            choice.delta.content = None;
+            choice.delta.reasoning_content = Some(reasoning.to_string());
+            c
+        };
+
+        // Three already-parsed chunks in a row, no raw chunk between them, no
+        // explicit terminal ever, then the stream just ends.
+        let responses = apply_stream(
+            stream::iter([
+                chunk(tool_call, false),
+                already_parsed_chunk("first"),
+                already_parsed_chunk("second"),
+                already_parsed_chunk("third"),
+            ]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>(),
+            vec![FinishReason::ToolCalls],
+            "N consecutive already-parsed gaps with no explicit terminal must still \
+             produce exactly one ToolCalls terminal at EOF, not zero and not N"
+        );
+    }
+
+    #[tokio::test]
+    async fn raw_gap_resume_second_gap_then_eof_finishes_once_in_order() {
+        // Distinct from `three_consecutive_already_parsed_gaps_then_eof_finishes_once`
+        // (which never resumes with a raw chunk in between): this drives raw -> gap ->
+        // raw-resumed (a fresh `ChoiceState`, `tool_emitted` reseeded from the
+        // `ChoiceRecord`) -> a SECOND gap on that resumed instance -> EOF, so the
+        // fold-into-record step at removal runs twice on two different `ChoiceState`
+        // instances for the same choice index.
+        let tool_call = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let already_parsed_chunk = |reasoning: &str| {
+            let mut c = chunk("", false);
+            let choice = &mut c.data.as_mut().unwrap().inner.choices[0];
+            choice.delta.content = None;
+            choice.delta.reasoning_content = Some(reasoning.to_string());
+            c
+        };
+
+        let responses = apply_stream(
+            stream::iter([
+                chunk(tool_call, false),
+                already_parsed_chunk("first gap"),
+                chunk(" resumed text", false),
+                already_parsed_chunk("second gap"),
+            ]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let choices = collect_choices(&responses);
+
+        let ordered: Vec<_> = choices
+            .iter()
+            .filter_map(|choice| {
+                if choice.delta.tool_calls.is_some() {
+                    Some("tool_call")
+                } else if let Some(ChatCompletionMessageContent::Text(text)) = &choice.delta.content
+                {
+                    if text.is_empty() {
+                        None
+                    } else {
+                        Some("content")
+                    }
+                } else {
+                    choice
+                        .delta
+                        .reasoning_content
+                        .as_deref()
+                        .map(|_| "reasoning")
+                }
+            })
+            .collect();
+        assert_eq!(
+            ordered,
+            vec!["tool_call", "reasoning", "content", "reasoning"],
+            "delivery order across the raw/gap/resume/gap sequence must be preserved: \
+             tool call, first gap's reasoning, resumed content, second gap's reasoning"
+        );
+
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .collect::<Vec<_>>(),
+            vec![FinishReason::ToolCalls],
+            "a second gap on a resumed (fresh) ChoiceState must still fold into the \
+             same choice's record and produce exactly one ToolCalls terminal at EOF, \
+             not zero and not two"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_only_stream_gets_no_synthetic_finish_reason() {
+        let responses = apply_stream(
+            stream::iter([chunk("hello world", false)]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert!(
+            choices.iter().all(|choice| choice.finish_reason.is_none()),
+            "there is no signal to synthesize a finish_reason from"
+        );
+    }
+
+    // --- error recovery ----------------------------------------------------------
+
+    #[test]
+    fn a_failed_parser_surfaces_buffered_text_and_stops_parsing() {
+        let mut state = test_state();
+        // The parser releases the settled text immediately and holds back only the
+        // bytes that could still turn out to be a `<tool_call>` opener.
+        assert_eq!(
+            state.push("hello <tool_c"),
+            vec![UnifiedParserEvent::Text("hello ".into())]
+        );
+        // Now force the failure path with those held-back bytes still buffered.
+        let recovered = state.give_up("");
+        assert_eq!(
+            recovered,
+            vec![UnifiedParserEvent::Text("<tool_c".into())],
+            "buffered bytes must be surfaced, not silently dropped"
+        );
+        assert!(state.failed);
+        // Every later chunk now passes through as plain text.
+        assert_eq!(
+            state.push("more"),
+            vec![UnifiedParserEvent::Text("more".into())]
+        );
+        assert!(state.finish().is_empty());
+    }
+
+    #[test]
+    fn a_failed_push_keeps_committed_events_before_recovered_bytes() {
+        let mut state = ChoiceState {
+            family: "test".to_string(),
+            parser: Box::new(PartialCommitParser {
+                recovered: "<broken>".to_string(),
+            }),
+            opened_calls: HashSet::new(),
+            tool_emitted: false,
+            failed: false,
+        };
+
+        assert_eq!(
+            state.push("ignored"),
+            vec![
+                UnifiedParserEvent::Text("committed".to_string()),
+                UnifiedParserEvent::Text("<broken>".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_error_suppresses_eof_recovery() {
+        let responses = apply_stream(
+            stream::iter([
+                chunk("hello <tool_c", false),
+                Annotated::from_error("backend exploded"),
+            ]),
+            None,
+            None,
+            false,
+            UnifiedParserStartingState::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+        let error_position = responses
+            .iter()
+            .position(Annotated::is_error)
+            .expect("terminal error");
+
+        assert!(
+            responses[error_position + 1..]
+                .iter()
+                .all(|response| response.data.is_none()),
+            "no parser data may be emitted after a terminal error"
+        );
+    }
+
+    #[test]
+    fn give_up_falls_back_to_the_chunk_when_nothing_was_buffered() {
+        let mut state = test_state();
+        assert_eq!(
+            state.give_up("the chunk that broke it"),
+            vec![UnifiedParserEvent::Text("the chunk that broke it".into())]
+        );
+    }
+
+    // --- batch -------------------------------------------------------------------
+
+    #[test]
+    fn parses_complete_output_with_reasoning_and_a_tool_call() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            concat!(
+                "<think>reason</think>answer ",
+                "<tool_call>\n<function=get_weather>\n",
+                "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+            ),
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.reasoning, "reason");
+        assert_eq!(parsed.text, "answer ");
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].function.name, "get_weather");
+        assert_eq!(
+            parsed.tool_calls[0].function.arguments,
+            r#"{"city":"Tokyo"}"#
+        );
+        assert!(parsed.tool_calls[0].id.starts_with("call-"));
+    }
+
+    #[test]
+    fn parses_complete_output_with_a_reasoning_prefill() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            "hidden</think>visible",
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+        assert_eq!(parsed.reasoning, "hidden");
+        assert_eq!(parsed.text, "visible");
+        assert!(parsed.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn unmatched_quote_before_real_reasoning_close_does_not_expose_reasoning() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            r#"hidden "unfinished</think>visible"#,
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.reasoning, r#"hidden "unfinished"#);
+        assert_eq!(parsed.text, "visible");
+    }
+
+    #[test]
+    fn unmatched_single_quote_before_real_reasoning_close_does_not_expose_reasoning() {
+        // Leading with a space keeps this a genuine quote-open candidate rather
+        // than the in-word apostrophe exception (e.g. "it's").
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            "hidden 'unfinished</think>visible",
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.reasoning, "hidden 'unfinished");
+        assert_eq!(parsed.text, "visible");
+    }
+
+    #[test]
+    fn unmatched_backtick_before_real_reasoning_close_does_not_expose_reasoning() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            "hidden `unfinished</think>visible",
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.reasoning, "hidden `unfinished");
+        assert_eq!(parsed.text, "visible");
+    }
+
+    #[test]
+    fn contains_unquoted_marker_finds_real_marker_past_many_unmatched_escaped_quotes() {
+        // Every `"` here is immediately preceded by an escaping backslash, so none of
+        // them closes any other: each is individually a "does an unescaped close exist
+        // later" candidate. `later_unescaped_quote_closes` answers all of these in one
+        // O(n) pass; a naive per-candidate rescan (the pre-fix `has_unescaped_close`
+        // called fresh per candidate) would instead be O(n^2) on input shaped like
+        // this. This case is a deterministic correctness check, not a timing
+        // assertion — see the stage evidence ledger for measured old-vs-new behavior.
+        let unit = "a".repeat(50) + "\\\"";
+        let filler: String = unit.repeat(4000);
+        let content = format!("{filler}</think>visible");
+
+        assert!(
+            contains_unquoted_marker(&content, "</think>"),
+            "the real marker after {} chars of adversarial unmatched-escaped-quote \
+             filler must still be found",
+            content.len()
+        );
+    }
+
+    #[test]
+    fn marker_looking_visible_text_stays_visible_in_batch() {
+        let literal = "The literal \"</think>\" closes reasoning.";
+        let parsed =
+            parse_complete(QWEN3_UNIFIED_FAMILY, literal, &GuidedToolConstraint::None).unwrap();
+        assert_eq!(parsed.text, literal);
+        assert!(parsed.reasoning.is_empty());
+
+        let embedded = "The string \"a </think> token\" stays visible.";
+        let parsed =
+            parse_complete(QWEN3_UNIFIED_FAMILY, embedded, &GuidedToolConstraint::None).unwrap();
+        assert_eq!(parsed.text, embedded);
+        assert!(parsed.reasoning.is_empty());
+    }
+
+    #[test]
+    fn plain_text_passes_through_the_batch_path_unchanged() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            "just an answer",
+            &GuidedToolConstraint::None,
+        )
+        .unwrap();
+        assert_eq!(parsed.text, "just an answer");
+        assert!(parsed.reasoning.is_empty());
+        assert!(parsed.tool_calls.is_empty());
+    }
+}

--- a/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/unified_parser.rs
@@ -1,0 +1,1379 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Opt-in ordered reasoning, text, and tool-call parsing through one state machine.
+//!
+//! Gated behind
+//! [`DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`](dynamo_runtime::config::environment_names::llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2).
+//!
+//! # What this replaces
+//!
+//! Dynamo serves a Qwen3 turn today by chaining two independent parsers: the reasoning
+//! parser strips `<think>...</think>` across the whole stream into one assembled
+//! `reasoning_content`, and the tool-call jail then scans whatever is left. That chain
+//! cannot represent WHERE a thought happened. Given
+//!
+//! ```text
+//! <think>Look it up.</think><tool_call>…</tool_call><think>Now answer.</think>It's 18C.
+//! ```
+//!
+//! it serves `reasoning("Look it up.Now answer.")`, then the call, then `text("It's 18C.")`:
+//! the second thought moved ahead of the call it followed and fused with the first. A
+//! client rendering thoughts inline puts them in the wrong place, and a client counting
+//! reasoning turns sees one where there were two.
+//!
+//! Ordering is not a field the split can add — it is lost at the seam between the two
+//! parsers. So when this path is enabled, ONE [`UnifiedParser`] owns the whole grammar
+//! and emits deltas in the order the model produced them, and this module maps those
+//! deltas onto the OpenAI streaming/batch wire shapes.
+//!
+//! # Why one chunk per delta
+//!
+//! [`ChatCompletionStreamResponseDelta`] carries `content`, `reasoning_content` and
+//! `tool_calls` side by side with no way to say which came first. Packing a whole
+//! `push` into one delta object would throw away exactly the ordering this path exists
+//! to preserve, so every [`UnifiedDelta`] becomes its own chunk.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
+
+use async_stream::stream;
+use dynamo_parsers::tool_calling::ToolDefinition;
+use dynamo_parsers_v2::{
+    Tool, UnifiedDelta, UnifiedEvent, UnifiedParser, UnifiedParserPrefill, UnifiedToolOutputMode,
+    create_unified_parser_for_family,
+};
+use dynamo_protocols::types::{
+    ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionMessageToolCall,
+    ChatCompletionMessageToolCallChunk, ChatCompletionStreamResponseDelta,
+    ChatCompletionToolChoiceOption, FinishReason, FunctionCall, FunctionCallStream, FunctionType,
+};
+use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
+use dynamo_runtime::protocols::annotated::Annotated;
+use futures::{Stream, StreamExt};
+use uuid::Uuid;
+
+use super::NvCreateChatCompletionStreamResponse;
+
+/// The `dynamo-parsers-v2` unified family that serves Qwen3.
+///
+/// `REGISTERED_UNIFIED_FAMILIES` accepts both `qwen3` and the `qwen3_coder` alias for
+/// the same XML grammar; `qwen3` is the canonical registry name and the one the
+/// conformance corpus uses, so it is what this module passes and logs.
+pub(crate) const QWEN3_UNIFIED_FAMILY: &str = "qwen3";
+
+/// Dynamo's `--dyn-tool-call-parser` name that pairs into [`QWEN3_UNIFIED_FAMILY`].
+const QWEN3_TOOL_CALL_PARSER: &str = "qwen3_coder";
+
+/// Dynamo's `--dyn-reasoning-parser` name that pairs into [`QWEN3_UNIFIED_FAMILY`].
+const QWEN3_REASONING_PARSER: &str = "qwen3";
+
+/// Whether the experimental v2 parser path is enabled. Read once — env vars are fixed
+/// for the process lifetime, so re-reading per request would only add syscalls.
+///
+/// This reuses `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` rather than adding a second switch.
+/// That flag already means "route this family through `dynamo-parsers-v2` instead of the
+/// v1 jail, for BOTH the batch and the streaming path". The unified parser is the same
+/// intent carried one step further: it also takes over reasoning, so the family stops
+/// needing a separate reasoning parser at all. Two flags would have to define what
+/// setting only one of them means for a family that has both, and the answer is not
+/// interesting — so there is one flag, and the parser PAIR decides which v2 shape a
+/// request gets (see `configured_family`).
+fn experimental_parsers_v2_enabled() -> bool {
+    static ENABLED: LazyLock<bool> =
+        LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2));
+    *ENABLED
+}
+
+/// The unified family this parser pair names, ignoring whether it is switched on.
+///
+/// Both halves must be set and must agree: a unified parser owns reasoning AND tool
+/// calls, so taking over a request configured with only one of them, or with a
+/// reasoning parser from a different family, would silently change what the operator
+/// asked for. Split out from [`selected_family`] so the pairing rule can be tested
+/// without the process-wide env flag.
+pub(crate) fn configured_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    match (tool_call_parser, reasoning_parser) {
+        (Some(QWEN3_TOOL_CALL_PARSER), Some(QWEN3_REASONING_PARSER)) => Some(QWEN3_UNIFIED_FAMILY),
+        _ => None,
+    }
+}
+
+/// The unified family to actually use for this parser pair, or `None` to keep the
+/// existing split reasoning-parser + tool-call-jail path.
+pub(crate) fn selected_family(
+    tool_call_parser: Option<&str>,
+    reasoning_parser: Option<&str>,
+) -> Option<&'static str> {
+    // A request that silently fell back to the split path is otherwise
+    // indistinguishable from one the unified parser handled — the two produce the
+    // same shape of response. One INFO line per stream lets an operator answer
+    // "did v2 actually run?" from the log instead of inferring it from a build
+    // pin, which is exactly the ambiguity that cost real debugging time here.
+    let configured = configured_family(tool_call_parser, reasoning_parser);
+    tracing::info!(
+        target: "dynamo_unified",
+        ?tool_call_parser,
+        ?reasoning_parser,
+        ?configured,
+        flag_on = experimental_parsers_v2_enabled(),
+        "unified parser path decision"
+    );
+    configured.filter(|family| match *family {
+        QWEN3_UNIFIED_FAMILY => experimental_parsers_v2_enabled(),
+        // A family with no opt-in flag stays off; adding one here is what turns it on.
+        _ => false,
+    })
+}
+
+/// Which channel the rendered generation prompt already opened, for the streaming path.
+///
+/// `prompt_injected_reasoning` is the per-request fact the preprocessor already
+/// computes: the rendered prompt ended with the family's reasoning opener, so generated
+/// output starts inside a thought the model will close without ever emitting the
+/// opener. Absent that, the answer is per family.
+pub(crate) fn stream_prefill(
+    family: &str,
+    prompt_injected_reasoning: bool,
+) -> UnifiedParserPrefill {
+    if prompt_injected_reasoning {
+        return UnifiedParserPrefill::Reasoning;
+    }
+    match family {
+        // Qwen3's generation prompt ends at the assistant header with no channel open,
+        // so the model emits `<think>` itself when it thinks.
+        QWEN3_UNIFIED_FAMILY => UnifiedParserPrefill::None,
+        // A family whose non-thinking prompt ends INSIDE the visible response channel
+        // would return `Response` here. None exists yet; an unknown family gets the
+        // conservative answer, which is to assume the model opens its own channels.
+        _ => UnifiedParserPrefill::None,
+    }
+}
+
+/// Which channel the prompt opened, inferred from complete output text.
+///
+/// The batch path has no prompt in hand, only what the model produced, so the channel
+/// state is read back off the text: a `<think>` opener means the model opened reasoning
+/// itself; a bare `</think>` with no opener means the prompt had already opened it; and
+/// neither marker means reasoning never ran for this turn.
+fn detect_prefill(family: &str, content: &str) -> anyhow::Result<UnifiedParserPrefill> {
+    match family {
+        QWEN3_UNIFIED_FAMILY => Ok(if content.contains("<think>") {
+            UnifiedParserPrefill::None
+        } else if content.contains("</think>") {
+            UnifiedParserPrefill::Reasoning
+        } else {
+            UnifiedParserPrefill::Response
+        }),
+        other => anyhow::bail!("no prefill detector for unified parser family '{other}'"),
+    }
+}
+
+/// Map dynamo's v1 [`ToolDefinition`]s onto the v2 parser's [`Tool`] shape.
+fn to_v2_tools(tools: Option<&[ToolDefinition]>) -> Vec<Tool> {
+    tools
+        .unwrap_or(&[])
+        .iter()
+        .map(|tool| Tool {
+            name: tool.name.clone(),
+            description: None,
+            parameters: tool.parameters.clone().unwrap_or(serde_json::Value::Null),
+            strict: tool.strict,
+        })
+        .collect()
+}
+
+/// Map the request's `tool_choice` onto the wire format the backend will produce.
+///
+/// A named or `required` choice is served by guided decoding, which constrains the
+/// model to bare JSON instead of Qwen's native `<tool_call>` XML: a named choice to
+/// that one tool's argument object, `required` to a call object or an array of them.
+/// Unset / `auto` / `none` leave the model in native markup.
+///
+/// Callers must not consult this when a structural tag is active — see
+/// [`apply_stream`]'s `uses_tool_call_structural_tag`.
+fn tool_output_mode(
+    tool_choice: Option<&ChatCompletionToolChoiceOption>,
+) -> UnifiedToolOutputMode<'_> {
+    match tool_choice {
+        Some(ChatCompletionToolChoiceOption::Named(named)) => UnifiedToolOutputMode::GuidedJson {
+            named_tool: Some(&named.function.name),
+        },
+        Some(ChatCompletionToolChoiceOption::Required) => {
+            UnifiedToolOutputMode::GuidedJson { named_tool: None }
+        }
+        None
+        | Some(ChatCompletionToolChoiceOption::Auto)
+        | Some(ChatCompletionToolChoiceOption::None) => UnifiedToolOutputMode::Native,
+    }
+}
+
+/// Merge adjacent same-kind text/reasoning deltas so one `push` does not become three
+/// chunks that say the same thing.
+///
+/// Tool-call deltas never merge: two fragments belonging to different `tool_index`es
+/// would fuse into one call, and even two fragments of the SAME call must keep their
+/// `name`-carrying first delta distinct from later argument-only ones.
+fn coalesce(deltas: Vec<UnifiedDelta>) -> Vec<UnifiedDelta> {
+    let mut out: Vec<UnifiedDelta> = Vec::with_capacity(deltas.len());
+    for delta in deltas {
+        match (out.last_mut(), delta) {
+            (Some(UnifiedDelta::Text { text: prev }), UnifiedDelta::Text { text }) => {
+                prev.push_str(&text)
+            }
+            (Some(UnifiedDelta::Reasoning { text: prev }), UnifiedDelta::Reasoning { text }) => {
+                prev.push_str(&text)
+            }
+            (_, delta) => out.push(delta),
+        }
+    }
+    out
+}
+
+/// An empty streaming choice for `index`, used as the base every emitted chunk is
+/// filled in from.
+///
+/// `logprobs` is dropped on purpose: once parsing rewrites a choice, the emitted text
+/// no longer lines up token-for-token with the backend's raw stream, so per-token
+/// logprobs would be attached to the wrong characters.
+fn empty_choice(index: u32) -> ChatChoiceStream {
+    #[allow(deprecated)]
+    ChatChoiceStream {
+        index,
+        delta: ChatCompletionStreamResponseDelta {
+            role: None,
+            content: None,
+            tool_calls: None,
+            function_call: None,
+            refusal: None,
+            reasoning_content: None,
+        },
+        finish_reason: None,
+        logprobs: None,
+    }
+}
+
+/// Per-choice streaming state: one parser instance plus the bookkeeping the OpenAI
+/// streaming tool-call contract needs. One instance parses exactly one choice of one
+/// request, which is what gives per-stream isolation by construction.
+struct ChoiceState {
+    family: &'static str,
+    parser: Box<dyn UnifiedParser>,
+    /// Tool indices whose opening chunk (id + type + name) has already gone out.
+    opened_calls: HashSet<usize>,
+    /// Whether any tool-call chunk was emitted; flips a terminal `Stop` to `ToolCalls`.
+    tool_emitted: bool,
+    /// The parser errored. Later chunks pass through as plain text instead of failing
+    /// the request — a parser bug must not turn a served answer into a 500.
+    failed: bool,
+}
+
+impl ChoiceState {
+    fn new(
+        family: &'static str,
+        tools: &[Tool],
+        prefill: UnifiedParserPrefill,
+        tool_output_mode: UnifiedToolOutputMode<'_>,
+    ) -> anyhow::Result<Self> {
+        let mut parser = create_unified_parser_for_family(family, tools)?;
+        parser.initialize_with_output_mode(prefill, tool_output_mode)?;
+        Ok(Self {
+            family,
+            parser,
+            opened_calls: HashSet::new(),
+            tool_emitted: false,
+            failed: false,
+        })
+    }
+
+    /// Feed one decoded text delta through the parser.
+    fn push(&mut self, text: &str) -> Vec<UnifiedDelta> {
+        if self.failed {
+            return text_delta(text.to_string());
+        }
+        match self.parser.push(text) {
+            Ok(deltas) => deltas,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    family = self.family,
+                    "unified parser push failed; falling back to plain text for this choice"
+                );
+                self.give_up(text)
+            }
+        }
+    }
+
+    /// Flush buffered partial state at end of stream.
+    fn finish(&mut self) -> Vec<UnifiedDelta> {
+        if self.failed {
+            return Vec::new();
+        }
+        match self.parser.finish() {
+            Ok(deltas) => deltas,
+            Err(error) => {
+                tracing::warn!(
+                    error = %error,
+                    family = self.family,
+                    "unified parser finish failed; recovering buffered text"
+                );
+                self.give_up("")
+            }
+        }
+    }
+
+    /// Stop using the parser and surface whatever it was holding.
+    ///
+    /// `reset()` hands back the bytes the parser had buffered but not yet emitted.
+    /// Dropping them would silently delete model output — the caller would see a
+    /// truncated answer with no indication anything was lost — so they go out as
+    /// visible text. When the parser had nothing buffered, the chunk that broke it
+    /// does instead, so that chunk is not lost either.
+    fn give_up(&mut self, fallback: &str) -> Vec<UnifiedDelta> {
+        self.failed = true;
+        let recovered = self.parser.reset();
+        if recovered.is_empty() {
+            text_delta(fallback.to_string())
+        } else {
+            text_delta(recovered)
+        }
+    }
+
+    /// Convert one ordered delta into a streaming choice for `index`.
+    fn delta_to_choice(&mut self, index: u32, delta: UnifiedDelta) -> ChatChoiceStream {
+        let mut choice = empty_choice(index);
+        match delta {
+            UnifiedDelta::Text { text } => {
+                choice.delta.content = Some(ChatCompletionMessageContent::Text(text));
+            }
+            UnifiedDelta::Reasoning { text } => {
+                choice.delta.reasoning_content = Some(text);
+            }
+            UnifiedDelta::ToolCall(call) => {
+                self.tool_emitted = true;
+                // The OpenAI streaming tool-call contract: the FIRST chunk for a tool
+                // index carries id + type + name, later chunks carry only argument
+                // fragments. `dynamo-parsers-v2` mints no ids (serving layers own them),
+                // so one is minted here per call, exactly once.
+                let first = self.opened_calls.insert(call.tool_index);
+                choice.delta.tool_calls = Some(vec![ChatCompletionMessageToolCallChunk {
+                    index: call.tool_index as u32,
+                    id: first.then(|| format!("call-{}", Uuid::new_v4())),
+                    r#type: first.then_some(FunctionType::Function),
+                    function: Some(FunctionCallStream {
+                        name: first.then_some(call.name).flatten(),
+                        arguments: Some(call.arguments),
+                    }),
+                }]);
+            }
+        }
+        choice
+    }
+
+    /// Convert an ordered delta run into the streaming choices it becomes.
+    ///
+    /// `role` / `refusal` ride on the first emitted choice and the terminating
+    /// `finish_reason` on the last, so a client that reassembles the stream sees the
+    /// same envelope it would have without this path.
+    fn choices_for(
+        &mut self,
+        original: &ChatChoiceStream,
+        deltas: Vec<UnifiedDelta>,
+        finish_reason: Option<FinishReason>,
+    ) -> Vec<ChatChoiceStream> {
+        let deltas = coalesce(deltas);
+        let index = original.index;
+        let count = deltas.len();
+        let mut choices = Vec::with_capacity(count.max(1));
+
+        for (position, delta) in deltas.into_iter().enumerate() {
+            let mut choice = self.delta_to_choice(index, delta);
+            if position == 0 {
+                choice.delta.role = original.delta.role;
+                choice.delta.refusal = original.delta.refusal.clone();
+            }
+            if position + 1 == count {
+                choice.finish_reason = self.normalize_finish_reason(finish_reason);
+            }
+            choices.push(choice);
+        }
+
+        // The parser produced nothing, but the chunk still carried envelope state that
+        // has to reach the client (the opening role chunk, a refusal, or the terminal
+        // finish_reason).
+        if choices.is_empty()
+            && (original.delta.role.is_some()
+                || original.delta.refusal.is_some()
+                || finish_reason.is_some())
+        {
+            let mut choice = empty_choice(index);
+            choice.delta.role = original.delta.role;
+            choice.delta.refusal = original.delta.refusal.clone();
+            choice.finish_reason = self.normalize_finish_reason(finish_reason);
+            choices.push(choice);
+        }
+
+        choices
+    }
+
+    /// OpenAI streaming contract: once a choice has emitted tool calls, a `Stop`
+    /// terminating reason must be reported as `ToolCalls`. `Length` / `ContentFilter`
+    /// describe why generation stopped and are preserved as-is.
+    fn normalize_finish_reason(&self, finish_reason: Option<FinishReason>) -> Option<FinishReason> {
+        if finish_reason == Some(FinishReason::Stop) && self.tool_emitted {
+            Some(FinishReason::ToolCalls)
+        } else {
+            finish_reason
+        }
+    }
+}
+
+/// One text delta, or nothing at all when the text is empty — an empty content chunk
+/// carries no information and clients render it as a stray empty string.
+fn text_delta(text: String) -> Vec<UnifiedDelta> {
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        vec![UnifiedDelta::Text { text }]
+    }
+}
+
+/// The aggregated result of parsing one complete (non-streaming) output.
+pub(crate) struct CompleteOutput {
+    pub text: String,
+    pub reasoning: String,
+    pub tool_calls: Vec<ChatCompletionMessageToolCall>,
+}
+
+/// Batch (non-streaming) path: run the whole output through the same parser lifecycle
+/// and fold the assembled events into the final message.
+///
+/// Routing batch through `push`/`finish` is what makes stream/batch parity structural
+/// rather than a property two code paths have to agree on.
+///
+/// Reasoning spans are concatenated because the non-streaming message schema has ONE
+/// `reasoning_content` string — the ordering the unified parser recovered survives only
+/// on the streaming path, which is where a client can act on it.
+pub(crate) fn parse_complete(family: &str, content: &str) -> anyhow::Result<CompleteOutput> {
+    let mut parser = create_unified_parser_for_family(family, &[])?;
+    parser.initialize(detect_prefill(family, content)?)?;
+
+    let mut text = String::new();
+    let mut reasoning = String::new();
+    let mut tool_calls = Vec::new();
+    for event in parser.parse_complete(content)? {
+        match event {
+            UnifiedEvent::Text { text: chunk } => text.push_str(&chunk),
+            UnifiedEvent::Reasoning { text: chunk } => reasoning.push_str(&chunk),
+            UnifiedEvent::ToolCall { name, arguments } => {
+                tool_calls.push(ChatCompletionMessageToolCall {
+                    id: format!("call-{}", Uuid::new_v4()),
+                    r#type: FunctionType::Function,
+                    // `assemble` already parsed the argument fragments into a typed
+                    // object, so this re-serializes rather than passing the model's
+                    // bytes through. Formatting is normalized as a result.
+                    function: FunctionCall {
+                        name,
+                        arguments: serde_json::to_string(&arguments)?,
+                    },
+                });
+            }
+        }
+    }
+
+    Ok(CompleteOutput {
+        text,
+        reasoning,
+        tool_calls,
+    })
+}
+
+/// Finish every choice that never received a terminating chunk, in index order.
+fn finish_unterminated_choices(
+    states: &mut HashMap<u32, ChoiceState>,
+    finished: &mut HashSet<u32>,
+) -> Vec<ChatChoiceStream> {
+    let mut indices: Vec<_> = states
+        .keys()
+        .copied()
+        .filter(|index| !finished.contains(index))
+        .collect();
+    indices.sort_unstable();
+
+    let mut choices = Vec::new();
+    for index in indices {
+        finished.insert(index);
+        let state = states
+            .get_mut(&index)
+            .expect("index came from this map's keys");
+        let deltas = state.finish();
+        // A choice that emitted tool calls must terminate with `ToolCalls` even when
+        // the backend never sent a finish_reason: a strict client waits for a non-null
+        // one before considering the call complete, and would otherwise hang.
+        let finish_reason = state.tool_emitted.then_some(FinishReason::ToolCalls);
+        let base = empty_choice(index);
+        choices.extend(state.choices_for(&base, deltas, finish_reason));
+    }
+    choices
+}
+
+/// Wrap one rewritten choice in a response built from `template`.
+///
+/// Usage, nvext and metrics are cleared: they belong to the chunk that carried them,
+/// and repeating them on a synthesized chunk would double-count.
+fn response_with_choice(
+    template: &NvCreateChatCompletionStreamResponse,
+    choice: ChatChoiceStream,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    let mut data = template.clone();
+    data.inner.choices = vec![choice];
+    data.inner.usage = None;
+    data.nvext = None;
+    data.llm_metrics = None;
+    Annotated::from_data(data)
+}
+
+/// Whether a choice arrived already parsed by something upstream and must be passed
+/// through untouched rather than re-parsed.
+fn already_parsed(choice: &ChatChoiceStream) -> bool {
+    matches!(
+        choice.delta.content,
+        Some(ChatCompletionMessageContent::Parts(_))
+    ) || choice.delta.tool_calls.is_some()
+        || choice.delta.reasoning_content.is_some()
+}
+
+/// Streaming path: one unified parser per response choice, replacing both the reasoning
+/// parser and the tool-call jail for this request.
+///
+/// `uses_tool_call_structural_tag` reports that the backend was given a structural tag
+/// constraining generation to the family's NATIVE grammar. When it is set the output is
+/// native markup no matter what `tool_choice` says, so `tool_choice` is not consulted;
+/// this path only parses guided JSON, it never builds the grammar that produces it.
+pub(crate) fn apply_stream<S>(
+    stream_in: S,
+    tool_definitions: Option<Vec<ToolDefinition>>,
+    tool_choice: Option<ChatCompletionToolChoiceOption>,
+    uses_tool_call_structural_tag: bool,
+    prefill: UnifiedParserPrefill,
+    family: &'static str,
+) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+where
+    S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+{
+    let tools = to_v2_tools(tool_definitions.as_deref());
+    stream! {
+        let mut states: HashMap<u32, ChoiceState> = HashMap::new();
+        let mut finished: HashSet<u32> = HashSet::new();
+        // Last data response with its choices cleared, so an end-of-stream flush has an
+        // envelope (id, model, created) to attach synthesized chunks to.
+        let mut template: Option<NvCreateChatCompletionStreamResponse> = None;
+
+        tokio::pin!(stream_in);
+
+        while let Some(mut response) = stream_in.next().await {
+            let Some(chat) = response.data.as_mut() else {
+                // Non-data annotations (errors, comments) pass through untouched.
+                yield response;
+                continue;
+            };
+
+            {
+                let mut next = chat.clone();
+                next.inner.choices.clear();
+                next.inner.usage = None;
+                next.nvext = None;
+                next.llm_metrics = None;
+                template = Some(next);
+            }
+
+            if chat.inner.choices.is_empty() {
+                // A usage-only chunk. OpenAI stream ordering requires every choice's
+                // terminal finish_reason to precede it, so flush first.
+                if let Some(template) = &template {
+                    for choice in finish_unterminated_choices(&mut states, &mut finished) {
+                        yield response_with_choice(template, choice);
+                    }
+                }
+                yield response;
+                continue;
+            }
+
+            let originals = std::mem::take(&mut chat.inner.choices);
+            let mut emitted: Vec<ChatChoiceStream> = Vec::new();
+            for original in originals {
+                if already_parsed(&original) {
+                    if original.finish_reason.is_some() {
+                        finished.insert(original.index);
+                    }
+                    emitted.push(original);
+                    continue;
+                }
+
+                let state = match states.entry(original.index) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        // A structural tag pins generation to native markup; only
+                        // without one does tool_choice select guided JSON.
+                        let mode = if uses_tool_call_structural_tag {
+                            UnifiedToolOutputMode::Native
+                        } else {
+                            tool_output_mode(tool_choice.as_ref())
+                        };
+                        match ChoiceState::new(family, &tools, prefill, mode) {
+                            Ok(state) => entry.insert(state),
+                            Err(error) => {
+                                tracing::warn!(
+                                    error = %error,
+                                    family,
+                                    choice = original.index,
+                                    "unified parser construction failed; passing choice through"
+                                );
+                                emitted.push(original);
+                                continue;
+                            }
+                        }
+                    }
+                };
+
+                let mut deltas = Vec::new();
+                if let Some(ChatCompletionMessageContent::Text(text)) =
+                    original.delta.content.as_ref()
+                {
+                    deltas.extend(state.push(text));
+                }
+                let terminal = original.finish_reason;
+                if terminal.is_some() && finished.insert(original.index) {
+                    deltas.extend(state.finish());
+                }
+
+                let mut parsed = state.choices_for(&original, deltas, terminal);
+                if parsed.is_empty() {
+                    // A marker-only chunk produced no deltas. Keep it as an empty
+                    // choice so the typed llm_metrics and annotation metadata it
+                    // carries still reach the client.
+                    parsed.push(empty_choice(original.index));
+                }
+                emitted.extend(parsed);
+            }
+
+            if emitted.is_empty() {
+                continue;
+            }
+
+            // One upstream chunk can fan out into several. Only the LAST carries the
+            // usage / nvext / metrics and the annotation fields, so nothing is counted
+            // or reported twice.
+            let last = emitted.len() - 1;
+            for (position, choice) in emitted.into_iter().enumerate() {
+                let is_last = position == last;
+                let mut data = chat.clone();
+                data.inner.choices = vec![choice];
+                if !is_last {
+                    data.inner.usage = None;
+                    data.nvext = None;
+                    data.llm_metrics = None;
+                }
+                yield Annotated {
+                    data: Some(data),
+                    id: if is_last { response.id.take() } else { None },
+                    event: if is_last { response.event.take() } else { None },
+                    comment: if is_last { response.comment.take() } else { None },
+                    error: if is_last { response.error.take() } else { None },
+                };
+            }
+        }
+
+        // Backstop: the stream ended without a terminating chunk for some choice.
+        if let Some(template) = &template {
+            for choice in finish_unterminated_choices(&mut states, &mut finished) {
+                yield response_with_choice(template, choice);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_parsers_v2::ToolCallDelta;
+    use dynamo_protocols::types::{CreateChatCompletionStreamResponse, Role};
+    use futures::stream;
+
+    fn chunk(text: &str, finish: bool) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let response = NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![ChatChoiceStream {
+                    index: 0,
+                    delta: ChatCompletionStreamResponseDelta {
+                        role: Some(Role::Assistant),
+                        content: Some(ChatCompletionMessageContent::Text(text.to_string())),
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: finish.then_some(FinishReason::Stop),
+                    logprobs: None,
+                }],
+                created: 0,
+                model: "qwen3".to_string(),
+                system_fingerprint: None,
+                service_tier: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        Annotated::from_data(response)
+    }
+
+    fn weather_tools() -> Vec<ToolDefinition> {
+        vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(serde_json::json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"]
+            })),
+            strict: None,
+        }]
+    }
+
+    fn collect_choices(
+        responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+    ) -> Vec<&ChatChoiceStream> {
+        responses
+            .iter()
+            .filter_map(|response| response.data.as_ref())
+            .flat_map(|data| data.inner.choices.iter())
+            .collect()
+    }
+
+    fn named_choice(name: &str) -> ChatCompletionToolChoiceOption {
+        serde_json::from_value(serde_json::json!({
+            "type": "function",
+            "function": {"name": name}
+        }))
+        .expect("named tool choice")
+    }
+
+    // --- selected_family / configured_family -------------------------------------
+
+    #[test]
+    fn pairs_only_qwen3_coder_with_qwen3() {
+        assert_eq!(
+            configured_family(Some("qwen3_coder"), Some("qwen3")),
+            Some(QWEN3_UNIFIED_FAMILY)
+        );
+        // A unified parser owns BOTH halves, so half a pair must not opt in.
+        assert_eq!(configured_family(Some("qwen3_coder"), None), None);
+        assert_eq!(configured_family(None, Some("qwen3")), None);
+        assert_eq!(configured_family(None, None), None);
+        // Right tool parser, wrong reasoning family.
+        assert_eq!(
+            configured_family(Some("qwen3_coder"), Some("deepseek_r1")),
+            None
+        );
+        // Right reasoning parser, wrong tool family.
+        assert_eq!(configured_family(Some("kimi_k2"), Some("qwen3")), None);
+        // The pairing is on dynamo's parser names, not the unified family name.
+        assert_eq!(configured_family(Some("qwen3"), Some("qwen3")), None);
+    }
+
+    #[test]
+    fn selected_family_needs_the_env_flag() {
+        // The env flag is process-wide and read once, so this asserts the relationship
+        // between the two functions rather than mutating the environment: whatever the
+        // flag says, `selected_family` never selects a pair `configured_family` rejects,
+        // and it agrees with `configured_family` exactly when the flag is on.
+        let pair = (Some("qwen3_coder"), Some("qwen3"));
+        assert_eq!(
+            configured_family(pair.0, pair.1),
+            Some(QWEN3_UNIFIED_FAMILY)
+        );
+        if experimental_parsers_v2_enabled() {
+            assert_eq!(
+                selected_family(pair.0, pair.1),
+                Some(QWEN3_UNIFIED_FAMILY),
+                "flag on: the configured pair must be selected"
+            );
+        } else {
+            assert_eq!(
+                selected_family(pair.0, pair.1),
+                None,
+                "flag off: the configured pair must NOT be selected"
+            );
+        }
+        // Never selected regardless of the flag.
+        assert_eq!(selected_family(Some("qwen3_coder"), None), None);
+        assert_eq!(selected_family(None, Some("qwen3")), None);
+    }
+
+    // --- tool_choice -> UnifiedToolOutputMode ------------------------------------
+
+    #[test]
+    fn maps_tool_choice_onto_the_output_mode() {
+        let named = named_choice("get_weather");
+        assert_eq!(
+            tool_output_mode(Some(&named)),
+            UnifiedToolOutputMode::GuidedJson {
+                named_tool: Some("get_weather")
+            }
+        );
+        assert_eq!(
+            tool_output_mode(Some(&ChatCompletionToolChoiceOption::Required)),
+            UnifiedToolOutputMode::GuidedJson { named_tool: None }
+        );
+        for native in [
+            None,
+            Some(&ChatCompletionToolChoiceOption::Auto),
+            Some(&ChatCompletionToolChoiceOption::None),
+        ] {
+            assert_eq!(
+                tool_output_mode(native),
+                UnifiedToolOutputMode::Native,
+                "{native:?} must stay on native markup"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn structural_tag_keeps_required_on_native_markup() {
+        // A structural tag constrains generation to Qwen's XML, so `required` must NOT
+        // put the parser into guided-JSON mode; doing so would surface the whole call
+        // as text.
+        let output = concat!(
+            "<think>reason</think>",
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        let responses = apply_stream(
+            stream::iter([chunk(output, true)]),
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            true,
+            UnifiedParserPrefill::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let call = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .next()
+            .expect("a native tool call");
+        let function = call.function.as_ref().expect("function");
+        assert_eq!(function.name.as_deref(), Some("get_weather"));
+        assert_eq!(function.arguments.as_deref(), Some(r#"{"city":"Tokyo"}"#));
+    }
+
+    // --- prefill -----------------------------------------------------------------
+
+    #[test]
+    fn prompt_injected_reasoning_selects_the_reasoning_prefill() {
+        assert_eq!(
+            stream_prefill(QWEN3_UNIFIED_FAMILY, true),
+            UnifiedParserPrefill::Reasoning
+        );
+        // Qwen3's template pre-opens no channel, so the model emits `<think>` itself.
+        assert_eq!(
+            stream_prefill(QWEN3_UNIFIED_FAMILY, false),
+            UnifiedParserPrefill::None
+        );
+    }
+
+    #[test]
+    fn detects_batch_prefill_from_complete_output() {
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "<think>reason</think>answer").unwrap(),
+            UnifiedParserPrefill::None
+        );
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "reason</think>answer").unwrap(),
+            UnifiedParserPrefill::Reasoning
+        );
+        assert_eq!(
+            detect_prefill(QWEN3_UNIFIED_FAMILY, "answer").unwrap(),
+            UnifiedParserPrefill::Response
+        );
+        assert!(detect_prefill("kimi_k3", "answer").is_err());
+    }
+
+    // --- delta -> chunk conversion -----------------------------------------------
+
+    fn call_delta(tool_index: usize, name: Option<&str>, arguments: &str) -> UnifiedDelta {
+        UnifiedDelta::ToolCall(ToolCallDelta {
+            tool_index,
+            name: name.map(str::to_string),
+            arguments: arguments.to_string(),
+        })
+    }
+
+    fn test_state() -> ChoiceState {
+        ChoiceState::new(
+            QWEN3_UNIFIED_FAMILY,
+            &[],
+            UnifiedParserPrefill::None,
+            UnifiedToolOutputMode::Native,
+        )
+        .expect("qwen3 unified parser")
+    }
+
+    #[test]
+    fn each_delta_becomes_its_own_chunk_in_order() {
+        // The whole point of this path: a thought that followed a call stays after it.
+        let mut state = test_state();
+        let base = empty_choice(0);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                UnifiedDelta::Reasoning {
+                    text: "look it up".into(),
+                },
+                call_delta(0, Some("get_weather"), r#"{"city":"Tokyo"}"#),
+                UnifiedDelta::Reasoning {
+                    text: "now answer".into(),
+                },
+                UnifiedDelta::Text {
+                    text: "It's 18C.".into(),
+                },
+            ],
+            Some(FinishReason::Stop),
+        );
+
+        assert_eq!(choices.len(), 4, "one chunk per delta: {choices:?}");
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("look it up")
+        );
+        assert!(choices[1].delta.tool_calls.is_some());
+        assert_eq!(
+            choices[2].delta.reasoning_content.as_deref(),
+            Some("now answer"),
+            "the second thought must stay AFTER the call, not fuse with the first"
+        );
+        assert_eq!(
+            choices[3].delta.content,
+            Some(ChatCompletionMessageContent::Text("It's 18C.".into()))
+        );
+        // Only the last chunk terminates, and Stop became ToolCalls.
+        assert_eq!(choices[3].finish_reason, Some(FinishReason::ToolCalls));
+        assert!(choices[..3].iter().all(|c| c.finish_reason.is_none()));
+    }
+
+    #[test]
+    fn first_tool_chunk_opens_the_call_and_later_ones_only_add_arguments() {
+        let mut state = test_state();
+        let base = empty_choice(7);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                call_delta(0, Some("get_weather"), r#"{"city":"#),
+                call_delta(0, None, r#""Tokyo"}"#),
+            ],
+            None,
+        );
+
+        assert_eq!(choices.len(), 2);
+        let first = &choices[0].delta.tool_calls.as_ref().unwrap()[0];
+        assert_eq!(choices[0].index, 7, "the choice index is preserved");
+        assert_eq!(first.index, 0, "the tool index is preserved");
+        assert!(first.id.is_some(), "the opening chunk mints an id");
+        assert_eq!(first.r#type, Some(FunctionType::Function));
+        assert_eq!(
+            first.function.as_ref().unwrap().name.as_deref(),
+            Some("get_weather")
+        );
+
+        let second = &choices[1].delta.tool_calls.as_ref().unwrap()[0];
+        assert!(second.id.is_none(), "only the first chunk carries an id");
+        assert!(second.r#type.is_none());
+        assert!(second.function.as_ref().unwrap().name.is_none());
+        assert_eq!(
+            second.function.as_ref().unwrap().arguments.as_deref(),
+            Some(r#""Tokyo"}"#)
+        );
+    }
+
+    #[test]
+    fn two_calls_get_distinct_ids_and_keep_their_indices() {
+        let mut state = test_state();
+        let base = empty_choice(0);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                call_delta(0, Some("a"), "{}"),
+                call_delta(1, Some("b"), "{}"),
+            ],
+            None,
+        );
+
+        let ids: Vec<_> = choices
+            .iter()
+            .map(|choice| {
+                let call = &choice.delta.tool_calls.as_ref().unwrap()[0];
+                (call.index, call.id.clone().expect("id"))
+            })
+            .collect();
+        assert_eq!(ids[0].0, 0);
+        assert_eq!(ids[1].0, 1);
+        assert_ne!(ids[0].1, ids[1].1, "each call gets its own id");
+    }
+
+    #[test]
+    fn adjacent_same_kind_deltas_coalesce_but_calls_never_do() {
+        let merged = coalesce(vec![
+            UnifiedDelta::Text { text: "he".into() },
+            UnifiedDelta::Text { text: "llo".into() },
+            call_delta(0, Some("f"), "{"),
+            call_delta(0, None, "}"),
+            UnifiedDelta::Reasoning { text: "a".into() },
+            UnifiedDelta::Reasoning { text: "b".into() },
+        ]);
+        assert_eq!(merged.len(), 4);
+        assert_eq!(
+            merged[0],
+            UnifiedDelta::Text {
+                text: "hello".into()
+            }
+        );
+        assert_eq!(merged[1], call_delta(0, Some("f"), "{"));
+        assert_eq!(merged[2], call_delta(0, None, "}"));
+        assert_eq!(merged[3], UnifiedDelta::Reasoning { text: "ab".into() });
+    }
+
+    #[test]
+    fn role_rides_the_first_chunk_and_finish_reason_the_last() {
+        let mut state = test_state();
+        let mut base = empty_choice(0);
+        base.delta.role = Some(Role::Assistant);
+        let choices = state.choices_for(
+            &base,
+            vec![
+                UnifiedDelta::Text { text: "a".into() },
+                call_delta(0, Some("f"), "{}"),
+            ],
+            Some(FinishReason::Stop),
+        );
+
+        assert_eq!(choices[0].delta.role, Some(Role::Assistant));
+        assert!(choices[1].delta.role.is_none());
+        assert!(choices[0].finish_reason.is_none());
+        assert_eq!(choices[1].finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[test]
+    fn an_empty_run_still_carries_the_terminating_envelope() {
+        let mut state = test_state();
+        let mut base = empty_choice(0);
+        base.delta.role = Some(Role::Assistant);
+        let choices = state.choices_for(&base, Vec::new(), Some(FinishReason::Length));
+
+        assert_eq!(choices.len(), 1);
+        assert_eq!(choices[0].delta.role, Some(Role::Assistant));
+        assert_eq!(
+            choices[0].finish_reason,
+            Some(FinishReason::Length),
+            "Length is not rewritten"
+        );
+    }
+
+    #[test]
+    fn an_empty_run_with_no_envelope_emits_nothing() {
+        let mut state = test_state();
+        let base = empty_choice(0);
+        assert!(state.choices_for(&base, Vec::new(), None).is_empty());
+    }
+
+    // --- end-to-end streaming ----------------------------------------------------
+
+    #[tokio::test]
+    async fn streams_ordered_reasoning_text_and_tool_calls() {
+        let output = concat!(
+            "<think>reason</think>answer ",
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        // Split into small chunks so markers straddle push() boundaries.
+        let mut chunks: Vec<_> = output
+            .as_bytes()
+            .chunks(7)
+            .map(|bytes| chunk(std::str::from_utf8(bytes).unwrap(), false))
+            .collect();
+        chunks.push(chunk("", true));
+
+        let responses = apply_stream(
+            stream::iter(chunks),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserPrefill::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let reasoning: String = choices
+            .iter()
+            .filter_map(|choice| choice.delta.reasoning_content.as_deref())
+            .collect();
+        let content: String = choices
+            .iter()
+            .filter_map(|choice| match &choice.delta.content {
+                Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        let arguments: String = choices
+            .iter()
+            .filter_map(|choice| choice.delta.tool_calls.as_ref())
+            .flatten()
+            .filter_map(|call| call.function.as_ref()?.arguments.as_deref())
+            .collect();
+
+        assert_eq!(reasoning, "reason");
+        assert_eq!(content, "answer ");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&arguments).unwrap()["city"],
+            "Tokyo"
+        );
+        for marker in ["<think>", "<tool_call>", "<function=", "<parameter="] {
+            assert!(
+                !content.contains(marker),
+                "raw markup {marker:?} leaked into content: {content:?}"
+            );
+        }
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .next_back(),
+            Some(FinishReason::ToolCalls)
+        );
+    }
+
+    #[tokio::test]
+    async fn named_guided_json_becomes_a_tool_call() {
+        let responses = apply_stream(
+            stream::iter([chunk("reason</think>{\"city\": \"Tokyo\"}", true)]),
+            Some(weather_tools()),
+            Some(named_choice("get_weather")),
+            false,
+            UnifiedParserPrefill::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("reason")
+        );
+        let call = &choices[1].delta.tool_calls.as_ref().unwrap()[0];
+        let function = call.function.as_ref().unwrap();
+        assert_eq!(function.name.as_deref(), Some("get_weather"));
+        assert_eq!(
+            function.arguments.as_deref(),
+            Some("{\"city\": \"Tokyo\"}"),
+            "a named choice passes the model's argument bytes through verbatim"
+        );
+        assert_eq!(choices[1].finish_reason, Some(FinishReason::ToolCalls));
+    }
+
+    #[tokio::test]
+    async fn required_guided_json_becomes_a_tool_call() {
+        let responses = apply_stream(
+            stream::iter([chunk(
+                r#"reason</think>[{"name":"get_weather","parameters":{"city":"Tokyo"}}]"#,
+                true,
+            )]),
+            Some(weather_tools()),
+            Some(ChatCompletionToolChoiceOption::Required),
+            false,
+            UnifiedParserPrefill::Reasoning,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        let call = &choices[1].delta.tool_calls.as_ref().unwrap()[0];
+        let function = call.function.as_ref().unwrap();
+        assert_eq!(function.name.as_deref(), Some("get_weather"));
+        assert_eq!(function.arguments.as_deref(), Some(r#"{"city":"Tokyo"}"#));
+    }
+
+    #[tokio::test]
+    async fn already_parsed_choices_pass_through_untouched() {
+        // A chunk that already carries reasoning_content was parsed upstream; running
+        // it through the parser again would double it.
+        let mut pre_parsed = chunk("", false);
+        let choice = &mut pre_parsed.data.as_mut().unwrap().inner.choices[0];
+        choice.delta.content = None;
+        choice.delta.reasoning_content = Some("already".to_string());
+
+        let responses = apply_stream(
+            stream::iter([pre_parsed]),
+            None,
+            None,
+            false,
+            UnifiedParserPrefill::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(choices.len(), 1);
+        assert_eq!(
+            choices[0].delta.reasoning_content.as_deref(),
+            Some("already")
+        );
+    }
+
+    #[tokio::test]
+    async fn a_stream_without_a_finish_reason_still_terminates_a_tool_call() {
+        let output = concat!(
+            "<tool_call>\n<function=get_weather>\n",
+            "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+        );
+        // No terminating chunk at all — the stream just ends.
+        let responses = apply_stream(
+            stream::iter([chunk(output, false)]),
+            Some(weather_tools()),
+            None,
+            false,
+            UnifiedParserPrefill::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert_eq!(
+            choices
+                .iter()
+                .filter_map(|choice| choice.finish_reason)
+                .next_back(),
+            Some(FinishReason::ToolCalls),
+            "the backstop must synthesize a terminal reason or a strict client hangs"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_only_stream_gets_no_synthetic_finish_reason() {
+        let responses = apply_stream(
+            stream::iter([chunk("hello world", false)]),
+            None,
+            None,
+            false,
+            UnifiedParserPrefill::None,
+            QWEN3_UNIFIED_FAMILY,
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        let choices = collect_choices(&responses);
+        assert!(
+            choices.iter().all(|choice| choice.finish_reason.is_none()),
+            "there is no signal to synthesize a finish_reason from"
+        );
+    }
+
+    // --- error recovery ----------------------------------------------------------
+
+    #[test]
+    fn a_failed_parser_surfaces_buffered_text_and_stops_parsing() {
+        let mut state = test_state();
+        // The parser releases the settled text immediately and holds back only the
+        // bytes that could still turn out to be a `<tool_call>` opener.
+        assert_eq!(
+            state.push("hello <tool_c"),
+            vec![UnifiedDelta::Text {
+                text: "hello ".into()
+            }]
+        );
+        // Now force the failure path with those held-back bytes still buffered.
+        let recovered = state.give_up("");
+        assert_eq!(
+            recovered,
+            vec![UnifiedDelta::Text {
+                text: "<tool_c".into()
+            }],
+            "buffered bytes must be surfaced, not silently dropped"
+        );
+        assert!(state.failed);
+        // Every later chunk now passes through as plain text.
+        assert_eq!(
+            state.push("more"),
+            vec![UnifiedDelta::Text {
+                text: "more".into()
+            }]
+        );
+        assert!(state.finish().is_empty());
+    }
+
+    #[test]
+    fn give_up_falls_back_to_the_chunk_when_nothing_was_buffered() {
+        let mut state = test_state();
+        assert_eq!(
+            state.give_up("the chunk that broke it"),
+            vec![UnifiedDelta::Text {
+                text: "the chunk that broke it".into()
+            }]
+        );
+    }
+
+    // --- batch -------------------------------------------------------------------
+
+    #[test]
+    fn parses_complete_output_with_reasoning_and_a_tool_call() {
+        let parsed = parse_complete(
+            QWEN3_UNIFIED_FAMILY,
+            concat!(
+                "<think>reason</think>answer ",
+                "<tool_call>\n<function=get_weather>\n",
+                "<parameter=city>Tokyo</parameter>\n</function>\n</tool_call>"
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(parsed.reasoning, "reason");
+        assert_eq!(parsed.text, "answer ");
+        assert_eq!(parsed.tool_calls.len(), 1);
+        assert_eq!(parsed.tool_calls[0].function.name, "get_weather");
+        assert_eq!(
+            parsed.tool_calls[0].function.arguments,
+            r#"{"city":"Tokyo"}"#
+        );
+        assert!(parsed.tool_calls[0].id.starts_with("call-"));
+    }
+
+    #[test]
+    fn parses_complete_output_with_a_reasoning_prefill() {
+        let parsed = parse_complete(QWEN3_UNIFIED_FAMILY, "hidden</think>visible").unwrap();
+        assert_eq!(parsed.reasoning, "hidden");
+        assert_eq!(parsed.text, "visible");
+        assert!(parsed.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn plain_text_passes_through_the_batch_path_unchanged() {
+        let parsed = parse_complete(QWEN3_UNIFIED_FAMILY, "just an answer").unwrap();
+        assert_eq!(parsed.text, "just an answer");
+        assert!(parsed.reasoning.is_empty());
+        assert!(parsed.tool_calls.is_empty());
+    }
+}

--- a/lib/llm/src/protocols/openai/tools.rs
+++ b/lib/llm/src/protocols/openai/tools.rs
@@ -22,14 +22,69 @@ pub enum ToolChoiceError {
     EmptyTools,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolChoiceValidation<'a> {
+    Unforced,
+    Required,
+    Named(&'a str),
+}
+
+/// Validate the forced-choice contract shared by wire and parser-facing tool types.
+pub(crate) fn validate_tool_choice_against_names<'a>(
+    tool_choice: ToolChoiceValidation<'_>,
+    tool_names: impl IntoIterator<Item = &'a str>,
+) -> Result<(), ToolChoiceError> {
+    let mut tool_names = tool_names.into_iter();
+    match tool_choice {
+        ToolChoiceValidation::Unforced => Ok(()),
+        ToolChoiceValidation::Required if tool_names.next().is_none() => {
+            Err(ToolChoiceError::EmptyTools)
+        }
+        ToolChoiceValidation::Named(name) if !tool_names.any(|tool_name| tool_name == name) => {
+            Err(ToolChoiceError::ToolNotFound(name.to_string()))
+        }
+        ToolChoiceValidation::Required | ToolChoiceValidation::Named(_) => Ok(()),
+    }
+}
+
+/// Validate an OpenAI `tool_choice` against the request's declared tools.
+pub(crate) fn validate_openai_tool_choice(
+    tool_choice: Option<&ChatCompletionToolChoiceOption>,
+    tools: Option<&[ChatCompletionTool]>,
+) -> Result<(), ToolChoiceError> {
+    let Some(tool_choice) = tool_choice else {
+        return Ok(());
+    };
+
+    match tool_choice {
+        ChatCompletionToolChoiceOption::None | ChatCompletionToolChoiceOption::Auto => Ok(()),
+        ChatCompletionToolChoiceOption::Required => {
+            let tools = tools.ok_or(ToolChoiceError::MissingTools)?;
+            validate_tool_choice_against_names(
+                ToolChoiceValidation::Required,
+                tools.iter().map(|tool| tool.function.name.as_str()),
+            )
+        }
+        ChatCompletionToolChoiceOption::Named(named) => {
+            let tools = tools.ok_or(ToolChoiceError::MissingTools)?;
+            validate_tool_choice_against_names(
+                ToolChoiceValidation::Named(&named.function.name),
+                tools.iter().map(|tool| tool.function.name.as_str()),
+            )
+        }
+    }
+}
+
 /// Builds the JSON schema enforced by Guided Decoding for the given tool_choice/tools pair.
 pub fn get_json_schema_from_tools(
     tool_choice: Option<&ChatCompletionToolChoiceOption>,
     tools: Option<&[ChatCompletionTool]>,
+    parallel_tool_calls: Option<bool>,
 ) -> Result<Option<Value>, ToolChoiceError> {
     let Some(choice) = tool_choice else {
         return Ok(None);
     };
+    validate_openai_tool_choice(Some(choice), tools)?;
 
     match choice {
         ChatCompletionToolChoiceOption::None | ChatCompletionToolChoiceOption::Auto => Ok(None),
@@ -41,10 +96,7 @@ pub fn get_json_schema_from_tools(
         }
         ChatCompletionToolChoiceOption::Required => {
             let tools = tools.ok_or(ToolChoiceError::MissingTools)?;
-            if tools.is_empty() {
-                return Err(ToolChoiceError::EmptyTools);
-            }
-            build_required_schema(tools).map(Some)
+            build_required_schema(tools, parallel_tool_calls).map(Some)
         }
     }
 }
@@ -113,7 +165,10 @@ fn clone_parameters(function: &FunctionObject) -> Value {
 /// We extract `$defs` from each tool's schema and merge them into a global `$defs` map
 /// at the root level. If multiple tools define the same type, we verify they match to
 /// avoid conflicts.
-fn build_required_schema(tools: &[ChatCompletionTool]) -> Result<Value, ToolChoiceError> {
+fn build_required_schema(
+    tools: &[ChatCompletionTool],
+    parallel_tool_calls: Option<bool>,
+) -> Result<Value, ToolChoiceError> {
     // Accumulator for all shared type definitions ($defs) across tools
     let mut defs: BTreeMap<String, Value> = BTreeMap::new();
     let mut any_of = Vec::with_capacity(tools.len());
@@ -146,6 +201,17 @@ fn build_required_schema(tools: &[ChatCompletionTool]) -> Result<Value, ToolChoi
             "anyOf": any_of,
         },
     });
+
+    // `parallel_tool_calls: false` is otherwise enforced only downstream, by discarding
+    // tool indices above zero in the HTTP stream. That leaves the extra calls GENERATED
+    // and observable by any consumer upstream of that filter, and it wastes the tokens
+    // spent producing them. Constraining generation is the earlier, cheaper fix; the
+    // HTTP filter stays as defense in depth.
+    if parallel_tool_calls == Some(false)
+        && let Value::Object(map) = &mut result
+    {
+        map.insert("maxItems".to_string(), json!(1));
+    }
 
     // Attach the merged $defs at the root level if any were collected
     if !defs.is_empty()
@@ -315,7 +381,8 @@ mod tests {
                 },
             },
         );
-        let schema = get_json_schema_from_tools(Some(&tool_choice), Some(&tools)).expect("schema");
+        let schema =
+            get_json_schema_from_tools(Some(&tool_choice), Some(&tools), None).expect("schema");
 
         assert_eq!(
             schema.unwrap(),
@@ -336,6 +403,7 @@ mod tests {
         let schema = get_json_schema_from_tools(
             Some(&ChatCompletionToolChoiceOption::Required),
             Some(&tools),
+            None,
         )
         .expect("schema");
 
@@ -363,7 +431,7 @@ mod tests {
                 },
             },
         );
-        let err = get_json_schema_from_tools(Some(&tool_choice), Some(&tools)).unwrap_err();
+        let err = get_json_schema_from_tools(Some(&tool_choice), Some(&tools), None).unwrap_err();
         assert_eq!(err, ToolChoiceError::ToolNotFound("unknown".to_string()));
     }
 
@@ -393,10 +461,38 @@ mod tests {
         }));
 
         let tools = vec![tool, tool_with_conflict];
-        let err = build_required_schema(&tools).unwrap_err();
+        let err = build_required_schema(&tools, None).unwrap_err();
         assert_eq!(
             err,
             ToolChoiceError::ConflictingDefinition("shared".to_string())
+        );
+    }
+
+    #[test]
+    fn required_schema_is_unbounded_by_default() {
+        let tools = sample_tools();
+        let schema = build_required_schema(&tools, None).expect("schema");
+        assert_eq!(schema["minItems"], json!(1));
+        assert!(
+            schema.get("maxItems").is_none(),
+            "parallel calls stay unbounded unless the request disables them"
+        );
+        let schema = build_required_schema(&tools, Some(true)).expect("schema");
+        assert!(schema.get("maxItems").is_none());
+    }
+
+    /// `parallel_tool_calls: false` must constrain GENERATION, not just be filtered
+    /// downstream - otherwise the extra calls are still produced, still cost tokens,
+    /// and are still observable upstream of the HTTP filter.
+    #[test]
+    fn required_schema_caps_at_one_when_parallel_calls_are_disabled() {
+        let tools = sample_tools();
+        let schema = build_required_schema(&tools, Some(false)).expect("schema");
+        assert_eq!(schema["minItems"], json!(1));
+        assert_eq!(
+            schema["maxItems"],
+            json!(1),
+            "parallel_tool_calls=false must cap the array at one element"
         );
     }
 }

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -7,6 +7,8 @@ use dynamo_runtime::config::{
     env_is_truthy, environment_names::llm::DYN_IGNORE_OPENAI_FE_UNSUPPORTED_FIELDS,
 };
 
+use super::tools::{ToolChoiceError, validate_openai_tool_choice};
+
 //
 // Hyperparameter Contraints
 //
@@ -590,25 +592,26 @@ pub fn validate_tool_choice(
 ) -> Result<(), anyhow::Error> {
     use dynamo_protocols::types::ChatCompletionToolChoiceOption;
 
-    let tools_empty = tools.is_none_or(|tools| tools.is_empty());
-
-    match tool_choice {
-        Some(ChatCompletionToolChoiceOption::Required) if tools_empty => {
-            anyhow::bail!("tool_choice is \"required\" but tools is empty");
+    match validate_openai_tool_choice(tool_choice.as_ref(), tools) {
+        Ok(()) => Ok(()),
+        Err(ToolChoiceError::EmptyTools) => {
+            anyhow::bail!("tool_choice is \"required\" but tools is empty")
         }
-        Some(ChatCompletionToolChoiceOption::Named(named)) => {
-            let tools = tools.unwrap_or(&[]);
-            if !tools.iter().any(|t| t.function.name == named.function.name) {
-                anyhow::bail!(
-                    "tool named \"{}\" in tool_choice is not present in tools",
-                    named.function.name
-                );
+        Err(ToolChoiceError::MissingTools) => match tool_choice {
+            Some(ChatCompletionToolChoiceOption::Required) => {
+                anyhow::bail!("tool_choice is \"required\" but tools is empty")
             }
+            Some(ChatCompletionToolChoiceOption::Named(named)) => anyhow::bail!(
+                "tool named \"{}\" in tool_choice is not present in tools",
+                named.function.name
+            ),
+            _ => Err(ToolChoiceError::MissingTools.into()),
+        },
+        Err(ToolChoiceError::ToolNotFound(name)) => {
+            anyhow::bail!("tool named \"{name}\" in tool_choice is not present in tools")
         }
-        _ => {}
+        Err(error) => Err(error.into()),
     }
-
-    Ok(())
 }
 
 /// Validates reasoning effort parameter

--- a/lib/llm/tests/aggregators.rs
+++ b/lib/llm/tests/aggregators.rs
@@ -521,6 +521,43 @@ async fn test_qwen_unified_batch_recovers_native_structural_tag_output() {
     assert_guided_batch_call(&result);
 }
 
+/// Regression for a `GuidedJsonNamed` fallback that recovers a DIFFERENT tool than the
+/// one `tool_choice` pinned, on the qwen3 unified-batch path. Site 3:
+/// `unified_parser::batch_tool_output_mode`/`parse_complete`'s native-fallback filter.
+#[tokio::test]
+async fn test_qwen_unified_batch_drops_native_tool_markup_naming_a_different_tool() {
+    if !env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2) {
+        return;
+    }
+
+    let raw = concat!(
+        "<think>Look it up.</think>",
+        "<tool_call>\n<function=get_stock_price>\n",
+        "<parameter=symbol>NVDA</parameter>\n</function>\n</tool_call>"
+    );
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+            .with_guided_tool_constraint(GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            }),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert!(
+        choice
+            .message
+            .tool_calls
+            .as_ref()
+            .is_none_or(|calls| calls.is_empty()),
+        "client pinned tool_choice to get_weather but received a call for a different tool \
+         (get_stock_price) recovered from the native fallback: {:?}",
+        choice.message.tool_calls,
+    );
+}
+
 #[tokio::test]
 async fn test_forced_batch_recovers_observed_native_tool_markup() {
     let native_cases = [
@@ -574,6 +611,49 @@ async fn test_forced_batch_recovers_observed_native_tool_markup() {
                 choice.message.content,
             );
         }
+    }
+}
+
+/// Regression for a `GuidedJsonNamed` fallback that recovers a DIFFERENT tool than the
+/// one `tool_choice` pinned: a malformed guided-JSON output that happens to embed native
+/// markup naming another tool must not be handed back to the client as if it were the
+/// forced tool. Site 1: `aggregator::parse_complete_tool_output`'s native-fallback path.
+#[tokio::test]
+async fn test_forced_batch_drops_native_tool_markup_naming_a_different_tool() {
+    let native_cases = [
+        (
+            "minimax_m2",
+            "<minimax:tool_call><invoke name=\"get_stock_price\"><parameter name=\"symbol\">NVDA</parameter></invoke></minimax:tool_call>",
+        ),
+        (
+            "kimi_k2",
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_stock_price:0<|tool_call_argument_begin|>{\"symbol\":\"NVDA\"}<|tool_call_end|><|tool_calls_section_end|>",
+        ),
+    ];
+
+    for (parser, raw) in native_cases {
+        let result = NvCreateChatCompletionResponse::from_annotated_stream(
+            futures::stream::iter([make_stream_delta(Some(raw), None)]),
+            ParsingOptions::new(Some(parser.to_string()), None).with_guided_tool_constraint(
+                GuidedToolConstraint::GuidedJsonNamed {
+                    tool_name: "get_weather".to_string(),
+                },
+            ),
+        )
+        .await
+        .unwrap();
+        let choice = result.inner.choices.first().expect("one choice");
+
+        assert!(
+            choice
+                .message
+                .tool_calls
+                .as_ref()
+                .is_none_or(|calls| calls.is_empty()),
+            "{parser}: client pinned tool_choice to get_weather but received a call for a \
+             different tool recovered from the native fallback: {:?}",
+            choice.message.tool_calls,
+        );
     }
 }
 
@@ -640,6 +720,35 @@ async fn test_forced_muse_batch_recovers_observed_native_markup() {
             "{constraint:?}",
         );
     }
+}
+
+/// Regression for a `GuidedJsonNamed` fallback that recovers a DIFFERENT tool than the
+/// one `tool_choice` pinned, on the muse unified-batch path. Site 2:
+/// `aggregator`'s muse unified-batch guided-JSON-error fallback branch.
+#[tokio::test]
+async fn test_forced_muse_batch_drops_native_markup_naming_a_different_tool() {
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter(muse_raw_batch_deltas()),
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None).with_guided_tool_constraint(
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_stock_price".to_string(),
+            },
+        ),
+    )
+    .await
+    .unwrap();
+    let choice = result.inner.choices.first().expect("one choice");
+
+    assert!(
+        choice
+            .message
+            .tool_calls
+            .as_ref()
+            .is_none_or(|calls| calls.is_empty()),
+        "client pinned tool_choice to get_stock_price but received a call for a different \
+         tool (get_weather) recovered from the native fallback: {:?}",
+        choice.message.tool_calls,
+    );
 }
 
 /// Topology B: raw muse markup reaches the aggregator un-split (the frontend

--- a/lib/llm/tests/aggregators.rs
+++ b/lib/llm/tests/aggregators.rs
@@ -5,7 +5,7 @@ use dynamo_llm::protocols::{
     Annotated, ContentProvider, DataStream,
     codec::{Message, SseCodecError, create_message_stream},
     openai::{
-        ParsingOptions,
+        GuidedToolConstraint, ParsingOptions,
         chat_completions::{
             NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse,
             aggregator::ChatCompletionAggregator,
@@ -17,6 +17,7 @@ use dynamo_protocols::types::{
     ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
     CreateChatCompletionStreamResponse, Role,
 };
+use dynamo_runtime::config::{env_is_truthy, environment_names::llm as env_llm};
 use futures::StreamExt;
 
 fn get_text(content: &ChatCompletionMessageContent) -> &str {
@@ -262,15 +263,192 @@ async fn test_nvext_none_when_absent() {
 // Muse unified batch finalize (topology B)
 // ===================================
 
-/// Topology B: raw muse markup reaches the aggregator un-split (the frontend
-/// holds the tool_call_parser, but the worker did not run the streaming hook, so
-/// the deltas carry raw text). The finalize block must route muse through the
-/// UNIFIED parser and populate reasoning_content + content + tool_calls on the
-/// final message — the reasoning channel is the one thing the v2 tool-only
-/// `parse_complete` cannot recover.
+async fn run_qwen_unified_batch_suppression_assertions() {
+    let raw = concat!(
+        "<think>Look it up.</think>",
+        "<tool_call>\n<function=get_weather>\n",
+        "<parameter=location>Paris</parameter>\n</function>\n</tool_call>"
+    );
+    let options = ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+        .with_tool_call_parsing_enabled(false);
+    assert!(
+        options.tool_call_parser.is_some(),
+        "with the flag set, the qwen3 pair must retain the whole-response decoder \
+         so it can still strip native markup even though tool calls are suppressed"
+    );
+
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        options,
+    )
+    .await
+    .unwrap();
+    let choice = result.inner.choices.first().expect("one choice");
+    let content = choice
+        .message
+        .content
+        .as_ref()
+        .map(get_text)
+        .unwrap_or_default();
+
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Look it up.")
+    );
+    assert!(choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty));
+    assert!(
+        !content.contains("<tool_call>"),
+        "raw markup leaked: {content:?}"
+    );
+}
+
 #[tokio::test]
-async fn test_muse_unified_batch_finalize_splits_all_channels() {
-    let deltas = vec![
+#[ignore = "only run as a child process spawned by \
+            test_qwen_unified_batch_suppresses_forbidden_calls_and_strips_markup, \
+            with the experimental flag set in that child's own environment; running \
+            it directly outside that harness gives no guarantee the flag is set"]
+async fn qwen_unified_batch_suppression_child() {
+    assert!(
+        env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2),
+        "this child test must only ever run with the flag set by its parent"
+    );
+    run_qwen_unified_batch_suppression_assertions().await;
+}
+
+#[test]
+fn test_qwen_unified_batch_suppresses_forbidden_calls_and_strips_markup() {
+    // The real suppression gate lives inside `ChatCompletionAggregator::apply`'s
+    // function body (`aggregator.rs`'s `qwen3_unified_family` block), re-checking
+    // the process-wide flag itself rather than taking it as a parameter — so no
+    // flag-independent call from this process can route through it. Mutating this
+    // (the shared, multi-threaded) test process's own environment would leak into
+    // every other test in this binary regardless of execution order, which is
+    // forbidden. Instead, this parent test — itself flag-independent, so it always
+    // actually runs and asserts something — re-executes this exact compiled test
+    // binary, filtered to ONLY the `#[ignore]`d child test above, with the flag set
+    // solely in that CHILD PROCESS's own environment. The child is a distinct,
+    // `#[ignore]`d function name, not this same function, so there is no recursive
+    // self-spawn: `--exact <child> --ignored` can only ever select that one child.
+    let exe = std::env::current_exe().expect("test binary path for self re-exec");
+    let status = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "qwen_unified_batch_suppression_child",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2, "1")
+        .status()
+        .expect("failed to spawn child test process");
+    assert!(
+        status.success(),
+        "child aggregator suppression test failed (see its own output above): {status:?}"
+    );
+}
+
+async fn run_qwen_unified_batch_flag_off_assertions() {
+    let raw = concat!(
+        "<think>Look it up.</think>",
+        "<tool_call>\n<function=get_weather>\n",
+        "<parameter=location>Paris</parameter>\n</function>\n</tool_call>"
+    );
+    let options = ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+        .with_tool_call_parsing_enabled(false);
+    assert_eq!(
+        options.tool_call_parser, None,
+        "with the flag unset, a qwen3 pair must not retain a whole-response decoder \
+         when tool-call parsing is disabled"
+    );
+
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        options,
+    )
+    .await
+    .unwrap();
+    let choice = result.inner.choices.first().expect("one choice");
+    let content = choice
+        .message
+        .content
+        .as_ref()
+        .map(get_text)
+        .unwrap_or_default();
+
+    assert_eq!(
+        content, raw,
+        "with no decoder retained (flag off), the raw markup must pass through \
+         unparsed rather than be silently stripped by a decoder that shouldn't be \
+         running"
+    );
+    assert_eq!(choice.message.reasoning_content, None);
+    assert!(choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty));
+}
+
+#[tokio::test]
+#[ignore = "only run as a child process spawned by \
+            test_qwen_unified_batch_stays_off_without_the_experimental_flag, with the \
+            experimental flag explicitly cleared in that child's own environment; \
+            running it directly outside that harness gives no guarantee the flag is \
+            actually unset"]
+async fn qwen_unified_batch_flag_off_child() {
+    assert!(
+        !env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2),
+        "this child test must only ever run with the flag explicitly cleared by its parent"
+    );
+    run_qwen_unified_batch_flag_off_assertions().await;
+}
+
+#[test]
+fn test_qwen_unified_batch_stays_off_without_the_experimental_flag() {
+    // Mirrors the suppression parent/child design above: re-executes this exact
+    // compiled test binary, filtered to ONLY the `#[ignore]`d child test, with the
+    // flag explicitly CLEARED in that child process's own environment
+    // (`env_remove`) rather than relying on the ambient absence of the flag. This
+    // parent is flag-independent and always spawns and requires the real-assertion
+    // child, so it passes correctly whether the surrounding test invocation (or
+    // ladder lane) happens to run with the flag externally set or unset — unlike a
+    // single-process test whose premise assertion would fail under a flag-on lane.
+    let exe = std::env::current_exe().expect("test binary path for self re-exec");
+    let status = std::process::Command::new(exe)
+        .args([
+            "--exact",
+            "qwen_unified_batch_flag_off_child",
+            "--ignored",
+            "--nocapture",
+            "--test-threads=1",
+        ])
+        .env_remove(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2)
+        .status()
+        .expect("failed to spawn child test process");
+    assert!(
+        status.success(),
+        "child aggregator flag-off test failed (see its own output above): {status:?}"
+    );
+}
+
+fn assert_guided_batch_call(result: &NvCreateChatCompletionResponse) {
+    let choice = result.inner.choices.first().expect("one choice");
+    let calls = choice.message.tool_calls.as_ref().expect("tool_calls");
+    assert_eq!(calls.len(), 1, "expected one guided tool call");
+    assert_eq!(calls[0].function.name, "get_weather");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&calls[0].function.arguments).unwrap(),
+        serde_json::json!({"location": "Paris"})
+    );
+    assert!(
+        choice
+            .message
+            .content
+            .as_ref()
+            .is_none_or(|content| get_text(content).is_empty()),
+        "guided payload must not be returned as visible content: {:?}",
+        choice.message.content
+    );
+}
+
+fn muse_raw_batch_deltas() -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+    vec![
         make_stream_delta(
             Some("<|start|>assistant to=self<|message|>Look it up.<|eom|>"),
             None,
@@ -285,17 +463,197 @@ async fn test_muse_unified_batch_finalize_splits_all_channels() {
             Some("<|start|>assistant to=user<|message|>It's 18C.<|eot|>"),
             None,
         ),
+    ]
+}
+
+#[tokio::test]
+async fn test_qwen_unified_batch_finalizes_raw_guided_json() {
+    for (raw, constraint) in [
+        (
+            r#"[{"name":"get_weather","parameters":{"location":"Paris"}}]"#,
+            GuidedToolConstraint::GuidedJsonRequired,
+        ),
+        (
+            r#"{"location":"Paris"}"#,
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            },
+        ),
+    ] {
+        let result = NvCreateChatCompletionResponse::from_annotated_stream(
+            futures::stream::iter([make_stream_delta(Some(raw), None)]),
+            ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+                .with_guided_tool_constraint(constraint),
+        )
+        .await
+        .unwrap();
+
+        assert_guided_batch_call(&result);
+    }
+}
+
+#[tokio::test]
+async fn test_qwen_unified_batch_recovers_native_structural_tag_output() {
+    if !env_is_truthy(env_llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2) {
+        return;
+    }
+
+    let raw = concat!(
+        "<think>Look it up.</think>",
+        "<tool_call>\n<function=get_weather>\n",
+        "<parameter=location>Paris</parameter>\n</function>\n</tool_call>"
+    );
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("qwen3_coder".to_string()), Some("qwen3".to_string()))
+            // Topology B does not carry the worker's installed structural tag back to
+            // the frontend, so request-only reconstruction may classify this as JSON.
+            .with_guided_tool_constraint(GuidedToolConstraint::GuidedJsonRequired),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Look it up.")
+    );
+    assert_guided_batch_call(&result);
+}
+
+#[tokio::test]
+async fn test_forced_batch_recovers_observed_native_tool_markup() {
+    let native_cases = [
+        (
+            "minimax_m2",
+            "<minimax:tool_call><invoke name=\"get_weather\"><parameter name=\"location\">Paris</parameter></invoke></minimax:tool_call>",
+        ),
+        (
+            "kimi_k2",
+            "<|tool_calls_section_begin|><|tool_call_begin|>functions.get_weather:0<|tool_call_argument_begin|>{\"location\":\"Paris\"}<|tool_call_end|><|tool_calls_section_end|>",
+        ),
+        (
+            "deepseek_v4",
+            "<｜DSML｜tool_calls>\n<｜DSML｜invoke name=\"get_weather\">\n<｜DSML｜parameter name=\"location\" string=\"true\">Paris</｜DSML｜parameter>\n</｜DSML｜invoke>\n</｜DSML｜tool_calls>",
+        ),
     ];
 
-    let stream = futures::stream::iter(deltas);
+    for (parser, raw) in native_cases {
+        for constraint in [
+            GuidedToolConstraint::GuidedJsonRequired,
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            },
+        ] {
+            let result = NvCreateChatCompletionResponse::from_annotated_stream(
+                futures::stream::iter([make_stream_delta(Some(raw), None)]),
+                ParsingOptions::new(Some(parser.to_string()), None)
+                    .with_guided_tool_constraint(constraint.clone()),
+            )
+            .await
+            .unwrap();
+            let choice = result.inner.choices.first().expect("one choice");
+            let calls = choice.message.tool_calls.as_ref().unwrap_or_else(|| {
+                panic!("{parser} {constraint:?} did not recover its native tool call")
+            });
+
+            assert_eq!(calls.len(), 1, "{parser} {constraint:?}");
+            assert_eq!(calls[0].function.name, "get_weather");
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&calls[0].function.arguments).unwrap(),
+                serde_json::json!({"location": "Paris"}),
+                "{parser} {constraint:?}",
+            );
+            assert!(
+                choice
+                    .message
+                    .content
+                    .as_ref()
+                    .is_none_or(|content| get_text(content).is_empty()),
+                "{parser} {constraint:?} leaked native markup as content: {:?}",
+                choice.message.content,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_muse_unified_batch_finalizes_raw_guided_json() {
+    for (raw, constraint) in [
+        (
+            r#"[{"name":"get_weather","parameters":{"location":"Paris"}}]"#,
+            GuidedToolConstraint::GuidedJsonRequired,
+        ),
+        (
+            r#"{"location":"Paris"}"#,
+            GuidedToolConstraint::GuidedJsonNamed {
+                tool_name: "get_weather".to_string(),
+            },
+        ),
+    ] {
+        let result = NvCreateChatCompletionResponse::from_annotated_stream(
+            futures::stream::iter([make_stream_delta(Some(raw), None)]),
+            ParsingOptions::new(Some("muse_glimmer".to_string()), None)
+                .with_guided_tool_constraint(constraint),
+        )
+        .await
+        .unwrap();
+
+        assert_guided_batch_call(&result);
+    }
+}
+
+#[tokio::test]
+async fn test_forced_muse_batch_recovers_observed_native_markup() {
+    for constraint in [
+        GuidedToolConstraint::GuidedJsonRequired,
+        GuidedToolConstraint::GuidedJsonNamed {
+            tool_name: "get_weather".to_string(),
+        },
+    ] {
+        let result = NvCreateChatCompletionResponse::from_annotated_stream(
+            futures::stream::iter(muse_raw_batch_deltas()),
+            ParsingOptions::new(Some("muse_glimmer".to_string()), None)
+                .with_guided_tool_constraint(constraint.clone()),
+        )
+        .await
+        .unwrap();
+        let choice = result.inner.choices.first().expect("one choice");
+
+        assert_eq!(
+            choice.message.reasoning_content.as_deref(),
+            Some("Look it up.")
+        );
+        assert_eq!(
+            get_text(choice.message.content.as_ref().expect("content")),
+            "It's 18C."
+        );
+        let calls =
+            choice.message.tool_calls.as_ref().unwrap_or_else(|| {
+                panic!("Muse {constraint:?} did not recover its native tool call")
+            });
+        assert_eq!(calls.len(), 1, "{constraint:?}");
+        assert_eq!(calls[0].function.name, "get_weather");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&calls[0].function.arguments).unwrap(),
+            serde_json::json!({"location": "Paris"}),
+            "{constraint:?}",
+        );
+    }
+}
+
+/// Topology B: raw muse markup reaches the aggregator un-split (the frontend
+/// holds the tool_call_parser, but the worker did not run the streaming hook, so
+/// the deltas carry raw text). The finalize block must route muse through the
+/// UNIFIED parser and populate reasoning_content + content + tool_calls on the
+/// final message — the reasoning channel is the one thing the v2 tool-only
+/// `parse_complete` cannot recover.
+#[tokio::test]
+async fn test_muse_unified_batch_finalize_splits_all_channels() {
+    let stream = futures::stream::iter(muse_raw_batch_deltas());
     let result = NvCreateChatCompletionResponse::from_annotated_stream(
         stream,
-        // The HTTP handlers derive this from the request's tool_choice via
-        // `batch_tool_choice_eligible`, which admits unset/auto. Setting it here is
-        // what an auto request really carries; leaving it default-false would be
-        // asserting against a shape no served request has.
-        ParsingOptions::new(Some("muse_glimmer".to_string()), None)
-            .with_experimental_v2_batch_eligible(true),
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None),
     )
     .await
     .unwrap();
@@ -324,28 +682,10 @@ async fn test_muse_unified_batch_finalize_splits_all_channels() {
 /// non-streaming response.
 #[tokio::test]
 async fn test_muse_unified_batch_finalize_routes_on_reasoning_name_only() {
-    let deltas = vec![
-        make_stream_delta(
-            Some("<|start|>assistant to=self<|message|>Look it up.<|eom|>"),
-            None,
-        ),
-        make_stream_delta(
-            Some(
-                "<|start|>assistant to=get_weather<|message|><atem:invoke name=\"get_weather\"><atem:parameter name=\"location\">Paris</atem:parameter></atem:invoke><|eom|>",
-            ),
-            None,
-        ),
-        make_stream_delta(
-            Some("<|start|>assistant to=user<|message|>It's 18C.<|eot|>"),
-            None,
-        ),
-    ];
-
-    let stream = futures::stream::iter(deltas);
+    let stream = futures::stream::iter(muse_raw_batch_deltas());
     let result = NvCreateChatCompletionResponse::from_annotated_stream(
         stream,
-        ParsingOptions::new(None, Some("muse_glimmer".to_string()))
-            .with_experimental_v2_batch_eligible(true),
+        ParsingOptions::new(None, Some("muse_glimmer".to_string())),
     )
     .await
     .unwrap();
@@ -370,32 +710,14 @@ async fn test_muse_unified_batch_finalize_routes_on_reasoning_name_only() {
 /// Batch counterpart of the streaming `none` pin. A caller that disabled tool calling
 /// still needs the reasoning/content split and the marker stripping — muse has no v1
 /// reasoning parser to fall back on — but must not receive `tool_calls`. The handlers
-/// express that by deriving `experimental_v2_batch_eligible` from the request, which
-/// `batch_tool_choice_eligible` sets false for an explicit `none`.
+/// express that with the shared tool-call response policy.
 #[tokio::test]
-async fn test_muse_unified_batch_finalize_suppresses_calls_when_not_eligible() {
-    let deltas = vec![
-        make_stream_delta(
-            Some("<|start|>assistant to=self<|message|>Look it up.<|eom|>"),
-            None,
-        ),
-        make_stream_delta(
-            Some(
-                "<|start|>assistant to=get_weather<|message|><atem:invoke name=\"get_weather\"><atem:parameter name=\"location\">Paris</atem:parameter></atem:invoke><|eom|>",
-            ),
-            None,
-        ),
-        make_stream_delta(
-            Some("<|start|>assistant to=user<|message|>It's 18C.<|eot|>"),
-            None,
-        ),
-    ];
-
-    let stream = futures::stream::iter(deltas);
+async fn test_muse_unified_batch_finalize_suppresses_calls_when_disabled() {
+    let stream = futures::stream::iter(muse_raw_batch_deltas());
     let result = NvCreateChatCompletionResponse::from_annotated_stream(
         stream,
         ParsingOptions::new(Some("muse_glimmer".to_string()), None)
-            .with_experimental_v2_batch_eligible(false),
+            .with_tool_call_parsing_enabled(false),
     )
     .await
     .unwrap();
@@ -407,7 +729,7 @@ async fn test_muse_unified_batch_finalize_suppresses_calls_when_not_eligible() {
             .tool_calls
             .as_ref()
             .is_none_or(|calls| calls.is_empty()),
-        "an ineligible tool_choice must not return tool_calls: {:?}",
+        "a request that disabled tools must not return tool_calls: {:?}",
         choice.message.tool_calls
     );
     // The split and the stripping still have to happen.
@@ -423,4 +745,209 @@ async fn test_muse_unified_batch_finalize_suppresses_calls_when_not_eligible() {
             "marker {marker:?} leaked: {content:?}"
         );
     }
+}
+
+// ===================================
+// Muse batch-finalize regression tests (Fix A/B/C)
+// ===================================
+
+/// Fix A: a guided-JSON response that legitimately contains zero tool calls
+/// (`[]` under `tool_choice: "required"`) must not wipe the batch's original raw
+/// text. Before the fix, the muse unified block's guided-JSON success arm
+/// (`Ok((calls, String::new(), String::new()))`) fed into an unconditional
+/// `choice.text = content`, which always blanked `choice.text` to empty
+/// regardless of whether the guided parse actually produced any calls.
+#[tokio::test]
+async fn test_muse_unified_batch_guided_json_zero_calls_preserves_original_text() {
+    let raw = "[]";
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None)
+            .with_guided_tool_constraint(GuidedToolConstraint::GuidedJsonRequired),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert!(
+        choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty),
+        "guided JSON with zero calls must not produce any tool_calls: {:?}",
+        choice.message.tool_calls
+    );
+    assert_eq!(
+        get_text(choice.message.content.as_ref().expect("content")),
+        raw,
+        "a guided-JSON parse that returns zero calls must preserve the original raw \
+         text instead of blanking choice.text to empty"
+    );
+}
+
+/// Devin Review finding (PR #12576): the muse batch finalize's zero-calls guard
+/// must only preserve raw text for the guided-JSON placeholder-content case
+/// (Fix A). A plain muse turn with NO tool call at all is the common case for
+/// muse responses and must have its markup stripped just like the sibling
+/// Qwen3 block does unconditionally — before this fix, ANY zero-calls result
+/// (not just the guided-JSON placeholder) skipped `choice.text = content`,
+/// leaking raw `<|start|>...<|message|>` control tokens to the client.
+#[tokio::test]
+async fn test_muse_unified_batch_toolless_response_strips_markup() {
+    let raw = "<|start|>assistant to=user<|message|>Hello there.<|eot|>";
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert!(
+        choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty),
+        "a plain toolless muse turn must not produce any tool_calls: {:?}",
+        choice.message.tool_calls
+    );
+    assert_eq!(
+        get_text(choice.message.content.as_ref().expect("content")),
+        "Hello there.",
+        "a toolless muse response must have its markup stripped, not leak raw \
+         control tokens as content"
+    );
+}
+
+/// Build a stream delta that carries ONLY `reasoning_content`, no visible text —
+/// used to pre-populate `choice.reasoning_content` via the normal per-delta
+/// aggregation path before the muse unified finalize block runs.
+#[allow(deprecated)]
+fn make_stream_delta_with_reasoning(
+    reasoning_content: &str,
+) -> Annotated<NvCreateChatCompletionStreamResponse> {
+    Annotated::from_data(NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices: vec![ChatChoiceStream {
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta {
+                    content: None,
+                    function_call: None,
+                    tool_calls: None,
+                    role: Some(Role::Assistant),
+                    refusal: None,
+                    reasoning_content: Some(reasoning_content.to_string()),
+                },
+                finish_reason: None,
+                logprobs: None,
+            }],
+            created: 1234567890,
+            model: "test-model".to_string(),
+            service_tier: None,
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+        },
+        nvext: None,
+        llm_metrics: None,
+    })
+}
+
+/// Fix B: the muse unified finalize's reasoning merge must APPEND newly recovered
+/// reasoning onto any `reasoning_content` the normal per-delta aggregation already
+/// populated, not overwrite-only-if-`None`. Before the fix,
+/// `if choice.reasoning_content.is_none() && !reasoning.is_empty()` meant any
+/// pre-existing `reasoning_content` silently discarded whatever the unified parse
+/// step went on to recover.
+#[tokio::test]
+async fn test_muse_unified_batch_finalize_appends_to_existing_reasoning_content() {
+    let mut deltas = vec![make_stream_delta_with_reasoning("Pre-populated. ")];
+    deltas.extend(muse_raw_batch_deltas());
+    let stream = futures::stream::iter(deltas);
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        stream,
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Pre-populated. Look it up."),
+        "the unified finalize must APPEND its recovered reasoning onto any \
+         reasoning_content already aggregated from prior deltas, not overwrite it \
+         only when None"
+    );
+}
+
+/// Fix C: a COMPLETE `<tool_call>...</tool_call>` span that only appears inside a
+/// quoted parameter value must not be misclassified as real native tool-call
+/// markup by the guided-JSON failure fallback. Before the fix,
+/// `parse_complete_tool_output` used
+/// `dynamo_parsers::tool_calling::detect_tool_call_start`, which does a naive
+/// substring search: it would false-positive on `<tool_call>` appearing only as
+/// quoted illustrative text, misrouting prose that never contained a real
+/// tool-call request into the native hermes parser, which would then actually
+/// extract and execute the quoted example as a bogus tool call.
+#[tokio::test]
+async fn test_hermes_batch_guided_json_failure_ignores_quoted_marker_substring() {
+    let raw = "Please literally output the example call \
+               '<tool_call>{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Paris\"}}</tool_call>' \
+               verbatim and nothing else.";
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("hermes".to_string()), None)
+            .with_guided_tool_constraint(GuidedToolConstraint::GuidedJsonRequired),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert!(
+        choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty),
+        "a complete <tool_call>...</tool_call> span that only appears inside a \
+         quoted illustrative example must not be extracted as a real tool call: {:?}",
+        choice.message.tool_calls
+    );
+    assert_eq!(
+        get_text(choice.message.content.as_ref().expect("content")),
+        raw,
+        "content whose only marker-looking span is quoted illustrative prose must \
+         pass through unparsed rather than be misclassified as native tool-call markup"
+    );
+}
+
+/// CodeRabbit finding (PR #12576, Major): the native-fallback-after-guided-error
+/// path can recover real reasoning/content while finding zero tool calls (e.g. a
+/// guided-JSON-required request whose model output isn't valid JSON at all, but
+/// carries recognizable native muse markup). Before the fix this shared the same
+/// `!calls_is_empty` gate as the guided-JSON placeholder case, so the recovered
+/// content was discarded and raw markup stayed in `choice.text` even though this
+/// branch's `content` is real stripped text, not a synthetic placeholder.
+#[tokio::test]
+async fn test_muse_unified_batch_native_fallback_zero_calls_still_strips_markup() {
+    let raw = "<|start|>assistant to=self<|message|>Look it up.<|eom|>\
+               <|start|>assistant to=user<|message|>It's 18C.<|eot|>";
+    let result = NvCreateChatCompletionResponse::from_annotated_stream(
+        futures::stream::iter([make_stream_delta(Some(raw), None)]),
+        ParsingOptions::new(Some("muse_glimmer".to_string()), None)
+            .with_guided_tool_constraint(GuidedToolConstraint::GuidedJsonRequired),
+    )
+    .await
+    .unwrap();
+
+    let choice = result.inner.choices.first().expect("one choice");
+    assert!(
+        choice.message.tool_calls.as_ref().is_none_or(Vec::is_empty),
+        "no tool call is present in this fixture: {:?}",
+        choice.message.tool_calls
+    );
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Look it up."),
+        "the native fallback must still recover reasoning"
+    );
+    assert_eq!(
+        get_text(choice.message.content.as_ref().expect("content")),
+        "It's 18C.",
+        "the native fallback's real recovered content must replace choice.text \
+         even when zero tool calls were found, not be discarded as if it were the \
+         guided-JSON synthetic placeholder"
+    );
 }

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -3585,6 +3585,82 @@ async fn tool_calls_qwen3_coder_auto_routes_through_experimental_gate() {
     );
 }
 
+async fn forbidden_qwen3_coder_tool_call(
+    request: &NvCreateChatCompletionRequest,
+) -> Vec<Annotated<NvCreateChatCompletionStreamResponse>> {
+    let tool_call = concat!(
+        "<tool_call>\n<function=get_weather>\n",
+        "<parameter=location>San Francisco</parameter>\n",
+        "</function>\n</tool_call>"
+    );
+    let preprocessor = build_preprocessor(Some("qwen3"), Some("qwen3_coder"));
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(tool_call), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+
+    preprocessor
+        .postprocessor_parsing_stream(input_stream, request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await
+}
+
+fn assert_forbidden_tool_call_is_suppressed(
+    case: &str,
+    responses: &[Annotated<NvCreateChatCompletionStreamResponse>],
+) {
+    let choices: Vec<_> = responses
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|response| response.inner.choices.iter())
+        .collect();
+    assert!(
+        choices
+            .iter()
+            .all(|choice| choice.delta.tool_calls.is_none()),
+        "{case}: a request that forbids tools exposed delta.tool_calls"
+    );
+    assert!(
+        choices
+            .iter()
+            .all(|choice| choice.finish_reason != Some(FinishReason::ToolCalls)),
+        "{case}: a request that forbids tools retained finish_reason=tool_calls"
+    );
+    let terminal = choices
+        .iter()
+        .position(|choice| choice.finish_reason == Some(FinishReason::Stop))
+        .expect("the suppressed call must terminate with finish_reason=stop");
+    assert!(
+        choices[terminal + 1..]
+            .iter()
+            .all(|choice| choice.finish_reason.is_none()),
+        "{case}: another terminal choice appeared after finish_reason=stop"
+    );
+}
+
+#[tokio::test]
+async fn unified_stream_with_no_tools_suppresses_parser_tool_call() {
+    let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "What's the weather?"}],
+        "stream": true
+    }))
+    .unwrap();
+
+    let responses = forbidden_qwen3_coder_tool_call(&request).await;
+    assert_forbidden_tool_call_is_suppressed("no tools", &responses);
+}
+
+#[tokio::test]
+async fn unified_stream_with_tool_choice_none_suppresses_parser_tool_call() {
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::None);
+
+    let responses = forbidden_qwen3_coder_tool_call(&request).await;
+    assert_forbidden_tool_call_is_suppressed("tool_choice=none", &responses);
+}
+
 /// DeepSeek V4/GLM + required + `prompt_injected_reasoning=true` +
 /// reasoning-close-marker JSON. This is not bare JSON; the reasoning parser
 /// must strip the pre-`</think>` prefix before the immediate jail sees JSON.
@@ -4551,6 +4627,67 @@ async fn postprocessor_parsing_stream_muse_routes_to_unified() {
     }
 }
 
+#[tokio::test]
+async fn postprocessor_parsing_stream_muse_force_nonempty_matches_batch_policy() {
+    let preprocessor = build_preprocessor(None, Some("muse_glimmer"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::None);
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"force_nonempty_content": true})).unwrap());
+
+    let reasoning_only = solo_output(&preprocessor, &request, &MUSE_MARKUP_SHAPE[..1]).await;
+    assert_eq!(reasoning_only.content, "Look it up.");
+    assert!(reasoning_only.reasoning.is_empty());
+
+    let reasoning_and_answer = solo_output(
+        &preprocessor,
+        &request,
+        &[MUSE_MARKUP_SHAPE[0], MUSE_MARKUP_SHAPE[2]],
+    )
+    .await;
+    assert_eq!(reasoning_and_answer.reasoning, "Look it up.");
+    assert_eq!(reasoning_and_answer.content, "It's 18C.");
+}
+
+#[tokio::test]
+async fn muse_force_nonempty_keeps_reasoning_before_a_tool_call_on_the_wire() {
+    let preprocessor = build_preprocessor(None, Some("muse_glimmer"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Auto);
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"force_nonempty_content": true})).unwrap());
+    let input_stream = stream::iter(
+        vec![
+            mock_content_chunk(MUSE_MARKUP_SHAPE[0]),
+            mock_content_chunk(MUSE_MARKUP_SHAPE[1]),
+            mock_final_chunk(),
+        ]
+        .into_iter()
+        .map(Annotated::from_data),
+    );
+    let responses = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor stream")
+        .collect::<Vec<_>>()
+        .await;
+    let choices: Vec<_> = responses
+        .iter()
+        .filter_map(|response| response.data.as_ref())
+        .flat_map(|data| data.inner.choices.iter())
+        .collect();
+    let reasoning = choices
+        .iter()
+        .position(|choice| choice.delta.reasoning_content.is_some())
+        .expect("reasoning delta");
+    let tool = choices
+        .iter()
+        .position(|choice| choice.delta.tool_calls.is_some())
+        .expect("tool-call delta");
+
+    assert!(reasoning < tool, "reasoning must precede the tool call");
+    assert!(choices.iter().all(|choice| {
+        !(choice.delta.reasoning_content.is_some() && choice.delta.tool_calls.is_some())
+    }));
+}
+
 /// `tool_choice=Required` is excluded by the guard (auto/none only), so the turn
 /// falls through to the guided-decode + jail path. No reasoning parser is
 /// configured there, so `reasoning_content` can never be produced — proof the
@@ -4697,5 +4834,395 @@ async fn postprocessor_parsing_stream_muse_none_routes_to_unified() {
         out.tool_calls.is_empty(),
         "tool_choice=None must not return tool_calls, got {:?}",
         out.tool_calls
+    );
+}
+
+// Guided tool-call routing matrix.
+//
+// For a forced `tool_choice` (`Required` or `Named`), a per-choice pre-commit
+// classifier buffers the stream until the first non-whitespace byte arrives.
+// `[` (required) or `{` (named) means the model is emitting guided JSON, so the
+// request streams as guided JSON. Anything else means NATIVE markup, and the
+// buffer is replayed UNTOUCHED into the existing v1 jail. Nothing may be emitted
+// before that decision is made.
+//
+// | # | Row                                                        | Proves                                                                        |
+// |---|------------------------------------------------------------|-------------------------------------------------------------------------------|
+// | 1 | minimax_m2 + required + native XML (thinking disabled)      | NATIVE classification does not break the existing v1 jail extraction (regression) |
+// | 2 | minimax_m2 + required + reasoning then native XML           | NATIVE replay preserves the pre-`</think>` reasoning split                     |
+// | 3 | qwen3_coder + required + guided JSON array                  | leading `[` under Required routes to guided JSON, args stay valid JSON         |
+// | 4 | qwen3_coder + named + bare guided arguments object          | leading `{` under Named routes to guided JSON, name comes from the request     |
+// | 5 | qwen3_coder + required + whitespace then guided array       | leading whitespace is skipped, classification lands on the first real byte     |
+// | 6 | minimax_m2 + required + native XML containing a later `{`   | only the FIRST non-whitespace byte classifies; an inner brace stays NATIVE     |
+// | 7 | qwen3_coder + required + whitespace-only first chunk        | classification survives a chunk boundary and lands on the later `[`            |
+// | 8 | minimax_m2 + named + native XML containing a later `{`      | named classification also uses only the first non-whitespace byte               |
+
+/// Row 1 - Regression. MiniMax M2 with thinking disabled emits its native
+/// `<minimax:tool_call>` XML directly. The first non-whitespace byte is `<`, so
+/// the classifier must pick NATIVE and replay the buffer into the v1 jail
+/// untouched: the tool call still extracts cleanly, no markup leaks into
+/// content, and the turn terminates with `finish_reason=ToolCalls`.
+#[tokio::test]
+async fn route_matrix_minimax_m2_required_native_xml_stays_native() {
+    let preprocessor = build_preprocessor(Some("minimax_m2"), Some("minimax_m2"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"thinking": false})).unwrap());
+    let tool_call = "<minimax:tool_call>\
+<invoke name=\"get_weather\"><parameter name=\"location\">San Francisco</parameter></invoke>\
+</minimax:tool_call>";
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(tool_call), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 1: minimax_m2 + required + native XML";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: native markup must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        !content.contains("minimax:tool_call"),
+        "{case}: native markup must not leak into content, got: {content:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 2 - Same NATIVE classification, but reasoning precedes the XML. The
+/// classifier sees `I` (not `[`/`{`), routes NATIVE, and the replayed buffer
+/// still splits at `</think>`: reasoning lands in `reasoning_content`, the tool
+/// call is extracted, and neither the think markers nor the XML leak.
+#[tokio::test]
+async fn route_matrix_minimax_m2_required_reasoning_before_native_xml_stays_native() {
+    let preprocessor = build_preprocessor(Some("minimax_m2"), Some("minimax_m2"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    let tool_call = "<minimax:tool_call>\
+<invoke name=\"get_weather\"><parameter name=\"location\">San Francisco</parameter></invoke>\
+</minimax:tool_call>";
+    let input_stream = stream::iter(
+        vec![
+            mock_content_chunk("I should call weather."),
+            mock_content_chunk("</think>"),
+            mock_content_chunk(tool_call),
+            mock_final_chunk(),
+        ]
+        .into_iter()
+        .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 2: minimax_m2 + required + reasoning before native XML";
+    assert_eq!(
+        reasoning, "I should call weather.",
+        "{case}: reasoning_content should hold only the pre-</think> text"
+    );
+    assert!(
+        !content.contains("minimax:tool_call"),
+        "{case}: native markup must not leak into content, got: {content:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 3 - `tool_choice=Required` with a guided JSON array payload. The first
+/// non-whitespace byte is `[`, so the request streams as guided JSON even though
+/// the model family (`qwen3_coder`) has a native markup parser configured. The
+/// tool call is extracted, arguments are valid JSON, and nothing leaks.
+#[tokio::test]
+async fn route_matrix_qwen3_coder_required_guided_json_array_routes_guided() {
+    let guided = r#"[{"name": "get_weather", "parameters": {"location": "San Francisco"}}]"#;
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(guided), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 3: qwen3_coder + required + guided JSON array";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: guided JSON must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        content.trim().is_empty(),
+        "{case}: guided JSON must be fully consumed, content should be empty, got: {content:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 4 - `tool_choice=Named` with a bare guided arguments object. The first
+/// non-whitespace byte is `{`, so the stream routes as guided JSON; the payload
+/// carries only the arguments, so the function name must come from the request's
+/// named tool choice.
+#[tokio::test]
+async fn route_matrix_qwen3_coder_named_bare_arguments_object_routes_guided() {
+    let bare_params = r#"{"location": "San Francisco"}"#;
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Named(
+        ChatCompletionNamedToolChoice {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionName {
+                name: "get_weather".to_string(),
+            },
+        },
+    ));
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(bare_params), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 4: qwen3_coder + named + bare guided arguments object";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: guided JSON must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        content.trim().is_empty(),
+        "{case}: guided JSON must be fully consumed, content should be empty, got: {content:?}"
+    );
+    // The name is NOT in the payload; it can only come from the named tool choice.
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 5 - Leading whitespace before the guided payload. The classifier skips
+/// whitespace and decides on the first REAL byte (`[`), so the request still
+/// routes as guided JSON and the whitespace never reaches the client.
+#[tokio::test]
+async fn route_matrix_qwen3_coder_required_leading_whitespace_still_guided() {
+    let guided =
+        "  \n\t [{\"name\": \"get_weather\", \"parameters\": {\"location\": \"San Francisco\"}}]";
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(guided), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 5: qwen3_coder + required + leading whitespace + guided JSON array";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: guided JSON must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        content.trim().is_empty(),
+        "{case}: guided JSON must be fully consumed, content should be empty, got: {content:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 6 - Native markup whose TEXT contains a `{` after the opening tag. The
+/// classifier looks only at the first non-whitespace byte (`<`), so this must be
+/// classified NATIVE and handled by the v1 jail. The inner brace stays part of
+/// the parameter value; it must never be reinterpreted as tool arguments, and the
+/// markup must not leak into content.
+#[tokio::test]
+async fn route_matrix_minimax_m2_required_native_xml_with_inner_brace_stays_native() {
+    let preprocessor = build_preprocessor(Some("minimax_m2"), Some("minimax_m2"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"thinking": false})).unwrap());
+    // The `{` appears well after the first byte and inside a parameter value.
+    let tool_call = "<minimax:tool_call>\
+<invoke name=\"get_weather\"><parameter name=\"location\">San Francisco {CA}</parameter></invoke>\
+</minimax:tool_call>";
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(tool_call), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 6: minimax_m2 + required + native XML containing a later `{`";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: native markup must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        !content.contains("minimax:tool_call") && !content.contains('{'),
+        "{case}: native markup must not leak into content, got: {content:?}"
+    );
+    // The brace is data, not structure: it stays inside the argument value.
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco {CA}");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 7 - The guided payload is split across chunks and the FIRST chunk is
+/// whitespace only. The classifier must stay undecided across that chunk
+/// boundary (emitting nothing) and commit on the `[` that arrives in a later
+/// chunk, then stream the reassembled payload as guided JSON.
+#[tokio::test]
+async fn route_matrix_qwen3_coder_required_whitespace_only_first_chunk_defers_classification() {
+    let preprocessor = build_preprocessor(None, Some("qwen3_coder"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    let input_stream = stream::iter(
+        vec![
+            mock_content_chunk(" \n "),
+            mock_content_chunk("  "),
+            mock_content_chunk("[{\"name\": \"get_weather\", "),
+            mock_content_chunk("\"parameters\": {\"location\": "),
+            mock_content_chunk("\"San Francisco\"}}]"),
+            mock_final_chunk(),
+        ]
+        .into_iter()
+        .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        finish_reasons,
+    } = drain_stream(output_stream).await;
+
+    let case = "row 7: qwen3_coder + required + whitespace-only first chunk + split guided JSON";
+    assert!(
+        reasoning.is_empty(),
+        "{case}: guided JSON must not become reasoning_content, got: {reasoning:?}"
+    );
+    assert!(
+        content.trim().is_empty(),
+        "{case}: guided JSON must be fully consumed, content should be empty, got: {content:?}"
+    );
+    assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    assert!(
+        finish_reasons.contains(&FinishReason::ToolCalls),
+        "{case}: expected ToolCalls finish_reason, got: {finish_reasons:?}"
+    );
+}
+
+/// Row 8: NAMED choice + native markup whose text contains a later `{`.
+///
+/// This is the row that actually pins "first non-whitespace byte only". A named choice
+/// looks for `{`, and native MiniMax XML frequently contains one inside a parameter
+/// value - so a classifier that scanned anywhere would mistake that brace for the start
+/// of an argument object and stream the markup as tool arguments. Row 6 cannot catch
+/// this: it is a `required` row, whose opener is `[`, and the XML contains no `[`.
+#[tokio::test]
+async fn route_matrix_minimax_m2_named_native_xml_with_inner_brace_stays_native() {
+    let preprocessor = build_preprocessor(Some("minimax_m2"), Some("minimax_m2"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Named(
+        ChatCompletionNamedToolChoice {
+            r#type: ChatCompletionToolType::Function,
+            function: FunctionName {
+                name: "get_weather".to_string(),
+            },
+        },
+    ));
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"thinking": false})).unwrap());
+    let tool_call = "<minimax:tool_call>\
+<invoke name=\"get_weather\"><parameter name=\"location\">San Francisco {CA}</parameter></invoke>\
+</minimax:tool_call>";
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(tool_call), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
+
+    let case = "row 8: minimax_m2 + named + native XML containing an inner brace";
+    assert!(
+        !content.contains("minimax:tool_call"),
+        "{case}: native markup must not leak into content, got: {content:?}"
+    );
+    assert_eq!(tool_calls.len(), 1, "{case}: expected one tool call");
+    assert_eq!(
+        tool_calls[0].name.as_deref(),
+        Some("get_weather"),
+        "{case}: wrong tool name"
+    );
+    let args: serde_json::Value = serde_json::from_str(&tool_calls[0].arguments)
+        .unwrap_or_else(|e| panic!("{case}: arguments not valid JSON: {e}"));
+    assert_eq!(
+        args,
+        serde_json::json!({"location": "San Francisco {CA}"}),
+        "{case}: the inner brace must stay argument DATA, not become structure"
     );
 }

--- a/lib/llm/tests/test_reasoning_parser.rs
+++ b/lib/llm/tests/test_reasoning_parser.rs
@@ -555,6 +555,7 @@ mod tests {
             None, // No tool_choice in this test
             None, // No tool_definitions in this test
             false,
+            false,
             reasoning_parsed_stream,
         );
 
@@ -670,6 +671,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             reasoning_parsed_stream,
         );
 
@@ -769,6 +771,7 @@ mod tests {
             Some("harmony".to_string()),
             None, // No tool_choice in this test
             None, // No tool_definitions in this test
+            false,
             false,
             reasoning_parsed_stream,
         );

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -174,6 +174,7 @@ async fn parse_response_stream(
                 None,  // No tool_choice in this test
                 None,  // No tool_definitions in this test
                 false, // No structural_tag in this test
+                false,
                 stream,
             ))
         } else {
@@ -1998,6 +1999,7 @@ mod tests {
             None,
             None,
             false,
+            false,
             Box::pin(futures::stream::iter(chunks)),
         )
         .collect()
@@ -2078,6 +2080,7 @@ async fn run_glm47_jail(
         Some("glm47".to_string()),
         None,
         None,
+        false,
         false,
         Box::pin(stream::iter(chunks)),
     )

--- a/lib/llm/tests/test_streaming_tool_parsers.rs
+++ b/lib/llm/tests/test_streaming_tool_parsers.rs
@@ -2202,3 +2202,121 @@ async fn test_glm47_streaming_emoji_content_no_marker_no_panic() {
     let out = run_glm47_jail(chunks).await;
     assert!(!out.is_empty());
 }
+
+// A partial, never-closed DSML invoke (same payload the finalize-recovery test above
+// proves the vendored jail WILL complete into a real `ToolCalls` chunk on a clean EOF
+// with no finish_reason at all — see
+// `test_deepseek_v4_stream_finalize_recovers_complete_invoke_without_outer_close`'s
+// sibling behavior, reproduced directly against bare EOF below) — but this time the
+// upstream stream ends in an error instead of a clean EOF. The jail's own vendored
+// finalize logic cannot distinguish "upstream failed" from "upstream legitimately
+// finished", so without the wrapper's error short-circuit it would still synthesize
+// and emit that same completed (but never actually confirmed) tool call — a data
+// fabrication bug: the request failed, yet the caller would see a normal-looking
+// `finish_reason: ToolCalls` with a plausible `location: "NYC"` argument that was never
+// truly finished being generated.
+fn deepseek_v4_partial_invoke_chunk() -> Annotated<NvCreateChatCompletionStreamResponse> {
+    Annotated {
+        id: Some("probe".to_string()),
+        data: Some(NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "probe".to_string(),
+                object: "chat.completion.chunk".to_string(),
+                created: 0,
+                model: "m".to_string(),
+                choices: vec![ChatChoiceStream {
+                    index: 0,
+                    delta: dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+                        role: Some(dynamo_protocols::types::Role::Assistant),
+                        content: Some(ChatCompletionMessageContent::Text(
+                            "<｜DSML｜tool_calls>\n\
+<｜DSML｜invoke name=\"get_weather\">\n\
+<｜DSML｜parameter name=\"location\" string=\"true\">NYC</｜DSML｜parameter>\n\
+</｜DSML｜invoke>"
+                                .to_string(),
+                        )),
+                        tool_calls: None,
+                        function_call: None,
+                        refusal: None,
+                        reasoning_content: None,
+                    },
+                    finish_reason: None,
+                    logprobs: None,
+                }],
+                usage: None,
+                service_tier: None,
+                system_fingerprint: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        }),
+        event: None,
+        comment: None,
+        error: None,
+    }
+}
+
+// Empirically confirms the vendored jail DOES finalize a complete tool call from bare
+// EOF with no finish_reason ever seen — the exact mechanism finding #6 describes. This
+// is the "red" half of the regression below: same payload, but terminated by a clean
+// EOF instead of an upstream error, is EXPECTED to recover the tool call normally.
+#[tokio::test]
+async fn test_deepseek_v4_finalize_recovers_at_bare_eof_with_no_finish_reason() {
+    let output_chunks = parse_response_stream(
+        stream::iter(vec![deepseek_v4_partial_invoke_chunk()]),
+        true,
+        false,
+        Some("deepseek_v4".to_string()),
+        None,
+    )
+    .await;
+
+    let aggregated = aggregate_content_from_chunks(&output_chunks);
+    assert!(
+        aggregated.has_tool_calls,
+        "sanity check: a clean EOF (no error) must still recover the finished invoke; \
+         got: {output_chunks:#?}"
+    );
+}
+
+// Finding #6 regression: the SAME partial invoke, but the upstream stream ends in an
+// error instead of a clean EOF. The jail wrapper must yield exactly that error and
+// nothing else — no synthesized `ToolCalls` finish chunk fabricated from the jail's
+// own EOF-triggered finalize, because the request never actually completed.
+#[tokio::test]
+async fn test_deepseek_v4_upstream_error_suppresses_jail_finalize() {
+    let output_chunks = parse_response_stream(
+        stream::iter(vec![
+            deepseek_v4_partial_invoke_chunk(),
+            Annotated::from_error("upstream disconnected"),
+        ]),
+        true,
+        false,
+        Some("deepseek_v4".to_string()),
+        None,
+    )
+    .await;
+
+    assert!(
+        !output_chunks.is_empty(),
+        "the terminal error itself must still reach the caller"
+    );
+    let last = output_chunks.last().expect("non-empty output");
+    assert!(
+        last.is_error(),
+        "the terminal error must be the LAST item in the output stream; got: {output_chunks:#?}"
+    );
+    assert_eq!(
+        output_chunks.iter().filter(|a| a.is_error()).count(),
+        1,
+        "the terminal error must be surfaced exactly once; got: {output_chunks:#?}"
+    );
+
+    let aggregated = aggregate_content_from_chunks(&output_chunks);
+    assert!(
+        !aggregated.has_tool_calls,
+        "an upstream error must suppress the jail's EOF finalize entirely — no \
+         synthesized tool call may reach the caller for a request that never actually \
+         completed; got: {output_chunks:#?}"
+    );
+}

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -401,6 +401,18 @@ pub mod llm {
     /// One switch, because both are the same decision: stop using v1.
     pub const DYN_ENABLE_EXPERIMENTAL_PARSERS_V2: &str = "DYN_ENABLE_EXPERIMENTAL_PARSERS_V2";
 
+    /// Rollback lever for incremental guided-tool-call streaming.
+    ///
+    /// A forced `tool_choice` (`required` or a named tool) installs a JSON grammar,
+    /// so by default the jail releases tool-call chunks as they arrive instead of
+    /// buffering the whole response. The grammar-constrained decoding itself lives
+    /// in the published `dynamo-parsers` dependency, not in this repo, so if a
+    /// backend in production doesn't correctly honor the grammar the only other
+    /// rollback is a dependency repin and a new release. On by default; set this
+    /// to a falsy value (`0`/`false`) to fall back to the old buffer-to-completion
+    /// behavior at runtime, no redeploy required.
+    pub const DYN_ENABLE_GUIDED_TOOL_STREAMING: &str = "DYN_ENABLE_GUIDED_TOOL_STREAMING";
+
     /// Backend stream inactivity timeout in seconds.
     ///
     /// When set to a positive integer, the frontend will kill the engine context
@@ -950,6 +962,7 @@ mod tests {
             llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH,
             llm::DYN_REASONING_FIELD_NAME,
             llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2,
+            llm::DYN_ENABLE_GUIDED_TOOL_STREAMING,
             llm::DYN_LORA_ALLOCATION_ENABLED,
             llm::DYN_LORA_ALLOCATION_ALGORITHM,
             llm::DYN_LORA_ALLOCATION_TIMESTEP_SECS,

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -386,10 +386,19 @@ pub mod llm {
     /// Accepted values: "reasoning_content" (default) or "reasoning".
     pub const DYN_REASONING_FIELD_NAME: &str = "DYN_REASONING_FIELD_NAME";
 
-    /// \[EXPERIMENTAL\] Route supported tool-call families (Qwen3-Coder, DeepSeek-V4)
-    /// through the `dynamo-parsers-v2` streaming parser for BOTH the batch and the
-    /// streaming path, bypassing the v1 tool-call jail. Off by default; when set, the
-    /// v2 parser owns incremental tool-call emission and drops values truncated at EOF.
+    /// \[EXPERIMENTAL\] Use `dynamo-parsers-v2` instead of the v1 tool-call jail, for
+    /// BOTH the batch and the streaming path. Off by default.
+    ///
+    /// Which v2 shape a request gets is decided by the configured parsers, not by a
+    /// second flag:
+    /// * tool-call parser only (Qwen3-Coder, DeepSeek-V4) -> the v2 TOOL parser owns
+    ///   incremental tool-call emission and drops values truncated at EOF.
+    /// * tool-call AND reasoning parser naming the same family (`qwen3_coder` +
+    ///   `qwen3`) -> the v2 UNIFIED parser owns reasoning, visible text and tool calls
+    ///   in one ordered stream, so reasoning that followed a tool call stays after it
+    ///   instead of being hoisted to the front and fused with the first thought.
+    ///
+    /// One switch, because both are the same decision: stop using v1.
     pub const DYN_ENABLE_EXPERIMENTAL_PARSERS_V2: &str = "DYN_ENABLE_EXPERIMENTAL_PARSERS_V2";
 
     /// Backend stream inactivity timeout in seconds.

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -360,10 +360,19 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
-    /// \[EXPERIMENTAL\] Route supported tool-call families (Qwen3-Coder, DeepSeek-V4)
-    /// through the `dynamo-parsers-v2` streaming parser for BOTH the batch and the
-    /// streaming path, bypassing the v1 tool-call jail. Off by default; when set, the
-    /// v2 parser owns incremental tool-call emission and drops values truncated at EOF.
+    /// \[EXPERIMENTAL\] Use `dynamo-parsers-v2` instead of the v1 tool-call jail, for
+    /// BOTH the batch and the streaming path. Off by default.
+    ///
+    /// Which v2 shape a request gets is decided by the configured parsers, not by a
+    /// second flag:
+    /// * tool-call parser only (Qwen3-Coder, DeepSeek-V4) -> the v2 TOOL parser owns
+    ///   incremental tool-call emission and drops values truncated at EOF.
+    /// * tool-call AND reasoning parser naming the same family (`qwen3_coder` +
+    ///   `qwen3`) -> the v2 UNIFIED parser owns reasoning, visible text and tool calls
+    ///   in one ordered stream, so reasoning that followed a tool call stays after it
+    ///   instead of being hoisted to the front and fused with the first thought.
+    ///
+    /// One switch, because both are the same decision: stop using v1.
     pub const DYN_ENABLE_EXPERIMENTAL_PARSERS_V2: &str = "DYN_ENABLE_EXPERIMENTAL_PARSERS_V2";
 
     /// Backend stream inactivity timeout in seconds.


### PR DESCRIPTION
#### Overview:

Guided tool calls now stream as they are generated on the default path, with no experimental flag. This affects named and required tool choices whose backend installs guided JSON. Previously the client received one terminal tool-call chunk only after the full call had been generated. `tool_choice="auto"` stays on native parsing and is unchanged.

Qwen3 also routes through the v2 unified parser under `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2`, so reasoning that follows a tool call stays after it.

> [!IMPORTANT]
> Scope changed from the original version of this PR. Guided streaming is not gated by `DYN_ENABLE_EXPERIMENTAL_PARSERS_V2` and is not Qwen3-only. Guided calls outside the Qwen3 parser-v2 route run through the v1 jail; Qwen3 under parser v2 runs through the unified parser. Both paths now honor `DYN_ENABLE_GUIDED_TOOL_STREAMING`; setting it to `0` buffers guided calls to completion without reverting code.

#### Example (before -> after):

Streaming request, `tool_choice="required"`, flag unset. Measured against a served model, long payload:

```
before -- 0 tool-call chunks, one terminal burst at the end of the stream

after  -- 169 chunks; first at 9.2% of the stream; argument bytes spread
          across every decile of stream time
```

Arrival histograms over deciles of stream time. A buffering path reads `[0,0,0,0,0,0,0,0,0,1]`:

| tool_choice | flag | deltas | first delta | delivery span | histogram |
|---|---|---|---|---|---|
| required | off | 169 | 9.2% in | 90.2% | `[3,20,21,23,20,16,17,16,16,17]` |
| named | off | 181 | 1.0% in | 98.7% | `[18,17,15,23,20,15,16,21,18,18]` |
| required | on | 229 | 19.9% in | 79.4% | `[0,2,36,29,27,26,31,23,25,30]` |
| named | on | 260 | 1.4% in | 98.4% | `[25,26,24,26,28,27,25,29,24,26]` |

Every reassembled payload parses as valid JSON, exactly once.

#### Details:

- `postprocessor_parsing_stream_with_constraint` reads the installed constraint and `DYN_ENABLE_GUIDED_TOOL_STREAMING` once per request, then passes the same decision to the jail or unified-v2 path. Before this wiring, three v2 cases produced the same 28 / 23 / 96 argument-fragment chunks with the flag unset and set to `0`. Unified rollback selects `RecoverAsText`, which buffers to completion, rather than `Reject`, which would return a typed error for malformed output.
- `apply_tool_choice_guided_decoding` reports the constraint it installed instead of a bool, so the postprocessor does not infer guided JSON from `tool_choice` alone. That keeps native fallback working when a backend ignores its grammar and prevents a forced request with no installed JSON schema from streaming native markup into `function.arguments`.
- `parallel_tool_calls=false` now constrains generation with `maxItems: 1`; the HTTP filter remains as defense in depth. Guided-streaming support uses published `dynamo-parsers 8.1.0` and `dynamo-parsers-v2 0.3.2` releases, with no frontend-crates path dependency.

#### Known issues:

- `DIS-2779`: a zero-argument tool under guided decoding generates whitespace until `max_tokens` and returns no usable call. Main reproduces this; this PR does not cause it.
- `DIS-2780`: a tool call cut off mid-string by `max_tokens` can return `arguments` that do not parse. This PR causes that behavior. On main, the same input drops the tool call and leaks raw tool markup into `content`.

#### Verification:

The streaming measurements above cover named and required guided calls. Tests cover the shared rollback decision and the unified buffer-to-completion path.

#### Where:

- `lib/llm/src/preprocessor.rs`, `lib/llm/src/preprocessor/{tool_choice,structural_tag}.rs`
- `lib/llm/src/protocols/openai/chat_completions/{tool_parser_v2,unified_parser,aggregator}.rs`
- `lib/llm/src/protocols/openai/tools.rs`
- `lib/llm/src/http/service.rs`, `lib/llm/src/http/service/{openai,anthropic}.rs`
- `lib/llm/src/discovery/worker_set.rs`
- `lib/llm/tests/{postprocessor_parsing_stream,tool_choice,aggregators}.rs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved structured tool-call handling for named, required, optional, and disabled tool choices.
  - Added better support for unified reasoning and tool parsing across supported models.
  - Improved streaming behavior, including response ordering, usage updates, and deferred content handling.
  - Added support for limiting required tool calls when parallel calls are disabled.

- **Bug Fixes**
  - Invalid tool configurations now return clear request validation errors.
  - Improved recovery when responses contain native tool-call markup or truncated content.
  - Prevented tool calls from appearing when tools are unavailable or disabled.

- **Documentation**
  - Clarified experimental parser configuration and its batch and streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->