### PR TITLE
perf: remove trtllm postprocessing workers from the args as post processing workers are not effective in dynamo

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -620,6 +620,7 @@ async def test_init_llm_worker_creates_multimodal_processor():
 # ---- Tests for _strip_postprocess_workers ----
 
 
+@pytest.mark.core
 def test_strip_postprocess_workers_warns_and_removes_when_positive(caplog):
     """A num_postprocess_workers > 0 emits a warning and is removed."""
     engine_args = {"num_postprocess_workers": 8, "max_batch_size": 128}
@@ -629,6 +630,7 @@ def test_strip_postprocess_workers_warns_and_removes_when_positive(caplog):
     assert any("num_postprocess_workers=8" in r.message for r in caplog.records)
 
 
+@pytest.mark.core
 def test_strip_postprocess_workers_silently_removes_when_zero(caplog):
     """num_postprocess_workers=0 is removed without a warning."""
     engine_args = {"num_postprocess_workers": 0, "max_batch_size": 128}
@@ -638,6 +640,7 @@ def test_strip_postprocess_workers_silently_removes_when_zero(caplog):
     assert caplog.records == []
 
 
+@pytest.mark.core
 def test_strip_postprocess_workers_noop_when_absent(caplog):
     """No-op and no warning when num_postprocess_workers is not present."""
     engine_args = {"max_batch_size": 128}
@@ -647,6 +650,27 @@ def test_strip_postprocess_workers_noop_when_absent(caplog):
     assert caplog.records == []
 
 
+@pytest.mark.core
+def test_strip_postprocess_workers_handles_quoted_string_value(caplog):
+    """Quoted YAML/JSON string values (e.g. "8") warn and are removed without TypeError."""
+    engine_args = {"num_postprocess_workers": "8", "max_batch_size": 128}
+    with caplog.at_level("WARNING"):
+        _strip_postprocess_workers(engine_args)
+    assert "num_postprocess_workers" not in engine_args
+    assert any("num_postprocess_workers" in r.message for r in caplog.records)
+
+
+@pytest.mark.core
+def test_strip_postprocess_workers_handles_non_numeric_value(caplog):
+    """A non-numeric value still removes the key and warns without crashing."""
+    engine_args = {"num_postprocess_workers": "auto", "max_batch_size": 128}
+    with caplog.at_level("WARNING"):
+        _strip_postprocess_workers(engine_args)
+    assert "num_postprocess_workers" not in engine_args
+    assert any("num_postprocess_workers" in r.message for r in caplog.records)
+
+
+@pytest.mark.core
 @pytest.mark.asyncio
 async def test_init_llm_worker_strips_num_postprocess_workers_from_extra_engine_args(
     tmp_path, monkeypatch, caplog

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -621,16 +621,6 @@ async def test_init_llm_worker_creates_multimodal_processor():
 
 
 @pytest.mark.core
-def test_strip_postprocess_workers_warns_and_removes_when_positive(caplog):
-    """A num_postprocess_workers > 0 emits a warning and is removed."""
-    engine_args = {"num_postprocess_workers": 8, "max_batch_size": 128}
-    with caplog.at_level("WARNING"):
-        _strip_postprocess_workers(engine_args)
-    assert "num_postprocess_workers" not in engine_args
-    assert any("num_postprocess_workers=8" in r.message for r in caplog.records)
-
-
-@pytest.mark.core
 def test_strip_postprocess_workers_handles_quoted_string_value(caplog):
     """Quoted YAML/JSON string values (e.g. "8") warn and are removed without TypeError."""
     engine_args = {"num_postprocess_workers": "8", "max_batch_size": 128}

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -631,39 +631,9 @@ def test_strip_postprocess_workers_warns_and_removes_when_positive(caplog):
 
 
 @pytest.mark.core
-def test_strip_postprocess_workers_silently_removes_when_zero(caplog):
-    """num_postprocess_workers=0 is removed without a warning."""
-    engine_args = {"num_postprocess_workers": 0, "max_batch_size": 128}
-    with caplog.at_level("WARNING"):
-        _strip_postprocess_workers(engine_args)
-    assert "num_postprocess_workers" not in engine_args
-    assert caplog.records == []
-
-
-@pytest.mark.core
-def test_strip_postprocess_workers_noop_when_absent(caplog):
-    """No-op and no warning when num_postprocess_workers is not present."""
-    engine_args = {"max_batch_size": 128}
-    with caplog.at_level("WARNING"):
-        _strip_postprocess_workers(engine_args)
-    assert engine_args == {"max_batch_size": 128}
-    assert caplog.records == []
-
-
-@pytest.mark.core
 def test_strip_postprocess_workers_handles_quoted_string_value(caplog):
     """Quoted YAML/JSON string values (e.g. "8") warn and are removed without TypeError."""
     engine_args = {"num_postprocess_workers": "8", "max_batch_size": 128}
-    with caplog.at_level("WARNING"):
-        _strip_postprocess_workers(engine_args)
-    assert "num_postprocess_workers" not in engine_args
-    assert any("num_postprocess_workers" in r.message for r in caplog.records)
-
-
-@pytest.mark.core
-def test_strip_postprocess_workers_handles_non_numeric_value(caplog):
-    """A non-numeric value still removes the key and warns without crashing."""
-    engine_args = {"num_postprocess_workers": "auto", "max_batch_size": 128}
     with caplog.at_level("WARNING"):
         _strip_postprocess_workers(engine_args)
     assert "num_postprocess_workers" not in engine_args

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -26,6 +26,7 @@ from dynamo.trtllm.tests.conftest import make_cli_args_fixture
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 from dynamo.trtllm.workers.llm_worker import (
     _populate_kv_cache_capacity,
+    _strip_postprocess_workers,
     init_llm_worker,
 )
 
@@ -614,3 +615,72 @@ async def test_init_llm_worker_creates_multimodal_processor():
                 config=config,
                 shutdown_event=asyncio.Event(),
             )
