### PR TITLE
fix(examples): update Triton example for CUDA 13 + fix libdcgm copy (DYN-3697)

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -12,9 +12,9 @@ FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 
 COPY --from=triton_source /opt/tritonserver /opt/tritonserver
 COPY --from=triton_source /usr/local/dcgm /usr/local/dcgm
-# libdcgm may not be present in all Triton releases; copy only when found
-RUN --mount=type=bind,from=triton_source,source=/lib/x86_64-linux-gnu,target=/triton_lib \
-    find /triton_lib -name "libdcgm*.so*" -exec cp -a {} /lib/x86_64-linux-gnu/ \; 2>/dev/null || true
+USER root
+RUN --mount=type=bind,from=triton_source,source=/usr/lib/x86_64-linux-gnu,target=/triton_usr_lib \
+    find /triton_usr_lib -name "libdcgm*.so*" -exec cp -a {} /lib/x86_64-linux-gnu/ \;
 ENV BACKEND_DIR=/opt/tritonserver/backends
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/opt/tritonserver/lib:/opt/tritonserver/backends:/usr/local/dcgm/lib64
 ENV PATH=/opt/tritonserver/bin:$PATH

--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -2,15 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DYNAMO_BASE_IMAGE="dynamo-base:latest"
-ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.01-py3"
+ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.10-py3"
 
 FROM ${TRITON_SERVER_IMAGE} AS triton_source
+# Ensure DCGM directory exists so COPY never fails when the source image omits it
+RUN mkdir -p /usr/local/dcgm
 
 FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 
 COPY --from=triton_source /opt/tritonserver /opt/tritonserver
 COPY --from=triton_source /usr/local/dcgm /usr/local/dcgm
-COPY --from=triton_source /lib/x86_64-linux-gnu/libdcgm*.so* /lib/x86_64-linux-gnu/
+# libdcgm may not be present in all Triton releases; copy only when found
+RUN --mount=type=bind,from=triton_source,source=/lib/x86_64-linux-gnu,target=/triton_lib \
+    find /triton_lib -name "libdcgm*.so*" -exec cp -a {} /lib/x86_64-linux-gnu/ \; 2>/dev/null || true
 ENV BACKEND_DIR=/opt/tritonserver/backends
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/opt/tritonserver/lib:/opt/tritonserver/backends:/usr/local/dcgm/lib64
 ENV PATH=/opt/tritonserver/bin:$PATH
@@ -24,3 +28,5 @@ USER dynamo
 
 RUN uv pip install --no-cache-dir tritonclient[grpc]
 RUN uv pip install /opt/tritonserver/python/triton*.whl
+# Validate CUDA ABI compatibility at build time
+RUN python3 -c "import tritonserver"

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -38,21 +38,26 @@ This example shows how to run Triton Server models through Dynamo's distributed 
 From the Dynamo repository root:
 
 ```bash
-# Build the base Dynamo image
+# Build the base Dynamo image (CUDA 13.0)
 python container/render.py --framework=dynamo --target=runtime --output-short-filename
 docker build -f container/rendered.Dockerfile -t dynamo-base:latest .
 
-# Build the Triton worker image
-cd examples/backends/tritonserver
-docker build -t dynamo-triton:latest .
+# Build the Triton worker image (defaults to tritonserver:25.10-py3, CUDA 13-compatible)
+docker build \
+  --build-arg DYNAMO_BASE_IMAGE=dynamo-base:latest \
+  -t dynamo-triton:latest \
+  examples/backends/tritonserver/
 ```
+
+> [!NOTE]
+> The default `TRITON_SERVER_IMAGE` is `nvcr.io/nvidia/tritonserver:25.10-py3`
 
 #### Step 2: Run the Container
 
 ```bash
 docker run --rm -it --gpus all --network host \
   dynamo-triton:latest \
-  ./examples/backends/tritonserver/launch/identity.sh
+  /workspace/launch/identity.sh
 ```
 
 #### Step 3: Test the Deployment


### PR DESCRIPTION
## Summary

- Bumps default `TRITON_SERVER_IMAGE` from `tritonserver:25.01-py3` (CUDA 12.8) to `tritonserver:25.10-py3` (CUDA 13.0.2) to match the CUDA 13-only Dynamo base image. The old image's `triton_bindings` linked against `libdcgm.so.3` / `libcudart.so.12`, both absent in the CUDA 13 environment.
- Fixes the DCGM library copy: Triton 25.10 ships `libdcgm.so.4` under `/usr/lib/x86_64-linux-gnu` (merged-usr convention) rather than `/lib/x86_64-linux-gnu`. Updates the bind-mount source path accordingly.
- Adds `USER root` before the `find … cp` step so the `dynamo-base` non-root user does not cause a permission-denied failure when writing to `/lib/x86_64-linux-gnu/`.
- Adds a build-time `python3 -c "import tritonserver"` smoke check so future ABI or library mismatches fail the image build rather than producing a silently broken image.

## Validation

Built `dynamo-triton:latest` from scratch on a host with 5× H100 80GB:

```
docker build --build-arg DYNAMO_BASE_IMAGE=dynamo-base:latest \
  -t dynamo-triton:latest examples/backends/tritonserver/
```

All 11 build steps passed, including the `import tritonserver` smoke check.

Ran the identity server and client end-to-end:

```
docker run --rm -d --gpus all --network host \
  -e DYN_HTTP_PORT=8777 --name dynamo-triton-test \
  dynamo-triton:latest /workspace/launch/identity.sh

docker exec dynamo-triton-test \
  python3 /workspace/src/client.py --port 8777 --iterations 3
```

```
✓ Identity verification passed   # iteration 1
✓ Identity verification passed   # iteration 2
✓ Identity verification passed   # iteration 3
```

Note: `DYN_HTTP_PORT` override needed when port 8000 is already in use on the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12577" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Triton server container build and deployment instructions for CUDA 13.0.
  * Clarified the default server image and corrected the container launch command.

* **Bug Fixes**
  * Improved Triton container setup by reliably including required GPU libraries.
  * Added build-time validation to confirm the Triton server package is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->