### PR TITLE
fix(test): add google-crc32c for vllm plugin startup in xpu suites

### DIFF
--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -20,6 +20,9 @@ datasets==4.4.1
 filelock==3.25.1
 # For faster model downloads
 hf-xet==1.4.3
+# Required by modelexpress plugin import path used during dynamo.vllm startup
+# in router/XPU tests (fixes ModuleNotFoundError: google_crc32c).
+google-crc32c
 # For Kubernetes operations in deploy tests
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0

--- a/container/deps/requirements.test.txt
+++ b/container/deps/requirements.test.txt
@@ -18,11 +18,11 @@ coverage[toml]==7.13.1
 # For IFEval dataset loading in kvbm tests
 datasets==4.4.1
 filelock==3.25.1
-# For faster model downloads
-hf-xet==1.4.3
 # Required by modelexpress plugin import path used during dynamo.vllm startup
 # in router/XPU tests (fixes ModuleNotFoundError: google_crc32c).
 google-crc32c
+# For faster model downloads
+hf-xet==1.4.3
 # For Kubernetes operations in deploy tests
 kr8s==0.20.13
 kubernetes_asyncio==32.0.0


### PR DESCRIPTION
## Overview:

Fixes XPU test runtime startup failures by adding a missing Python dependency required by the vLLM plugin import path.

## Details:

- Added `google-crc32c` to test image dependencies in container/deps/requirements.test.txt.
- This ensures `dynamo.vllm` can start successfully in XPU test environments where the `modelexpress` plugin is imported at startup.

## Where should the reviewer start?

- container/deps/requirements.test.txt

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12693" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a test dependency to support plugin imports during Dynamo vLLM startup tests.
  * Improved reliability for router and XPU test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->