### PR TITLE
OPS-8007: fix(ci): hard-kill GPU-parallel test children that outlive their timeout

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -719,7 +719,21 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
       cpu_only_test_markers: pre_merge and sglang and gpu_0
-      gpu_test_markers: pre_merge and sglang and gpu_1
+      # Widened from `pre_merge` to also cover `post_merge`, for this lane only.
+      # The post_merge-only tests here are 8 extra test_sglang_deployment cases,
+      # and their absence is why pre_merge never saw the parallel-stage hang that
+      # failed 63% of post_merge and 82% of nightly sglang GPU jobs over
+      # 2026-07-26..07-31 -- ~220 runner-hours, all invisible on PRs. Catching
+      # that class of failure before merge is worth the extra stage time.
+      gpu_test_markers: (pre_merge or post_merge) and sglang and gpu_1
+      # 30m default -> 90m, because the widened marker set roughly doubles this
+      # stage. Measured over the same window: the narrow pre_merge pool ran
+      # p50 20m / max 29m (already grazing the 30m default), while the same
+      # widened pool in post_merge ran p50 32m / p90 58m. 90m clears p90 with
+      # headroom without masking a hang -- the orchestrator now hard-kills any
+      # child that outlives its own timeout, so a hang costs one failed test
+      # rather than the whole stage.
+      gpu_test_timeout_minutes: 90
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled SGLang pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.

