### PR TITLE
fix(frontend): preserve zero top logprobs in release/1.4.0

### DIFF
--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -288,7 +288,7 @@ def _build_dynamo_preproc(
     logprobs = request.get("logprobs")
     top_logprobs = request.get("top_logprobs")
     if logprobs is True:
-        logprobs_val = top_logprobs or 1
+        logprobs_val = top_logprobs if top_logprobs is not None else 1
     elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
         logprobs_val = logprobs
     elif top_logprobs not in (None, 0):

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -322,6 +322,15 @@ class TestBuildDynamoPreproc:  # FRONTEND.7 — worker subprocess preproc constr
         )
         assert result["output_options"]["logprobs"] == 5
 
+    def test_logprobs_true_preserves_zero_top_logprobs(self):
+        result = _build_dynamo_preproc(
+            {"model": "test", "logprobs": True, "top_logprobs": 0},
+            [1],
+            "test",
+            None,
+        )
+        assert result["output_options"]["logprobs"] == 0
+
     def test_logprobs_true_without_top_logprobs(self):
         """logprobs=True without top_logprobs yields 1."""
         result = _build_dynamo_preproc(

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -10,6 +10,7 @@ tool_choice='none' and the exclude_tools_when_tool_choice_none flag.
 import importlib.util
 import json
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from _routed_engine_fakes import FakeRoutedEngine as _FakeRoutedEngine
@@ -718,6 +719,75 @@ def vllm_processor_module(monkeypatch):
     monkeypatch.setattr(module._nvtx, "start_range", lambda *args, **kwargs: object())
     monkeypatch.setattr(module._nvtx, "end_range", lambda rng: None)
     return module
+
+
+@pytest.mark.asyncio
+async def test_generator_preserves_zero_top_logprobs(
+    vllm_processor_module,
+    monkeypatch,
+    caplog,
+):
+    class RequestForSampling(SimpleNamespace):
+        model_fields = {}
+
+    monkeypatch.setattr(
+        vllm_processor_module,
+        "preprocess_chat_request",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                request_for_sampling=RequestForSampling(
+                    max_completion_tokens=None,
+                    max_tokens=1,
+                    logprobs=True,
+                    top_logprobs=0,
+                    cache_salt=None,
+                    mm_processor_kwargs=None,
+                ),
+                tool_parser=None,
+                chat_template_kwargs={},
+                engine_prompt={"prompt": "Hello"},
+                prompt_token_ids=[1],
+            )
+        ),
+    )
+
+    class ProjectionObserved(Exception):
+        pass
+
+    def process_inputs(request_id, engine_inputs, sampling_params, supported_tasks):
+        assert sampling_params.logprobs == 0
+        raise ProjectionObserved
+
+    input_processor = SimpleNamespace(
+        generation_config_fields={},
+        renderer=SimpleNamespace(process_for_engine_async=AsyncMock(return_value={})),
+        process_inputs=process_inputs,
+    )
+
+    processor = vllm_processor_module.VllmProcessor(
+        tokenizer=SimpleNamespace(eos_token_id=2),
+        input_processor=input_processor,
+        output_processor=object(),
+        tool_parser_class=None,
+        reasoning_parser_class=None,
+        routed_engine=object(),
+    )
+
+    with pytest.raises(ProjectionObserved):
+        await anext(
+            processor._generator_inner(
+                {
+                    "model": "test",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "logprobs": True,
+                    "top_logprobs": 0,
+                }
+            )
+        )
+    assert (
+        "Logprobs requested but not supported in distributed inference mode"
+        in caplog.messages
+    )
 
 
 def _make_processor(module, routed_engine):

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -516,12 +516,14 @@ class VllmProcessor:
         logprobs = request_for_sampling.logprobs
         top_logprobs = request_for_sampling.top_logprobs
         if logprobs is True:
-            sampling_params.logprobs = top_logprobs or 1
+            sampling_params.logprobs = top_logprobs if top_logprobs is not None else 1
         elif isinstance(logprobs, int) and not isinstance(logprobs, bool):
             sampling_params.logprobs = logprobs
         elif top_logprobs not in (None, 0):
             sampling_params.logprobs = top_logprobs
-        if sampling_params.logprobs is not None and sampling_params.logprobs > 0:
+        # TODO: Support logprobs in the distributed vLLM chat processor by
+        # converting worker log_probs/top_logprobs into EngineCoreOutput.new_logprobs.
+        if sampling_params.logprobs is not None:
             logger.warning(
                 "Logprobs requested but not supported in distributed inference mode"
             )


### PR DESCRIPTION
## Summary

- Cherry-pick #12650 to `release/1.4.0`.
- Preserve explicit `top_logprobs=0` values in SGLang and vLLM chat preprocessing; default only omitted or null values to `1`.

Fixes DIS-2624

## Original PR

- Main PR: #12650
- Merge commit: `a92c7d25d3fc8dc94d6ced034ae0415bfce98d1f`

## Validation

- Stable patch ID matches the merged source commit: `e38812d163e62d6f16acc32b6ec52775c10baf06`.
- `python -m pytest -xq components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — 48 passed.
- `python -m pytest -xq components/src/dynamo/frontend/tests/test_sglang_processor_unit.py::TestBuildDynamoPreproc` — 32 passed.
- `pre-commit run --files components/src/dynamo/frontend/sglang_processor.py components/src/dynamo/frontend/tests/test_sglang_processor_unit.py components/src/dynamo/frontend/vllm_processor.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — passed.
- `git diff --check HEAD^` — passed.