### PR TITLE
docs: repoint dead SGLang diffusion links at the rendered docs site

### DIFF
--- a/docs/fern/pages/cli/installation/install-dynamo.mdx
+++ b/docs/fern/pages/cli/installation/install-dynamo.mdx
@@ -107,7 +107,7 @@ This covers single-machine setups only. Multi-node disaggregated serving additio
         sudo apt install python3-dev
         ```
 
-        For CUDA 13 (B300/GB300), the container is recommended. See the [SGLang install docs](https://docs.sglang.io/get_started/install.html) for details.
+        For CUDA 13 (B300/GB300), the container is recommended. See the [SGLang install docs](https://docs.sglang.io/docs/get-started/install) for details.
       </Tab>
       <Tab title="TensorRT-LLM" language="trtllm">
         TensorRT-LLM is available through the prebuilt container. The selector does not offer a wheel command for this backend. See the [TensorRT-LLM backend guide](../../developer-guide/knowledge-base/modular-components/backends/tensorrt-llm/overview.md) for details.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/chat-processor.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/chat-processor.md
@@ -63,7 +63,7 @@ python -m dynamo.frontend \
   --tool-call-parser hermes
 ```
 
-Any parser supported by SGLang can be used. See the [SGLang documentation](https://docs.sglang.ai/) for the full list of available tool call parsers.
+Any parser supported by SGLang can be used. See the [SGLang documentation](https://docs.sglang.io/) for the full list of available tool call parsers.
 
 ### Example: Tool Call Request
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/hicache.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/hicache.md
@@ -11,8 +11,8 @@ This guide covers running SGLang's Hierarchical Cache (HiCache) with Dynamo, and
 
 SGLang HiCache extends RadixAttention with a multi-tier KV cache that transparently moves pages between GPU HBM, host memory, and an optional external storage backend (e.g. Mooncake). For a full description of HiCache itself — flag reference, storage backends, memory layouts, prefetch policies — see SGLang's own documentation:
 
-- [SGLang HiCache Design](https://docs.sglang.ai/advanced_features/hicache_design.html)
-- [SGLang HiCache Best Practices](https://docs.sglang.ai/advanced_features/hicache_best_practices.html)
+- [SGLang HiCache Design](https://docs.sglang.io/docs/advanced_features/hicache_design)
+- [SGLang HiCache Best Practices](https://docs.sglang.io/docs/advanced_features/hicache_best_practices)
 
 What Dynamo adds on top of HiCache:
 
@@ -43,7 +43,7 @@ python -m dynamo.frontend --http-port 8000
 ```
 
 > [!NOTE]
-> The HiCache flags (`--enable-hierarchical-cache`, `--hicache-ratio`, `--hicache-write-policy`, `--hicache-storage-backend`, `--hicache-mem-layout`, etc.) are SGLang-native — Dynamo passes them through unchanged. See [SGLang's best-practices doc](https://docs.sglang.ai/advanced_features/hicache_best_practices.html) for the complete flag reference and tuning guidance.
+> The HiCache flags (`--enable-hierarchical-cache`, `--hicache-ratio`, `--hicache-write-policy`, `--hicache-storage-backend`, `--hicache-mem-layout`, etc.) are SGLang-native — Dynamo passes them through unchanged. See [SGLang's best-practices doc](https://docs.sglang.io/docs/advanced_features/hicache_best_practices) for the complete flag reference and tuning guidance.
 
 ## Tier-Aware Shared KV Cache Routing
 
@@ -231,7 +231,7 @@ curl -s localhost:8000/metrics | grep shared_cache
 
 ## Further Reading
 
-- [SGLang HiCache Design](https://docs.sglang.ai/advanced_features/hicache_design.html) and [Best Practices](https://docs.sglang.ai/advanced_features/hicache_best_practices.html)
+- [SGLang HiCache Design](https://docs.sglang.io/docs/advanced_features/hicache_design) and [Best Practices](https://docs.sglang.io/docs/advanced_features/hicache_best_practices)
 - [Mooncake](https://github.com/kvcache-ai/Mooncake) — the shared KV store used as the external tier
 - [SGLang PR #22894](https://github.com/sgl-project/sglang/pull/22894) — the tier-annotated events prerequisite
 - [KVBM Guide](../../kvbm/kvbm-guide.md) — Dynamo's own block manager, an alternative to HiCache

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/observability.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/observability.md
@@ -11,7 +11,7 @@ This guide covers metrics, tracing, and visualization for SGLang deployments run
 
 When running SGLang through Dynamo, SGLang engine metrics are automatically passed through and exposed on Dynamo's `/metrics` endpoint (default port 8081). This allows you to access both SGLang engine metrics (prefixed with `sglang:`) and Dynamo runtime metrics (prefixed with `dynamo_*`) from a single worker backend endpoint.
 
-**For the complete and authoritative list of all SGLang metrics**, always refer to the [official SGLang Production Metrics documentation](https://docs.sglang.io/references/production_metrics.html).
+**For the complete and authoritative list of all SGLang metrics**, always refer to the [official SGLang Production Metrics documentation](https://docs.sglang.io/docs/references/production_metrics).
 
 For Dynamo runtime metrics, see the [Metrics Catalog](../../../../../reference/observability/metrics-catalog.mdx).
 
@@ -80,7 +80,7 @@ sglang:generation_tokens_total{model_name="meta-llama/Llama-3.1-8B-Instruct"} 75
 sglang:cache_hit_rate{model_name="meta-llama/Llama-3.1-8B-Instruct"} 0.0075
 ```
 
-**Note:** The specific metrics shown above are examples and may vary depending on your SGLang version. Always inspect your actual `/metrics` endpoint or refer to the [official documentation](https://docs.sglang.io/references/production_metrics.html) for the current list.
+**Note:** The specific metrics shown above are examples and may vary depending on your SGLang version. Always inspect your actual `/metrics` endpoint or refer to the [official documentation](https://docs.sglang.io/docs/references/production_metrics) for the current list.
 
 ### Metric Categories
 
@@ -91,7 +91,7 @@ SGLang provides metrics in the following categories (all prefixed with `sglang:`
 - **Latency metrics** - Request and token latency measurements
 - **Disaggregation metrics** - Metrics specific to disaggregated deployments (when enabled)
 
-**Note:** Specific metrics are subject to change between SGLang versions. Always refer to the [official documentation](https://docs.sglang.io/references/production_metrics.html) or inspect the `/metrics` endpoint for your SGLang version.
+**Note:** Specific metrics are subject to change between SGLang versions. Always refer to the [official documentation](https://docs.sglang.io/docs/references/production_metrics) or inspect the `/metrics` endpoint for your SGLang version.
 
 ### Available Metrics
 
@@ -102,7 +102,7 @@ The official SGLang documentation includes complete metric definitions with:
 - Setup guide for Prometheus + Grafana monitoring
 - Troubleshooting tips and configuration examples
 
-For the complete and authoritative list of all SGLang metrics, see the [official SGLang Production Metrics documentation](https://docs.sglang.io/references/production_metrics.html).
+For the complete and authoritative list of all SGLang metrics, see the [official SGLang Production Metrics documentation](https://docs.sglang.io/docs/references/production_metrics).
 
 ### Implementation Details
 
@@ -486,7 +486,7 @@ This is useful for automated benchmarking pipelines where you want to capture me
 ## Related Documentation
 
 ### SGLang Metrics
-- [Official SGLang Production Metrics](https://docs.sglang.io/references/production_metrics.html)
+- [Official SGLang Production Metrics](https://docs.sglang.io/docs/references/production_metrics)
 - [SGLang GitHub - Metrics Collector](https://github.com/sgl-project/sglang/blob/v0.5.9/python/sglang/srt/metrics/collector.py)
 
 ### Dynamo Observability

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/overview.md
@@ -207,7 +207,7 @@ cd $DYNAMO_HOME/examples/backends/sglang
 
 ### Multi-Node TP
 
-SGLang supports multi-node tensor parallelism via the native `--dist-init-addr`, `--nnodes`, and `--node-rank` flags. See [SGLang server arguments](https://docs.sglang.ai/advanced_features/server_arguments.html) for the canonical reference; the same flags work with `python -m dynamo.sglang`. For a Kubernetes deployment example, see [`disagg-multinode.yaml`](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/deploy/disagg-multinode.yaml).
+SGLang supports multi-node tensor parallelism via the native `--dist-init-addr`, `--nnodes`, and `--node-rank` flags. See [SGLang server arguments](https://docs.sglang.io/docs/advanced_features/server_arguments) for the canonical reference; the same flags work with `python -m dynamo.sglang`. For a Kubernetes deployment example, see [`disagg-multinode.yaml`](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/sglang/deploy/disagg-multinode.yaml).
 
 ### Kubernetes Deployment
 

--- a/docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md
+++ b/docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md
@@ -7,7 +7,7 @@ subtitle: Generate text through iterative refinement with SGLang diffusion langu
 
 Diffusion Language Models generate text through iterative refinement rather than autoregressive token-by-token generation. The model starts with masked tokens and progressively replaces them with predictions, refining low-confidence tokens each step. See the [Diffusion Overview](../overview.md) for backend setup.
 
-LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://docs.sglang.ai/docs/supported-models/diffusion_language_models).
+LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://docs.sglang.io/docs/supported-models/diffusion_language_models).
 
 ## Launch
 
@@ -35,4 +35,4 @@ curl -X POST http://localhost:8001/v1/chat/completions \
 
 - [Diffusion Overview](../overview.md)
 - [SGLang Examples](../../../recipes/cli-templates/sglang.mdx)
-- [SGLang Diffusion LMs (upstream)](https://docs.sglang.ai/docs/supported-models/diffusion_language_models)
+- [SGLang Diffusion LMs (upstream)](https://docs.sglang.io/docs/supported-models/diffusion_language_models)

--- a/docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md
+++ b/docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md
@@ -7,7 +7,7 @@ subtitle: Generate text through iterative refinement with SGLang diffusion langu
 
 Diffusion Language Models generate text through iterative refinement rather than autoregressive token-by-token generation. The model starts with masked tokens and progressively replaces them with predictions, refining low-confidence tokens each step. See the [Diffusion Overview](../overview.md) for backend setup.
 
-LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/supported-models/diffusion_language_models.mdx).
+LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://docs.sglang.ai/docs/supported-models/diffusion_language_models).
 
 ## Launch
 
@@ -35,4 +35,4 @@ curl -X POST http://localhost:8001/v1/chat/completions \
 
 - [Diffusion Overview](../overview.md)
 - [SGLang Examples](../../../recipes/cli-templates/sglang.mdx)
-- [SGLang Diffusion LMs (upstream)](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/supported-models/diffusion_language_models.mdx)
+- [SGLang Diffusion LMs (upstream)](https://docs.sglang.ai/docs/supported-models/diffusion_language_models)


### PR DESCRIPTION
## Overview:

The Docs link check (`lychee`) is failing on `main` — two dead links to an SGLang page that upstream moved out of `docs_new/`.

## Details:

**Commit 1 — the CI fix.** Both links in `docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md` pointed at `sgl-project/sglang/blob/main/docs_new/docs/supported-models/diffusion_language_models.mdx`. SGLang relocated that file to `docs/docs/supported-models/`, so the old blob path 404s. Both now point at the rendered docs site rather than a blob path, so they survive the next file reshuffle.

A repo-wide grep confirms those were the only two `docs_new` references anywhere in the tree, matching lychee's `Errors: 2`.

**Commit 2 — link normalization** (from CodeRabbit review). The repo had accumulated a split between `docs.sglang.ai` (7 links) and `docs.sglang.io` (6), and most carried the old `.html` path style. `.ai` 301s to `.io`, and the legacy paths then 308 again — so nearly every SGLang link in the repo depended on one or two redirect hops. All now point at final URLs.

Every SGLang link in the repo returns 200 directly, verified with curl *without* following redirects:

```
200 https://docs.sglang.io/
200 https://docs.sglang.io/docs/advanced_features/hicache_best_practices
200 https://docs.sglang.io/docs/advanced_features/hicache_design
200 https://docs.sglang.io/docs/advanced_features/server_arguments
200 https://docs.sglang.io/docs/get-started/install
200 https://docs.sglang.io/docs/references/production_metrics
200 https://docs.sglang.io/docs/supported-models/diffusion_language_models
```

Content-only throughout; no frontmatter, headings, or navigation touched.

## Where should the reviewer start?

`docs/fern/pages/use-cases/diffusion/workflows/text-to-text-llm-diffusion.md` — that file alone is what unblocks CI. The other five files are the redirect normalization and are mechanical URL swaps.

**Validation.** `pre-commit run --files <changed>` passes clean. Every resulting URL verified 200 with no redirect following; the two original blob URLs verified 404.

Failing runs this unblocks: `dfc15c35d`, `ff999f2d8`, `1152719cd` on `main`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)