### PR TITLE
fix(llm): emit role once in chat streams

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -554,6 +554,8 @@ class StreamingPostProcessor:
         if self._should_buffer_for_non_streaming_tool_parse():
             return self._process_non_streaming_tool_output(output)
 
+        # TODO: Emit the role only once per choice here instead of relying on
+        # HTTP stream deduplication to remove repeated postprocessor roles.
         delta_token_ids = list(output.token_ids or [])
         # vLLM output_processor already applies stop-token/stop-string trimming
         # to text. Re-detokenizing from token_ids can reintroduce stop markers.

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -6415,7 +6415,7 @@ mod tests {
     #[test]
     fn test_deduplicate_stream_roles_preserves_only_first_role_per_choice() {
         let mut emitted_roles = HashSet::new();
-        let mut first = make_delta(
+        let mut first_choice_zero = make_delta(
             None,
             Some("thinking"),
             None,
@@ -6425,7 +6425,7 @@ mod tests {
             None,
             None,
         );
-        let mut second = make_delta(
+        let mut first_choice_one = make_delta(
             None,
             None,
             None,
@@ -6435,12 +6435,44 @@ mod tests {
             None,
             None,
         );
+        first_choice_one.inner.choices[0].index = 1;
+        let mut second_choice_zero = make_delta(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Role::Assistant),
+            None,
+            None,
+        );
+        let mut second_choice_one = make_delta(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Role::Assistant),
+            None,
+            None,
+        );
+        second_choice_one.inner.choices[0].index = 1;
 
-        deduplicate_stream_roles(&mut first, &mut emitted_roles);
-        deduplicate_stream_roles(&mut second, &mut emitted_roles);
+        deduplicate_stream_roles(&mut first_choice_zero, &mut emitted_roles);
+        deduplicate_stream_roles(&mut first_choice_one, &mut emitted_roles);
+        deduplicate_stream_roles(&mut second_choice_zero, &mut emitted_roles);
+        deduplicate_stream_roles(&mut second_choice_one, &mut emitted_roles);
 
-        assert_eq!(first.inner.choices[0].delta.role, Some(Role::Assistant));
-        assert_eq!(second.inner.choices[0].delta.role, None);
+        assert_eq!(
+            first_choice_zero.inner.choices[0].delta.role,
+            Some(Role::Assistant)
+        );
+        assert_eq!(
+            first_choice_one.inner.choices[0].delta.role,
+            Some(Role::Assistant)
+        );
+        assert_eq!(second_choice_zero.inner.choices[0].delta.role, None);
+        assert_eq!(second_choice_one.inner.choices[0].delta.role, None);
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1825,7 +1825,6 @@ fn push_dispatch_event(
 }
 
 /// Empty stream chunk produced by multi-byte token assembly (e.g. emoji).
-/// `role` is excluded; backends set it on every delta.
 fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool {
     if resp.nvext.is_some() {
         return false;
@@ -1836,7 +1835,7 @@ fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool
                 content,
                 function_call,
                 tool_calls,
-                role: _,
+                role,
                 refusal,
                 reasoning_content,
             } = &c.delta;
@@ -1852,9 +1851,22 @@ fn is_empty_stream_response(resp: &NvCreateChatCompletionStreamResponse) -> bool
                 && content_empty
                 && function_call.is_none()
                 && tool_calls.is_none()
+                && role.is_none()
                 && refusal.is_none()
                 && reasoning_content.is_none()
         })
+}
+
+/// Preserve the first role delta for each choice and remove parser-generated repeats.
+fn deduplicate_stream_roles(
+    resp: &mut NvCreateChatCompletionStreamResponse,
+    emitted_roles: &mut HashSet<u32>,
+) {
+    for choice in &mut resp.inner.choices {
+        if choice.delta.role.is_some() && !emitted_roles.insert(choice.index) {
+            choice.delta.role = None;
+        }
+    }
 }
 
 /// Completions variant of [`is_empty_stream_response`].
@@ -2152,6 +2164,7 @@ async fn chat_completions(
         let reasoning_field = state.reasoning_field();
         let mut reasoning_buffer: HashMap<u32, String> = HashMap::new();
         let mut dispatched_tool_ids: HashSet<String> = HashSet::new();
+        let mut emitted_roles: HashSet<u32> = HashSet::new();
 
         // Optionally prepend extra SSE events before each regular chunk:
         //   - `event: tool_call_dispatch`  — complete tool call detected early (tool dispatch)
@@ -2176,6 +2189,10 @@ async fn chat_completions(
                             }
                         }
                     }
+                }
+
+                if let Some(data) = response.data.as_mut() {
+                    deduplicate_stream_roles(data, &mut emitted_roles);
                 }
 
                 // Drop empty chunks from multi-byte token assembly.
