### PR TITLE
chore(release): backport sidecar SGLang/TRT-LLM changes to 1.4.0

### DIFF
--- a/lib/sidecar/sglang/Dockerfile
+++ b/lib/sidecar/sglang/Dockerfile
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal image for the SGLang Rust sidecar (`dynamo-sglang-sidecar`).
+# A pure gRPC connector — no GPU, no engine runtime — that runs beside the
+# engine container over loopback (see deploy/agg.yaml).
+#
+#   docker build -f lib/sidecar/sglang/Dockerfile -t dynamo-sglang-sidecar:1.3.0 .
+
+FROM rust:1.96.1-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        libclang-dev \
+        protobuf-compiler \
+        perl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release --locked -p dynamo-sglang-sidecar \
+    && strip target/release/dynamo-sglang-sidecar
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group sidecar
+
+COPY --from=builder /src/target/release/dynamo-sglang-sidecar /usr/local/bin/dynamo-sglang-sidecar
+
+# Numeric UID so Kubernetes runAsNonRoot can verify it.
+USER 1000
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/dynamo-sglang-sidecar"]

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -1,5 +1,11 @@
 # SGLang sidecar
 
+> [!WARNING]
+> **Experimental.** These deployment examples and the standalone sidecar image
+> are experimental and not yet packaged for distribution (the launcher module
+> ships inside `ai-dynamo-runtime`). The manifests, flags, and behavior may change
+> without notice.
+
 `dynamo-sglang-sidecar` connects Dynamo's unified worker lifecycle to an
 out-of-process SGLang engine through SGLang's native gRPC service. It is a
 standalone Rust executable and is also compiled into `ai-dynamo-runtime` for
