### PR TITLE
fix(mocker): use logical KV tokens for decode timing [DYN-3851]

### DIFF
--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -82,7 +82,7 @@ pub enum PerfModel {
     #[default]
     Polynomial,
     /// Interpolation-based model using profiler data
-    /// Decode axes: (active_kv_tokens, context_length)
+    /// Decode axes: (scheduled logical KV tokens, mean context length)
     Interpolated {
         prefill_interp: Arc<dyn PrefillInterpolator>,
         decode_interp: Arc<dyn DecodeInterpolator>,
@@ -126,7 +126,7 @@ impl PerfModel {
     /// Expected arrays in NPZ file:
     /// - prefill_isl: 1D array of input sequence lengths
     /// - prefill_ttft_ms: 1D array of time to first token in milliseconds
-    /// - decode_active_kv_tokens: 1D array of active KV token counts
+    /// - decode_active_kv_tokens: 1D array of scheduled logical KV token counts
     /// - decode_context_length: 1D array of context lengths
     /// - decode_itl: 2D array of inter-token latencies in milliseconds
     pub fn from_npz(path: &Path) -> Result<Self> {
@@ -248,8 +248,11 @@ impl PerfModel {
 
     /// Predict decode time in milliseconds.
     ///
+    /// `active_kv_tokens` is the capped sum of logical context lengths in the
+    /// scheduled batch, not the number of distinct physically resident tokens.
+    ///
     /// Callers always pass all parameters; each variant uses what it needs:
-    /// - Polynomial: uses (active_kv_tokens, total_kv_tokens) as utilization
+    /// - Polynomial: uses logical active KV tokens relative to total capacity
     /// - Interpolated: uses (active_kv_tokens, context_length)
     /// - Aiconfigurator: uses (batch_size, context_length)
     pub fn predict_decode_time(

--- a/lib/mocker/src/common/perf_model.rs
+++ b/lib/mocker/src/common/perf_model.rs
@@ -248,11 +248,12 @@ impl PerfModel {
 
     /// Predict decode time in milliseconds.
     ///
-    /// `active_kv_tokens` is the capped sum of logical context lengths in the
-    /// scheduled batch, not the number of distinct physically resident tokens.
+    /// `active_kv_tokens` is the sum of logical context lengths in the scheduled
+    /// batch, not the number of distinct physically resident tokens.
     ///
     /// Callers always pass all parameters; each variant uses what it needs:
-    /// - Polynomial: uses logical active KV tokens relative to total capacity
+    /// - Polynomial: uses logical active KV tokens relative to total capacity,
+    ///   clamped to full utilization
     /// - Interpolated: uses (active_kv_tokens, context_length)
     /// - Aiconfigurator: uses (batch_size, context_length)
     pub fn predict_decode_time(
@@ -291,7 +292,7 @@ fn polynomial_prefill_time(batch_size: usize, new_tokens_per_request: usize) -> 
 
 fn polynomial_decode_time(active_kv_tokens: usize, total_kv_tokens: usize) -> f64 {
     let active_perc = if total_kv_tokens > 0 {
-        active_kv_tokens as f64 / total_kv_tokens as f64
+        (active_kv_tokens as f64 / total_kv_tokens as f64).min(1.0)
     } else {
         tracing::warn!("Total KV tokens is 0, using 1.0 as capacity");
         1.0

--- a/lib/mocker/src/kv_manager/g1_manager.rs
+++ b/lib/mocker/src/kv_manager/g1_manager.rs
@@ -59,15 +59,6 @@ enum DecodeBlockReservationBackend {
     Native(NativeDecodeBlockReservation),
 }
 
-impl DecodeBlockReservation {
-    pub(crate) fn len(&self) -> usize {
-        match &self.inner {
-            DecodeBlockReservationBackend::Kvbm(reservation) => reservation.len(),
-            DecodeBlockReservationBackend::Native(reservation) => reservation.len(),
-        }
-    }
-}
-
 pub(crate) struct DestinationReservation {
     inner: DestinationReservationBackend,
 }

--- a/lib/mocker/src/kv_manager/vllm_backend.rs
+++ b/lib/mocker/src/kv_manager/vllm_backend.rs
@@ -143,12 +143,6 @@ pub(crate) struct NativeDecodeBlockReservation {
     pool: BlockReservation,
 }
 
-impl NativeDecodeBlockReservation {
-    pub(crate) fn len(&self) -> usize {
-        self.pool.fresh_len()
-    }
-}
-
 pub(crate) struct NativeDestinationReservation {
     request_id: Uuid,
     pool: BlockReservation,

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -247,7 +247,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         .map(SglangRequest::current_sequence_len)
         .sum();
     let avg_context = total_context / running.len();
-    let active_kv_tokens = total_context.min(config.total_kv_tokens);
+    let active_kv_tokens = total_context;
     let decode_time = config.perf_model.predict_decode_time(
         running.len(),
         active_kv_tokens,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -2200,8 +2200,8 @@ impl VllmCore {
         let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
             (Duration::ZERO, decode_start_ms)
         } else {
-            let active_kv_tokens = self.kv_manager.num_active_blocks() * self.args.block_size;
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
+            let active_kv_tokens = total_length.min(total_kv_tokens);
             let context_length = total_length / ready.len();
             let decode_ms = self.args.perf_model.predict_decode_time(
                 ready.len(),
@@ -2435,12 +2435,8 @@ impl VllmCore {
         let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
             (Duration::ZERO, decode_start_ms)
         } else {
-            let active_kv_tokens = self
-                .kv_manager
-                .num_active_blocks()
-                .saturating_sub(reservation.len())
-                * self.args.block_size;
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
+            let active_kv_tokens = total_length.min(total_kv_tokens);
             let context_length = total_length / ready.len();
             let decode_ms = self.args.perf_model.predict_decode_time(
                 ready.len(),

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -2201,7 +2201,7 @@ impl VllmCore {
             (Duration::ZERO, decode_start_ms)
         } else {
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
-            let active_kv_tokens = total_length.min(total_kv_tokens);
+            let active_kv_tokens = total_length;
             let context_length = total_length / ready.len();
             let decode_ms = self.args.perf_model.predict_decode_time(
                 ready.len(),
@@ -2436,7 +2436,7 @@ impl VllmCore {
             (Duration::ZERO, decode_start_ms)
         } else {
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
-            let active_kv_tokens = total_length.min(total_kv_tokens);
+            let active_kv_tokens = total_length;
             let context_length = total_length / ready.len();
             let decode_ms = self.args.perf_model.predict_decode_time(
                 ready.len(),


### PR DESCRIPTION
## Summary

- Align Mocker decode timing with the scheduled logical KV-token semantics used by profiler-derived performance data.
- Stop using distinct physically resident blocks as a decode-compute proxy, which undercounts heterogeneous batches when prefix caching deduplicates shared blocks.
- Keep the full logical sum uncapped for interpolation while saturating only the legacy polynomial model's utilization ratio at 1.0.

This does not change KV allocation, prefix-cache ownership, routing, or direct AIC decode prediction.

## Details

- vLLM ordinary and speculative decode now pass the summed context lengths of the requests scheduled for decode.
- SGLang uses the same uncapped logical-KV meaning.
- Removed reservation-size accessors that were only needed by the physical-block timing proxy.

## Where should the reviewer start?

Start with `lib/mocker/src/scheduler/vllm/core.rs` for the semantic change and `lib/mocker/src/common/perf_model.rs` for the timing-model boundary.

## Related Issues

- [x] Confirmed — no related issue

## Validation

- `cargo test -p dynamo-mocker test_fpm_prefill_and_decode_mixed_batch -- --nocapture` (vLLM and SGLang cases passed locally and on a clean Linux checkout)
- `cargo test -p dynamo-mocker --features kvbm-offload speculative_decode_reservation_waits_without_preempting -- --nocapture`
- `cargo fmt --all -- --check`, commit hooks, and `git diff --check`
- ComputeLab SC-01: single H100, Qwen3-1.7B, vLLM TP1, 38,863 runtime GPU KV blocks, four prefix groups at 68.68-74.85% measured prefix-cache token hit rate, three trials each at concurrency 8 and 128, zero request errors or output-length mismatches.
- At concurrency 128, candidate median ITL was 21.69 ms versus live 22.12 ms; baseline was 8.98 ms. Candidate output-throughput error was -19.6% versus baseline +40.8%.
- Paired trace at scheduler batch 106/context 4,103 showed candidate `active_kv_tokens=434,972` (106.01 logical contexts) versus baseline `143,968` (35.09 contexts), confirming the corrected timing input tracks the scheduled batch under prefix dedup.

- Lower-level attribution on the exact live stack (H100 80GB, pinned vLLM 0.23.1 development image, Qwen3-1.7B BF16 TP1, FlashAttention 3) reproduced the scheduler shape at batch 106 with 434,976 logical KV tokens. At fixed batch and logical total, the actual ragged request vector was within 0.5% of the homogeneous attention control.
- The old batch-35 proxy underpriced direct paged FlashAttention by 58.2% and steady-state engine decode by 48.6% versus the actual batch-106 workload. This directly validates removing the dedup-aware scheduler cap.
- Physical prefix-block aliasing reduced attention time by 35.7% versus an unaliased replay. That is a separate attention-model fidelity opportunity; it does not make deduplicated physical blocks a valid proxy for the scheduled decode batch.

The live image reports vLLM `0.23.1rc1.dev1502`; the available AIC interpolation data is for vLLM `0.24.0`. Candidate mean and upper-tail simulated ITL remained conservative, so the campaign validates the accounting semantics and center-of-distribution parity rather than exact end-to-end calibration across those versions.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
