### PR TITLE
fix(container): add google-crc32c to vLLM runtime for ModelExpress 0.…

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -41,6 +41,11 @@ def _make_config(**overrides) -> Mock:
         "route_to_encoder": False,
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
+        # Pin to the real Config default: an auto-created Mock attribute is
+        # truthy, which enables the GMS shadow-mode path and imports the
+        # optional gpu_memory_service package (absent in some test images).
+        "gms_shadow_mode": False,
+        "realtime": False,
     }
     defaults.update(overrides)
     return Mock(**defaults)

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -210,12 +210,18 @@ RUN uv pip uninstall triton && \
 
 {% if context.vllm.enable_modelexpress == "true" %}
 # Install only the ModelExpress client package. --no-deps preserves the upstream
-# vLLM runtime dependency stack.
+# vLLM runtime dependency stack. google-crc32c is imported eagerly by the MX
+# vLLM plugin (>=0.5.0) and is not in the XPU base image, so install it
+# alongside; the plugin-load check below runs the exact vllm.general_plugins
+# entry point vLLM executes at every startup, failing the build on any future
+# --no-deps gap.
 RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     uv pip install {{ pip_target }} --no-deps \
-        "modelexpress==${MODELEXPRESS_VERSION}"
+        "modelexpress==${MODELEXPRESS_VERSION}"; \
+    uv pip install {{ pip_target }} "google-crc32c>=1.5.0"; \
+    python3 -c "import modelexpress; modelexpress.register_modelexpress_loaders()"
 {% endif %}
 
 {% endif %}

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -212,16 +212,14 @@ RUN uv pip uninstall triton && \
 # Install only the ModelExpress client package. --no-deps preserves the upstream
 # vLLM runtime dependency stack. google-crc32c is imported eagerly by the MX
 # vLLM plugin (>=0.5.0) and is not in the XPU base image, so install it
-# alongside; the plugin-load check below runs the exact vllm.general_plugins
-# entry point vLLM executes at every startup, failing the build on any future
-# --no-deps gap.
+# alongside; the plugin-load guard later in this stage fails the build on any
+# remaining --no-deps gap.
 RUN --mount=type=cache,id=uv-root-{{ context.dynamo.uv_version }},target=/root/.cache/uv,sharing=locked \
     set -eux; \
     export UV_CACHE_DIR=/root/.cache/uv; \
     uv pip install {{ pip_target }} --no-deps \
         "modelexpress==${MODELEXPRESS_VERSION}"; \
-    uv pip install {{ pip_target }} "google-crc32c>=1.5.0"; \
-    python3 -c "import modelexpress; modelexpress.register_modelexpress_loaders()"
+    uv pip install {{ pip_target }} "google-crc32c>=1.5.0"
 {% endif %}
 
 {% endif %}
@@ -310,6 +308,18 @@ RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/
 # collection conflicts (duplicate conftest plugin registration) and stale
 # tool scripts referencing files not present in Dynamo's build context.
 RUN rm -rf /workspace/vllm
+
+{% if target not in ("dev", "local-dev") and context.vllm.enable_modelexpress == "true" %}
+# Regression guard for the --no-deps ModelExpress install above: resolve and
+# invoke the vllm.general_plugins entry points exactly as vLLM does at every
+# startup, so a missing transitive dependency fails the build here instead of
+# at pod startup. Runs after every package/library install in this stage
+# (including the XPU apt step) so the check is order-independent.
+RUN python3 -c "from importlib.metadata import entry_points; \
+eps = [ep for ep in entry_points(group='vllm.general_plugins') if ep.name == 'modelexpress']; \
+assert eps, 'modelexpress vllm.general_plugins entry point not found'; \
+[ep.load()() for ep in eps]"
+{% endif %}
 
 USER dynamo
 


### PR DESCRIPTION
MX 0.5.0's vLLM plugin eagerly imports google_crc32c at every vLLM startup; the XPU base image lacks it, breaking XPU 2-card router e2e. Mirrors the sglang fix and adds a build-time plugin-load guard.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12665" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->