### PR TITLE
feat(router): expose non-max-overlap selections

### DIFF
--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -283,6 +283,14 @@ The router exposes metrics for routing decisions and overhead. Not every metric 
   Predicted KV cache hit rate at routing time (0.0–1.0).
 </ParamField>
 
+<ParamField path="dynamo_component_router_non_max_overlap_selections_total" type="counter">
+  Admitted scheduler selections routed to a worker with less KV cache overlap than another eligible worker. Pinned requests and equal-overlap ties are excluded. Labeled by `worker_type` (`prefill` or `decode`).
+</ParamField>
+
+<ParamField path="dynamo_component_router_overlap_blocks_lost" type="histogram">
+  Difference in effective KV cache overlap between the highest-overlap eligible worker and the selected worker for each non-max-overlap selection. Labeled by `worker_type` (`prefill` or `decode`).
+</ParamField>
+
 ### Per-request routing overhead
 
 `dynamo_router_overhead_*` histograms (milliseconds) track time spent in each phase of the routing decision. Registered on the frontend port with a `router_id` label (the frontend's discovery instance ID). Created only when the frontend has DRT discovery enabled (`--router-mode kv`); absent in non-KV modes and on the standalone router.

--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -284,11 +284,11 @@ The router exposes metrics for routing decisions and overhead. Not every metric 
 </ParamField>
 
 <ParamField path="dynamo_component_router_non_max_overlap_selections_total" type="counter">
-  Admitted scheduler selections routed to a worker with less KV cache overlap than another eligible worker. Pinned requests and equal-overlap ties are excluded. Labeled by `worker_type` (`prefill` or `decode`).
+  Admitted prefill scheduler selections routed to a worker with less KV cache overlap than another eligible worker. Pinned requests and equal-overlap ties are excluded. Labeled by `worker_type` (`prefill`).
 </ParamField>
 
 <ParamField path="dynamo_component_router_overlap_blocks_lost" type="histogram">
-  Difference in effective KV cache overlap between the highest-overlap eligible worker and the selected worker for each non-max-overlap selection. Labeled by `worker_type` (`prefill` or `decode`).
+  Difference in effective KV cache overlap between the highest-overlap eligible prefill worker and the selected worker for each non-max-overlap selection. Labeled by `worker_type` (`prefill`).
 </ParamField>
 
 ### Per-request routing overhead

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -98,6 +98,10 @@ class frontend_service:
     KV_HIT_RATE = "kv_hit_rate"
     # Upper-bound estimation of KV cache transfer latency in disaggregated serving (seconds)
     KV_TRANSFER_ESTIMATED_LATENCY_SECONDS = "kv_transfer_estimated_latency_seconds"
+    # Scheduler selections with less overlap than another eligible worker
+    NON_MAX_OVERLAP_SELECTIONS_TOTAL = "non_max_overlap_selections_total"
+    # Effective KV overlap blocks lost by non-max-overlap selections
+    OVERLAP_BLOCKS_LOST = "overlap_blocks_lost"
     # Number of cached tokens (prefix cache hits) per request
     CACHED_TOKENS = "cached_tokens"
     # Tokenizer latency in milliseconds
@@ -373,6 +377,10 @@ class router:
     OUTPUT_SEQUENCE_TOKENS = "router_output_sequence_tokens"
     # Predicted KV cache hit rate at routing time (0.0-1.0)
     KV_HIT_RATE = "router_kv_hit_rate"
+    # Scheduler selections with less overlap than another eligible worker
+    NON_MAX_OVERLAP_SELECTIONS_TOTAL = "router_non_max_overlap_selections_total"
+    # Effective KV overlap blocks lost by non-max-overlap selections
+    OVERLAP_BLOCKS_LOST = "router_overlap_blocks_lost"
     # Whether the router currently has a worker/dp_rank registered (1 = registered)
     WORKER_REGISTERED = "router_worker_registered"
 

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -18,8 +18,9 @@ use super::prefill_load::PrefillLoadEstimator;
 use super::queue::{ClassQueueStats, SchedulerQueue};
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
-    AdvisorySchedulingResponse, KvSchedulerError, OverloadedWorkerProvider, PotentialLoad,
-    ScheduleMode, ScheduleRequest, SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
+    AdvisorySchedulingResponse, KvSchedulerError, NonMaxOverlapSelectionObserver,
+    OverloadedWorkerProvider, PotentialLoad, ScheduleMode, ScheduleRequest, SchedulingRequest,
+    SchedulingResponse, TierOverlapBlocks,
 };
 use crate::protocols::RoutingConstraints;
 use crate::protocols::{LocalBlockHash, WorkerConfigLike, WorkerId, WorkerWithDpRank};
@@ -315,6 +316,16 @@ where
     ) -> Result<AdvisorySchedulingResponse, KvSchedulerError> {
         let (request, _block_hashes) = self.make_scheduling_request(request, None);
         self.queue.select_without_admission(request).await
+    }
+
+    /// Install the observer for admitted selections that sacrifice KV overlap.
+    ///
+    /// Returns `false` when an observer is already installed.
+    pub fn set_non_max_overlap_selection_observer(
+        &self,
+        observer: NonMaxOverlapSelectionObserver,
+    ) -> bool {
+        self.queue.set_non_max_overlap_selection_observer(observer)
     }
 
     #[expect(clippy::too_many_arguments)]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -3,8 +3,8 @@
 
 use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use crossbeam_queue::SegQueue;
