### PR TITLE
feat(frontend): accept modality-aware custom encoder inputs

### DIFF
--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -73,6 +73,7 @@ fn preprocessed_multimodal_cache_keys(request: &PreprocessedRequest) -> Vec<Stri
             // reuse intentionally relies on text-prefix routing and affinity
             // to the worker that owns the processor/embedding cache entry.
             MultimodalData::UuidOnly(_) => {}
+            MultimodalData::CustomEncoderData { .. } => {}
         }
     }
     keys.sort();

--- a/lib/llm/src/grpc/service/tensor.rs
+++ b/lib/llm/src/grpc/service/tensor.rs
@@ -60,6 +60,10 @@ pub async fn tensor_response_stream(
     streaming: bool,
     metadata: &MetadataMap,
 ) -> Result<impl Stream<Item = Annotated<NvCreateTensorResponse>>, Status> {
+    request
+        .validate_custom_encoder_data()
+        .map_err(|error| Status::invalid_argument(error.to_string()))?;
+
     // create the context for the request
     let request_id = get_or_create_request_id(request.id.as_deref());
     let model_name = request.model.clone();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2797,6 +2797,17 @@ pub fn validate_response_unsupported_fields(
 ) -> Option<impl IntoResponse> {
     let inner = &request.inner;
 
+    if request
+        .nvext
+        .as_ref()
+        .is_some_and(|nvext| nvext.custom_encoder_data.is_some())
+    {
+        return Some(ErrorMessage::not_implemented_error(
+            VALIDATION_PREFIX.to_string()
+                + "`nvext.custom_encoder_data` is supported only by the Chat Completions API.",
+        ));
+    }
+
     if let Some(field) = request
         .nvext
         .as_ref()
@@ -4334,6 +4345,26 @@ mod tests {
             result.is_none(),
             "store should be supported for audit opt-in"
         );
+    }
+
+    #[test]
+    fn test_validate_unsupported_fields_rejects_custom_encoder_data() {
+        let mut request = make_base_request();
+        request.nvext = Some(
+            serde_json::from_value(serde_json::json!({
+                "custom_encoder_data": {
+                    "version": 1,
+                    "items": [{
+                        "modality": "image",
+                        "placement": {"message_index": 0, "content_index": 0},
+                        "payload": {"kind": "tensor_ref", "uri": "s3://bucket/tensor"}
+                    }]
+                }
+            }))
+            .unwrap(),
+        );
+
+        assert!(validate_response_unsupported_fields(&request).is_some());
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -178,10 +178,11 @@ impl EncoderRouter {
     fn should_encode(request: &PreprocessedRequest) -> bool {
         !request.is_probe
             && request.encoder_result.is_none()
-            && request
-                .multi_modal_data
-                .as_ref()
-                .is_some_and(|media| media.values().any(|items| !items.is_empty()))
+            && request.multi_modal_data.as_ref().is_some_and(|media| {
+                media
+                    .iter()
+                    .any(|(kind, items)| kind != "custom_encoder_data" && !items.is_empty())
+            })
     }
 
     async fn consume_encode_stream(
@@ -328,6 +329,28 @@ mod tests {
             .output_options(OutputOptions::default())
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn custom_encoder_inputs_bypass_legacy_encoder_router() {
+        let request = PreprocessedRequest::builder()
+            .model("model".to_string())
+            .token_ids(vec![1, 2, 3])
+            .multi_modal_data(Some(HashMap::from([(
+                "custom_encoder_data".to_string(),
+                vec![MultimodalData::CustomEncoderData {
+                    modality: crate::protocols::common::extensions::CustomEncoderModality::Image,
+                    payload: json!({"kind": "tensor_ref"}),
+                }],
+            )])))
+            .stop_conditions(StopConditions::default())
+            .sampling_options(SamplingOptions::default())
+            .output_options(OutputOptions::default())
+            .build()
+            .unwrap();
+
+        assert!(!EncoderRouter::should_encode(&request));
+        assert!(EncoderRouter::should_encode(&multimodal_request()));
     }
 
     #[tokio::test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -68,7 +68,10 @@ use crate::protocols::{
     TokenIdType,
     common::{
         OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider,
-        extensions::{AgentHints, NvExtProvider, request_cache_salt, routing_constraints_to_kv},
+        extensions::{
+            AgentHints, CustomEncoderModality, NvExtProvider, request_cache_salt,
+            routing_constraints_to_kv,
+        },
     },
     openai::{
         DeltaGeneratorExt,
@@ -328,11 +331,28 @@ impl MultimodalCounts {
                 .and_then(|m| m.get(key))
                 .map_or(0, |v| v.len())
         };
-        Self {
+        let mut counts = Self {
             image: count("image_url"),
             video: count("video_url"),
             audio: count("audio_url"),
+        };
+        if let Some(items) = request
+            .multi_modal_data
+            .as_ref()
+            .and_then(|media| media.get("custom_encoder_data"))
+        {
+            for item in items {
+                let MultimodalData::CustomEncoderData { modality, .. } = item else {
+                    continue;
+                };
+                match modality {
+                    CustomEncoderModality::Image => counts.image += 1,
+                    CustomEncoderModality::Video => counts.video += 1,
+                    CustomEncoderModality::Audio => counts.audio += 1,
+                }
+            }
         }
+        counts
     }
 }
 
@@ -1126,6 +1146,20 @@ impl OpenAIPreprocessor {
         let preprocess_start = Instant::now();
         let mut builder = self.builder(request)?;
 
+        if let Some(custom_data) = request
+            .nvext()
+            .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+        {
+            let messages = request.typed_messages().ok_or_else(|| {
+                invalid_argument_error(
+                    "nvext.custom_encoder_data is supported only by the Chat Completions API",
+                )
+            })?;
+            custom_data
+                .validate_chat_messages(messages)
+                .map_err(|error| invalid_argument_error(error.to_string()))?;
+        }
+
         let template_start = Instant::now();
         let formatted_prompt = {
             let _nvtx = dynamo_nvtx_range!("preprocess.template");
@@ -1203,11 +1237,11 @@ impl OpenAIPreprocessor {
         //
         // Multimodal `token_ids` carry unexpanded image placeholders, so prefer
         // the MM-expanded length when available, else defer to the backend.
-        let has_images = preprocessed
-            .multi_modal_data
-            .as_ref()
-            .and_then(|m| m.get("image_url"))
-            .is_some_and(|v| !v.is_empty());
+        let has_images = preprocessed.multi_modal_data.as_ref().is_some_and(|media| {
+            ["image_url", "custom_encoder_data"]
+                .iter()
+                .any(|key| media.get(*key).is_some_and(|items| !items.is_empty()))
+        });
         let effective_prompt_len = Self::effective_prompt_len_for_cap(
             preprocessed
                 .mm_routing_info
@@ -1604,6 +1638,9 @@ impl OpenAIPreprocessor {
         // Cleared and returned to the caller; empty for non-image / text-only requests.
         #[cfg(feature = "mm-routing")]
         let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        let custom_data = request
+            .nvext()
+            .and_then(|nvext| nvext.custom_encoder_data.as_ref());
         // Private per-request total for frontend metrics. `None` means the SMG
         // counter is unavailable or checked addition overflowed.
         #[cfg(feature = "mm-routing")]
@@ -1629,8 +1666,28 @@ impl OpenAIPreprocessor {
         let mut url_passthrough_images: Vec<(u64, String)> = Vec::new();
 
         let Some(messages) = request.typed_messages() else {
+            if custom_data.is_some() {
+                return Err(invalid_argument_error(
+                    "nvext.custom_encoder_data is supported only by the Chat Completions API",
+                ));
+            }
             return Ok((Vec::new(), None));
         };
+
+        if let Some(custom_data) = custom_data {
+            custom_data
+                .validate_chat_messages(messages)
+                .map_err(|error| invalid_argument_error(error.to_string()))?;
+            let slots = media_map
+                .entry("custom_encoder_data".to_string())
+                .or_default();
+            for item in custom_data.items_in_prompt_order() {
+                slots.push(MultimodalData::CustomEncoderData {
+                    modality: item.modality,
+                    payload: item.payload.clone(),
+                });
+            }
+        }
         let has_media_loader = self.media_loader.is_some();
 
         for message in messages.iter() {
@@ -1844,7 +1901,7 @@ impl OpenAIPreprocessor {
             // Preserve original messages and formatted prompt in extra_args for multimodal
             // workers (e.g., TRT-LLM needs messages and the template-rendered prompt with
             // <image> placeholders for embedding-path / NIXL flows).
-            let messages_json = serde_json::to_value(request.messages())?;
+            let messages_json = serde_json::to_value(messages)?;
             let mut extra_args = serde_json::json!({
                 "messages": messages_json
             });
@@ -4277,6 +4334,33 @@ mod tests {
         assert_eq!(counts.image, 2);
         assert_eq!(counts.video, 1);
         assert_eq!(counts.audio, 0);
+    }
+
+    #[test]
+    fn test_multimodal_counts_include_custom_encoder_inputs() {
+        let mut map: MultimodalDataMap = HashMap::new();
+        map.insert(
+            "custom_encoder_data".to_string(),
+            vec![
+                MultimodalData::CustomEncoderData {
+                    modality: CustomEncoderModality::Image,
+                    payload: serde_json::json!({"id": 1}),
+                },
+                MultimodalData::CustomEncoderData {
+                    modality: CustomEncoderModality::Video,
+                    payload: serde_json::json!({"id": 2}),
+                },
+                MultimodalData::CustomEncoderData {
+                    modality: CustomEncoderModality::Audio,
+                    payload: serde_json::json!({"id": 3}),
+                },
+            ],
+        );
+
+        let counts = MultimodalCounts::from_preprocessed(&preprocessed_with_media(Some(map)));
+        assert_eq!(counts.image, 1);
+        assert_eq!(counts.video, 1);
+        assert_eq!(counts.audio, 1);
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/prompt.rs
+++ b/lib/llm/src/preprocessor/prompt.rs
@@ -29,6 +29,51 @@ use crate::protocols::openai::{
     chat_completions::NvCreateChatCompletionRequest, completions::NvCreateCompletionRequest,
 };
 
+fn chat_messages_for_rendering(request: &NvCreateChatCompletionRequest) -> serde_json::Value {
+    let mut messages = serde_json::to_value(&request.inner.messages).unwrap();
+    let Some(custom_data) = request
+        .nvext
+        .as_ref()
+        .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+    else {
+        return messages;
+    };
+
+    // Request validation reports placement errors. Keep this rendering helper
+    // total for callers that inspect messages before validation.
+    if custom_data
+        .validate_chat_messages(&request.inner.messages)
+        .is_err()
+    {
+        return messages;
+    }
+
+    let messages_array = messages
+        .as_array_mut()
+        .expect("chat messages must serialize as an array");
+    let mut inserted_per_message = std::collections::HashMap::<usize, usize>::new();
+    for (ordinal, item) in custom_data.items_in_prompt_order().into_iter().enumerate() {
+        let placement = item.placement;
+        let inserted = inserted_per_message
+            .entry(placement.message_index)
+            .or_default();
+        let content = messages_array[placement.message_index]["content"]
+            .as_array_mut()
+            .expect("custom encoder placement must reference array-form user content");
+        content.insert(
+            placement.content_index + *inserted,
+            serde_json::json!({
+                "type": "image_url",
+                "image_url": {
+                    "url": format!("dynamo://custom-encoder/{ordinal}")
+                }
+            }),
+        );
+        *inserted += 1;
+    }
+    messages
+}
+
 /// lib/llm-local extension carrying multimodal media-IO config. Kept off
 /// [`OAIChatLikeRequest`] so `dynamo_renderer` stays free of the media module;
 /// the multimodal preprocessing path bounds on `OAIChatLikeRequest + MediaRequestExt`.
@@ -42,7 +87,7 @@ impl OAIChatLikeRequest for NvCreateChatCompletionRequest {
     }
 
     fn messages(&self) -> Value {
-        let messages_json = serde_json::to_value(&self.inner.messages).unwrap();
+        let messages_json = chat_messages_for_rendering(self);
         Value::from_serialize(&messages_json)
     }
 
@@ -280,5 +325,52 @@ pub fn prompt_formatter_from_mdc(mdc: &ModelDeploymentCard) -> Result<PromptForm
         | PromptFormatterArtifact::HfChatTemplateJson { .. } => Err(anyhow::anyhow!(
             "prompt_formatter should not have type HfChatTemplate*"
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_encoder_placeholders_exist_only_in_rendered_messages() {
+        let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test/model",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "before"},
+                    {"type": "text", "text": "after"}
+                ]
+            }],
+            "nvext": {
+                "custom_encoder_data": {
+                    "version": 1,
+                    "items": [
+                        {
+                            "modality": "image",
+                            "placement": {"message_index": 0, "content_index": 2},
+                            "payload": {"id": "second"}
+                        },
+                        {
+                            "modality": "image",
+                            "placement": {"message_index": 0, "content_index": 1},
+                            "payload": {"id": "first"}
+                        }
+                    ]
+                }
+            }
+        }))
+        .unwrap();
+
+        let rendered = chat_messages_for_rendering(&request);
+        let parts = rendered[0]["content"].as_array().unwrap();
+        assert_eq!(parts[0]["text"], "before");
+        assert_eq!(parts[1]["image_url"]["url"], "dynamo://custom-encoder/0");
+        assert_eq!(parts[2]["text"], "after");
+        assert_eq!(parts[3]["image_url"]["url"], "dynamo://custom-encoder/1");
+
+        let original = serde_json::to_value(&request.inner.messages).unwrap();
+        assert_eq!(original[0]["content"].as_array().unwrap().len(), 2);
     }
 }

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -59,6 +59,14 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
     type Error = anyhow::Error;
 
     fn try_from(req: AnthropicCreateMessageRequest) -> Result<Self, Self::Error> {
+        let nvext = crate::protocols::common::extensions::parse_nvext(req.nvext.clone())?;
+        anyhow::ensure!(
+            nvext
+                .as_ref()
+                .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+                .is_none(),
+            "nvext.custom_encoder_data is supported only by the Chat Completions API"
+        );
         let mut messages = Vec::new();
 
         // Prepend system message if present
@@ -148,7 +156,7 @@ impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
                 top_k: req.top_k.map(|k| k as i32),
                 ..Default::default()
             },
-            nvext: crate::protocols::common::extensions::parse_nvext(req.nvext)?,
+            nvext,
             // chat_template_args may be augmented by the Anthropic handler
             // (anthropic.rs) after conversion — e.g., setting enable_thinking=true
             // when a reasoning parser is configured. The conversion layer only
@@ -715,6 +723,30 @@ mod tests {
 
         assert!(err.to_string().contains("invalid nvext"));
         assert!(err.to_string().contains("unknown field `agent_context`"));
+    }
+
+    #[test]
+    fn test_custom_encoder_data_is_rejected_before_anthropic_conversion() {
+        let json = r#"{
+            "model": "test-model",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "Hi"}],
+            "nvext": {
+                "custom_encoder_data": {
+                    "version": 1,
+                    "items": [{
+                        "modality": "image",
+                        "placement": {"message_index": 0, "content_index": 0},
+                        "payload": {"kind": "tensor_ref"}
+                    }]
+                }
+            }
+        }"#;
+
+        let request: AnthropicCreateMessageRequest = serde_json::from_str(json).unwrap();
+        let error = NvCreateChatCompletionRequest::try_from(request).unwrap_err();
+
+        assert!(error.to_string().contains("Chat Completions API"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -47,6 +47,145 @@ pub struct MetadataUpload {
     pub url: String,
 }
 
+/// Opaque custom-encoder inputs attached to a Chat Completions request.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CustomEncoderData {
+    pub version: u32,
+    pub items: Vec<CustomEncoderDataItem>,
+}
+
+/// One custom-encoder input and its position in the rendered prompt.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub struct CustomEncoderDataItem {
+    /// Semantic media slot rendered by the frontend. Deployments may support a subset.
+    pub modality: CustomEncoderModality,
+
+    pub placement: CustomEncoderPlacement,
+
+    /// Backend-owned semantic JSON. Object key order and original JSON spelling are not preserved.
+    pub payload: serde_json::Value,
+}
+
+/// Model-facing media semantics for an opaque custom-encoder payload.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CustomEncoderModality {
+    Image,
+    Video,
+    Audio,
+}
+
+impl CustomEncoderModality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Image => "image",
+            Self::Video => "video",
+            Self::Audio => "audio",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct CustomEncoderPlacement {
+    /// Index in the original Chat Completions `messages` array.
+    pub message_index: usize,
+
+    /// Insertion slot in the original user-content array; its length means append.
+    /// Items sharing a slot retain their order in the envelope.
+    pub content_index: usize,
+}
+
+impl CustomEncoderData {
+    pub const VERSION: u32 = 1;
+
+    /// Validate the public envelope against the original Chat Completions messages.
+    pub fn validate_chat_messages(
+        &self,
+        messages: &[dynamo_protocols::types::ChatCompletionRequestMessage],
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.version == Self::VERSION,
+            "nvext.custom_encoder_data.version must be {}",
+            Self::VERSION
+        );
+        anyhow::ensure!(
+            !self.items.is_empty(),
+            "nvext.custom_encoder_data.items must not be empty"
+        );
+
+        let messages = serde_json::to_value(messages)?;
+        let messages = messages
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("chat messages must serialize as an array"))?;
+
+        for (item_index, item) in self.items.iter().enumerate() {
+            anyhow::ensure!(
+                item.modality == CustomEncoderModality::Image,
+                "nvext.custom_encoder_data.items[{item_index}].modality `{}` is not supported; only `image` is currently supported",
+                item.modality.as_str()
+            );
+            let placement = item.placement;
+            let message = messages.get(placement.message_index).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "nvext.custom_encoder_data.items[{item_index}].placement.message_index is out of range"
+                )
+            })?;
+            anyhow::ensure!(
+                message.get("role").and_then(serde_json::Value::as_str) == Some("user"),
+                "nvext.custom_encoder_data.items[{item_index}] must be placed in a user message"
+            );
+            let content = message
+                .get("content")
+                .and_then(serde_json::Value::as_array)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "nvext.custom_encoder_data.items[{item_index}] requires array-form user content"
+                    )
+                })?;
+            anyhow::ensure!(
+                placement.content_index <= content.len(),
+                "nvext.custom_encoder_data.items[{item_index}].placement.content_index is out of range"
+            );
+        }
+
+        let has_standard_media = messages.iter().any(|message| {
+            message
+                .get("content")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|parts| {
+                    parts.iter().any(|part| {
+                        matches!(
+                            part.get("type").and_then(serde_json::Value::as_str),
+                            Some("image_url" | "video_url" | "audio_url" | "input_audio")
+                        )
+                    })
+                })
+        });
+        anyhow::ensure!(
+            !has_standard_media,
+            "nvext.custom_encoder_data cannot be combined with standard multimodal content"
+        );
+
+        Ok(())
+    }
+
+    /// Return inputs in their prompt order, preserving envelope order at equal placements.
+    pub fn items_in_prompt_order(&self) -> Vec<&CustomEncoderDataItem> {
+        let mut indexed: Vec<_> = self.items.iter().enumerate().collect();
+        indexed.sort_by_key(|(index, item)| {
+            (
+                item.placement.message_index,
+                item.placement.content_index,
+                *index,
+            )
+        });
+        indexed.into_iter().map(|(_, item)| item).collect()
+    }
+}
+
 fn deserialize_metadata_upload_url<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -161,6 +300,11 @@ pub struct NvExt {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub extra_fields: Option<Vec<String>>,
+
+    /// Versioned, opaque inputs for a custom encoder. Chat Completions only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub custom_encoder_data: Option<CustomEncoderData>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
@@ -1262,6 +1406,121 @@ mod tests {
             .build()
             .unwrap();
         assert!(!nvext.has_query_instance_id_annotation());
+    }
+
+    #[test]
+    fn custom_encoder_data_round_trips_opaque_payload() {
+        let value = serde_json::json!({
+            "custom_encoder_data": {
+                "version": 1,
+                "items": [{
+                    "modality": "video",
+                    "placement": {"message_index": 0, "content_index": 1},
+                    "payload": {
+                        "kind": "tensor_ref",
+                        "uri": "s3://bucket/tensor.safetensors",
+                        "options": [null, true, 7, {"nested": "value"}]
+                    }
+                }]
+            }
+        });
+
+        let nvext: NvExt = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(nvext).unwrap(), value);
+    }
+
+    #[test]
+    fn custom_encoder_data_validates_placements_and_prompt_order() {
+        let messages: Vec<dynamo_protocols::types::ChatCompletionRequestMessage> =
+            serde_json::from_value(serde_json::json!([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "first"},
+                    {"type": "text", "text": "second"}
+                ]
+            },
+            {"role": "assistant", "content": "answer"},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "third"}]
+            }
+            ]))
+            .unwrap();
+        let data = CustomEncoderData {
+            version: 1,
+            items: vec![
+                CustomEncoderDataItem {
+                    modality: CustomEncoderModality::Image,
+                    placement: CustomEncoderPlacement {
+                        message_index: 2,
+                        content_index: 1,
+                    },
+                    payload: serde_json::json!("later"),
+                },
+                CustomEncoderDataItem {
+                    modality: CustomEncoderModality::Image,
+                    placement: CustomEncoderPlacement {
+                        message_index: 0,
+                        content_index: 1,
+                    },
+                    payload: serde_json::json!("earlier"),
+                },
+            ],
+        };
+
+        data.validate_chat_messages(&messages).unwrap();
+        let ordered = data.items_in_prompt_order();
+        assert_eq!(ordered[0].payload, serde_json::json!("earlier"));
+        assert_eq!(ordered[1].payload, serde_json::json!("later"));
+
+        let mut invalid = data.clone();
+        invalid.items[0].placement.message_index = 1;
+        assert!(
+            invalid
+                .validate_chat_messages(&messages)
+                .unwrap_err()
+                .to_string()
+                .contains("user message")
+        );
+    }
+
+    #[test]
+    fn custom_encoder_data_rejects_standard_media_and_unsupported_modality() {
+        let messages: Vec<dynamo_protocols::types::ChatCompletionRequestMessage> =
+            serde_json::from_value(serde_json::json!([{
+                "role": "user",
+                "content": [{
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/image.png"}
+                }]
+            }]))
+            .unwrap();
+        let data = CustomEncoderData {
+            version: 1,
+            items: vec![CustomEncoderDataItem {
+                modality: CustomEncoderModality::Video,
+                placement: CustomEncoderPlacement {
+                    message_index: 0,
+                    content_index: 0,
+                },
+                payload: serde_json::json!({}),
+            }],
+        };
+
+        let unsupported_modality_error = data
+            .validate_chat_messages(&messages)
+            .unwrap_err()
+            .to_string();
+        assert!(unsupported_modality_error.contains("only `image` is currently supported"));
+
+        let mut data = data;
+        data.items[0].modality = CustomEncoderModality::Image;
+        let mixed_media_error = data
+            .validate_chat_messages(&messages)
+            .unwrap_err()
+            .to_string();
+        assert!(mixed_media_error.contains("cannot be combined"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -12,7 +12,7 @@ use dynamo_kv_router::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use super::extensions::{AgentContext, RouterParams};
+use super::extensions::{AgentContext, CustomEncoderModality, RouterParams};
 use super::timing::RequestTracker;
 use super::{OutputOptions, SamplingOptions, StopConditions};
 use crate::preprocessor::media::RdmaMediaDataDescriptor;
@@ -154,6 +154,11 @@ pub enum MultimodalData {
     Decoded(RdmaMediaDataDescriptor),
     /// Payload-free media slot resolved by a backend processor cache.
     UuidOnly(String),
+    /// Opaque input interpreted by a configured custom encoder.
+    CustomEncoderData {
+        modality: CustomEncoderModality,
+        payload: serde_json::Value,
+    },
 }
 
 // multimodal map containing {mm_part_type: [data...]}
@@ -511,6 +516,22 @@ mod tests {
         assert_eq!(guided["require_reasoning"], true);
         let back: PreprocessedRequest = serde_json::from_value(guided).unwrap();
         assert!(back.require_reasoning);
+    }
+
+    #[test]
+    fn custom_encoder_multimodal_data_round_trips() {
+        let value = serde_json::json!({
+            "CustomEncoderData": {
+                "modality": "image",
+                "payload": {
+                    "kind": "tensor_ref",
+                    "uri": "s3://bucket/tensor.safetensors"
+                }
+            }
+        });
+
+        let data: MultimodalData = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(serde_json::to_value(data).unwrap(), value);
     }
 
     /// Canary payloads carry only engine-relevant fields. All other required

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -538,6 +538,13 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
         validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
+        if let Some(custom_data) = self
+            .nvext
+            .as_ref()
+            .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+        {
+            custom_data.validate_chat_messages(&self.inner.messages)?;
+        }
         validate::validate_model(&self.inner.model)?;
         // none for store
         validate::validate_reasoning_effort(&self.inner.reasoning_effort)?;
@@ -636,6 +643,40 @@ mod tests {
         }))
         .expect("Failed to deserialize request");
         assert!(ValidateRequest::validate(&invalid_request).is_err());
+    }
+
+    #[test]
+    fn custom_encoder_data_is_validated_only_when_present() {
+        let ordinary: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .unwrap();
+        ValidateRequest::validate(&ordinary).unwrap();
+
+        let invalid_version: NvCreateChatCompletionRequest =
+            serde_json::from_value(serde_json::json!({
+                "model": "test-model",
+                "messages": [{
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hello"}]
+                }],
+                "nvext": {
+                    "custom_encoder_data": {
+                        "version": 2,
+                        "items": [{
+                            "modality": "image",
+                            "placement": {"message_index": 0, "content_index": 1},
+                            "payload": {"kind": "tensor_ref"}
+                        }]
+                    }
+                }
+            }))
+            .unwrap();
+        let error = ValidateRequest::validate(&invalid_version)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("version must be 1"));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/completions.rs
+++ b/lib/llm/src/protocols/openai/completions.rs
@@ -467,6 +467,13 @@ impl ValidateRequest for NvCreateCompletionRequest {
             get_prompt_batch_size(&self.inner.prompt) * self.inner.n.unwrap_or(1) as usize,
             self.nvext.as_ref(),
         )?;