@@ -6346,9 +6363,9 @@ mod tests {
             "usage present → not empty",
         );
 
-        // Role-only: still empty (backends repeat role on every chunk)
+        // Role-only: not empty; duplicate roles are removed before this predicate.
         assert!(
-            is_empty_stream_response(&make_delta(
+            !is_empty_stream_response(&make_delta(
                 None,
                 None,
                 None,
@@ -6358,7 +6375,7 @@ mod tests {
                 None,
                 None,
             )),
-            "role-only → empty",
+            "role-only → not empty",
         );
 
         // Not empty: has refusal
@@ -6393,6 +6410,37 @@ mod tests {
             )),
             "function_call present → not empty",
         );
+    }
+
+    #[test]
+    fn test_deduplicate_stream_roles_preserves_only_first_role_per_choice() {
+        let mut emitted_roles = HashSet::new();
+        let mut first = make_delta(
+            None,
+            Some("thinking"),
+            None,
+            None,
+            None,
+            Some(Role::Assistant),
+            None,
+            None,
+        );
+        let mut second = make_delta(
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Role::Assistant),
+            None,
+            None,
+        );
+
+        deduplicate_stream_roles(&mut first, &mut emitted_roles);
+        deduplicate_stream_roles(&mut second, &mut emitted_roles);
+
+        assert_eq!(first.inner.choices[0].delta.role, Some(Role::Assistant));
+        assert_eq!(second.inner.choices[0].delta.role, None);
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -42,7 +42,12 @@ use dynamo_runtime::metrics::frontend_perf::{
     DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, STAGE_DURATION_SECONDS, STAGE_PREPROCESS,
     StageGuard, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
 };
-use std::{any::Any, collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    any::Any,
+    collections::{HashMap, HashSet},
+    pin::Pin,
+    sync::Arc,
+};
 use tracing;
 
 #[cfg(feature = "mm-routing")]
@@ -2698,6 +2703,30 @@ impl OpenAIPreprocessor {
         Ok(transformed_stream)
     }
 
+    /// Ensure the first emitted delta for each choice carries the assistant role.
+    ///
+    /// This runs after reasoning and tool-call parsing so a parser that buffers the
+    /// original role-bearing delta cannot leave downstream consumers without a role.
+    fn normalize_chat_stream_roles<S>(
+        stream: S,
+    ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static
+    where
+        S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        let mut role_emitted_choices = HashSet::new();
+
+        stream.map(move |mut response| {
+            if let Some(data) = response.data.as_mut() {
+                for choice in &mut data.inner.choices {
+                    choice.delta.role = role_emitted_choices
+                        .insert(choice.index)
+                        .then_some(dynamo_protocols::types::Role::Assistant);
+                }
+            }
+            response
+        })
+    }
+
     pub fn transform_postprocessor_stream<S, Resp>(
         stream: S,
         generator: Box<dyn DeltaGeneratorExt<Resp>>,
@@ -3915,6 +3944,7 @@ impl
             prompt_injected_reasoning,
             uses_tool_call_structural_tag,
         )?;
