### PR TITLE
fix(sidecar): emit SGLang delta tokens, not the cumulative stream

### DIFF
--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -24,7 +24,7 @@ use crate::client::{self, Client, Discovery, Pool};
 use crate::proto as pb;
 use crate::protocol::{
     build_generate_request, disaggregated_params_to_json, engine_data_from_meta, extract_logprobs,
-    meta_u32, output_ids_to_u32, terminal_from_meta,
+    meta_u32, new_output_ids, output_ids_to_u32, terminal_from_meta,
 };
 
 pub struct SglangSidecarEngine {
@@ -242,6 +242,7 @@ impl LLMEngine for SglangSidecarEngine {
             let mut generated = 0_u32;
             let mut observed_prompt_tokens = prompt_tokens;
             let mut logprob_offset = 0_usize;
+            let mut token_offset = 0_usize;
             loop {
                 tokio::select! {
                     biased;
@@ -273,13 +274,22 @@ impl LLMEngine for SglangSidecarEngine {
                         if let Some(value) = meta_u32(&response.meta_info, "prompt_tokens") {
                             observed_prompt_tokens = value;
                         }
-                        let token_ids = match output_ids_to_u32(&response.output_ids) {
+                        // SGLang streams output_ids cumulatively (the whole sequence
+                        // so far, like its logprob metadata), so emit only the tokens
+                        // appended since the previous chunk.
+                        let token_ids = match output_ids_to_u32(new_output_ids(
+                            &response.output_ids,
+                            token_offset,
+                        )) {
                             Ok(ids) => ids,
                             Err(err) => {
                                 yield Err(err);
                                 break;
                             }
                         };
+                        // Never rewind: a regressive chunk (shorter than what we
+                        // already emitted) must not let later growth re-emit tokens.
+                        token_offset = token_offset.max(response.output_ids.len());
                         let (log_probs, top_logprobs, next_offset) =
                             match extract_logprobs(
                                 &response.meta_info,

--- a/lib/sidecar/sglang/src/protocol.rs
+++ b/lib/sidecar/sglang/src/protocol.rs
@@ -327,6 +327,13 @@ fn json_value_to_string(value: &Value) -> String {
     }
 }
 
+/// Tokens appended since the previous chunk. SGLang streams `output_ids`
+/// cumulatively, so each chunk carries the full sequence so far; `offset` is the
+/// previous chunk's total length. Guards against a non-growing chunk.
+pub(crate) fn new_output_ids(output_ids: &[i32], offset: usize) -> &[i32] {
+    output_ids.get(offset..).unwrap_or(&[])
+}
+
 pub(crate) fn output_ids_to_u32(ids: &[i32]) -> Result<Vec<u32>, DynamoError> {
     ids.iter()
         .map(|id| {
@@ -550,7 +557,7 @@ mod tests {
 
     use super::{
         build_generate_request, disaggregated_params_to_json, engine_data_from_meta,
-        extract_logprobs, terminal_from_meta,
+        extract_logprobs, new_output_ids, terminal_from_meta,
     };
 
     fn request() -> PreprocessedRequest {
@@ -641,6 +648,34 @@ mod tests {
         .unwrap();
 
         assert_eq!(decode.disaggregated_params, Some(handoff));
+    }
+
+    #[test]
+    fn new_output_ids_slices_the_cumulative_stream() {
+        // SGLang re-sends the whole sequence each chunk; only the tail is new.
+        assert_eq!(new_output_ids(&[1, 2, 3], 0), &[1, 2, 3]);
+        assert_eq!(new_output_ids(&[1, 2, 3], 2), &[3]);
+        assert_eq!(new_output_ids(&[1, 2, 3], 3), &[] as &[i32]);
+        // A chunk that did not grow (or an over-large offset) yields nothing.
+        assert_eq!(new_output_ids(&[1, 2, 3], 5), &[] as &[i32]);
+    }
+
+    #[test]
+    fn cumulative_offset_never_rewinds_on_regression() {
+        // Mirror the engine loop: emit the new tail, then advance the offset
+        // monotonically (token_offset.max(len)) so a regressive chunk can't cause
+        // re-emission when the sequence later grows again.
+        let mut offset = 0usize;
+        let mut step = |ids: &[i32]| -> Vec<i32> {
+            let new = new_output_ids(ids, offset).to_vec();
+            offset = offset.max(ids.len());
+            new
+        };
+        assert_eq!(step(&[1, 2, 3]), vec![1, 2, 3]);
+        // Regressive chunk: emits nothing and leaves the offset at 3.
+        assert_eq!(step(&[1, 2]), Vec::<i32>::new());
+        // Growth resumes: only the genuinely-new tail is emitted, not 1..3 again.
+        assert_eq!(step(&[1, 2, 3, 4]), vec![4]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Backport of #12249 to `release/1.4.0`.

Cherry-picked from `main` commit `677f92cc38` with `git cherry-pick -x` (source SHA recorded in the commit message). No changes beyond the cherry-pick.

## Validation

- Cherry-picked cleanly onto `release/1.4.0` with no conflicts.
- Original PR #12249 was CI-validated on `main` prior to merge.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12605" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->