+        anyhow::ensure!(
+            self.nvext
+                .as_ref()
+                .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+                .is_none(),
+            "nvext.custom_encoder_data is supported only by the Chat Completions API"
+        );
         // none for stream
         // none for stream_options
         validate::validate_logprobs(self.inner.logprobs)?;
@@ -556,6 +563,30 @@ mod tests {
             .extract_output_options()
             .expect("Failed to extract output options");
         assert_eq!(output_options.prompt_logprobs, Some(3));
+    }
+
+    #[test]
+    fn test_custom_encoder_data_rejected_for_text_and_token_completions() {
+        for prompt in [json!("Hello"), json!([1, 2, 3])] {
+            let request: NvCreateCompletionRequest = serde_json::from_value(json!({
+                "model": "test-model",
+                "prompt": prompt,
+                "nvext": {
+                    "custom_encoder_data": {
+                        "version": 1,
+                        "items": [{
+                            "modality": "image",
+                            "placement": {"message_index": 0, "content_index": 0},
+                            "payload": {"kind": "tensor_ref", "uri": "s3://bucket/input"}
+                        }]
+                    }
+                }
+            }))
+            .unwrap();
+
+            let error = ValidateRequest::validate(&request).unwrap_err();
+            assert!(error.to_string().contains("Chat Completions API"));
+        }
     }
 
     #[test]