+        let transformed_stream = Self::normalize_chat_stream_roles(transformed_stream);
 
         // Apply request payload aggregation strategy.
         // The payload branch already returns Pin<Box<...>> from scan/fold_aggregate_with_future,
@@ -4159,6 +4189,72 @@ impl
 #[cfg(test)]
 mod strip_tests {
     use super::OpenAIPreprocessor;
+
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
+        CreateChatCompletionStreamResponse, Role,
+    };
+    use dynamo_runtime::protocols::annotated::Annotated;
+    use futures::{StreamExt, stream};
+
+    fn chat_stream_chunk(
+        index: u32,
+        role: Option<Role>,
+    ) -> Annotated<super::NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index,
+            delta: ChatCompletionStreamResponseDelta {
+                role,
+                content: Some(ChatCompletionMessageContent::Text("content".to_string())),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+        Annotated::from_data(super::NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![choice],
+                created: 0,
+                model: "test".to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_normalize_chat_stream_roles_recovers_missing_first_role_per_choice() {
+        let input = stream::iter(vec![
+            // Mirrors a parser releasing buffered content without the role that
+            // arrived on the original, swallowed chunk.
+            chat_stream_chunk(0, None),
+            chat_stream_chunk(1, None),
+            chat_stream_chunk(0, Some(Role::Assistant)),
+            chat_stream_chunk(1, Some(Role::Assistant)),
+        ]);
+
+        let output: Vec<_> = OpenAIPreprocessor::normalize_chat_stream_roles(input)
+            .collect()
+            .await;
+        let roles: Vec<_> = output
+            .iter()
+            .map(|response| response.data.as_ref().unwrap().inner.choices[0].delta.role)
+            .collect();
+
+        assert_eq!(
+            roles,
+            vec![Some(Role::Assistant), Some(Role::Assistant), None, None,]
+        );
+    }
 
     #[test]
     fn test_strip_inline_data_urls_replaces_data_urls() {

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4190,72 +4190,6 @@ impl
 mod strip_tests {
     use super::OpenAIPreprocessor;
 
-    use dynamo_protocols::types::{
-        ChatChoiceStream, ChatCompletionMessageContent, ChatCompletionStreamResponseDelta,
-        CreateChatCompletionStreamResponse, Role,
-    };
-    use dynamo_runtime::protocols::annotated::Annotated;
-    use futures::{StreamExt, stream};
-
-    fn chat_stream_chunk(
-        index: u32,
-        role: Option<Role>,
-    ) -> Annotated<super::NvCreateChatCompletionStreamResponse> {
-        #[allow(deprecated)]
-        let choice = ChatChoiceStream {
-            index,
-            delta: ChatCompletionStreamResponseDelta {
-                role,
-                content: Some(ChatCompletionMessageContent::Text("content".to_string())),
-                tool_calls: None,
-                function_call: None,
-                refusal: None,
-                reasoning_content: None,
-            },
-            finish_reason: None,
-            logprobs: None,
-        };
-        Annotated::from_data(super::NvCreateChatCompletionStreamResponse {
-            inner: CreateChatCompletionStreamResponse {
-                id: "test".to_string(),
-                choices: vec![choice],
-                created: 0,
-                model: "test".to_string(),
-                system_fingerprint: None,
-                object: "chat.completion.chunk".to_string(),
-                usage: None,
-                service_tier: None,
-            },
-            nvext: None,
-            llm_metrics: None,
-        })
-    }
-
-    #[tokio::test]
-    async fn test_normalize_chat_stream_roles_recovers_missing_first_role_per_choice() {
-        let input = stream::iter(vec![
-            // Mirrors a parser releasing buffered content without the role that
-            // arrived on the original, swallowed chunk.
-            chat_stream_chunk(0, None),
-            chat_stream_chunk(1, None),
-            chat_stream_chunk(0, Some(Role::Assistant)),
-            chat_stream_chunk(1, Some(Role::Assistant)),
-        ]);
-
-        let output: Vec<_> = OpenAIPreprocessor::normalize_chat_stream_roles(input)
-            .collect()
-            .await;
-        let roles: Vec<_> = output
-            .iter()
-            .map(|response| response.data.as_ref().unwrap().inner.choices[0].delta.role)
-            .collect();
-
-        assert_eq!(
-            roles,
-            vec![Some(Role::Assistant), Some(Role::Assistant), None, None,]
-        );
-    }
-
     #[test]
     fn test_strip_inline_data_urls_replaces_data_urls() {
         let mut messages = serde_json::json!([{
@@ -4315,6 +4249,69 @@ mod tests {
     use super::*;
     use crate::protocols::common::preprocessor::MultimodalData;
     use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
+        Role,
+    };
+
+    fn chat_stream_chunk(
+        index: u32,
+        role: Option<Role>,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index,
+            delta: ChatCompletionStreamResponseDelta {
+                role,
+                content: Some(ChatCompletionMessageContent::Text("content".to_string())),
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+        Annotated::from_data(NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![choice],
+                created: 0,
+                model: "test".to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+            llm_metrics: None,
+        })
+    }
+
+    #[tokio::test]
+    async fn test_normalize_chat_stream_roles_recovers_missing_first_role_per_choice() {
+        let input = stream::iter(vec![
+            // Mirrors a parser releasing buffered content without the role that
+            // arrived on the original, swallowed chunk.
+            chat_stream_chunk(0, None),
+            chat_stream_chunk(1, None),
+            chat_stream_chunk(0, Some(Role::Assistant)),
+            chat_stream_chunk(1, Some(Role::Assistant)),
+        ]);
+
+        let output: Vec<_> = OpenAIPreprocessor::normalize_chat_stream_roles(input)
+            .collect()
+            .await;
+        let roles: Vec<_> = output
+            .iter()
+            .map(|response| response.data.as_ref().unwrap().inner.choices[0].delta.role)
+            .collect();
+
+        assert_eq!(
+            roles,
+            vec![Some(Role::Assistant), Some(Role::Assistant), None, None,]
+        );
+    }
 
     #[test]
     fn prompt_invalid_request_maps_to_invalid_argument() {

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -170,6 +170,7 @@ impl DeltaGenerator {
         };
 
         let choices = vec![choice];
+        self.msg_counter += 1;
 
         // According to OpenAI spec: when stream_options.include_usage is true,
         // all intermediate chunks should have usage: null
@@ -510,6 +511,25 @@ mod tests {
             .expect("completion token details should be propagated");
 
         assert_eq!(completion_details.reasoning_tokens, Some(3));
+    }
+
+    #[test]
+    fn test_role_is_emitted_only_in_first_delta() {
+        let request = create_test_request();
+        let mut generator = request.response_generator("req-stream-role".to_string());
+
+        let first = generator
+            .choice_from_postprocessor(final_backend_output())
+            .expect("first choice generation");
+        let second = generator
+            .choice_from_postprocessor(final_backend_output())
+            .expect("second choice generation");
+
+        assert_eq!(
+            first.inner.choices[0].delta.role,
+            Some(dynamo_protocols::types::Role::Assistant)
+        );
+        assert_eq!(second.inner.choices[0].delta.role, None);
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {

--- a/lib/llm/src/protocols/openai/chat_completions/delta.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/delta.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use super::{NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse};
 use crate::{
@@ -52,8 +52,8 @@ pub struct DeltaGenerator {
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Tracks token usage for the completion request.
     usage: dynamo_protocols::types::CompletionUsage,
-    /// Counter tracking the number of messages issued.
-    msg_counter: u64,
+    /// Choice indices for which the assistant role has already been emitted.
+    emitted_role_choices: HashSet<u32>,
     /// Configuration options for response generation.
     options: DeltaGeneratorOptions,
     /// Request tracker for per-request metrics (shared with PreprocessedRequest).
@@ -71,7 +71,7 @@ impl DeltaGenerator {
             system_fingerprint: None,
             service_tier: None,
             usage,
-            msg_counter: 0,
+            emitted_role_choices: HashSet::new(),
             options,
             tracker,
         }
@@ -153,11 +153,10 @@ impl DeltaGenerator {
             content: text.map(dynamo_protocols::types::ChatCompletionMessageContent::Text),
             function_call: None,
             tool_calls: None,
-            role: if self.msg_counter == 0 {
-                Some(dynamo_protocols::types::Role::Assistant)
-            } else {
-                None
-            },
+            role: self
+                .emitted_role_choices
+                .insert(index)
+                .then_some(dynamo_protocols::types::Role::Assistant),
             refusal: None,
             reasoning_content: None,
         };
@@ -170,8 +169,6 @@ impl DeltaGenerator {
         };
 
         let choices = vec![choice];
-        self.msg_counter += 1;
-
         // According to OpenAI spec: when stream_options.include_usage is true,
         // all intermediate chunks should have usage: null
         // The final usage chunk will be sent separately with empty choices
@@ -514,22 +511,40 @@ mod tests {
     }
 
     #[test]
-    fn test_role_is_emitted_only_in_first_delta() {
+    fn test_role_is_emitted_once_per_choice() {
         let request = create_test_request();
         let mut generator = request.response_generator("req-stream-role".to_string());
 
-        let first = generator
+        let first_choice_zero = generator
             .choice_from_postprocessor(final_backend_output())
-            .expect("first choice generation");
-        let second = generator
+            .expect("first choice 0 generation");
+
+        let mut choice_one_output = final_backend_output();
+        choice_one_output.index = Some(1);
+        let first_choice_one = generator
+            .choice_from_postprocessor(choice_one_output)
+            .expect("first choice 1 generation");
+
+        let second_choice_zero = generator
             .choice_from_postprocessor(final_backend_output())
-            .expect("second choice generation");
+            .expect("second choice 0 generation");
+
+        let mut choice_one_output = final_backend_output();
+        choice_one_output.index = Some(1);
+        let second_choice_one = generator
+            .choice_from_postprocessor(choice_one_output)
+            .expect("second choice 1 generation");
 
         assert_eq!(
-            first.inner.choices[0].delta.role,
+            first_choice_zero.inner.choices[0].delta.role,
             Some(dynamo_protocols::types::Role::Assistant)
         );
-        assert_eq!(second.inner.choices[0].delta.role, None);
+        assert_eq!(
+            first_choice_one.inner.choices[0].delta.role,
+            Some(dynamo_protocols::types::Role::Assistant)
+        );
+        assert_eq!(second_choice_zero.inner.choices[0].delta.role, None);
+        assert_eq!(second_choice_one.inner.choices[0].delta.role, None);
     }
 
     fn create_test_request_with_extra_fields(fields: Vec<String>) -> NvCreateChatCompletionRequest {


### PR DESCRIPTION
## Summary

- Advance the chat delta generator's message counter so it emits `delta.role` only on the first generated chunk.
- Deduplicate roles per choice after tool and reasoning parser transformations, which can synthesize new role-bearing chunks.
- Preserve the initial role-only chunk instead of filtering it as empty.

Both layers are required: fixing only the base generator does not cover parser-generated chunks, while boundary-only normalization would hide the generator defect.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --lib test_role_is_emitted_only_in_first_delta`
- `cargo test -p dynamo-llm --lib test_deduplicate_stream_roles_preserves_only_first_role_per_choice`

## Tracking

Internal: [DIS-2622](https://linear.app/nvidia/issue/DIS-2622/emit-assistant-role-once-across-the-chat-streaming-pipeline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat response streaming so assistant role information is preserved when received in a standalone update.
  - Prevented repeated role information from appearing in subsequent streamed chunks.
  - Improved handling of multiple choices so each choice emits its role correctly and independently.
  - Updated streaming behavior to avoid incorrectly discarding meaningful role-only updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->