### PR TITLE
fix(mocker): publish shared scheduler KV events at pass end

### DIFF
--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -25,8 +25,8 @@ use dc_ckf_parity::{DirectCkfParityConfig, DirectCkfParityIndexer, DirectCkfPari
 #[cfg(feature = "mocker-kvbm-offload")]
 use dynamo_bench::kv_router_common::replay::generate_g2_replay_artifacts_with_capacity;
 use dynamo_bench::kv_router_common::replay::{
-    WorkerReplayArtifacts, generate_replay_artifacts,
-    generate_replay_artifacts_with_args_and_visibility, process_mooncake_trace,
+    WorkerReplayArtifacts, generate_replay_artifacts, generate_replay_artifacts_with_args,
+    process_mooncake_trace,
 };
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
@@ -39,8 +39,7 @@ use dynamo_kv_router::{ConcurrentRadixTreeCompressed, ThreadPoolIndexer};
 use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, SglangArgs};
 use dynamo_mocker::loadgen::{ReplayRequestHashes, SessionTrace, Trace, TurnTrace};
 use dynamo_mocker::replay::{
-    ReplayKvEventVisibility, ReplayTimedKvEvent, ReplayTimedRequest, ReplayWorkerArtifacts,
-    native_g1_parent_chain_artifact,
+    ReplayTimedKvEvent, ReplayTimedRequest, ReplayWorkerArtifacts, native_g1_parent_chain_artifact,
 };
 use mooncake_open_loop::{
     MooncakeOperationPayload, OpenLoopConfig, PreparedMooncakeCorpus, prepare_mooncake_corpus,
@@ -112,13 +111,6 @@ impl MockEngineParityKind {
             Self::Vllm => EngineType::Vllm,
             Self::Sglang => EngineType::Sglang,
             Self::Trtllm => EngineType::Trtllm,
-        }
-    }
-
-    fn kv_event_visibility_override(self) -> Option<ReplayKvEventVisibility> {
-        match self {
-            Self::Sglang => Some(ReplayKvEventVisibility::PassStart),
-            Self::Vllm | Self::Trtllm => None,
         }
     }
 
