### PR TITLE
fix(llm): skip redundant tool ban for none choice

### DIFF
--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -22,6 +22,10 @@ fn requires_intrinsic_structural_tag(parser_name: Option<&str>, tool_choice: &To
     is_kimi_k3_parser(parser_name) && matches!(tool_choice, ToolChoice::Named(_))
 }
 
+fn should_skip_tool_call_ban(exclude_tools_when_none: bool, tool_choice: &ToolChoice) -> bool {
+    exclude_tools_when_none && matches!(tool_choice, ToolChoice::None)
+}
+
 impl OpenAIPreprocessor {
     /// Apply structural tag guided decoding when enabled for this request.
     pub(super) fn apply_tool_choice_structural_tag(
@@ -50,6 +54,16 @@ impl OpenAIPreprocessor {
         let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
             return Ok(false);
         };
+
+        if should_skip_tool_call_ban(
+            self.runtime_config.exclude_tools_when_tool_choice_none,
+            tool_choice,
+        ) {
+            // The prompt formatter already omits tools for this request. Avoid
+            // sending a redundant AnyTokens structural tag: vLLM cannot
+            // validate token-string exclusions without tokenizer metadata.
+            return Ok(false);
+        }
 
         if matches!(tool_choice, ToolChoice::None) {
             if tools.is_empty() {
@@ -197,5 +211,12 @@ mod tests {
             Some("hermes"),
             &ToolChoice::Named("get_weather".to_string())
         ));
+    }
+
+    #[test]
+    fn tool_choice_none_skips_structural_tag_when_tools_are_excluded() {
+        assert!(should_skip_tool_call_ban(true, &ToolChoice::None));
+        assert!(!should_skip_tool_call_ban(false, &ToolChoice::None));
+        assert!(!should_skip_tool_call_ban(true, &ToolChoice::Required));
     }
 }

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -43,6 +43,16 @@ impl OpenAIPreprocessor {
             return Ok(false);
         }
 
+        if should_skip_tool_call_ban(
+            self.runtime_config.exclude_tools_when_tool_choice_none,
+            tool_choice,
+        ) {
+            // The prompt formatter already omits tools for this request. Avoid
+            // sending a redundant AnyTokens structural tag: vLLM cannot
+            // validate token-string exclusions without tokenizer metadata.
+            return Ok(false);
+        }
+
         let Some(parser_name) = parser_name else {
             tracing::warn!(
                 "Structural tag is enabled but --dyn-tool-call-parser is not set; \
@@ -54,16 +64,6 @@ impl OpenAIPreprocessor {
         let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
             return Ok(false);
         };
-
-        if should_skip_tool_call_ban(
-            self.runtime_config.exclude_tools_when_tool_choice_none,
-            tool_choice,
-        ) {
-            // The prompt formatter already omits tools for this request. Avoid
-            // sending a redundant AnyTokens structural tag: vLLM cannot
-            // validate token-string exclusions without tokenizer metadata.
-            return Ok(false);
-        }
 
         if matches!(tool_choice, ToolChoice::None) {
             if tools.is_empty() {

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -192,7 +192,36 @@ impl OpenAIPreprocessor {
 
 #[cfg(test)]
 mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
+    use crate::{
+        model_card::ModelDeploymentCard,
+        protocols::common::{OutputOptions, SamplingOptions, StopConditions},
+    };
+
     use super::*;
+
+    fn structural_tag_preprocessor(exclude_tools_when_none: bool) -> Arc<OpenAIPreprocessor> {
+        let model_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/sample-models/mock-llama-3.1-8b-instruct");
+        let mut mdc = ModelDeploymentCard::load_from_disk(model_path, None).unwrap();
+        mdc.runtime_config.structural_tag_mode = StructuralTagMode::On;
+        mdc.runtime_config.tool_call_parser = Some("qwen3_coder".to_string());
+        mdc.runtime_config.exclude_tools_when_tool_choice_none = exclude_tools_when_none;
+
+        OpenAIPreprocessor::new(mdc).unwrap()
+    }
+
+    fn preprocessed_request() -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test-model".to_string())
+            .token_ids(Vec::new())
+            .stop_conditions(StopConditions::default())
+            .sampling_options(SamplingOptions::default())
+            .output_options(OutputOptions::default())
+            .build()
+            .unwrap()
+    }
 
     #[test]
     fn named_kimi_k3_is_intrinsic_even_when_global_mode_is_off() {
@@ -214,9 +243,38 @@ mod tests {
     }
 
     #[test]
-    fn tool_choice_none_skips_structural_tag_when_tools_are_excluded() {
-        assert!(should_skip_tool_call_ban(true, &ToolChoice::None));
-        assert!(!should_skip_tool_call_ban(false, &ToolChoice::None));
-        assert!(!should_skip_tool_call_ban(true, &ToolChoice::Required));
+    fn tool_choice_none_skips_ban_only_when_prompt_excludes_tools() {
+        let tools = [ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: None,
+            strict: None,
+        }];
+
+        let preprocessor = structural_tag_preprocessor(true);
+        let mut request = preprocessed_request();
+        let applied = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::None, &tools, None, false, &mut request)
+            .unwrap();
+
+        assert!(!applied);
+        assert!(request.sampling_options.guided_decoding.is_none());
+
+        let preprocessor = structural_tag_preprocessor(false);
+        let mut request = preprocessed_request();
+        let applied = preprocessor
+            .apply_tool_choice_structural_tag(&ToolChoice::None, &tools, None, false, &mut request)
+            .unwrap();
+
+        assert!(applied);
+        let structural_tag = request
+            .sampling_options
+            .guided_decoding
+            .as_ref()
+            .and_then(|guided| guided.structural_tag.as_ref())
+            .expect("tool-call ban should be installed");
+        assert_eq!(
+            structural_tag["format"]["content"]["exclude_tokens"],
+            serde_json::json!(["<tool_call>"])
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Skip structural-tag tool-call bans for `tool_choice: none` when the prompt formatter already excludes tools.
- Retain the existing ban path when tools remain available.
- Add focused policy regression coverage.

The redundant AnyTokens exclusion could be rejected by vLLM when token-string exclusions lacked tokenizer metadata, even though no tools were present in the formatted prompt.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --lib tool_choice_none_skips_structural_tag_when_tools_are_excluded`

## Tracking

Internal: [DIS-2623](https://linear.app/nvidia/issue/DIS-2623/skip-redundant-structural-tag-ban-when-tool-choice-none-excludes-tools)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Avoided applying redundant tool restrictions when tools are already excluded by configuration.
  * Preserved existing behavior for other tool-selection settings.

* **Tests**
  * Added coverage for configurations where the restriction should be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Why vLLM 0.26.0 crashes

vLLM uses `auto` as its default structured-output backend. For this request:

1. XGrammar first validates the canonical structural tag generated by Dynamo.
2. Resolving `exclude_tokens: ["<tool_call>"]` requires tokenizer information, but the validation call does not supply it. XGrammar rejects the constraint with `InvalidStructuralTagError: Token string resolution requires tokenizer_info`.
3. vLLM catches that validation failure and falls back to llguidance.
4. The llguidance path only understands the legacy structural-tag representation with top-level `triggers` and `structures`. Dynamo supplied the canonical `format` representation, so the fallback raises `KeyError: 'triggers'`.

The request therefore fails before inference and surfaces as an HTTP 500 instead of returning a normal response with no tool call.