### PR TITLE
docs(router): update topology-aware KV transfer guidance [DYN-3848]

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/multinode/topology-aware-kv-transfer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/multinode/topology-aware-kv-transfer.md
@@ -1,11 +1,11 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Topology-Aware KV Transfer
 subtitle: Keep disaggregated prefill and decode KV-cache transfers within a selected topology domain
 ---
 
-Topology-aware KV transfer lets a disaggregated Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
+**Experimental.** Topology-aware KV transfer lets a disaggregated NVIDIA Dynamo deployment route decode requests toward workers that share the selected prefill worker's topology domain, such as zone or rack. This reduces slow cross-domain KV-cache transfers when prefill and decode workers exchange KV data over NIXL.
 
 Use this feature when:
 
@@ -20,20 +20,30 @@ For RDMA/NIXL transport setup, see [Disagg Communication](../kubernetes-operator
 
 ```mermaid
 flowchart LR
-    DGD["DGD spec.experimental.kvTransferPolicy"] --> Operator["Operator injects worker env + Downward API volume"]
-    Node["Node label"] --> Controller["Topology label controller"]
+    DGD["DGD spec.experimental.kvTransferPolicy"] --> Operator["Operator configures workers"]
+    Operator --> Source{"Topology source"}
+    Source --> Label["labelKey"]
+    Source --> Grove["clusterTopologyName"]
+    Label --> Controller["Topology label controller"]
+    Grove --> Controller
+    Node["Node topology labels"] --> Controller
     Controller --> Pod["Worker pod label"]
-    Pod --> Volume["/etc/dynamo/topology/<domain>"]
+    Pod --> Volume["/etc/dynamo/topology/<domain> files"]
     Volume --> Runtime["Worker publishes ModelRuntimeConfig topology metadata"]
     Runtime --> Prefill["Prefill router derives decode constraints"]
     Prefill --> Decode["Decode router selects same or preferred topology"]
 ```
 
-The operator configures worker pods from `spec.experimental.kvTransferPolicy`:
+Set exactly one topology source in `spec.experimental.kvTransferPolicy`:
 
-- Adds a `nvidia.com/topology-label-key` annotation to worker pods.
-- Runs a topology-label controller that copies the configured node label onto the worker pod after scheduling.
-- Projects that pod label into `/etc/dynamo/topology/<domain>` with a Downward API volume.
+- `labelKey` copies one Kubernetes node label onto the worker pod under the same key.
+- `clusterTopologyName` uses the domain-to-node-label mappings from a Grove topology resource. The controller copies every topology level onto the worker pod under `nvidia.com/dynamo-topology.<domain>` labels.
+
+For either source, the operator:
+
+- Annotates worker pods with the selected topology source.
+- Runs a topology-label controller that copies node topology values onto the worker pod after scheduling.
+- Projects the copied pod labels into `/etc/dynamo/topology/<domain>` files with a Downward API volume.
 - Injects worker environment variables that tell the backend runtime which topology domain and enforcement policy to publish.
 
 The frontend does not read this policy from its own environment. Workers publish the topology metadata in their `ModelRuntimeConfig`; the router reads it from runtime discovery.
@@ -44,7 +54,9 @@ The frontend does not read this policy from its own environment. Workers publish
 |-------------|---------|
 | Disaggregated serving | Separate prefill and decode worker services. |
 | KV router | The frontend should use `DYN_ROUTER_MODE=kv`. |
-| Node topology labels | Every node that can host a worker must carry the configured `labelKey`. |
+| Topology source | Set exactly one of `labelKey` or `clusterTopologyName`. |
+| Node topology labels | Every worker node must carry the configured `labelKey`, or every source label defined by the Grove topology resource. |
+| Grove pathway | Required only for `clusterTopologyName`. Install and enable Grove, and do not set `nvidia.com/enable-grove: "false"` on the DGD. See [Grove](grove.md). |
 | Dynamo operator | The operator must include topology-label controller and node-read RBAC. |
 | KV transfer transport | RDMA, EFA, or another NIXL-compatible transport should already be configured for production disaggregated deployments. |
 
@@ -119,6 +131,21 @@ spec:
 
 > [!IMPORTANT]
 > `required` is a decode-routing constraint, not a capacity planner. The `DynamoGraphDeployment` author or cluster administrator must ensure that every topology domain that can receive prefill workers also has sufficient same-domain decode capacity. If a domain has prefill workers but no matching decode workers, or too little decode capacity, the router cannot spill to another domain without violating the policy.
+
+### Use a Grove Topology Source
+
+To use topology levels defined by Grove, set `clusterTopologyName` instead of `labelKey`. The selected `domain` must exist in the referenced topology resource.
+
+```yaml
+spec:
+  experimental:
+    kvTransferPolicy:
+      clusterTopologyName: my-cluster-topology
+      domain: rack
+      enforcement: required
+```
+
+This path requires Grove to be enabled in the operator and for the DGD. The operator projects every topology level from the referenced resource, while the router uses only the selected `domain` for the KV-transfer constraint.
 
 ### Capacity Planning Across Domains
 
@@ -259,10 +286,14 @@ spec:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `labelKey` | Yes | Kubernetes node label key to copy onto worker pods, for example `topology.kubernetes.io/zone`. |
-| `domain` | Yes | Logical topology domain name published by workers, for example `zone` or `rack`. Must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`. |
+| `labelKey` | One topology source | Kubernetes node label key to copy onto worker pods, for example `topology.kubernetes.io/zone`. Mutually exclusive with `clusterTopologyName`. |
+| `clusterTopologyName` | One topology source | Name of a Grove topology resource. Requires the Grove pathway and is mutually exclusive with `labelKey`. |
+| `domain` | Yes | Logical topology domain published by workers, for example `zone` or `rack`. Must match `^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`; with `clusterTopologyName`, it must name a level in the referenced resource. |
 | `enforcement` | No | `required` or `preferred`. Defaults to `required`. |
 | `preferredWeight` | Only with `preferred` | Bias weight from `0` to `1`; only valid with `enforcement: preferred`. |
+
+> [!IMPORTANT]
+> `kvTransferPolicy` is immutable after the DGD is created. To add, remove, or change the policy, delete and recreate the DGD.
 
 The runtime uses `domain`, not the Kubernetes label key, when creating routing constraints. For example, `labelKey: topology.kubernetes.io/zone` and `domain: zone` produce worker topology metadata like:
 
@@ -278,27 +309,45 @@ The runtime uses `domain`, not the Kubernetes label key, when creating routing c
 
 ## Verify the Deployment
 
-After the DGD creates worker pods, verify the operator pipeline from node label to runtime topology file.
+After the DGD creates worker pods, verify the operator pipeline from the selected topology source to the runtime topology files.
 
 ```bash
 export NAMESPACE=<namespace>
 export POD=<worker-pod>
+```
 
+For a `labelKey` source, verify the source annotation and copied label:
+
+```bash
 kubectl get pod "$POD" -n "$NAMESPACE" \
   -o jsonpath='{.metadata.annotations.nvidia\.com/topology-label-key}{"\n"}'
 
 kubectl get pod "$POD" -n "$NAMESPACE" \
   -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
+```
 
+For a `clusterTopologyName` source, verify the source annotation and the canonical label for the selected domain:
+
+```bash
+kubectl get pod "$POD" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.annotations.nvidia\.com/topology-cluster-topology-name}{"\n"}'
+
+kubectl get pod "$POD" -n "$NAMESPACE" \
+  -o jsonpath='{.metadata.labels.nvidia\.com/dynamo-topology\.rack}{"\n"}'
+```
+
+For either source, inspect the projected topology files:
+
+```bash
 kubectl exec "$POD" -n "$NAMESPACE" -- \
   sh -c 'find /etc/dynamo/topology -maxdepth 1 -type f -print -exec cat {} \;'
 ```
 
 Expected results:
 
-- The annotation value is the configured `labelKey`.
-- The worker pod has the copied topology label.
-- `/etc/dynamo/topology/<domain>` exists and contains the topology value.
+- The source annotation contains the configured `labelKey` or `clusterTopologyName`.
+- The worker pod has the copied topology label or canonical Grove topology labels.
+- `/etc/dynamo/topology/<domain>` exists for the selected domain and contains the topology value. The Grove path also projects files for the other topology levels.
 
 Worker logs should include topology config during startup:
 
@@ -310,12 +359,14 @@ kubectl logs "$POD" -n "$NAMESPACE" | grep -i "Topology config"
 
 ### Pod Has No Copied Topology Label
 
-Check whether the node has the configured label:
+For a `labelKey` source, check whether the node has the configured label:
 
 ```bash
 NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
 kubectl get node "$NODE" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
 ```
+
+For a `clusterTopologyName` source, verify that the referenced Grove topology resource exists, contains the selected `domain`, and maps each domain to a label present on the node. Also verify that the DGD does not set `nvidia.com/enable-grove: "false"`.
 
 If the label is missing, the topology-label controller emits a warning event with reason `TopologyLabelMissing` and leaves topology metadata unavailable for that worker.
 
@@ -329,8 +380,8 @@ kubectl get events -n "$NAMESPACE" \
 When topology is enabled, the worker waits for the transfer-domain file to appear and contain data. If it stays empty, check:
 
 - `spec.experimental.kvTransferPolicy.domain` matches the projected file name.
-- `spec.experimental.kvTransferPolicy.labelKey` exists on the worker's node.
-- The worker pod has the `nvidia.com/topology-label-key` annotation.
+- The configured `labelKey`, or the source label for the selected Grove topology domain, exists on the worker's node.
+- The worker pod has the source annotation for `labelKey` or `clusterTopologyName`.
 - The topology-label controller is running and has node `get` RBAC.
 
 ### Required Policy Fails Requests

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/multinode/topology-aware-kv-transfer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/multinode/topology-aware-kv-transfer.md
@@ -319,21 +319,26 @@ export POD=<worker-pod>
 For a `labelKey` source, verify the source annotation and copied label:
 
 ```bash