@@ -23,8 +23,9 @@ use super::prefill_load::{PrefillLoadEstimator, effective_prefill_tokens};
 use super::queue_admission::WorkerPlacement;
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
-    AdvisorySchedulingResponse, AdvisoryWorkerLoad, KvSchedulerError, OverloadedWorkerProvider,
-    SchedulingContext, SchedulingRequest, SchedulingResponse,
+    AdvisorySchedulingResponse, AdvisoryWorkerLoad, KvSchedulerError, NonMaxOverlapSelection,
+    NonMaxOverlapSelectionObserver, OverloadedWorkerProvider, SchedulingContext, SchedulingRequest,
+    SchedulingResponse,
 };
 use crate::protocols::{
     LocalBlockHash, PrefillLoadHint, WorkerConfigLike, WorkerId, WorkerSelectionResult,
@@ -61,6 +62,45 @@ struct SelectedWorkerForRequest {
     selection: WorkerSelectionResult,
     selected_worker_tiers: SelectedWorkerTierSnapshot,
     selected_worker_load: AdvisoryWorkerLoad,
+    non_max_overlap_selection: Option<NonMaxOverlapSelection>,
+}
+
+fn non_max_overlap_selection<C: WorkerConfigLike>(
+    workers: &HashMap<WorkerId, C>,
+    request: &SchedulingRequest,
+    eligibility: RoutingEligibility<'_>,
+    selected_worker: WorkerWithDpRank,
+    selected_overlap_blocks: f64,
+) -> Option<NonMaxOverlapSelection> {
+    if eligibility.pinned_worker().is_some() {
+        return None;
+    }
+
+    let mut highest_overlap = None;
+    for (&worker, &overlap_blocks) in &request.overlap.effective_overlap_blocks {
+        if overlap_blocks <= selected_overlap_blocks
+            || eligibility.validate_worker_rank(workers, worker).is_err()
+        {
+            continue;
+        }
+        let is_better = highest_overlap.is_none_or(
+            |(current_worker, current_overlap): (WorkerWithDpRank, f64)| {
+                overlap_blocks > current_overlap
+                    || (overlap_blocks == current_overlap && worker < current_worker)
+            },
+        );
+        if is_better {
+            highest_overlap = Some((worker, overlap_blocks));
+        }
+    }
+
+    let (highest_overlap_worker, highest_overlap_blocks) = highest_overlap?;
+    (highest_overlap_blocks > selected_overlap_blocks).then_some(NonMaxOverlapSelection {
+        selected_worker,
+        highest_overlap_worker,
+        highest_overlap_blocks,
+        selected_overlap_blocks,
+    })
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -176,6 +216,7 @@ struct SchedulerQueueActor<
     overlap_scores_refresh: Option<Arc<RF>>,
     overlap_refresh_after: Option<Duration>,
     overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+    non_max_overlap_selection_observer: Arc<OnceLock<NonMaxOverlapSelectionObserver>>,
 }
 
 /// Queue that gates scheduling requests behind a capacity check.
@@ -201,6 +242,7 @@ pub struct SchedulerQueue<
     workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
     queueing_enabled: bool,
     supports_overlap_refresh: bool,
+    non_max_overlap_selection_observer: Arc<OnceLock<NonMaxOverlapSelectionObserver>>,
     _marker: PhantomData<fn() -> (Sel, RF)>,
 }
 
@@ -318,6 +360,7 @@ impl<
         );
         let (admission_tx, admission_rx) = mpsc::channel(admission_channel_capacity);
         let cleanup = Arc::new(AdmissionCleanup::default());
+        let non_max_overlap_selection_observer = Arc::new(OnceLock::new());
         let actor = SchedulerQueueActor {
             pending,
             cleanup: Arc::clone(&cleanup),
@@ -335,6 +378,7 @@ impl<
             overlap_scores_refresh,
             overlap_refresh_after,
             overloaded_worker_provider,
+            non_max_overlap_selection_observer: Arc::clone(&non_max_overlap_selection_observer),
         };
         tokio::spawn(actor.run(admission_rx));
         Ok(Self {
@@ -347,6 +391,7 @@ impl<
             workers_with_configs,
             queueing_enabled,
             supports_overlap_refresh: overlap_refresh_after.is_some(),
+            non_max_overlap_selection_observer,
             _marker: PhantomData,
         })
     }
@@ -434,6 +479,18 @@ impl<
                 tracing::warn!(worker_id, %error, "Invalid externally-provided worker topology");
             }
         }
+    }
+
+    /// Install the observer for admitted selections that sacrifice KV overlap.
+    ///
+    /// Returns `false` when an observer is already installed.
+    pub fn set_non_max_overlap_selection_observer(
+        &self,
+        observer: NonMaxOverlapSelectionObserver,
+    ) -> bool {
+        self.non_max_overlap_selection_observer
+            .set(observer)
+            .is_ok()
     }
 
     /// Enqueue a new request.
@@ -935,6 +992,19 @@ impl<
             self.selector
                 .select_worker(&workers, request, eligibility, self.block_size)
                 .map(|selection| {
+                    let non_max_overlap_selection = if request.mode.is_tracked()
+                        && self.non_max_overlap_selection_observer.get().is_some()
+                    {
+                        non_max_overlap_selection(
+                            &workers,
+                            request,
+                            eligibility,
+                            selection.worker,
+                            selection.effective_overlap_blocks,
+                        )
+                    } else {
+                        None
+                    };
                     let config = workers
                         .get(&selection.worker.worker_id)
                         .expect("selected worker config must exist");
@@ -954,6 +1024,7 @@ impl<
                         selection,
                         selected_worker_tiers,
                         selected_worker_load,
+                        non_max_overlap_selection,
                     }
                 })
         }
