### PR TITLE
docs(vllm): cherry-pick worker-role flag corrections and --kv-transfer-config reference

### DIFF
--- a/docs/fern/backends/vllm/vllm-config-reference.mdx
+++ b/docs/fern/backends/vllm/vllm-config-reference.mdx
@@ -8,7 +8,7 @@ subtitle: Field reference for the Dynamo-specific CLI flags and environment vari
 `DynamoVllmConfig` holds the Dynamo-specific configuration for the vLLM backend (`python -m dynamo.vllm`). Every field, type, default, and choice on this page comes from the [`DynamoVllmArgGroup` and `DynamoVllmConfig`](https://github.com/ai-dynamo/dynamo/blob/main/components/src/dynamo/vllm/backend_args.py) definitions. For features and operational details, see the [vLLM Reference Guide](vllm-reference-guide.md).
 
 <Note>
-  These are **only** the Dynamo wrapper flags. The vLLM backend also accepts every native vLLM `EngineArgs` argument (`--model`, `--tensor-parallel-size`, `--max-model-len`, and so on) in the same command, plus the cross-cutting [Dynamo Runtime](../../reference/runtime-config-reference.mdx) flags (`--namespace`, `--endpoint`, and others). Except for the KV event interoperability note below, this page covers neither — only the vLLM-specific `DYN_VLLM_*` surface.
+  These are **only** the Dynamo wrapper flags. The vLLM backend also accepts every native vLLM `EngineArgs` argument (`--model`, `--tensor-parallel-size`, `--max-model-len`, and so on) in the same command, plus the cross-cutting [Dynamo Runtime](../../reference/runtime-config-reference.mdx) flags (`--namespace`, `--endpoint`, and others). Except for the native KV event and KV transfer sections below, this page covers neither — only the vLLM-specific `DYN_VLLM_*` surface.
 </Note>
 
 ## How the config is loaded
@@ -72,12 +72,39 @@ The `endpoint` value is the base ZeroMQ port. vLLM assigns each data-parallel ra
 
 If workers do not publish KV events, configure the frontend with `--no-router-kv-events` for prediction-based KV routing or `--load-aware` for load-only routing.
 
+## Native KV transfer configuration
+
+`--kv-transfer-config` is a native vLLM engine argument rather than a `DynamoVllmConfig` field, so it has no `DYN_VLLM_*` environment variable. It selects the KV connector that moves cache blocks between prefill and decode workers.
+
+<Warning>
+A worker started with `--disaggregation-mode prefill` must be passed `--kv-transfer-config` explicitly. Without it, the worker raises a `ValueError` during argument parsing and never starts. All non-prefill modes — `agg`, `pd`, `decode`, and `encode` — do not enforce this check.
+</Warning>
+
+The value is a JSON object. For NIXL-based prefill/decode disaggregation:
+
+```bash
+python -m dynamo.vllm \
+  --model Qwen/Qwen3-0.6B \
+  --disaggregation-mode prefill \
+  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
+```
+
+Only the prefill worker is required to set it, but both halves of a NIXL pair must agree on a connector for transfers to succeed. Pass the same `--kv-transfer-config` value to the decode worker, as the [disaggregated vLLM launch script](https://github.com/ai-dynamo/dynamo/blob/release/1.4.0/examples/backends/vllm/launch/disagg.sh) does.
+
+The earlier `--connector` flag is no longer accepted by the vLLM backend. Setting it — on the command line or through the `DYN_CONNECTOR` environment variable — raises a `ValueError` during argument parsing. The message depends on the value:
+
+- An active connector, such as `--connector nixl` or `DYN_CONNECTOR=nixl`, reports the equivalent `--kv-transfer-config` JSON to use instead.
+- `--connector none` or `--connector null` reports that the flag is no longer needed, because no connector is already the default. There is no equivalent value to migrate to, so none is shown.
+- `DYN_CONNECTOR` set to an empty or whitespace-only value reports that the variable is no longer supported, without an equivalent value.
+
 ## Worker role and disaggregation
 
 These flags control which role this worker plays in a disaggregated deployment. The default when no `--disaggregation-mode` is set is aggregated (`agg`).
 
 <ParamField path="--disaggregation-mode" type="string" default="null">
   Worker disaggregation mode. `agg` (default when unset) runs a combined aggregated prefill+decode worker. `pd` is a legacy alias for `agg`. `prefill` and `decode` split the pipeline for prefill/decode disaggregation. `encode` starts a multimodal encode-only worker.
+
+  `prefill` additionally requires the native `--kv-transfer-config` argument - see [Native KV transfer configuration](#native-kv-transfer-configuration).
 
   <span className="enum-values"><span className="enum-label">Allowed values:</span> <Badge intent="note" minimal>pd</Badge> <Badge intent="note" minimal>agg</Badge> <Badge intent="note" minimal>prefill</Badge> <Badge intent="note" minimal>decode</Badge> <Badge intent="note" minimal>encode</Badge></span>
 
@@ -204,18 +231,6 @@ These flags control the self-benchmark sweep that runs on startup before the wor
 
 These flags are retained for backward compatibility and will be removed in a future release. Each is mapped to its replacement at startup with a deprecation warning.
 
-<ParamField path="--is-prefill-worker" type="boolean" default="false" deprecated={true}>
-  **Deprecated** — use `--disaggregation-mode=prefill`. Enable prefill functionality for this worker.
-
-  Environment variable: `DYN_VLLM_IS_PREFILL_WORKER`
-</ParamField>
-
-<ParamField path="--is-decode-worker" type="boolean" default="false" deprecated={true}>
-  **Deprecated** — use `--disaggregation-mode=decode`. Mark this as a decode worker that does not publish KV events.
-
-  Environment variable: `DYN_VLLM_IS_DECODE_WORKER`
-</ParamField>
-
 <ParamField path="--model-express-url" type="string" default="null" deprecated={true}>
   **Deprecated** — accepted for compatibility with older ModelExpress manifests only. The vLLM ModelExpress plugin reads its own configuration.
 
@@ -224,8 +239,6 @@ These flags are retained for backward compatibility and will be removed in a fut
 
 ## Validation rules
 
-- `--disaggregation-mode` cannot be combined with `--is-prefill-worker` or `--is-decode-worker`.
-- `--is-prefill-worker` and `--is-decode-worker` cannot both be set at the same time.
 - `--embedding-worker` is only valid with `--disaggregation-mode=agg` (or the default aggregated mode) and cannot be combined with `--enable-multimodal` or `--benchmark-mode`.
 
 ## Related pages


### PR DESCRIPTION
Cherry-pick of #12568 (merged to `main` as 27e6820 on Aug 3) onto `release/1.4.0`, for NVBug [6550447](https://nvbugs.nvidia.com/6550447) / DYN-3726 (P0).

## Why this is not a clean cherry-pick

`main` has since restructured the Fern docs tree. The file lives at `docs/fern/pages/reference/backends/vllm-configuration.mdx` on `main` and at `docs/fern/backends/vllm/vllm-config-reference.mdx` here, so `git cherry-pick` does not apply. The content change is the same; the relative link to the runtime config reference uses this branch's path, and the launch-script link points at `release/1.4.0` instead of `main`.

## What changed

- Adds a **Native KV transfer configuration** section documenting `--kv-transfer-config` as a native vLLM engine argument, and warns that `--disaggregation-mode prefill` raises a `ValueError` at argument parsing without it.
- Records that `--connector` / `DYN_CONNECTOR` are no longer accepted, with the message each rejected value produces.
- Cross-references the new section from the `--disaggregation-mode` field.
- Removes the `--is-prefill-worker` and `--is-decode-worker` entries and their two validation rules. The backend no longer accepts either flag, so the page documented them as working.

Following the page as written on this branch fails: the removed role flags are shown as usable and the mandatory `--kv-transfer-config` is absent.

Fixes 6550447
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12666" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->