### PR TITLE
WIP: fix(runtime): honor DYN_EVENT_PLANE=zmq for @dynamo_worker / planner

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1098,6 +1098,15 @@ impl DistributedRuntime {
         };
         let request_plane: RequestPlaneMode = request_plane.parse().map_err(to_pyerr)?;
         let explicit_event_plane = event_plane.as_deref().filter(|value| !value.is_empty());
+        // Treat DYN_EVENT_PLANE the same as an explicit constructor kwarg: when the
+        // caller opts into ZMQ (or NATS) via env, ambient NATS_SERVER must not force
+        // a NATS client. Frontend/worker paths already pass event_plane=; planner and
+        // other @dynamo_worker components historically only set the env var.
+        let env_event_plane_set =
+            std::env::var(config::environment_names::event_plane::DYN_EVENT_PLANE)
+                .ok()
+                .filter(|value| !value.is_empty())
+                .is_some();
         let event_transport_kind =
             resolve_event_transport_kind(&discovery_backend_config, event_plane.as_deref())?;
 
@@ -1127,6 +1136,7 @@ impl DistributedRuntime {
                 dynamo_runtime::discovery::EventTransportKind::Nats
             )
             || (explicit_event_plane.is_none()
+                && !env_event_plane_set
                 && std::env::var(config::environment_names::nats::NATS_SERVER).is_ok());
 
         let runtime_config = DistributedConfig {

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1013,6 +1013,15 @@ impl DistributedRuntime {
         };
         let request_plane: RequestPlaneMode = request_plane.parse().map_err(to_pyerr)?;
         let explicit_event_plane = event_plane.as_deref().filter(|value| !value.is_empty());
+        // Treat DYN_EVENT_PLANE the same as an explicit constructor kwarg: when the
+        // caller opts into ZMQ (or NATS) via env, ambient NATS_SERVER must not force
+        // a NATS client. Frontend/worker paths already pass event_plane=; planner and
+        // other @dynamo_worker components historically only set the env var.
+        let env_event_plane_set =
+            std::env::var(config::environment_names::event_plane::DYN_EVENT_PLANE)
+                .ok()
+                .filter(|value| !value.is_empty())
+                .is_some();
         let event_transport_kind =
             resolve_event_transport_kind(&discovery_backend_config, event_plane.as_deref())?;
 
@@ -1050,6 +1059,7 @@ impl DistributedRuntime {
                 dynamo_runtime::discovery::EventTransportKind::Nats
             )
             || (explicit_event_plane.is_none()
+                && !env_event_plane_set
                 && std::env::var(config::environment_names::nats::NATS_SERVER).is_ok());
 
         let runtime_config = DistributedConfig {

--- a/lib/bindings/python/src/dynamo/runtime/__init__.py
+++ b/lib/bindings/python/src/dynamo/runtime/__init__.py
@@ -42,7 +42,15 @@ def dynamo_worker(enable_nats: Optional[bool] = None):
             loop = asyncio.get_running_loop()
             request_plane = os.environ.get("DYN_REQUEST_PLANE", "tcp")
             discovery_backend = os.environ.get("DYN_DISCOVERY_BACKEND", "etcd")
-            runtime = DistributedRuntime(loop, discovery_backend, request_plane)
+            # Match frontend/worker create_runtime: pass DYN_EVENT_PLANE through so
+            # DYN_EVENT_PLANE=zmq does not connect to an ambient NATS_SERVER.
+            event_plane = os.environ.get("DYN_EVENT_PLANE") or None
+            runtime = DistributedRuntime(
+                loop,
+                discovery_backend,
+                request_plane,
+                event_plane=event_plane,
+            )
 
             await func(runtime, *args, **kwargs)
 

--- a/lib/bindings/python/tests/test_deprecated_enable_nats.py
+++ b/lib/bindings/python/tests/test_deprecated_enable_nats.py
@@ -123,6 +123,28 @@ def test_event_plane_zmq_ignores_ambient_nats(monkeypatch):
 
 
 @pytest.mark.forked
+def test_event_plane_env_zmq_ignores_ambient_nats(monkeypatch):
+    """DYN_EVENT_PLANE=zmq should skip ambient NATS even without event_plane kwarg.
+
+    Planner and other @dynamo_worker components historically only set the env var;
+    frontend/worker paths pass event_plane= explicitly. Both must avoid connecting
+    to Operator-injected NATS_SERVER when ZMQ is selected.
+    """
+
+    async def _run():
+        monkeypatch.setenv("NATS_SERVER", "nats://127.0.0.1:9")
+        monkeypatch.setenv("DYN_EVENT_PLANE", "zmq")
+        runtime = DistributedRuntime(
+            asyncio.get_running_loop(),
+            "file",
+            "tcp",
+        )
+        runtime.shutdown()
+
+    asyncio.run(_run())
+
+
+@pytest.mark.forked
 def test_invalid_event_plane_errors():
     async def _run():
         with pytest.raises(ValueError, match="Invalid event_plane value"):
@@ -197,6 +219,27 @@ def test_dynamo_worker_returns_working_decorator():
             pass
 
     assert inspect.iscoroutinefunction(_sample_worker)
+
+
+@patch("dynamo.runtime.DistributedRuntime")
+def test_dynamo_worker_passes_event_plane_from_env(mock_runtime_cls, monkeypatch):
+    """@dynamo_worker should forward DYN_EVENT_PLANE like frontend/worker create_runtime."""
+    mock_runtime_cls.return_value = MagicMock()
+    monkeypatch.setenv("DYN_DISCOVERY_BACKEND", "file")
+    monkeypatch.setenv("DYN_REQUEST_PLANE", "tcp")
+    monkeypatch.setenv("DYN_EVENT_PLANE", "zmq")
+
+    @dynamo_worker()
+    async def _sample_worker(runtime, *args, **kwargs):
+        return runtime
+
+    async def _run():
+        await _sample_worker()
+
+    asyncio.run(_run())
+    mock_runtime_cls.assert_called_once()
+    _, kwargs = mock_runtime_cls.call_args
+    assert kwargs.get("event_plane") == "zmq"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `@dynamo_worker` (used by Planner and other components) now forwards `DYN_EVENT_PLANE` into `DistributedRuntime`, matching frontend/worker `create_runtime` behavior.
- Python bindings treat a set `DYN_EVENT_PLANE` env var as an explicit event-plane selection, so `DYN_EVENT_PLANE=zmq` no longer forces a NATS client when Operator injects ambient `NATS_SERVER`.
- Adds regression coverage for env-based ZMQ selection and `dynamo_worker` forwarding.

## Problem
With Operator-injected `NATS_SERVER` and `DYN_EVENT_PLANE=zmq`, Planner still crashed on startup:

```
Failed to connect to NATS: IO error: Connection refused
```

Workers/frontend were fine because they pass `event_plane=` explicitly; Planner only set the env var via `@dynamo_worker()`.

## Test plan
- [ ] `pytest lib/bindings/python/tests/test_deprecated_enable_nats.py -k 'event_plane or dynamo_worker_passes'`
- [ ] Deploy Planner with `DYN_EVENT_PLANE=zmq` and Operator-injected `NATS_SERVER` pointing at an unreachable address; confirm Planner starts without NATS connect errors
- [ ] Confirm `DYN_EVENT_PLANE=nats` (or unset + `NATS_SERVER`) still enables NATS as before


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12629" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based event-plane configuration through `DYN_EVENT_PLANE`.
  * Explicit event-plane selections now take precedence over automatic NATS detection.
  * Worker startup consistently forwards the configured event-plane setting.

* **Bug Fixes**
  * Prevented unintended NATS connections when ZMQ is selected, including when configured solely through the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->