### PR TITLE
fix(operator): remove duplicate GMS update validation

### DIFF
--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -159,10 +159,7 @@ func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentS
 	fldPath *field.Path,
 ) field.ErrorList {
 	// Standalone DCD updates preserve direct replica modification.
-	const (
-		canModifyReplicas                = true
-		validateGPUMemoryServiceNewState = false // ValidateUpdate already runs the stateless new-state traversal.
-	)
+	const canModifyReplicas = true
 
 	allErrs := field.ErrorList{}
 	if newSpec.BackendFramework != oldSpec.BackendFramework {
@@ -180,7 +177,6 @@ func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentS
 		fldPath,
 		canModifyReplicas,
 		nvidiacomv1beta1.DynamoComponentDeploymentGVK.GroupKind(),
-		validateGPUMemoryServiceNewState,
 	)...)
 	return allErrs
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -544,7 +544,6 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdat
 	}
 
 	canModifyReplicas := v.userInfo != nil && internalwebhook.CanModifyDGDReplicas(v.operatorPrincipal, *v.userInfo)
-	const validateGPUMemoryServiceNewState = true // DGD updates do not run the stateless new-state traversal.
 	componentsPath := fldPath.Child("components")
 	for i := range newSpec.Components {
 		newComponent := &newSpec.Components[i]
@@ -558,7 +557,6 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdat
 			componentsPath.Index(i),
 			canModifyReplicas,
 			nvidiacomv1beta1.DynamoGraphDeploymentGVK.GroupKind(),
-			validateGPUMemoryServiceNewState,
 		)...)
 	}
 

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -151,7 +151,6 @@ func TestRuntimeVersionImageAbsenceRatcheting(t *testing.T) {
 			field.NewPath("spec"),
 			true,
 			schema.GroupKind{Group: nvidiacomv1beta1.GroupVersion.Group, Kind: "DynamoComponentDeployment"},
-			false,
 		)
 		assertFieldPaths(t, errs, nil)
 	})

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -394,7 +394,6 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 	fldPath *field.Path,
 	canModifyReplicas bool,
 	ownerKind schema.GroupKind,
-	validateGPUMemoryServiceNewState bool,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if (newComponent.ScalingAdapter != nil || oldComponent.ScalingAdapter != nil) && !canModifyReplicas &&
@@ -434,13 +433,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			newComponent.Experimental,
 			oldComponent.Experimental,
 			fldPath.Child("experimental"),
-			experimentalSpecUpdateValidationOptions{
-				ownerKind:                        ownerKind,
-				componentType:                    newComponent.ComponentType,
-				resources:                        dynamo.GetMainContainerResources(newComponent),
-				containers:                       podTemplateContainers(newComponent.PodTemplate),
-				validateGPUMemoryServiceNewState: validateGPUMemoryServiceNewState,
-			},
+			ownerKind,
 		)...)
 	} else if oldComponent.Experimental != nil {
 		oldGMS := gpuMemoryServiceForExperimental(oldComponent.Experimental)
@@ -497,40 +490,22 @@ func (v *sharedValidation) validateTopologyConstraintUpdate(
 	)}
 }
 
-type experimentalSpecUpdateValidationOptions struct {
-	ownerKind                        schema.GroupKind
-	componentType                    nvidiacomv1beta1.ComponentType
-	resources                        corev1.ResourceRequirements
-	containers                       []corev1.Container
-	validateGPUMemoryServiceNewState bool
-}
-
 // validateExperimentalSpecUpdate validates an experimental spec update.
-// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition and options.ownerKind.Kind must not be empty.
+// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition and ownerKind.Kind must not be empty.
 func (v *sharedValidation) validateExperimentalSpecUpdate(
 	newExperimental *nvidiacomv1beta1.ExperimentalSpec,
 	oldExperimental *nvidiacomv1beta1.ExperimentalSpec,
 	fldPath *field.Path,
-	options experimentalSpecUpdateValidationOptions,
+	ownerKind schema.GroupKind,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	newGMS := newExperimental.GPUMemoryService
-	if newGMS != nil && options.validateGPUMemoryServiceNewState {
-		allErrs = append(allErrs, v.validateGPUMemoryServiceSpec(
-			newGMS,
-			fldPath.Child("gpuMemoryService"),
-			options.componentType,
-			options.resources,
-			options.containers,
-		)...)
-	}
-
 	oldGMS := gpuMemoryServiceForExperimental(oldExperimental)
 	if isInterPodGMS(newGMS) != isInterPodGMS(oldGMS) {
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("gpuMemoryService", "mode"),
 			k8sptr.Deref(newGMS, nvidiacomv1beta1.GPUMemoryServiceSpec{}).Mode,
-			fmt.Sprintf("the inter-pod GMS layout cannot be toggled after creation; delete and recreate the %s", options.ownerKind.Kind),
+			fmt.Sprintf("the inter-pod GMS layout cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 		))
 	}
 
@@ -540,7 +515,7 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("failover"),
 			newFailover,
-			fmt.Sprintf("inter-pod GMS failover cannot be toggled after creation; delete and recreate the %s", options.ownerKind.Kind),
+			fmt.Sprintf("inter-pod GMS failover cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 		))
 	}
 	if isInterPodFailover(newFailover) && isInterPodFailover(oldFailover) &&
@@ -548,7 +523,7 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("failover", "numShadows"),
 			newFailover.NumShadows,
-			fmt.Sprintf("is immutable for inter-pod GMS failover; delete and recreate the %s to change it", options.ownerKind.Kind),
+			fmt.Sprintf("is immutable for inter-pod GMS failover; delete and recreate the %s to change it", ownerKind.Kind),
 		))
 	}
 	return allErrs


### PR DESCRIPTION
## Summary

- Remove the update-only GMS new-state validation branch introduced in #12580.
- Keep new-state GMS validation on the existing stateless traversal.
- Simplify the shared update validator by removing the now-unused flag and options plumbing.

`DynamoGraphDeploymentHandler.ValidateUpdate` already calls stateless `Validate` before the stateful `ValidateUpdate` traversal, while `DynamoComponentDeploymentValidator.ValidateUpdate` performs its own full new-state traversal. The additional DGD update-side pass was therefore unreachable for invalid objects and could duplicate field errors if the handler later aggregates validation results.

This is a cleanup follow-up discovered while reviewing the `release/1.4.0` backport in #12644. It does not change the intended admission behavior from #12580.

## Validation

- `go test ./internal/webhook/validation -count=1`
- `go vet ./internal/webhook/validation`
- `git diff --check`