+export LABEL_KEY=<label-key>
+
 kubectl get pod "$POD" -n "$NAMESPACE" \
   -o jsonpath='{.metadata.annotations.nvidia\.com/topology-label-key}{"\n"}'
 
 kubectl get pod "$POD" -n "$NAMESPACE" \
-  -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
+  -o go-template='{{ index .metadata.labels "'"$LABEL_KEY"'" }}{{ "\n" }}'
 ```
 
 For a `clusterTopologyName` source, verify the source annotation and the canonical label for the selected domain:
 
 ```bash
+export DOMAIN=<domain>
+TOPOLOGY_LABEL="nvidia.com/dynamo-topology.$DOMAIN"
+
 kubectl get pod "$POD" -n "$NAMESPACE" \
   -o jsonpath='{.metadata.annotations.nvidia\.com/topology-cluster-topology-name}{"\n"}'
 
 kubectl get pod "$POD" -n "$NAMESPACE" \
-  -o jsonpath='{.metadata.labels.nvidia\.com/dynamo-topology\.rack}{"\n"}'
+  -o go-template='{{ index .metadata.labels "'"$TOPOLOGY_LABEL"'" }}{{ "\n" }}'
 ```
 
 For either source, inspect the projected topology files:
@@ -362,8 +367,10 @@ kubectl logs "$POD" -n "$NAMESPACE" | grep -i "Topology config"
 For a `labelKey` source, check whether the node has the configured label:
 
 ```bash
