### PR TITLE
fix(ci): avoid branch cleanup-key collisions

### DIFF
--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -123,9 +123,10 @@ runs:
           BRANCH_SANITIZED="${BRANCH//\//-}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED/pull-request/pr}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED//./-}"
+          BRANCH_PRE_NORMALIZATION="${BRANCH_SANITIZED}"
           BRANCH_SANITIZED="$(printf '%s' "${BRANCH_SANITIZED}" | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^[^A-Za-z0-9]+//; s/[^A-Za-z0-9]+$//')"
-          if [[ -z "${BRANCH_SANITIZED}" || ${#BRANCH_SANITIZED} -gt 10 ]]; then
-            # Keep truncated cleanup keys valid and distinct across similarly named branches.
+          if [[ "${BRANCH_SANITIZED}" != "${BRANCH_PRE_NORMALIZATION}" || -z "${BRANCH_SANITIZED}" || ${#BRANCH_SANITIZED} -gt 10 ]]; then
+            # Keep normalized or truncated keys valid and distinct across branch names.
             BRANCH_HASH="$(printf '%s' "${BRANCH}" | sha256sum | cut -c1-6)"
             BRANCH_PREFIX="$(printf '%s' "${BRANCH_SANITIZED:0:10}" | sed -E 's/[^[:alnum:]]+$//')"
             if [[ -n "${BRANCH_PREFIX}" ]]; then

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -123,11 +123,16 @@ runs:
           BRANCH_SANITIZED="${BRANCH//\//-}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED/pull-request/pr}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED//./-}"
-          if [[ ${#BRANCH_SANITIZED} -gt 10 ]]; then
+          BRANCH_SANITIZED="$(printf '%s' "${BRANCH_SANITIZED}" | sed -E 's/[^A-Za-z0-9_.-]+/-/g; s/^[^A-Za-z0-9]+//; s/[^A-Za-z0-9]+$//')"
+          if [[ -z "${BRANCH_SANITIZED}" || ${#BRANCH_SANITIZED} -gt 10 ]]; then
             # Keep truncated cleanup keys valid and distinct across similarly named branches.
             BRANCH_HASH="$(printf '%s' "${BRANCH}" | sha256sum | cut -c1-6)"
             BRANCH_PREFIX="$(printf '%s' "${BRANCH_SANITIZED:0:10}" | sed -E 's/[^[:alnum:]]+$//')"
-            BRANCH_SANITIZED="${BRANCH_PREFIX}-${BRANCH_HASH}"
+            if [[ -n "${BRANCH_PREFIX}" ]]; then
+              BRANCH_SANITIZED="${BRANCH_PREFIX}-${BRANCH_HASH}"
+            else
+              BRANCH_SANITIZED="${BRANCH_HASH}"
+            fi
           fi
           echo "namespace=gh-id-${{ github.run_id }}-${BRANCH_SANITIZED}-dt" >> "$GITHUB_OUTPUT"
           echo "namespace_suffix=${BRANCH_SANITIZED}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-dynamo-operator/action.yml
+++ b/.github/actions/setup-dynamo-operator/action.yml
@@ -123,7 +123,12 @@ runs:
           BRANCH_SANITIZED="${BRANCH//\//-}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED/pull-request/pr}"
           BRANCH_SANITIZED="${BRANCH_SANITIZED//./-}"
-          BRANCH_SANITIZED="${BRANCH_SANITIZED:0:10}"
+          if [[ ${#BRANCH_SANITIZED} -gt 10 ]]; then
+            # Keep truncated cleanup keys valid and distinct across similarly named branches.
+            BRANCH_HASH="$(printf '%s' "${BRANCH}" | sha256sum | cut -c1-6)"
+            BRANCH_PREFIX="$(printf '%s' "${BRANCH_SANITIZED:0:10}" | sed -E 's/[^[:alnum:]]+$//')"
+            BRANCH_SANITIZED="${BRANCH_PREFIX}-${BRANCH_HASH}"
+          fi
           echo "namespace=gh-id-${{ github.run_id }}-${BRANCH_SANITIZED}-dt" >> "$GITHUB_OUTPUT"
           echo "namespace_suffix=${BRANCH_SANITIZED}" >> "$GITHUB_OUTPUT"
         fi


### PR DESCRIPTION
## Overview

Current `main` produces Kubernetes-valid cleanup keys, but truncating branch-derived values to ten characters can map different branches to the same `dynamo.github/cleanup-key`. For example, multiple `release/*` branches collapse to `release-1`.

This change retains readable prefixes while adding a deterministic suffix whenever normalization or truncation is required, so distinct branch names remain distinct in the current branch set.

## Details

- Preserve existing keys for short names such as `main` and `pull-request/12641`.
- Normalize unsupported label characters and trim invalid boundary characters.
- For normalized, empty, or longer-than-ten-character values, append a six-character SHA-256 suffix derived from the original branch name.
- Keep the resulting value within the Kubernetes label limit; the longest generated key in the replay was 17 characters.

The external `nscleanup` controller is not part of this repository. This change assumes `dynamo.github/cleanup-key` is treated as an opaque grouping value rather than reconstructed from a truncated branch name.

## Validation

- Replayed the current-main and proposed builders over all 3,514 remote branch names.
  - Current `main`: 324 colliding cleanup-key groups.
  - This PR: 0 colliding groups, 0 invalid label values, and 3,514 distinct keys.
- Verified representative outputs:
  - `main` -> `main`
  - `pull-request/12641` -> `pr-12641`
  - `release/1.3.1` -> `release-1-a0ce1f`
  - `release/1.4.0` -> `release-1-5abf5f`
- Verified adversarial short names such as `fix`, `fix-`, and `-fix` remain distinct.
- `uvx pre-commit run --files .github/actions/setup-dynamo-operator/action.yml`
- `git diff --check origin/main...HEAD`
- Parsed `.github/actions/setup-dynamo-operator/action.yml` with Ruby `YAML.load_file`.

## Where should the reviewer start?

`.github/actions/setup-dynamo-operator/action.yml`, in the `Resolve names` step where `BRANCH_SANITIZED` is generated.

## Related Issues

Related to #12645 and #12994. Those changes fixed invalid cleanup-key label values; this PR addresses the remaining collision risk.