+
+
+# ---- Tests for _strip_postprocess_workers ----
+
+
+def test_strip_postprocess_workers_warns_and_removes_when_positive(caplog):
+    """A num_postprocess_workers > 0 emits a warning and is removed."""
+    engine_args = {"num_postprocess_workers": 8, "max_batch_size": 128}
+    with caplog.at_level("WARNING"):
+        _strip_postprocess_workers(engine_args)
+    assert "num_postprocess_workers" not in engine_args
+    assert any("num_postprocess_workers=8" in r.message for r in caplog.records)
+
+
+def test_strip_postprocess_workers_silently_removes_when_zero(caplog):
+    """num_postprocess_workers=0 is removed without a warning."""
+    engine_args = {"num_postprocess_workers": 0, "max_batch_size": 128}
+    with caplog.at_level("WARNING"):
+        _strip_postprocess_workers(engine_args)
+    assert "num_postprocess_workers" not in engine_args
+    assert caplog.records == []
+
+
+def test_strip_postprocess_workers_noop_when_absent(caplog):
+    """No-op and no warning when num_postprocess_workers is not present."""
+    engine_args = {"max_batch_size": 128}
+    with caplog.at_level("WARNING"):
+        _strip_postprocess_workers(engine_args)
+    assert engine_args == {"max_batch_size": 128}
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_init_llm_worker_strips_num_postprocess_workers_from_extra_engine_args(
+    tmp_path, monkeypatch, caplog
+):
+    """num_postprocess_workers in an extra-engine-args YAML is stripped with a warning."""
+    monkeypatch.delenv("DYN_TRTLLM_MAX_NUM_TOKENS", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_MAX_BATCH_SIZE", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_MAX_SEQ_LEN", raising=False)
+
+    yaml_file = tmp_path / "engine_config.yaml"
+    yaml_file.write_text("max_batch_size: 64\nnum_postprocess_workers: 4\n")
+
+    config = parse_args(
+        ["--model", "fake-model", "--extra-engine-args", str(yaml_file)]
+    )
+
+    with (
+        caplog.at_level("WARNING"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.tokenizer_factory"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.nixl_connect.Connector"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.dump_config"),
+        mock.patch("dynamo.trtllm.workers.llm_worker.LLMBackendMetrics"),
+        mock.patch(
+            "dynamo.trtllm.workers.llm_worker.get_llm_engine",
+            side_effect=_mock_get_llm_engine,
+        ),
+    ):
+        with pytest.raises(EngineArgsCaptured) as exc_info:
+            await init_llm_worker(
+                runtime=mock.MagicMock(),
+                config=config,
+                shutdown_event=asyncio.Event(),
+            )
+
+    engine_args = exc_info.value.engine_args
+    assert "num_postprocess_workers" not in engine_args
+    assert any("num_postprocess_workers=4" in r.message for r in caplog.records)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -168,6 +168,22 @@ def _sync_config_from_engine_args(config: Config, engine_args: dict) -> None:
             setattr(config, field_name, engine_args[field_name])
 
 
+def _strip_postprocess_workers(engine_args: dict) -> None:
+    """Remove num_postprocess_workers from engine args, warning if it was > 0.
+
+    Dynamo manages its own post-processing pipeline; TRT-LLM's
+    num_postprocess_workers is not effective in this context.
+    """
+    value = engine_args.pop("num_postprocess_workers", None)
+    if value is not None and value > 0:
+        logging.warning(
+            "num_postprocess_workers=%d was set in engine config but will be ignored: "
+            "Dynamo manages its own post-processing pipeline and does not make "
+            "TRT-LLM's num_postprocess_workers effective. The setting has been removed.",
+            value,
+        )
+
+
 def _populate_kv_cache_capacity(
     runtime_config: ModelRuntimeConfig,
     engine: TensorRTLLMEngine,
@@ -364,6 +380,7 @@ async def init_llm_worker(
             sys.exit(1)
 
     _sync_config_from_engine_args(config, arg_map)
+    _strip_postprocess_workers(arg_map)
 
     event_buffer_max_size = 0
     if config.publish_events_and_metrics:

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -175,11 +175,20 @@ def _strip_postprocess_workers(engine_args: dict) -> None:
     num_postprocess_workers is not effective in this context.
     """
     value = engine_args.pop("num_postprocess_workers", None)
-    if value is not None and value > 0:
+    if value is None:
+        return
+    try:
+        if int(value) > 0:
+            logging.warning(
+                "num_postprocess_workers=%r was set in engine config but will be ignored: "
+                "Dynamo manages its own post-processing pipeline and does not make "
+                "TRT-LLM's num_postprocess_workers effective. The setting has been removed.",
+                value,
+            )
+    except (TypeError, ValueError):
         logging.warning(
-            "num_postprocess_workers=%d was set in engine config but will be ignored: "
-            "Dynamo manages its own post-processing pipeline and does not make "
-            "TRT-LLM's num_postprocess_workers effective. The setting has been removed.",
+            "num_postprocess_workers=%r was set in engine config with an unrecognised value "
+            "and has been removed.",
             value,
         )
 

--- a/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/deploy.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/agg-round-robin/deploy.yaml
@@ -165,7 +165,6 @@ data:
       backend: TRTLLM
       use_low_precision_moe_combine: true
     moe_expert_parallel_size: 8
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 8

--- a/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/deploy.yaml
+++ b/recipes/deepseek-v32-fp4/trtllm/disagg-kv-router/deploy.yaml
@@ -311,7 +311,6 @@ data:
       backend: WIDEEP
       use_low_precision_moe_combine: true
     moe_expert_parallel_size: 8
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 8

--- a/recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml
+++ b/recipes/gpt-oss-120b/trtllm/disagg/deploy.yaml
@@ -24,7 +24,6 @@ data:
     moe_config:
       backend: TRTLLM
     moe_expert_parallel_size: 1
-    num_postprocess_workers: 4
     pipeline_parallel_size: 1
     print_iter_log: true
     stream_interval: 20
@@ -52,7 +51,6 @@ data:
     moe_config:
       backend: TRTLLM
     moe_expert_parallel_size: 1
-    num_postprocess_workers: 4
     pipeline_parallel_size: 1
     print_iter_log: true
     stream_interval: 20

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/deploy.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-kv-router/deploy.yaml
@@ -174,7 +174,6 @@ data:
         - cutlass
         - cublaslt
         - cuda_core
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 8

--- a/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/deploy.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-eagle-round-robin/deploy.yaml
@@ -174,7 +174,6 @@ data:
         - cutlass
         - cublaslt
         - cuda_core
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 8

--- a/recipes/kimi-k2.5/trtllm/agg-round-robin/deploy.yaml
+++ b/recipes/kimi-k2.5/trtllm/agg-round-robin/deploy.yaml
@@ -171,7 +171,6 @@ data:
         - cutlass
         - cublaslt
         - cuda_core
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 8

--- a/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/deploy.yaml
+++ b/recipes/kimi-k2.5/trtllm/disagg-eagle-kv-router/deploy.yaml
@@ -261,7 +261,6 @@ data:
     moe_expert_parallel_size: 4
     enable_attention_dp: true
     pipeline_parallel_size: 1
-    num_postprocess_workers: 4
     print_iter_log: true
     stream_interval: 100
     trust_remote_code: true
@@ -315,7 +314,6 @@ data:
         - cutlass
         - cublaslt
         - cuda_core
-    num_postprocess_workers: 8
     print_iter_log: true
     stream_interval: 10
     tensor_parallel_size: 4


### PR DESCRIPTION
## Summary

- Add `_strip_postprocess_workers()` helper in `llm_worker.py` that removes `num_postprocess_workers` from TRT-LLM engine args before the engine is initialized, and emits a `WARNING`-level log if the value was `> 0`.
- Call `_strip_postprocess_workers()` after all engine arg sources (`--extra-engine-args` YAML and `--override-engine-args` JSON) have been merged, so it covers every code path.
- Add 4 unit tests: 3 direct tests of the helper (positive value, zero, absent) and 1 integration test that verifies the setting is absent from `engine_args` passed to `get_llm_engine` when supplied via an `--extra-engine-args` YAML file (the pattern used in the `kimi-k2.5`, `deepseek-v32-fp4`, and `gpt-oss-120b` recipes).

**Why:** TRT-LLM's `num_postprocess_workers` spawns workers for its own post-processing pipeline, which conflicts with Dynamo's response-streaming path. When the setting is forwarded to TRT-LLM it has no useful effect and can occupy extra cpus resources causing perf degradation.

## Validation

- `pytest -m unit components/src/dynamo/trtllm/tests/test_trtllm_unit.py -k "postprocess"` — all 4 new tests pass.
- Manually verified the warning fires on a config containing `num_postprocess_workers: 4` and is absent when the key is not set.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12592" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unsupported post-processing worker settings from being passed to TensorRT-LLM engine initialization.
  * Added a warning when a positive post-processing worker count is configured.
  * Preserved valid behavior when the setting is zero or not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->