### PR TITLE
fix(power-agent): cherry-pick keep apiVersion off SPDX comment (#12651)

### DIFF
--- a/deploy/helm/charts/power-agent/Chart.yaml
+++ b/deploy/helm/charts/power-agent/Chart.yaml
@@ -36,7 +36,10 @@ type: application
 # COPY now includes it, and the dev-pod script ConfigMap MUST add a
 # `managed_state.py` key. Minor bump per SemVer (additive module; dev-pod
 # users must extend their ConfigMap, see templates/dev-pod.yaml header).
-version: 1.3.0
+# 1.3.1: fix whitespace-trim that glued apiVersion onto the SPDX comment and
+# blocked default helm install. Patch bump; appVersion unchanged (image code
+# unchanged).
+version: 1.3.1
 # appVersion tracks the agent image's runtime code. It stayed 1.1.0 across
 # chart 1.2.0 because that bump was values-only (image.digest field, no image
 # code change). Chart 1.3.0 adds managed_state.py to the image COPY, so the

--- a/deploy/helm/charts/power-agent/templates/daemonset.yaml
+++ b/deploy/helm/charts/power-agent/templates/daemonset.yaml
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- if .Values.daemonset.enabled }}
-{{- include "power-agent.validateTerminationGracePeriod" . -}}
+{{- include "power-agent.validateTerminationGracePeriod" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/deploy/helm/charts/power-agent/templates/dev-pod.yaml
+++ b/deploy/helm/charts/power-agent/templates/dev-pod.yaml
@@ -31,7 +31,7 @@
 # 'managed_state'`.
 
 {{- if .Values.dev.enabled }}
-{{- include "power-agent.validateTerminationGracePeriod" . -}}
+{{- include "power-agent.validateTerminationGracePeriod" . }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression for DYN-3741 / NVBug 6555989: a right-trim (`-}}`) on the
+# silent validateTerminationGracePeriod include ate the newline before
+# `apiVersion`, gluing it onto the SPDX comment:
+#
+#   # SPDX-License-Identifier: Apache-2.0apiVersion: apps/v1
+#
+# helm template / helm lint both exit 0 on that broken render; only
+# install/apply fails with "apiVersion not set". The existing suite
+# (including grace_period_test.yaml) also stayed green because nothing
+# asserted apiVersion / isAPIVersion. This suite is the gate that
+# would have caught it.
+
+suite: apiVersion survives whitespace-trim around grace validation
+release:
+  name: power-agent
+  namespace: dynamo-system
+
+tests:
+  - it: DaemonSet default path keeps apiVersion as a document key
+    templates:
+      - templates/daemonset.yaml
+    set:
+      image.tag: v1.4.0
+    asserts:
+      - isKind:
+          of: DaemonSet
+      - isAPIVersion:
+          of: apps/v1
+      - equal:
+          path: apiVersion
+          value: apps/v1
+
+  - it: dev pod path keeps apiVersion as a document key
+    templates:
+      - templates/dev-pod.yaml
+    set:
+      daemonset.enabled: false
+      dev.enabled: true
+      dev.nodeName: gpu-node-0
+    asserts:
+      - isKind:
+          of: Pod
+      - isAPIVersion:
+          of: v1
+      - equal:
+          path: apiVersion
+          value: v1

--- a/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
+++ b/deploy/helm/charts/power-agent/tests/api_version_whitespace_test.yaml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Regression for DYN-3741 / NVBug 6555989: a right-trim (`-}}`) on the
-# silent validateTerminationGracePeriod include ate the newline before
-# `apiVersion`, gluing it onto the SPDX comment:
+# Regression: right-trim (`-}}`) on silent validateTerminationGracePeriod
+# include ate the newline before `apiVersion`, gluing it onto the SPDX
+# comment:
 #
 #   # SPDX-License-Identifier: Apache-2.0apiVersion: apps/v1
 #


### PR DESCRIPTION
## Summary

Cherry-pick of both commits from #12651 onto `release/1.4.0`:

- `4bb3761f85` — fix the whitespace trim and add the regression suite
- `cafb4f55e6` — remove internal ticket references and bump chart version to 1.3.1

Clears P1 NVBug [6555989](https://nvbugs.nvidia.com/6555989) / [DYN-3741](https://linear.app/nvidia/issue/DYN-3741): the power-agent chart's default DaemonSet path cannot be installed after selecting the required image because a whitespace-trim action glues `apiVersion` onto the SPDX comment. The same issue affects the opt-in dev-pod path.

Both commits were cherry-picked with `-x`. Their stable patch IDs match the source commits, and the final `deploy/helm/charts/power-agent/` subtree is identical to the #12651 source-branch tip. Actual diff: 4 files, +56/-3.

## Main PR

https://github.com/ai-dynamo/dynamo/pull/12651

## Validation

- [x] Both source commits cherry-picked with `-x`
- [x] Final power-agent chart subtree matches #12651 source tip `cafb4f55e6`
- [x] `make -C deploy/helm/charts/power-agent lint test` passes in release-branch CI: 5 suites, 50 tests
- [x] Full `PR` workflow and its status gates pass
- [x] Pre-merge checks pass

The separate `lychee` docs-link check is red on two 404 links in untouched `docs/fern/features/diffusion/text-to-text/README.md`; this PR changes no documentation.

## Related

- Relates to #12651
- Linear: https://linear.app/nvidia/issue/DYN-3741
- NVBug: https://nvbugs.nvidia.com/6555989
