### PR TITLE
fix(runtime): negotiate request codec per worker

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
@@ -49,14 +49,6 @@ legacy destination does not advertise a codec, the client uses JSON. The setting
 process does not control its outbound requests. Each request and its responses use the same selected
 codec.
 
-Codec selection happens independently on every hop. For example, a mixed-version SGLang deployment
-can use different codecs across one request path:
-
-| Hop | Selected Codec | Reason |
-| --- | --- | --- |
-| Dynamo 1.4 frontend → Dynamo 1.4 encode worker | MessagePack | The encode endpoint advertises the default `msgpack` preference. |
-| Dynamo 1.4 encode worker → Dynamo 1.2 backend worker | JSON | The legacy backend endpoint has no codec metadata, so the client falls back to JSON. |
-
 ## Configuration
 
 ### Environment Variable

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
@@ -38,6 +38,25 @@ For example, a deployment with TCP request plane can use different KV event plan
 - **ZMQ KV events (local indexer)**: requests use TCP, KV events use direct ZMQ pub/sub, and persistence lives on workers.
 - **No KV events**: requests use TCP and KV routing predicts cache state from routing decisions.
 
+## Payload Codec Negotiation
+
+`DYN_REQUEST_PLANE_CODEC` sets the payload codec preference advertised by every request-plane
+endpoint served by the process. Supported values are `json` and `msgpack`; the default is `msgpack`.
+The value is process-wide and cached on its first codec lookup. Restart the process after changing it.
+
+For each request, the client discovers the destination endpoint and uses its advertised codec. If a
+legacy destination does not advertise a codec, the client uses JSON. The setting on the sending
+process does not control its outbound requests. Each request and its responses use the same selected
+codec.
+
+Codec selection happens independently on every hop. For example, a mixed-version SGLang deployment
+can use different codecs across one request path:
+
+| Hop | Selected Codec | Reason |
+| --- | --- | --- |
+| Dynamo 1.4 frontend → Dynamo 1.4 encode worker | MessagePack | The encode endpoint advertises the default `msgpack` preference. |
+| Dynamo 1.4 encode worker → Dynamo 1.2 backend worker | JSON | The legacy backend endpoint has no codec metadata, so the client falls back to JSON. |
+
 ## Configuration
 
 ### Environment Variable

--- a/docs/fern/pages/reference/components/runtime-configuration.mdx
+++ b/docs/fern/pages/reference/components/runtime-configuration.mdx
@@ -111,6 +111,18 @@ Unless a field is marked environment-only, it has both a CLI flag and an environ
   Environment variable: `DYN_REQUEST_PLANE`
 </ParamField>
 
+<ParamField path="DYN_REQUEST_PLANE_CODEC" type="string" default="msgpack">
+  Preferred payload codec advertised by every request-plane endpoint served by this process. Clients
+  select the codec independently for each destination endpoint. They use the destination's advertised
+  codec, or `json` when a legacy destination does not advertise one. Setting this variable does not
+  force the codec for outbound requests from the process.
+
+  Dynamo caches this process-wide value on its first codec lookup. Restart the process after changing
+  it.
+
+  <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>json</Badge> <Badge intent="note" minimal>msgpack</Badge></span>
+</ParamField>
+
 <ParamField path="--event-plane" type="string" default="zmq">
   Event publishing transport. ZMQ is the default for every discovery backend; select `nats`
   explicitly to use NATS Core. See [Event Plane](../../developer-guide/knowledge-base/concepts/communication-planes/event-plane.md) for design details.

--- a/lib/llm/src/discovery/kv_source_membership.rs
+++ b/lib/llm/src/discovery/kv_source_membership.rs
@@ -507,6 +507,7 @@ mod tests {
                 instance_id: publisher_id,
                 transport: TransportType::Tcp("tcp://127.0.0.1:1234".to_string()),
                 device_type: None,
+                request_plane_codec: None,
             }),
             ..source(endpoint, worker_id, rank, publisher_id)
         }