@@ -997,6 +1068,7 @@ impl<
             selected_worker_tiers: selected.selected_worker_tiers,
             potential_decode_blocks: selected.selection.potential_decode_blocks,
         };
+        let non_max_overlap_selection = selected.non_max_overlap_selection;
 
         if !request.mode.is_tracked() {
             request.respond(Ok(response));
@@ -1024,7 +1096,12 @@ impl<
             worker: selected.selection.worker,
             lora_name: request.lora_name.take(),
         };
-        self.book_and_respond(request, sequence_request, response)
+        self.book_and_respond(
+            request,
+            sequence_request,
+            response,
+            non_max_overlap_selection,
+        )
     }
 
     /// A closed receiver means the actor-owned request was abandoned before
@@ -1037,6 +1114,7 @@ impl<
         mut request: SchedulingRequest,
         sequence_request: SequenceRequest,
         response: SchedulingResponse,
+        non_max_overlap_selection: Option<NonMaxOverlapSelection>,
     ) -> bool {
         if request.response_is_closed() {
             tracing::debug!(
@@ -1054,6 +1132,11 @@ impl<
         }
 
         if request.respond(Ok(response)) {
+            if let Some(selection) = non_max_overlap_selection
+                && let Some(observer) = self.non_max_overlap_selection_observer.get()
+            {
+                observer(&request_id, selection);
+            }
             return true;
         }
 
@@ -1742,6 +1825,130 @@ mod tests {
             resp_tx: Some(tx),
         };
         (req, rx)
+    }
+
+    #[test]
+    fn non_max_overlap_selection_ignores_ties_pins_and_ineligible_workers() {
+        let workers = HashMap::from([
+            (0, SimpleWorkerConfig::default()),
+            (1, SimpleWorkerConfig::default()),
+        ]);
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let (mut request, _rx) = make_request("locality-exclusions", 64);
+        request
+            .overlap
+            .effective_overlap_blocks
+            .extend([(worker0, 8.0), (worker1, 8.0)]);
+        assert!(
+            non_max_overlap_selection(&workers, &request, request.eligibility(), worker1, 8.0)
+                .is_none()
+        );
+
+        request
+            .overlap
+            .effective_overlap_blocks
+            .insert(worker1, 2.0);
+        request.pinned_worker = Some(worker1);
+        assert!(
+            non_max_overlap_selection(&workers, &request, request.eligibility(), worker1, 2.0)
+                .is_none()
+        );
+
+        request.pinned_worker = None;
+        request.allowed_worker_ids = Some(HashSet::from([worker1.worker_id]));
+        assert!(
+            non_max_overlap_selection(&workers, &request, request.eligibility(), worker1, 2.0)
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_observer_receives_non_max_overlap_selection() {
+        let (queue, _slots) = make_queue_with_custom_selector(
+            2,
+            16,
+            64,
+            None,
+            MinDecodeSelector { rendezvous: None },
+        );
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let observed = Arc::new(StdMutex::new(Vec::new()));
+        let observer_events = Arc::clone(&observed);
+        assert!(queue.set_non_max_overlap_selection_observer(Arc::new(
+            move |request_id, event| {
+                observer_events
+                    .lock()
+                    .unwrap()
+                    .push((request_id.to_string(), event));
+            }
+        )));
+        let (mut request, response_rx) = make_request("locality-response", 64);
+        request
+            .overlap
+            .effective_overlap_blocks
+            .extend([(worker0, 1.0), (worker1, 4.0)]);
+
+        queue.enqueue(request).await;
+        let response = response_rx.await.unwrap().unwrap();
+
+        assert_eq!(response.best_worker, worker0);
+        let events = observed.lock().unwrap();
+        assert_eq!(events[0].1.overlap_blocks_lost(), 3.0);
+        assert_eq!(
+            events.as_slice(),
+            [(
+                "locality-response".to_string(),
+                NonMaxOverlapSelection {
+                    selected_worker: worker0,
+                    highest_overlap_worker: worker1,
+                    highest_overlap_blocks: 4.0,
+                    selected_overlap_blocks: 1.0,
+                },
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_observer_ignores_advisory_and_abandoned_requests() {
+        let (queue, _slots) = make_queue_with_custom_selector(
+            2,
+            16,
+            64,
+            None,
+            MinDecodeSelector { rendezvous: None },
+        );
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let observed = Arc::new(StdMutex::new(Vec::new()));
+        let observer_events = Arc::clone(&observed);
+        assert!(queue.set_non_max_overlap_selection_observer(Arc::new(
+            move |request_id, event| {
+                observer_events
+                    .lock()
+                    .unwrap()
+                    .push((request_id.to_string(), event));
+            }
+        )));
+
+        let (mut advisory, _advisory_rx) = make_request("locality-advisory", 64);
+        advisory
+            .overlap
+            .effective_overlap_blocks
+            .extend([(worker0, 1.0), (worker1, 4.0)]);
+        let response = queue.select_without_admission(advisory).await.unwrap();
+        assert_eq!(response.response.best_worker, worker0);
+
+        let (mut abandoned, abandoned_rx) = make_request("locality-abandoned", 64);
+        abandoned
+            .overlap
+            .effective_overlap_blocks
+            .extend([(worker0, 1.0), (worker1, 4.0)]);
+        drop(abandoned_rx);
+        queue.enqueue(abandoned).await;
+
+        assert!(observed.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1132,10 +1132,8 @@ impl<
         }
 
         if request.respond(Ok(response)) {
-            if let Some(selection) = non_max_overlap_selection
-                && let Some(observer) = self.non_max_overlap_selection_observer.get()
-            {
-                observer(&request_id, selection);
+            if let Some(selection) = non_max_overlap_selection {
+                self.dispatch_non_max_overlap_selection(request_id, selection);
             }
             return true;
         }
@@ -1145,6 +1143,20 @@ impl<
             tracing::error!(%request_id, %error, "Failed to roll back scheduler booking");
         }
         false
+    }
+
+    fn dispatch_non_max_overlap_selection(
+        &self,
+        request_id: String,
+        selection: NonMaxOverlapSelection,
+    ) {
+        let Some(observer) = self.non_max_overlap_selection_observer.get() else {
+            return;
+        };
+        let observer = Arc::clone(observer);
+        let _observer_task = tokio::task::spawn_blocking(move || {
+            observer(&request_id, selection);
+        });
     }
 
     fn prefill_load_hint_for(
@@ -1874,14 +1886,12 @@ mod tests {
         );
         let worker0 = WorkerWithDpRank::new(0, 0);
         let worker1 = WorkerWithDpRank::new(1, 0);
-        let observed = Arc::new(StdMutex::new(Vec::new()));
-        let observer_events = Arc::clone(&observed);
+        let (observer_tx, mut observer_rx) = tokio::sync::mpsc::unbounded_channel();
         assert!(queue.set_non_max_overlap_selection_observer(Arc::new(
             move |request_id, event| {
-                observer_events
-                    .lock()
-                    .unwrap()
-                    .push((request_id.to_string(), event));
+                observer_tx
+                    .send((request_id.to_string(), event))
+                    .expect("observer receiver should remain open");
             }
         )));
         let (mut request, response_rx) = make_request("locality-response", 64);
@@ -1894,11 +1904,14 @@ mod tests {
         let response = response_rx.await.unwrap().unwrap();
 
         assert_eq!(response.best_worker, worker0);
-        let events = observed.lock().unwrap();
-        assert_eq!(events[0].1.overlap_blocks_lost(), 3.0);
+        let event = tokio::time::timeout(Duration::from_secs(1), observer_rx.recv())
+            .await
+            .expect("observer did not run")
+            .expect("observer channel closed");
+        assert_eq!(event.1.overlap_blocks_lost(), 3.0);
         assert_eq!(
-            events.as_slice(),
-            [(
+            event,
+            (
                 "locality-response".to_string(),
                 NonMaxOverlapSelection {
                     selected_worker: worker0,
@@ -1906,8 +1919,68 @@ mod tests {
                     highest_overlap_blocks: 4.0,
                     selected_overlap_blocks: 1.0,
                 },
-            )]
+            )
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn scheduler_observer_does_not_block_actor() {
+        let (queue, _slots) = make_queue_with_custom_selector(
+            2,
+            16,
+            64,
+            None,
+            MinDecodeSelector { rendezvous: None },
+        );
+        let observer_gate = Arc::new((StdMutex::new(false), Condvar::new()));
+        let callback_gate = Arc::clone(&observer_gate);
+        let (started_tx, mut started_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (finished_tx, mut finished_rx) = tokio::sync::mpsc::unbounded_channel();
+        assert!(queue.set_non_max_overlap_selection_observer(Arc::new(
+            move |_request_id, _event| {
+                started_tx.send(()).unwrap();
+                let (released, wake) = &*callback_gate;
+                let mut released = released.lock().unwrap();
+                while !*released {
+                    released = wake.wait(released).unwrap();
+                }
+                finished_tx.send(()).unwrap();
+            }
+        )));
+
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let (mut first, first_rx) = make_request("blocking-observer", 64);
+        first
+            .overlap
+            .effective_overlap_blocks
+            .extend([(worker0, 1.0), (worker1, 4.0)]);
+        let first_queue = Arc::clone(&queue);
+        let first_enqueue = tokio::spawn(async move {
+            first_queue.enqueue(first).await;
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+            .await
+            .expect("observer did not start")
+            .expect("observer start channel closed");
+
+        let (second, second_rx) = make_request("actor-remains-responsive", 64);
+        tokio::time::timeout(Duration::from_secs(1), queue.enqueue(second))
+            .await
+            .expect("observer blocked the scheduler actor");
+
+        let (released, wake) = &*observer_gate;
+        *released.lock().unwrap() = true;
+        wake.notify_one();
+
+        first_enqueue.await.unwrap();
+        first_rx.await.unwrap().unwrap();
+        second_rx.await.unwrap().unwrap();
+        tokio::time::timeout(Duration::from_secs(1), finished_rx.recv())
+            .await
+            .expect("observer did not finish")
+            .expect("observer finish channel closed");
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -95,7 +95,8 @@ pub struct NonMaxOverlapSelection {
     pub selected_overlap_blocks: f64,
 }
 
-/// Callback invoked after an admitted non-max-overlap selection is delivered.
+/// Callback dispatched off the scheduler actor after an admitted non-max-overlap selection is
+/// delivered.
 pub type NonMaxOverlapSelectionObserver =
     Arc<dyn Fn(&str, NonMaxOverlapSelection) + Send + Sync + 'static>;
 

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -78,6 +78,34 @@ pub struct SchedulingResponse {
     pub potential_decode_blocks: usize,
 }
 
+/// A routing decision that selected less KV overlap than another eligible worker.
+///
+/// This records the observable locality tradeoff without attributing its cause. The
+/// final selection may differ because of worker load, routing preferences, or
+/// temperature-based sampling.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct NonMaxOverlapSelection {
+    /// Worker selected by the scheduler's complete scoring policy.
+    pub selected_worker: WorkerWithDpRank,
+    /// Eligible worker with the greatest effective KV overlap.
+    pub highest_overlap_worker: WorkerWithDpRank,
+    /// Effective overlap available on `highest_overlap_worker`.
+    pub highest_overlap_blocks: f64,
+    /// Effective overlap available on `selected_worker`.
+    pub selected_overlap_blocks: f64,
+}
+
+/// Callback invoked after an admitted non-max-overlap selection is delivered.
+pub type NonMaxOverlapSelectionObserver =
+    Arc<dyn Fn(&str, NonMaxOverlapSelection) + Send + Sync + 'static>;
+
+impl NonMaxOverlapSelection {
+    /// Return the effective overlap blocks sacrificed by the final selection.
+    pub fn overlap_blocks_lost(self) -> f64 {
+        self.highest_overlap_blocks - self.selected_overlap_blocks
+    }
+}
+
 #[derive(Debug)]
 pub struct AdvisorySchedulingResponse {
     pub response: SchedulingResponse,

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -17,7 +17,8 @@
 //!   - Frontend (aggregated and disaggregated): available on default port 8000
 //!   - Standalone router: not created (frontend-only)
 //!
-//! - [`RouterRequestMetrics`]: Per-request aggregate histograms (TTFT, ITL, tokens, KV hit rate).
+//! - [`RouterRequestMetrics`]: Per-request aggregate histograms and counters (TTFT, ITL,
+//!   tokens, KV hit rate, and non-max-overlap routing decisions).
 //!   Registered on the DRT `MetricsRegistry` hierarchy via `Component::metrics()`.
 //!   Eagerly created so they appear as zeros before any requests arrive.
 //!   Populated by `KvPushRouter::generate()` and its `RequestGuard` as it observes
@@ -57,9 +58,12 @@ fn router_metric(suffix: &str) -> String {
     format!("{}{}", router_request::METRIC_PREFIX, suffix)
 }
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts};
+use prometheus::{
+    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+};
 
 use crate::http::service::metrics::generate_log_buckets;
+use crate::protocols::common::timing::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
 
 pub(crate) const ROUTER_WORKER_ID_LABEL: &str = "router_worker_id";
 const TARGET_NAMESPACE_LABEL: &str = "target_namespace";
@@ -828,6 +832,8 @@ pub struct RouterRequestMetrics {
     pub kv_transfer_estimated_latency_seconds: prometheus::Histogram,
     pub shared_cache_hit_rate: prometheus::Histogram,
     pub shared_cache_beyond_blocks: prometheus::Histogram,
+    pub non_max_overlap_selections_total: IntCounterVec,
+    pub overlap_blocks_lost: HistogramVec,
 }
 
 static ROUTER_REQUEST_METRICS: OnceLock<Arc<RouterRequestMetrics>> = OnceLock::new();
@@ -944,6 +950,27 @@ impl RouterRequestMetrics {
                         Some(prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()),
                     )
                     .expect("failed to create router_shared_cache_beyond_blocks");
+                let non_max_overlap_selections_total = metrics
+                    .create_intcountervec(
+                        &router_metric(frontend_service::NON_MAX_OVERLAP_SELECTIONS_TOTAL),
+                        "Total admitted scheduler selections with less KV cache overlap than another eligible worker",
+                        &[labels::WORKER_TYPE],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_non_max_overlap_selections_total");
+                let overlap_blocks_lost = metrics
+                    .create_histogramvec(
+                        &router_metric(frontend_service::OVERLAP_BLOCKS_LOST),
+                        "Difference in effective KV cache overlap between the highest-overlap eligible worker and selected worker",
+                        &[labels::WORKER_TYPE],
+                        extra_labels,
+                        Some(prometheus::exponential_buckets(0.25, 2.0, 16).unwrap()),
+                    )
+                    .expect("failed to create router_overlap_blocks_lost");
+                for worker_type in [WORKER_TYPE_PREFILL, WORKER_TYPE_DECODE] {
+                    non_max_overlap_selections_total.with_label_values(&[worker_type]);
+                    overlap_blocks_lost.with_label_values(&[worker_type]);
+                }
                 Arc::new(Self {
                     requests_total,
                     time_to_first_token_seconds,
@@ -954,9 +981,22 @@ impl RouterRequestMetrics {
                     kv_transfer_estimated_latency_seconds,
                     shared_cache_hit_rate,
                     shared_cache_beyond_blocks,
+                    non_max_overlap_selections_total,
+                    overlap_blocks_lost,
                 })
             })
             .clone()
+    }
+
+    /// Record a selection that sacrificed KV cache overlap.
+    pub fn observe_non_max_overlap_selection(&self, worker_type: &str, overlap_blocks_lost: f64) {
+        debug_assert!(overlap_blocks_lost > 0.0);
+        self.non_max_overlap_selections_total
+            .with_label_values(&[worker_type])
+            .inc();
+        self.overlap_blocks_lost
+            .with_label_values(&[worker_type])
+            .observe(overlap_blocks_lost);
     }
 }
 

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -63,7 +63,7 @@ use prometheus::{
 };
 
 use crate::http::service::metrics::generate_log_buckets;
-use crate::protocols::common::timing::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
+use crate::protocols::common::timing::WORKER_TYPE_PREFILL;
 
 pub(crate) const ROUTER_WORKER_ID_LABEL: &str = "router_worker_id";
 const TARGET_NAMESPACE_LABEL: &str = "target_namespace";
@@ -953,7 +953,7 @@ impl RouterRequestMetrics {
                 let non_max_overlap_selections_total = metrics
                     .create_intcountervec(
                         &router_metric(frontend_service::NON_MAX_OVERLAP_SELECTIONS_TOTAL),
-                        "Total admitted scheduler selections with less KV cache overlap than another eligible worker",
+                        "Total admitted prefill scheduler selections with less KV cache overlap than another eligible worker",
                         &[labels::WORKER_TYPE],
                         extra_labels,
                     )
@@ -961,16 +961,14 @@ impl RouterRequestMetrics {
                 let overlap_blocks_lost = metrics
                     .create_histogramvec(
                         &router_metric(frontend_service::OVERLAP_BLOCKS_LOST),
-                        "Difference in effective KV cache overlap between the highest-overlap eligible worker and selected worker",
+                        "Difference in effective KV cache overlap between the highest-overlap eligible prefill worker and selected worker",
                         &[labels::WORKER_TYPE],
                         extra_labels,
                         Some(prometheus::exponential_buckets(0.25, 2.0, 16).unwrap()),
                     )
                     .expect("failed to create router_overlap_blocks_lost");
-                for worker_type in [WORKER_TYPE_PREFILL, WORKER_TYPE_DECODE] {
-                    non_max_overlap_selections_total.with_label_values(&[worker_type]);
-                    overlap_blocks_lost.with_label_values(&[worker_type]);
-                }
+                non_max_overlap_selections_total.with_label_values(&[WORKER_TYPE_PREFILL]);
+                overlap_blocks_lost.with_label_values(&[WORKER_TYPE_PREFILL]);
                 Arc::new(Self {
                     requests_total,
                     time_to_first_token_seconds,

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -6,13 +6,14 @@ pub use dynamo_kv_router::scheduling::overlap_refresh::{
     NoopOverlapScoresRefresh, OverlapScoresRefresh, RefreshedOverlap,
 };
 pub use dynamo_kv_router::scheduling::{
-    AdvisorySchedulingResponse, KvSchedulerError, LocalScheduler, OverloadedWorkerProvider,
-    PotentialLoad, ScheduleRequest, SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
+    AdvisorySchedulingResponse, KvSchedulerError, LocalScheduler, NonMaxOverlapSelectionObserver,
+    OverloadedWorkerProvider, PotentialLoad, ScheduleRequest, SchedulingRequest,
+    SchedulingResponse, TierOverlapBlocks,
 };
 pub use dynamo_kv_router::selector::DefaultWorkerSelector;
 use dynamo_kv_router::selector::WorkerSelector as WorkerSelectorTrait;
 
-use super::metrics::{ROUTER_QUEUE_METRICS, RouterQueueMetricHandles};
+use super::metrics::{ROUTER_QUEUE_METRICS, RouterQueueMetricHandles, RouterRequestMetrics};
 use super::sequence::{
     RuntimeSequencePublisher, SequenceError, SequenceRequest, create_multi_worker_sequences,
 };
@@ -115,6 +116,30 @@ where
             worker_type,
             watch_worker_configs,
         )?);
+        let locality_observer: NonMaxOverlapSelectionObserver =
+            Arc::new(move |request_id, selection| {
+                let overlap_blocks_lost = selection.overlap_blocks_lost();
+                if let Some(metrics) = RouterRequestMetrics::get() {
+                    metrics.observe_non_max_overlap_selection(worker_type, overlap_blocks_lost);
+                }
+                tracing::debug!(
+                    request_id,
+                    worker_type,
+                    selected_worker_id = selection.selected_worker.worker_id,
+                    selected_dp_rank = selection.selected_worker.dp_rank,
+                    selected_overlap_blocks = selection.selected_overlap_blocks,
+                    highest_overlap_worker_id = selection.highest_overlap_worker.worker_id,
+                    highest_overlap_dp_rank = selection.highest_overlap_worker.dp_rank,
+                    highest_overlap_blocks = selection.highest_overlap_blocks,
+                    overlap_blocks_lost,
+                    "Router selected a worker with lower KV cache overlap"
+                );
+            });
+        if !inner.set_non_max_overlap_selection_observer(locality_observer) {
+            return Err(KvSchedulerError::InitFailed(
+                "non-max-overlap observer is already installed".to_string(),
+            ));
+        }
 
         let metrics_scheduler = Arc::clone(&inner);
         let background_metrics = queue_metrics.clone();

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -19,6 +19,7 @@ use super::sequence::{
 };
 use crate::discovery::RuntimeConfigWatch;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
+use crate::protocols::common::timing::WORKER_TYPE_PREFILL;
 use anyhow::Result;
 use dynamo_kv_router::{
     PrefillLoadEstimator,
@@ -116,29 +117,31 @@ where
             worker_type,
             watch_worker_configs,
         )?);
-        let locality_observer: NonMaxOverlapSelectionObserver =
-            Arc::new(move |request_id, selection| {
-                let overlap_blocks_lost = selection.overlap_blocks_lost();
-                if let Some(metrics) = RouterRequestMetrics::get() {
-                    metrics.observe_non_max_overlap_selection(worker_type, overlap_blocks_lost);
-                }
-                tracing::debug!(
-                    request_id,
-                    worker_type,
-                    selected_worker_id = selection.selected_worker.worker_id,
-                    selected_dp_rank = selection.selected_worker.dp_rank,
-                    selected_overlap_blocks = selection.selected_overlap_blocks,
-                    highest_overlap_worker_id = selection.highest_overlap_worker.worker_id,
-                    highest_overlap_dp_rank = selection.highest_overlap_worker.dp_rank,
-                    highest_overlap_blocks = selection.highest_overlap_blocks,
-                    overlap_blocks_lost,
-                    "Router selected a worker with lower KV cache overlap"
-                );
-            });
-        if !inner.set_non_max_overlap_selection_observer(locality_observer) {
-            return Err(KvSchedulerError::InitFailed(
-                "non-max-overlap observer is already installed".to_string(),
-            ));
+        if worker_type == WORKER_TYPE_PREFILL {
+            let locality_observer: NonMaxOverlapSelectionObserver =
+                Arc::new(move |request_id, selection| {
+                    let overlap_blocks_lost = selection.overlap_blocks_lost();
+                    if let Some(metrics) = RouterRequestMetrics::get() {
+                        metrics.observe_non_max_overlap_selection(worker_type, overlap_blocks_lost);
+                    }
+                    tracing::debug!(
+                        request_id,
+                        worker_type,
+                        selected_worker_id = selection.selected_worker.worker_id,
+                        selected_dp_rank = selection.selected_worker.dp_rank,
+                        selected_overlap_blocks = selection.selected_overlap_blocks,
+                        highest_overlap_worker_id = selection.highest_overlap_worker.worker_id,
+                        highest_overlap_dp_rank = selection.highest_overlap_worker.dp_rank,
+                        highest_overlap_blocks = selection.highest_overlap_blocks,
+                        overlap_blocks_lost,
+                        "Router selected a worker with lower KV cache overlap"
+                    );
+                });
+            if !inner.set_non_max_overlap_selection_observer(locality_observer) {
+                return Err(KvSchedulerError::InitFailed(
+                    "non-max-overlap observer is already installed".to_string(),
+                ));
+            }
         }
 
         let metrics_scheduler = Arc::clone(&inner);

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -80,6 +80,20 @@ pub trait PrometheusMetric: prometheus::core::Collector + Clone + Send + Sync + 
         panic!("with_histogram_opts_and_buckets is not implemented for this metric type");
     }
 
+    /// Create a histogram vector with custom buckets and label names.
+    fn with_histogram_opts_buckets_and_label_names(
+        _opts: prometheus::HistogramOpts,
+        _buckets: Option<Vec<f64>>,
+        _label_names: &[&str],
+    ) -> Result<Self, prometheus::Error>
+    where
+        Self: Sized,
+    {
+        panic!(
+            "with_histogram_opts_buckets_and_label_names is not implemented for this metric type"
+        );
+    }
+
     /// Create a new metric with counter options and label names (for CounterVec)
     /// This is a default implementation that will panic for non-countervec metrics
     fn with_opts_and_label_names(
@@ -179,6 +193,25 @@ impl PrometheusMetric for prometheus::Histogram {
             opts = opts.buckets(custom_buckets);
         }
         prometheus::Histogram::with_opts(opts)
+    }
+}
+
+impl PrometheusMetric for prometheus::HistogramVec {
+    fn with_opts(_opts: prometheus::Opts) -> Result<Self, prometheus::Error> {
+        Err(prometheus::Error::Msg(
+            "HistogramVec requires histogram options and label names".to_string(),
+        ))
+    }
+
+    fn with_histogram_opts_buckets_and_label_names(
+        mut opts: prometheus::HistogramOpts,
+        buckets: Option<Vec<f64>>,
+        label_names: &[&str],
+    ) -> Result<Self, prometheus::Error> {
+        if let Some(custom_buckets) = buckets {
+            opts = opts.buckets(custom_buckets);
+        }
+        prometheus::HistogramVec::new(opts, label_names)
     }
 }
 
@@ -341,6 +374,14 @@ pub fn create_metric<T: PrometheusMetric, H: MetricsHierarchy + ?Sized>(
         let label_names = const_labels
             .ok_or_else(|| anyhow::anyhow!("GaugeVec requires const_labels parameter"))?;
         T::with_opts_and_label_names(opts, label_names)?
+    } else if std::any::TypeId::of::<T>() == std::any::TypeId::of::<prometheus::HistogramVec>() {
+        let mut opts = prometheus::HistogramOpts::new(&metric_name, metric_desc);
+        for (key, value) in &updated_labels {
+            opts = opts.const_label(key.clone(), value.clone());
+        }
+        let label_names = const_labels
+            .ok_or_else(|| anyhow::anyhow!("HistogramVec requires const_labels parameter"))?;
+        T::with_histogram_opts_buckets_and_label_names(opts, buckets, label_names)?
     } else if std::any::TypeId::of::<T>() == std::any::TypeId::of::<prometheus::Histogram>() {
         // Special handling for Histogram with custom buckets
         // buckets parameter is valid for Histogram, const_labels is not used
@@ -428,7 +469,7 @@ impl<H: MetricsHierarchy> Metrics<H> {
     // - GaugeVec: ✅ IMPLEMENTED - create_gaugevec()
     // - GaugeHistogram: create_gauge_histogram() - for gauge histograms
     // - Histogram: ✅ IMPLEMENTED - create_histogram()
-    // - HistogramVec with custom buckets: create_histogram_with_buckets()
+    // - HistogramVec: ✅ IMPLEMENTED - create_histogramvec()
     // - Info: create_info() - for info metrics with labels
     // - IntCounter: ✅ IMPLEMENTED - create_intcounter()
     // - IntCounterVec: ✅ IMPLEMENTED - create_intcountervec()
@@ -507,6 +548,25 @@ impl<H: MetricsHierarchy> Metrics<H> {
         buckets: Option<Vec<f64>>,
     ) -> anyhow::Result<prometheus::Histogram> {
         create_metric(&self.hierarchy, name, description, labels, buckets, None)
+    }
+
+    /// Create a HistogramVec metric with custom buckets and label names.
+    pub fn create_histogramvec(
+        &self,
+        name: &str,
+        description: &str,
+        label_names: &[&str],
+        labels: &[(&str, &str)],
+        buckets: Option<Vec<f64>>,
+    ) -> anyhow::Result<prometheus::HistogramVec> {
+        create_metric(
+            &self.hierarchy,
+            name,
+            description,
+            labels,
+            buckets,
+            Some(label_names),
+        )
     }
 
     /// Create an IntCounter metric

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -212,6 +212,12 @@ pub mod frontend_service {
     /// Shared cache blocks beyond device overlap for the selected worker
     pub const SHARED_CACHE_BEYOND_BLOCKS: &str = "shared_cache_beyond_blocks";
 
+    /// Scheduler selections with less overlap than another eligible worker
+    pub const NON_MAX_OVERLAP_SELECTIONS_TOTAL: &str = "non_max_overlap_selections_total";
+
+    /// Effective KV overlap blocks lost by non-max-overlap selections
+    pub const OVERLAP_BLOCKS_LOST: &str = "overlap_blocks_lost";
+
     /// Number of cached tokens (prefix cache hits) per request
     pub const CACHED_TOKENS: &str = "cached_tokens";
 
@@ -641,6 +647,12 @@ pub mod router {
 
     /// Shared cache blocks beyond device overlap for the selected worker
     pub const SHARED_CACHE_BEYOND_BLOCKS: &str = "router_shared_cache_beyond_blocks";
+
+    /// Scheduler selections with less overlap than another eligible worker
+    pub const NON_MAX_OVERLAP_SELECTIONS_TOTAL: &str = "router_non_max_overlap_selections_total";
+
+    /// Effective KV overlap blocks lost by non-max-overlap selections
+    pub const OVERLAP_BLOCKS_LOST: &str = "router_overlap_blocks_lost";
 
     /// Whether the router currently has a worker/dp_rank registered (1 = registered)
     pub const WORKER_REGISTERED: &str = "router_worker_registered";


### PR DESCRIPTION
## Overview:

Add a focused diagnostic for cases where the KV scheduler selects an eligible worker with less effective KV-cache overlap than another eligible worker.

This makes cache-locality regressions visible without changing routing behavior or the public `SchedulingResponse` API.

## Details:

- Detect strict non-max-overlap selections after the existing selector applies its complete scoring policy.
- Compare only workers eligible for the request, including worker constraints, overload state, taints, worker existence, and DP rank.
- Exclude pinned selections and equal-overlap ties.
- Observe only admitted decisions whose response was delivered successfully; advisory and abandoned requests are excluded.
- Export `dynamo_component_router_non_max_overlap_selections_total` and `dynamo_component_router_overlap_blocks_lost`.
- Emit a structured DEBUG log with the request ID, worker type, selected worker/rank/overlap, highest-overlap worker/rank/overlap, and blocks lost.
- Document the metrics and expose their generated Rust and Python names.

The diagnostic records the observable locality tradeoff but intentionally does not attribute a cause. The final choice may differ because of load, routing preferences, or temperature-based sampling.

## Where should the reviewer start?

1. `lib/kv-router/src/scheduling/queue.rs` for eligibility-aware detection, delivery semantics, and focused behavior tests.
2. `lib/llm/src/kv_router/scheduler.rs` for the metrics and structured-log observer.
3. `lib/llm/src/kv_router/metrics.rs` for Prometheus registration.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed - no related issue

Related work: #11936 proposes broader router-decision telemetry. This draft is intentionally narrower: it reports the specific best-overlap-versus-selected divergence and leaves the public scheduling response unchanged.

## Validation

- Built this patch's `ai-dynamo` and native `ai-dynamo-runtime` Linux wheels on an AKS CPU node.
- Deployed the wheels on AKS with one KV-routing frontend and two Qwen3-0.6B mock workers.
- Verified the running frontend and workers loaded `/tmp/dynamo-test/dynamo/_core.abi3.so` from the built wheel.
- Sent 18 successful repeated-prefix chat requests. The new counter increased from `0` to `5`; the loss histogram recorded `5` observations and `30` total overlap blocks lost.
- Confirmed the structured DEBUG log includes the request ID and both selected and highest-overlap worker details.
- Confirmed the DGD was `Ready=True` with the frontend and both workers `1/1 Running`.
- Rebased onto `main` at `2dacf615fc`.
- Measured the diagnostic scan in a release-mode scheduler microbenchmark over 100,000 iterations per size. Added cost was 27.8 ns at 2 workers, 90.2 ns at 8, 253.2 ns at 32, and 1.094 us at 128 workers. The temporary benchmark harness was removed after measurement.
- `cargo test -p dynamo-kv-router --lib --no-fail-fast` - 828 passed, 2 ignored.
- `cargo test -p dynamo-llm --lib --no-default-features kv_router::metrics::tests --no-fail-fast` - 6 passed.
- `cargo clippy -p dynamo-kv-router --all-targets -- -D warnings` - passed.
- `cargo clippy -p dynamo-llm --lib --no-default-features -- -D warnings` - passed.
- `cargo fmt --all -- --check` - passed.
- Pre-commit hooks for all eight changed files - passed.
- `git diff --check` - passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability for routing decisions that select a worker without the highest available KV-cache overlap.
  * Added metrics measuring the number of such selections and the overlap capacity lost.
  * Expanded the metrics catalog with definitions and guidance for these router metrics.

* **Bug Fixes**
  * Improved visibility into potentially suboptimal scheduler decisions through detailed logging and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->