+export LABEL_KEY=<label-key>
 NODE=$(kubectl get pod "$POD" -n "$NAMESPACE" -o jsonpath='{.spec.nodeName}')
-kubectl get node "$NODE" -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}{"\n"}'
+kubectl get node "$NODE" \
+  -o go-template='{{ index .metadata.labels "'"$LABEL_KEY"'" }}{{ "\n" }}'
 ```
 
 For a `clusterTopologyName` source, verify that the referenced Grove topology resource exists, contains the selected `domain`, and maps each domain to a label present on the node. Also verify that the DGD does not set `nvidia.com/enable-grove: "false"`.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
@@ -210,7 +210,7 @@ For Kimi-style TP-only MoE runs, use `--aic-moe-tp-size` equal to `--aic-tp-size
 
 ## Topology-Aware KV Transfer
 
-Topology-aware KV transfer is configured on workers through runtime metadata, not with frontend router flags. In Kubernetes, use `spec.experimental.kvTransferPolicy` on the `DynamoGraphDeployment`; the operator injects the worker environment and topology files. Outside Kubernetes, set `DYN_TOPOLOGY_ENABLED`, `DYN_TOPOLOGY_MOUNT_PATH`, `DYN_KV_TRANSFER_DOMAIN`, `DYN_KV_TRANSFER_ENFORCEMENT`, and `DYN_KV_TRANSFER_PREFERRED_WEIGHT` on workers.
+Topology-aware KV transfer is configured on workers through runtime metadata, not with frontend router flags. In Kubernetes, use `spec.experimental.kvTransferPolicy` on the `DynamoGraphDeployment`; the operator injects the worker environment and topology files. Outside Kubernetes, set `DYN_TOPOLOGY_ENABLED`, `DYN_TOPOLOGY_MOUNT_PATH`, `DYN_KV_TRANSFER_DOMAIN`, and `DYN_KV_TRANSFER_ENFORCEMENT` on workers. Set `DYN_KV_TRANSFER_PREFERRED_WEIGHT` only when enforcement is `preferred`.
 
 For the full runtime contract and routing behavior, see [Topology-Aware KV Transfer](topology-aware-kv-transfer.md).
 For Kubernetes deployment examples, see [Kubernetes Topology-Aware KV Transfer](../../kubernetes/multinode/topology-aware-kv-transfer.md).

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
@@ -90,7 +90,7 @@ Decode workers without that taint are ineligible. If no eligible decode worker e
 preferred_taints = {"dynamo.topology/zone=us-east-1a": 0.85}
 ```
 
-All decode workers remain eligible, but matching workers receive a routing-cost bias. `preferredWeight` is required, must be from `0` to `1`, and controls the strength of that bias. It is not a probability and does not guarantee same-domain selection.
+Decode workers that satisfy existing required constraints remain eligible, but matching workers receive a routing-cost bias. When enforcement is `preferred`, `preferredWeight` is required, must be from `0` to `1`, and controls the strength of that bias. It is not a probability and does not guarantee same-domain selection.
 
 ## Worker Environment Contract
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/topology-aware-kv-transfer.md
@@ -1,11 +1,11 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Topology-Aware KV Transfer
 subtitle: Runtime metadata and decode routing semantics for topology-aware prefill/decode handoff
 ---
 
-Topology-aware KV transfer constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
+**Experimental.** Topology-aware KV transfer in NVIDIA Dynamo constrains or biases decode worker selection after a prefill worker has been selected. The router derives standard `RoutingConstraints` from the selected prefill worker's published topology metadata, then merges those constraints into the decode request.
 
 Use the Kubernetes operator path when possible.
 For deployment examples, see [Kubernetes Topology-Aware KV Transfer](../../kubernetes/multinode/topology-aware-kv-transfer.md).
@@ -90,7 +90,7 @@ Decode workers without that taint are ineligible. If no eligible decode worker e
 preferred_taints = {"dynamo.topology/zone=us-east-1a": 0.85}
 ```
 
