### PR TITLE
fix(container): reuse pinned protoc in runtime image (#12535) [cherry-pick → release/1.4.0]

### DIFF
--- a/container/templates/dynamo_runtime.Dockerfile
+++ b/container/templates/dynamo_runtime.Dockerfile
@@ -54,6 +54,13 @@ RUN --mount=type=bind,from=wheel_builder,source=/usr/local/,target=/tmp/usr/loca
     cp -r /tmp/usr/local/src/ffmpeg /usr/local/src/ && \
     ldconfig
 
+# Runtime test images rebuild Rust crates, so carry the same version-matched
+# protoc binary and well-known schemas used by the wheel builder.
+COPY --from=wheel_builder /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=wheel_builder /usr/local/include/google/protobuf/ /usr/local/include/google/protobuf/
+ENV PROTOC=/usr/local/bin/protoc
+RUN protoc --version && test -f /usr/local/include/google/protobuf/struct.proto
+
 {% if target not in ("dev", "local-dev") %}
 # Copy built artifacts (not needed for dev/local-dev; users build from source)
 COPY --chown=dynamo: --from=wheel_builder $CARGO_TARGET_DIR $CARGO_TARGET_DIR
@@ -73,7 +80,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         python${PYTHON_VERSION}-venv \
         build-essential \
         cmake \
-        protobuf-compiler \
         pkg-config \
         clang \
         libclang-dev \


### PR DESCRIPTION
## Summary

Cherry-pick of #12535 to `release/1.4.0`.

Unblocks the v1.4.0 RC crate-staging failure where `dynamo-vllm-sidecar` cannot compile `vllm_grpc.proto` because `google/protobuf/struct.proto` is absent from the runtime test image. The fix is on `main` but was missing from this release branch, so RC staging still fails without it.

- Copy the pinned `protoc` 25.3 binary and its matching well-known schemas from `wheel_builder` into the Dynamo runtime image.
- Point runtime rebuilds at `/usr/local/bin/protoc` via `PROTOC`.
- Drop the distro `protobuf-compiler` package from the runtime stage rather than mixing a 3.21.x compiler with schemas from a different protobuf version.

## Original PR

- Main PR: #12535
- Merge commit: `0a2cf56352a9f7cefbbd0d9dbd3b2be8d8461280`

## Validation

- Cherry-pick applied with no conflicts; the resulting diff is byte-identical to what merged on `main`.
- Confirmed the prerequisite already exists on `release/1.4.0`: `container/templates/wheel_builder.Dockerfile` pins `PROTOC_VERSION=25.3` and sets `PROTOC=/usr/local/bin/protoc`, so the binary and `google/protobuf` schema tree this patch copies from are present in that stage.
- The `protoc` install in `wheel_builder` is unconditional, so `/usr/local/bin/protoc` and the schema tree exist for every framework and architecture.
- This is a swap, not an addition: the runtime stage already shipped a `protoc` via the `protobuf-compiler` apt package that this diff removes.
- Full CI passed on #12535 before merge (PR, PR-XPU, Fern Docs).
- [ ] CI passes on this release branch

## Related Issues

**This PR is not linked to an issue:**
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12584" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->