### PR TITLE
feat(sidecar): cherry-pick SGLang deploy examples (#12239)

### DIFF
--- a/lib/sidecar/sglang/Dockerfile
+++ b/lib/sidecar/sglang/Dockerfile
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal image for the SGLang Rust sidecar (`dynamo-sglang-sidecar`).
+# A pure gRPC connector — no GPU, no engine runtime — that runs beside the
+# engine container over loopback (see deploy/agg.yaml).
+#
+#   docker build -f lib/sidecar/sglang/Dockerfile -t dynamo-sglang-sidecar:1.3.0 .
+
+FROM rust:1.96.1-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        libclang-dev \
+        protobuf-compiler \
+        perl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release --locked -p dynamo-sglang-sidecar \
+    && strip target/release/dynamo-sglang-sidecar
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group sidecar
+
+COPY --from=builder /src/target/release/dynamo-sglang-sidecar /usr/local/bin/dynamo-sglang-sidecar
+
+# Numeric UID so Kubernetes runAsNonRoot can verify it.
+USER 1000
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/dynamo-sglang-sidecar"]

--- a/lib/sidecar/sglang/README.md
+++ b/lib/sidecar/sglang/README.md
@@ -1,5 +1,11 @@
 # SGLang sidecar
 
+> [!WARNING]
+> **Experimental.** These deployment examples and the standalone sidecar image
+> are experimental and not yet packaged for distribution (the launcher module
+> ships inside `ai-dynamo-runtime`). The manifests, flags, and behavior may change
+> without notice.
+
 `dynamo-sglang-sidecar` connects Dynamo's unified worker lifecycle to an
 out-of-process SGLang engine through SGLang's native gRPC service. It is a
 standalone Rust executable and is also compiled into `ai-dynamo-runtime` for
@@ -13,8 +19,8 @@ cargo build --release -p dynamo-sglang-sidecar
     --sglang-endpoint http://127.0.0.1:30001
 ```
 
-Distribution and container packaging for the standalone executable are
-intentionally deferred to a follow-up change.
+There is no published image yet; the "Deploy on Kubernetes" section below builds
+a minimal one from `Dockerfile`. Official packaging is deferred to a follow-up.
 
 ## SGLang-managed module contract
 
@@ -31,3 +37,80 @@ The entry point configures Dynamo logging when `main()` runs, then calls the
 private `dynamo._core.backend._run_sglang_sidecar(argv)` binding. The binding
 prepends the executable name expected by clap, releases the GIL, and runs the
 same unified worker lifecycle as the standalone executable.
+
+## Deploy on Kubernetes (quick start)
+
+`deploy/agg.yaml` runs an aggregated deployment (a frontend plus one worker pod
+that colocates the sidecar with an SGLang engine). `deploy/disagg.yaml` runs
+disaggregated prefill/decode with NIXL KV transfer.
+
+There is no published sidecar image yet, so you build and push your own from
+`Dockerfile` — the same pattern as the TensorRT-LLM and vLLM sidecars.
+
+> [!NOTE]
+> The engine image must be a stock SGLang **v0.5.16+** build: the native gRPC
+> server (`--grpc-port`) landed there, and Dynamo's `sglang-runtime` pins an
+> older SGLang without it. `deploy/agg.yaml` uses `lmsysorg/sglang:v0.5.16`.
+
+### Prerequisites
+
+- A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
+  gate) with the Dynamo operator and a GPU node (multiple GPUs plus an RDMA fabric
+  for `disagg.yaml`). The engine runs as a native sidecar (`initContainers` with
+  `restartPolicy: Always`), which requires that version.
+- `kubectl` set to that cluster, and a namespace to deploy into.
+- A Hugging Face token for the model.
+- A container registry you can push to and the cluster can pull from.
+
+### 1. Build and push the sidecar image
+
+Build a multi-arch image so it runs on any node — `amd64` (x86) or `arm64`
+(GB200/Grace):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f lib/sidecar/sglang/Dockerfile \
+  -t <your-registry>/dynamo-sglang-sidecar:1.3.0 --push .
+```
+
+### 2. Point the manifest at your image
+
+In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
+If your registry is private, add `imagePullSecrets` to the worker pod spec.
+
+### 3. Create the Hugging Face token secret
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" -n <namespace>
+```
+
+### 4. Deploy
+
+```bash
+kubectl apply -f lib/sidecar/sglang/deploy/agg.yaml -n <namespace>
+```
+
+Wait for the worker pod to reach `2/2 Running`:
+
+```bash
+kubectl get pods -n <namespace> -w
+```
+
+### 5. Send a request
+
+```bash
+kubectl port-forward -n <namespace> svc/sglang-sidecar-agg-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models | jq .
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+### Disaggregated
+
+`deploy/disagg.yaml` runs prefill and decode as separate worker pods that hand
+off KV cache over a bootstrap server + NIXL. It needs multiple GPUs and an RDMA
+fabric, and both worker pods must reach `2/2 Running`.

--- a/lib/sidecar/sglang/deploy/agg.yaml
+++ b/lib/sidecar/sglang/deploy/agg.yaml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Aggregated SGLang deployment using the Rust sidecar.
+#
+# Worker pod = two containers:
+#   - main: Dynamo worker (dynamo-sglang-sidecar), no GPU; talks to the engine
+#     over gRPC on 127.0.0.1 and auto-discovers the model/role (no --model-path).
+#     Must be named "main" (operator injects env + probes).
+#   - sglang-engine: stock SGLang image, holds the GPU, runs its native gRPC
+#     server as a native sidecar (see initContainers).
+#
+# The engine's gRPC has no auth/TLS; safe only because it stays on loopback.
+#
+# SGLang can also load the sidecar in-process (`--sidecar dynamo.sglang.sidecar`,
+# see README); this example uses the standalone image for consistency with the
+# TensorRT-LLM and vLLM sidecars.
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend; operator adds the command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+  - name: SGLangWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        # sglang-engine as a native sidecar (initContainer + restartPolicy: Always):
+        # starts before `main`, stops after. Native gRPC `--grpc-port` needs SGLang
+        # v0.5.16+ (Dynamo's sglang-runtime pins an older SGLang without it).
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
+          # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10     # must exceed the RPC timeout + interpreter spawn
+            failureThreshold: 60   # ~5 min for model load; raise for big models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase for larger models.
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 127.0.0.1
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+        containers:
+        # Sidecar worker. No published image yet — build from
+        # lib/sidecar/sglang/Dockerfile, set <your-registry> (see README), add
+        # imagePullSecrets if private. Must be named "main" (operator injects
+        # discovery env + probes by name).
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret

--- a/lib/sidecar/sglang/deploy/disagg.yaml
+++ b/lib/sidecar/sglang/deploy/disagg.yaml
@@ -1,0 +1,211 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# EXPERIMENTAL. Disaggregated SGLang deployment using the Rust sidecar.
+#
+# Prefill and decode run as separate worker pods, each with two containers:
+#   - main: Dynamo worker (dynamo-sglang-sidecar), no GPU; auto-discovers its
+#     prefill/decode role from the engine. Must be named "main".
+#   - sglang-engine: stock SGLang image in --disaggregation-mode prefill|decode
+#     with the NIXL backend, holds the GPU. KV moves prefill -> decode over
+#     NIXL/RDMA. Native sidecar.
+#
+# Unlike aggregated, the engine binds 0.0.0.0 so its bootstrap server (8998) is
+# reachable across pods; the decode worker dials the prefill worker's advertised
+# bootstrap (SGLANG_DISAGGREGATION_BOOTSTRAP_HOST = pod IP). SGLang's single
+# --host binds ALL listeners, so the unauthenticated native gRPC (30001) is also
+# exposed on the pod network — rely on NetworkPolicy, not loopback isolation.
+#
+# PREREQUISITES / CAVEATS (from the SGLang disagg recipes + sidecar contract; NOT
+# validated here — needs a multi-GPU RDMA cluster and an SGLang build with the
+# experimental gRPC + --sidecar + disaggregation support):
+#   - RDMA/NIXL: engines need rdma/ib devices, IPC_LOCK, and shared memory; tune
+#     for your fabric (UCX_NET_DEVICES etc.). NIXL/UCX ship in sglang-runtime.
+#   - Model / served-model-name / TP must match between prefill and decode.
+#   - `main` runs the standalone dynamo-sglang-sidecar image (no GPU); build from
+#     lib/sidecar/sglang/Dockerfile (see README).
+
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: sglang-sidecar-disagg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+
+  - name: SGLangPrefillWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          # Real gRPC HealthCheck (see agg.yaml). startupProbe gates `main`;
+          # readinessProbe drops the worker if the engine dies at runtime.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --disaggregation-mode
+          - prefill
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          env:
+          # Advertise this pod's IP as the bootstrap host decode workers dial.
+          - name: SGLANG_DISAGGREGATION_BOOTSTRAP_HOST
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+
+  - name: SGLangDecodeWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Gi
+        initContainers:
+        - name: sglang-engine
+          image: lmsysorg/sglang:v0.5.16
+          restartPolicy: Always
+          securityContext:
+            capabilities:
+              add: ["IPC_LOCK"]
+          # Real gRPC HealthCheck (see agg.yaml). startupProbe gates `main`;
+          # readinessProbe drops the worker if the engine dies at runtime.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10
+            failureThreshold: 60
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:30001').unary_unary('/sglang.runtime.v1.SglangService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+            requests:
+              nvidia.com/gpu: "1"
+              rdma/ib: "1"
+              ephemeral-storage: 2Gi
+          volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+          command:
+          - python3
+          - -m
+          - sglang.launch_server
+          args:
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          - --host
+          - 0.0.0.0
+          - --port
+          - "30000"
+          - --grpc-port
+          - "30001"
+          - --disaggregation-mode
+          - decode
+          - --disaggregation-bootstrap-port
+          - "8998"
+          - --disaggregation-transfer-backend
+          - nixl
+        containers:
+        - name: main
+          image: <your-registry>/dynamo-sglang-sidecar:1.3.0
+          command:
+          - dynamo-sglang-sidecar
+          args:
+          - --sglang-endpoint
+          - 127.0.0.1:30001
+          envFrom:
+          - secretRef:
+              name: hf-token-secret


### PR DESCRIPTION
## Summary

Cherry-picks merged #12239 (`b78bd135fb50505a2490c90f4a492f63ed65a424`) onto `release/1.4.0`.

- Adds the validated aggregated and disaggregated SGLang Kubernetes examples and minimal sidecar image.
- Signed-off cherry-pick for DCO compliance.
- Merge dependency: merge after the release backports of #12249 and #12271.

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12239

## Validation

- [x] Patch applies cleanly and matches the mainline patch ID.
- [x] Relevant pre-commit checks pass, including YAML, codespell, file-mode, and whitespace checks.
- [x] Main PR cluster-validation evidence is preserved by patch equivalence.
- [ ] Release-branch CI passes.

## Related Issues

- Relates to #12239.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12600" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->