### PR TITLE
fix(vllm): flatten 0-d omni audio payloads before delta comparison

### DIFF
--- a/components/src/dynamo/vllm/omni/realtime_handler.py
+++ b/components/src/dynamo/vllm/omni/realtime_handler.py
@@ -462,8 +462,10 @@ def tensor_to_numpy(value: Any) -> np.ndarray | None:
             arr = np.asarray(value)
         except Exception:  # noqa: BLE001 - non-array engine payloads are skipped
             return None
-    if arr.ndim > 1:
-        arr = arr.reshape(-1)
+    # Flatten unconditionally, including 0-d: a list payload yields its last
+    # entry, so a scalar there would reach waveform_to_deltas as a 0-d array and
+    # raise IndexError on the next step's shape[0].
+    arr = arr.reshape(-1)
     return arr.astype(np.float32, copy=False)
 
 

--- a/components/src/dynamo/vllm/tests/omni/test_omni_realtime_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_realtime_handler.py
@@ -24,7 +24,7 @@ try:
     # so the fake engine outputs below must use the real type, not a plain dict.
     from vllm_omni.outputs.mm_outputs import MultimodalPayload
 
-    from dynamo.vllm.omni.realtime_handler import RealtimeOmniHandler
+    from dynamo.vllm.omni.realtime_handler import RealtimeOmniHandler, Turn
 except (ImportError, ModuleNotFoundError):
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
 
@@ -422,3 +422,21 @@ def test_concurrent_turns_capped():
     assert engine.peak == cap  # never more than the cap in flight at once
     done = [e for e in out if e["type"] == "response.done"]
     assert len(done) == 4 and all(e["response"]["status"] == "completed" for e in done)
+
+
+def test_scalar_step_does_not_break_the_next_delta():
+    # A list payload yields its last entry; a scalar there must flatten to 1-d
+    # so the following step's prefix comparison has a shape[0] to read.
+    turn = Turn(engine_client=None, streaming_input_factory=None)
+    first = turn.extract_audio_chunks(
+        SimpleNamespace(multimodal_output=MultimodalPayload(tensors={"audio": [0.25]}))
+    )
+    assert [c.tolist() for c in first] == [[0.25]]
+    second = turn.extract_audio_chunks(
+        SimpleNamespace(
+            multimodal_output=MultimodalPayload(
+                tensors={"audio": np.float32([0.25, 0.5])}
+            )
+        )
+    )
+    assert [c.tolist() for c in second] == [[0.5]]


### PR DESCRIPTION
## Overview:

`tensor_to_numpy` in the realtime Omni handler only flattened when `ndim > 1`, so a **0-d** array passed through unchanged and later crashed the turn.

`extract_audio_chunks` treats a list payload as "list of waveforms, take the last". If that last entry is a scalar, `np.asarray` produces a 0-d array, which becomes `self.audio_ref`. On the next step, `numpy_audio_prefix_match` reads `prev.shape[0]` and raises:

```
IndexError: tuple index out of range
```

`run_turn`'s blanket handler converts that into an `error` event plus `response.done(status=failed)`, so one scalar step fails the whole turn.

## Details:

Flatten unconditionally. `reshape(-1)` turns a 0-d array into a 1-element 1-d array and is a no-op for the 1-d case that already worked, so every downstream consumer (`shape[0]`, slicing, `concatenate`) gets the 1-d array it already assumes.

Found while fixing an unrelated payload-shape bug in #12667 and split out of it, since this path is reachable on `main` independently of that change. A `graham-code-review` pass flagged mixing the two.

## Where should the reviewer start?

`components/src/dynamo/vllm/omni/realtime_handler.py` — `tensor_to_numpy` is a two-line change.

**Validation.** `pre-commit run --files <changed>` passes clean.

The test could not be executed locally (this checkout has no `vllm_omni` install), so the real module text was run old-vs-new against stubs, driving the exact two-step sequence the new test asserts:

| | `main` | with this fix |
|---|---|---|
| scalar step, then a real delta | `IndexError: tuple index out of range` | `first=[[0.25]]`, `second=[[0.5]]` |

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime audio processing for scalar and vector payloads.
  * Prevented previously processed audio samples from being repeated across consecutive updates.

* **Tests**
  * Added coverage for consecutive audio payloads, including list, scalar, and NumPy-based inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->