### PR TITLE
docs: cherry-pick experimental sidecar guides (#12414)

### DIFF
--- a/docs/fern/backends/sglang/README.md
+++ b/docs/fern/backends/sglang/README.md
@@ -13,6 +13,13 @@ We recommend using the [latest stable release](https://github.com/ai-dynamo/dyna
 
 Dynamo SGLang integrates [SGLang](https://github.com/sgl-project/sglang) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with SGLang's native engine arguments. It supports LLM inference, embedding models, multimodal vision models, and diffusion-based generation (LLM, image, video).
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside SGLang and
+connects through SGLang's native gRPC API. It keeps SGLang's native server and
+argument surface while separating Dynamo and engine dependencies. See
+[SGLang Sidecar](sidecar.md) for current readiness and launch examples.
+
 ## Prerequisites
 
 - **CUDA toolkit headers** for bare-metal builds (e.g. `nvcc`, `cuda_runtime.h`). See [CUDA Requirements](../../getting-started/local-installation.mdx#system-requirements). Not required when running the pre-built `sglang-runtime` container.

--- a/docs/fern/backends/sglang/sidecar.md
+++ b/docs/fern/backends/sglang/sidecar.md
@@ -1,0 +1,75 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: SGLang Sidecar
+subtitle: Run Dynamo beside a stock SGLang engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The SGLang sidecar, launchers, packaging, and feature
+> coverage can change without notice.
+
+`dynamo-sglang-sidecar` is a CPU-only Dynamo worker that connects to SGLang's
+native gRPC service. It preserves the upstream engine process and argument
+surface while using Dynamo for request handling and distributed serving. See
+the [Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Validated on two GPUs with NIXL |
+| Kubernetes example | Validated | Validated with NIXL |
+
+This table covers launch topology only. The
+[SGLang feature matrix](README.md#feature-support-matrix) describes the
+in-process backend; sidecar feature parity is still under evaluation. See the
+[SGLang sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/README.md)
+for current protocol details.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-sglang-sidecar` is on `PATH`. Install SGLang v0.5.16 or later, which
+provides the native `--grpc-port` server option.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/sglang/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+To run separate prefill and decode engines on two GPUs:
+
+```bash
+./lib/sidecar/sglang/launch/disagg.sh --model Qwen/Qwen3-0.6B
+```
+
+Each launcher starts the Dynamo frontend, the SGLang engine process or
+processes, and the matching sidecar workers. It binds SGLang's HTTP and native
+gRPC endpoints to loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published SGLang sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream SGLang
+image. The source tree includes
+[aggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/deploy/agg.yaml)
+and
+[disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/sglang/deploy/disagg.yaml)
+manifests.

--- a/docs/fern/backends/trtllm/README.md
+++ b/docs/fern/backends/trtllm/README.md
@@ -13,6 +13,14 @@ We recommend using the [latest stable release](https://github.com/ai-dynamo/dyna
 
 Dynamo TensorRT-LLM integrates [TensorRT-LLM](https://github.com/NVIDIA/TensorRT-LLM) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, multi-node deployments, and request cancellation. It supports LLM inference, multimodal models, video diffusion, and advanced features like speculative decoding and attention data parallelism.
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside TensorRT-LLM and
+connects through TensorRT-LLM's native gRPC API. It keeps TensorRT-LLM's native
+server and argument surface while separating Dynamo and engine dependencies.
+See [TensorRT-LLM Sidecar](sidecar.md) for current readiness and a launch
+example.
+
 ## Feature Support Matrix
 
 ### Core Dynamo Features

--- a/docs/fern/backends/trtllm/sidecar.md
+++ b/docs/fern/backends/trtllm/sidecar.md
@@ -1,0 +1,68 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: TensorRT-LLM Sidecar
+subtitle: Run Dynamo beside a stock TensorRT-LLM engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The TensorRT-LLM sidecar, launcher, packaging, and feature
+> coverage can change without notice.
+
+`dynamo-trtllm-sidecar` is a CPU-only Dynamo worker that connects to
+TensorRT-LLM's native gRPC service. It preserves the upstream engine process
+and argument surface while using Dynamo for request handling and distributed
+serving. See the
+[Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Not supported |
+| Kubernetes example | Validated | Not supported |
+
+This table covers launch topology only. The
+[TensorRT-LLM feature matrix](README.md#feature-support-matrix) describes the
+in-process backend; sidecar feature parity is still under evaluation. The
+current native gRPC contract does not provide the prefill/decode handoff needed
+for disaggregated serving. See the
+[TensorRT-LLM sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/README.md)
+for other protocol limitations.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-trtllm-sidecar` is on `PATH`. Install a TensorRT-LLM release that
+provides `tensorrt_llm.commands.serve --grpc`.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/trtllm/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+The launcher starts the Dynamo frontend, TensorRT-LLM engine, and sidecar. It
+binds TensorRT-LLM's native gRPC endpoint to loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published TensorRT-LLM sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream
+TensorRT-LLM image. The source tree includes an
+[aggregated deployment manifest](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/trtllm/deploy/agg.yaml).

--- a/docs/fern/backends/vllm/README.md
+++ b/docs/fern/backends/vllm/README.md
@@ -6,6 +6,13 @@ title: vLLM
 
 Dynamo vLLM integrates [vLLM](https://github.com/vllm-project/vllm) engines into Dynamo's distributed runtime, enabling disaggregated serving, KV-aware routing, and request cancellation while maintaining full compatibility with vLLM's native engine arguments. Dynamo leverages vLLM's native KV cache events, NIXL-based transfer mechanisms, and metric reporting to enable KV-aware routing and P/D disaggregation.
 
+## Experimental Sidecar
+
+The experimental sidecar path runs the Dynamo worker outside vLLM and connects
+through vLLM's native gRPC API. It keeps vLLM's native server and argument
+surface while separating Dynamo and engine dependencies. See
+[vLLM Sidecar](sidecar.md) for current readiness and launch examples.
+
 ## Installation
 
 ### Install Latest Release

--- a/docs/fern/backends/vllm/sidecar.md
+++ b/docs/fern/backends/vllm/sidecar.md
@@ -1,0 +1,75 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: vLLM Sidecar
+subtitle: Run Dynamo beside a stock vLLM engine through native gRPC.
+---
+
+> [!WARNING]
+> **Experimental.** The vLLM sidecar, launchers, packaging, and feature coverage
+> can change without notice.
+
+`dynamo-vllm-sidecar` is a CPU-only Dynamo worker that connects to vLLM's native
+gRPC service. It preserves the upstream engine process and argument surface
+while using Dynamo for request handling and distributed serving. See the
+[Sidecar Backends](../../design-docs/sidecar-backends.md) page for the common
+architecture.
+
+## Readiness
+
+| Deployment path | Aggregated | Disaggregated |
+|---|---|---|
+| Local launcher | Validated on one GPU | Validated on two GPUs with NIXL |
+| Kubernetes example | Validated | Validated with NIXL |
+
+This table covers launch topology only. The
+[vLLM feature matrix](README.md#feature-support-matrix) describes the in-process
+backend; sidecar feature parity is still under evaluation. See the
+[vLLM sidecar README](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/README.md)
+for current protocol limitations.
+
+## Launch Locally
+
+From a Dynamo source checkout, build or install Dynamo so
+`dynamo-vllm-sidecar` is on `PATH`. Install a vLLM build that provides
+`vllm-rs` and its native gRPC server.
+
+Start Dynamo's local discovery services, then run the aggregated launcher:
+
+```bash
+docker compose -f dev/docker-compose.yml up -d
+./lib/sidecar/vllm/launch/agg.sh --model Qwen/Qwen3-0.6B
+```
+
+To run separate prefill and decode engines on two GPUs:
+
+```bash
+./lib/sidecar/vllm/launch/disagg.sh --model Qwen/Qwen3-0.6B
+```
+
+Each launcher starts the Dynamo frontend, the vLLM engine process or processes,
+and the matching sidecar workers. It binds the native gRPC endpoints to
+loopback.
+
+Verify the frontend:
+
+```bash
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "max_tokens": 32
+  }'
+```
+
+## Deploy on Kubernetes
+
+No published vLLM sidecar image is available yet. Follow the
+[Kubernetes quick start](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/README.md#deploy-on-kubernetes-quick-start)
+to build the CPU-only sidecar image and pair it with a stock upstream vLLM
+image. The source tree includes
+[aggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/deploy/agg.yaml)
+and
+[disaggregated](https://github.com/ai-dynamo/dynamo/blob/main/lib/sidecar/vllm/deploy/disagg.yaml)
+manifests.

--- a/docs/fern/cli/overview.mdx
+++ b/docs/fern/cli/overview.mdx
@@ -10,6 +10,14 @@ This guide walks through the basic **aggregated deployment** flow: a single fron
 
 A deployment is always a **frontend** (`python -m dynamo.frontend`, the HTTP ingress) plus **one or more workers** (`python -m dynamo.<backend>`, which wrap an inference engine). Workers register with the frontend automatically on startup. The steps below start one of each.
 
+<Warning>
+**Experimental sidecar launch mode.** The steps below run an integrated backend,
+with the Dynamo worker and inference engine in the same process. The
+[Sidecar Backends](../design-docs/sidecar-backends.md) page explains how to run
+a stock engine server beside a CPU-only Dynamo worker and links to the
+framework-specific launch guides.
+</Warning>
+
 > **Prerequisites.** Dynamo installed for your backend (see the [installation guide](../getting-started/local-installation.mdx)), and etcd + NATS reachable on localhost so the frontend and worker can discover each other:
 >
 > ```bash

--- a/docs/fern/design-docs/architecture.md
+++ b/docs/fern/design-docs/architecture.md
@@ -41,6 +41,21 @@ Dynamo addresses these constraints by separating serving, control, and state pro
 
 ## System Model
 
+### Backend Execution Modes
+
+Dynamo supports two ways to connect an inference engine to the request plane:
+
+- An **integrated backend** runs the Dynamo worker and inference engine in the
+  same process.
+- An **experimental sidecar backend** runs a stock inference engine server
+  beside a CPU-only Dynamo sidecar. The request plane calls the engine's native
+  gRPC API directly, while discovery and events flow through the sidecar.
+
+The sidecar mode preserves the engine's native serve interface and separates
+engine dependencies from Dynamo, but it does not yet match the integrated
+backends' feature coverage. See [Sidecar Backends](sidecar-backends.md) for the
+architecture and current readiness.
+
 ### Request Plane (critical data path)
 
 The request plane is responsible for request/response execution:

--- a/docs/fern/design-docs/sidecar-backends.md
+++ b/docs/fern/design-docs/sidecar-backends.md
@@ -1,0 +1,72 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Sidecar Backends
+subtitle: Run Dynamo beside a stock inference engine through its native gRPC API.
+---
+
+> [!WARNING]
+> **Experimental.** Sidecar packaging, launchers, and API coverage are still
+> evolving. The sidecar path does not yet match every feature of the in-process
+> backends.
+
+A Dynamo sidecar runs beside the inference engine process. It registers the
+engine with Dynamo discovery and forwards engine events into the Dynamo event
+plane. Today, requests also pass through the sidecar. The target design routes
+requests directly to the engine's native gRPC service.
+
+## Design Goals
+
+- Keep the upstream engine's native serve path and argument surface.
+- Move toward public, versioned gRPC contracts with explicit backward
+  compatibility instead of importing private engine APIs.
+- Isolate Dynamo and engine dependencies in separate processes.
+- Attribute failures through engine-specific and Dynamo-specific logs and health
+  checks.
+- Reuse Dynamo's frontend, routing, planning, and disaggregated-serving
+  orchestration.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  F[Dynamo Frontend]
+  subgraph W[Same host or Kubernetes pod]
+    direction TB
+    S[Dynamo Sidecar] <-->|Native gRPC| E[Inference Engine]
+  end
+  S -->|Discovery and Event planes| F
+  F -->|Request plane*<br/>Native gRPC| E
+```
+
+<sup>*</sup> The direct request path is the target design. Today, requests pass
+through the sidecar.
+
+In the target design, the frontend and router resolve the engine endpoint
+through discovery, then send requests directly to the engine. The sidecar stays
+off the request path and uses the engine's native gRPC service for metadata and
+event integration with Dynamo's discovery and event planes.
+
+## Target Responsibilities
+
+| Layer | Responsibility |
+|---|---|
+| Dynamo frontend and router | OpenAI-compatible API, preprocessing, routing, and direct native gRPC requests to the engine |
+| Dynamo sidecar | Engine registration and discovery, plus metadata and event forwarding |
+| Inference engine | Native gRPC request serving, scheduling, sampling, token generation, KV cache, and GPU execution |
+
+## Current Readiness
+
+| Backend | Local launcher | Kubernetes example |
+|---|---|---|
+| [vLLM](../backends/vllm/sidecar.md) | Aggregated and disaggregated | Aggregated and disaggregated |
+| [SGLang](../backends/sglang/sidecar.md) | Aggregated and disaggregated | Aggregated and disaggregated |
+| [TensorRT-LLM](../backends/trtllm/sidecar.md) | Aggregated | Aggregated |
+
+Disaggregated launch paths require multiple GPUs and use NIXL for KV transfer.
+This table describes validated launch topologies, not feature parity with the
+in-process backends.
+
+See the
+[sidecar source and engine-specific READMEs](https://github.com/ai-dynamo/dynamo/tree/main/lib/sidecar)
+for implementation details.

--- a/docs/fern/getting-started/introduction.mdx
+++ b/docs/fern/getting-started/introduction.mdx
@@ -115,6 +115,9 @@ This page covers the **Kubernetes** path. To run Dynamo directly on a workstatio
       <Card title="Model Deployment Introduction" icon="regular circle-info" href="kubernetes-deployment.mdx">
         Choose a deployment workflow and learn the core Kubernetes resources.
       </Card>
+      <Card title="Sidecar Backends (Experimental)" icon="regular server" href="../design-docs/sidecar-backends.md">
+        Run Dynamo beside a stock inference engine and find backend-specific deployment examples.
+      </Card>
       <Card title="Deploy with DGD" icon="regular cloud-arrow-up" href="../kubernetes/dgd-guide.md">
         Define and apply a DynamoGraphDeployment.
       </Card>

--- a/docs/fern/index.yml
+++ b/docs/fern/index.yml
@@ -138,6 +138,8 @@ navigation:
         contents:
           - page: Introduction
             path: getting-started/kubernetes-deployment.mdx
+          - page: Sidecar Backends (Experimental)
+            path: design-docs/sidecar-backends.md
           - page: Deploy with DGD
             path: kubernetes/dgd-guide.md
           - page: Expose the Frontend
@@ -557,6 +559,8 @@ navigation:
                     path: design-docs/dynamo-flow.md
                   - page: Distributed Runtime
                     path: design-docs/distributed-runtime.md
+                  - page: Sidecar Backends (Experimental)
+                    path: design-docs/sidecar-backends.md
                   - page: Disaggregated Serving
                     path: design-docs/disagg-serving.md
               - section: Communication Planes
@@ -710,6 +714,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/sglang/README.md
+                      - page: Sidecar
+                        path: backends/sglang/sidecar.md
                       - page: Reference Guide
                         path: backends/sglang/sglang-reference-guide.md
                       - page: Agents on SGLang
@@ -732,6 +738,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/trtllm/README.md
+                      - page: Sidecar
+                        path: backends/trtllm/sidecar.md
                       - page: Reference Guide
                         path: backends/trtllm/trtllm-reference-guide.md
                       - page: Observability
@@ -746,6 +754,8 @@ navigation:
                     contents:
                       - page: Overview
                         path: backends/vllm/README.md
+                      - page: Sidecar
+                        path: backends/vllm/sidecar.md
                       - page: Reference Guide
                         path: backends/vllm/vllm-reference-guide.md
                       - page: Chat Processor


### PR DESCRIPTION
## Summary

Cherry-picks merged #12414 (`1ca750a1b673a33dc3ba270d4a9ddf8a96165430`) onto `release/1.4.0`.

- Documents the experimental sidecar architecture and local and Kubernetes launch paths for vLLM, SGLang, and TensorRT-LLM.
- Signed-off cherry-pick for DCO compliance.
- Merge dependency: merge after the release backports of #12265, #12272, #12249, #12271, #12239, and #12206.

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12414

## Validation

- [x] Patch applies cleanly and matches the mainline patch ID.
- [x] `fern check` reports 0 errors.
- [x] `fern docs broken-links` passes.
- [x] Relevant pre-commit documentation and whitespace checks pass.
- [ ] Release-branch CI passes.

## Related Issues

- Relates to #12414.
- Internal tracking: [DIS-2490](https://linear.app/nvidia/issue/DIS-2490/documentation-added-for-each-sidecar-and-a-general-doc-on-how-it-works).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12602" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->