-All decode workers remain eligible, but matching workers receive a lower routing cost. `preferredWeight` controls the strength of the preference from `0` to `1`.
+All decode workers remain eligible, but matching workers receive a routing-cost bias. `preferredWeight` is required, must be from `0` to `1`, and controls the strength of that bias. It is not a probability and does not guarantee same-domain selection.
 
 ## Worker Environment Contract
 
@@ -102,7 +102,7 @@ The Python backend utility reads topology from files and transfer policy from en
 | `DYN_TOPOLOGY_MOUNT_PATH` | Directory containing topology files. Defaults to `/etc/dynamo/topology`. |
 | `DYN_KV_TRANSFER_DOMAIN` | Required when topology is enabled. Names the topology file and runtime domain to use for KV transfer constraints. |
 | `DYN_KV_TRANSFER_ENFORCEMENT` | `required` or `preferred`. Defaults to `required` when a domain is set. |
-| `DYN_KV_TRANSFER_PREFERRED_WEIGHT` | Weight used when enforcement is `preferred`. |
+| `DYN_KV_TRANSFER_PREFERRED_WEIGHT` | Required when enforcement is `preferred`; must be from `0` to `1`. |
 
 Each non-hidden, non-empty file under `DYN_TOPOLOGY_MOUNT_PATH` is interpreted as one topology domain. The file name is the domain; the file content is the worker's value for that domain.
 
@@ -118,7 +118,7 @@ export DYN_KV_TRANSFER_DOMAIN=zone
 export DYN_KV_TRANSFER_ENFORCEMENT=required
 ```
 
-When topology is enabled, the worker polls until the selected transfer-domain file exists and has content. If it remains missing or empty through the timeout window, the worker exits so the bad topology source is visible during startup.
+When topology is enabled, the worker polls once per second for up to 30 seconds until the selected transfer-domain file exists and has content. If it remains missing or empty, the worker exits so the bad topology source is visible during startup.
 
 ## Backend Support
 
@@ -127,6 +127,7 @@ The integrated Python backends apply the topology config during worker registrat
 - vLLM
 - SGLang
 - TensorRT-LLM
+- Mocker, for simulation and tests
 
 The topology utility writes the fields onto `ModelRuntimeConfig`; Rust owns validation and canonical topology-taint generation.
 


### PR DESCRIPTION
## Summary

- document both direct `labelKey` and Grove `clusterTopologyName` topology sources for KV transfer
- clarify the experimental runtime contract, preferred-routing weight semantics, startup timeout, and Mocker support
- document policy immutability plus source-specific verification and troubleshooting steps

## Validation

- `fern check`
- `fern docs broken-links`
- pre-commit hooks for all three changed Markdown files
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Kubernetes topology-aware KV transfer guidance, including Grove configuration, prerequisites, verification steps, constraints, and troubleshooting.
  * Clarified that topology sources are mutually exclusive and documented immutability requirements.
  * Updated routing configuration guidance for preferred enforcement and valid weight ranges.
  * Marked topology-aware KV transfer as experimental and documented polling behavior and Mocker backend support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->