--- a/lib/llm/src/discovery/kv_source_watch.rs
+++ b/lib/llm/src/discovery/kv_source_watch.rs
@@ -351,6 +351,7 @@ mod tests {
                 instance_id: publisher_id,
                 transport: TransportType::Tcp("tcp://127.0.0.1:1234".to_string()),
                 device_type: None,
+                request_plane_codec: None,
             }),
             ..source(endpoint, worker_id, publisher_id)
         }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -26,6 +26,7 @@ use super::{
 use dynamo_runtime::{
     component::{Endpoint, build_transport_type},
     discovery::{Discovery, DiscoverySpec},
+    pipeline::network::RequestPlanePayloadCodec,
     prelude::DistributedRuntimeProvider,
     protocols::EndpointId,
 };
@@ -1265,6 +1266,7 @@ impl ModelManager {
             endpoint: router_endpoint_id.name.clone(),
             transport,
             device_type: None,
+            request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
         };
 
         discovery.register(discovery_spec).await?;

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -1355,6 +1355,7 @@ mod tests {
                 instance_id: publisher_id,
                 transport: TransportType::Nats(String::new()),
                 device_type: None,
+                request_plane_codec: None,
             }),
         )
     }
@@ -2588,6 +2589,7 @@ mod tests {
                     endpoint: serving_id.name.clone(),
                     transport: TransportType::Tcp("tcp://127.0.0.1:1".to_string()),
                     device_type: None,
+                    request_plane_codec: None,
                 })
                 .await
                 .unwrap();

