### PR TITLE
fix(docs): repair the 15 broken links lychee reports on release/1.3.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 - [Propose a feature](https://github.com/ai-dynamo/dynamo/issues/new?template=feature_request.yml)
 - [Design Proposals](https://github.com/ai-dynamo/enhancements)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf)
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io/)
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [Office Hours](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
 - [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you're running a single model on a single GPU, your inference engine alone is
 
 | | [SGLang](https://docs.nvidia.com/dynamo/backends/sg-lang) | [TensorRT-LLM](https://docs.nvidia.com/dynamo/backends/tensor-rt-llm) | [vLLM](https://docs.nvidia.com/dynamo/backends/v-llm) |
 |---|:----:|:----------:|:--:|
-| [**Disaggregated Serving**](https://docs.nvidia.com/dynamo/design-docs/disaggregated-serving) | ✅ | ✅ | ✅ |
+| [**Disaggregated Serving**](https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/design-docs/disagg-serving.md) | ✅ | ✅ | ✅ |
 | [**KV-Aware Routing**](https://docs.nvidia.com/dynamo/components/router) | ✅ | ✅ | ✅ |
 | [**SLA-Based Planner**](https://docs.nvidia.com/dynamo/components/planner/planner-guide) | ✅ | ✅ | ✅ |
 | [**KVBM**](https://docs.nvidia.com/dynamo/components/kvbm) | 🚧 | ✅ | ✅ |
@@ -90,7 +90,7 @@ Most inference engines optimize a single GPU or a single node. Dynamo is the **o
 
 | Capability | What it does | Why it matters |
 |------------|-------------|----------------|
-| [**Disaggregated Prefill/Decode**](https://docs.nvidia.com/dynamo/design-docs/disaggregated-serving) | Separates prefill and decode into independently scalable GPU pools | Maximizes GPU utilization; each phase runs on hardware tuned for its workload |
+| [**Disaggregated Prefill/Decode**](https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/design-docs/disagg-serving.md) | Separates prefill and decode into independently scalable GPU pools | Maximizes GPU utilization; each phase runs on hardware tuned for its workload |
 | [**KV-Aware Routing**](https://docs.nvidia.com/dynamo/components/router) | Routes requests based on worker load and KV cache overlap | Eliminates redundant prefill computation — 2x faster TTFT |
 | [**KV Block Manager (KVBM)**](https://docs.nvidia.com/dynamo/components/kvbm) | Offloads KV cache across GPU → CPU → SSD → remote storage | Extends effective context length beyond GPU memory |
 | [**ModelExpress**](https://github.com/ai-dynamo/modelexpress) | Streams model weights GPU-to-GPU via NIXL/NVLink | 7x faster cold-start for new replicas |

--- a/deploy/helm/charts/platform/templates/NOTES.txt
+++ b/deploy/helm/charts/platform/templates/NOTES.txt
@@ -27,7 +27,7 @@
   This release must use dynamo-operator.upgradeCRD=false and use CRDs managed
   by the cluster-wide operator. Use cluster-wide mode for production deployments.
 
-  See: https://github.com/ai-dynamo/dynamo/blob/main/docs/kubernetes/installation-guide.md
+  See: https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/kubernetes/installation-guide.md
 ================================================================================
 
 {{- end }}

--- a/docs/benchmarks/qwen3-6-35b-feature-stack.mdx
+++ b/docs/benchmarks/qwen3-6-35b-feature-stack.mdx
@@ -25,7 +25,7 @@ Three configurations run on the same single-GPU node (H100 or GB200, selected at
 
 ## Results
 
-Full result tables are reproduced below from the [source study](https://github.com/ai-dynamo/dynamo/blob/main/docs/benchmarks/embedding_cache.md); the headline numbers:
+Full result tables are reproduced below from the [source study](https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/benchmarks/embedding_cache.md); the headline numbers:
 
 ### H100
 

--- a/docs/benchmarks/qwen3-vl-embedding-cache.mdx
+++ b/docs/benchmarks/qwen3-vl-embedding-cache.mdx
@@ -94,7 +94,7 @@ The helper script `recipes/qwen3-vl-30b/vllm/agg-embedding-cache/run-benchmark.s
 ## Notes
 
 - Exact cache hit rates cannot be pinned via the dataset because of LRU eviction; shrinking the image pool relative to request count (or growing the cache) raises the hit probability.
-- The aggregated embedding cache uses vLLM's native `ec_both` ECConnector role, supported in vLLM 0.17+ with no patches — see [multimodal vLLM docs](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md#embedding-cache).
+- The aggregated embedding cache uses vLLM's native `ec_both` ECConnector role, supported in vLLM 0.17+ with no patches — see [multimodal vLLM docs](https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/features/multimodal/multimodal-vllm.md#embedding-cache).
 - Replace the `storageClassName` and `image:` placeholders in the YAML files before running.
 - Source: [recipes/qwen3-vl-30b](https://github.com/ai-dynamo/dynamo/tree/main/recipes/qwen3-vl-30b)
 

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -16,7 +16,7 @@ With 200+ external contributors, 220+ merged community PRs, and new contributors
 
 Join the community:
 
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf) -- join CNCF Slack and find us in `#ai-dynamo`
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io/) -- join CNCF Slack and find us in `#ai-dynamo`
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - [Design Proposals](https://github.com/ai-dynamo/enhancements) -- RFCs for major features
@@ -69,7 +69,7 @@ Ready to write code? See the [Contribution Workflow](#contribution-workflow) sec
 
 Not all contributions are code. You can also:
 
-- Answer questions on [Discord](https://discord.gg/D92uqZRjCZ) or in the `#ai-dynamo` channel on [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)
+- Answer questions on [Discord](https://discord.gg/D92uqZRjCZ) or in the `#ai-dynamo` channel on [CNCF Slack](https://slack.cncf.io/)
 - Review pull requests
 - Share how you're using Dynamo -- blog posts, talks, or social media
 - Star the [repository](https://github.com/ai-dynamo/dynamo)
@@ -426,7 +426,7 @@ If you discover a security vulnerability, please follow the instructions in our 
 
 ## Getting Help
 
-- **CNCF Slack**: [Join CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) and find us in `#ai-dynamo`
+- **CNCF Slack**: [Join CNCF Slack](https://slack.cncf.io/) and find us in `#ai-dynamo`
 - **Discord**: [Join our community](https://discord.gg/D92uqZRjCZ)
 - **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - **Design Proposals**: [RFCs for major features](https://github.com/ai-dynamo/enhancements)

--- a/docs/contribution-guide.zh-CN.md
+++ b/docs/contribution-guide.zh-CN.md
@@ -17,7 +17,7 @@ Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并�
 
 加入社区：
 
-- [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf) -- 加入 CNCF Slack，并在 `#ai-dynamo` 中找到我们
+- [CNCF Slack (`#ai-dynamo`)](https://slack.cncf.io/) -- 加入 CNCF Slack，并在 `#ai-dynamo` 中找到我们
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - [设计提案](https://github.com/ai-dynamo/enhancements) -- 重大功能的 RFC
@@ -70,7 +70,7 @@ Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并�
 
 并非所有贡献都是代码。你还可以：
 
-- 在 [Discord](https://discord.gg/D92uqZRjCZ) 或 [CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf) 的 `#ai-dynamo` 频道中回答问题
+- 在 [Discord](https://discord.gg/D92uqZRjCZ) 或 [CNCF Slack](https://slack.cncf.io/) 的 `#ai-dynamo` 频道中回答问题
 - 审阅 pull request
 - 分享你如何使用 Dynamo -- 博客文章、演讲或社交媒体都可以
 - 为[仓库](https://github.com/ai-dynamo/dynamo)点 star
@@ -427,7 +427,7 @@ git commit -s -m "fix: your descriptive message"
 
 ## 获取帮助
 
-- **CNCF Slack**: [加入 CNCF Slack](https://communityinviter.com/apps/cloud-native/cncf)，并在 `#ai-dynamo` 中找到我们
+- **CNCF Slack**: [加入 CNCF Slack](https://slack.cncf.io/)，并在 `#ai-dynamo` 中找到我们
 - **Discord**: [加入我们的社区](https://discord.gg/D92uqZRjCZ)
 - **Discussions**: [GitHub Discussions](https://github.com/ai-dynamo/dynamo/discussions)
 - **设计提案**: [重大功能的 RFC](https://github.com/ai-dynamo/enhancements)

--- a/docs/features/multimodal/multimodal-kv-routing.md
+++ b/docs/features/multimodal/multimodal-kv-routing.md
@@ -99,7 +99,7 @@ Frontend (round-robin) → MM Router Worker → Backend Workers
                               └─ KvRouter selects best worker
 ```
 
-For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend workers. See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for setup instructions.
+For TRT-LLM, a dedicated MM Router Worker sits between the frontend and backend workers. See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/release/1.3.1/examples/backends/trtllm/mm_router_worker/README.md) for setup instructions.
 
 ### SGLang
 
@@ -199,7 +199,7 @@ cd $DYNAMO_HOME/examples/backends/trtllm/mm_router_worker
 ./launch.sh
 ```
 
-See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/trtllm/mm_router_worker/README.md) for full setup instructions and configuration options.
+See the [TRT-LLM MM Router README](https://github.com/ai-dynamo/dynamo/tree/release/1.3.1/examples/backends/trtllm/mm_router_worker/README.md) for full setup instructions and configuration options.
 
 ### SGLang
 

--- a/recipes/qwen3-vl-30b/README.md
+++ b/recipes/qwen3-vl-30b/README.md
@@ -48,7 +48,7 @@ kubectl apply -f data-gen/generate-datasets-job.yaml -n ${NAMESPACE}
 
 1. Exact cache hit rates cannot be explicitly controlled via dataset due to potential LRU embedding cache eviction policies; however, decreasing the image pool relative to the number of requests allows for proportionally higher probabilities of seeing duplicate images and cache hits. Increasing the embedding cache capacity also allows for higher cache hit rate because it will evict less.
 
-**2. Agg embedding cache uses vLLM's native `ec_both` ECConnector role, supported in vLLM 0.17+. No patches required. See [multimodal-vllm.md](https://github.com/ai-dynamo/dynamo/blob/main/docs/features/multimodal/multimodal-vllm.md#embedding-cache) for more details.**
+**2. Agg embedding cache uses vLLM's native `ec_both` ECConnector role, supported in vLLM 0.17+. No patches required. See [multimodal-vllm.md](https://github.com/ai-dynamo/dynamo/blob/release/1.3.1/docs/features/multimodal/multimodal-vllm.md#embedding-cache) for more details.**
 
 3. Replace placeholders in `*.yaml` before running:
    - `storageClassName: "your-storage-class-name"` in `model-cache/model-cache.yaml`


### PR DESCRIPTION
## Summary

`lychee` fails on every PR against `release/1.3.1`. The 15 errors fall into three unrelated classes; all are fixed here, and **every replacement URL was verified to return 200**.

| Class | Hits | Fix |
|---|---|---|
| Dead external link | 7 | `communityinviter.com/apps/cloud-native/cncf` 404s. Replaced with `https://slack.cncf.io/` |
| Links into `main` whose targets moved | 5 | Repointed at the release tree |
| Docs-site URL that never existed | 2 | `docs.nvidia.com/dynamo/design-docs/disaggregated-serving` 404s; the page is in-repo as `disagg-serving.md` |

## Detail

**CNCF invite** — `CONTRIBUTING.md`, `docs/contribution-guide.md`, `docs/contribution-guide.zh-CN.md`. The old invite URL is dead upstream; `slack.cncf.io` is the current entry point.

**Moved doc links** — the Fern migration restructured these paths on `main`, so release-branch files linking into `main` now 404. This is the same fix #12618 applies on `release/1.4.0`. All four targets were verified present on `release/1.3.1` before repointing:

- `deploy/helm/charts/platform/templates/NOTES.txt` -> `docs/kubernetes/installation-guide.md`
- `docs/benchmarks/qwen3-6-35b-feature-stack.mdx` -> `docs/benchmarks/embedding_cache.md`
- `docs/benchmarks/qwen3-vl-embedding-cache.mdx` -> `docs/features/multimodal/multimodal-vllm.md#embedding-cache`
- `docs/features/multimodal/multimodal-kv-routing.md` -> `examples/backends/trtllm/mm_router_worker/README.md` (2 links)
- `recipes/qwen3-vl-30b/README.md` -> `docs/features/multimodal/multimodal-vllm.md#embedding-cache`

**Disaggregated serving** — both `README.md` table links pointed at a docs-site path that has never resolved. The page exists in-repo as `docs/design-docs/disagg-serving.md`, so they now point there on the release tree.

## Not addressed

A `kubebuilder.io` request timeout in `docs/kubernetes/webhooks.md`. That is a flake, not a broken link, and fixing it is not in scope.

## Test plan

- [ ] `lychee` passes on `release/1.3.1`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->