### PR TITLE
fix(runtime): support legacy event channel metadata

### DIFF
--- a/lib/runtime/src/discovery/kube/crd.rs
+++ b/lib/runtime/src/discovery/kube/crd.rs
@@ -123,7 +123,8 @@ pub async fn apply_cr(
 mod tests {
     use super::*;
     use crate::discovery::{
-        DiscoveryInstance, DiscoveryQuery, EventScope, EventSourceQuery, MAX_JSON_SAFE_PUBLISHER_ID,
+        DiscoveryInstance, DiscoveryQuery, EventChannelQuery, EventScope, EventSourceQuery,
+        MAX_JSON_SAFE_PUBLISHER_ID,
     };
     use crate::protocols::EndpointId;
     use kube::Resource;
@@ -163,6 +164,48 @@ mod tests {
             serde_json::from_str(&json).expect("Failed to deserialize CR");
 
         assert_eq!(deserialized.spec.data, data);
+    }
+
+    #[test]
+    fn v1_2_event_channels_deserialize_without_hiding_worker_metadata() {
+        let cr: DynamoWorkerMetadata =
+            serde_json::from_str(include_str!("fixtures/v1_2_dwm.json")).unwrap();
+        let metadata: DiscoveryMetadata = serde_json::from_value(cr.spec.data).unwrap();
+
+        assert_eq!(metadata.get_all_endpoints().len(), 1);
+        assert_eq!(metadata.get_all_model_cards().len(), 1);
+
+        let component_channels = metadata.filter(&DiscoveryQuery::EventChannels(
+            EventChannelQuery::topic("dynamo", "backend", "kv-events"),
+        ));
+        assert!(matches!(
+            component_channels.as_slice(),
+            [DiscoveryInstance::EventChannel {
+                scope: EventScope::Component {
+                    namespace,
+                    component
+                },
+                ..
+            }] if namespace == "dynamo" && component == "backend"
+        ));
+
+        let namespace_channels = metadata.filter(&DiscoveryQuery::EventChannels(
+            EventChannelQuery::namespace_topic("dynamo", "kv_metrics"),
+        ));
+        assert!(matches!(
+            namespace_channels.as_slice(),
+            [DiscoveryInstance::EventChannel {
+                scope: EventScope::Namespace { name },
+                ..
+            }] if name == "dynamo"
+        ));
+
+        let serialized = serde_json::to_value(metadata).unwrap();
+        for channel in serialized["event_channels"].as_object().unwrap().values() {
+            assert!(channel.get("scope").is_some());
+            assert!(channel.get("namespace").is_none());
+            assert!(channel.get("component").is_none());
+        }
     }
 
     #[test]

--- a/lib/runtime/src/discovery/kube/crd.rs
+++ b/lib/runtime/src/discovery/kube/crd.rs
@@ -124,10 +124,43 @@ mod tests {
     use super::*;
     use crate::discovery::{
         DiscoveryInstance, DiscoveryQuery, EventChannelQuery, EventScope, EventSourceQuery,
-        MAX_JSON_SAFE_PUBLISHER_ID,
+        EventTransport, MAX_JSON_SAFE_PUBLISHER_ID,
     };
     use crate::protocols::EndpointId;
     use kube::Resource;
+
+    #[derive(serde::Deserialize)]
+    struct V1_2DiscoveryMetadata {
+        endpoints: std::collections::HashMap<String, serde_json::Value>,
+        model_cards: std::collections::HashMap<String, serde_json::Value>,
+        event_channels: std::collections::HashMap<String, V1_2EventChannel>,
+    }
+
+    #[derive(serde::Deserialize)]
+    #[serde(tag = "type")]
+    enum V1_2EventChannel {
+        EventChannel {
+            namespace: String,
+            component: String,
+            topic: String,
+            instance_id: u64,
+            transport: EventTransport,
+        },
+    }
+
+    impl V1_2EventChannel {
+        fn into_parts(self) -> (String, String, String, u64, EventTransport) {
+            match self {
+                Self::EventChannel {
+                    namespace,
+                    component,
+                    topic,
+                    instance_id,
+                    transport,
+                } => (namespace, component, topic, instance_id, transport),
+            }
+        }
+    }
 
     #[test]
     fn test_crd_metadata() {
@@ -201,11 +234,68 @@ mod tests {
         ));
 
         let serialized = serde_json::to_value(metadata).unwrap();
-        for channel in serialized["event_channels"].as_object().unwrap().values() {
-            assert!(channel.get("scope").is_some());
-            assert!(channel.get("namespace").is_none());
-            assert!(channel.get("component").is_none());
-        }
+        let component_channel = &serialized["event_channels"]["dynamo/backend/kv-events/2a"];
+        assert!(component_channel.get("scope").is_some());
+        assert_eq!(component_channel["namespace"], "dynamo");
+        assert_eq!(component_channel["component"], "backend");
+
+        let namespace_channel = &serialized["event_channels"]["dynamo//kv_metrics/2a"];
+        assert!(namespace_channel.get("scope").is_some());
+        assert_eq!(namespace_channel["namespace"], "dynamo");
+        assert_eq!(namespace_channel["component"], "");
+    }
+
+    #[test]
+    fn current_event_channels_serialize_for_v1_2_frontends() {
+        let cr: DynamoWorkerMetadata =
+            serde_json::from_str(include_str!("fixtures/v1_2_dwm.json")).unwrap();
+        let mut metadata: DiscoveryMetadata = serde_json::from_value(cr.spec.data).unwrap();
+        let endpoint = EndpointId {
+            namespace: "dynamo".to_string(),
+            component: "backend".to_string(),
+            name: "generate".to_string(),
+        };
+        let subject_prefix = "namespace.dynamo.component.backend.endpoint.generate";
+        metadata
+            .register_event_channel(DiscoveryInstance::EventChannel {
+                scope: EventScope::Endpoint {
+                    endpoint: endpoint.clone(),
+                },
+                topic: "endpoint-kv-events".to_string(),
+                instance_id: 43,
+                transport: EventTransport::nats(subject_prefix),
+            })
+            .unwrap();
+
+        let cr = build_cr("current-worker", "current-worker", "pod-uid", &metadata).unwrap();
+        let legacy: V1_2DiscoveryMetadata = serde_json::from_value(cr.spec.data.clone()).unwrap();
+        assert_eq!(legacy.endpoints.len(), 1);
+        assert_eq!(legacy.model_cards.len(), 1);
+        assert_eq!(legacy.event_channels.len(), 3);
+
+        let endpoint_channel = legacy
+            .event_channels
+            .into_values()
+            .map(V1_2EventChannel::into_parts)
+            .find(|(_, _, topic, _, _)| topic == "endpoint-kv-events")
+            .unwrap();
+        assert_eq!(endpoint_channel.0, "dynamo");
+        assert_eq!(endpoint_channel.1, "backend");
+        assert_eq!(endpoint_channel.3, 43);
+        assert_eq!(endpoint_channel.4, EventTransport::nats(subject_prefix));
+
+        let current: DiscoveryMetadata = serde_json::from_value(cr.spec.data).unwrap();
+        assert_eq!(
+            current.filter(&DiscoveryQuery::EventChannels(
+                EventChannelQuery::endpoint_topic(endpoint.clone(), "endpoint-kv-events")
+            )),
+            vec![DiscoveryInstance::EventChannel {
+                scope: EventScope::Endpoint { endpoint },
+                topic: "endpoint-kv-events".to_string(),
+                instance_id: 43,
+                transport: EventTransport::nats(subject_prefix),
+            }]
+        );
     }
 
     #[test]

--- a/lib/runtime/src/discovery/kube/fixtures/v1_2_dwm.json
+++ b/lib/runtime/src/discovery/kube/fixtures/v1_2_dwm.json
@@ -1,0 +1,64 @@
+{
+  "apiVersion": "nvidia.com/v1alpha1",
+  "kind": "DynamoWorkerMetadata",
+  "metadata": {
+    "name": "legacy-worker"
+  },
+  "spec": {
+    "data": {
+      "endpoints": {
+        "dynamo/backend/generate/2a": {
+          "type": "Endpoint",
+          "namespace": "dynamo",
+          "component": "backend",
+          "endpoint": "generate",
+          "instance_id": 42,
+          "transport": {
+            "nats_tcp": "dynamo.backend.generate"
+          }
+        }
+      },
+      "model_cards": {
+        "dynamo/backend/generate/2a": {
+          "type": "Model",
+          "namespace": "dynamo",
+          "component": "backend",
+          "endpoint": "generate",
+          "instance_id": 42,
+          "card_json": {
+            "display_name": "Qwen/Qwen3-0.6B"
+          },
+          "model_suffix": null
+        }
+      },
+      "event_channels": {
+        "dynamo/backend/kv-events/2a": {
+          "type": "EventChannel",
+          "namespace": "dynamo",
+          "component": "backend",
+          "topic": "kv-events",
+          "instance_id": 42,
+          "transport": {
+            "kind": "Nats",
+            "config": {
+              "subject_prefix": "namespace.dynamo.component.backend"
+            }
+          }
+        },
+        "dynamo//kv_metrics/2a": {
+          "type": "EventChannel",
+          "namespace": "dynamo",
+          "component": "",
+          "topic": "kv_metrics",
+          "instance_id": 42,
+          "transport": {
+            "kind": "Nats",
+            "config": {
+              "subject_prefix": "namespace.dynamo"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -704,7 +704,7 @@ impl DiscoverySpec {
 
 /// Registered instances in the discovery plane
 /// Represents objects that have been successfully registered with an instance ID
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "type")]
 pub enum DiscoveryInstance {
     /// Registered endpoint instance - wraps the component::Instance directly
@@ -737,6 +737,111 @@ pub enum DiscoveryInstance {
         publisher_id: u64,
         metadata: serde_json::Value,
     },
+}
+
+// Deserialize through a wire-only representation so v1.2 EventChannel records can be normalized
+// from their sibling `namespace` and `component` fields. Serialization remains canonical through
+// DiscoveryInstance's derived Serialize implementation.
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum DiscoveryInstanceWire {
+    Endpoint(crate::component::Instance),
+    Model {
+        namespace: String,
+        component: String,
+        endpoint: String,
+        instance_id: u64,
+        card_json: serde_json::Value,
+        #[serde(default)]
+        model_suffix: Option<String>,
+    },
+    EventChannel {
+        #[serde(default)]
+        scope: Option<EventScope>,
+        #[serde(default)]
+        namespace: Option<String>,
+        #[serde(default)]
+        component: Option<String>,
+        topic: String,
+        instance_id: u64,
+        transport: EventTransport,
+    },
+    EventSource {
+        scope: EventScope,
+        topic: String,
+        publisher_id: u64,
+        metadata: serde_json::Value,
+    },
+}
+
+impl<'de> Deserialize<'de> for DiscoveryInstance {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = DiscoveryInstanceWire::deserialize(deserializer)?;
+
+        match wire {
+            DiscoveryInstanceWire::Endpoint(instance) => Ok(Self::Endpoint(instance)),
+            DiscoveryInstanceWire::Model {
+                namespace,
+                component,
+                endpoint,
+                instance_id,
+                card_json,
+                model_suffix,
+            } => Ok(Self::Model {
+                namespace,
+                component,
+                endpoint,
+                instance_id,
+                card_json,
+                model_suffix,
+            }),
+            DiscoveryInstanceWire::EventChannel {
+                scope,
+                namespace,
+                component,
+                topic,
+                instance_id,
+                transport,
+            } => {
+                let scope = match (scope, namespace, component) {
+                    (Some(scope), _, _) => scope,
+                    (None, Some(namespace), Some(component)) if component.is_empty() => {
+                        EventScope::Namespace { name: namespace }
+                    }
+                    (None, Some(namespace), Some(component)) => EventScope::Component {
+                        namespace,
+                        component,
+                    },
+                    (None, _, _) => {
+                        return Err(serde::de::Error::custom(
+                            "event channel is missing `scope` and legacy `namespace`/`component`",
+                        ));
+                    }
+                };
+
+                Ok(Self::EventChannel {
+                    scope,
+                    topic,
+                    instance_id,
+                    transport,
+                })
+            }
+            DiscoveryInstanceWire::EventSource {
+                scope,
+                topic,
+                publisher_id,
+                metadata,
+            } => Ok(Self::EventSource {
+                scope,
+                topic,
+                publisher_id,
+                metadata,
+            }),
+        }
+    }
 }
 
 /// Validate an idempotent registration for one semantic event-source incarnation.

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -704,8 +704,7 @@ impl DiscoverySpec {
 
 /// Registered instances in the discovery plane
 /// Represents objects that have been successfully registered with an instance ID
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
-#[serde(tag = "type")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveryInstance {
     /// Registered endpoint instance - wraps the component::Instance directly
     Endpoint(crate::component::Instance),
@@ -718,7 +717,6 @@ pub enum DiscoveryInstance {
         /// This allows lib/runtime to remain independent of lib/llm types
         card_json: serde_json::Value,
         /// Optional suffix appended after instance_id in the key path (e.g., for LoRA adapters)
-        #[serde(default, skip_serializing_if = "Option::is_none")]
         model_suffix: Option<String>,
     },
     /// Registered event channel instance for event plane pub/sub
@@ -739,10 +737,10 @@ pub enum DiscoveryInstance {
     },
 }
 
-// Deserialize through a wire-only representation so v1.2 EventChannel records can be normalized
-// from their sibling `namespace` and `component` fields. Serialization remains canonical through
-// DiscoveryInstance's derived Serialize implementation.
-#[derive(Deserialize)]
+// Serialize and deserialize through a wire-only representation so current and v1.2 readers can
+// consume the same EventChannel record. `scope` is authoritative for current readers; the sibling
+// `namespace` and `component` fields are its legacy projection.
+#[derive(Serialize, Deserialize)]
 #[serde(tag = "type")]
 enum DiscoveryInstanceWire {
     Endpoint(crate::component::Instance),
@@ -752,7 +750,7 @@ enum DiscoveryInstanceWire {
         endpoint: String,
         instance_id: u64,
         card_json: serde_json::Value,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "Option::is_none")]
         model_suffix: Option<String>,
     },
     EventChannel {
@@ -772,6 +770,76 @@ enum DiscoveryInstanceWire {
         publisher_id: u64,
         metadata: serde_json::Value,
     },
+}
+
+fn legacy_event_scope(scope: &EventScope) -> (&str, &str) {
+    match scope {
+        EventScope::Namespace { name } => (name, ""),
+        EventScope::Component {
+            namespace,
+            component,
+        } => (namespace, component),
+        EventScope::Endpoint { endpoint } => (&endpoint.namespace, &endpoint.component),
+    }
+}
+
+impl From<&DiscoveryInstance> for DiscoveryInstanceWire {
+    fn from(instance: &DiscoveryInstance) -> Self {
+        match instance {
+            DiscoveryInstance::Endpoint(instance) => Self::Endpoint(instance.clone()),
+            DiscoveryInstance::Model {
+                namespace,
+                component,
+                endpoint,
+                instance_id,
+                card_json,
+                model_suffix,
+            } => Self::Model {
+                namespace: namespace.clone(),
+                component: component.clone(),
+                endpoint: endpoint.clone(),
+                instance_id: *instance_id,
+                card_json: card_json.clone(),
+                model_suffix: model_suffix.clone(),
+            },
+            DiscoveryInstance::EventChannel {
+                scope,
+                topic,
+                instance_id,
+                transport,
+            } => {
+                let (namespace, component) = legacy_event_scope(scope);
+                Self::EventChannel {
+                    scope: Some(scope.clone()),
+                    namespace: Some(namespace.to_string()),
+                    component: Some(component.to_string()),
+                    topic: topic.clone(),
+                    instance_id: *instance_id,
+                    transport: transport.clone(),
+                }
+            }
+            DiscoveryInstance::EventSource {
+                scope,
+                topic,
+                publisher_id,
+                metadata,
+            } => Self::EventSource {
+                scope: scope.clone(),
+                topic: topic.clone(),
+                publisher_id: *publisher_id,
+                metadata: metadata.clone(),
+            },
+        }
+    }
+}
+
+impl Serialize for DiscoveryInstance {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        DiscoveryInstanceWire::from(self).serialize(serializer)
+    }
 }
 
 impl<'de> Deserialize<'de> for DiscoveryInstance {
@@ -807,7 +875,21 @@ impl<'de> Deserialize<'de> for DiscoveryInstance {
                 transport,
             } => {
                 let scope = match (scope, namespace, component) {
-                    (Some(scope), _, _) => scope,
+                    (Some(scope), None, None) => scope,
+                    (Some(scope), Some(namespace), Some(component)) => {
+                        let (expected_namespace, expected_component) = legacy_event_scope(&scope);
+                        if namespace != expected_namespace || component != expected_component {
+                            return Err(serde::de::Error::custom(
+                                "event channel `scope` conflicts with legacy `namespace`/`component`",
+                            ));
+                        }
+                        scope
+                    }
+                    (Some(_), _, _) => {
+                        return Err(serde::de::Error::custom(
+                            "event channel legacy scope must contain both `namespace` and `component`",
+                        ));
+                    }
                     (None, Some(namespace), Some(component)) if component.is_empty() => {
                         EventScope::Namespace { name: namespace }
                     }
@@ -1453,5 +1535,33 @@ mod tests {
             }
             _ => panic!("expected endpoint discovery metadata"),
         }
+    }
+
+    #[test]
+    fn conflicting_current_and_legacy_event_scopes_are_rejected() {
+        let metadata = serde_json::json!({
+            "type": "EventChannel",
+            "scope": {
+                "kind": "endpoint",
+                "endpoint": {
+                    "namespace": "dynamo",
+                    "component": "backend",
+                    "name": "generate"
+                }
+            },
+            "namespace": "other",
+            "component": "backend",
+            "topic": "kv-events",
+            "instance_id": 42,
+            "transport": {
+                "kind": "Nats",
+                "config": {
+                    "subject_prefix": "namespace.dynamo.component.backend.endpoint.generate"
+                }
+            }
+        });
+
+        let error = serde_json::from_value::<DiscoveryInstance>(metadata).unwrap_err();
+        assert!(error.to_string().contains("conflicts with legacy"));
     }
 }


### PR DESCRIPTION
## Summary

- deserialize v1.2 EventChannel metadata that encodes scope as namespace/component fields
- serialize current EventChannel metadata with both the authoritative scope and a legacy namespace/component projection
- reject dual records whose current and legacy scope fields disagree
- cover both compatibility directions with a representative v1.2 DWM fixture and a frozen v1.2 event-channel reader

## Root cause

The event-channel scope migration replaced the top-level namespace/component fields with scope. That made one legacy event channel reject the complete DWM in a current frontend, and made one current event channel reject the complete DWM in a v1.2 frontend. In either direction, otherwise valid endpoint and model records were hidden.

## Compatibility behavior

- namespace scope serializes as namespace plus an empty legacy component
- component scope serializes as the same namespace/component pair
- endpoint scope serializes its endpoint namespace/component as the lossy legacy projection
- current readers preserve the exact scope; v1.2 readers ignore the unknown scope field and consume the legacy projection

This restores bidirectional discovery/request-plane compatibility. Combined with #12658, either frontend/worker version pairing can discover the worker and negotiate the request codec.

## Compatibility scope

This does not make current endpoint-scoped publishers and v1.2 component-scoped NATS subscribers use the same event subject, nor does it add legacy EventSource identity adaptation. KV-aware routing can therefore remain degraded in mixed-version deployments.

Stacked on #12658.

## Validation

- cargo test -p dynamo-runtime discovery::kube::crd::tests --lib
- cargo test -p dynamo-runtime conflicting_current_and_legacy_event_scopes_are_rejected --lib
- cargo test -p dynamo-runtime --lib (523 passed)
- cargo clippy -p dynamo-runtime --lib --tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check