--- a/lib/runtime/src/component.rs
+++ b/lib/runtime/src/component.rs
@@ -41,7 +41,9 @@ use crate::{
 
 use super::{DistributedRuntime, Runtime, traits::*, transports::nats::Slug, utils::Duration};
 
-use crate::pipeline::network::{PushWorkHandler, ingress::push_endpoint::PushEndpoint};
+use crate::pipeline::network::{
+    PushWorkHandler, RequestPlanePayloadCodec, ingress::push_endpoint::PushEndpoint,
+};
 use crate::protocols::EndpointId;
 use async_nats::{
     rustls::quic,
@@ -112,6 +114,10 @@ pub struct Instance {
     pub transport: TransportType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub device_type: Option<DeviceType>,
+    /// Payload codec accepted by this worker's request-plane endpoint.
+    /// Missing metadata identifies a legacy JSON-only worker.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub request_plane_codec: Option<RequestPlanePayloadCodec>,
 }
 
 impl Instance {

--- a/lib/runtime/src/component/endpoint.rs
+++ b/lib/runtime/src/component/endpoint.rs
@@ -12,7 +12,9 @@ use tokio_util::sync::CancellationToken;
 use crate::{
     component::{DeviceType, Endpoint, Instance, TransportType},
     distributed::RequestPlaneMode,
-    pipeline::network::{PushWorkHandler, ingress::push_endpoint::PushEndpoint},
+    pipeline::network::{
+        PushWorkHandler, RequestPlanePayloadCodec, ingress::push_endpoint::PushEndpoint,
+    },
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
     transports::nats,
@@ -181,6 +183,7 @@ impl EndpointConfigBuilder {
                 instance_id: connection_id,
                 transport: transport.clone(),
                 device_type: endpoint_device_type(),
+                request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
             };
             tracing::debug!(endpoint_name = %endpoint.name, "Registering endpoint health check target");
             let guard = system_health.lock();
@@ -236,6 +239,7 @@ impl EndpointConfigBuilder {
             endpoint: endpoint_id.name.clone(),
             transport,
             device_type: endpoint_device_type(),
+            request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
         };
 
         let discovery_instance = match discovery.register(discovery_spec).await {
@@ -400,6 +404,7 @@ impl Endpoint {
             instance_id,
             transport,
             device_type: endpoint_device_type(),
+            request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
         });
 
         let discovery = drt.discovery();
@@ -442,6 +447,7 @@ impl Endpoint {
             endpoint: endpoint_id.name,
             transport,
             device_type: endpoint_device_type(),
+            request_plane_codec: Some(RequestPlanePayloadCodec::configured()),
         };
 
         let discovery = drt.discovery();

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -667,8 +667,9 @@ pub mod router {
 
 /// Request plane transport environment variables
 pub mod request_plane {
-    /// Request plane payload codec selection: "json" or "msgpack".
-    /// JSON is the compatibility default.
+    /// Preferred payload codec advertised by every request-plane endpoint in this process.
+    /// The process-wide value is cached on first use and defaults to "msgpack". Outbound requests
+    /// use the destination endpoint's advertised codec, or "json" for a legacy destination.
     pub const DYN_REQUEST_PLANE_CODEC: &str = "DYN_REQUEST_PLANE_CODEC";
 }
 

--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -520,6 +520,7 @@ mod tests {
             instance_id,
             transport: TransportType::Tcp(transport.to_string()),
             device_type: None,
+            request_plane_codec: None,
         })
     }
 

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -702,6 +702,7 @@ mod tests {
             instance_id,
             transport: TransportType::Nats("nats://127.0.0.1:4222".to_string()),
             device_type: None,
+            request_plane_codec: None,
         })
     }
 
@@ -1008,6 +1009,7 @@ mod tests {
             component: "comp1".to_string(),
             endpoint: "ep1".to_string(),
             device_type: None,
+            request_plane_codec: None,
             transport: TransportType::Nats("nats://localhost:4222".to_string()),
         };
         client.register(spec1).await.unwrap();
@@ -1016,6 +1018,7 @@ mod tests {
             namespace: "ns1".to_string(),
             component: "comp1".to_string(),
             device_type: None,
+            request_plane_codec: None,
             endpoint: "ep2".to_string(),
             transport: TransportType::Nats("nats://localhost:4222".to_string()),
         };
@@ -1024,6 +1027,7 @@ mod tests {
         let spec3 = DiscoverySpec::Endpoint {
             namespace: "ns2".to_string(),
             device_type: None,
+            request_plane_codec: None,
             component: "comp2".to_string(),
             endpoint: "ep1".to_string(),
             transport: TransportType::Nats("nats://localhost:4222".to_string()),
@@ -1072,6 +1076,7 @@ mod tests {
 
             let spec = DiscoverySpec::Endpoint {
                 device_type: None,
+                request_plane_codec: None,
                 namespace: "test".to_string(),
                 component: "comp1".to_string(),
                 endpoint: "ep1".to_string(),

--- a/lib/runtime/src/discovery/metadata.rs
+++ b/lib/runtime/src/discovery/metadata.rs
@@ -494,6 +494,7 @@ mod tests {
             instance_id: 123,
             transport: TransportType::Nats("nats://localhost:4222".to_string()),
             device_type: None,
+            request_plane_codec: None,
         });
 
         metadata.register_endpoint(instance).unwrap();
@@ -521,6 +522,7 @@ mod tests {
                 instance_id: i,
                 transport: TransportType::Nats("nats://localhost:4222".to_string()),
                 device_type: None,
+                request_plane_codec: None,
             });
             metadata.register_endpoint(instance).unwrap();
         }
@@ -693,6 +695,7 @@ mod tests {
             instance_id: 1,
             transport: TransportType::Nats("nats://localhost:4222".to_string()),
             device_type: None,
+            request_plane_codec: None,
         });
         metadata.register_endpoint(endpoint).unwrap();
 

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -296,6 +296,7 @@ mod tests {
             endpoint: "endpoint".to_string(),
             transport: TransportType::Tcp(transport.to_string()),
             device_type: None,
+            request_plane_codec: None,
         };
         let mut stream = client.list_and_watch(query.clone(), None).await.unwrap();
 
@@ -370,6 +371,7 @@ mod tests {
             endpoint: "test-ep".to_string(),
             transport: crate::component::TransportType::Nats("test-subject".to_string()),
             device_type: None,
+            request_plane_codec: None,
         };
 
         let query = DiscoveryQuery::Endpoint {

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -23,7 +23,10 @@ mod kube;
 pub use kube::{KubeDiscoveryClient, hash_pod_name};
 
 pub mod utils;
-use crate::component::{DeviceType, Instance, TransportType};
+use crate::{
+    component::{DeviceType, Instance, TransportType},
+    pipeline::network::RequestPlanePayloadCodec,
+};
 pub use utils::watch_and_extract_field;
 
 /// Largest publisher ID exactly representable by float64-backed JSON metadata.
@@ -554,6 +557,9 @@ pub enum DiscoverySpec {
         /// Optional execution device for this endpoint instance.
         /// Used by hetero routing to distinguish CPU and CUDA workers.
         device_type: Option<DeviceType>,
+        /// Payload codec accepted by this endpoint's request-plane worker.
+        /// `None` represents a legacy JSON-only worker.
+        request_plane_codec: Option<RequestPlanePayloadCodec>,
     },
     Model {
         namespace: String,
@@ -642,6 +648,7 @@ impl DiscoverySpec {
                 endpoint,
                 transport,
                 device_type,
+                request_plane_codec,
             } => DiscoveryInstance::Endpoint(crate::component::Instance {
                 namespace,
                 component,
@@ -649,6 +656,7 @@ impl DiscoverySpec {
                 instance_id: default_instance_id,
                 transport,
                 device_type,
+                request_plane_codec,
             }),
             Self::Model {
                 namespace,
@@ -1308,7 +1316,7 @@ pub trait Discovery: Send + Sync {
 }
 
 #[cfg(test)]
-mod event_channel_scope_tests {
+mod tests {
     use super::*;
 
     #[test]
@@ -1347,5 +1355,41 @@ mod event_channel_scope_tests {
         let path = id.to_path();
         assert!(!path.contains("ns.with/slash"));
         assert_eq!(EventSourceInstanceId::from_path(&path).unwrap(), id);
+    }
+
+    #[test]
+    fn endpoint_codec_metadata_round_trips_and_defaults_when_omitted() {
+        let instance = DiscoverySpec::Endpoint {
+            namespace: "default".to_string(),
+            component: "worker".to_string(),
+            endpoint: "generate".to_string(),
+            transport: TransportType::Nats("worker.generate".to_string()),
+            device_type: None,
+            request_plane_codec: Some(RequestPlanePayloadCodec::Msgpack),
+        }
+        .into_instance(42);
+
+        let mut metadata = serde_json::to_value(&instance).unwrap();
+        assert_eq!(metadata["request_plane_codec"], "msgpack");
+        let round_trip: DiscoveryInstance = serde_json::from_value(metadata.clone()).unwrap();
+        match round_trip {
+            DiscoveryInstance::Endpoint(instance) => assert_eq!(
+                instance.request_plane_codec,
+                Some(RequestPlanePayloadCodec::Msgpack)
+            ),
+            _ => panic!("expected endpoint discovery metadata"),
+        }
+
+        metadata
+            .as_object_mut()
+            .unwrap()
+            .remove("request_plane_codec");
+        let legacy: DiscoveryInstance = serde_json::from_value(metadata).unwrap();
+        match legacy {
+            DiscoveryInstance::Endpoint(instance) => {
+                assert_eq!(instance.request_plane_codec, None)
+            }
+            _ => panic!("expected endpoint discovery metadata"),
+        }
     }
 }

--- a/lib/runtime/src/health_check.rs
+++ b/lib/runtime/src/health_check.rs
@@ -503,6 +503,7 @@ mod push_handler_notify_tests {
                 instance_id: 0,
                 transport: TransportType::Nats(endpoint_name.to_string()),
                 device_type: None,
+                request_plane_codec: None,
             },
             payload,
         );
@@ -744,6 +745,7 @@ mod integration_tests {
                 instance_id: 12345,
                 transport: crate::component::TransportType::Nats(endpoint.to_string()),
                 device_type: None,
+                request_plane_codec: None,
             },
             payload.clone(),
         );
@@ -780,6 +782,7 @@ mod integration_tests {
                     instance_id: i,
                     transport: crate::component::TransportType::Nats(endpoint.clone()),
                     device_type: None,
+                    request_plane_codec: None,
                 },
                 payload,
             );
@@ -824,6 +827,7 @@ mod integration_tests {
                 instance_id: 999,
                 transport: crate::component::TransportType::Nats(endpoint.to_string()),
                 device_type: None,
+                request_plane_codec: None,
             },
             payload.clone(),
         );

--- a/lib/runtime/src/pipeline/network.rs
+++ b/lib/runtime/src/pipeline/network.rs
@@ -513,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    fn request_control_message_defaults_missing_metadata() {
+    fn legacy_frontend_control_message_defaults_payload_codec_to_json() {
         let json = r#"{
             "id": "request-123",
             "request_type": "single_in",
@@ -535,6 +535,20 @@ mod tests {
         assert_eq!(message.connection_info.info, "{}");
         assert!(message.metadata.is_empty());
         assert!(message.frontend_send_ts_ns.is_none());
+
+        let payload = br#"{"id":7,"text":"legacy","tokens":[1,2]}"#;
+        let decoded: TestPayload = message
+            .payload_codec
+            .decode(payload)
+            .expect("worker should decode the legacy frontend's JSON payload");
+        assert_eq!(
+            decoded,
+            TestPayload {
+                id: 7,
+                text: "legacy".to_string(),
+                tokens: vec![1, 2],
+            }
+        );
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -148,11 +148,11 @@ fn build_request_envelope<T>(
     recv_conn_info: ConnectionInfo,
     send_conn_info: Option<ConnectionInfo>,
     request: Option<&T>,
+    payload_codec: RequestPlanePayloadCodec,
 ) -> Result<bytes::Bytes, Error>
 where
     T: serde::Serialize,
 {
-    let payload_codec = RequestPlanePayloadCodec::configured();
     let request_id = context.id();
     let request_type = if send_conn_info.is_some() {
         RequestType::ManyIn
@@ -199,6 +199,12 @@ where
     let codec = TwoPartCodec::default();
     let buffer = codec.encode_message(msg)?;
     Ok(buffer)
+}
+
+fn payload_codec_for_worker(instance: Option<&Instance>) -> RequestPlanePayloadCodec {
+    instance
+        .and_then(|instance| instance.request_plane_codec)
+        .unwrap_or(RequestPlanePayloadCodec::Json)
 }
 
 /// Await the network request-stream dial-in (if `request_stream_provider` is `Some`)
@@ -483,7 +489,7 @@ impl AddressedPushRouter {
         let inflight_guard = InflightGuard::new();
 
         let enable_request_stream = input_stream.is_some();
-        let payload_codec = RequestPlanePayloadCodec::configured();
+        let payload_codec = payload_codec_for_worker(instance);
 
         // Hold the `RegisteredStream` as their RAII cleanup stays armed while held,
         // which simplifies the cancellation of registration on error. Each side is
@@ -527,6 +533,7 @@ impl AddressedPushRouter {
             recv_registered.connection_info.clone(),
             send_registered.as_ref().map(|r| r.connection_info.clone()),
             request,
+            payload_codec,
         )?;
         REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
 
@@ -855,8 +862,14 @@ where
 mod tests {
     use super::{
         CONTROL_MESSAGE_MAX_BYTES, ConnectionInfo, RequestControlMessage, RequestPlanePayloadCodec,
-        RequestType, ResponseType, serialize_control_message,
+        RequestType, ResponseType, TwoPartCodec, build_request_envelope, payload_codec_for_worker,
+        serialize_control_message,
     };
+    use crate::{
+        component::{Instance, TransportType},
+        pipeline::Context,
+    };
+    use serde::{Deserialize, Serialize};
     use std::collections::BTreeMap;
 
     fn base_control_message(metadata: BTreeMap<String, String>) -> RequestControlMessage {
@@ -873,6 +886,49 @@ mod tests {
             frontend_send_ts_ns: None,
             request_stream_connection_info: None,
         }
+    }
+
+    #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
+    struct TestRequest {
+        value: u64,
+    }
+
+    #[test]
+    fn legacy_worker_without_codec_metadata_receives_json() {
+        let worker = Instance {
+            component: "worker".to_string(),
+            endpoint: "generate".to_string(),
+            namespace: "default".to_string(),
+            instance_id: 42,
+            transport: TransportType::Nats("worker.generate".to_string()),
+            device_type: None,
+            request_plane_codec: None,
+        };
+        let payload_codec = payload_codec_for_worker(Some(&worker));
+        assert_eq!(payload_codec, RequestPlanePayloadCodec::Json);
+
+        let request = TestRequest { value: 123 };
+        let buffer = build_request_envelope(
+            &Context::new(()),
+            ConnectionInfo {
+                transport: "tcp".to_string(),
+                info: "{}".to_string(),
+            },
+            None,
+            Some(&request),
+            payload_codec,
+        )
+        .expect("legacy-worker request envelope should encode");
+        let message = TwoPartCodec::default()
+            .decode_message(buffer)
+            .expect("request envelope should decode");
+
+        let control: RequestControlMessage = serde_json::from_slice(&message.header).unwrap();
+        assert_eq!(control.payload_codec, RequestPlanePayloadCodec::Json);
+        assert_eq!(
+            serde_json::from_slice::<TestRequest>(&message.data).unwrap(),
+            request
+        );
     }
 
     #[test]

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -2725,6 +2725,7 @@ mod tests {
                 instance_id: 1,
                 transport: TransportType::Tcp(tcp_addr),
                 device_type: None,
+                request_plane_codec: None,
             }])
             .unwrap();
 

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -1235,6 +1235,7 @@ mod integration_tests {
                             instance_id: 1,
                             transport: crate::component::TransportType::Nats(endpoint.to_string()),
                             device_type: None,
+                            request_plane_codec: None,
                         },
                         health_check_payload.clone(),
                     );


### PR DESCRIPTION
## Summary

- Publish each endpoint worker's configured request-plane payload codec in discovery metadata.
- Encode frontend requests and decode responses with the selected worker's codec.
- Fall back to JSON when a worker omits codec metadata, preserving compatibility with pre-codec workers.
- Keep workers compatible with older frontends by treating a missing request control-message codec as JSON.

Fixes #12657

## Root cause

The frontend selected one process-wide request-plane codec. During a rolling upgrade, a new frontend could therefore send the v1.4 MsgPack default to a v1.2 worker that only understands JSON.

## Validation

- `cargo test -p dynamo-runtime --lib` — 520 passed
- `cargo check -p dynamo-runtime -p dynamo-llm`
- `cargo clippy -p dynamo-runtime -p dynamo-llm --lib --tests -- -D warnings`
- `uvx pre-commit run --files <changed files>`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request payload codec metadata to endpoint discovery and worker registration.
  * Request and response forwarding now uses the target worker’s configured codec when available.
  * Added compatibility fallback to JSON for workers without codec metadata.

* **Bug Fixes**
  * Improved interoperability with legacy JSON-only workers.
  * Added coverage for codec serialization, deserialization, fallback behavior, and round-trip messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->