### PR TITLE
fix(profiler): align PVC path test with v1beta1

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -853,13 +853,14 @@ def test_update_model_from_pvc_absolute_path_inside_mount_is_not_doubled(
         pvc_path=model_path,
     )
 
-    services = result["spec"]["services"]
-    for svc_name, svc in services.items():
-        args = svc.get("extraPodSpec", {}).get("mainContainer", {}).get("args", [])
+    components = _components_by_name(result)
+    worker_components = _worker_components(result)
+    assert worker_components, "Expected at least one worker component"
+    components_to_check = [components["Frontend"], *worker_components]
+    for component in components_to_check:
+        args = _main_container(component).get("args", [])
         flat_args = " ".join(args) if args else ""
         assert f"{pvc_mount_path}{pvc_mount_path}" not in flat_args
-        if svc_name in BaseConfigModifier._NON_WORKER_SERVICES:
-            continue
         assert model_path in flat_args
 
 


### PR DESCRIPTION
## Overview:

Align the absolute PVC model-path regression test with the current v1beta1 DynamoGraphDeployment representation.

This restores repository lint coverage for the test without changing production behavior.

## Details:

- Replace the legacy `spec.services` and `extraPodSpec` traversal with the existing v1beta1 component helpers.
- Check the generated Frontend and worker component arguments through `spec.components` and `podTemplate`.
- Preserve coverage that an absolute `pvcModelPath` already under `pvcMountPath` is not doubled and remains the model path passed to relevant components.

## Where should the reviewer start?

`components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py`, in `test_update_model_from_pvc_absolute_path_inside_mount_is_not_doubled`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Follow-up test alignment for #12493 after the v1beta1 profiler migration in #12506.

## Validation

- `pre-commit run --files components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py` — passed.
- `git diff --check` — passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated regression coverage for model-path handling across frontend and worker components.
  * Improved validation of duplicate mount paths across relevant containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->