### PR TITLE
docs(router): refresh router behavior and examples [DYN-3848]

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -179,7 +179,7 @@ class KvRouterArgGroup(ArgGroup):
             help=(
                 "KV Router: Credit multiplier for device-local prefix overlap. "
                 "Must be finite and non-negative; values above 1.0 give device "
-                "overlap extra credit and can make the adjusted prefill cost negative."
+                "overlap extra credit, with adjusted prefill cost clamped at zero."
             ),
             arg_type=float,
             dest="overlap_score_credit",
@@ -314,8 +314,9 @@ class KvRouterArgGroup(ArgGroup):
             dest="router_track_output_blocks",
             help=(
                 "KV Router: Track output blocks during generation. When enabled, the router adds "
-                "placeholder blocks as tokens are generated and applies fractional decay based on "
-                "progress toward expected output sequence length."
+                "placeholder blocks as tokens are generated. With expected output sequence length, "
+                "fractional decay applies to output blocks and the structurally exclusive prompt "
+                "suffix; shared prompt blocks retain full weight."
             ),
             obsolete_flag="--track-output-blocks",
         )

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -207,10 +207,12 @@ The default pool selection uses a 2D grid lookup. Each dimension is divided into
 
 **Decode Pool Selection** (disagg mode, based on request token count and ITL target):
 
-The handler currently passes `len(request["token_ids"])` into the strategy's
-`context_length` dimension. It does not add subsequently generated tokens. The
-bucket calculation otherwise uses `context_length_*` and `itl_target` with
-`decode_pool_mapping`.
+Valid `PreprocessedRequest` payloads require `token_ids`. The handler passes the
+length of that list into the strategy's `context_length` dimension and does not
+add subsequently generated tokens. Its `request.get("token_ids", [])` fallback
+only protects malformed direct calls; a missing field routes those calls with a
+request token count of `0`. The bucket calculation otherwise uses
+`context_length_*` and `itl_target` with `decode_pool_mapping`.
 
 **Agg Pool Selection** (agg mode, based on TTFT and ITL targets, with optional ISL):
 

--- a/components/src/dynamo/global_router/README.md
+++ b/components/src/dynamo/global_router/README.md
@@ -11,7 +11,7 @@ A hierarchical routing service that sits between the Dynamo frontend and local r
 
 The Global Router supports two modes:
 
-- **Disagg mode** (default): Registers as both prefill and decode worker. Routes prefill requests based on (ISL, TTFT) and decode requests based on (context_length, ITL) to separate pool types.
+- **Disagg mode** (default): Registers as both prefill and decode worker. Routes prefill requests based on (ISL, TTFT) and decode requests based on (request token count, ITL) to separate pool types. The decode strategy retains the `context_length_*` configuration names.
 - **Agg mode**: Registers as a single generate worker. Routes all requests by (TTFT target, ITL target), with an optional ISL dimension, to unified pools that handle both prefill and decode.
 
 Both modes support priority-based pool overrides from agent hints and optional priority retry to faster pools.
@@ -22,8 +22,8 @@ Both modes support priority-based pool overrides from agent hints and optional p
 - **Mocker** - Uses same synchronous path as vLLM
 - **SGLang** - Uses the bootstrap path (async KV transfer)
 
-**Not supported:**
-- **TensorRT-LLM** - Bootstrap path not implemented
+**Not currently supported or validated:**
+- **TensorRT-LLM** - The core frontend supports a non-bootstrap handoff path, but Global Router has no dedicated TensorRT-LLM end-to-end integration.
 
 ## Architecture
 
@@ -205,9 +205,12 @@ The default pool selection uses a 2D grid lookup. Each dimension is divided into
    - `ttft_idx = clamp((ttft_target_ms - ttft_min_ms) / ttft_step_ms, 0, ttft_resolution - 1)`
 4. Lookup pool: `pool_index = prefill_pool_mapping[isl_idx][ttft_idx]`
 
-**Decode Pool Selection** (disagg mode, based on context length and ITL target):
+**Decode Pool Selection** (disagg mode, based on request token count and ITL target):
 
-Same logic but using `context_length` and `itl_target` with `decode_pool_mapping`.
+The handler currently passes `len(request["token_ids"])` into the strategy's
+`context_length` dimension. It does not add subsequently generated tokens. The
+bucket calculation otherwise uses `context_length_*` and `itl_target` with
+`decode_pool_mapping`.
 
 **Agg Pool Selection** (agg mode, based on TTFT and ITL targets, with optional ISL):
 
@@ -291,7 +294,7 @@ The preprocessor forwards `nvext.router` to the backend as the typed `router` fi
 5. Local router forwards to a prefill worker
 6. Prefill response returns with `disaggregated_params`
 7. Frontend sends decode request to Global Router (registered as decode)
-8. Global Router selects decode pool based on (context_length, ITL_target, priority)
+8. Global Router selects decode pool based on (request token count, ITL_target, priority)
 9. Request is forwarded to local router in the selected decode pool namespace
 10. If forwarding fails before streaming tokens and priority retry is enabled, Global Router retries faster decode pools
 11. Tokens stream back through the chain

--- a/components/src/dynamo/global_router/handler.py
+++ b/components/src/dynamo/global_router/handler.py
@@ -6,7 +6,7 @@ Global Router Handler for hierarchical routing to worker pools.
 
 Supports two modes:
 - "disagg": Routes prefill and decode requests to separate pool types
-  based on (ISL, TTFT) and (context_length, ITL) respectively.
+  based on (ISL, TTFT) and (request token count, ITL) respectively.
 - "agg": Routes generate requests to unified pools that handle both
   prefill and decode, based on (TTFT, ITL) or optionally (ISL, TTFT, ITL).
 
@@ -269,17 +269,16 @@ class GlobalRouterHandler:
         """
         Handle decode requests from the frontend (disagg mode).
 
-        Selects the appropriate decode pool based on context length, ITL target,
+        Selects the appropriate decode pool based on request token count, ITL target,
         and optional priority, then forwards the request to the local
         router in that pool.
         """
         assert self.config.decode_pool_selection_strategy is not None
         assert self.config.decode_pool_dynamo_namespaces is not None
 
-        # Extract context length (input tokens + any previously generated)
+        # The strategy field retains the context_length name, but decode routing
+        # currently sees the request token IDs before generation begins.
         token_ids = request.get("token_ids", [])
-        # context_length should be averaged ISL + OSL // 2
-        # TODO: predict OSL based on ISL
         context_length = len(token_ids)
 
         router_params = request.get("router") or {}

--- a/components/src/dynamo/global_router/pool_selection.py
+++ b/components/src/dynamo/global_router/pool_selection.py
@@ -7,8 +7,8 @@ Configuration loading and pool selection logic for the Global Router.
 Supports two modes:
 - "disagg" (default): Separate prefill and decode pools with independent
   grid-based selection strategies mapping (ISL, TTFT) -> prefill pool
-  and (context_length, ITL) -> decode pool.
-- "agg": Unified pools handling both prefill and decode (chunked prefill),
+  and (request token count, ITL) -> decode pool.
+- "agg": Unified pools handling both prefill and decode,
   with grid-based selection mapping (TTFT, ITL) -> agg pool, optionally
   extended to (ISL, TTFT, ITL) -> agg pool.
 
@@ -198,7 +198,7 @@ class PrefillPoolSelectionStrategy:
 
 @dataclass
 class DecodePoolSelectionStrategy:
-    """Strategy for selecting decode pools based on context length and ITL target."""
+    """Strategy for selecting decode pools based on a token-count bucket and ITL target."""
 
     itl_min_ms: float
     itl_max_ms: float
@@ -231,7 +231,7 @@ class DecodePoolSelectionStrategy:
         Select decode pool based on context length, ITL target, and optional priority.
 
         Args:
-            context_length: Total context length (prompt + generated tokens so far)
+            context_length: Request token count supplied by the global router
             itl_target_ms: Target inter-token latency in ms. If None, uses middle of range.
             priority: Request priority from agent hints. If set and a priority
                 override rule matches, the override takes precedence over the grid.

--- a/docs/fern/pages/cli/kv-aware-routing/overview.mdx
+++ b/docs/fern/pages/cli/kv-aware-routing/overview.mdx
@@ -50,7 +50,7 @@ The vLLM and SGLang presets start two workers and require 2 GPUs. The TensorRT-L
 
 ## Disaggregated serving with KV routing
 
-The vLLM and SGLang presets start 2 prefill and 2 decode workers and require 4 GPUs. The TensorRT-LLM preset starts 1 prefill and 1 decode worker and requires 2 GPUs. The frontend runs in KV routing mode and automatically detects the typed prefill service to activate an internal prefill router.
+The vLLM and SGLang presets start 2 prefill and 2 decode workers and require 4 GPUs. The TensorRT-LLM preset starts 1 prefill and 1 decode worker and requires 2 GPUs. The frontend runs in KV routing mode and activates its internal prefill router after discovering compatible typed prefill and decode services for the same model and namespace.
 
 <Tabs>
   <Tab title="vLLM" language="vllm">