@@ -214,13 +206,8 @@ async fn generate_mock_engine_parity_artifacts(
         MockEngineParityKind::Sglang,
         MockEngineParityKind::Trtllm,
     ] {
-        let artifacts = generate_replay_artifacts_with_args_and_visibility(
-            traces,
-            engine.mock_engine_args()?,
-            None,
-            engine.kv_event_visibility_override(),
-        )
-        .await?;
+        let artifacts =
+            generate_replay_artifacts_with_args(traces, engine.mock_engine_args()?, None).await?;
         assert_no_removed_kv_events(engine.name(), &artifacts);
         artifact_sets.push(MockEngineReplayArtifacts {
             engine_name: engine.name(),

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -2454,10 +2454,10 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_worker_trace_kv_router_debug_snapshot_tracks_queue_and_cached_dispatch() {
+    fn test_multi_worker_trace_kv_router_delays_cached_visibility_until_pass_completion() {
         let policy = RouterQueuePolicy::Fcfs;
         let mut args = queueing_router_args(policy);
-        // Preserve this snapshot's historical KVBM event-visibility semantics.
+        // Exercise the shared scheduler's KVBM event capture path.
         args.g1_backend = Some(G1Backend::Kvbm);
         let mut runtime = AggRuntime::new(
             &args,
@@ -2517,7 +2517,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![1, 1]
         );
-        assert!(initial_router.indexer.total_cached_blocks > 0);
+        assert_eq!(initial_router.indexer.total_cached_blocks, 0);
 
         assert!(runtime.advance_one_timestamp().unwrap());
         let queued = runtime.debug_snapshot();
@@ -2528,15 +2528,13 @@ mod tests {
         assert_eq!(queued_router.pending.len(), 1);
         assert_eq!(queued_router.pending[0].uuid, Uuid::from_u128(33));
 
-        let cached_workers = queued_router.pending[0]
-            .overlap_blocks_by_worker
-            .iter()
-            .filter(|(_, overlap)| *overlap > 0)
-            .map(|(worker_idx, _)| *worker_idx)
-            .collect::<Vec<_>>();
-        assert_eq!(cached_workers.len(), 1);
-        let cached_worker = cached_workers[0];
-
+        assert!(
+            queued_router.pending[0]
+                .overlap_blocks_by_worker
+                .iter()
+                .all(|(_, overlap)| *overlap == 0),
+            "a mid-pass arrival must not observe KV blocks before pass completion"
+        );
         while !runtime
             .stats
             .assigned_worker_by_uuid
@@ -2547,9 +2545,15 @@ mod tests {
 
         let dispatched = runtime.debug_snapshot();
         assert!(dispatched.router_pending_request_ids.is_empty());
-        assert_eq!(
-            runtime.stats.assigned_worker_by_uuid[&Uuid::from_u128(33)],
-            cached_worker
+        assert!(
+            dispatched
+                .router
+                .as_ref()
+                .unwrap()
+                .indexer
+                .total_cached_blocks
+                > 0,
+            "completed passes must publish their KV blocks"
         );
     }
 

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -1284,7 +1284,7 @@ mod tests {
     }
 
     #[test]
-    fn kv_visibility_follows_backend_contract_and_fpm_waits_for_completion() {
+    fn kv_events_wait_for_completion_for_all_backends() {
         let make_engine = |engine_type| {
             let args = MockEngineArgs::builder()
                 .engine_type(engine_type)
@@ -1315,21 +1315,25 @@ mod tests {
         };
         let mut collector = TraceCollector::default();
 
-        let mut vllm = make_engine(EngineType::Vllm);
-        vllm.dispatch(0, request(Uuid::from_u128(10))).unwrap();
-        let vllm_start = vllm.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert!(!vllm_start.pass_start_events.0.is_empty());
-        let vllm_end = take_only_completion(vllm_start);
-        assert!(vllm_end.engine_events.0.is_empty());
-        assert!(vllm_end.fpm.is_some());
-
-        let mut sglang = make_engine(EngineType::Sglang);
-        sglang.dispatch(0, request(Uuid::from_u128(11))).unwrap();
-        let sglang_start = sglang.drive_ready(0.0, Some(&mut collector)).unwrap();
-        assert!(sglang_start.pass_start_events.0.is_empty());
-        let sglang_end = take_only_completion(sglang_start);
-        assert!(!sglang_end.engine_events.0.is_empty());
-        assert!(sglang_end.fpm.is_some());
+        for (engine_type, uuid) in [
+            (EngineType::Vllm, Uuid::from_u128(10)),
+            (EngineType::Trtllm, Uuid::from_u128(11)),
+            (EngineType::Sglang, Uuid::from_u128(12)),
+        ] {
+            let mut engine = make_engine(engine_type);
+            engine.dispatch(0, request(uuid)).unwrap();
+            let pass_start = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+            assert!(
+                pass_start.pass_start_events.0.is_empty(),
+                "{engine_type:?} exposed KV events before pass completion"
+            );
+            let pass_end = take_only_completion(pass_start);
+            assert!(
+                !pass_end.engine_events.0.is_empty(),
+                "{engine_type:?} did not expose KV events at pass completion"
+            );
+            assert!(pass_end.fpm.is_some());
+        }
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/entrypoints.rs
+++ b/lib/mocker/src/replay/offline/entrypoints.rs
@@ -1956,8 +1956,8 @@ mod tests {
         assert_eq!(kv_ingest.tier_counts["device"], 40);
         assert_eq!(kv_ingest.tier_counts["host_pinned"], 62);
         assert_eq!(kv_ingest.boundaries["offload_tick"].events, 63);
-        assert_eq!(kv_ingest.boundaries["pass_start"].events, 39);
-        assert_eq!(kv_ingest.boundaries["pass_end"].events, 0);
+        assert_eq!(kv_ingest.boundaries["pass_start"].events, 0);
+        assert_eq!(kv_ingest.boundaries["pass_end"].events, 39);
         assert_eq!(
             kv_ingest.boundaries["offload_tick"].last_at_ms,
             report.throughput.duration_ms

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1675,7 +1675,7 @@ impl VllmCore {
             admissions,
             lifecycle_events: std::mem::take(&mut self.lifecycle_events),
             mocker_metrics: self.mocker_metrics(),
-            router_event_visibility: RouterEventVisibility::PassStart,
+            router_event_visibility: RouterEventVisibility::PassEnd,
             kv_events: self
                 .kv_event_buffer
                 .as_ref()

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1821,9 +1821,13 @@ mod core_behavior {
 mod router_events {
     use super::*;
 
-    #[test]
-    fn test_vllm_pass_visibility_is_pass_start() {
-        let mut core = VllmCore::new_with_kv_capture(router_args(), ROUTER_TEST_WORKER_ID);
+    #[rstest]
+    #[case::vllm(EngineType::Vllm)]
+    #[case::trtllm(EngineType::Trtllm)]
+    fn test_shared_vllm_core_pass_visibility_is_pass_end(#[case] engine_type: EngineType) {
+        let mut args = router_args();
+        args.engine_type = engine_type;
+        let mut core = VllmCore::new_with_kv_capture(args, ROUTER_TEST_WORKER_ID);
         core.receive(DirectRequest {
             tokens: (0..8).collect(),
             max_output_tokens: 2,
@@ -1837,10 +1841,7 @@ mod router_events {
         let mut collector = crate::replay::TraceCollector::default();
         let pass = core.execute_pass(&mut collector, 0.0);
 
-        assert_eq!(
-            pass.router_event_visibility,
-            RouterEventVisibility::PassStart
-        );
+        assert_eq!(pass.router_event_visibility, RouterEventVisibility::PassEnd);
         assert!(!pass.kv_events.is_empty());
         assert!(
             pass.kv_events


### PR DESCRIPTION
## Summary

- publish buffered KV events from the shared vLLM/TensorRT-LLM scheduler at pass completion instead of pass start
- cover both shared-core engine types and the common offline engine boundary
- update the multi-worker replay regression so a mid-pass arrival cannot observe KV blocks before the producing pass completes

## Root cause

The shared scheduler captured KV events while performing eager scheduler bookkeeping, and `RouterEventVisibility::PassStart` made those events immediately visible to the offline router. For vLLM, native event publication occurs from `update_from_output()` after model execution completes, so replay could route a mid-pass arrival using KV data that was not yet externally visible.

This change uses the same completion boundary for TensorRT-LLM because it shares `VllmCore`. It models the normal per-pass publication boundary; pipelined async-scheduling publication remains a separate modeling concern.

Fixes #12643

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker --lib` (710 passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cached KV blocks are now published only after a processing pass completes, preventing premature visibility or overlap during in-progress requests.
  * KV events now follow consistent completion-time visibility across supported inference backends.
  * Completed pass events now include the expected performance metric.

* **Tests**
  * Expanded regression coverage across multiple inference engines to verify KV caching and event timing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->