### PR TITLE
feat(recipes): add Qwen3.6-27B benchmark recipe

### DIFF
--- a/recipes/qwen3.6-27b/README.md
+++ b/recipes/qwen3.6-27b/README.md
@@ -1,0 +1,226 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Qwen3.6-27B — 3-way `vllm serve` vs Dynamo benchmark
+
+K8s recipe for benchmarking
+[`Qwen/Qwen3.6-27B`](https://huggingface.co/Qwen/Qwen3.6-27B)
+across three configs on the same multi-GPU hardware target:
+
+| Config         | Stack         | Multimodal | Frontend-decoding | Embedding cache |
+|----------------|---------------|------------|-------------------|-----------------|
+| `vllm-serve`   | vanilla vLLM  | n/a        | n/a               | n/a             |
+| `dynamo-fd`    | Dynamo + vLLM | on         | on                | off             |
+| `dynamo-fd-ec` | Dynamo + vLLM | on         | on                | 8 GiB           |
+
+All three configs share one hardware target (H100 or GB200) chosen at
+deploy time via `--hw {h100,gb200}`. See [Hardware targets](#hardware-targets) below.
+
+This recipe mirrors the layout of the sibling
+[`qwen3.6-35b`](../qwen3.6-35b) recipe (which benchmarks
+`Qwen/Qwen3.6-35B-A3B-FP8`), with one key difference: `Qwen/Qwen3.6-27B`
+is a **dense** 27B-param model (~56 GB checkpoint) shipped in **BF16**
+(no FP8 checkpoint yet), so every config here runs
+`--tensor-parallel-size 2` — the pinned node needs **2 free GPUs**, not 1.
+
+## Pre-requisites
+
+1. Kubectl context pointing at a cluster with the right GPUs (2 free
+   GPUs on the pinned node — see point 4).
+2. A namespace you have write access to (`$NAMESPACE` below).
+3. A `shared-model-cache` PVC in that namespace (RWX). If your cluster
+   pre-provisions it (common on platform-managed AWS / FSx clusters),
+   you don't need to do anything. Otherwise see
+   [Storage: shared-model-cache](#storage-shared-model-cache).
+4. **Fill in your hostname** in `hw/h100.env` or `hw/gb200.env` —
+   replace the `<FILL-IN-…-HOSTNAME>` placeholder. See
+   [Hardware targets](#hardware-targets) for the lookup command.
+5. `envsubst` on the laptop driving the recipe (Ubuntu:
+   `apt install gettext-base`; macOS: `brew install gettext`).
+6. **HuggingFace token: not required.** `Qwen/Qwen3.6-27B` is
+   public (`apache-2.0`), so neither the download Job nor `vllm serve`
+   needs one. To swap in a gated model, uncomment the commented
+   `hf-token-secret` block in `deploy/vllm-serve.yaml` (add an equivalent
+   `envFrom` to `model-cache/model-download.yaml` and `deploy/dynamo-fd*.yaml`
+   if you need it there too — they don't ship one yet) and create:
+   ```bash
+   kubectl -n "$NAMESPACE" create secret generic hf-token-secret \
+     --from-literal=HF_TOKEN="$HF_TOKEN"
+   ```
+
+## Quick start
+
+```bash
+export NAMESPACE=<your-namespace>
+export HW=gb200   # or h100
+
+# Run all three configs sequentially (prep + deploy + bench + retrieve + clean
+# per config). Artifacts land under
+# ~/workspace/dynamo-tmp/logs/<MM-DD>/qwen3627-${HW}/{vllm-serve,dynamo-fd,dynamo-fd-ec}/,
+# nested one level deeper as .../artifacts/qwen3627/<config>/ (the bench pod's
+# own /perf-cache/artifacts/qwen3627/<label>/ layout, tarred as-is).
+./run-all-benchmarks.sh -n ${NAMESPACE} --hw ${HW}
+```
+
+Each config's `profile_export_aiperf.json` is retrieved under the matching
+sub-directory (see the `find` line `retrieve()` prints for the exact path);
+throughput / TTFT / ITL numbers can be read directly from that file.
+
+Or step-by-step for a single config:
+
+```bash
+./run-benchmark.sh -n ${NAMESPACE} --hw ${HW} --config vllm-serve
+./run-benchmark.sh -n ${NAMESPACE} --hw ${HW} --config dynamo-fd
+./run-benchmark.sh -n ${NAMESPACE} --hw ${HW} --config dynamo-fd-ec
+```
+
+`run-benchmark.sh` accepts `--step {pvc|download|dataset|deploy|bench|retrieve|clean}` for granular control. `pvc`, `download`, and `dataset` are config-agnostic (any `--config` works to run them once).
+
+## Directory layout
+
+```text
+qwen3.6-27b/
+├── README.md
+├── run-benchmark.sh            # Unified driver — branches on --config/--hw
+├── run-all-benchmarks.sh       # Sequential 3-config orchestrator
+├── perf.yaml                   # Single shared aiperf bench Pod template
+├── data-gen-job.yaml           # Sliding-window jsonl generator Job
+├── hw/                         # Per-cluster user state — edit hostname here
+│   ├── h100.env
+│   └── gb200.env
+├── model-cache/                # Model-caching subsystem
+│   └── model-download.yaml
+└── deploy/                     # 3 deploy targets — grouped because >1 sibling
+    ├── vllm-serve.yaml         # Plain Deployment + Service (baseline)
+    ├── dynamo-fd.yaml          # DynamoGraphDeployment, frontend-decoding ON
+    └── dynamo-fd-ec.yaml       # DynamoGraphDeployment, FD + embedding cache
+```
+
+Layout rule: **singletons flatten to root** (`perf.yaml`, `data-gen-job.yaml`); **dirs hold ≥2 files** (`hw/`, `deploy/`); **`model-cache/` is the exception** — a role bucket kept for future model-caching siblings.
+
+The three deploy targets share one `perf.yaml` because the only deltas
+across them (pod name, frontend service, run-label) are exported as
+`${BENCH_POD}` / `${BENCH_FRONTEND}` / `${BENCH_RUN_LABEL}` by
+`run-benchmark.sh` and resolved via `envsubst` at apply time.
+
+## Hardware targets
+
+`hw/h100.env` and `hw/gb200.env` are sibling to the three config
+directories and shared across all three. Each file exports three vars
+the YAML templates substitute via `envsubst`:
+
+- `VLLM_IMAGE` — `nvcr.io/nvidia/ai-dynamo/vllm-runtime:<tag>` (multi-arch
+  manifest, same tag works on amd64 / arm64).
+- `HW_NODE_SELECTOR` — JSON-flow nodeSelector (currently
+  `{"kubernetes.io/hostname":"…"}` for both targets).
+- `HW_TOLERATIONS` — JSON-flow toleration array. H100 has `[]`; GB200
+  carries the `kubernetes.io/arch=arm64:NoSchedule` toleration.
+
+**Before first use**: edit `hw/h100.env` and `hw/gb200.env` and replace
+the `<FILL-IN-…-HOSTNAME>` placeholders with `kubernetes.io/hostname`
+values from your cluster — the pinned node needs **2 free GPUs**
+(this is a dense BF16 model at TP=2, unlike the sibling `qwen3.6-35b`
+FP8 recipe which only needs 1):
+
+```bash
+# H100
+kubectl get nodes -L nvidia.com/gpu.product | awk '/H100/'
+# GB200
+kubectl get nodes -L kubernetes.io/arch -L nvidia.com/gpu.product \
+  | awk '/arm64/ && /GB200/'
+```
+
+Adding a new hardware target later is a one-file change in `hw/`.
+
+## Storage: shared-model-cache
+
+The recipe expects a single PVC named `shared-model-cache` (RWX) in
+the target namespace — typically backed by FSx Lustre on AWS or any
+RWX storage class on your cluster. It's mounted at three locations:
+
+| Mount in pod | subPath | What lives there |
+|--------------|---------|------------------|
+| `/home/dynamo/.cache/huggingface` | — (root) | Shared HF Hub cache (anything else in the namespace re-uses it) |
+| `/home/dynamo/.cache/vllm`        | `qwen3627-bench/vllm-cache` | vllm cudagraph compilation cache |
+| `/perf-cache`                     | `qwen3627-bench/perf-cache` | Generated dataset + aiperf artifacts |
+
+The per-recipe subPath prefix `qwen3627-bench/` keeps this recipe's
+private state from colliding with other recipes in the same namespace
+(including the sibling `qwen36-bench/` used by `qwen3.6-35b`).
+
+The HF cache is mounted at the root so any model already cached in
+the namespace is reused. The Qwen3.6-27B download (~56 GB BF16) lands
+in the standard `hub/models--Qwen--Qwen3.6-27B/` directory.
+
+If your cluster doesn't pre-provision `shared-model-cache`, create it
+out-of-band before running the recipe, picking an RWX storage class
+(e.g. `dgxc-enterprise-file` on dgxc, FSx Lustre on AWS):
+
+```yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-model-cache
+spec:
+  accessModes: [ReadWriteMany]
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: <your-rwx-storage-class>
+```
+
+Prefer RWX/Retain (e.g. FSx Lustre) over RWO/Delete (e.g. EBS) —
+RWO EBS volumes get pinned to whichever AZ the first-consumer pod
+schedules into, leaving the GPU pod unschedulable if your GPU
+nodes live in a different AZ.
+
+## aiperf install
+
+We install `aiperf==0.10.0` from PyPI. This release includes
+[PR 824](https://github.com/ai-dynamo/aiperf/pull/824)
+(`feat(dataset): add session_id to single-turn for causal ordering`),
+which makes `single_turn` mode honor `session_id` ordering so
+prefix-cache hits across the 8 turns of a given user are real.
+
+The version is pinned in `perf.yaml` and applies identically across
+all three configs. Bump the `aiperf==` pin there to roll forward.
+
+## Naming & ownership
+
+All resources carry a `qwen3627-` prefix (per-model) and these labels:
+
+```yaml
+labels:
+  app.kubernetes.io/name: qwen3.6-27b
+  app.kubernetes.io/managed-by: dynamo-recipe
+```
+
+So in a shared namespace you can find this recipe's resources via:
+
+```bash
+kubectl -n "$NAMESPACE" get pvc,deploy,job,pod \
+  -l app.kubernetes.io/name=qwen3.6-27b
+```
+
+## Notes
+
+- Dataset is sliding-window with `window=5`, `turns=8`, `users=30`,
+  `image_size=2400x1080`, `user_text_tokens=8000`. Yields 240 requests
+  (`users × turns`) over 12 unique images per user
+  (`window + turns - 1`). Base64-inlined. Same dataset shape as the
+  sibling `qwen3.6-35b` recipe, so results are directly comparable
+  across the two model sizes.
+- Each jsonl row carries `session_id=user_<N>`. With aiperf PR 824, the
+  `single_turn` dataset type honors session ordering so the 8 turns of
+  any one user are sent in causal order, letting prefix-cache hits land.
+- The vllm command in `deploy/*.yaml` uses `--mm-processor-cache-gb 30`
+  and `--max-model-len 32768` to handle the 5-image multimodal context
+  (mirrors the sibling `qwen3.6-35b` recipe's settings; well within
+  `Qwen/Qwen3.6-27B`'s native 262,144-token context).
+- `Qwen/Qwen3.6-27B` is dense BF16 (~56 GB weights), unlike the
+  sibling's FP8 MoE checkpoint, so this recipe uses
+  `--tensor-parallel-size 2` throughout instead of `1`. Adjust
+  `gpu-memory-utilization` / `max-model-len` in `deploy/*.yaml` if you
+  target a different GPU count or memory budget.

--- a/recipes/qwen3.6-27b/data-gen-job.yaml
+++ b/recipes/qwen3.6-27b/data-gen-job.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generate 30u_8t_5w_8000word_base64.jsonl into /perf-cache/datasets/.
+# Sliding-window: 30 users × 8 turns × window=5 = 240 requests over 12
+# unique images per user (window + turns - 1 = 5 + 8 - 1 = 12), so 360
+# total images; 8000 text tokens per request, 2400x1080 base64-inlined.
+# Each row has session_id=user_<N> so aiperf can issue same-user turns
+# in causal order (requires aiperf PR 824).
+#
+# The 8-turn variant is the standard sliding-window EC test bed: from
+# turn 2 onwards each turn reuses 4-of-5 images from the previous turn's
+# window, exercising multimodal-processor-cache and (future) embedding-
+# cache hit rates. The 3-turn variant barely warms either cache.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen3627-generate-datasets
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: data-gen
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backoffLimit: 1
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen3.6-27b
+        app.kubernetes.io/component: data-gen
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
+      containers:
+        - name: generate-datasets
+          image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+          imagePullPolicy: IfNotPresent
+          # No privilege escalation, drop all Linux caps, default seccomp.
+          # runAsUser:0 is set at the pod level for PVC fsGroup writes —
+          # this container security context complements it without removing
+          # the root requirement.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            # nvcr.io/.../vllm-runtime:1.3.0 was cut from a release branch
+            # that predates dynamo PR 8201 (sliding-window strategy), so the
+            # baked /workspace/benchmarks/multimodal/jsonl/main.py is the
+            # older single-turn-only version. Pull a pinned main SHA to get
+            # the sliding-window subcommand. Bump DYNAMO_REF when you want
+            # newer generator fixes.
+            - name: DYNAMO_REF
+              value: "e2f63d01e07b6deadf4c0912269564503846d204"
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              GEN_SRC=/tmp/dynamo-jsonl
+              rm -rf "$GEN_SRC"
+              # Shallow fetch a specific SHA (or ref). `git clone --branch`
+              # doesn't accept SHAs, so use init + fetch <sha> + checkout
+              # — works for both SHAs and branch names.
+              git init -q "$GEN_SRC"
+              git -C "$GEN_SRC" remote add origin https://github.com/ai-dynamo/dynamo.git
+              git -C "$GEN_SRC" fetch --depth=1 origin "$DYNAMO_REF"
+              git -C "$GEN_SRC" checkout -q FETCH_HEAD
+              cd "$GEN_SRC/benchmarks/multimodal/jsonl"
+              echo "[gen] using dynamo @ $(git -C $GEN_SRC rev-parse --short HEAD)"
+              python3 main.py --help | head -3
+              OUTPUT_DIR="/perf-cache/datasets"
+              IMAGE_DIR="/perf-cache/images/2400x1080"
+              mkdir -p "${OUTPUT_DIR}" "${IMAGE_DIR}"
+              python3 main.py sliding-window \
+                --num-users 30 \
+                --turns-per-user 8 \
+                --window-size 5 \
+                --image-size 2400 1080 \
+                --image-mode base64 \
+                --image-dir "${IMAGE_DIR}" \
+                --user-text-tokens 8000 \
+                -o "${OUTPUT_DIR}/30u_8t_5w_8000word_base64.jsonl"
+              ls -lh "${OUTPUT_DIR}/30u_8t_5w_8000word_base64.jsonl"
+              echo "Dataset generation complete in ${OUTPUT_DIR}"
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /perf-cache
+              # Per-recipe subdir so different recipes (qwen3627, qwen36,
+              # qwen3-vl-30b…) don't collide on /perf-cache/datasets and
+              # /perf-cache/images.
+              subPath: qwen3627-bench/perf-cache
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/qwen3.6-27b/deploy/dynamo-fd-ec.yaml
+++ b/recipes/qwen3.6-27b/deploy/dynamo-fd-ec.yaml
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated Dynamo on a 2-GPU node, with multimodal frontend-decoding
+# and embedding-cache enabled. Modeled on
+# recipes/qwen3.6-35b/deploy/dynamo-fd-ec.yaml but adapted for the
+# dense BF16 Qwen/Qwen3.6-27B checkpoint (TP=2, max-model-len 32768)
+# and the PR 8235 `dynamo-fd-ec` config:
+#   - --enable-multimodal           : MM request handling on
+#   - --frontend-decoding           : Frontend (Rust) decodes images; worker receives embeddings
+#   - --multimodal-embedding-cache-capacity-gb 8 : 8 GiB EC per worker (DRAM-backed post-encoder cache)
+#   - --mm-processor-cache-gb 30    : 30 GiB HF processor cache (pre-encoder)
+#   - --dyn-tool-call-parser / --dyn-reasoning-parser : qwen3 tool/reasoning routing
+#
+# DGD's operator auto-creates a Service named `qwen3627-dynamo-fd-ec-frontend`
+# on port 8000 which perf.yaml targets.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3627-dynamo-fd-ec
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: dynamo-fd-ec
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+        - name: DYN_HTTP_BODY_LIMIT_MB
+          value: "200"
+      extraPodSpec:
+        # Hostname pin + toleration + image come from hw/${HW}.env
+        # (shared across vllm-serve, dynamo-fd, dynamo-fd-ec). Both
+        # Frontend and VllmWorker get the same nodeSelector so the
+        # gang scheduler places both on that exact node. This
+        # supersedes inter-pod podAffinity (which never worked under
+        # kai-scheduler gang scheduling — see git log).
+        # If the pinned host has no 2 free GPUs at apply time, both
+        # pods stay Pending — edit hw/${HW}.env to retarget.
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      # Frontend-decoding does CPU-side image decode + base64 parsing,
+      # so we give it more CPU than a text-only frontend would need.
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          cpu: "8"
+          memory: 32Gi
+      subComponentType: null
+
+    VllmWorker:
+      componentType: worker
+      extraPodSpec:
+        # Same hostname pin as Frontend — keeps the NIXL embedding
+        # transfer a same-node memcpy.
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --enable-multimodal \
+                --frontend-decoding \
+                --multimodal-embedding-cache-capacity-gb "${DYN_MULTIMODAL_EMBEDDING_CACHE_GB}" \
+                --mm-processor-cache-gb 30 \
+                --dyn-tool-call-parser qwen3_coder \
+                --dyn-reasoning-parser qwen3 \
+                --tensor-parallel-size 2 \
+                --gpu-memory-utilization 0.85 \
+                --max-model-len 32768 \
+                --enable-prefix-caching \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen3.6-27B"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            # nixl-write is the EC connector's transfer mode for the
+            # post-encoder embeddings between workers (matters at TP=2:
+            # keeps the embedding handoff off the tensor-parallel NCCL
+            # ring).
+            - name: DYN_VLLM_EMBEDDING_TRANSFER_MODE
+              value: nixl-write
+            # 8 GiB embedding cache per worker.
+            - name: DYN_MULTIMODAL_EMBEDDING_CACHE_GB
+              value: "8"
+            # Permit http:// image URLs (our jsonl uses local PNG paths,
+            # not URLs — keeping this on doesn't hurt and future-proofs).
+            - name: DYN_MM_ALLOW_INTERNAL
+              value: "1"
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        limits:
+          gpu: "2"
+        requests:
+          gpu: "2"
+      subComponentType: null
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface
+          # Same shared FSx HF cache as vllm-serve recipe. No subPath →
+          # benefit from already-downloaded weights. Compilation cache
+          # is NOT persisted here (single PVC, single mount point in
+          # DGD's volumeMounts grammar); we eat a torch.compile JIT
+          # penalty per pod restart. Acceptable for bench runs that
+          # stay up for the entire sweep.

--- a/recipes/qwen3.6-27b/deploy/dynamo-fd.yaml
+++ b/recipes/qwen3.6-27b/deploy/dynamo-fd.yaml
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated Dynamo on a 2-GPU node with **frontend-decoding ON**,
+# **embedding cache OFF** — isolates the frontend-decoding effect from
+# the EC effect when compared against:
+#   - deploy/vllm-serve.yaml    : baseline (no Dynamo features)
+#   - deploy/dynamo-fd-ec.yaml  : Dynamo + frontend-decoding + EC
+#
+# Per-config flag diff:
+#                  fd        fd-ec        vllm-serve
+#   processor cache 30 GB    30 GB        30 GB         (same → fair comparison)
+#   --frontend-decoding yes  yes          n/a
+#   --multimodal-embedding-cache-capacity-gb  --  8 GB  n/a
+#
+# TP=2 (not TP=1 like the sibling qwen3.6-35b) because Qwen/Qwen3.6-27B
+# is a dense 28B-param BF16 checkpoint — no FP8 release to shrink it to
+# 1 GPU yet.
+apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: qwen3627-dynamo-fd
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: dynamo-fd
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  pvcs:
+    - create: false
+      name: shared-model-cache
+  services:
+    Frontend:
+      componentType: frontend
+      envs:
+        - name: HF_HOME
+          value: /home/dynamo/.cache/huggingface
+        - name: DYN_REQUEST_PLANE
+          value: tcp
+        - name: DYN_HTTP_BODY_LIMIT_MB
+          value: "200"
+      extraPodSpec:
+        # Hostname pin + image come from hw/${HW}.env (shared with
+        # vllm-serve, dynamo-fd-ec). See deploy/dynamo-fd-ec.yaml for
+        # full rationale on why a hostname pin (not podAffinity).
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: 16Gi
+        limits:
+          cpu: "8"
+          memory: 32Gi
+      subComponentType: null
+
+    VllmWorker:
+      componentType: worker
+      extraPodSpec:
+        nodeSelector: ${HW_NODE_SELECTOR}
+        tolerations: ${HW_TOLERATIONS}
+        mainContainer:
+          command:
+            - /bin/bash
+            - -lc
+          args:
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              python3 -m dynamo.vllm \
+                --model "${MODEL_NAME}" \
+                --enable-multimodal \
+                --frontend-decoding \
+                --mm-processor-cache-gb 30 \
+                --dyn-tool-call-parser qwen3_coder \
+                --dyn-reasoning-parser qwen3 \
+                --tensor-parallel-size 2 \
+                --gpu-memory-utilization 0.85 \
+                --max-model-len 32768 \
+                --enable-prefix-caching \
+                --no-enable-log-requests
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen3.6-27B"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: HF_HUB_OFFLINE
+              value: "1"
+            - name: DYN_REQUEST_PLANE
+              value: tcp
+            # DYN_VLLM_EMBEDDING_TRANSFER_MODE and DYN_MULTIMODAL_EMBEDDING_CACHE_GB
+            # intentionally omitted — no embedding cache in this config.
+            - name: DYN_MM_ALLOW_INTERNAL
+              value: "1"
+          workingDir: /workspace
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+      replicas: 1
+      resources:
+        limits:
+          gpu: "2"
+        requests:
+          gpu: "2"
+      subComponentType: null
+      volumeMounts:
+        - name: shared-model-cache
+          mountPoint: /home/dynamo/.cache/huggingface

--- a/recipes/qwen3.6-27b/deploy/vllm-serve.yaml
+++ b/recipes/qwen3.6-27b/deploy/vllm-serve.yaml
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# vllm serve baseline — no Dynamo components. Mounts the namespace's
+# `shared-model-cache` PVC (RWX, e.g. FSx Lustre) at HF_HOME so the HF
+# Hub cache is shared across all configs in the namespace, AND at a
+# subPath for the per-model vllm compilation cache.
+#
+# Qwen/Qwen3.6-27B is a dense 28B-param BF16 checkpoint (no FP8
+# release yet), so unlike the sibling qwen3.6-35b (FP8 MoE, TP=1) this
+# recipe runs --tensor-parallel-size 2 — 2 GPUs on the pinned node.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qwen3627-vllm-serve
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: vllm-serve
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: vllm-serve
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: qwen3627-vllm-serve
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: vllm-serve
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  replicas: 1
+  # First-time bootstrap = image pull (~3 min) + model load from FSx (~5 min,
+  # ~56 GB BF16 checkpoint) + torch.compile (~1 min) + cudagraph capture for
+  # 102 sizes (~5 min) ≈ 14 min. K8s default of 600s declares the rollout
+  # failed at 10 min even though the pod is healthy and still booting. Bump
+  # to 30 min.
+  progressDeadlineSeconds: 1800
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: qwen3.6-27b
+      app.kubernetes.io/component: vllm-serve
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen3.6-27b
+        app.kubernetes.io/component: vllm-serve
+        app.kubernetes.io/managed-by: dynamo-recipe
+    spec:
+      restartPolicy: Always
+      # Hostname pin + image come from hw/${HW}.env (sibling to this
+      # recipe's vllm-serve/ dir). All three configs (vllm-serve,
+      # dynamo-fd, dynamo-fd-ec) share that file so they land on the
+      # same node and benchmark on identical hardware. envsubst in
+      # run-benchmark.sh resolves these placeholders at apply time.
+      nodeSelector: ${HW_NODE_SELECTOR}
+      tolerations: ${HW_TOLERATIONS}
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: vllm
+          image: ${VLLM_IMAGE}
+          imagePullPolicy: IfNotPresent
+          workingDir: /workspace
+          command:
+            - /bin/bash
+            - -lc
+            - |
+              set -euo pipefail
+              ulimit -l unlimited
+              exec vllm serve "${MODEL_NAME}" \
+                --host 0.0.0.0 \
+                --port 8000 \
+                --tensor-parallel-size 2 \
+                --gpu-memory-utilization 0.85 \
+                --max-model-len 32768 \
+                --mm-processor-cache-gb 30 \
+                --enable-prefix-caching \
+                --enable-auto-tool-choice \
+                --tool-call-parser qwen3_coder \
+                --reasoning-parser qwen3 \
+                --no-enable-log-requests
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen3.6-27B"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            - name: VLLM_CACHE_ROOT
+              value: /home/dynamo/.cache/vllm
+            - name: HF_HUB_OFFLINE
+              value: "1"
+          # Qwen/Qwen3.6-27B is a public model (apache-2.0) — vllm serve
+          # doesn't need an HF token to load it. Plus HF_HUB_OFFLINE=1
+          # above short-circuits any hub lookups at runtime. Uncomment
+          # when swapping in a gated model.
+          # envFrom:
+          #   - secretRef:
+          #       name: hf-token-secret
+          #       optional: true
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            # 60 + 120*10 = 1260s (~21 min) budget — comfortably above the
+            # ~14 min documented bootstrap above (bumped from the sibling
+            # FP8 recipe's failureThreshold: 60 / ~11 min, too tight for
+            # this BF16 checkpoint's longer load).
+            failureThreshold: 120
+          resources:
+            requests:
+              cpu: "16"
+              memory: 96Gi
+              nvidia.com/gpu: "2"
+            limits:
+              cpu: "24"
+              memory: 160Gi
+              nvidia.com/gpu: "2"
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /home/dynamo/.cache/huggingface
+              # No subPath — share the HF cache root with the namespace
+              # so already-downloaded models (Qwen3-30B-A3B, etc.) are
+              # available, and our Qwen3.6-27B download appears under the
+              # standard `hub/models--Qwen--Qwen3.6-27B` layout.
+            - name: shared-model-cache
+              mountPath: /home/dynamo/.cache/vllm
+              subPath: qwen3627-bench/vllm-cache
+            - name: shm
+              mountPath: /dev/shm
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache
+        - name: shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 40Gi

--- a/recipes/qwen3.6-27b/hw/gb200.env
+++ b/recipes/qwen3.6-27b/hw/gb200.env
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Hardware target: GB200 (ARM64 / Blackwell, single NVL4 tray).
+# Shared by all three configs (vllm-serve, dynamo-fd, dynamo-fd-ec).
+#
+# Qwen/Qwen3.6-27B ships BF16, so this recipe runs tensor-parallel-size
+# 2 — the pinned node needs **2 free GPUs** on the tray.
+#
+# BEFORE FIRST USE: replace <FILL-IN-GB200-HOSTNAME> below with the
+# kubernetes.io/hostname of the target GB200 node. Find candidates via:
+#
+#   kubectl get nodes -L kubernetes.io/arch -L nvidia.com/gpu.product \
+#     | awk '/arm64/ && /GB200/'
+#
+# Same multi-arch tag as h100.env — nvcr.io vllm-runtime ships amd64 +
+# arm64 under one manifest. If GB200 needs a different build, change
+# the tag here (does not affect H100).
+export VLLM_IMAGE="nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0"
+
+export HW_NODE_SELECTOR='{"kubernetes.io/hostname":"<FILL-IN-GB200-HOSTNAME>"}'
+
+# GB200 nodes are tainted kubernetes.io/arch=arm64:NoSchedule — the
+# hostname pin alone is not enough; the toleration is required.
+export HW_TOLERATIONS='[{"key":"kubernetes.io/arch","operator":"Equal","value":"arm64","effect":"NoSchedule"}]'

--- a/recipes/qwen3.6-27b/hw/h100.env
+++ b/recipes/qwen3.6-27b/hw/h100.env
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Hardware target: H100.
+# Shared by all three configs (vllm-serve, dynamo-fd, dynamo-fd-ec) —
+# pinning to one specific hostname so they all benchmark on identical
+# hardware.
+#
+# Qwen/Qwen3.6-27B ships BF16 (no FP8 checkpoint yet), so unlike the
+# sibling qwen3.6-35b (FP8, TP=1) this recipe runs tensor-parallel-size
+# 2 — the target node needs **2 free H100 GPUs**, not 1.
+#
+# BEFORE FIRST USE: replace <FILL-IN-H100-HOSTNAME> with the
+# kubernetes.io/hostname of the target H100 node. Find candidates via:
+#
+#   kubectl get nodes -L nvidia.com/gpu.product | awk '/H100/'
+
+# Multi-arch manifest — same tag works on amd64 (H100) and arm64 (GB200).
+export VLLM_IMAGE="nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0"
+
+# JSON-flow value (single line) so envsubst can drop it inline into the
+# YAML without indentation gymnastics.
+export HW_NODE_SELECTOR='{"kubernetes.io/hostname":"<FILL-IN-H100-HOSTNAME>"}'
+
+# H100 nodes carry no special taint — empty toleration array.
+export HW_TOLERATIONS='[]'

--- a/recipes/qwen3.6-27b/model-cache/model-download.yaml
+++ b/recipes/qwen3.6-27b/model-cache/model-download.yaml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Mounts shared-model-cache at the standard HF_HOME path so the
+# downloaded weights land at /home/dynamo/.cache/huggingface/hub/
+# models--Qwen--Qwen3.6-27B/, sharing the HF Hub cache layout
+# with anything else in the namespace (other downloads in the same
+# namespace are reused — no double download).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: qwen3627-model-download
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: model-download
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: qwen3.6-27b
+        app.kubernetes.io/component: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          env:
+            - name: MODEL_NAME
+              value: "Qwen/Qwen3.6-27B"
+            - name: HF_HOME
+              value: /home/dynamo/.cache/huggingface
+            # Uses up to 64 GB RAM for XET buffers; set "0" on low-memory nodes (8 GB cap): https://huggingface.co/docs/hub/en/xet/using-xet-storage#download-buffers
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+            - name: MODEL_REVISION
+              value: "main"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
+          resources:
+            requests:
+              cpu: "2"
+              memory: "64Gi"
+            limits:
+              cpu: "8"
+              memory: "64Gi"
+          volumeMounts:
+            - name: shared-model-cache
+              mountPath: /home/dynamo/.cache/huggingface
+      volumes:
+        - name: shared-model-cache
+          persistentVolumeClaim:
+            claimName: shared-model-cache

--- a/recipes/qwen3.6-27b/perf.yaml
+++ b/recipes/qwen3.6-27b/perf.yaml
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared aiperf benchmark pod template for all 3 configs (vllm-serve,
+# dynamo-fd, dynamo-fd-ec). run-benchmark.sh exports the per-config
+# values (${BENCH_POD}, ${BENCH_FRONTEND}, ${BENCH_RUN_LABEL}) plus
+# the per-hardware ones (${HW_NODE_SELECTOR}, ${HW_TOLERATIONS}) and
+# pipes this file through `envsubst` before `kubectl apply`.
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${BENCH_POD}
+  labels:
+    app.kubernetes.io/name: qwen3.6-27b
+    app.kubernetes.io/component: benchmark
+    app.kubernetes.io/managed-by: dynamo-recipe
+spec:
+  restartPolicy: Never
+  # Hostname pin + toleration come from hw/${HW}.env — same target
+  # as the deploy target (vllm-serve Deployment, or DGD Frontend +
+  # Worker). That same-node guarantee is what we actually rely on;
+  # we deliberately do NOT add a podAffinity rule:
+  #   * vllm-serve vs DGD pods carry different label schemas, so a
+  #     single rule wouldn't cover all three configs.
+  #   * podAffinity would be a no-op anyway given the hostname pin.
+  nodeSelector: ${HW_NODE_SELECTOR}
+  tolerations: ${HW_TOLERATIONS}
+  containers:
+    - name: benchmark
+      image: python:3.11
+      command:
+        - /bin/bash
+        - -lc
+        - |
+          set -euo pipefail
+          ulimit -n 1048576
+          ulimit -u 65536
+
+          # aiperf>=0.8.0 depends on crick, which has no Linux aarch64 wheel.
+          # GB200 benchmark pods need build tools to compile it from source.
+          apt update && apt install -y --no-install-recommends curl jq git build-essential
+
+          pip install --no-cache-dir "aiperf==0.10.0"
+          python -c "import aiperf; print('aiperf', aiperf.__version__, 'OK')"
+
+          echo "Waiting for model '${MODEL_NAME}' at http://${FRONTEND}:8000/v1/models (timeout ${MODEL_READY_TIMEOUT_SECONDS}s) ..."
+          waited=0
+          until curl -s "http://${FRONTEND}:8000/v1/models" \
+              | jq -e --arg m "${MODEL_NAME}" '.data[]? | select(.id == $m)' >/dev/null 2>&1; do
+            if [[ "${waited}" -ge "${MODEL_READY_TIMEOUT_SECONDS}" ]]; then
+              echo "ERROR: model '${MODEL_NAME}' not ready after ${MODEL_READY_TIMEOUT_SECONDS}s" >&2
+              exit 1
+            fi
+            echo "[$(date '+%H:%M:%S')] not ready, sleeping 10s"
+            sleep 10
+            waited=$((waited + 10))
+          done
+          echo "Model '${MODEL_NAME}' is ready."
+
+          INPUT_FILE="${DATASET_DIR}/30u_8t_5w_8000word_base64.jsonl"
+          if [[ ! -f "${INPUT_FILE}" ]]; then
+            echo "Dataset not found: ${INPUT_FILE}" >&2
+            exit 1
+          fi
+
+          RUN_DIR="${ARTIFACT_BASE_DIR}/${RUN_LABEL}"
+          mkdir -p "${RUN_DIR}"
+          echo "Running benchmark; artifacts → ${RUN_DIR}"
+
+          # single_turn (NOT multi_turn): each jsonl row is one request.
+          # PR 824 makes single_turn respect session_id, so the 8 turns
+          # of user_<N> are issued in causal order (no out-of-order
+          # interleave across user_<M>'s turns).
+          aiperf profile \
+            --model "${MODEL_NAME}" \
+            --input-file "${INPUT_FILE}" \
+            --custom-dataset-type single_turn \
+            --url "http://${FRONTEND}:8000" \
+            --streaming \
+            --ui-type none \
+            --request-count "${REQUEST_COUNT}" \
+            --concurrency "${CONCURRENCY}" \
+            --request-rate-mode constant \
+            --warmup-request-count "${WARMUP_REQUEST_COUNT}" \
+            --artifact-dir "${RUN_DIR}" \
+            --extra-inputs "max_tokens:${MAX_TOKENS}" \
+            --extra-inputs "min_tokens:${MAX_TOKENS}" \
+            --extra-inputs "ignore_eos:true"
+
+          # aiperf writes inputs.json containing every prompt + every
+          # base64 image actually sent — ~4-12 GB for our multimodal
+          # datasets, vs ~30 MB of actual metric outputs. It's
+          # regenerable from the input jsonl + aiperf args, so we drop
+          # it by default. Set KEEP_INPUTS_JSON=1 to retain it for
+          # individual-request debugging.
+          if [[ "${KEEP_INPUTS_JSON:-}" != "1" ]]; then
+            rm -fv "${RUN_DIR}/inputs.json" || true
+          else
+            echo "KEEP_INPUTS_JSON=1 → retaining $(du -sh ${RUN_DIR}/inputs.json 2>/dev/null | cut -f1) inputs.json"
+          fi
+
+          echo "Run complete. Artifacts in ${RUN_DIR}"
+          sleep 3600
+      env:
+        - name: MODEL_NAME
+          value: Qwen/Qwen3.6-27B
+        - name: FRONTEND
+          value: ${BENCH_FRONTEND}
+        - name: RUN_LABEL
+          value: ${BENCH_RUN_LABEL}
+        - name: MAX_TOKENS
+          value: "1024"
+        - name: REQUEST_COUNT
+          value: "240"  # 30 users × 8 turns
+        - name: CONCURRENCY
+          value: "30"
+        - name: WARMUP_REQUEST_COUNT
+          value: "2"
+        # Bounds the /v1/models readiness poll — without this the loop would
+        # spin forever on a bad service name / model-id mismatch / stuck
+        # frontend, keeping the bench pod (and the sweep) alive indefinitely.
+        - name: MODEL_READY_TIMEOUT_SECONDS
+          value: "1800"
+        - name: DATASET_DIR
+          value: /perf-cache/datasets
+        - name: ARTIFACT_BASE_DIR
+          value: /perf-cache/artifacts/qwen3627
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "1800"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "1800"
+      resources:
+        requests:
+          cpu: "8"
+          memory: 16Gi
+        limits:
+          cpu: "16"
+          memory: 32Gi
+      volumeMounts:
+        - name: shared-model-cache
+          mountPath: /perf-cache
+          subPath: qwen3627-bench/perf-cache
+  volumes:
+    - name: shared-model-cache
+      persistentVolumeClaim:
+        claimName: shared-model-cache

--- a/recipes/qwen3.6-27b/run-all-benchmarks.sh
+++ b/recipes/qwen3.6-27b/run-all-benchmarks.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sequentially run all three configs (vllm-serve, dynamo-fd, dynamo-fd-ec)
+# against the same hardware target and collect aiperf artifacts side-by-side
+# under one dated directory ready for the 3-way comparison.
+#
+# Order per config: deploy → bench → retrieve → clean. Cleaning between
+# configs frees the GPUs for the next deployment so they share one node.
+#
+# Usage:
+#   ./run-all-benchmarks.sh -n <namespace>                    # H100
+#   ./run-all-benchmarks.sh -n <namespace> --hw gb200         # GB200
+#   ./run-all-benchmarks.sh -n <namespace> --hw gb200 --skip-prep   # already PVC/download/dataset-ready
+#
+# Prep step (PVC + model download + data gen) runs once before the first
+# deploy unless --skip-prep is passed.
+set -euo pipefail
+
+NAMESPACE=""
+HW="h100"
+SKIP_PREP="0"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
+    --hw) HW="$2"; shift 2 ;;
+    --skip-prep) SKIP_PREP="1"; shift ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+if [[ -z "$NAMESPACE" ]]; then
+  echo "ERROR: -n <namespace> required" >&2; exit 2
+fi
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DRIVER="$HERE/run-benchmark.sh"
+CONFIGS=(vllm-serve dynamo-fd dynamo-fd-ec)
+
+TS_DIR="$(date +%m-%d)"
+# Override the summary root via $BENCHMARK_RESULTS_DIR — also picked up by
+# run-benchmark.sh's retrieve(), so the two paths stay in sync.
+BASE_DIR="${BENCHMARK_RESULTS_DIR:-$HOME/workspace/dynamo-tmp/logs}"
+SUMMARY_DIR="$BASE_DIR/${TS_DIR}/qwen3627-${HW}"
+mkdir -p "$SUMMARY_DIR"
+RUN_LOG="$SUMMARY_DIR/run-all-benchmarks.log"
+echo "[run-all] hw=$HW namespace=$NAMESPACE" | tee -a "$RUN_LOG"
+echo "[run-all] summary dir: $SUMMARY_DIR" | tee -a "$RUN_LOG"
+
+# Prep is config-agnostic; --config vllm-serve is passed only to satisfy the
+# driver's required --config argument (run-benchmark.sh resolves per-config
+# values inline, there's no separate config.env to load).
+if [[ "$SKIP_PREP" != "1" ]]; then
+  for step in pvc download dataset; do
+    echo "[prep] $step" | tee -a "$RUN_LOG"
+    "$DRIVER" -n "$NAMESPACE" --hw "$HW" --config vllm-serve --step "$step" 2>&1 | tee -a "$RUN_LOG"
+  done
+fi
+
+for cfg in "${CONFIGS[@]}"; do
+  echo "" | tee -a "$RUN_LOG"
+  echo "========== [$cfg] ==========" | tee -a "$RUN_LOG"
+  for step in deploy bench retrieve clean; do
+    "$DRIVER" -n "$NAMESPACE" --hw "$HW" --config "$cfg" --step "$step" 2>&1 | tee -a "$RUN_LOG"
+  done
+done
+
+echo "" | tee -a "$RUN_LOG"
+echo "[run-all] all three configs done." | tee -a "$RUN_LOG"
+echo "[run-all] results: $SUMMARY_DIR/{vllm-serve,dynamo-fd,dynamo-fd-ec}/" | tee -a "$RUN_LOG"
+echo "[run-all] each config's profile_export_aiperf.json holds the headline metrics." | tee -a "$RUN_LOG"

--- a/recipes/qwen3.6-27b/run-benchmark.sh
+++ b/recipes/qwen3.6-27b/run-benchmark.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Unified driver for the Qwen3.6-27B 3-way benchmark.
+# Idempotent — re-running steps that already completed is a no-op.
+#
+# Two axes:
+#   --hw <name>      → sources hw/<name>.env (VLLM_IMAGE, HW_NODE_SELECTOR, HW_TOLERATIONS)
+#   --config <name>  → resolves to DEPLOY_KIND, DEPLOY_NAME, BENCH_POD inline (see CONFIGS table below)
+#
+# Usage:
+#   ./run-benchmark.sh -n <namespace> --hw h100 --config vllm-serve
+#   ./run-benchmark.sh -n <namespace> --hw gb200 --config dynamo-fd-ec --step deploy
+#
+# Steps: pvc | download | dataset | deploy | bench | retrieve | clean | all
+#   pvc/download/dataset are config-agnostic (idempotent prep).
+#   deploy/bench/retrieve/clean are config-specific.
+set -euo pipefail
+
+NAMESPACE=""
+STEP="all"
+HW="h100"
+CONFIG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace) NAMESPACE="$2"; shift 2 ;;
+    --step) STEP="$2"; shift 2 ;;
+    --hw) HW="$2"; shift 2 ;;
+    --config) CONFIG="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+if [[ -z "$NAMESPACE" ]]; then
+  echo "ERROR: -n <namespace> required" >&2; exit 2
+fi
+HERE="$(cd "$(dirname "$0")" && pwd)"
+
+# Per-config metadata. Keep this list in sync with the sibling config dirs.
+#   DEPLOY_KIND branches deploy() + clean():
+#     deployment → kubectl rollout status + delete Deployment+Service
+#     dgd        → kubectl wait on operator-stamped DGD pod labels + delete DGD
+#   BENCH_POD       — name of the aiperf Pod for this config.
+#   BENCH_FRONTEND  — service name the bench Pod hits at $FRONTEND:8000.
+#                     vllm-serve: a plain Service; DGDs: `<dgd-name>-frontend`
+#                     created automatically by the dynamo operator.
+#   BENCH_RUN_LABEL — sub-directory written under /perf-cache/artifacts/
+#                     so the 3 configs' aiperf artifacts don't collide.
+case "$CONFIG" in
+  vllm-serve)
+    DEPLOY_KIND="deployment"
+    DEPLOY_NAME="qwen3627-vllm-serve"
+    BENCH_POD="qwen3627-bench"
+    BENCH_FRONTEND="qwen3627-vllm-serve"
+    BENCH_RUN_LABEL="vllm-serve"
+    ;;
+  dynamo-fd)
+    DEPLOY_KIND="dgd"
+    DEPLOY_NAME="qwen3627-dynamo-fd"
+    BENCH_POD="qwen3627-fd-bench"
+    BENCH_FRONTEND="qwen3627-dynamo-fd-frontend"
+    BENCH_RUN_LABEL="dynamo-fd"
+    ;;
+  dynamo-fd-ec)
+    DEPLOY_KIND="dgd"
+    DEPLOY_NAME="qwen3627-dynamo-fd-ec"
+    BENCH_POD="qwen3627-fd-ec-bench"
+    BENCH_FRONTEND="qwen3627-dynamo-fd-ec-frontend"
+    BENCH_RUN_LABEL="dynamo-fd-ec"
+    ;;
+  "")
+    echo "ERROR: --config <name> required" >&2
+    echo "Available: vllm-serve dynamo-fd dynamo-fd-ec" >&2
+    exit 2 ;;
+  *)
+    echo "ERROR: unknown config: $CONFIG" >&2
+    echo "Available: vllm-serve dynamo-fd dynamo-fd-ec" >&2
+    exit 2 ;;
+esac
+export BENCH_POD BENCH_FRONTEND BENCH_RUN_LABEL
+
+HW_ENV="$HERE/hw/${HW}.env"
+if [[ ! -f "$HW_ENV" ]]; then
+  echo "ERROR: hardware env file not found: $HW_ENV" >&2
+  echo "Available: $(ls "$HERE/hw/" 2>/dev/null | tr '\n' ' ')" >&2
+  exit 2
+fi
+DEPLOY_TPL="$HERE/deploy/${CONFIG}.yaml"
+
+if ! command -v envsubst >/dev/null 2>&1; then
+  echo "ERROR: envsubst missing. Install gettext-base (apt) or gettext (brew)." >&2
+  exit 2
+fi
+
+# shellcheck disable=SC1090
+set -a; . "$HW_ENV"; set +a
+echo "[hw]     $HW → image=$VLLM_IMAGE node=$HW_NODE_SELECTOR"
+echo "[config] $CONFIG → kind=$DEPLOY_KIND deploy=$DEPLOY_NAME bench-pod=$BENCH_POD"
+
+K="kubectl -n $NAMESPACE"
+# Limit envsubst to our own template vars so embedded ${MODEL_NAME} /
+# ${KEEP_INPUTS_JSON:-} shell vars inside perf.yaml's inline bash stay
+# literal. $BENCH_* drive the shared perf.yaml; $VLLM_IMAGE / $HW_*
+# drive deploy.yaml + perf.yaml.
+TPL_VARS='$VLLM_IMAGE $HW_NODE_SELECTOR $HW_TOLERATIONS $BENCH_POD $BENCH_FRONTEND $BENCH_RUN_LABEL'
+APPLY_TPL() { envsubst "$TPL_VARS" <"$1" | $K apply -f -; }
+
+# ---------------- config-agnostic prep ----------------
+
+pvc() {
+  # `shared-model-cache` is expected to be pre-provisioned in the namespace
+  # (RWX, e.g. FSx Lustre). If your cluster doesn't pre-provision it, create
+  # the PVC out-of-band — see README.md → "Storage: shared-model-cache".
+  if ! $K get pvc shared-model-cache >/dev/null 2>&1; then
+    echo "[pvc] ERROR: PVC 'shared-model-cache' not found in namespace '$NAMESPACE'" >&2
+    echo "[pvc] See README.md → 'Storage: shared-model-cache' for provisioning guidance." >&2
+    exit 1
+  fi
+  $K get pvc shared-model-cache
+}
+
+download() {
+  if $K get job qwen3627-model-download >/dev/null 2>&1; then
+    if [[ "$($K get job qwen3627-model-download -o jsonpath='{.status.succeeded}')" == "1" ]]; then
+      echo "[download] already complete"
+      return
+    fi
+    echo "[download] previous job present but not Complete — deleting and re-applying"
+    $K delete job qwen3627-model-download
+  fi
+  $K apply -f "$HERE/model-cache/model-download.yaml"
+  $K wait --for=condition=Complete job/qwen3627-model-download --timeout=3600s
+}
+
+dataset() {
+  if $K get job qwen3627-generate-datasets >/dev/null 2>&1; then
+    if [[ "$($K get job qwen3627-generate-datasets -o jsonpath='{.status.succeeded}')" == "1" ]]; then
+      echo "[dataset] already complete"
+      return
+    fi
+    $K delete job qwen3627-generate-datasets
+  fi
+  $K apply -f "$HERE/data-gen-job.yaml"
+  $K wait --for=condition=Complete job/qwen3627-generate-datasets --timeout=1800s
+  $K logs job/qwen3627-generate-datasets | tail -20
+}
+
+# ---------------- config-specific lifecycle ----------------
+
+# `kubectl wait` errors out immediately with "no matching resources found"
+# if a label selector matches zero pods at call time — a real race right
+# after `kubectl apply` of a DGD, before the operator has created the Pod
+# objects. Poll for at least one matching pod first.
+wait_pod_created() {
+  local selector="$1" timeout="$2" waited=0
+  while [[ "$($K get pod -l "$selector" --no-headers 2>/dev/null | wc -l)" -eq 0 ]]; do
+    if (( waited >= timeout )); then
+      echo "ERROR: no pod matching '$selector' after ${timeout}s" >&2
+      return 1
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+}
+
+deploy() {
+  APPLY_TPL "$DEPLOY_TPL"
+  case "$DEPLOY_KIND" in
+    deployment)
+      # 1800s matches deploy/vllm-serve.yaml's progressDeadlineSeconds so the
+      # CLI watch doesn't give up before the Deployment controller would.
+      $K rollout status "deploy/$DEPLOY_NAME" --timeout=1800s
+      ;;
+    dgd)
+      local sel_fe="nvidia.com/dynamo-graph-deployment-name=$DEPLOY_NAME,nvidia.com/dynamo-component-type=frontend"
+      local sel_wk="nvidia.com/dynamo-graph-deployment-name=$DEPLOY_NAME,nvidia.com/dynamo-component-type=worker"
+      echo "[deploy] waiting for DGD Frontend pod to be created ..."
+      wait_pod_created "$sel_fe" 900
+      echo "[deploy] waiting for DGD Frontend pod ..."
+      $K wait --for=condition=Ready pod -l "$sel_fe" --timeout=900s
+      echo "[deploy] waiting for VllmWorker pod to be created ..."
+      wait_pod_created "$sel_wk" 1500
+      echo "[deploy] waiting for VllmWorker pod ..."
+      $K wait --for=condition=Ready pod -l "$sel_wk" --timeout=1500s
+      ;;
+    *)
+      echo "ERROR: unknown DEPLOY_KIND=$DEPLOY_KIND" >&2; exit 2 ;;
+  esac
+}
+
+bench() {
+  $K delete pod "$BENCH_POD" --ignore-not-found
+  APPLY_TPL "$HERE/perf.yaml"
+  $K wait --for=condition=Ready "pod/$BENCH_POD" --timeout=300s
+  echo "[bench] streaming logs — auto-detaches once the run reports complete"
+  echo "[bench] (perf.yaml then sleeps 3600s in-pod so retrieve() can still exec in afterward)"
+  # perf.yaml prints "Run complete." then sleeps 3600s so retrieve() can
+  # exec in later. A plain `kubectl logs -f | awk '...{exit}'` pipeline does
+  # NOT return early even though awk exits: bash waits for every stage of a
+  # pipeline to finish, and `kubectl logs -f` itself only exits once the
+  # container does (or the connection drops) — it won't get SIGPIPE until
+  # its *next write*, and the pod goes quiet after "Run complete.", so it
+  # would just block for the full 3600s anyway. Run the log follower in the
+  # background instead, read it via a FIFO in the foreground, and kill it
+  # explicitly once we see the marker.
+  local logdir logfifo logpid found=0
+  logdir="$(mktemp -d)"
+  logfifo="$logdir/bench.fifo"
+  mkfifo "$logfifo"
+  $K logs -f "$BENCH_POD" >"$logfifo" 2>&1 &
+  logpid=$!
+  while IFS= read -r line; do
+    echo "$line"
+    if [[ "$line" == "Run complete."* ]]; then
+      found=1
+      break
+    fi
+  done <"$logfifo"
+  kill "$logpid" 2>/dev/null || true
+  wait "$logpid" 2>/dev/null || true
+  rm -rf "$logdir"
+  # A stream that ends without ever printing "Run complete." — pod crashed,
+  # aiperf errored out, connection dropped early — is a real failed run;
+  # fail here so `set -e` aborts the sweep instead of silently continuing
+  # into retrieve()/clean() as though the benchmark had passed.
+  if [[ "$found" -ne 1 ]]; then
+    echo "ERROR: benchmark pod log stream ended without 'Run complete.'" >&2
+    return 1
+  fi
+}
+
+retrieve() {
+  # Override the destination root via $BENCHMARK_RESULTS_DIR if your
+  # workspace layout differs from the default.
+  local base="${BENCHMARK_RESULTS_DIR:-$HOME/workspace/dynamo-tmp/logs}"
+  local dest="$base/$(date +%m-%d)/qwen3627-${HW}/${CONFIG}"
+  mkdir -p "$dest"
+  $K exec "$BENCH_POD" -- \
+      tar c --exclude='inputs.json' -C /perf-cache artifacts \
+    | tar x -C "$dest"
+  echo "[retrieve] landed at $dest"
+  find "$dest" -name 'profile_export_aiperf.json' -print
+}
+
+clean() {
+  $K delete pod "$BENCH_POD" --ignore-not-found
+  case "$DEPLOY_KIND" in
+    deployment)
+      $K delete deploy "$DEPLOY_NAME" --ignore-not-found
+      $K delete service "$DEPLOY_NAME" --ignore-not-found
+      ;;
+    dgd)
+      $K delete dynamographdeployment "$DEPLOY_NAME" --ignore-not-found
+      ;;
+  esac
+  # Note: PVCs intentionally NOT deleted — that would force model re-download.
+  # To wipe everything:
+  #   kubectl -n $NS delete pvc shared-model-cache
+}
+
+all() {
+  pvc
+  download
+  dataset
+  deploy
+  bench
+  retrieve
+}
+
+case "$STEP" in
+  pvc|download|dataset|deploy|bench|retrieve|clean|all) "$STEP" ;;
+  *) echo "unknown step: $STEP" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## Summary

Adds `recipes/qwen3.6-27b`, a 3-way `vllm serve` vs. Dynamo (frontend-decoding,
frontend-decoding + embedding cache) benchmark recipe for `Qwen/Qwen3.6-27B`,
in preparation for `Qwen/Qwen3.8-27B` releasing next week.

Mirrors the sibling [`recipes/qwen3.6-35b`](recipes/qwen3.6-35b), with one
difference: `Qwen3.6-27B` is dense BF16 (no FP8 checkpoint), so it runs
`--tensor-parallel-size 2` instead of `1`. Resources use a `qwen3627-`
prefix so they don't collide with the sibling in a shared namespace.

## Validation

See testing-scope comment below — no GPU cluster available to me, so this
covers schema/render/control-flow checks only, not a real hardware run.