### PR TITLE
build(container): cherry-pick libprotobuf-dev dev-image fix (#12443)

### DIFF
--- a/container/templates/dev.Dockerfile
+++ b/container/templates/dev.Dockerfile
@@ -84,6 +84,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         pybind11-dev \
         pkg-config \
         protobuf-compiler \
+        libprotobuf-dev \
         # Debugging / tracing
         gdb \
         valgrind \


### PR DESCRIPTION
## Summary

Cherry-picks merged #12443 (`34445087b98a5ab35fd65437a1fcb9163171ea77`) onto `release/1.4.0`.

- Installs the protobuf well-known schemas required by `cargo check --workspace` in Dynamo development images.
- Signed-off cherry-pick for DCO compliance.
- Merge dependency: independent, but merge after the release backport of #12414 to preserve mainline order.

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12443

## Validation

- [x] Patch applies cleanly and matches the mainline patch ID.
- [x] vLLM, SGLang, and TensorRT-LLM dev Dockerfiles render successfully.
- [x] All three rendered Dockerfiles contain `libprotobuf-dev`.
- [ ] Release-branch CI passes.
- [ ] Post-merge dev-image builds pass; PR CI does not build these images.

## Related Issues

- Relates to #12443.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->