--- a/lib/llm/src/protocols/tensor.rs
+++ b/lib/llm/src/protocols/tensor.rs
@@ -205,6 +205,19 @@ pub struct NvCreateTensorRequest {
     pub nvext: Option<NvExt>,
 }
 
+impl NvCreateTensorRequest {
+    pub fn validate_custom_encoder_data(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.nvext
+                .as_ref()
+                .and_then(|nvext| nvext.custom_encoder_data.as_ref())
+                .is_none(),
+            "nvext.custom_encoder_data is supported only by the Chat Completions API"
+        );
+        Ok(())
+    }
+}
+
 /// A response structure for unary chat completion responses, embedding OpenAI's
 /// `CreateChatCompletionResponse`.
 #[derive(Serialize, Deserialize, Validate, Debug, Clone)]
@@ -267,6 +280,38 @@ impl AnnotationsProvider for NvCreateTensorRequest {
 pub struct DeltaAggregator {
     response: Option<NvCreateTensorResponse>,
     error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_encoder_data_is_rejected_for_tensor_requests() {
+        let request: NvCreateTensorRequest = serde_json::from_value(serde_json::json!({
+            "model": "test-model",
+            "tensors": [],
+            "nvext": {
+                "custom_encoder_data": {
+                    "version": 1,
+                    "items": [{
+                        "modality": "image",
+                        "placement": {"message_index": 0, "content_index": 0},
+                        "payload": {"kind": "tensor_ref"}
+                    }]
+                }
+            }
+        }))
+        .unwrap();
+
+        assert!(
+            request
+                .validate_custom_encoder_data()
+                .unwrap_err()
+                .to_string()
+                .contains("Chat Completions API")
+        );
+    }
 }
 
 impl NvCreateTensorResponse {


### PR DESCRIPTION
_Based on #11850._

## Why

Custom encoders need model-owned inputs that do not fit OpenAI media content types, while the frontend still needs semantic modality and prompt placement. A versioned `nvext.custom_encoder_data` envelope keeps payload interpretation in the backend and avoids exposing model-specific placeholder tokens. The interface represents image, video, and audio; this first execution path admits images only and rejects unsupported modalities before rendering or dispatch.

## Effect

```json
{"nvext":{"custom_encoder_data":{"version":1,"items":[{"modality":"image","placement":{"message_index":0,"content_index":1},"payload":{"kind":"tensor_ref","uri":"s3://bucket/input"}}]}}}
```

## What Change

- Add versioned modality, placement, and opaque-payload request types.
- Render image anchors while preserving original worker-bound messages.
- Reject unsupported endpoints, mixed media, and legacy encoder routing.

## Test Plan

- Run focused `dynamo-llm` tests with and without `mm-routing`.
- Run pre-commit on all changed Rust files.