### PR TITLE
test(vllm): add a real-model realtime e2e on a shared WebSocket driver

### DIFF
--- a/tests/frontend/test_realtime_omni_bridge.py
+++ b/tests/frontend/test_realtime_omni_bridge.py
@@ -19,8 +19,6 @@ the two processes coordinate without etcd or nats. Mirrors
 from __future__ import annotations
 
 import asyncio
-import base64
-import json
 import logging
 
 import aiohttp
@@ -30,6 +28,7 @@ import requests
 
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.port_utils import ServicePorts
+from tests.utils.realtime_ws import collect_turn, commit_audio, open_session
 
 logger = logging.getLogger(__name__)
 
@@ -106,101 +105,23 @@ def realtime_omni_frontend(
             yield frontend_port
 
 
-async def _recv_json(ws: aiohttp.ClientWebSocketResponse, timeout_s: float) -> dict:
-    msg = await asyncio.wait_for(ws.receive(), timeout=timeout_s)
-    if msg.type is not aiohttp.WSMsgType.TEXT:
-        raise AssertionError(f"unexpected websocket frame: {msg.type!r} {msg.data!r}")
-    return json.loads(msg.data)
-
-
-async def _drain_until(
-    ws: aiohttp.ClientWebSocketResponse, expected_type: str, timeout_s: float = 5.0
-) -> dict:
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout_s
-    while loop.time() < deadline:
-        remaining = deadline - loop.time()
-        event = await _recv_json(ws, max(remaining, 0.01))
-        if event.get("type") == expected_type:
-            return event
-    raise AssertionError(
-        f"timed out waiting for a {expected_type!r} frame on the websocket"
-    )
-
-
 async def _audio_round_trip(port: int) -> None:
     async with aiohttp.ClientSession() as session:
         async with session.ws_connect(f"ws://127.0.0.1:{port}/v1/realtime") as ws:
-            await _drain_until(ws, "session.created")
+            await open_session(ws, {"type": "realtime", "model": MODEL_NAME})
 
-            await ws.send_str(
-                json.dumps(
-                    {
-                        "type": "session.update",
-                        "session": {"type": "realtime", "model": MODEL_NAME},
-                    }
-                )
-            )
-            await _drain_until(ws, "session.updated")
-
-            # Send a short PCM16 ramp; the mock engine echoes it back as audio.
+            # A short PCM16 ramp; the mock engine echoes it back as audio.
             pcm16 = np.linspace(-8000, 8000, 128, dtype=np.int16).tobytes()
-            await ws.send_str(
-                json.dumps(
-                    {
-                        "type": "input_audio_buffer.append",
-                        "audio": base64.b64encode(pcm16).decode("utf-8"),
-                    }
-                )
-            )
-            await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+            await commit_audio(ws, pcm16)
+            turn = await collect_turn(ws, timeout_s=10.0)
 
-            response_id: str | None = None
-            audio_b64_parts: list[str] = []
-            transcript_parts: list[str] = []
-            saw_audio_done = False
-            response_done_status: str | None = None
-
-            loop = asyncio.get_event_loop()
-            deadline = loop.time() + 10.0
-            while response_done_status is None:
-                remaining = deadline - loop.time()
-                if remaining <= 0:
-                    raise AssertionError(
-                        "timed out before response.done; "
-                        f"audio_parts={len(audio_b64_parts)}, "
-                        f"saw_audio_done={saw_audio_done}"
-                    )
-                event = await _recv_json(ws, remaining)
-                etype = event.get("type")
-                if etype == "response.created":
-                    response_id = event["response"]["id"]
-                elif etype == "response.output_audio_transcript.delta":
-                    transcript_parts.append(event["delta"])
-                    assert event["response_id"] == response_id, event
-                elif etype == "response.output_audio.delta":
-                    audio_b64_parts.append(event["delta"])
-                    assert event["response_id"] == response_id, event
-                elif etype == "response.output_audio.done":
-                    saw_audio_done = True
-                    assert event["response_id"] == response_id, event
-                elif etype == "response.done":
-                    response_done_status = event["response"]["status"]
-                    assert event["response"]["id"] == response_id, event
-                else:
-                    raise AssertionError(f"unexpected event type {etype!r}: {event}")
-
-            assert response_id is not None
-            assert saw_audio_done, "engine should emit response.output_audio.done"
-            assert response_done_status == "completed", response_done_status
-            assert "".join(transcript_parts) == MOCK_TRANSCRIPT, transcript_parts
+            assert turn.saw_audio_done, "engine should emit response.output_audio.done"
+            assert turn.status == "completed", turn.status
+            assert turn.transcript == MOCK_TRANSCRIPT, turn.transcript
 
             # Concatenated audio deltas decode back to the input ramp (echo).
-            out_bytes = b"".join(base64.b64decode(p) for p in audio_b64_parts)
             in_f32 = np.frombuffer(pcm16, dtype=np.int16).astype(np.float32) / 32768.0
-            out_f32 = (
-                np.frombuffer(out_bytes, dtype=np.int16).astype(np.float32) / 32767.0
-            )
+            out_f32 = turn.audio_pcm16.astype(np.float32) / 32767.0
             assert out_f32.shape == in_f32.shape, (out_f32.shape, in_f32.shape)
             assert np.allclose(out_f32, in_f32, atol=2e-4)
 

--- a/tests/serve/test_realtime_omni_real_model.py
+++ b/tests/serve/test_realtime_omni_real_model.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Realtime WebSocket end-to-end test against a real vLLM-Omni model.
+
+``tests/frontend/test_realtime_omni_bridge.py`` covers the same wire protocol
+with a mock engine, which keeps it GPU-free but means the engine's own output
+shapes are never exercised -- so a change to those shapes upstream lands
+unnoticed. This closes that gap: it launches the real
+``dynamo.vllm.omni --realtime`` worker (the same command as
+``examples/backends/vllm/launch/agg_omni_realtime.sh``) and drives one turn.
+
+Skipped on CI, and it cannot currently be otherwise. The realtime path requires
+the model class to implement vLLM's ``SupportsRealtime``, and in vLLM-Omni
+exactly one model does: ``Qwen3OmniMoeForConditionalGeneration``. Every
+published Qwen3-Omni checkpoint is 30B-A3B, so there is no small stand-in --
+``Qwen2.5-Omni-3B`` is supported by vLLM-Omni generally but does not implement
+``SupportsRealtime``. CI runs on shared 24 GB L4s; ``test_vllm_omni.py`` already
+skips the *7B* omni as needing ~80 GB.
+
+To run it on a suitable host, drop the ``pytest.mark.skip`` entry from
+``pytestmark`` below (pytest has no flag that overrides an unconditional skip)::
+
+    pytest tests/serve/test_realtime_omni_real_model.py -s
+
+``TENSOR_PARALLEL_SIZE`` and the ``gpu_4`` marker are a starting point, not a
+measured configuration. Profile with ``tests/utils/profile_pytest.py`` and add
+the resulting ``profiled_vram_gib`` / ``requested_vllm_kv_cache_bytes`` markers
+before wiring this into any automated tier (see
+``.ai/test-model-size-guardrails.md``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import aiohttp
+import numpy as np
+import pytest
+import requests
+
+from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
+from tests.utils.port_utils import ServicePorts
+from tests.utils.realtime_ws import collect_turn, commit_audio, open_session
+
+logger = logging.getLogger(__name__)
+
+MODEL_ID = "Qwen/Qwen3-Omni-30B-A3B-Instruct"
+TENSOR_PARALLEL_SIZE = 4
+
+SKIP_REASON = (
+    f"{MODEL_ID} is the only vLLM-Omni model implementing SupportsRealtime, and "
+    "its weights exceed CI capacity (24 GB L4). Run manually on a multi-GPU host."
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.integration,
+    pytest.mark.vllm,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_4,
+    pytest.mark.post_merge,
+    pytest.mark.model(MODEL_ID),
+    pytest.mark.skip(reason=SKIP_REASON),
+]
+
+# Model load dominates; the turn itself is seconds.
+WORKER_READY_TIMEOUT_S = 1800
+TURN_TIMEOUT_S = 120.0
+
+
+class RealtimeOmniWorkerProcess(ManagedProcess):
+    """Launch the real realtime Omni worker; ready once the frontend lists it.
+
+    Mirrors ``agg_omni_realtime.sh``: ``--output-modalities audio`` drives the
+    talker so the response carries synthesized speech rather than text alone.
+    """
+
+    def __init__(self, request, *, frontend_port: int) -> None:
+        super().__init__(
+            command=[
+                "python3",
+                "-m",
+                "dynamo.vllm.omni",
+                "--realtime",
+                "--model",
+                MODEL_ID,
+                "--output-modalities",
+                "audio",
+                "--trust-remote-code",
+                "--enforce-eager",
+                "--tensor-parallel-size",
+                str(TENSOR_PARALLEL_SIZE),
+            ],
+            health_check_urls=[
+                (f"http://localhost:{frontend_port}/v1/models", self._model_listed)
+            ],
+            timeout=WORKER_READY_TIMEOUT_S,
+            display_output=True,
+            terminate_all_matching_process_names=False,
+            straggler_commands=["-m dynamo.vllm.omni"],
+            log_dir=f"{request.node.name}_realtime_omni_real_worker",
+        )
+
+    @staticmethod
+    def _model_listed(response: requests.Response) -> bool:
+        try:
+            if response.status_code != 200:
+                return False
+            data = response.json()
+        except (ValueError, KeyError):
+            return False
+        return any(model.get("id") == MODEL_ID for model in data.get("data", []))
+
+
+@pytest.fixture(scope="function")
+def realtime_omni_real_frontend(
+    request, file_storage_backend, dynamo_dynamic_ports: ServicePorts
+):
+    """Launch the frontend + real Omni realtime worker; yield the frontend port."""
+    _ = file_storage_backend  # sets DYN_FILE_KV for both subprocesses
+    frontend_port = dynamo_dynamic_ports.frontend_port
+    with DynamoFrontendProcess(
+        request,
+        frontend_port=frontend_port,
+        extra_args=[
+            "--discovery-backend",
+            "file",
+            "--request-plane",
+            "tcp",
+            "--event-plane",
+            "zmq",
+        ],
+        terminate_all_matching_process_names=False,
+    ):
+        logger.info("Frontend started on port %s", frontend_port)
+        with RealtimeOmniWorkerProcess(request, frontend_port=frontend_port):
+            logger.info("Realtime Omni worker registered %s", MODEL_ID)
+            yield frontend_port
+
+
+def _tone_pcm16() -> bytes:
+    """One second of 16 kHz PCM16 to open and commit a turn.
+
+    The content is not asserted on -- what matters is that a committed turn
+    reaches the engine and comes back completed. A tone keeps the test hermetic.
+    """
+    t = np.linspace(0.0, 1.0, 16000, endpoint=False, dtype=np.float32)
+    return (0.3 * np.sin(2 * np.pi * 440.0 * t) * 32767.0).astype(np.int16).tobytes()
+
+
+async def _real_model_turn(port: int) -> None:
+    async with aiohttp.ClientSession() as session:
+        async with session.ws_connect(f"ws://127.0.0.1:{port}/v1/realtime") as ws:
+            await open_session(
+                ws,
+                {
+                    "type": "realtime",
+                    "model": MODEL_ID,
+                    "output_modalities": ["audio"],
+                },
+            )
+            await commit_audio(ws, _tone_pcm16())
+            # A real engine may emit event types the mock never produces; an
+            # ``error`` frame still fails the turn.
+            turn = await collect_turn(
+                ws, timeout_s=TURN_TIMEOUT_S, allow_unknown_events=True
+            )
+
+            assert turn.status == "completed", turn.status
+            assert turn.saw_audio_done, "engine should emit response.output_audio.done"
+            assert turn.audio_b64_parts, "talker produced no audio deltas"
+
+            # Real audio is only checked for shape: it must decode as PCM16 and
+            # carry a non-silent signal.
+            samples = turn.audio_pcm16
+            assert samples.size > 0, "decoded audio was empty"
+            assert np.abs(samples).max() > 0, "decoded audio was pure silence"
+
+            logger.info(
+                "realtime turn completed: %d audio samples, transcript=%r",
+                samples.size,
+                turn.transcript,
+            )
+
+
+@pytest.mark.timeout(WORKER_READY_TIMEOUT_S + 300)
+def test_real_model_audio_round_trip(realtime_omni_real_frontend) -> None:
+    """One committed turn against the real engine yields audio and completes."""
+    asyncio.run(_real_model_turn(realtime_omni_real_frontend))

--- a/tests/utils/realtime_ws.py
+++ b/tests/utils/realtime_ws.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Client-side driver for the ``/v1/realtime`` WebSocket endpoint.
+
+Shared by the realtime tests so the turn protocol -- open a session, commit a
+buffer of audio, collect the response envelope -- is implemented once. Tests
+supply the audio and assert on the returned ``TurnResult``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from dataclasses import dataclass, field
+
+import aiohttp
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TurnResult:
+    """Server events from one committed turn, grouped by kind."""
+
+    response_id: str | None = None
+    audio_b64_parts: list[str] = field(default_factory=list)
+    transcript_parts: list[str] = field(default_factory=list)
+    saw_audio_done: bool = False
+    status: str | None = None
+
+    @property
+    def transcript(self) -> str:
+        return "".join(self.transcript_parts)
+
+    @property
+    def audio_bytes(self) -> bytes:
+        return b"".join(base64.b64decode(p) for p in self.audio_b64_parts)
+
+    @property
+    def audio_pcm16(self) -> np.ndarray:
+        return np.frombuffer(self.audio_bytes, dtype=np.int16)
+
+
+async def recv_json(ws: aiohttp.ClientWebSocketResponse, timeout_s: float) -> dict:
+    msg = await asyncio.wait_for(ws.receive(), timeout=timeout_s)
+    if msg.type is not aiohttp.WSMsgType.TEXT:
+        raise AssertionError(f"unexpected websocket frame: {msg.type!r} {msg.data!r}")
+    return json.loads(msg.data)
+
+
+async def drain_until(
+    ws: aiohttp.ClientWebSocketResponse, expected_type: str, timeout_s: float = 5.0
+) -> dict:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        remaining = deadline - loop.time()
+        event = await recv_json(ws, max(remaining, 0.01))
+        if event.get("type") == expected_type:
+            return event
+    raise AssertionError(
+        f"timed out waiting for a {expected_type!r} frame on the websocket"
+    )
+
+
+async def open_session(
+    ws: aiohttp.ClientWebSocketResponse, session: dict, timeout_s: float = 5.0
+) -> dict:
+    """Await ``session.created``, send ``session.update``, await the echo."""
+    await drain_until(ws, "session.created", timeout_s)
+    await ws.send_str(json.dumps({"type": "session.update", "session": session}))
+    return await drain_until(ws, "session.updated", timeout_s)
+
+
+async def commit_audio(ws: aiohttp.ClientWebSocketResponse, pcm16: bytes) -> None:
+    """Append one PCM16 buffer and close the turn."""
+    await ws.send_str(
+        json.dumps(
+            {
+                "type": "input_audio_buffer.append",
+                "audio": base64.b64encode(pcm16).decode("utf-8"),
+            }
+        )
+    )
+    await ws.send_str(json.dumps({"type": "input_audio_buffer.commit"}))
+
+
+async def collect_turn(
+    ws: aiohttp.ClientWebSocketResponse,
+    timeout_s: float,
+    *,
+    allow_unknown_events: bool = False,
+) -> TurnResult:
+    """Collect one turn's server events, up to and including ``response.done``.
+
+    An ``error`` frame always raises -- a turn that fails is never a pass.
+    ``allow_unknown_events`` relaxes only the check on *unrecognized* event
+    types, for callers driving a real engine that may emit more of them.
+    """
+    result = TurnResult()
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout_s
+
+    while result.status is None:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise AssertionError(
+                "timed out before response.done; "
+                f"audio_parts={len(result.audio_b64_parts)}, "
+                f"saw_audio_done={result.saw_audio_done}"
+            )
+        event = await recv_json(ws, remaining)
+        etype = event.get("type")
+
+        if etype == "error":
+            raise AssertionError(f"server error event: {event}")
+        elif etype == "response.created":
+            result.response_id = event["response"]["id"]
+        elif etype == "response.output_audio_transcript.delta":
+            result.transcript_parts.append(event["delta"])
+            assert event["response_id"] == result.response_id, event
+        elif etype == "response.output_audio.delta":
+            result.audio_b64_parts.append(event["delta"])
+            assert event["response_id"] == result.response_id, event
+        elif etype == "response.output_audio.done":
+            result.saw_audio_done = True
+            assert event["response_id"] == result.response_id, event
+        elif etype == "response.done":
+            result.status = event["response"]["status"]
+            assert event["response"]["id"] == result.response_id, event
+        elif allow_unknown_events:
+            logger.info("ignoring unasserted event type %r", etype)
+        else:
+            raise AssertionError(f"unexpected event type {etype!r}: {event}")
+
+    assert result.response_id is not None
+    return result


### PR DESCRIPTION
## Overview:

The vLLM-Omni realtime path is covered only by mocks. A mock encodes a *snapshot* of the engine's contract, so it cannot notice that contract changing — which is exactly how a payload-shape change upstream (root-caused in #12667) reached a release with every test green.

This adds the one shape of test that would have caught it, and removes the duplication that made writing it awkward.

## Details:

**1. `tests/utils/realtime_ws.py`** — the `/v1/realtime` turn protocol, implemented once: `open_session`, `commit_audio`, `collect_turn`, and a `TurnResult` holding the response envelope. `collect_turn` **always** raises on an `error` frame; only the unknown-event-type check is relaxable via `allow_unknown_events`, so a real engine emitting extra event types doesn't force the assertion to be dropped wholesale.

**2. `tests/frontend/test_realtime_omni_bridge.py`** — refactored onto it. Drops 79 lines (211 → 132) and no longer carries its own copy of the event loop.

**3. `tests/serve/test_realtime_omni_real_model.py`** — launches the real `dynamo.vllm.omni --realtime` worker (same invocation as `agg_omni_realtime.sh`), drives one turn, and asserts it completes with decodable non-silent audio and no `error` event.

### It ships skipped, and cannot currently be otherwise

The realtime path requires the model class to implement vLLM's `SupportsRealtime` (`OpenAIServingRealtime.transcribe_realtime` calls `model_cls.buffer_realtime_audio`). In vLLM-Omni exactly one model does — `Qwen3OmniMoeForConditionalGeneration` — and every published Qwen3-Omni checkpoint is 30B-A3B:

```
Qwen/Qwen3-Omni-30B-A3B-Instruct
Qwen/Qwen3-Omni-30B-A3B-Captioner
Qwen/Qwen3-Omni-30B-A3B-Thinking
```

`Qwen2.5-Omni-3B` is supported by vLLM-Omni generally but does **not** implement `SupportsRealtime`, so it cannot stand in at any size. CI runs on shared 24 GB L4s, and `tests/serve/test_vllm_omni.py` already skips the *7B* omni as needing ~80 GB. Same convention followed here: defined, reviewed, one marker away from running.

## Where should the reviewer start?

`tests/utils/realtime_ws.py` — everything else is either a caller of it or the worker-launch boilerplate.

**Validation.** `pre-commit run --files <changed>` passes clean; all three modules compile.

**This test has never executed.** This checkout has no `vllm_omni` install and could not load the model regardless. Two consequences stated plainly rather than papered over:

- `TENSOR_PARALLEL_SIZE = 4` and the `gpu_4` marker are a starting point, not a measured configuration.
- It deliberately carries **no** `profiled_vram_gib` marker. The guardrails require one for model-loading tests, but fabricating a number would corrupt the `--max-vram-gib` scheduler. The docstring says it must be profiled before this is wired into any automated tier.

The bridge-test refactor is exercised by CI and is the part that carries real risk here; the new module is not.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added shared real-time WebSocket test utilities for session setup, audio submission, event handling, transcript collection, and audio validation.
  * Expanded coverage for complete real-time audio turns, including response status, transcripts, completion events, and echoed audio.
  * Added a skipped GPU end-to-end test for validating real-model audio round trips.
  * Improved handling and validation of unexpected events, errors, timeouts, and incomplete responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->