### PR TITLE
fix(frontend): preserve zero top logprobs in sglang/vllm chat processors

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -324,7 +324,7 @@ def _build_dynamo_preproc(
     logprobs = request.get("logprobs")
     top_logprobs = request.get("top_logprobs")
     if logprobs is True:
-        logprobs_val = top_logprobs or 1
+        logprobs_val = top_logprobs if top_logprobs is not None else 1
     elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
         logprobs_val = logprobs
     elif top_logprobs not in (None, 0):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -337,6 +337,15 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
         )
         assert result["output_options"]["logprobs"] == 5
 
+    def test_logprobs_true_preserves_zero_top_logprobs(self):
+        result = _build_dynamo_preproc(
+            {"model": "test", "logprobs": True, "top_logprobs": 0},
+            [1],
+            "test",
+            None,
+        )
+        assert result["output_options"]["logprobs"] == 0
+
     def test_logprobs_true_without_top_logprobs(self):
         """logprobs=True without top_logprobs yields 1."""
         result = _build_dynamo_preproc(

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -725,6 +725,7 @@ def vllm_processor_module(monkeypatch):
 async def test_generator_preserves_zero_top_logprobs(
     vllm_processor_module,
     monkeypatch,
+    caplog,
 ):
     class RequestForSampling(SimpleNamespace):
         model_fields = {}
@@ -783,6 +784,10 @@ async def test_generator_preserves_zero_top_logprobs(
                 }
             )
         )
+    assert (
+        "Logprobs requested but not supported in distributed inference mode"
+        in caplog.messages
+    )
 
 
 def _make_processor(module, routed_engine):

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -10,6 +10,7 @@ tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 import importlib.util
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from _routed_engine_fakes import FakeRoutedEngine as _FakeRoutedEngine
@@ -718,6 +719,70 @@ def vllm_processor_module(monkeypatch):
     monkeypatch.setattr(module._nvtx, "start_range", lambda *args, **kwargs: object())
     monkeypatch.setattr(module._nvtx, "end_range", lambda rng: None)
     return module
+
+
+@pytest.mark.asyncio
+async def test_generator_preserves_zero_top_logprobs(
+    vllm_processor_module,
+    monkeypatch,
+):
+    class RequestForSampling(SimpleNamespace):
+        model_fields = {}
+
+    monkeypatch.setattr(
+        vllm_processor_module,
+        "preprocess_chat_request",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                request_for_sampling=RequestForSampling(
+                    max_completion_tokens=None,
+                    max_tokens=1,
+                    logprobs=True,
+                    top_logprobs=0,
+                    cache_salt=None,
+                    mm_processor_kwargs=None,
+                ),
+                tool_parser=None,
+                chat_template_kwargs={},
+                engine_prompt={"prompt": "Hello"},
+                prompt_token_ids=[1],
+            )
+        ),
+    )
+
+    class ProjectionObserved(Exception):
+        pass
+
+    def process_inputs(request_id, engine_inputs, sampling_params, supported_tasks):
+        assert sampling_params.logprobs == 0
+        raise ProjectionObserved
+
+    input_processor = SimpleNamespace(
+        generation_config_fields={},
+        renderer=SimpleNamespace(process_for_engine_async=AsyncMock(return_value={})),
+        process_inputs=process_inputs,
+    )
+
+    processor = vllm_processor_module.VllmProcessor(
+        tokenizer=SimpleNamespace(eos_token_id=2),
+        input_processor=input_processor,
+        output_processor=object(),
+        tool_parser_class=None,
+        reasoning_parser_class=None,
+        routed_engine=object(),
+    )
+
+    with pytest.raises(ProjectionObserved):
+        await anext(
+            processor._generator_inner(
+                {
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "logprobs": True,
+                    "top_logprobs": 0,
+                }
+            )
+        )
 
 
 def _make_processor(module, routed_engine):

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -516,7 +516,7 @@ class VllmProcessor:
         logprobs = request_for_sampling.logprobs
         top_logprobs = request_for_sampling.top_logprobs
         if logprobs is True:
-            sampling_params.logprobs = top_logprobs or 1
+            sampling_params.logprobs = top_logprobs if top_logprobs is not None else 1
         elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
             sampling_params.logprobs = logprobs
         elif top_logprobs not in (None, 0):

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -521,7 +521,9 @@ class VllmProcessor:
             sampling_params.logprobs = logprobs
         elif top_logprobs not in (None, 0):
             sampling_params.logprobs = top_logprobs
-        if sampling_params.logprobs is not None and sampling_params.logprobs > 0:
+        # TODO: Support logprobs in the distributed vLLM chat processor by
+        # converting worker log_probs/top_logprobs into EngineCoreOutput.new_logprobs.
+        if sampling_params.logprobs is not None:
             logger.warning(
                 "Logprobs requested but not supported in distributed inference mode"
             )


### PR DESCRIPTION
## Summary

- Preserve an explicit `top_logprobs=0` when SGLang and vLLM chat preprocessing project OpenAI-compatible requests to backend output options.
- Default to `1` only when `top_logprobs` is omitted or `null`.
- Add focused regression coverage at both request-projection boundaries.

The root cause was truthiness-based defaulting: `top_logprobs or 1` conflated the valid integer `0` with an absent value.

### Upstream behavior

| Server | Internal mapping for `logprobs=true, top_logprobs=0` | OpenAI response per generated token |
| --- | --- | --- |
| [vLLM](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/chat_completion/protocol.py#L663-L680) | `SamplingParams.logprobs = 0` | Includes the selected token's `logprob`; `top_logprobs: []` |
| [SGLang](https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/entrypoints/openai/serving_chat.py#L902-L912) | `return_logprob = true`, `top_logprobs_num = 0` | Includes the selected token's `logprob`; `top_logprobs: []` |

Both upstream servers preserve `0`: `logprobs=true` enables the selected-token probability, while `top_logprobs=0` requests zero alternative-token entries.

Closes #12649

Internal tracking: [DIS-2624](https://linear.app/nvidia/issue/DIS-2624/dynamorelease140frontend-sglang-processor-treats-top-logprobs0-as-1)

## Validation

- `.venv-vllm-reasoning/bin/python -m pytest -xvv components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — 48 passed
- `.venv-sglang-reasoning/bin/python -m pytest -xvv components/src/dynamo/frontend/tests/test_sglang_processor_unit.py::TestBuildDynamoPreproc` — 34 passed
- `pre-commit run --files components/src/dynamo/frontend/vllm_processor.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — passed
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved an explicitly configured `top_logprobs=0` value when log probabilities are enabled, instead of replacing it with the default value.
* **Tests**
  * Added coverage to verify the corrected log probability option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->