### PR TITLE
fix(frontend): drop unset SGLang fields from chat-template tool dicts

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -377,12 +377,25 @@ def _filter_template_tools(
     if _is_named_tool_choice(tool_choice):
         chosen_name = tool_choice["function"]["name"]
         return [
-            tool.model_dump()
+            _tool_template_dict(tool)
             for tool in sglang_tools
             if tool.function.name == chosen_name
         ]
 
-    return [tool.model_dump() for tool in sglang_tools]
+    return [_tool_template_dict(tool) for tool in sglang_tools]
+
+
+def _tool_template_dict(tool: SglangTool) -> dict[str, Any]:
+    """Serialize a tool for the chat template without SGLang-internal fields.
+
+    ``model_dump()`` emits every declared field on ``SglangTool``, including
+    bookkeeping the caller never sent, such as ``defer_loading``. Templates that
+    render tool declarations as compact JSON inline each unset field verbatim:
+    Kimi-K3 turns every tool into ``...,"defer_loading":null``, about five tokens
+    apiece. A 264-tool agent request measured 97,487 prompt tokens against the
+    reference encoder's 96,161; dropping the unset fields brings it to 96,167.
+    """
+    return tool.model_dump(exclude_none=True)
 
 
 def _flatten_message_content(content: Any) -> Any:

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -27,6 +27,7 @@ from dynamo.frontend.sglang_prepost import (
     SglangPreprocessResult,
     SglangStreamingPostProcessor,
     _flatten_message_content,
+    _filter_template_tools,
     _guided_tool_choice_requires_reasoning,
     _normalize_assistant_tool_call_arguments,
     _normalize_prompt_token_ids,
@@ -511,6 +512,47 @@ class TestMapFinishReason:  # FRONTEND.5 — finish_reason remap (frontend layer
 # ---------------------------------------------------------------------------
 # convert_tools
 # ---------------------------------------------------------------------------
+
+
+class TestFilterTemplateTools:
+    """Tool dicts handed to the chat template carry only caller-supplied fields."""
+
+    TOOL = {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Look up the weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+
+    def _rendered(self, tool_choice="auto"):
+        request = {"tools": [self.TOOL], "tool_choice": tool_choice}
+        return _filter_template_tools(
+            request,
+            sglang_tools=convert_tools([self.TOOL]),
+            exclude_tools_when_tool_choice_none=True,
+        )
+
+    def test_drops_unset_internal_fields(self):
+        # defer_loading is SGLang bookkeeping the caller never sent. Templates
+        # that render declarations as compact JSON inline it as
+        # '"defer_loading":null' on every tool.
+        (rendered,) = self._rendered()
+        assert "defer_loading" not in rendered
+        assert rendered["type"] == "function"
+        assert rendered["function"]["name"] == "get_weather"
+        assert rendered["function"]["parameters"] == self.TOOL["function"]["parameters"]
+
+    def test_named_tool_choice_path_drops_them_too(self):
+        (rendered,) = self._rendered(
+            tool_choice={"type": "function", "function": {"name": "get_weather"}}
+        )
+        assert "defer_loading" not in rendered
 
 
 class TestConvertTools:  # FRONTEND.3 — OpenAI tool schema → SGLang Tool/Function


### PR DESCRIPTION
## What

`_filter_template_tools` serializes each tool with `model_dump()`, which emits every declared field on `SglangTool` — including bookkeeping the caller never sent, such as `defer_loading`. Templates that render tool declarations as compact JSON inline those unset fields verbatim.

Kimi-K3 renders declarations through `encoding_k3._render_tool_declare` → `json.dumps(..., separators=(",", ":"))`, so every tool picks up a literal `"defer_loading":null` — roughly five tokens apiece.

## Impact

Agent clients send large tool catalogs. On a captured 264-tool request that is **1,326 tokens of noise**, measured against the model's own reference encoder (`transformers.apply_chat_template` with the raw OpenAI tool dicts):

| rendering | prompt tokens |
|---|---|
| reference encoder | 96,161 |
| dynamo (before) | **97,487** (+1,326) |
| dynamo (after) | 96,167 (+6) |

The remaining 6-token delta is `strict`, which is part of the OpenAI tool schema and legitimately set on two of those tools.

## Fix

```python
-    return [tool.model_dump() for tool in sglang_tools]
+    return [_tool_template_dict(tool) for tool in sglang_tools]
```

where `_tool_template_dict` is `tool.model_dump(exclude_none=True)`. Fields the caller actually set are untouched, so a request that explicitly sets `defer_loading` or `strict` still renders them. Both call sites (named `tool_choice` and the general path) go through the helper.

## Tests

Added `TestFilterTemplateTools` to `test_sglang_processor_unit.py`, covering both call sites and asserting the caller's schema survives intact.

Verified on a running 1.4.0.dev deployment: prompt tokens dropped 97,487 → 96,167 for the same conversation, and the rendered prompt tail matches the reference encoder exactly.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12700" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool selection compatibility by excluding unsupported empty fields when sending tool definitions to chat templates.
  * Preserved caller-provided tool schema fields for both automatic and named tool choices.

* **Tests**
  * Added coverage to verify filtering behavior across supported tool-selection modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->