### PR TITLE
fix(frontend): disable tokenizer.json baked-in padding

### DIFF
--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -1245,6 +1245,15 @@ impl ModelDeploymentCard {
                         .context("failed to disable tokenizer.json truncation")?;
                 }
 
+                // Padding belongs to the batching layer, not individual online requests.
+                if hf.get_padding().is_some() {
+                    tracing::warn!(
+                        "tokenizer.json declares a padding config; disabling it for online \
+                         tokenization"
+                    );
+                    hf.with_padding(None);
+                }
+
                 // Hold onto specials before any move of `hf`.
                 let specials: Vec<String> = if cache_enabled {
                     extract_hf_special_tokens(&hf)

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -203,6 +203,65 @@ fn test_basetenkenizer_load_failure_falls_back_to_hf() {
 
 #[test]
 #[serial_test::serial]
+fn test_hf_model_card_disables_serialized_padding_and_truncation() {
+    temp_env::with_vars([("DYN_TOKENIZER_CACHE", Some("0"))], || {
+        let dir = tempdir().unwrap();
+        let tokenizer_path = dir.path().join("tokenizer.json");
+        std::fs::write(
+            &tokenizer_path,
+            r#"{
+                "version": "1.0",
+                "truncation": {
+                    "direction": "Right",
+                    "max_length": 2,
+                    "strategy": "LongestFirst",
+                    "stride": 0
+                },
+                "padding": {
+                    "strategy": {"Fixed": 8},
+                    "direction": "Right",
+                    "pad_to_multiple_of": null,
+                    "pad_id": 0,
+                    "pad_type_id": 0,
+                    "pad_token": "[UNK]"
+                },
+                "added_tokens": [],
+                "normalizer": null,
+                "pre_tokenizer": {"type": "Whitespace"},
+                "post_processor": null,
+                "decoder": null,
+                "model": {
+                    "type": "WordLevel",
+                    "vocab": {"[UNK]": 0, "hello": 1, "world": 2, "again": 3},
+                    "unk_token": "[UNK]"
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let raw = HuggingFaceTokenizer::from_file(tokenizer_path.to_str().unwrap()).unwrap();
+        assert_eq!(
+            raw.encode("hello world again").unwrap().token_ids(),
+            &[1, 2, 0, 0, 0, 0, 0, 0],
+            "fixture must exercise serialized truncation and padding"
+        );
+
+        let mut mdc = ModelDeploymentCard::with_name_only("hf-online-normalization");
+        mdc.tokenizer = Some(TokenizerKind::HfTokenizerJson(
+            CheckedFile::from_disk(&tokenizer_path).unwrap(),
+        ));
+
+        let tokenizer = mdc.tokenizer().unwrap();
+        assert_eq!(
+            tokenizer.encode("hello world again").unwrap().token_ids(),
+            &[1, 2, 3],
+            "online tokenization must not apply serialized padding or truncation"
+        );
+    });
+}
+
+#[test]
+#[serial_test::serial]
 fn test_tiktoken_model_card_cache_matches_direct_tokenizer_and_records_tokens() {
     let model = "model-card-tiktoken-cache-integration";
     let mut mdc = ModelDeploymentCard::load_from_disk(TIKTOKEN_PATH, None).unwrap();


### PR DESCRIPTION
## Overview:

The Dynamo frontend loads `tokenizer.json` through the Hugging Face `tokenizers`
crate, which honors padding serialized in that file during `encode()`. Some
model repositories ship fixed padding as an export artifact. For example,
`nvidia/NVIDIA-Nemotron-Parse-2.0` pads every encode to 9,000 tokens, causing a
six-token multimodal prompt rendered in pieces to expand to 54,000 token IDs in
the native frontend and fail context-length validation.

Python `transformers` resets serialized padding when loading a tokenizer, so
the Python/vLLM chat processor does not exhibit this behavior. This change
makes Dynamo's native Rust processor follow the same online-tokenization
contract without requiring `--dyn-chat-processor vllm`.

## Details:

- Clear serialized Hugging Face padding in `ModelDeploymentCard::tokenizer`, at
  the same boundary where Dynamo already clears serialized truncation.
- Emit a warning when a padding configuration is disabled.
- Add a model-neutral regression test whose raw tokenizer truncates and pads a
  three-token input, while the tokenizer loaded through the model card returns
  all three semantic token IDs without padding.

The behavior is not keyed to Nemotron Parse. Online tokenization returns
semantic IDs; explicit context validation and batching remain responsible for
length limits and padding. Tokenizers without serialized padding are unchanged,
including NVIDIA-Nemotron-Parse-v1.2, whose `padding` field is `null`.

## Where should the reviewer start?

- `lib/llm/src/model_card.rs` — normalization beside the existing serialized
  truncation handling.
- `lib/llm/tests/model_card.rs` — the synthetic Hugging Face tokenizer
  regression test.

## Validation

- `cargo test -p dynamo-llm --test model_card --test tokenizers` — 33 passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- Built a current-main vLLM runtime and served
  `nvidia/NVIDIA-Nemotron-Parse-2.0` through the native frontend without
  `--dyn-chat-processor vllm`:
  - Logo fixture: 6 prompt tokens, 35 completion tokens, `stop`.
  - Dense-image fixture: 6 prompt tokens, coherent structured output through
    the requested 2,048-token limit.
- Ran the same native transport/inference controls with
  NVIDIA-Nemotron-Parse-v1.2; both image requests completed normally.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved online Hugging Face tokenization by disabling incompatible configured padding.
  * Added a warning when padding settings are detected and overridden.
  * Preserved padding and truncation behavior for direct raw tokenizer loading.

* **Tests**
  * Added regression coverage for tokenizer padding and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->