### PR TITLE
feat(sidecar): cherry-pick TensorRT-LLM deploy example (#12206)

### DIFF
--- a/lib/sidecar/trtllm/Dockerfile
+++ b/lib/sidecar/trtllm/Dockerfile
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal image for the TensorRT-LLM Rust sidecar (`dynamo-trtllm-sidecar`).
+# A pure gRPC connector — no GPU, no engine runtime — that runs beside the
+# engine container over loopback (see deploy/agg.yaml).
+#
+#   docker build -f lib/sidecar/trtllm/Dockerfile -t dynamo-trtllm-sidecar:1.3.0 .
+
+FROM rust:1.96.1-bookworm AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        clang \
+        libclang-dev \
+        protobuf-compiler \
+        perl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+RUN cargo build --release --locked -p dynamo-trtllm-sidecar \
+    && strip target/release/dynamo-trtllm-sidecar
+
+FROM debian:bookworm-slim AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --uid 1000 --user-group sidecar
+
+COPY --from=builder /src/target/release/dynamo-trtllm-sidecar /usr/local/bin/dynamo-trtllm-sidecar
+
+# Numeric UID so Kubernetes runAsNonRoot can verify it.
+USER 1000
+EXPOSE 9090
+ENTRYPOINT ["/usr/local/bin/dynamo-trtllm-sidecar"]

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -5,6 +5,11 @@ SPDX-License-Identifier: Apache-2.0
 
 # TensorRT-LLM sidecar
 
+> [!WARNING]
+> **Experimental.** This sidecar and its deployment example are experimental and
+> not yet packaged for distribution (see [Packaging](#packaging)). The manifest,
+> flags, and behavior may change without notice.
+
 `dynamo-trtllm-sidecar` connects a Dynamo worker to TensorRT-LLM's native
 `trtllm.TrtllmService` gRPC `Generate` service. It is a standalone Rust
 executable composed with `dynamo_backend_common::run`: TensorRT-LLM runs as its
@@ -27,7 +32,7 @@ carries no context-phase handoff.
 
 ## Run
 
-Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`+):
+Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`; rc22 has a broken `--grpc`):
 
 ```bash
 python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
@@ -48,5 +53,99 @@ dynamo-trtllm-sidecar \
 Use `TRTLLM_GRPC_ENDPOINT` instead of `--trtllm-endpoint` when the endpoint is
 provided through the environment.
 
-Distribution and container packaging for the executable are intentionally
-deferred to a follow-up change.
+## Deploy on Kubernetes (quick start)
+
+`deploy/agg.yaml` deploys a frontend and one worker pod. The worker runs the
+sidecar next to a TensorRT-LLM engine and serves `Qwen/Qwen3-0.6B` on one GPU.
+
+There is no published sidecar image yet (see [Packaging](#packaging)), so you
+build and push your own.
+
+### Prerequisites
+
+- A Kubernetes cluster (**v1.29+**, or v1.28 with the `SidecarContainers` feature
+  gate) with the Dynamo operator and a GPU node. The engine runs as a native
+  sidecar (`initContainers` with `restartPolicy: Always`), which requires that
+  version.
+- `kubectl` set to that cluster, and a namespace to deploy into.
+- A Hugging Face token for the model.
+- A container registry you can push to and the cluster can pull from.
+
+### 1. Build and push the sidecar image
+
+Build a multi-arch image so it runs on any node — `amd64` (x86) or `arm64`
+(GB200/Grace):
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f lib/sidecar/trtllm/Dockerfile \
+  -t <your-registry>/dynamo-trtllm-sidecar:1.3.0 --push .
+```
+
+To build faster for one arch, pass just that platform (e.g. `linux/arm64` for
+GB200/Grace).
+
+### 2. Point the manifest at your image
+
+In `deploy/agg.yaml`, set the `main` worker image to the one you just pushed.
+If your registry is private, add `imagePullSecrets` to the worker pod spec.
+
+### 3. Create the Hugging Face token secret
+
+Read the token from an env var so it stays out of your shell history (or use
+`--from-file` / an external secret manager):
+
+```bash
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="$HF_TOKEN" -n <namespace>
+```
+
+### 4. Deploy
+
+```bash
+kubectl apply -f lib/sidecar/trtllm/deploy/agg.yaml -n <namespace>
+```
+
+Wait for the worker pod to reach `2/2 Running`:
+
+```bash
+kubectl get pods -n <namespace> -w
+```
+
+### 5. Send a request
+
+Port-forward the frontend and call it:
+
+```bash
+kubectl port-forward -n <namespace> svc/trtllm-sidecar-agg-frontend 8000:8000 &
+
+curl -s localhost:8000/v1/models | jq .
+
+curl -s localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"Hello"}],"max_tokens":32}' | jq .
+```
+
+`/v1/models` should list `Qwen/Qwen3-0.6B`, and the chat call returns a reply.
+
+## Tuning
+
+The engine streams tokens to the sidecar over gRPC. By default it sends one
+message per token, and that per-token serialization is the sidecar's main
+throughput cost versus an in-process backend. The `trtllm-engine-config`
+ConfigMap in `deploy/agg.yaml` sets `stream_interval`, which emits one chunk per
+`N` decode steps instead:
+
+- Higher `N` → fewer, larger gRPC messages → higher throughput under load.
+- Trade-off: the client receives tokens in bursts of `N`.
+
+On a single GB200 (Qwen3-0.6B, 2000-in / 256-out) raising `stream_interval` from
+1 to 5 roughly doubled output throughput at high concurrency (~6.3k → ~12k
+tok/s) and even lowered TTFT. `5` keeps streaming smooth while capturing nearly
+all the gain.
+
+## Packaging
+
+There is no published image yet. That is deferred to a follow-up change. Once
+the sidecar crate is published, you just install it onto a minimal base image.
+Until then, build and push your own as shown above.

--- a/lib/sidecar/trtllm/deploy/agg.yaml
+++ b/lib/sidecar/trtllm/deploy/agg.yaml
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated TensorRT-LLM deployment using the Rust sidecar.
+#
+# Worker pod = two containers:
+#   - main: Dynamo worker (dynamo-trtllm-sidecar), no GPU; talks to the engine
+#     over gRPC on 127.0.0.1. Must be named "main" (operator injects env + probes).
+#   - trtllm-engine: stock TRT-LLM image, holds the GPU, runs the gRPC server as
+#     a native sidecar (see initContainers).
+#
+# The engine's gRPC has no auth/TLS; safe only because it stays on loopback.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: trtllm-engine-config
+data:
+  config.yaml: |
+    # One gRPC chunk per N decode steps, not per token: N>1 cuts per-token gRPC
+    # serialization for a throughput win, at the cost of bursty delivery.
+    stream_interval: 5
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: trtllm-sidecar-agg
+spec:
+  components:
+  - name: Frontend
+    type: frontend
+    replicas: 1
+    podTemplate:
+      spec:
+        containers:
+        # Dynamo frontend; operator adds the command.
+        - name: main
+          image: nvcr.io/nvidia/ai-dynamo/dynamo-frontend:1.3.0
+  - name: TRTLLMWorker
+    type: worker
+    replicas: 1
+    podTemplate:
+      spec:
+        # trtllm-engine as a native sidecar (initContainer + restartPolicy: Always):
+        # starts before `main`, stops after. --grpc needs rc21; rc22 crashes on
+        # startup (protobuf version mismatch).
+        initContainers:
+        - name: trtllm-engine
+          image: nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21
+          restartPolicy: Always
+          # gRPC HealthCheck via exec (tcpSocket/grpc: dial the pod IP, not the
+          # loopback engine). startupProbe gates `main`; readinessProbe drops dead workers.
+          startupProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:50051').unary_unary('/trtllm.TrtllmService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 5
+            timeoutSeconds: 10     # must exceed the RPC timeout + interpreter spawn
+            failureThreshold: 60   # ~5 min for model load; raise for big models
+          readinessProbe:
+            exec:
+              command:
+              - python3
+              - -c
+              - import grpc; grpc.insecure_channel('127.0.0.1:50051').unary_unary('/trtllm.TrtllmService/HealthCheck')(b'', timeout=3)
+            periodSeconds: 10
+            timeoutSeconds: 10
+            failureThreshold: 3
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+            requests:
+              # Increase for larger models.
+              ephemeral-storage: 2Gi
+          command:
+          - python3
+          - -m
+          - tensorrt_llm.commands.serve
+          args:
+          - Qwen/Qwen3-0.6B
+          - --grpc
+          - --host
+          - 127.0.0.1
+          - --port
+          - "50051"
+          # Engine tuning from the ConfigMap above.
+          - --extra_llm_api_options
+          - /config/config.yaml
+          volumeMounts:
+          - name: engine-config
+            mountPath: /config
+        containers:
+        # Sidecar worker. No published image yet — build from
+        # lib/sidecar/trtllm/Dockerfile, set <your-registry> (see README), add
+        # imagePullSecrets if private. Must be named "main" (operator injects
+        # discovery env + probes by name).
+        - name: main
+          image: <your-registry>/dynamo-trtllm-sidecar:1.3.0
+          command:
+          - dynamo-trtllm-sidecar
+          args:
+          - --trtllm-endpoint
+          - 127.0.0.1:50051
+          - --model-path
+          - Qwen/Qwen3-0.6B
+          # Engine reports 0 for context length; set it here or requests that
+          # omit max_tokens are rejected.
+          - --context-length
+          - "40960"
+          envFrom:
+          - secretRef:
+              name: hf-token-secret
+        volumes:
+        - name: engine-config
+          configMap:
+            name: trtllm-engine-config


### PR DESCRIPTION
## Summary

Cherry-picks merged #12206 (`48f2f0200f6eff5b0080c937bf776169edba436d`) onto `release/1.4.0`.

- Adds the validated TensorRT-LLM Kubernetes example and minimal sidecar image.
- Signed-off cherry-pick for DCO compliance.
- Merge dependency: merge after the release backport of #12239.

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12206

## Validation

- [x] Patch applies cleanly and matches the mainline patch ID.
- [x] Relevant pre-commit checks pass, including YAML, codespell, file-mode, and whitespace checks.
- [x] Main PR cluster-validation evidence is preserved by patch equivalence.
- [ ] Release-branch CI passes.

## Related Issues

- Relates to #12206.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12601" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->