### PR TITLE
fix(docs): remove duplicate unscoped community-rail CSS rules

### DIFF
--- a/docs/fern/components/LandingStyles.tsx
+++ b/docs/fern/components/LandingStyles.tsx
@@ -2138,34 +2138,6 @@ article:has(.dynamo-community-page) { margin-bottom: 0; }
   text-transform: uppercase;
 }
 
-.dynamo-welcome__community {
-    position: static;
-    width: min(100%, 720px);
-    margin: 2rem auto 0;
-    flex-direction: row;
-  }
-
-.dynamo-welcome__notification {
-    flex: 1;
-    min-width: 0;
-  }
-
-.dynamo-welcome__community {
-    width: min(100%, 350px);
-    flex-direction: column;
-  }
-
-.dynamo-welcome__notification {
-    width: 100%;
-  }
-
-.dynamo-welcome__notification,
-  .dynamo-story__step,
-  .dynamo-story__step-copy,
-  .dynamo-story__stage-panel {
-    transition: none;
-  }
-
 @media (max-width: 1360px) {
 
   .dynamo-welcome__community {


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

the mobile-only rule bodies appear twice: once unguarded at the top level, once correctly wrapped in their @media blocks. CSS cascade order lets the unguarded copy win everywhere. 

```
// line 2002
.dynamo-welcome__community {
  position: absolute;
  top: -20rem;
  right: calc((100vw - 1200px) / -2 + 1rem);
  z-index: 30;
  display: flex;
  width: 242px;
  flex-direction: column;
  gap: 0.55rem;
}

....

// line 2141
.dynamo-welcome__community {
    position: static;
    width: min(100%, 720px);
    margin: 2rem auto 0;
    flex-direction: row;
  }
....  
  
```

In result,  desktop browsers (>1360px) get the narrow-screen sidebar layout instead of the floating rail, and hover/scroll animations are disabled for all users, not just prefers-reduced-motion users. 

The solution is to delete the stray unguarded duplicate, keep only the properly @media-scoped versions.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12615" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed duplicate responsive and reduced-motion styling for the community notification rail.
  * Preserved its responsive layout and transition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->