### PR TITLE
fix(ci): pass image_tag to nightly deploy tests

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -605,13 +605,13 @@ jobs:
 
   deploy-test-vllm:
     name: vLLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, vllm-build, vllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, vllm-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/shared-deploy-test.yml
     with:
       framework: vllm
       profiles: '["agg"]'
-      image_suffix: ${{ format('{0}-nightly', needs.vllm-build.outputs.target_tag_plain) }}
+      image_tag: ${{ needs.vllm-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -619,13 +619,13 @@ jobs:
 
   deploy-test-sglang:
     name: sglang Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, sglang-build, sglang-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, sglang-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/shared-deploy-test.yml
     with:
       framework: sglang
       profiles: '["agg"]'
-      image_suffix: ${{ format('{0}-nightly', needs.sglang-build.outputs.target_tag_plain) }}
+      image_tag: ${{ needs.sglang-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}
@@ -633,13 +633,13 @@ jobs:
 
   deploy-test-trtllm:
     name: TensorRT-LLM Nightly Deploy Test
-    needs: [compute-release-mode, deploy-operator, trtllm-build, trtllm-copy-to-acr]
+    needs: [compute-release-mode, deploy-operator, trtllm-copy-to-acr]
     if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
     uses: ./.github/workflows/shared-deploy-test.yml
     with:
       framework: trtllm
       profiles: '["agg"]'
-      image_suffix: ${{ format('{0}-nightly', needs.trtllm-build.outputs.target_tag_plain) }}
+      image_tag: ${{ needs.trtllm-copy-to-acr.outputs.image_tag }}
       namespace: ${{ needs.deploy-operator.outputs.namespace }}
       vcluster_name: ${{ needs.deploy-operator.outputs.vcluster_name }}
       operator_tag: ${{ needs.deploy-operator.outputs.operator_tag }}


### PR DESCRIPTION
## Summary

The nightly pipeline has not run since #12090 merged. Run [30894125332](https://github.com/ai-dynamo/dynamo/actions/runs/30894125332) ended in `startup_failure` — GitHub rejected the workflow file, so **no jobs ran at all**, not just the deploy tests:

```
Invalid workflow file: .github/workflows/nightly-ci.yml#L610
(Line: 610, Col: 11): Input image_tag is required, but not provided while calling.
(Line: 614, Col: 21): Invalid input, image_suffix is not defined in the referenced workflow.
```

Two bugs, one hiding behind the other:

1. **Wrong input name.** The three `deploy-test-*` jobs pass `image_suffix` to `shared-deploy-test.yml`, which defines no such input — its required input is `image_tag`. GitHub validates reusable-workflow inputs when it instantiates the caller, which is why this takes down the whole file. All three jobs have the defect; GitHub only reports the first.

2. **Wrong value.** `format('{0}-nightly', <fw>-build.outputs.target_tag_plain)` omits the `<version>-ci-<sha>-` prefix that `shared-copy.yml` prepends when it publishes to ACR. Even with the input named correctly, the deploy tests would have failed on image pull.

Both are fixed by consuming `<fw>-copy-to-acr.outputs.image_tag` — the tag actually pushed to ACR — which is what `post-merge-ci.yml:877` already does. `<fw>-build` drops out of each `needs` list because `<fw>-copy-to-acr` already depends on it.

Nothing on the original PR could have caught this: reusable-workflow input contracts are only validated when the calling workflow is instantiated, and `nightly-ci.yml` never runs on a PR. Adding an `actionlint` pre-commit hook would catch this class statically — it reproduces the exact GitHub error offline — and will follow in a separate PR.

## Validation

- `actionlint` on the branch reports **0** `workflow-call` errors in `nightly-ci.yml`; on `main` it reports 6 (the `image_tag`-required and `image_suffix`-undefined pair for each of the vllm/sglang/trtllm jobs), matching GitHub's startup failure verbatim.
- Input name and source now match the working `post-merge-ci.yml` deploy-test callers.
- Full confirmation is the next nightly reaching the job graph instead of `startup_failure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12637" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly deployment test reliability by using the exact image tags produced during image publishing.
  * Removed unnecessary build-job dependencies from nightly deployment test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->