@@ -13,8 +19,8 @@ cargo build --release -p dynamo-sglang-sidecar
     --sglang-endpoint http://127.0.0.1:30001
 ```
 
-Distribution and container packaging for the standalone executable are
-intentionally deferred to a follow-up change.
+There is no published image yet; the "Deploy on Kubernetes" section below builds
+a minimal one from `Dockerfile`. Official packaging is deferred to a follow-up.
 
 ## SGLang-managed module contract
 
@@ -31,3 +37,80 @@ The entry point configures Dynamo logging when `main()` runs, then calls the
 private `dynamo._core.backend._run_sglang_sidecar(argv)` binding. The binding
 prepends the executable name expected by clap, releases the GIL, and runs the
 same unified worker lifecycle as the standalone executable.
+
+## Deploy on Kubernetes (quick start)
+
+`deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
+that colocates the sidecar with an SGLang engine). `deploy/disagg.yaml` runs
+disaggregated prefill/decode with NIXL KV transfer.
+
+There is no published sidecar image yet, so you build and push your own from
+`Dockerfile` — the same pattern as the TensorRT-LLM and vLLM sidecars.
+
+> [!NOTE]
+> The engine image must be a stock SGLang **v0.5.16+** build: the native gRPC
+> server (`--grpc-port`) landed there, and Dynamo's `sglang-runtime` pins an
+> older SGLang without it. `deploy/agg.yaml` uses `lmsysorg/sglang:v0.5.16`.
+
+### Prerequisites
+
+- A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
+  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
+  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
+  `restartPolicy: Always`), which requires that version.
+- `kubectl` set to that cluster, and a namespace to deploy into.
+- A Hugging Face token for the model.
+- A container registry you can push to and the cluster can pull from.
+
+### 1. Build and push the sidecar image
+
+Build a multi-arch image so it runs on any node — `amd64` (x86) or `arm64`
+(GB200/Grace):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f lib/sidecar/sglang/Dockerfile \
+  -t <your-registry>/dynamo-sglang-sidecar:1.3.0 --push .
+```
+
+### 2. Point the manifest at your image
+
+In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
+If your registry is private, add `imagePullSecrets` to the worker pod spec.
+
+### 3. Create the Hugging Face token secret
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" -n <namespace>
+```
+
+### 4. Deploy
+
+```bash
+kubectl apply -f lib/sidecar/sglang/deploy/agg.yaml -n <namespace>
+```
+
+Wait for the worker pod to reach `2/2 Running`:
+
+```bash
+kubectl get pods -n <namespace> -w
+```
+
+### 5. Send a request
+
+```bash
+kubectl port-forward -n <namespace> svc/sglang-sidecar-agg-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models | jq .
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+### Disaggregated
+
+`deploy/disagg.yaml` runs prefill and decode as separate worker pods that hand
+off KV cache over a bootstrap server + NIXL. It needs multiple GPUs and an RDMA
+fabric, and both worker pods must reach `2/2 Running`.

--- a/lib/sidecar/sglang/deploy/agg.yaml
+++ b/lib/sidecar/sglang/deploy/agg.yaml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated SGLang deployment using the Rust sidecar.
+#
+# Worker pod = two containers:
+#   - main: Dynamo worker (dynamo-sglang-sidecar), no GPU; talks to the engine
+#     over gRPC on 127.0.0.1 and auto-discovers the model/role (no --model-path).
+#     Must be named "main" (operator injects env + probes).
+#   - sglang-engine: stock SGLang image, holds the GPU, runs its native gRPC
+#     server as a native sidecar (see initContainers).
+#
+# The engine's gRPC has no auth/TLS; safe only because it stays on loopback.
+#
+# SGLang can also load the sidecar in-process (`--sidecar dynamo.sglang.sidecar`,
+# see README); this example uses the standalone image for consistency with the
+# TensorRT-LLM and vLLM sidecars.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend; operator adds the command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+  - name: SGLangWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        # sglang-engine as a native sidecar (initContainer + restartPolicy: Always):
+        # starts before `main`, stops after. Native gRPC `--grpc-port` needs SGLang
+        # v0.5.16+ (Dynamo's sglang-runtime pins an older SGLang without it).
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
+          # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10     # must exceed the RPC timeout + interpreter spawn
+            failureThreshold: 60   # ~5 min for model load; raise for big models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase for larger models.
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 127.0.0.1
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+        containers:
+        # Sidecar worker. No published image yet — build from
+        # lib/sidecar/sglang/Dockerfile, set <your-registry> (see README), add
+        # imagePullSecrets if private. Must be named "main" (operator injects
+        # discovery env + probes by name).
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/sglang/deploy/disagg.yaml
+++ b/lib/sidecar/sglang/deploy/disagg.yaml
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Disaggregated SGLang deployment using the Rust sidecar.
+#
+# Prefill and decode run as separate worker pods, each with two containers:
+#   - main: Dynamo worker (dynamo-sglang-sidecar), no GPU; auto-discovers its
+#     prefill/decode role from the engine. Must be named "main".
+#   - sglang-engine: stock SGLang image in --disaggregation-mode prefill|decode
+#     with the NIXL backend, holds the GPU. KV moves prefill -> decode over
+#     NIXL/RDMA. Native sidecar.
+#
+# Unlike aggregated, the engine binds 0.0.0.0 so its bootstrap server (8998) is
+# reachable across pods; the decode worker dials the prefill worker's advertised
+# bootstrap (SGLANG_DISAGGREGATION_BOOTSTRAP_HOST = pod IP). SGLang's single
+# --host binds ALL listeners, so the unauthenticated native gRPC (30001) is also
+# exposed on the pod network — rely on NetworkPolicy, not loopback isolation.
+#
+# PREREQUISITES / CAVEATS (from the SGLang disagg recipes + sidecar contract; NOT
+# validated here — needs a multi-GPU RDMA cluster and an SGLang build with the
+# experimental gRPC + --sidecar + disaggregation support):
+#   - RDMA/NIXL: engines need rdma/ib devices, IPC_LOCK, and shared memory; tune
+#     for your fabric (UCX_NET_DEVICES etc.). NIXL/UCX ship in sglang-runtime.
+#   - Model / served-model-name / TP must match between prefill and decode.
+#   - `main` runs the standalone dynamo-sglang-sidecar image (no GPU); build from
+#     lib/sidecar/sglang/Dockerfile (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-disagg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+
+  - name: SGLangPrefillWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          # Real gRPC HealthCheck (see agg.yaml). startupProbe gates `main`;
+          # readinessProbe drops the worker if the engine dies at runtime.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          env:
+          # Advertise this pod's IP as the bootstrap host decode workers dial.
+          - name: SGLANG_DISAGGREGATION_BOOTSTRAP_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+
+  - name: SGLangDecodeWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          # Real gRPC HealthCheck (see agg.yaml). startupProbe gates `main`;
+          # readinessProbe drops the worker if the engine dies at runtime.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -24,7 +24,7 @@ use crate::client::{self, Client, Discovery, Pool};
 use crate::proto as pb;
 use crate::protocol::{
     build_generate_request, disaggregated_params_to_json, engine_data_from_meta, extract_logprobs,
-    meta_u32, output_ids_to_u32, terminal_from_meta,
+    meta_u32, new_output_ids, output_ids_to_u32, terminal_from_meta,
 };
 
 pub struct SglangSidecarEngine {
@@ -242,6 +242,7 @@ impl LLMEngine for SglangSidecarEngine {
             let mut generated = 0_u32;
             let mut observed_prompt_tokens = prompt_tokens;
             let mut logprob_offset = 0_usize;
+            let mut token_offset = 0_usize;
             loop {
                 tokio::select! {
                     biased;
@@ -273,13 +274,22 @@ impl LLMEngine for SglangSidecarEngine {
                         if let Some(value) = meta_u32(&response.meta_info, "prompt_tokens") {
                             observed_prompt_tokens = value;
                         }
-                        let token_ids = match output_ids_to_u32(&response.output_ids) {
+                        // SGLang streams output_ids cumulatively (the whole sequence
+                        // so far, like its logprob metadata), so emit only the tokens
+                        // appended since the previous chunk.
+                        let token_ids = match output_ids_to_u32(new_output_ids(
+                            &response.output_ids,
+                            token_offset,
+                        )) {
                             Ok(ids) => ids,
                             Err(err) => {
                                 yield Err(err);
                                 break;
                             }
                         };
+                        // Never rewind: a regressive chunk (shorter than what we
+                        // already emitted) must not let later growth re-emit tokens.
+                        token_offset = token_offset.max(response.output_ids.len());
                         let (log_probs, top_logprobs, next_offset) =
                             match extract_logprobs(
                                 &response.meta_info,

--- a/lib/sidecar/sglang/src/protocol.rs
+++ b/lib/sidecar/sglang/src/protocol.rs
@@ -327,6 +327,13 @@ fn json_value_to_string(value: &Value) -> String {
     }
 }
 
+/// Tokens appended since the previous chunk. SGLang streams `output_ids`
+/// cumulatively, so each chunk carries the full sequence so far; `offset` is the
+/// previous chunk's total length. Guards against a non-growing chunk.
+pub(crate) fn new_output_ids(output_ids: &[i32], offset: usize) -> &[i32] {
+    output_ids.get(offset..).unwrap_or(&[])
+}
+
 pub(crate) fn output_ids_to_u32(ids: &[i32]) -> Result<Vec<u32>, DynamoError> {
     ids.iter()
         .map(|id| {
@@ -550,7 +557,7 @@ mod tests {
 
     use super::{
         build_generate_request, disaggregated_params_to_json, engine_data_from_meta,
-        extract_logprobs, terminal_from_meta,
+        extract_logprobs, new_output_ids, terminal_from_meta,
     };
 
     fn request() -> PreprocessedRequest {
@@ -641,6 +648,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(decode.disaggregated_params, Some(handoff));
+    }
+
+    #[test]
+    fn new_output_ids_slices_the_cumulative_stream() {
+        // SGLang re-sends the whole sequence each chunk; only the tail is new.
+        assert_eq!(new_output_ids(&[1, 2, 3], 0), &[1, 2, 3]);
+        assert_eq!(new_output_ids(&[1, 2, 3], 2), &[3]);
+        assert_eq!(new_output_ids(&[1, 2, 3], 3), &[] as &[i32]);
+        // A chunk that did not grow (or an over-large offset) yields nothing.
+        assert_eq!(new_output_ids(&[1, 2, 3], 5), &[] as &[i32]);
+    }
+
+    #[test]
+    fn cumulative_offset_never_rewinds_on_regression() {
+        // Mirror the engine loop: emit the new tail, then advance the offset
+        // monotonically (token_offset.max(len)) so a regressive chunk can't cause
+        // re-emission when the sequence later grows again.
+        let mut offset = 0usize;
+        let mut step = |ids: &[i32]| -> Vec<i32> {
+            let new = new_output_ids(ids, offset).to_vec();
+            offset = offset.max(ids.len());
+            new
+        };
+        assert_eq!(step(&[1, 2, 3]), vec![1, 2, 3]);
+        // Regressive chunk: emits nothing and leaves the offset at 3.
+        assert_eq!(step(&[1, 2]), Vec::<i32>::new());
+        // Growth resumes: only the genuinely-new tail is emitted, not 1..3 again.
+        assert_eq!(step(&[1, 2, 3, 4]), vec![4]);
     }
 
     #[test]

--- a/lib/sidecar/trtllm/Dockerfile
+++ b/lib/sidecar/trtllm/Dockerfile
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal image for the TensorRT-LLM Rust sidecar (`dynamo-trtllm-sidecar`).
+# A pure gRPC connector — no GPU, no engine runtime — that runs beside the
+# engine container over loopback (see deploy/agg.yaml).
+#
+#   docker build -f lib/sidecar/trtllm/Dockerfile -t dynamo-trtllm-sidecar:1.3.0 .
+
+FROM rust:1.96.1-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        libclang-dev \
+        protobuf-compiler \
+        perl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release --locked -p dynamo-trtllm-sidecar \
+    && strip target/release/dynamo-trtllm-sidecar
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group sidecar
+
+COPY --from=builder /src/target/release/dynamo-trtllm-sidecar /usr/local/bin/dynamo-trtllm-sidecar
+
+# Numeric UID so Kubernetes runAsNonRoot can verify it.
+USER 1000
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/dynamo-trtllm-sidecar"]

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # TensorRT-LLM sidecar
 
+> [!WARNING]
+> **Experimental.** This sidecar and its deployment example are experimental and
+> not yet packaged for distribution (see [Packaging](#packaging)). The manifest,
+> flags, and behavior may change without notice.
+
 `dynamo-trtllm-sidecar` connects a Dynamo worker to TensorRT-LLM's native
 `trtllm.TrtllmService` gRPC `Generate` service. It is a standalone Rust
 executable composed with `dynamo_backend_common::run`: TensorRT-LLM runs as its
@@ -27,7 +32,7 @@ carries no context-phase handoff.
 
 ## Run
 
-Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`+):
+Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`; rc22 has a broken `--grpc`):
 
 ```bash
 python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
