### PR TITLE
fix(power-agent): keep apiVersion off SPDX comment line

### DIFF
--- a/deploy/helm/charts/power-agent/Chart.yaml
+++ b/deploy/helm/charts/power-agent/Chart.yaml
@@ -36,7 +36,10 @@ type: application
 # COPY now includes it, and the dev-pod script ConfigMap MUST add a
 # `managed_state.py` key. Minor bump per SemVer (additive module; dev-pod
 # users must extend their ConfigMap, see templates/dev-pod.yaml header).
-version: 1.3.0
+# 1.3.1: fix whitespace-trim that glued apiVersion onto the SPDX comment and
+# blocked default helm install. Patch bump; appVersion unchanged (image code
+# unchanged).
+version: 1.3.1
 # appVersion tracks the agent image's runtime code. It stayed 1.1.0 across
 # chart 1.2.0 because that bump was values-only (image.digest field, no image
 # code change). Chart 1.3.0 adds managed_state.py to the image COPY, so the

--- a/deploy/helm/charts/power-agent/templates/daemonset.yaml
+++ b/deploy/helm/charts/power-agent/templates/daemonset.yaml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.daemonset.enabled }}
-{{- include "power-agent.validateTerminationGracePeriod" . -}}
+{{- include "power-agent.validateTerminationGracePeriod" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deploy/helm/charts/power-agent/templates/dev-pod.yaml
+++ b/deploy/helm/charts/power-agent/templates/dev-pod.yaml
@@ -31,7 +31,7 @@
 # 'managed_state'`.
 
 {{- if .Values.dev.enabled }}
-{{- include "power-agent.validateTerminationGracePeriod" . -}}
+{{- include "power-agent.validateTerminationGracePeriod" . }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression for DYN-3741 / NVBug 6555989: a right-trim (`-}}`) on the
+# silent validateTerminationGracePeriod include ate the newline before
+# `apiVersion`, gluing it onto the SPDX comment:
+#
+#   # SPDX-License-Identifier: Apache-2.0apiVersion: apps/v1
+#
+# helm template / helm lint both exit 0 on that broken render; only
+# install/apply fails with "apiVersion not set". The existing suite
+# (including grace_period_test.yaml) also stayed green because nothing
+# asserted apiVersion / isAPIVersion. This suite is the gate that
+# would have caught it.
+
+suite: apiVersion survives whitespace-trim around grace validation
+release:
+  name: power-agent
+  namespace: dynamo-system
+
+tests:
+  - it: DaemonSet default path keeps apiVersion as a document key
+    templates:
+      - templates/daemonset.yaml
+    set:
+      image.tag: v1.4.0
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: apiVersion
+          value: apps/v1
+
+  - it: dev pod path keeps apiVersion as a document key
+    templates:
+      - templates/dev-pod.yaml
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: gpu-node-0
+    asserts:
+      - isKind:
+          of: Pod
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: apiVersion
+          value: v1

--- a/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Regression for DYN-3741 / NVBug 6555989: a right-trim (`-}}`) on the
-# silent validateTerminationGracePeriod include ate the newline before
-# `apiVersion`, gluing it onto the SPDX comment:
+# Regression: right-trim (`-}}`) on silent validateTerminationGracePeriod
+# include ate the newline before `apiVersion`, gluing it onto the SPDX
+# comment:
 #
 #   # SPDX-License-Identifier: Apache-2.0apiVersion: apps/v1
 #


### PR DESCRIPTION
## Summary
- Fixes DYN-3741 / NVBug [6555989](https://nvbugs.nvidia.com/6555989): default `helm install` of `deploy/helm/charts/power-agent` failed with `apiVersion not set` because a trailing whitespace-trim (`-}}`) on the silent `validateTerminationGracePeriod` include glued `apiVersion` onto the SPDX comment (`Apache-2.0apiVersion: apps/v1`).
- Drop that trailing `-` in `daemonset.yaml` and `dev-pod.yaml` (Fix A).
- Add `isAPIVersion` helm-unittest coverage. `helm template` / `helm lint` exit 0 on the broken render; the previous 48 unittests stayed green because nothing asserted `apiVersion`.

## Validation
- [x] `helm template ... --set image.tag=v1.4.0` emits standalone `apiVersion: apps/v1` (DaemonSet) and `apiVersion: v1` (dev pod)
- [x] `make lint` in `deploy/helm/charts/power-agent`
- [x] `make test` — 50 passed (incl. new `api_version_whitespace_test.yaml`)

## Related
- Linear: https://linear.app/nvidia/issue/DYN-3741
- NVBug: https://nvbugs.nvidia.com/6555989
- Follow-up: cherry-pick onto `release/1.4.0` for RC
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Helm chart rendering to preserve the `apiVersion` field correctly in DaemonSet and development Pod manifests.
  * Added regression coverage to verify valid rendered Kubernetes resources and prevent whitespace-related manifest issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->