### PR TITLE
chore: update Aiconfigurator release source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=7564a73006c1af79f6034e3671fa7b16836ef137#7564a73006c1af79f6034e3671fa7b16836ef137"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = { version = "2" }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "7564a73006c1af79f6034e3671fa7b16836ef137" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3",
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#subdirectory=aic-core",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
     "aiperf==0.10.0",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required by experimental KV router --router-prefill-load-model=aic.
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core
 
 # tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -4,9 +4,9 @@
 # Dependencies required by the planner, profiler, and global_planner services.
 
 # Keep both layers on the same immutable AIC source revision.
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137
 
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=7564a73006c1af79f6034e3671fa7b16836ef137#7564a73006c1af79f6034e3671fa7b16836ef137"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -120,7 +120,7 @@ opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "7564a73006c1af79f6034e3671fa7b16836ef137" }
 
 [profile.profiling]
 inherits = "release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
## Summary

- follow up on #12519 while preserving its source-build and lockfile changes
- update every Python and Rust source pin for `aiconfigurator` and `aiconfigurator-core` from `0ee4eacf9079eff65cbe45cbbbd9cab1d98c06e3` to `7564a73006c1af79f6034e3671fa7b16836ef137`
- keep Dynamo `release/1.4.0` aligned with the current tip of Aiconfigurator `release/0.11.0`, including the non-negative FPM regression-slope fix

This branch was created from Dynamo `release/1.4.0` at `5f392f55314324619edd53520f6fefabb7bc4579`, which was rechecked against the live remote immediately before push.

## Validation

- verified `7564a73006c1af79f6034e3671fa7b16836ef137` exists and is the live tip of Aiconfigurator `release/0.11.0`
- parsed all affected TOML files and seven PEP 508 Aiconfigurator requirements
- verified both Cargo patch tables and lockfiles reference the requested revision
- ran feature-enabled inverse dependency checks for the root workspace and Python bindings; both resolve `aiconfigurator-core v0.11.0` from `7564a730`
- `git diff --check`