@@ -48,5 +53,99 @@ dynamo-trtllm-sidecar \
 Use `TRTLLM_GRPC_ENDPOINT` instead of `--trtllm-endpoint` when the endpoint is
 provided through the environment.
 
-Distribution and container packaging for the executable are intentionally
-deferred to a follow-up change.
+## Deploy on Kubernetes (quick start)
+
+`deploy/agg.yaml` deploys a frontend and one worker pod. The worker runs the
+sidecar next to a TensorRT-LLM engine and serves `Qwen/Qwen3-0.6B` on one GPU.
+
+There is no published sidecar image yet (see [Packaging](#packaging)), so you
+build and push your own.
+
+### Prerequisites
+
+- A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
+  gate) with the Dynamo operator and a GPU node. The engine runs as a native
+  sidecar (`initContainers` with `restartPolicy: Always`), which requires that
+  version.
+- `kubectl` set to that cluster, and a namespace to deploy into.
+- A Hugging Face token for the model.
+- A container registry you can push to and the cluster can pull from.
+
+### 1. Build and push the sidecar image
+
+Build a multi-arch image so it runs on any node — `amd64` (x86) or `arm64`
+(GB200/Grace):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f lib/sidecar/trtllm/Dockerfile \
+  -t <your-registry>/dynamo-trtllm-sidecar:1.3.0 --push .
+```
+
+To build faster for one arch, pass just that platform (e.g. `linux/arm64` for
+GB200/Grace).
+
+### 2. Point the manifest at your image
+
+In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
+If your registry is private, add `imagePullSecrets` to the worker pod spec.
+
+### 3. Create the Hugging Face token secret
+
+Read the token from an env var so it stays out of your shell history (or use
+`--from-file` / an external secret manager):
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" -n <namespace>
+```
+
+### 4. Deploy
+
+```bash
+kubectl apply -f lib/sidecar/trtllm/deploy/agg.yaml -n <namespace>
+```
+
+Wait for the worker pod to reach `2/2 Running`:
+
+```bash
+kubectl get pods -n <namespace> -w
+```
+
+### 5. Send a request
+
+Port-forward the frontend and call it:
+
+```bash
+kubectl port-forward -n <namespace> svc/trtllm-sidecar-agg-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models | jq .
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+`/v1/models` should list `Qwen/Qwen3-0.6B`, and the chat call returns a reply.
+
+## Tuning
+
+The engine streams tokens to the sidecar over gRPC. By default it sends one
+message per token, and that per-token serialization is the sidecar's main
+throughput cost versus an in-process backend. The `trtllm-engine-config`
+ConfigMap in `deploy/agg.yaml` sets `stream_interval`, which emits one chunk per
+`N` decode steps instead:
+
+- Higher `N` → fewer, larger gRPC messages → higher throughput under load.
+- Trade-off: the client receives tokens in bursts of `N`.
+
+On a single GB200 (Qwen3-0.6B, 2000-in / 256-out) raising `stream_interval` from
+1 to 5 roughly doubled output throughput at high concurrency (~6.3k → ~12k
+tok/s) and even lowered TTFT. `5` keeps streaming smooth while capturing nearly
+all the gain.
+
+## Packaging
+
+There is no published image yet. That is deferred to a follow-up change. Once
+the sidecar crate is published, you just install it onto a minimal base image.
+Until then, build and push your own as shown above.

--- a/lib/sidecar/trtllm/deploy/agg.yaml
+++ b/lib/sidecar/trtllm/deploy/agg.yaml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated TensorRT-LLM deployment using the Rust sidecar.
+#
+# Worker pod = two containers:
+#   - main: Dynamo worker (dynamo-trtllm-sidecar), no GPU; talks to the engine
+#     over gRPC on 127.0.0.1. Must be named "main" (operator injects env + probes).
+#   - trtllm-engine: stock TRT-LLM image, holds the GPU, runs the gRPC server as
+#     a native sidecar (see initContainers).
+#
+# The engine's gRPC has no auth/TLS; safe only because it stays on loopback.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trtllm-engine-config
+data:
+  config.yaml: |
+    # One gRPC chunk per N decode steps, not per token: N>1 cuts per-token gRPC
+    # serialization for a throughput win, at the cost of bursty delivery.
+    stream_interval: 5
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-sidecar-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend; operator adds the command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+  - name: TRTLLMWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        # trtllm-engine as a native sidecar (initContainer + restartPolicy: Always):
+        # starts before `main`, stops after. --grpc needs rc21; rc22 crashes on
+        # startup (protobuf version mismatch).
+        initContainers:
+        - name: trtllm-engine
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21
+          restartPolicy: Always
+          # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
+          # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:50051').unary_unary('/trtllm.TrtllmService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10     # must exceed the RPC timeout + interpreter spawn
+            failureThreshold: 60   # ~5 min for model load; raise for big models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:50051').unary_unary('/trtllm.TrtllmService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase for larger models.
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - tensorrt_llm.commands.serve
+          args:
+          - Qwen/Qwen3-0.6B
+          - --grpc
+          - --host
+          - 127.0.0.1
+          - --port
+          - "50051"
+          # Engine tuning from the ConfigMap above.
+          - --extra_llm_api_options
+          - /config/config.yaml
+          volumeMounts:
+          - name: engine-config
+            mountPath: /config
+        containers:
+        # Sidecar worker. No published image yet — build from
+        # lib/sidecar/trtllm/Dockerfile, set <your-registry> (see README), add
+        # imagePullSecrets if private. Must be named "main" (operator injects
+        # discovery env + probes by name).
+        - name: main
+          image: <your-registry>/dynamo-trtllm-sidecar:1.3.0
+          command:
+          - dynamo-trtllm-sidecar
+          args:
+          - --trtllm-endpoint
+          - 127.0.0.1:50051
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          # Engine reports 0 for context length; set it here or requests that
+          # omit max_tokens are rejected.
+          - --context-length
+          - "40960"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+        volumes:
+        - name: engine-config
+          configMap:
+            name: trtllm-engine-config


### PR DESCRIPTION
## Summary

Backports the following merged `main` PRs onto `release/1.4.0`:

- #12249 — fix(sidecar): emit SGLang delta tokens, not the cumulative stream
- #12239 — feat(sidecar): add SGLang sidecar deploy examples (agg + disagg)
- #12206 — feat(sidecar): add trtllm sidecar deploy example and minimal image

Each commit was cherry-picked with `-x` (source SHA recorded in the commit message).

Also requested but **skipped — already present on `release/1.4.0`**:
- #12217 (single-source NIXL version from `NIXL_REF`) — commit `d2e3f2f6a4` is already an ancestor
- #11833 (docs: fix stale references to removed unified backend) — commit `fcdd947f18` is already an ancestor

## Validation

- All three commits cherry-picked cleanly with no conflicts.
- Original PRs were CI-validated on `main` prior to merge.
- No source changes beyond the cherry-picks; no separate build was run in this backport.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12594" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->