--- a/docs/fern/pages/cli/kv-aware-routing/overview.mdx
+++ b/docs/fern/pages/cli/kv-aware-routing/overview.mdx
@@ -17,11 +17,11 @@ A KV-routed deployment is still just a frontend plus workers (see the [Overview]
 - The **frontend** runs in KV routing mode so it tracks cache state across workers.
 - Each **worker** publishes KV cache events (over ZMQ by default) so the frontend knows what each worker holds.
 
-You run **two or more workers** so the router has somewhere to choose between. The pre-built `launch/agg_router.sh` presets wire this up for you.
+Use **two or more workers** when you want to evaluate worker selection. The vLLM and SGLang `launch/agg_router.sh` presets wire up two workers; the TensorRT-LLM preset is a one-worker router-path smoke setup.
 
 ## Aggregated serving with KV routing
 
-Two workers behind the KV-aware router, maximizing cache reuse. Requires 2 GPUs.
+The vLLM and SGLang presets start two workers and require 2 GPUs. The TensorRT-LLM preset starts one worker and requires 1 GPU; use it to verify the router path, then add workers when you need worker selection.
 
 <Tabs>
   <Tab title="vLLM" language="vllm">
@@ -50,7 +50,7 @@ Two workers behind the KV-aware router, maximizing cache reuse. Requires 2 GPUs.
 
 ## Disaggregated serving with KV routing
 
-Scales to 2 prefill + 2 decode workers with KV-aware routing on both pools. The frontend runs in KV routing mode and automatically detects prefill workers to activate an internal prefill router. Requires 4 GPUs.
+The vLLM and SGLang presets start 2 prefill and 2 decode workers and require 4 GPUs. The TensorRT-LLM preset starts 1 prefill and 1 decode worker and requires 2 GPUs. The frontend runs in KV routing mode and automatically detects the typed prefill service to activate an internal prefill router.
 
 <Tabs>
   <Tab title="vLLM" language="vllm">

--- a/docs/fern/pages/cli/kv-aware-routing/standalone-router.md
+++ b/docs/fern/pages/cli/kv-aware-routing/standalone-router.md
@@ -52,44 +52,65 @@ The standalone router exposes three Dynamo runtime endpoints:
 
 Clients can use `generate` when the router should forward the request, `best_worker_id` when an external scheduler wants to make the final call itself, or `get_overlap_scores` when the scheduler needs the raw tiered overlap signal.
 
-## Manual prefill routing example
+## Runtime client example
 
-> [!NOTE]
-> This is an advanced alternative setup. For most disaggregated serving deployments, use the frontend's automatic prefill routing, which activates when workers register with `WorkerType.Prefill`. See [Disaggregated Serving](../../developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md).
-
-Use a standalone router when you need explicit control over prefill routing configuration or want to manage prefill and decode routers separately.
+This example places the standalone service in front of aggregated workers. Start
+the router against the workers' registered endpoint:
 
 ```bash
-# Start frontend routing for decode workers.
-python -m dynamo.frontend \
-  --router-mode kv \
-  --http-port 8000 \
-  --router-kv-overlap-score-credit 0
-
-# Start standalone routing for prefill workers.
 python -m dynamo.router \
-  --endpoint dynamo.prefill.generate \
-  --router-block-size 64 \
-  --no-router-track-active-blocks
-
-# Start decode workers.
-python -m dynamo.vllm \
-  --model MODEL_NAME \
-  --block-size 64 \
-  --disaggregation-mode decode \
-  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
-
-# Start prefill workers.
-python -m dynamo.vllm \
-  --model MODEL_NAME \
-  --block-size 64 \
-  --disaggregation-mode prefill \
-  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
+  --endpoint dynamo.backend.generate \
+  --router-block-size 64
 ```
 
-For an integrated frontend disaggregated example, see [`examples/backends/vllm/launch/disagg_router.sh`](https://github.com/ai-dynamo/dynamo/blob/main/examples/backends/vllm/launch/disagg_router.sh). For explicit multi-router composition, see the [Global Router README](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/global_router/README.md).
+Start two workers with matching block sizes and unique KV event endpoints. For
+example, use the worker commands from [Router Examples](../../developer-guide/knowledge-base/modular-components/router/router-examples.md#setup).
 
-For event-driven prefix-cache state, add the backend-specific KV event publishing flags to the workers that the router indexes. Use `--no-router-kv-events` on the router only when approximate cache-state prediction is acceptable.
+The standalone service is not an HTTP server. Call its Runtime `generate`
+endpoint from a Dynamo client:
+
+```python
+import asyncio
+
+import uvloop
+
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+
+
+@dynamo_worker()
+async def main(runtime: DistributedRuntime):
+    client = await runtime.endpoint("dynamo.router.generate").client()
+    await client.wait_for_instances()
+
+    request = {
+        "model": "Qwen/Qwen3-0.6B",
+        "token_ids": [1, 2, 3, 4],
+        "stop_conditions": {"max_tokens": 20},
+        "sampling_options": {},
+        "output_options": {},
+    }
+    stream = await client.generate(request)
+    async for response in stream:
+        if response.is_error():
+            raise RuntimeError(response.comments())
+        print(response.data())
+
+
+if __name__ == "__main__":
+    uvloop.run(main())
+```
+
+For most disaggregated serving deployments, use the frontend's automatic
+prefill routing. A standalone prefill router only exposes Runtime endpoints; a
+custom client must call it, consume the returned `disaggregated_params`, and
+perform the decode handoff. Merely launching it beside `dynamo.frontend` does
+not insert it into the frontend request path. See [Disaggregated Serving](../../developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md)
+and the [Global Router README](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/global_router/README.md).
+
+For event-driven prefix-cache state, add the backend-specific KV event
+publishing flags to the workers that the router indexes. Use
+`--no-router-kv-events` on the router only when approximate cache-state
+prediction is acceptable.
 
 ## Configuration guidance
 

--- a/docs/fern/pages/cli/operations/lora-adapters.md
+++ b/docs/fern/pages/cli/operations/lora-adapters.md
@@ -330,6 +330,12 @@ LoRA (Low-Rank Adaptation) serves specialized model variants without duplicating
 
 ## KV Cache-Aware LoRA Routing
 
+> [!IMPORTANT]
+> With `DYN_LORA_ENABLED`, only KV, random, and round-robin routing are LoRA-aware.
+> Direct, power-of-two, least-loaded, and device-aware-weighted modes fail startup.
+> Session affinity with LoRA is supported only in KV mode; random and round-robin
+> plus affinity are rejected.
+
 <AccordionGroup>
   <Accordion title="How LoRA-aware KV routing works">
     When KV-aware routing is enabled, the router accounts for LoRA adapter identity when computing block hashes:

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md
@@ -86,30 +86,17 @@ The launcher configures KV events on each worker and sets `--router-mode kv` wit
 | `KV_EVENTS_PORT_BASE` | `29090` | Starting port for per-worker KV event publishers |
 | `SGLANG_EXTRA_ARGS` | unset | Additional arguments for `python -m dynamo.sglang` |
 
-### Source-Build Requirements
+### Version Requirements
 
 The Dynamo SGLang image includes both routing prerequisites:
 
 - Dynamo is built with the `mm-routing` Rust feature.
-- SGLang includes `GenerateReqInput.mm_hashes` support.
+- SGLang 0.5.13 or later includes `GenerateReqInput.mm_hashes` support. Dynamo currently pins 0.5.16.
 
-When using a custom SGLang installation, apply the `mm_hashes` change from [sgl-project/sglang#25300](https://github.com/sgl-project/sglang/pull/25300). Without it, requests still complete but fall back to text-prefix-only routing.
-
-To apply only the Python portion of the patch:
-
-```bash
-SITE_PACKAGES_ROOT="$(python3 -c 'import pathlib, sglang; print(pathlib.Path(sglang.__file__).resolve().parent.parent)')"
-cd "$SITE_PACKAGES_ROOT"
-curl -sL https://github.com/sgl-project/sglang/pull/25300.diff | python3 -c '
-import sys
-chunks = sys.stdin.read().split("diff --git ")
-filtered = [c for c in chunks if c.startswith("a/python/sglang/")]
-print("".join("diff --git " + c for c in filtered), end="")
-' > /tmp/sglang_pr25300_python_only.diff
-patch --dry-run -p2 < /tmp/sglang_pr25300_python_only.diff
-patch -p2 < /tmp/sglang_pr25300_python_only.diff
-cd -
-```
+Custom installations on SGLang 0.5.12 or earlier need the `mm_hashes` change
+from [sgl-project/sglang#25300](https://github.com/sgl-project/sglang/pull/25300).
+Without it, requests still complete but fall back to text-prefix-only routing.
+Prefer upgrading to 0.5.13 or later instead of patching an installed package.
 
 Enable `DYN_LOG=info,mm_routing=debug` to inspect image-token counts, multimodal hashes, and the selected worker's overlap. A repeated request should select the same worker with high block overlap.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/multimodal.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/multimodal.md
@@ -55,13 +55,13 @@ TensorRT-LLM multimodal KV routing uses the Rust frontend to give the router and
 
 1. The frontend computes an `mm_hash` for each image.
 2. It represents the image identity as hash-derived pad-value tokens in the routing view.
-3. The KV router selects the worker with the highest block overlap.
+3. The KV router credits that overlap in its combined prefill-and-decode cost and selects the lowest-cost eligible worker.
 4. The frontend forwards each hash as `multi_modal_uuids`.
 5. The worker associates the UUID with the matching image-token run in its KV events.
 
-For HTTP inputs, routing identity is based on the full image URL by default. Set `--frontend-decoding` to hash decoded image content when different URLs can refer to identical images.
+For HTTP inputs, routing identity is based on the exact full image URL, including the query string, by default. Set `--frontend-decoding` to hash decoded image content when different URLs can refer to identical images.
 
-Workers must enable KV event publishing and block reuse. The provided launcher configures `--publish-events-and-metrics`, `enable_block_reuse: true`, and a KV-routing frontend:
+Workers must enable KV event publishing and block reuse. The provided launcher configures `--publish-kv-events`, `enable_block_reuse: true`, and a KV-routing frontend:
 
 ```bash
 cd $DYNAMO_HOME

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/multimodal.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/multimodal.md
@@ -75,10 +75,10 @@ The default path keeps multimodal processing on the worker:
 1. The frontend computes an `mm_hash` for each image.
 2. A model-specific processor specification resolves the image placeholder and calculates its expanded token count.
 3. The frontend expands the placeholder in a routing-only token view and builds per-block multimodal metadata.
-4. The KV router selects the worker with the highest overlap.
+4. The KV router credits that overlap in its combined prefill-and-decode cost and selects the lowest-cost eligible worker.
 5. The frontend forwards `mm_hashes`, which the worker passes to vLLM as `multi_modal_uuids`.
 
-For `data:` URIs, the frontend hashes the decoded bytes. For HTTP URLs, it hashes the full URL by default. Set `--frontend-decoding` on the worker to register frontend media decoding and use decoded image content as the hash input. Content-addressed hashing lets different URLs for identical image bytes share a routing key.
+By default, the frontend hashes the exact full URI: the complete `data:` URI string or the HTTP URL including its query string. Set `--frontend-decoding` on the worker to register frontend media decoding and use decoded image content as the hash input. Content-addressed hashing lets different URLs for identical image bytes share a routing key.
 
 Launch the default path:
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md
@@ -13,7 +13,7 @@ For the routing cost model and worker-selection behavior, see
 
 ## Routing Behavior
 
-- `--router-kv-overlap-score-credit`: Device-local prefix-overlap credit multiplier in the prefill cost calculation. It must be finite and nonnegative. Values greater than `1.0` give overlap extra credit and can make adjusted prefill cost negative. When set to `0`, the router ignores prefix caches and skips creating a local indexer. Defaults to `1.0`.
+- `--router-kv-overlap-score-credit`: Device-local prefix-overlap credit multiplier in the prefill cost calculation. It must be finite and nonnegative. Values greater than `1.0` give overlap extra credit, but the adjusted prefill contribution is clamped at zero. When set to `0`, the router ignores prefix caches and skips creating a local indexer. Defaults to `1.0`.
 - `--router-kv-overlap-score-credit-decay`: Decays device-local overlap credit for workers whose active prefill load exceeds the least-loaded eligible worker. `0` disables decay. Defaults to 0.
 - `--router-prefill-load-scale`: Scale applied to adjusted prompt-side prefill load after device, lower-tier, and shared-cache credits are subtracted. Defaults to 1.
 - `--router-decode-active-request-weight`: Experimental finite, nonnegative block-equivalent decode cost added for each active request on a candidate worker. Defaults to 0.
@@ -30,9 +30,9 @@ For the routing cost model and worker-selection behavior, see
 For how queue backpressure differs from candidate filtering and busy-threshold overload handling, see [Router Filtering](worker-filtering.md).
 
 `fcfs` orders by adjusted arrival time (`priority_jump - arrival_offset`) and optimizes tail TTFT.
-`wspt` orders by `(1 + priority_jump) / isl_tokens` and optimizes average TTFT.
-Policy-class YAML can additionally select `lcfs` for controlled comparison experiments;
-the `--router-queue-policy` CLI option does not accept it.
+`wspt` orders by `(1 + priority_jump) / scheduling_cost_tokens` and optimizes average TTFT, where
+`scheduling_cost_tokens = max(1, raw_isl_tokens - cached_tokens)`. Both the CLI and policy-class
+YAML accept only `fcfs` and `wspt`.
 
 For each policy, the complete pending-queue key is
 `(strict_priority, policy_key)`. Higher strict tiers always win; the selected
@@ -54,8 +54,10 @@ Missing, empty, unknown, or ordinary physical-class names use
 `default_policy_family`, so a client cannot bypass cache bucketing by naming a
 matrix class directly.
 
-Each class owns its FCFS or WSPT heap, busy thresholds, queue limits, quantum,
-deficit, and counters. Absolute and fractional busy thresholds use OR
+Each class owns a shared FCFS or WSPT heap plus one heap for each exact-worker
+lane, along with its busy thresholds, queue limits, quantum, deficit, and
+counters. Arbitration compares the shared head with the currently dispatchable
+exact-worker lane heads. Absolute and fractional busy thresholds use OR
 semantics. A class queues only when at least one threshold is configured and
 every eligible worker is busy for that class, but a new arrival cannot bypass
 an existing backlog in the same class.
@@ -129,6 +131,10 @@ the binding.
 The configured value is the idle timeout. It is independent of
 `--router-ttl-secs` and `--router-predicted-ttl-secs`. Omit the session-affinity
 option to keep affinity disabled.
+
+With `DYN_LORA_ENABLED`, session affinity is supported in KV mode. It is rejected
+at startup with random or round-robin routing; the other router modes are not
+LoRA-aware and are rejected independently.
 
 When session affinity is enabled, routers synchronize affinity bindings through the
 Runtime event plane. The origin publishes a binding after successful dispatch so
@@ -218,10 +224,11 @@ For Kubernetes deployment examples, see [Kubernetes Topology-Aware KV Transfer](
 ## Block Tracking
 
 - `--no-router-track-active-blocks`: Disables tracking of active blocks used for ongoing generation or decode phases. Disable this when routing to workers that only perform prefill.
-- `--router-track-output-blocks`: **Experimental.** Enables tracking of output blocks during generation. When enabled, the router adds placeholder blocks as tokens are generated and applies fractional decay based on progress toward the expected output sequence length (`agent_hints.osl` in `nvext`). For the cost-model behavior, see [Decode Load Modeling](routing-concepts.md#decode-load-modeling).
+- `--router-track-output-blocks`: **Experimental.** Enables tracking of output blocks during generation. When enabled, the router adds placeholder blocks as tokens are generated. With an expected output sequence length (`agent_hints.osl` in `nvext`), fractional decay applies to output blocks and the structurally exclusive prompt suffix; shared prompt blocks retain full weight. For the cost-model behavior, see [Decode Load Modeling](routing-concepts.md#decode-load-modeling).
 - `--no-router-assume-kv-reuse`: When tracking active blocks, disables the assumption of KV cache reuse. This is useful in disaggregated setups where transferred blocks are not actually deduplicated on the decode side.
 - `--no-router-track-prefill-tokens`: Disables prompt-side prefill token accounting in the router's active load model. Use this for decode-only routing paths where prompt processing already happened elsewhere.
 - `--router-replica-sync`: Disabled by default. Enables best-effort Runtime event-plane synchronization of KV active-sequence state. Session-affinity synchronization is independent and starts when `--router-session-affinity-ttl-secs` is set.
+- `DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS`: Environment-only safety timeout for stale active requests in the router's slot tracker, including entries learned through replica sync. Each router periodically force-expires entries older than this value; the default is `300` seconds. It does not turn best-effort synchronization into authoritative state.
 
 ### Tracking Hash Identities
 
@@ -277,7 +284,7 @@ For details on per-request agent hints (`priority`, `osl`, `speculative_prefill`
 
 ## Tuning Guidelines
 
-`--router-kv-overlap-score-credit` is the primary knob for cache reuse. It credits device-local prefix overlap against the prefill load and must be finite and nonnegative. Higher values steer requests toward workers with better cache overlap and reduce TTFT. Values above `1.0` can subtract more than the matched device-local prefix and make adjusted prefill cost negative, so use them deliberately. Lower values distribute load more evenly and reduce ITL. The default of `1.0` is a reasonable starting point. For direct router APIs and EPP integrations, the same router policy can be overridden per request with `router_config_override.overlap_score_credit`; it is not an `nvext.agent_hints` field.
+`--router-kv-overlap-score-credit` is the primary knob for cache reuse. It credits device-local prefix overlap against the prefill load and must be finite and nonnegative. Higher values steer requests toward workers with better cache overlap and reduce TTFT. Values above `1.0` can saturate the adjusted prefill contribution at zero, so use them deliberately: additional credit cannot make that contribution negative. Lower values distribute load more evenly and reduce ITL. The default of `1.0` is a reasonable starting point. For direct router APIs and EPP integrations, the same router policy can be overridden per request with `router_config_override.overlap_score_credit`; it is not an `nvext.agent_hints` field.
 
 Use `--router-kv-overlap-score-credit-decay` to reduce that device-local credit when a worker has more active prefill work than the least-loaded eligible worker. This helps prevent busy, cache-rich workers from repeatedly winning while newly autoscaled or lightly loaded workers receive too little traffic. The router normalizes the excess active prefill blocks by the incoming request size and multiplies the configured overlap credit by `1 / (1 + decay * normalized_excess)`. For example, a decay of `1` halves device credit at one request-equivalent of excess prefill load. Host, disk, and shared-cache credits are unchanged. This setting requires prefill-token tracking to have an effect and defaults to `0`.
 
@@ -285,7 +292,7 @@ Use `--load-aware` when you want the KV scheduler's active load model without pr
 
 Deprecated: `--router-kv-overlap-score-weight`, `--kv-overlap-score-weight`, `DYN_ROUTER_KV_OVERLAP_SCORE_WEIGHT`, and `DYN_OVERLAP_SCORE_WEIGHT` are still accepted, but emit deprecation warnings. Nonzero legacy values map to `prefill_load_scale` to preserve existing behavior without changing overlap credit. A legacy value of 0 maps to both `prefill_load_scale=0` and `overlap_score_credit=0`, which preserves the old no-overlap/no-indexer behavior. If a deprecated overlap score weight is still present, it takes precedence over the newer prefill load scale field; a legacy value of 0 also takes precedence over the newer overlap credit field. When migrating to `--router-prefill-load-scale` or `DYN_ROUTER_PREFILL_LOAD_SCALE`, remove the deprecated flag, env var, or JSON field from the deployment config. Use `--router-kv-overlap-score-credit` or `DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT` only when you mean to tune the cache-overlap credit itself.
 
-When migrating the deprecated overlap score weight, use `--router-prefill-load-scale` to preserve its scaling role. Tune `--router-kv-overlap-score-credit` separately only when you intend to change device-local cache credit; values above `1.0` are supported but can produce negative adjusted prefill cost.
+When migrating the deprecated overlap score weight, use `--router-prefill-load-scale` to preserve its scaling role. Tune `--router-kv-overlap-score-credit` separately only when you intend to change device-local cache credit; values above `1.0` are supported, with adjusted prefill cost clamped at zero.
 
 Use `--router-prefill-load-scale` when prompt-side load should count more or less than decode-side block load after cache-hit credits are applied. The final score is `prefill_load_scale * adjusted_prefill_blocks + potential_decode_blocks + decode_active_request_weight * active_requests`.
 
@@ -303,7 +310,7 @@ Use `--no-router-assume-kv-reuse` in disaggregated setups where the decode worke
 
 Use `--no-router-track-prefill-tokens` when a router is serving decode-only traffic and prompt processing has already completed elsewhere. This keeps decode routing decisions focused on decode-side load instead of briefly charging prompt tokens to the decode worker after handoff.
 
-Use `--router-track-output-blocks` when your workload is output-heavy and you want the router to account for output-side KV cache growth in load balancing. If you also pass `nvext.agent_hints.osl` per request, the router applies fractional decay to output blocks so that requests nearing completion contribute less future load. See [Decode Load Modeling](routing-concepts.md#decode-load-modeling) for the cost-model details.
+Use `--router-track-output-blocks` when your workload is output-heavy and you want the router to account for output-side KV cache growth in load balancing. If you also pass `nvext.agent_hints.osl` per request, the router applies fractional decay to output blocks and the structurally exclusive prompt suffix so that requests nearing completion contribute less future load. Shared prompt blocks retain full weight. See [Decode Load Modeling](routing-concepts.md#decode-load-modeling) for the cost-model details.
 
 `--router-queue-threshold` controls when incoming requests are held in a priority queue. The router waits while all eligible workers exceed `threshold * max_num_batched_tokens`, then releases work as capacity frees up. A lower value queues earlier; `0.0` queues as soon as all eligible workers have any active prefill tokens. Priority hints have no router-level effect when requests do not enter this queue.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/deficit-round-robin.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/deficit-round-robin.md
@@ -6,14 +6,14 @@ subtitle: Weighted arbitration across router policy classes
 ---
 
 The router uses a Deficit Round Robin (DRR) variant that is work-conserving
-across dispatchable physical policy-class heads. DRR determines which class
-can dispatch next; the configured FCFS or WSPT policy determines request
-order within that class.
+across dispatchable physical policy classes. DRR determines which class can
+dispatch next; the configured FCFS or WSPT policy determines request order
+within that class's shared and exact-worker lanes.
 
 This separation provides:
 
 - Weighted service across policy classes with different request sizes.
-- Independent within-class ordering and strict-priority tiers.
+- Independent within-class ordering, exact-worker lanes, and strict-priority tiers.
 - Progress for requests whose token cost is much larger than their class quantum.
 - Bounded arbitration work that does not loop once per token or DRR round.
 
@@ -40,7 +40,9 @@ amounts of credit.
 
 The scheduler maintains the following state for each physical class:
 
-- A pending heap ordered by strict priority and the class's FCFS or WSPT policy.
+- A shared pending heap for requests that can use any eligible worker.
+- One pending heap per exact-worker target, ordered by the same strict priority
+  and FCFS or WSPT policy.
 - A deficit containing earned but unspent credit.
 - A quantum controlling how quickly the deficit grows.
 
@@ -50,13 +52,15 @@ the configured class order from becoming a permanent preference.
 
 ## Selecting the Next Request
 
-For each class in cursor order, the scheduler examines only the class head:
+For each class in cursor order, the scheduler selects a class candidate by
+comparing the dispatchable shared-heap head with the dispatchable head of each
+exact-worker lane. It then applies DRR to that candidate:
 
 1. If the class is empty, reset its deficit to zero.
-2. If its head cannot currently dispatch, retain its deficit but add no credit.
-3. If existing deficit covers the head cost, dispatch it without adding another quantum.
-4. Otherwise, add one quantum and dispatch if the head is now affordable.
-5. If the head remains unaffordable, continue to the next class.
+2. If none of its lane heads can currently dispatch, retain its deficit but add no credit.
+3. If existing deficit covers the selected candidate's cost, dispatch it without adding another quantum.
+4. Otherwise, add one quantum and dispatch if the candidate is now affordable.
+5. If the candidate remains unaffordable, continue to the next class.
 
 Quantum is granted per ring round, not per request. A class that retained
 enough credit can dispatch multiple requests from the same weighted allocation:
@@ -128,16 +132,18 @@ unbounded burst while preserving work they had already earned.
 
 ## Dispatchability and Head-of-Line Behavior
 
-A class head is dispatchable when its eligible workers are not all above the
-class busy threshold. If no eligible endpoint remains, the head proceeds to
-worker selection so the router can return the appropriate error instead of
-parking it indefinitely. Eligibility continues to enforce exact pins, worker
-allow-lists, DP-rank bounds, taints, and overload filtering.
+A shared head is dispatchable when its eligible workers are not all above the
+class busy threshold. An exact-worker lane head is checked against its target
+worker. If no eligible endpoint remains, the candidate proceeds to worker
+selection so the router can return the appropriate error instead of parking it
+indefinitely. Eligibility continues to enforce exact pins, worker allow-lists,
+DP-rank bounds, taints, and overload filtering.
 
-Only the class head participates in arbitration. A constrained or pinned head
-can therefore block later requests in the same class even if those later
-requests could use another worker. This is intentional current behavior;
-FCFS/WSPT ordering is not bypassed to search deeper in a class heap.
+Head-of-line blocking is lane-local. The shared heap does not search past a
+blocked shared head, and an exact-worker lane does not search past its own
+blocked head. A blocked exact-worker lane does not prevent another exact-worker
+lane, or a dispatchable shared head, from competing for the class. FCFS/WSPT
+ordering is not bypassed within any individual lane.
 
 New arrivals also join an existing backlog in their resolved class instead of
 bypassing queued work. Queue limits, ordering, and DRR charging apply equally
@@ -151,19 +157,31 @@ One arbitration call performs:
 2. One linear calculation for bulk virtual rounds when required.
 3. At most one final ring scan.
 
-For `C` configured classes, arbitration is therefore `O(C)` regardless of the
-request cost or quantum. The queue actor calls arbitration repeatedly while
-work remains dispatchable, but each individual selection is bounded and
-continuation draining remains local to the actor.
+For `C` configured classes and `L` exact-worker lane heads that must be
+inspected or rechecked, arbitration is `O(C + L log L)` in the worst case,
+regardless of request cost or quantum. Candidate exact-worker heads are tree
+indexed, so ordinary selections do not need to rescan every ready lane; a
+worker-state recheck can visit the affected blocked lanes and pay the tree
+update factor. The queue actor calls arbitration repeatedly while work remains
+dispatchable, but each individual selection is bounded and continuation
+draining remains local to the actor.
 
-With only the synthetic no-YAML `default` class, the ring contains one class
-and DRR reduces to ordinary single-queue dispatch.
+With only the synthetic no-YAML `default` class, the ring contains one class.
+DRR reduces to single-class arbitration, but exact-worker requests still use
+their separate lanes.
 
 ## Configuration
 
 Set each physical class's `quantum` in the router policy YAML:
 
 ```yaml
+default_policy_family: standard
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: cached
+  - min_tokens: 3072
+    bucket: uncached
+
 policy_classes:
   - name: cached
     policy_family: standard

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/disaggregated-serving.md
@@ -5,7 +5,7 @@ title: Disaggregated Serving
 subtitle: Prefill and decode routing with the Dynamo router
 ---
 
-Dynamo supports disaggregated serving where prefill (prompt processing) and decode (token generation) are handled by separate worker pools. When you register prefill workers with `WorkerType.Prefill`, the frontend automatically detects them and activates an internal prefill router.
+Dynamo supports disaggregated serving where prefill (prompt processing) and decode (token generation) are handled by separate worker pools. The frontend activates an internal prefill router when it discovers compatible typed prefill and decode services.
 
 For the high-level deployment matrix, see [Router Guide](router-guide.md). For the router flags used in this setup, see [Configuration and Tuning](configuration-and-tuning.md).
 
@@ -14,18 +14,21 @@ If prefill and decode workers span topology domains such as zones or racks, use 
 ## Automatic Prefill Router Activation
 
 The prefill router is automatically created when:
-1. A decode model is registered, for example via `register_model()` with `ModelType.Chat | ModelType.Completions`.
-2. A prefill worker is detected with the same model name and `WorkerType.Prefill`.
+1. A decode worker is registered with `WorkerType.Decode`, for example via `register_model()` with `ModelType.Chat | ModelType.Completions`.
+2. A prefill service in the same Runtime namespace is registered with the same model name and `WorkerType.Prefill`.
 
 Key characteristics of the prefill router:
 - **Always disables active block tracking** (`track_active_blocks=false`) since prefill workers do not perform decode.
-- **Seamlessly integrates** into the request pipeline between preprocessing and decode routing.
-- **Falls back gracefully** to decode-only mode if prefill fails or no prefill workers are available.
+- **Runs between preprocessing and decode routing** and returns handoff metadata for the selected decode worker.
+- **Uses decode-only routing when no prefill router is active.** Once a request has been dispatched to prefill, a prefill or handoff failure is returned to the request; it does not retry through an aggregated decode-only path.
 
 Key characteristics of the decode routing stage in disaggregated mode:
 - **Disables overlap scoring** (`overlap_score_credit=0`) because decode routing should not chase prefix reuse.
 - **Disables KV reuse assumption** (`assume_kv_reuse=false`) unless the backend can truly deduplicate transferred blocks.
 - **Disables prefill-token tracking** (`track_prefill_tokens=false`) so decode-side load reflects decode work rather than already-completed prompt work.
+
+> [!NOTE]
+> The Rust router contains an experimental conditional bypass path for programmatic or embedded configurations. It can keep a cache-hot request on a selected decode worker instead of performing remote prefill. The standard `dynamo.frontend` and standalone Python router CLIs do not expose that configuration, so ordinary CLI deployments follow the prefill-handoff-decode flow documented below.
 
 ## Setup Example
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
@@ -22,16 +22,16 @@ A KV event consumer (router, cache coordinator) subscribes to a live stream of b
 | **Event ordering** | Monotonic sequence number (8-byte int) | Monotonic `event_id` with consecutive-ID validation |
 | **Lookup** | Linear scan (`for seq, buf in buffer`) | Binary search (`binary_search_by_key`) |
 | **Serialization** | Pre-serialized msgpack bytes stored in buffer | Structured events stored; serialized on demand |
-| **Fallback when buffer too old** | Consumer must rebuild externally | Tree dump of full RadixTree state |
+| **Fallback when buffer too old** | Consumer must rebuild externally | Full RadixTree snapshot |
 | **Initial sync** | Not built in — consumer starts from live stream | Tree dump (request with `start_event_id=None`) |
-| **Authoritative state** | Buffer only | RadixTree (buffer is an optimization layer) |
+| **Recoverable state** | Buffer only | RadixTree snapshot (buffer is an optimization layer) |
 | **Compression / dedup** | Events stored as-is (pre-serialized) | RadixTree compresses shared prefixes across sequences |
-| **Expiration** | Implicit via `maxlen` eviction | TTL expiration via `PruneManager` |
+| **Expiration** | Replay history expires through `maxlen` eviction | Replay history expires through buffer eviction; event-backed tree state changes through worker events, not router TTL pruning |
 | **Transport** | ZMQ PUB/SUB + ROUTER/REQ | Dynamo service RPC (request/response) |
 | **Multi-rank** | Port offset per DP rank | Separate query endpoint per DP rank |
 | **Thread model** | Background thread with queue | Single-threaded tokio runtime on dedicated OS thread |
-| **Delivery guarantee** | At-least-once (consumer dedupes) | At-least-once (router dedupes via event ID tracking) |
-| **Dedup responsibility** | Consumer must filter by seq number | Handled inside indexer infrastructure |
+| **Delivery guarantee** | Fire-and-forget live delivery; replay is bounded by retained history | Fire-and-forget live delivery; recovery can return retained events or a snapshot |
+| **Duplicate/stale events** | Consumer filters by sequence number | Router filters stale event IDs and coordinates per-rank recovery |
 
 ## How Each System Works
 
@@ -57,20 +57,23 @@ Dynamo's `LocalKvIndexer` (in `lib/kv-router/src/indexer/local.rs`) wraps a `KvI
 
 ```text
 LocalKvIndexer
-├── indexer: KvIndexer          // Authoritative state (RadixTree)
+├── indexer: KvIndexer          // Current state and snapshot source (RadixTree)
 ├── event_buffer: VecDeque      // Circular buffer for fast replay
 └── max_buffer_size: usize
 ```
 
-When the router queries a worker for events via `get_events_in_id_range(start_id, end_id)`, the local indexer returns one of three responses:
+When the router queries a worker, the local indexer can return six response variants:
 
 | Response | When | What happens |
 |----------|------|--------------|
-| `Events` | Requested range within buffer | Returns buffered events directly (binary search for slice bounds) |
-| `TreeDump` | Range too old or initial sync (`start_id=None`) | Dumps the full RadixTree as synthetic events — complete state snapshot |
-| `TooNew` | Consumer is ahead of producer | Error response; no gap to fill |
+| `Events` | Requested start is available in the buffer | Returns retained events and a real-event watermark |
+| `TreeDump` | Initial/full recovery or retained events cannot cover the request | Returns a full RadixTree snapshot as synthetic events plus the latest real-event watermark |
+| `TreeDumpFailed` | The worker cannot construct an exact snapshot and the client opted into explicit failure | Returns the failure and watermark so the router can reset the rank and continue in degraded mode |
+| `TooNew` | Requested range begins after the newest available event | Reports the available watermark without applying state |
+| `InvalidRange` | The requested end precedes the start | Rejects the malformed range |
+| `Error` | The worker query itself fails | Returns a serialized query error |
 
-The tree dump fallback means that when the buffer can't satisfy the request, the indexer falls back to dumping the entire tree state. This makes "buffer too old" a recoverable condition at the cost of additional complexity and memory for maintaining the tree.
+The snapshot fallback makes an evicted replay range recoverable while the worker-local indexer is available. A successful tree dump transactionally replaces that worker rank in the router's index. It is not a transport delivery guarantee: both the live stream and the query can fail, and router state can remain temporarily degraded.
 
 ## Gap Detection
 
@@ -84,8 +87,10 @@ if last_seq >= 0 and seq > last_seq + 1:
     # ... receive and process replayed events
 ```
 
-**Dynamo** (from `lib/llm/src/kv_router/worker_query.rs`):
-The router tracks `last_recovered_event_id` per worker and requests `recover_from_worker(worker_id, dp_rank, start_event_id, end_event_id)` when it detects a gap or on initial discovery. The local indexer handles the complexity of deciding whether to replay from buffer or dump the tree.
+**Dynamo** (from `lib/llm/src/kv_router/indexer/recovery/worker_query_state.rs`):
+The router tracks an admission cursor per worker and data-parallel rank. Discovering and activating a source with a recovery target starts an initial full recovery immediately; live events arriving during recovery are admitted or buffered according to the rank state. A later gap buffers the live event, resets that rank, and requests a full snapshot with both range bounds unset. This deliberately favors a current, self-contained snapshot over trying to splice a bounded missing range into potentially stale state.
+
+On success, the router transactionally replaces the rank from `TreeDump`, advances to the worker's real-event watermark, then drains buffered live events. If snapshot construction or transport fails, the router resets or fences the affected rank as appropriate and continues with degraded live-event processing. A later gap or source change can trigger another recovery.
 
 ## When to Use Which
 
@@ -95,11 +100,11 @@ The router tracks `last_recovered_event_id` per worker and requests `recover_fro
 - You are building a custom external router or cache coordinator and want to consume KV events directly from vLLM without wrapping it in another framework.
 
 **Dynamo's local indexer** is a good fit when:
-- You need robust recovery, including initial state sync for newly joined routers or consumers that were offline for extended periods.
-- You are running multiple router replicas that may start at different times and need to converge on a consistent view of cache state.
+- You need snapshot-based recovery, including initial state sync for newly joined routers or consumers that were offline for extended periods.
+- You are running multiple router replicas that may start at different times and should independently rebuild cache state from workers.
 - You want dedup and recovery handled by the infrastructure rather than implementing it in each consumer.
 
-The two approaches share the same core idea — a FIFO ring buffer for catching up on small, transient gaps. Dynamo adds a RadixTree underneath as authoritative state, which enables the tree dump fallback for full state recovery at the cost of additional memory and complexity. vLLM keeps it simple with just the buffer, which is sufficient when consumers are stable and gaps are short-lived.
+The two approaches share the same core idea — a FIFO ring buffer for catching up on small, transient gaps. Dynamo adds a RadixTree underneath, which enables a current-state snapshot fallback at the cost of additional memory and complexity. vLLM keeps replay history in the buffer, which is sufficient when consumers are stable and gaps remain inside the retained window.
 
 For deployments using Dynamo's KV-aware routing, the local indexer is used automatically. For standalone vLLM deployments where you want to build your own event consumer, vLLM's replay buffer provides a lightweight starting point.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/offloading-support-matrix.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/offloading-support-matrix.md
@@ -9,11 +9,11 @@ Use this matrix to see which KV offloading tiers the Dynamo KV router can use fo
 
 ## Support Matrix
 
-Legend: ✅ tier-aware routing · 🟡 router-visible, tier-agnostic · 🚧 Dynamo integration in progress · ❌ not yet supported · — does not exist for this framework.
+Legend: ✅ tier-aware routing · ⚠️ available but not fully validated · 🟡 router-visible, tier-agnostic · 🚧 Dynamo integration in progress · ❌ not yet supported · — does not exist for this framework.
 
 | Framework | Version gates | GPU | CPU RAM | Disk | Shared pool |
 | --- | --- | --- | --- | --- | --- |
-| [**vLLM**](#vllm) | vLLM v0.24.0+; Dynamo v1.3.0+ | ✅ KV events | ✅ `OffloadingConnector` + self-describing KV events (aggregated) | 🚧 vLLM main emits FS/OBJ events; Dynamo tier mapping is in progress | 🚧 vLLM locality events are merged; Dynamo shared-pool indexing is in progress |
+| [**vLLM**](#vllm) | vLLM v0.24.0+; Dynamo v1.3.0+ | ✅ KV events | ✅ `OffloadingConnector` + self-describing KV events (aggregated) | ⚠️ Unified `STORAGE` events map to the Disk tier with locality gating; available but not fully validated | 🚧 Remote locality is dropped; shared-pool indexing is still planned |
 | [**SGLang**](#sglang) | SGLang v0.5.11+; v0.5.13+ with Mooncake; Dynamo v1.2+ | ✅ KV events | ✅ HiCache + KV events | — no separate disk tier; HiCache's third tier is the shared pool (next column) | ✅ HiCache + Mooncake + `--shared-cache-type hicache` |
 | [**TensorRT-LLM**](#tensorrt-llm) | Dynamo v1.3.0+ for the current event flag | 🟡 `--publish-kv-events`; merged GPU + RAM view | 🟡 native host cache shares one router view with GPU; per-tier weights do not apply | — no native disk tier | — |
 
@@ -61,8 +61,9 @@ PYTHONHASHSEED=0 python3 -m dynamo.vllm \
 ```
 
 - Versions: vLLM v0.24.0 or later. Earlier versions publish placeholder CPU events that the router silently drops — offloading still works engine-side, but the router only sees the GPU tier.
-- Disk and multi-tier offloading (`TieringOffloadingSpec`): vLLM main emits FS and OBJ events. Dynamo tier mapping is in progress.
-- Shared pools: vLLM main publishes optional `LOCAL` / `REMOTE` locality metadata on FS and OBJ events. Dynamo shared-pool indexing is in progress.
+- Disk and multi-tier offloading (`TieringOffloadingSpec`): vLLM emits a unified `STORAGE` medium. Dynamo maps worker-local `STORAGE` events to the Disk tier. The path is available but not yet fully validated.
+- Shared pools: `LOCAL` or absent locality remains worker-local; `REMOTE` or unknown locality is dropped. Dynamo does not yet build a shared-pool index from these events.
+- Cache-salted requests do not currently reuse `STORAGE`-tier entries for routing because those events omit the extra cache-namespace keys. See [Known Limitations](../backends/vllm/native-kv-offloading.md#known-limitations).
 
 See [Native KV Offloading](../backends/vllm/native-kv-offloading.md) for the full support matrix (including disaggregated and tensor-parallel status), setup commands, verification, and troubleshooting.
 
@@ -112,7 +113,7 @@ See the [TensorRT-LLM backend docs](../backends/tensorrt-llm/overview.md) for wo
 The Rust worker selector (`lib/kv-router/src/scheduling/selector.rs`) scores each candidate worker with:
 
 ```
-overlap_credit_blocks = device_overlap_blocks       * 1.0   // overlap_score_credit, configurable
+overlap_credit_blocks = device_overlap_blocks       * effective_device_credit
                       + host_pinned_overlap_blocks  * 0.75  // host_cache_hit_weight, configurable in router config
                       + disk_overlap_blocks         * 0.25  // disk_cache_hit_weight, configurable in router config
                       + shared_overlap_blocks       * shared_cache_multiplier
@@ -120,8 +121,13 @@ overlap_credit_blocks = device_overlap_blocks       * 1.0   // overlap_score_cre
 adjusted_prefill_blocks = max(raw_prefill_blocks - overlap_credit_blocks, 0)
 
 logit = prefill_load_scale * adjusted_prefill_blocks   // default 1.0
-      + decode_blocks                                    // load term
+      + decode_blocks                                    // active/projected KV load
+      + decode_active_request_weight * active_requests  // optional, default 0
 ```
+
+Before applying the device term, the router computes
+`effective_device_credit = overlap_score_credit / (1 + overlap_score_credit_decay * normalized_excess_prefill)`.
+The host, disk, and shared-cache credits do not decay.
 
 The router picks the worker with the **minimum** logit.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -51,6 +51,7 @@ For deployment modes and quick start steps, see the [Router Guide](router-guide.
 
 **Limitations:**
 - Static endpoints are not supported with KV routing; use dynamic discovery so the router can track worker instances and KV cache state
+- With `DYN_LORA_ENABLED`, only KV, random, and round-robin routing are LoRA-aware. Direct, power-of-two, least-loaded, and device-aware-weighted modes fail startup. Session affinity is supported with LoRA only in KV mode; LoRA plus random or round-robin affinity is rejected.
 
 For basic model registration without KV routing, use `--router-mode round-robin`, `--router-mode random`, `--router-mode power-of-two`, `--router-mode least-loaded`, or `--router-mode device-aware-weighted` with both static and dynamic endpoints.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-design.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-design.md
@@ -64,13 +64,14 @@ The router uses a cost function that combines cache-aware prefill cost, potentia
 
 4. **Cost formula**:
    ```text
-   adjusted_prefill_blocks = (
+   effective_device_credit = overlap_score_credit * overlap_score_credit_decay_factor
+   adjusted_prefill_blocks = max(0, (
        prefill_blocks
-       - overlap_score_credit * device_overlap_blocks
+       - effective_device_credit * device_overlap_blocks
        - host_cache_hit_weight * host_overlap_blocks
        - disk_cache_hit_weight * disk_overlap_blocks
        - shared_cache_multiplier * shared_beyond_blocks
-   )
+   ))
    active_request_blocks = decode_active_request_weight * active_requests
    cost = (
        prefill_load_scale * adjusted_prefill_blocks
@@ -80,9 +81,13 @@ The router uses a cost function that combines cache-aware prefill cost, potentia
    ```
    - Lower costs indicate better routing choices
    - `overlap_score_credit` is a finite, nonnegative device-local prefix-overlap credit multiplier
+   - `overlap_score_credit_decay_factor` is `1 / (1 + decay * normalized_excess_prefill)`; it is `1` when decay is disabled or the worker has no excess prefill load
+   - The combined cache credit is clamped so adjusted prefill blocks cannot become negative
    - `prefill_load_scale` controls adjusted prompt-side load relative to potential decode blocks
    - `decode_active_request_weight` defaults to `0`; use a positive value only when decode step latency depends materially on active batch size
    - Higher overlap credits favor cache reuse (improving TTFT), while lower credits prioritize even load distribution (improving ITL)
+
+   The experimental conditional-disaggregation path has a decode-worker exception. When the decode worker does not track prefill tokens and a positive overlap credit permits conditional prefill bypass, its score is `max(0, potential_decode_blocks - overlap_credit_blocks) + active_request_blocks`; it does not add the ordinary prefill term.
 
 #### Worker Selection
 
@@ -158,15 +163,15 @@ The KVIndexer supports two backend implementations, selected via `--router-event
 
 ### Inter-Router Communication
 
-In distributed deployments with multiple routers, each router maintains visibility over only a portion of the total requests. To ensure consistent routing decisions, routers synchronize their states through three event types:
+In distributed deployments with multiple routers, each router initially sees only the active requests it routed. With replica sync enabled, routers exchange three best-effort lifecycle event types to improve that view:
 
-1. **AddRequest**: Notifies other routers when a request is assigned to a worker. Includes request ID, worker ID, token sequence blocks, and overlap score to track block usage across the system.
+1. **AddRequest**: Notifies peer routers when a request is assigned to a worker. It carries the request ID, worker ID and DP rank, token sequence, whether to track prefill tokens, the expected output length, and the prefill load hint.
 
 2. **MarkPrefillCompleted**: Signals when a request moves from prefill to decode phase, allowing routers to update their worker load calculations by excluding completed prefill tokens.
 
 3. **Free**: Indicates request completion and resource release, enabling accurate block reference counting across all routers.
 
-Each event carries a unique router ID to prevent self-event processing. This asynchronous communication system ensures optimal routing decisions by maintaining consistent KV cache state across all routers, even as they handle different request streams.
+Each event carries a unique router ID to prevent self-event processing. Publication is fire-and-forget and the bounded outbound publisher queue drops the newest event when full. These events improve cross-replica active-load estimates; they do not synchronize prefix-cache state or guarantee identical routing decisions. Output-block growth is tracked locally rather than published as a lifecycle event. Routers periodically force-expire stale synchronized requests; configure the safety timeout with `DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS` (default `300` seconds).
 
 ## Event Transport Modes
 
@@ -217,7 +222,7 @@ graph TD
 1. Each worker assigns monotonically increasing event IDs starting from 0
 2. The router tracks the last received event ID per worker
 3. If an event arrives with `event_id > last_id + 1`, the router detects a gap
-4. The router queries the worker's local indexer for the missing event range `[last_id+1, event_id-1]`
+4. The router resets that worker rank and requests a full snapshot (`start_event_id=None`, `end_event_id=None`)
 5. On worker discovery (Added event), the router dumps the worker's entire local indexer state
 
 **Startup behavior:**
@@ -234,7 +239,7 @@ In addition to cached blocks, each router replica needs to track active blocks (
 - The first token is generated (prefill complete)
 - The response ends (request freed)
 
-This is managed locally in each router via a "slot manager". To maintain consistency across the system, router replicas synchronize these local predictions with each other through NATS core messaging.
+This is managed locally in each router via a "slot manager". With `--router-replica-sync`, router replicas exchange lifecycle predictions through the configured Runtime event plane (ZMQ by default, with NATS Core available by configuration).
 
 ```mermaid
 sequenceDiagram
@@ -271,10 +276,10 @@ sequenceDiagram
     R2-->>R1: Sync: Free(B)
     deactivate R2
 
-    Note over R1,R2: Both routers have consistent<br/>view of active blocks
+    Note over R1,R2: Both routers have a more complete,<br/>best-effort view of active blocks
 ```
 
-This dual-layer approach—worker-recoverable KV cache state and ephemeral active-block synchronization across router replicas—balances cache reuse with current load.
+This dual-layer approach—worker-recoverable KV cache state and ephemeral, best-effort active-block synchronization across router replicas—balances cache reuse with current load without treating router lifecycle events as authoritative storage.
 
 ## See Also
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
@@ -44,9 +44,21 @@ The `KvRouter` provides the following methods:
 
 ### Setup
 
-First, launch your backend engines:
+First, launch at least two backend engines so the router has a meaningful
+selection to make. Each worker needs a unique system port and KV event endpoint:
+
 ```bash
-python -m dynamo.vllm --model meta-llama/Llama-2-7b-hf
+export PYTHONHASHSEED=0
+
+DYN_SYSTEM_PORT=8081 CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm \
+  --model Qwen/Qwen3-0.6B \
+  --block-size 64 \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
+
+DYN_SYSTEM_PORT=8082 CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm \
+  --model Qwen/Qwen3-0.6B \
+  --block-size 64 \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
 ```
 
 ### Example Script
@@ -59,14 +71,14 @@ from dynamo.llm import KvRouter, KvRouterConfig
 async def main():
     # Get runtime and create endpoint
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", "nats")
+    runtime = DistributedRuntime(loop, "etcd", "tcp")
     endpoint = runtime.endpoint("dynamo.backend.generate")
 
     # Create KV router
     kv_router_config = KvRouterConfig()
     router = KvRouter(
         endpoint=endpoint,
-        block_size=16,
+        block_size=64,
         kv_router_config=kv_router_config
     )
 
@@ -79,7 +91,7 @@ async def main():
     # Generate with per-request routing override
     stream = await router.generate(
         token_ids=token_ids,
-        model="meta-llama/Llama-2-7b-hf",
+        model="Qwen/Qwen3-0.6B",
         stop_conditions={
             "max_tokens": 20,        # Generate exactly 20 tokens
             "ignore_eos": True,      # Don't stop at EOS token
@@ -180,21 +192,35 @@ stream = await router.generate(token_ids=tokens, model="model-name")
 ### 2. Manual State Management (Advanced)
 Use `best_worker(request_id=...)` to select and track, then manage the request yourself:
 ```python
-worker_id, _dp_rank, overlap = await router.best_worker(
+worker_id, dp_rank, overlap = await router.best_worker(
     tokens,
     request_id="req-123",
-    update_indexer=True,  # needed for approximate mode (use_kv_events=False)
 )
-response = await client.generate(tokens, request_id="req-123")
-# await anext(response)  # Get first token
-await router.mark_prefill_complete("req-123")  # After first token
-# async for _ in response:  # Continue generating
-#     ...
-await router.free("req-123")  # After completion
+client = await endpoint.client()
+request = {
+    "model": "Qwen/Qwen3-0.6B",
+    "token_ids": tokens,
+    "stop_conditions": {"max_tokens": 20},
+    "sampling_options": {},
+    "routing": {"dp_rank": dp_rank},
+}
+
+stream = await client.direct(request, worker_id)
+try:
+    first = await anext(stream)
+    if first.get("finish_reason") == "error":
+        raise RuntimeError(f"Worker returned an error: {first}")
+    print(first)
+    await router.mark_prefill_complete("req-123")
+    async for response in stream:
+        print(response)
+finally:
+    await router.free("req-123")
 ```
 - **Best for**: Custom request handling with router state tracking
 - **Requires**: Calling `mark_prefill_complete()` and `free()` at correct lifecycle points
-- **Approximate mode**: Pass `update_indexer=True` when `use_kv_events=False` so the router learns from manual worker selections
+- **Approximate mode**: Pass `update_indexer=True` to `best_worker()` when `use_kv_events=False` so the router learns from manual worker selections
+- **Direct dispatch**: `Client.direct()` targets the returned worker instance; include the returned DP rank in the preprocessed request's `routing` field
 - **Caution**: Incorrect lifecycle management degrades load balancing accuracy
 
 ### 3. Hierarchical Router Probing
@@ -240,12 +266,12 @@ from dynamo.llm import KvRouter, KvRouterConfig
 async def minimize_ttft_routing():
     # Setup router
     loop = asyncio.get_running_loop()
-    runtime = DistributedRuntime(loop, "etcd", "nats")
+    runtime = DistributedRuntime(loop, "etcd", "tcp")
     endpoint = runtime.endpoint("dynamo.backend.generate")
 
     router = KvRouter(
         endpoint=endpoint,
-        block_size=16,
+        block_size=64,
         kv_router_config=KvRouterConfig()
     )
 
@@ -264,7 +290,7 @@ async def minimize_ttft_routing():
     # Route directly to the selected worker
     stream = await router.generate(
         token_ids=token_ids,
-        model="meta-llama/Llama-2-7b-hf",
+        model="Qwen/Qwen3-0.6B",
         worker_id=best_worker['worker_id'],  # Force routing to optimal worker
         stop_conditions={"max_tokens": 20}
     )

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
@@ -208,12 +208,14 @@ request = {
 stream = await client.direct(request, worker_id)
 try:
     first = await anext(stream)
-    if first.get("finish_reason") == "error":
-        raise RuntimeError(f"Worker returned an error: {first}")
-    print(first)
+    if first.is_error():
+        raise RuntimeError(f"Worker returned an error: {first.comments()}")
+    print(first.data())
     await router.mark_prefill_complete("req-123")
     async for response in stream:
-        print(response)
+        if response.is_error():
+            raise RuntimeError(f"Worker returned an error: {response.comments()}")
+        print(response.data())
 finally:
     await router.free("req-123")
 ```

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -82,7 +82,7 @@ The standalone router does not include the HTTP frontend and does not expose `/v
 
 ## Deployment Modes
 
-The Dynamo router can be deployed in several configurations. The table below shows every combination and when to use it:
+The Dynamo router can be deployed in several configurations. The table below shows common combinations and when to use them:
 
 | Mode | Command | Routing Logic | KV Events | Topology | Use Case |
 |------|---------|---------------|-----------|----------|----------|
@@ -95,6 +95,12 @@ The Dynamo router can be deployed in several configurations. The table below sho
 | **Frontend + Device-Aware Weighted** | `python -m dynamo.frontend --router-mode device-aware-weighted` | Device-aware budget + least-loaded within selected device group | None | Aggregated or disaggregated fallback | Heterogeneous fleet balancing (CPU/non-CPU); degenerates to least-loaded when only one device class is present |
 | **Frontend + Direct** | `python -m dynamo.frontend --router-mode direct` | Worker ID from request hints | None | Aggregated | External orchestrator (e.g., EPP/GAIE) selects workers |
 | **Standalone Router** | `python -m dynamo.router` | KV cache overlap + load | NATS Core / ZMQ | Any | Routing without the HTTP frontend (multi-tier, custom pipelines) |
+
+> [!IMPORTANT]
+> With `DYN_LORA_ENABLED`, use KV, random, or round-robin routing. Direct,
+> power-of-two, least-loaded, and device-aware-weighted modes are not LoRA-aware
+> and fail startup. Session affinity with LoRA is supported only in KV mode;
+> random and round-robin plus affinity are rejected.
 
 ### Routing Modes (`--router-mode`)
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
@@ -59,7 +59,7 @@ python -m dynamo.frontend --router-mode kv --http-port 8000 --router-replica-syn
 python -m dynamo.frontend --router-mode kv --http-port 8001 --router-replica-sync
 ```
 
-With replica sync enabled, a new router still starts with zero active-block knowledge, but it converges through live request handling and active-sequence events from other replicas. Without it, each replica keeps an isolated active-block view, which can lead to suboptimal load balancing.
+With replica sync enabled, a new router still starts with zero active-block knowledge, but its view improves through live request handling and active-sequence events from other replicas. The channel is fire-and-forget and its bounded outbound publisher queue drops the newest event when full, so replicas can temporarily disagree. Add, prefill-complete, and free lifecycle events are synchronized; output-block growth remains local. Stale synchronized entries are force-expired after `DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS` (default `300` seconds). Without replica sync, each replica keeps an isolated active-block view, which can lead to suboptimal load balancing.
 
 Session-affinity synchronization starts automatically when
 `--router-session-affinity-ttl-secs` is set. That path is best effort: each replica
@@ -136,7 +136,7 @@ Backend KV event publishing is independent of the frontend's `--no-router-kv-eve
 
 - **vLLM**: Pass `--kv-events-config '{"enable_kv_cache_events": false}'` to disable, or `'{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557"}'` to enable.
 - **SGLang**: Pass `--kv-events-config` with a JSON config to enable, or omit it to keep publishing disabled.
-- **TRT-LLM**: Pass `--publish-events-and-metrics` to enable, or omit it to keep publishing disabled.
+- **TRT-LLM**: Pass `--publish-kv-events` to enable, or omit it to keep publishing disabled. The legacy `--publish-events-and-metrics` alias is accepted but deprecated.
 
 The CLI arg `--router-ttl-secs` controls local cache prediction lifetime when the router operates without receiving events from workers. When workers are configured to publish KV events, the router relies on worker-side eviction events and this parameter is ignored.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/routing-concepts.md
@@ -27,13 +27,15 @@ The cost function combines three worker-specific cost terms:
 
 ```text
 raw_prefill_blocks = active_prefill_blocks + incoming_prompt_blocks
-adjusted_prefill_blocks = raw_prefill_blocks - overlap_credit_blocks
+adjusted_prefill_blocks = max(0, raw_prefill_blocks - overlap_credit_blocks)
 potential_decode_blocks = active_decode_blocks + incoming_active_blocks
 active_request_blocks = decode_active_request_weight * active_requests
 cost = prefill_load_scale * adjusted_prefill_blocks + potential_decode_blocks + active_request_blocks
 ```
 
-`overlap_credit_blocks` combines the configured device, host, disk, and shared-cache credits. `overlap_score_credit_decay` can reduce the device-local portion when a cache-rich worker has excess active prefill load. `decode_active_request_weight` defaults to `0`, so the active-request term is opt-in. The router selects the lowest-cost eligible worker. For exact tuning behavior, see [Configuration and Tuning](configuration-and-tuning.md#tuning-guidelines).
+`overlap_credit_blocks` combines the configured device, host, disk, and shared-cache credits. `overlap_score_credit_decay` can reduce the device-local portion when a cache-rich worker has excess active prefill load. The adjusted prefill term is clamped at zero, so overlap credits never make it negative. `decode_active_request_weight` defaults to `0`, so the active-request term is opt-in. The router selects the lowest-cost eligible worker. For exact tuning behavior, see [Configuration and Tuning](configuration-and-tuning.md#tuning-guidelines).
+
+The experimental conditional-disaggregation path uses a decode-worker exception when prefill tracking is disabled and overlap credit remains positive: `cost = max(0, potential_decode_blocks - overlap_credit_blocks) + active_request_blocks`. This lets a cache-hot decode worker bypass the ordinary prefill path.
 
 ### Active Load Modeling
 
@@ -53,7 +55,7 @@ This model changes router-side prompt load accounting only; it does not change b
 
 For decode load, the router tracks active KV blocks and active-request count for each worker. It captures both values in the same request-specific worker-load projection. By default, the cost covers the prompt-side blocks that are already assigned to active requests and frees them when each request finishes.
 
-When `--router-track-output-blocks` is enabled, the router also adds placeholder output blocks as generation crosses block boundaries. If the request includes `nvext.agent_hints.osl`, those output blocks receive a fractional weight based on progress toward the expected output length. This expected OSL proxy lets requests near completion contribute less future decode load. Without an expected OSL, tracked output blocks count at full weight until the request finishes.
+When `--router-track-output-blocks` is enabled, the router also adds placeholder output blocks as generation crosses block boundaries. If the request includes `nvext.agent_hints.osl`, those output blocks and the structurally exclusive prompt suffix receive a fractional weight based on progress toward the expected output length. Shared prompt blocks retain full weight. This expected OSL proxy lets requests near completion contribute less future decode load. Without an expected OSL, tracked output blocks count at full weight until the request finishes.
 
 When `--router-decode-active-request-weight` is positive, every active request also adds the configured block-equivalent cost. This can improve data-parallel batch balance when decode latency is sensitive to request count, but it can reduce cache locality or over-penalize batches when KV-memory traffic remains the dominant cost. The default is `0`.
 
@@ -77,7 +79,7 @@ To enable KV cache-aware routing, start the frontend node like this:
 python -m dynamo.frontend --router-mode kv
 ```
 
-When KV blocks are created or removed, the engine notifies the Dynamo router, which then identifies the worker with the best matching blocks and routes traffic accordingly.
+When KV blocks are created or removed, the engine notifies the Dynamo router. Those matches become cache-credit inputs to the combined cache-and-load score used for subsequent routing decisions.
 
 To evaluate the benefits of KV-aware routing, compare your workload's performance using `--router-mode random|round-robin` against KV-aware routing.
 
@@ -90,13 +92,14 @@ Dynamo supports several routing strategies when sending requests from one compon
 First, create a client tied to a component endpoint. Here we get a client tied to the `generate` endpoint of the `VllmWorker` component.
 
 ```python
-client = runtime.endpoint("dynamo.VllmWorker.generate").client()
+client = await runtime.endpoint("dynamo.VllmWorker.generate").client()
 ```
 
 You can then use the default routing methods exposed by the client class to send requests to the `VllmWorker` component.
 
-- **Random routing**: Default strategy, available via `client.generate()` or `client.random()`
-- **Round-robin routing**: Cycles through available workers via `client.round_robin()`
+- **Round-robin routing**: Default strategy, available through `client.generate()` on a standard endpoint client or explicitly through `client.round_robin()`
+- **Random routing**: Selects a random worker through `client.random()`
+- **Power-of-two routing**: Samples two workers and selects the less-loaded one through `--router-mode power-of-two`
 - **Direct routing**: Explicitly targets a specific worker via `client.direct(input, component_id)`
 - **Least-loaded routing**: Routes to the worker with fewest active connections via `--router-mode least-loaded`
 - **Device-aware weighted routing**: Routes using CPU/non-CPU ratio budgeting plus least-loaded selection within the selected device group via `--router-mode device-aware-weighted`

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
@@ -104,7 +104,8 @@ The service is exposed through the Python bindings package and launched with `py
 cd lib/bindings/python && VIRTUAL_ENV=../../../.venv ../../../.venv/bin/maturin develop --uv --features kv-indexer
 ```
 
-After installation, launch the service with `python -m dynamo.indexer`.
+After installation, launch the service from `lib/bindings/python` with
+`../../../.venv/bin/python -m dynamo.indexer`.
 
 ### Standalone build with metrics
 
@@ -483,7 +484,11 @@ If no `replay_endpoint` is configured, gaps are logged as warnings but not recov
 
 Deregistration removes the listener's sequence watermark. Re-registering the same worker and
 DP rank therefore starts with a fresh watermark; it does not continue incremental replay from
-the previous listener's `last_seq`.
+the previous listener's `last_seq`. If the first live batch starts above sequence `0`, a configured
+`replay_endpoint` triggers replay from sequence `0` before that live batch is applied. This only
+recovers history still retained by the engine. Without a replay endpoint, or when the requested
+range is no longer retained, restart with a healthy indexer in `--peers` to recover its startup
+snapshot, or perform another full resynchronization before relying on the rebuilt worker state.
 
 ## Limitations
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-indexer.md
@@ -21,8 +21,10 @@ For Dynamo-native remote indexing, use `--serve-indexer` on `dynamo.frontend` or
 The HTTP API follows the [Mooncake KV Indexer RFC](https://github.com/kvcache-ai/Mooncake/issues/1403) conventions.
 
 `DYN_ROUTER_MIN_INITIAL_WORKERS` is also honored here. When set to a positive integer, the
-standalone indexer waits for that many workers to register before opening its startup-ready
-gate, matching the frontend/router startup behavior.
+standalone indexer registers the initial `--workers` entries, attempts `--peers` recovery, and
+then waits for that catalog count before binding its HTTP listener. Because `/register` is
+unavailable during this wait, the threshold must be met by initial workers, workers recovered
+from peers, or a combination of both.
 
 ## Model and Routing Group Support
 
@@ -99,7 +101,7 @@ The service is exposed through the Python bindings package and launched with `py
 ### Standalone build
 
 ```bash
-cd lib/bindings/python && VIRTUAL_ENV=../../.venv ../../.venv/bin/maturin develop --uv --features kv-indexer
+cd lib/bindings/python && VIRTUAL_ENV=../../../.venv ../../../.venv/bin/maturin develop --uv --features kv-indexer
 ```
 
 After installation, launch the service with `python -m dynamo.indexer`.
@@ -107,7 +109,7 @@ After installation, launch the service with `python -m dynamo.indexer`.
 ### Standalone build with metrics
 
 ```bash
-cd lib/bindings/python && VIRTUAL_ENV=../../.venv ../../.venv/bin/maturin develop --uv --features kv-indexer,kv-indexer-metrics
+cd lib/bindings/python && VIRTUAL_ENV=../../../.venv ../../../.venv/bin/maturin develop --uv --features kv-indexer,kv-indexer-metrics
 ```
 
 This keeps the default `kv-indexer` build lean while still allowing Prometheus metrics when needed.
@@ -135,7 +137,9 @@ python -m dynamo.indexer --port 8090 [--threads 4] [--block-size 16 --model-name
 
 Set `DYN_ROUTER_MIN_INITIAL_WORKERS=<n>` to require at least `<n>` workers before the
 standalone indexer, frontend push-router path, and KV router config-ready gate all proceed.
-Leave it unset or set it to `0` to disable the startup wait.
+For the standalone indexer, the gate runs before the HTTP listener is bound, so its count can
+only be satisfied by initial `--workers` and workers recovered through `--peers`; `/register`
+cannot satisfy it. Leave the variable unset or set it to `0` to disable the startup wait.
 
 ## HTTP API
 
@@ -477,7 +481,9 @@ When a `replay_endpoint` is provided during `/register`, the indexer connects a 
 
 If no `replay_endpoint` is configured, gaps are logged as warnings but not recovered.
 
-The sequence counter (`last_seq`) persists across unregister/register cycles, so re-registering a worker after a gap will trigger replay on the first batch received by the new listener.
+Deregistration removes the listener's sequence watermark. Re-registering the same worker and
+DP rank therefore starts with a fresh watermark; it does not continue incremental replay from
+the previous listener's `last_seq`.
 
 ## Limitations
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/standalone-selection.md
@@ -103,10 +103,17 @@ Content-Type: application/json
 }
 ```
 
-`POST /workers` returns `201`. `PATCH /workers/{worker_id}` updates supplied
-fields, `DELETE /workers/{worker_id}` removes the worker, and `GET /workers`
-lists catalog state. `model_name` and `routing_group` scope all selection, indexer,
-and load state; both default to `"default"` when omitted.
+`worker_id` is service-wide, not scoped by model or routing group. `POST /workers`
+is an upsert and returns `201`: reusing an existing ID replaces its catalog
+record. If the model or routing group changes, the worker is removed from the
+previous partition and moved to the new one, which can leave the previous
+partition not ready. Assign a unique ID to every live worker across the entire
+service.
+
+`PATCH /workers/{worker_id}` updates supplied fields, `DELETE
+/workers/{worker_id}` removes the worker, and `GET /workers` lists catalog
+state. `model_name` and `routing_group` scope selection, indexer, and load state;
+both default to `"default"` when omitted.
 
 `GET /health` is process liveness. `GET /ready` returns `200` only after at
 least one worker is schedulable, otherwise `503` with lifecycle details.

--- a/docs/fern/pages/reference/components/frontend-configuration.mdx
+++ b/docs/fern/pages/reference/components/frontend-configuration.mdx
@@ -109,8 +109,8 @@ router. See [Router Guide](../../developer-guide/knowledge-base/modular-componen
 
 <ParamField path="--router-kv-overlap-score-credit" type="float" default="1.0">
   Credit multiplier for device-local prefix overlap. The value must be finite and nonnegative.
-  Values greater than `1.0` give device overlap extra credit and can make adjusted prefill cost
-  negative. See [Configuration and Tuning](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#tuning-guidelines).
+  Values greater than `1.0` give device overlap extra credit, but adjusted prefill cost is
+  clamped at zero. See [Configuration and Tuning](../../developer-guide/knowledge-base/modular-components/router/configuration-and-tuning.md#tuning-guidelines).
 
   Environment variable: `DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT`
 </ParamField>
@@ -248,7 +248,8 @@ router. See [Router Guide](../../developer-guide/knowledge-base/modular-componen
 </ParamField>
 
 <ParamField path="--router-track-output-blocks / --no-router-track-output-blocks" type="boolean" default="false">
-  Track output blocks with fractional decay during generation.
+  Track output blocks during generation. With `nvext.agent_hints.osl`, fractional decay applies
+  to output blocks and the structurally exclusive prompt suffix; shared prompt blocks retain full weight.
 
   Environment variable: `DYN_ROUTER_TRACK_OUTPUT_BLOCKS`
 </ParamField>

--- a/docs/fern/pages/reference/components/global-router-configuration.mdx
+++ b/docs/fern/pages/reference/components/global-router-configuration.mdx
@@ -130,13 +130,13 @@ The Global Router reads a JSON file at the path given to `--config`. There is no
 </ParamField>
 
 <ParamField path="--default-ttft-target-ms" type="number" default="null">
-  Default TTFT target in milliseconds for prefill pool selection. Applied to requests that carry no `ttft_target` in their `extra_args`. When unset, the prefill selection strategy falls back to the midpoint of its configured TTFT range. Replaces the deprecated `--default-ttft-target` flag.
+  Default TTFT target in milliseconds for prefill pool selection. Applied to requests that carry no `ttft_target` in the typed `router` field, which the frontend derives from `nvext.router`. When unset, the prefill selection strategy falls back to the midpoint of its configured TTFT range. Replaces the deprecated `--default-ttft-target` flag.
 
   Environment variable: `DYN_GLOBAL_ROUTER_DEFAULT_TTFT_TARGET_MS`
 </ParamField>
 
 <ParamField path="--default-itl-target-ms" type="number" default="null">
-  Default ITL target in milliseconds for decode pool selection. Applied to requests that carry no `itl_target` in their `extra_args`. When unset, the decode selection strategy falls back to the midpoint of its configured ITL range. Replaces the deprecated `--default-itl-target` flag.
+  Default ITL target in milliseconds for decode pool selection. Applied to requests that carry no `itl_target` in the typed `router` field, which the frontend derives from `nvext.router`. When unset, the decode selection strategy falls back to the midpoint of its configured ITL range. Replaces the deprecated `--default-itl-target` flag.
 
   Environment variable: `DYN_GLOBAL_ROUTER_DEFAULT_ITL_TARGET_MS`
 </ParamField>
@@ -145,8 +145,8 @@ The Global Router reads a JSON file at the path given to `--config`. There is no
 
 The file passed to `--config` is a JSON object matching the `GlobalRouterConfig` schema. Two modes are supported:
 
-- **`disagg`** (default): separate prefill and decode pools. Prefill routing uses the grid `(ISL, TTFT target) → prefill pool index`; decode routing uses `(context length, ITL target) → decode pool index`.
-- **`agg`**: unified pools handling both prefill and decode (chunked-prefill topologies). Routing uses the grid `(TTFT target, ITL target) → agg pool index`.
+- **`disagg`** (default): separate prefill and decode pools. Prefill routing uses the grid `(ISL, TTFT target) → prefill pool index`; decode routing currently uses `(request token count, ITL target) → decode pool index` through the strategy's `context_length_*` fields.
+- **`agg`**: unified pools handling both prefill and decode. Routing uses `(TTFT target, ITL target) → agg pool index`, optionally extended with ISL as the leading dimension.
 
 Both modes support optional priority-based pool overrides and priority retry.
 
@@ -159,7 +159,9 @@ Both modes support optional priority-based pool overrides and priority retry.
 </ParamField>
 
 <ParamField path="enable_priority_retry" type="boolean" default="false">
-  When `true`, if the initially selected pool cannot accept a request, the router retries through progressively faster pools (lower `*_pool_priorities` values), from slowest to fastest. When `false`, only the grid-selected pool is attempted.
+  When `true`, if a pool attempt raises an exception before producing its first streamed output, the router retries through progressively faster pools (lower `*_pool_priorities` values), from slowest to fastest. Once an attempt has streamed output, later failures are returned without retry. When `false`, only the grid-selected pool is attempted.
+
+  In disaggregated mode, the router can attempt decode retries, but current Dynamo backends do not support them safely: a failed decode attempt may already have caused the prefill engine to retire or drop that request's KV cache.
 </ParamField>
 
 ### Disaggregated mode fields
@@ -195,7 +197,7 @@ The following fields are required when `mode` is `"disagg"` and are ignored in `
 </ParamField>
 
 <ParamField path="decode_pool_selection_strategy" type="DecodePoolSelectionStrategy" default="null">
-  Grid mapping `(context length, ITL target)` to a decode pool index. Required for `disagg` mode. See [DecodePoolSelectionStrategy](#decodepoolselectionstrategy).
+  Grid mapping `(request token count, ITL target)` to a decode pool index. Required for `disagg` mode. See [DecodePoolSelectionStrategy](#decodepoolselectionstrategy).
 </ParamField>
 
 ### Aggregated mode fields
@@ -215,7 +217,7 @@ The following fields are required when `mode` is `"agg"` and are ignored in `"di
 </ParamField>
 
 <ParamField path="agg_pool_selection_strategy" type="AggPoolSelectionStrategy" default="null">
-  Grid mapping `(TTFT target, ITL target)` to an agg pool index. Required for `agg` mode. See [AggPoolSelectionStrategy](#aggpoolselectionstrategy).
+  Grid mapping `(TTFT target, ITL target)` to an agg pool index, or `(ISL, TTFT target, ITL target)` when all three optional `isl_*` fields are set. Required for `agg` mode. See [AggPoolSelectionStrategy](#aggpoolselectionstrategy).
 </ParamField>
 
 ## Additional types
@@ -260,7 +262,7 @@ Routes a request to a prefill pool based on its input sequence length (ISL) and 
 
 ### DecodePoolSelectionStrategy
 
-Routes a request to a decode pool based on its context length (prompt + tokens generated so far) and ITL target. The routing space is a 2D grid of `context_length_resolution × itl_resolution` cells. `decode_pool_mapping[ctx_idx][itl_idx]` gives the pool index.
+Routes a request to a decode pool based on its `context_length` bucket and ITL target. The current handler computes `context_length` as the number of request `token_ids` at decode routing time; it does not add subsequently generated tokens. The routing space is a 2D grid of `context_length_resolution × itl_resolution` cells. `decode_pool_mapping[ctx_idx][itl_idx]` gives the pool index.
 
 <ParamField path="itl_min_ms" type="number" required={true}>
   Lower bound of the ITL target range, in milliseconds. Also accepts the deprecated key `itl_min`.
@@ -275,11 +277,11 @@ Routes a request to a decode pool based on its context length (prompt + tokens g
 </ParamField>
 
 <ParamField path="context_length_min" type="integer" required={true}>
-  Lower bound of the context length range (tokens). Requests shorter than this are clamped to the first row.
+  Lower bound of the request-token-count range used by the current handler as `context_length`. Smaller requests are clamped to the first row.
 </ParamField>
 
 <ParamField path="context_length_max" type="integer" required={true}>
-  Upper bound of the context length range (tokens). Must be strictly greater than `context_length_min`.
+  Upper bound of the request-token-count range used as `context_length`. Must be strictly greater than `context_length_min`.
 </ParamField>
 
 <ParamField path="context_length_resolution" type="integer" required={true}>
@@ -296,7 +298,7 @@ Routes a request to a decode pool based on its context length (prompt + tokens g
 
 ### AggPoolSelectionStrategy
 
-Routes a request to an aggregated pool based on both its TTFT and ITL targets. Used in `mode: "agg"` where each pool handles both prefill and decode. The routing space is a 2D grid of `ttft_resolution × itl_resolution` cells. `agg_pool_mapping[ttft_idx][itl_idx]` gives the pool index.
+Routes a request to an aggregated pool based on both its TTFT and ITL targets. Used in `mode: "agg"` where each pool handles both prefill and decode. By default, the routing space is a 2D grid of `ttft_resolution × itl_resolution` cells. Configuring all three optional `isl_*` fields adds a leading ISL dimension. This dimension works whether or not chunked prefill is enabled.
 
 <ParamField path="ttft_min_ms" type="number" required={true}>
   Lower bound of the TTFT target range, in milliseconds. Also accepts the deprecated key `ttft_min`.
@@ -322,8 +324,20 @@ Routes a request to an aggregated pool based on both its TTFT and ITL targets. U
   Number of ITL grid columns (the second dimension of `agg_pool_mapping`). Must be a positive integer.
 </ParamField>
 
-<ParamField path="agg_pool_mapping" type="[][]integer" required={true}>
-  2D array of pool indices with shape `[ttft_resolution][itl_resolution]`. Each entry is a zero-based agg pool index in `[0, num_agg_pools)`. Row `i` covers the `i`-th TTFT bucket; column `j` covers the `j`-th ITL bucket.
+<ParamField path="isl_min" type="integer" default="null">
+  Optional lower bound for aggregated-mode input sequence length. Set this together with `isl_max` and `isl_resolution` to enable 3D selection.
+</ParamField>
+
+<ParamField path="isl_max" type="integer" default="null">
+  Optional upper bound for aggregated-mode input sequence length. Must be greater than `isl_min` when ISL selection is enabled.
+</ParamField>
+
+<ParamField path="isl_resolution" type="integer" default="null">
+  Optional number of aggregated-mode ISL buckets. Must be a positive integer when ISL selection is enabled.
+</ParamField>
+
+<ParamField path="agg_pool_mapping" type="[][]integer | [][][]integer" required={true}>
+  Without `isl_*`, a 2D array with shape `[ttft_resolution][itl_resolution]`. With all three `isl_*` fields, a 3D array with shape `[isl_resolution][ttft_resolution][itl_resolution]`. Each entry is a zero-based agg pool index in `[0, num_agg_pools)`. ISL, TTFT, and ITL values outside their configured ranges are clamped to the nearest bucket.
 </ParamField>
 
 <ParamField path="priority_overrides" type="[]PriorityPoolOverride" default="[]">
@@ -359,7 +373,8 @@ The router validates the configuration at startup and exits if any rule is viola
 - All `*_resolution` values must be positive integers.
 - `prefill_pool_mapping` must have exactly `isl_resolution` rows, each of length `ttft_resolution`; all pool indices must be in `[0, num_prefill_pools)`.
 - `decode_pool_mapping` must have exactly `context_length_resolution` rows, each of length `itl_resolution`; all pool indices must be in `[0, num_decode_pools)`.
-- `agg_pool_mapping` must have exactly `ttft_resolution` rows, each of length `itl_resolution`; all pool indices must be in `[0, num_agg_pools)`.
+- Without aggregated `isl_*` fields, `agg_pool_mapping` must have exactly `ttft_resolution` rows, each of length `itl_resolution`; all pool indices must be in `[0, num_agg_pools)`.
+- For aggregated selection, `isl_min`, `isl_max`, and `isl_resolution` must be omitted together or set together. When set, `isl_min < isl_max`, `isl_resolution` is positive, and `agg_pool_mapping` must have shape `[isl_resolution][ttft_resolution][itl_resolution]` instead of the 2D shape above.
 - In each `priority_overrides` entry: `min_priority` must be ≤ `max_priority`, and `target_pool` must be a valid pool index for the enclosing strategy.
 
 ## Related pages

--- a/docs/fern/pages/use-cases/multimodal-serving/multimodal-kv-routing.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/multimodal-kv-routing.md
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Multimodal KV Routing
-subtitle: Route multimodal requests to workers with the best KV cache overlap
+subtitle: Include multimodal identity in the router's combined cache-and-load cost
 ---
 
 ## Overview
 
 Multimodal KV routing extends Dynamo's KV-aware router to account for image content when calculating cache overlap. The frontend assigns each image a stable hash and includes its identity in the routing view of the prompt.
 
-When an image appears again, the KV router sends the request to the worker with the most matching KV cache blocks. This increases prefix-cache reuse and avoids repeating prefill work for cached multimodal content.
+When an image appears again, its identity contributes to each worker's KV overlap. The router balances that cache credit against projected prefill and decode load, so the worker with the largest overlap does not necessarily win when it is busy. Cache-aware placement increases prefix reuse without abandoning load balancing.
 
 > [!IMPORTANT]
 > The KV cache stores attention key/value state so a worker can skip repeated prefill work. The embedding cache stores vision encoder outputs so the encoder can skip repeated image processing. You can use both features together. See [Embedding Cache](embedding-cache.md).
@@ -30,7 +30,14 @@ The routing flow in general has three steps:
 
 1. The frontend computes a stable identity for each image.
 2. The frontend represents the image in a routing-only token view that matches the backend's cache identity.
-3. The KV router selects the worker with the highest block overlap and forwards the same image identity to that worker.
+3. The KV router includes that overlap in its combined cache-and-load score, selects the lowest-cost eligible worker, and forwards the same image identity.
+
+By default, an HTTP image's identity hashes the exact URL bytes, including its
+query string. Reusing the identical URL produces the same identity, but two URLs
+for the same image bytes do not. Enable `--frontend-decoding` when you need
+content-stable identity across URLs; the frontend then hashes decoded image
+content. Data URLs follow the same rule: the default path hashes the full data
+URI string, while frontend decoding hashes the decoded bytes.
 
 <Tabs>
   <Tab title="vLLM" language="vllm">
@@ -106,5 +113,5 @@ The routing flow in general has three steps:
 |---------|--------------|--------|-------|
 | [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/multimodal.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Supported families include Qwen2-VL, Qwen2.5-VL, Qwen3-VL, LLaVA 1.5, LLaVA-NeXT, Llama 4, Kimi K2.5/K2.6, Qwen3.5, and Qwen3.6. The rest use text-prefix-only routing. |
 | [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/multimodal.md#multimodal-kv-routing) | Python chat processor | <Badge intent="success" minimal>Yes</Badge> | Uses vLLM’s own multimodal processor — supports any VLM that vLLM supports. |
-| [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Dynamo's SGLang image includes hash-forwarding support; custom installations must add it. |
+| [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/multimodal.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Hash forwarding is upstream in SGLang 0.5.13+; Dynamo pins 0.5.16. Older custom installations need the upstream patch. |
 | [TensorRT-LLM](../../developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/multimodal.md#multimodal-kv-routing) | Rust frontend (default) | <Badge intent="success" minimal>Yes</Badge> | Supported model scope is the Qwen2-VL family (Qwen2-VL / Qwen2.5-VL / Qwen3-VL) and Kimi (Kimi-K2.5 / Kimi-K2.6). Other multimodal models fall back to text-prefix routing. |

--- a/docs/fern/pages/use-cases/multimodal-serving/overview.md
+++ b/docs/fern/pages/use-cases/multimodal-serving/overview.md
@@ -32,7 +32,7 @@ Dynamo provides support for improving latency and throughput for multimodal work
     Cache vision encoder embeddings to skip re-encoding repeated multimodal content
   </Card>
   <Card title="Multimodal KV Routing" icon="regular arrows-split-up-and-left" href="multimodal-kv-routing.md">
-    Route multimodal requests to workers with the best KV cache overlap
+    Include multimodal identity in cache-aware, load-balanced worker selection
   </Card>
   <Card title="EPD Disaggregation" icon="regular microchip" href="encoder-disaggregation.md">
     Separate vision encoding into a dedicated worker for independent scaling

--- a/examples/backends/trtllm/launch/agg_multimodal_router.sh
+++ b/examples/backends/trtllm/launch/agg_multimodal_router.sh
@@ -43,7 +43,7 @@ python3 -m dynamo.trtllm \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
   --enable-multimodal \
   "${TRTLLM_OVERRIDE_ARGS[@]}" \
-  --publish-events-and-metrics \
+  --publish-kv-events \
   --kv-block-size "$BLOCK_SIZE" &
 
 # Frontend: KV routing over the worker's published KV-cache events.

--- a/examples/backends/trtllm/launch/agg_router.sh
+++ b/examples/backends/trtllm/launch/agg_router.sh
@@ -33,7 +33,7 @@ python3 -m dynamo.trtllm \
   --model-path "$MODEL_PATH" \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$AGG_ENGINE_ARGS" \
-  --publish-events-and-metrics \
+  --publish-kv-events \
   "${TRTLLM_OVERRIDE_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/trtllm/launch/disagg_router.sh
+++ b/examples/backends/trtllm/launch/disagg_router.sh
@@ -32,7 +32,7 @@ CUDA_VISIBLE_DEVICES=$PREFILL_CUDA_VISIBLE_DEVICES python3 -m dynamo.trtllm \
   --served-model-name "$SERVED_MODEL_NAME" \
   --extra-engine-args "$PREFILL_ENGINE_ARGS" \
   --disaggregation-mode prefill \
-  --publish-events-and-metrics &
+  --publish-kv-events &
 
 # run decode worker
 # No event publishing needed - prefill handles it

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1759,7 +1759,7 @@ class KvRouterConfig:
 
         Args:
             overlap_score_weight: Deprecated positional/keyword alias for prefill_load_scale. When present, it takes precedence over prefill_load_scale; a value of 0 also sets overlap_score_credit to 0.
-            overlap_score_credit: Finite, non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit and can make adjusted prefill cost negative.
+            overlap_score_credit: Finite, non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit, with adjusted prefill cost clamped at zero.
             prefill_load_scale: Scale for adjusted prompt-side prefill load after cache-hit credits (default: 1.0)
             decode_active_request_weight: Experimental block-equivalent decode cost added for each active request on a candidate worker (default: 0.0)
             host_cache_hit_weight: Credit multiplier for host-pinned cache hits (default: 0.75)
@@ -1770,8 +1770,9 @@ class KvRouterConfig:
             router_track_active_blocks: Track active blocks for load balancing (default: True)
             router_track_output_blocks: Track output blocks during generation (default: False).
                 When enabled, the router adds placeholder blocks as tokens are generated
-                and applies fractional decay based on progress toward expected output
-                sequence length (agent_hints.osl in nvext).
+                and, with expected output sequence length (agent_hints.osl in nvext),
+                applies fractional decay to output blocks and the structurally exclusive
+                prompt suffix. Shared prompt blocks retain full weight.
             router_assume_kv_reuse: Assume KV cache reuse when tracking active blocks (default: True).
                 When True, computes actual block hashes. When False, generates random hashes.
             router_track_prefill_tokens: Include prompt-side prefill tokens in active load accounting (default: True).


### PR DESCRIPTION
## Summary

- Align router cost, scheduling, event recovery, and replica-sync guidance with current implementations.
- Refresh standalone, Global Router, offloading, multimodal, LoRA, and disaggregated-serving behavior and examples.
- Replace deprecated TensorRT-LLM KV-event flags in router launch scripts.
- Keep topology-aware and Kubernetes-owned documentation out of scope.

## Validation

- `git diff --check`
- `.venv/bin/pre-commit run --files <changed files>`
- `fern check --local` (0 errors; only unauthenticated redirect and existing color-contrast warnings)
- `fern docs broken-links --strict`
- `.venv/bin/python -m py_compile` for changed Python files
- `bash -n` for changed launch scripts
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified request-token-based decode routing, disaggregated serving, startup behavior, recovery, and worker registration.
  * Added standalone router client examples, updated deployment guidance, and refreshed configuration examples.
  * Documented LoRA routing compatibility and session-affinity limitations.
  * Expanded guidance for multimodal KV routing, image identity hashing, cache/load scoring, and SGLang version requirements.
  * Clarified cache-credit clamping, output-block decay, queue policies, offloading support, and TensorRT-LLM requirements.

* **Improvements**
  * Updated TensorRT-LLM launch examples to publish KV events using the current configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->