### PR TITLE
fix: drop v1beta1/ from DynamoCheckpoint manifest paths

### DIFF
--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -95,7 +95,7 @@ class CheckpointBackendConfig:
 CHECKPOINT_BACKENDS = {
     "vllm": CheckpointBackendConfig(
         name="vllm",
-        manifest=("examples", "backends", "vllm", "deploy", "v1beta1", "agg.yaml"),
+        manifest=("examples", "backends", "vllm", "deploy", "agg.yaml"),
         decode_component="VllmDecodeWorker",
         frontend_component=FRONTEND_COMPONENT,
         target_container=TARGET_CONTAINER,
@@ -116,7 +116,6 @@ CHECKPOINT_BACKENDS = {
             "backends",
             "sglang",
             "deploy",
-            "v1beta1",
             "agg.yaml",
         ),
         decode_component="decode",
@@ -143,7 +142,6 @@ CHECKPOINT_BACKENDS = {
             "backends",
             "trtllm",
             "deploy",
-            "v1beta1",
             "agg.yaml",
         ),
         decode_component="TRTLLMWorker",


### PR DESCRIPTION
**Overview**                                                                                                                                                          
                                                                                                                                                                    
  Fix stale `v1beta1/ `path components in `test_dynamocheckpoint.py` left behind after #12375 promoted `v1beta1` manifests to top-level.                                  
                                                                                                                                                                    
  Details                                                                                                                                                           
                                                                                                                                                                    
  #12375 removed the v1beta1/ subdirectory from backend deploy examples, moving agg.yaml directly under examples/backends/{vllm,sglang,trtllm}/deploy/. The three   
  CheckpointBackendConfig entries in test_dynamocheckpoint.py were not updated and continued referencing the deleted paths, breaking the DynamoCheckpoint CI tests. 
                                                                                                                                                                    
  Drops the "v1beta1" tuple element from all three manifest path definitions.                                                                                       
                                                                                                                                                                    
  Where should the reviewer start?                                                                                                                                  
                                                                                                                                                                    
  tests/deploy/test_dynamocheckpoint.py — three one-line removals at the manifest= field of each backend entry (vllm, sglang, trtllm).                              
                                                                                                                                                                    
  Related Issues                                                                                                                                                    
                                                                                                                                                                    
  - Closes #12506           
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated checkpoint deployment configurations for vLLM, SGLang, and TensorRT-LLM to use the correct paths.
  * Improved deployment compatibility by removing outdated directory references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->