### PR TITLE
fix(examples): cherry-pick Triton CUDA 13 image + libdcgm copy (#12577)

### DIFF
--- a/examples/backends/tritonserver/Dockerfile
+++ b/examples/backends/tritonserver/Dockerfile
@@ -2,15 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG DYNAMO_BASE_IMAGE="dynamo-base:latest"
-ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.01-py3"
+ARG TRITON_SERVER_IMAGE="nvcr.io/nvidia/tritonserver:25.10-py3"
 
 FROM ${TRITON_SERVER_IMAGE} AS triton_source
+# Ensure DCGM directory exists so COPY never fails when the source image omits it
+RUN mkdir -p /usr/local/dcgm
 
 FROM ${DYNAMO_BASE_IMAGE} AS dynamo_base
 
 COPY --from=triton_source /opt/tritonserver /opt/tritonserver
 COPY --from=triton_source /usr/local/dcgm /usr/local/dcgm
-COPY --from=triton_source /lib/x86_64-linux-gnu/libdcgm*.so* /lib/x86_64-linux-gnu/
+USER root
+RUN --mount=type=bind,from=triton_source,source=/usr/lib/x86_64-linux-gnu,target=/triton_usr_lib \
+    find /triton_usr_lib -name "libdcgm*.so*" -exec cp -a {} /lib/x86_64-linux-gnu/ \;
 ENV BACKEND_DIR=/opt/tritonserver/backends
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/opt/tritonserver/lib:/opt/tritonserver/backends:/usr/local/dcgm/lib64
 ENV PATH=/opt/tritonserver/bin:$PATH
@@ -24,3 +28,5 @@ USER dynamo
 
 RUN uv pip install --no-cache-dir tritonclient[grpc]
 RUN uv pip install /opt/tritonserver/python/triton*.whl
+# Validate CUDA ABI compatibility at build time
+RUN python3 -c "import tritonserver"

--- a/examples/backends/tritonserver/README.md
+++ b/examples/backends/tritonserver/README.md
@@ -38,21 +38,26 @@ This example shows how to run Triton Server models through Dynamo's distributed 
 From the Dynamo repository root:
 
 ```bash
-# Build the base Dynamo image
+# Build the base Dynamo image (CUDA 13.0)
 python container/render.py --framework=dynamo --target=runtime --output-short-filename
 docker build -f container/rendered.Dockerfile -t dynamo-base:latest .
 
-# Build the Triton worker image
-cd examples/backends/tritonserver
-docker build -t dynamo-triton:latest .
+# Build the Triton worker image (defaults to tritonserver:25.10-py3, CUDA 13-compatible)
+docker build \
+  --build-arg DYNAMO_BASE_IMAGE=dynamo-base:latest \
+  -t dynamo-triton:latest \
+  examples/backends/tritonserver/
 ```
+
+> [!NOTE]
+> The default `TRITON_SERVER_IMAGE` is `nvcr.io/nvidia/tritonserver:25.10-py3`
 
 #### Step 2: Run the Container
 
 ```bash
 docker run --rm -it --gpus all --network host \
   dynamo-triton:latest \
-  ./examples/backends/tritonserver/launch/identity.sh
+  /workspace/launch/identity.sh
 ```
 
 #### Step 3: Test the Deployment


### PR DESCRIPTION
## Summary

Cherry-pick of #12577 (`ba294ab0d9`, merged to main 2026-08-03 22:19 UTC) onto `release/1.4.0`.

Clears P0 NVBug [6541824](https://nvbugs.nvidia.com/6541824) / [DYN-3697](https://linear.app/nvidia/issue/DYN-3697): the Triton example container cannot start because of a CUDA ABI mismatch.

Applies clean, no conflicts. Diff is identical to #12577: 2 files, +18/-7. Authorship preserved (@nealvaidya), `-x` records the source commit.

## What it fixes

The image bump alone is not sufficient. `tritonserver:25.10-py3` ships `libdcgm.so.4` under `/usr/lib/x86_64-linux-gnu` rather than `/lib/…`, so the previous `COPY` glob would silently match nothing. The bind-mount plus `find -exec cp -a` handles the merged-usr move and preserves the symlink chain.

The build-time `import tritonserver` check turns the reported symptom into a build gate, so a future base-image CUDA bump fails loudly rather than shipping a container that cannot start.

The README run-path change is a second real fix: `launch/` is copied to `/workspace/launch/` with `WORKDIR /workspace`, so the previous `./examples/backends/tritonserver/launch/identity.sh` path did not exist inside the container.

## History

Originally opened staged ahead of main, picking the two pre-merge commits. Re-picked from the squash commit once #12577 landed, so the provenance trailer points at the real merged SHA. Content unchanged.