--- a/tests/utils/pytest_parallel_gpu.py
+++ b/tests/utils/pytest_parallel_gpu.py
@@ -21,12 +21,19 @@ Flags:
 
 A 10-second cooldown between launches avoids the vLLM profiling race
 (bug #10643). Tests that fail due to profiling race are retried up to 3 times.
+
+Every child also has a hard deadline of ``timeout + DYN_GPU_PARALLEL_KILL_GRACE_S``
+enforced from this process. ``--timeout`` alone is not enough: pytest-timeout is
+signal-based and cannot interrupt a blocking Rust FFI call, so a child stuck in
+one runs forever and starves every queued test behind it. See
+``_deadline_action``.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -109,6 +116,36 @@ class _GpuState:
     running_count: int = 0
 
 
+def _print(msg: str = "") -> None:
+    """Print to stderr so pytest doesn't capture it."""
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _env_float(name: str, default: float) -> float:
+    """Read a positive float from the environment, falling back on junk input."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        value = float(raw)
+    except ValueError:
+        _print(f"WARNING: ignoring non-numeric {name}={raw!r}, using {default}")
+        return default
+    if value <= 0:
+        _print(f"WARNING: ignoring non-positive {name}={raw!r}, using {default}")
+        return default
+    return value
+
+
+# Headroom past a test's own --timeout before this process kills the child.
+# pytest-timeout should always fire first and produce a real traceback; this
+# grace only has to cover fixture teardown and output flush. It is a backstop
+# for the case where pytest-timeout cannot fire at all.
+_HARD_KILL_GRACE_S = _env_float("DYN_GPU_PARALLEL_KILL_GRACE_S", 120.0)
+# How long a killed child gets to die from SIGTERM before we escalate.
+_SIGKILL_AFTER_SIGTERM_S = _env_float("DYN_GPU_PARALLEL_SIGKILL_AFTER_S", 15.0)
+
+
 @dataclass
 class _RunningTest:
     """State for a test subprocess currently executing on a GPU."""
@@ -118,11 +155,56 @@ class _RunningTest:
     start_time: float
     captured: list[str] = field(default_factory=list)
     reader_thread: threading.Thread | None = None
+    # Hard-kill bookkeeping; both stay None for a child that exits on its own.
+    term_sent_at: float | None = None
+    kill_sent_at: float | None = None
+
+    @property
+    def deadline(self) -> float:
+        """Monotonic time past which this child is killed unconditionally."""
+        return self.start_time + self.test.timeout + _HARD_KILL_GRACE_S
+
+    @property
+    def hard_killed(self) -> bool:
+        return self.term_sent_at is not None
 
 
-def _print(msg: str = "") -> None:
-    """Print to stderr so pytest doesn't capture it."""
-    print(msg, file=sys.stderr, flush=True)
+def _deadline_action(run_info: _RunningTest, now: float) -> str | None:
+    """Decide what signal a still-running child is owed: None, "term" or "kill".
+
+    Split out from the scheduling loop so the escalation state machine is
+    testable without spawning processes.
+    """
+    if run_info.kill_sent_at is not None:
+        return None  # already SIGKILLed; nothing left to escalate to
+    if run_info.term_sent_at is not None:
+        if now - run_info.term_sent_at >= _SIGKILL_AFTER_SIGTERM_S:
+            return "kill"
+        return None
+    if now >= run_info.deadline:
+        return "term"
+    return None
+
+
+def _signal_group(run_info: _RunningTest, sig: int) -> None:
+    """Signal the child's whole process group.
+
+    Children are spawned with ``start_new_session=True``, so each is its own
+    process-group leader and every engine process it starts inherits that
+    group. Signalling the group is what actually frees the GPU -- killing only
+    the pytest child would leave its SGLang/vLLM workers holding VRAM and
+    poison every test scheduled after it.
+    """
+    proc = run_info.proc
+    try:
+        os.killpg(os.getpgid(proc.pid), sig)
+    except OSError:
+        # Group already gone, or os.killpg unavailable: fall back to the direct
+        # child so the kill still happens.
+        try:
+            proc.send_signal(sig)
+        except OSError:
+            pass
 
 
 def _fmt_req(test: _TestEntry) -> str:
@@ -162,6 +244,66 @@ def _parse_junit_skipped(junit_path: str) -> str | None:
         if skip_el is not None:
             return skip_el.get("message", "skipped")
     return None
+
+
+def _junit_path_for(test: _TestEntry) -> str:
+    """Per-child JUnit XML path. Must match between launch and completion."""
+    safe_name = test.name.replace("/", "_").replace("::", "__")
+    return os.path.join(_JUNIT_DIR, f"{safe_name}.xml")
+
+
+def _junit_ids(test_id: str) -> tuple[str, str]:
+    """Split a pytest node id into (classname, name) the way pytest's own
+    junitxml plugin does: dotted module path (plus class, if any) and the
+    trailing test name with its parametrization."""
+    path, _, rest = test_id.partition("::")
+    module = path.removesuffix(".py").replace("/", ".").replace("\\", ".")
+    parts = [p for p in rest.split("::") if p]
+    if not parts:
+        return module, path
+    classname = ".".join([module, *parts[:-1]])
+    return classname, parts[-1]
+
+
+def _write_timeout_junit(
+    junit_path: str, test: _TestEntry, duration: float, message: str
+) -> None:
+    """Write a minimal failing JUnit report for a child we had to kill.
+
+    A killed child never reaches pytest's own junitxml writer, so without this
+    the test disappears from the combined XML entirely and the stage fails with
+    no attributable test.
+    """
+    import xml.etree.ElementTree as ET
+
+    classname, name = _junit_ids(test.id)
+    suite = ET.Element(
+        "testsuite",
+        {
+            "name": "pytest",
+            "tests": "1",
+            "errors": "0",
+            "failures": "1",
+            "skipped": "0",
+            "time": f"{duration:.3f}",
+        },
+    )
+    case = ET.SubElement(
+        suite,
+        "testcase",
+        {"classname": classname, "name": name, "time": f"{duration:.3f}"},
+    )
+    failure = ET.SubElement(
+        case, "failure", {"message": message, "type": "OrchestratorTimeout"}
+    )
+    failure.text = message
+    try:
+        os.makedirs(os.path.dirname(junit_path), exist_ok=True)
+        ET.ElementTree(suite).write(
+            junit_path, encoding="unicode", xml_declaration=True
+        )
+    except OSError as exc:
+        _print(f"WARNING: could not write timeout JUnit XML {junit_path}: {exc}")
 
 
 def _aggregate_junit_xml(junit_dir: str) -> str | None:
@@ -711,7 +853,7 @@ def run_parallel(
         parent_cov_file = env.get("COVERAGE_FILE")
         if parent_cov_file:
             env["COVERAGE_FILE"] = f"{parent_cov_file}.w{test.w_id}"
-        junit_path = os.path.join(_JUNIT_DIR, f"{safe_name}.xml")
+        junit_path = _junit_path_for(test)
         has_tb = extra_pytest_args and any(
             a.startswith("--tb") for a in extra_pytest_args
         )
@@ -739,12 +881,18 @@ def run_parallel(
             child_basetemp = os.path.join(parent_basetemp, f"w{test.w_id}-{safe_name}")
             cmd.extend(["--basetemp", child_basetemp])
 
+        # start_new_session puts the child in its own process group so that a
+        # deadline kill can take out the engine processes it spawned too (see
+        # _signal_group). The trade-off is that Ctrl-C no longer propagates to
+        # children automatically -- run_parallel's KeyboardInterrupt handler
+        # signals the groups explicitly instead.
         proc = subprocess.Popen(
             cmd,
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            start_new_session=True,
         )
         run_info = _RunningTest(proc=proc, test=test, start_time=time.monotonic())
         w_id = test.w_id
@@ -760,6 +908,39 @@ def run_parallel(
 
     env_base = os.environ.copy()
 
+    def _on_interrupt(signum, _frame):
+        """Forward Ctrl-C / SIGTERM to the detached child process groups.
+
+        start_new_session means children no longer share our process group, so
+        without this an interrupt would leave engine processes holding the GPU.
+        """
+        live = list(running.values())
+        _print(f"\nReceived signal {signum} — terminating {len(live)} running test(s)")
+        for ri in live:
+            _signal_group(ri, signal.SIGTERM)
+        grace_until = time.monotonic() + _SIGKILL_AFTER_SIGTERM_S
+        while time.monotonic() < grace_until:
+            if all(ri.proc.poll() is not None for ri in live):
+                break
+            time.sleep(0.2)
+        for ri in live:
+            if ri.proc.poll() is None:
+                _signal_group(ri, signal.SIGKILL)
+        if signum == signal.SIGINT:
+            # Keep normal Ctrl-C semantics for the caller (pytest prints its own
+            # KeyboardInterrupt summary).
+            raise KeyboardInterrupt
+        # Otherwise die from the signal so our exit status stays honest.
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    prev_handlers: dict[int, object] = {}
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            prev_handlers[_sig] = signal.signal(_sig, _on_interrupt)
+        except (ValueError, OSError):
+            pass  # not the main thread; nothing to restore
+
     while pending or running:
         now = time.monotonic()
 
@@ -767,6 +948,32 @@ def run_parallel(
         for w_id in list(running.keys()):
             run_info = running[w_id]
             rc = run_info.proc.poll()
+            if rc is None:
+                # --- Hard-kill backstop ---
+                # The child's own --timeout is signal-based and cannot fire while
+                # it is blocked inside an uninterruptible FFI call, so a hung
+                # child would otherwise sit here until the CI step timeout and
+                # starve every queued test behind it. Enforce the deadline from
+                # out here, where nothing the child does can block us.
+                action = _deadline_action(run_info, now)
+                if action == "term":
+                    run_info.term_sent_at = now
+                    _print(
+                        f"[w{w_id}] {run_info.test.name} TIMEOUT after "
+                        f"{now - run_info.start_time:.0f}s "
+                        f"(timeout={int(run_info.test.timeout)}s "
+                        f"+ {int(_HARD_KILL_GRACE_S)}s grace) — "
+                        f"sending SIGTERM to its process group"
+                    )
+                    _signal_group(run_info, signal.SIGTERM)
+                elif action == "kill":
+                    run_info.kill_sent_at = now
+                    _print(
+                        f"[w{w_id}] {run_info.test.name} did not exit "
+                        f"{int(_SIGKILL_AFTER_SIGTERM_S)}s after SIGTERM — "
+                        f"escalating to SIGKILL"
+                    )
+                    _signal_group(run_info, signal.SIGKILL)
             if rc is not None:
                 if run_info.reader_thread is not None:
                     run_info.reader_thread.join(timeout=5)
@@ -775,8 +982,16 @@ def run_parallel(
                 test = run_info.test
                 gi = test.assigned_gpu
 
-                # Detect retryable init errors (profiling race, OOM at startup)
-                if not passed and test.retries < _MAX_RETRIES:
+                # Detect retryable init errors (profiling race, OOM at startup).
+                # Never retry a child we killed ourselves: its captured output
+                # can contain the -9/-15 health-check markers as a side effect of
+                # our own signal, and retrying a hang just burns another full
+                # timeout+grace.
+                if (
+                    not passed
+                    and test.retries < _MAX_RETRIES
+                    and not run_info.hard_killed
+                ):
                     matched_marker = None
                     for line in run_info.captured:
                         for marker in _RETRYABLE_INIT_MARKERS:
@@ -804,12 +1019,16 @@ def run_parallel(
                 skipped = False
                 skip_reason: str | None = None
                 if passed:
-                    safe_name = test.name.replace("/", "_").replace("::", "__")
-                    junit_path = os.path.join(_JUNIT_DIR, f"{safe_name}.xml")
-                    skip_reason = _parse_junit_skipped(junit_path)
+                    skip_reason = _parse_junit_skipped(_junit_path_for(test))
                     if skip_reason is not None:
                         passed = False
                         skipped = True
+
+                # A killed child never reached pytest's junitxml writer, so
+                # synthesize its record here or it vanishes from the report.
+                if run_info.hard_killed:
+                    passed = False
+                    skipped = False
 
                 # Dump buffered output on failure only (matches pytest behavior).
                 # With -s, output was already streamed live.
@@ -824,6 +1043,17 @@ def run_parallel(
                         if stripped and not stripped.startswith("="):
                             fail_reason = stripped
                             break
+                if run_info.hard_killed:
+                    fail_reason = (
+                        f"killed by the GPU-parallel orchestrator after "
+                        f"{duration:.0f}s: still running at timeout="
+                        f"{int(test.timeout)}s plus {int(_HARD_KILL_GRACE_S)}s grace, "
+                        f"so pytest-timeout never fired — the child was most likely "
+                        f"blocked in an uninterruptible call"
+                    )
+                    _write_timeout_junit(
+                        _junit_path_for(test), test, duration, fail_reason
+                    )
 
                 if skipped:
                     status = "SKIPPED"
@@ -946,6 +1176,9 @@ def run_parallel(
 
         if running or pending:
             time.sleep(1.0)
+
+    for _sig, _prev in prev_handlers.items():
+        signal.signal(_sig, _prev)
 
     # Summary
     wall_time = time.monotonic() - t0

--- a/tests/utils/test_pytest_parallel_gpu.py
+++ b/tests/utils/test_pytest_parallel_gpu.py
@@ -11,13 +11,28 @@ the VRAM-aware ordering beats the legacy timeout-sorted first-fit. No GPU or
 
 from __future__ import annotations
 
+import os
+import signal
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+
 import pytest
 
+from tests.utils import pytest_parallel_gpu
 from tests.utils.pytest_parallel_gpu import (
+    _HARD_KILL_GRACE_S,
+    _SIGKILL_AFTER_SIGTERM_S,
+    _aggregate_junit_xml,
+    _deadline_action,
     _GpuState,
+    _junit_ids,
     _priority_key,
+    _RunningTest,
     _select_launches,
+    _signal_group,
     _TestEntry,
+    _write_timeout_junit,
 )
 from tests.utils.vram_utils import VRAM_MULTI_PROC_MARGIN
 
@@ -184,6 +199,143 @@ def test_blocked_test_launches_once_occupant_frees():
     # 12 fits (19-3.8=15.2) and is highest priority; the extra 3.8 no longer fits
     # (19-15.8=3.2<3.8).
     assert launches == [(0, 0)]
+
+
+# --------------------------------------------------------------------------- #
+# hard-kill backstop: deadline state machine
+# --------------------------------------------------------------------------- #
+def _running(timeout: float = 300.0, start_time: float = 0.0) -> _RunningTest:
+    """A _RunningTest with a dummy proc -- _deadline_action never touches it."""
+    return _RunningTest(
+        proc=None,  # type: ignore[arg-type]
+        test=_t("hang", 12.0, timeout=timeout),
+        start_time=start_time,
+    )
+
+
+def test_deadline_is_test_timeout_plus_grace():
+    run_info = _running(timeout=320.0, start_time=1000.0)
+    assert run_info.deadline == 1000.0 + 320.0 + _HARD_KILL_GRACE_S
+
+
+def test_no_action_before_the_deadline():
+    run_info = _running(timeout=320.0)
+    # A test at 319s is still inside its own --timeout; pytest-timeout owns it.
+    assert _deadline_action(run_info, 319.0) is None
+    # And through the grace window, where teardown legitimately runs.
+    assert _deadline_action(run_info, 320.0 + _HARD_KILL_GRACE_S - 1) is None
+    assert not run_info.hard_killed
+
+
+def test_sigterm_at_the_deadline_then_sigkill_after_grace():
+    run_info = _running(timeout=320.0)
+    deadline = run_info.deadline
+
+    assert _deadline_action(run_info, deadline) == "term"
+    run_info.term_sent_at = deadline  # caller records what it sent
+    assert run_info.hard_killed
+
+    # SIGTERM gets its own window before we escalate.
+    assert _deadline_action(run_info, deadline + _SIGKILL_AFTER_SIGTERM_S - 1) is None
+    assert _deadline_action(run_info, deadline + _SIGKILL_AFTER_SIGTERM_S) == "kill"
+
+    # Once SIGKILL is out there is nothing left to escalate to.
+    run_info.kill_sent_at = deadline + _SIGKILL_AFTER_SIGTERM_S
+    assert _deadline_action(run_info, deadline + 10_000) is None
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def test_kills_the_whole_process_group_not_just_the_child(tmp_path):
+    # The failure this guards: killing only the pytest child leaves its engine
+    # workers alive holding VRAM, poisoning every test scheduled after it. The
+    # backgrounded grandchild here stands in for those workers -- it survives a
+    # plain proc.kill() and dies only when the whole group is signalled.
+    pid_file = tmp_path / "grandchild.pid"
+    proc = subprocess.Popen(
+        ["sh", "-c", f"sleep 60 & echo $! > {pid_file}; sleep 60"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    run_info = _RunningTest(proc=proc, test=_t("hang", 12.0), start_time=0.0)
+    pgid = os.getpgid(proc.pid)
+    try:
+        grandchild = -1
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            raw = pid_file.read_text().strip() if pid_file.exists() else ""
+            if raw:
+                grandchild = int(raw)
+                break
+            time.sleep(0.05)
+        assert grandchild > 0, "grandchild never reported its pid"
+        assert _alive(grandchild)
+
+        _signal_group(run_info, signal.SIGKILL)
+        proc.wait(timeout=10)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and _alive(grandchild):
+            time.sleep(0.05)
+        assert not _alive(grandchild), "grandchild outlived the process-group kill"
+    finally:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except OSError:
+            pass
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+# --------------------------------------------------------------------------- #
+# hard-kill backstop: JUnit record for a killed child
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "test_id, expected",
+    [
+        (
+            "tests/router/test_r.py::test_sync[nats-tcp]",
+            ("tests.router.test_r", "test_sync[nats-tcp]"),
+        ),
+        (
+            "tests/utils/test_u.py::TestGroup::test_case",
+            ("tests.utils.test_u.TestGroup", "test_case"),
+        ),
+    ],
+)
+def test_junit_ids_match_pytest_conventions(test_id, expected):
+    assert _junit_ids(test_id) == expected
+
+
+def test_killed_child_still_lands_in_the_combined_junit(tmp_path, monkeypatch):
+    # Without a synthesized record the killed test vanishes from the report and
+    # the stage fails with no attributable test.
+    # _aggregate_junit_xml always writes to the module-global combined path.
+    monkeypatch.setattr(
+        pytest_parallel_gpu, "_JUNIT_COMBINED", str(tmp_path / "combined.xml")
+    )
+    test = _t("tests/router/test_r.py::test_sync[nats-tcp]", 12.0, timeout=320)
+    junit_path = str(tmp_path / "killed.xml")
+    _write_timeout_junit(junit_path, test, duration=443.0, message="killed by X")
+
+    combined = _aggregate_junit_xml(str(tmp_path))
+    assert combined is not None
+    suite = ET.parse(combined).getroot()
+    assert suite.get("tests") == "1"
+    assert suite.get("failures") == "1"
+    case = suite.find("testcase")
+    assert case is not None
+    assert case.get("classname") == "tests.router.test_r"
+    assert case.get("name") == "test_sync[nats-tcp]"
+    assert case.find("failure").get("message") == "killed by X"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

A single stuck test currently takes down the whole GPU-parallel stage. This makes it cost one failed test instead, and turns the SGLang PR lane on so the failure is visible before merge rather than only after.

**OPS-8007**

### The defect

`tests/utils/pytest_parallel_gpu.py`'s monitor loop only called `proc.poll()`. It never compared `now - run_info.start_time` against `test.timeout` and never killed a child, so the declared per-test timeout was advisory — used for LPT ordering and passed to the child as `--timeout`, nothing more.

That is fine while pytest-timeout can fire inside the child. `test_sglang_indexers_sync[nats-tcp]` blocks in an uninterruptible call where it cannot, and then nothing stops the child at all.

Measured over 2026-07-26..07-31, across every `sglang-runtime / Test cuda13.0, amd64` job that reached a real conclusion (1,420 workflow runs enumerated, logs of all 244 failing-step jobs scanned):

| Workflow | Completed job runs | Hung | Rate |
|---|---|---|---|
| PR | 861 | 6 | 0.7% |
| post_merge | 143 | 90 | **63%** |
| nightly | 11 | 9 | **82%** |

~220 runner-hours in five days. Stuck time clusters at ~6,100s (post_merge, 120m cap) and ~12,500–13,200s (nightly, 240m cap) against a 133s healthy runtime. Separation is unambiguous: hangs are all ≥656s, non-hangs top out at 193s.

Two knock-on effects, both worse than the wasted time: every test queued behind the hang never runs and is reported as neither pass nor fail, and the child's buffered stdout is printed only on completion — which never arrives — so a hang produces zero diagnostics.

### The fix

Enforce the deadline from the orchestrator, which is outside the child and cannot be blocked by it. At `timeout + grace` send SIGTERM, escalating to SIGKILL 15s later. Grace defaults to 120s (`DYN_GPU_PARALLEL_KILL_GRACE_S`), enough to cover fixture teardown after pytest-timeout fires normally.

Signals go to the child's **process group**, not the child. Children now spawn with `start_new_session=True`; killing only the pytest child would leave its engine workers holding VRAM and poison every test scheduled after it. That also stops Ctrl-C reaching children, so SIGINT/SIGTERM are forwarded to the groups explicitly and `KeyboardInterrupt` re-raised to keep pytest's semantics.

Two consequences of killing a child needed handling: killed children are excluded from the retry path (their captured output can contain the `-9`/`-15` health-check markers as a side effect of our own signal, so they'd be retried, burning another full timeout+grace), and `_write_timeout_junit` synthesizes the JUnit record the killed child never writes — without it the test vanishes from the combined XML and the stage fails with nothing attributable.

### Why the second commit

`pr.yaml`'s SGLang lane ran `pre_merge and sglang and gpu_1`; post_merge and nightly ran the superset. The 8 post_merge-only `test_sglang_deployment` cases that difference hides are exactly why this hang was invisible on PRs. Widening this lane — and only this lane — to `(pre_merge or post_merge)` means the PR CI on this very PR exercises the pool where the bug reproduces.

Cost: the stage roughly doubles, so its cap goes from the 30m default to 90m. The narrow pool ran p50 20m / max 29m (already grazing the default); the same widened pool in post_merge ran p50 32m / p90 58m.

## Validation

**Unit** — 20 tests pass in `tests/utils/test_pytest_parallel_gpu.py`, 7 new: the deadline state machine (no action before the deadline, SIGTERM at it, SIGKILL after the escalation window, nothing after that), `_junit_ids` against pytest's own conventions, the synthesized record surviving into the combined XML, and a real-process test that the whole group dies.

That last one has teeth: verified by control that a plain `proc.kill()` leaves the backgrounded grandchild alive while the group kill does not. An earlier version asserted group-emptiness via `os.killpg(pgid, 0)` and reported "gone" with the grandchild still running — it would have passed against the unfixed code.

**End-to-end** — drove `run_parallel` against a child that swallows SIGALRM the way the real hang does:

```
[w0] test_hangs_uninterruptibly TIMEOUT after 9s (timeout=5s + 4s grace) — sending SIGTERM to its process group
[w0] test_hangs_uninterruptibly FAILED [10s]
FAILED [w0] ... - killed by the GPU-parallel orchestrator after 10s: still running at
timeout=5s plus 4s grace, so pytest-timeout never fired — the child was most likely
blocked in an uninterruptible call
======================== 1 failed, 1 passed in 10.06s ========================
```

The sibling test still passed, `rc=1`, and the combined JUnit contained the killed case with the right `classname`/`name`. Separately verified the SIGKILL escalation with a child that ignores SIGTERM too (killed at 12s), and that a killed child's buffered output now gets dumped — previously a hang produced none.

**In CI** — the second commit is what validates this end to end: the SGLang GPU lane on this PR now runs the same pool that fails 63% of the time on post_merge.

## Out of scope

The root cause — the test blocking in an uninterruptible FFI call — is unchanged and tracked separately; this PR is containment. Streaming child output live so a hang is debuggable at all is a follow-up.

Also worth flagging, found while investigating and not fixed here: `skip_in_nightly` is inert. `pyproject.toml` documents it as "Used via `not skip_in_nightly` in nightly-ci.yml marker filters", but no workflow references the marker, so the mitigation applied to this test has never taken effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU test reliability by enforcing hard timeouts and terminating spawned processes cleanly.
  * Preserved timed-out and externally terminated tests in aggregated JUnit reports with clear failure reasons.
  * Prevented retries for tests stopped by the test orchestrator.

* **Tests**
  * Expanded coverage for timeout handling, process cleanup, retry behavior, and JUnit reporting.

* **Chores**
  * Updated the single-GPU CI lane to run both pre-merge and post-merge tests.
  * Increased the GPU test timeout from 30 to 90 minutes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->