### PR TITLE
fix(snapshot): preserve restore sentinel for independent readers

### DIFF
--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -90,10 +90,11 @@ class SnapshotConfig:
             await asyncio.sleep(SENTINEL_POLL_INTERVAL_SEC)
 
     def _cleanup_ready_and_sentinels(self) -> None:
+        # Keep restore-complete for the kubelet startup probe; the snapshot agent
+        # removes it before restoring the next container incarnation.
         for name in (
             READY_FOR_SNAPSHOT_FILE,
             SNAPSHOT_COMPLETE_FILE,
-            RESTORE_COMPLETE_FILE,
         ):
             path = os.path.join(self.control_dir, name)
             try:

--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -90,10 +90,10 @@ class SnapshotConfig:
             await asyncio.sleep(SENTINEL_POLL_INTERVAL_SEC)
 
     def _cleanup_ready_and_sentinels(self) -> None:
+        # Keep restore-complete for the kubelet startup probe to observe independently.
         for name in (
             READY_FOR_SNAPSHOT_FILE,
             SNAPSHOT_COMPLETE_FILE,
-            RESTORE_COMPLETE_FILE,
         ):
             path = os.path.join(self.control_dir, name)
             try:

--- a/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
+++ b/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
@@ -52,7 +52,7 @@ async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tm
         assert await lifecycle is True
         assert controller.resumed is True
         assert not (tmp_path / READY_FOR_SNAPSHOT_FILE).exists()
-        assert not (tmp_path / RESTORE_COMPLETE_FILE).exists()
+        assert (tmp_path / RESTORE_COMPLETE_FILE).read_text(encoding="utf-8") == "done"
     finally:
         if not lifecycle.done():
             lifecycle.cancel()


### PR DESCRIPTION
## Summary

- keep `restore-complete` after the restored workload observes it so the independent kubelet startup probe can observe the same marker
- continue removing the capture-only `ready-for-snapshot` and `snapshot-complete` sentinels
- the snapshot agent still removes a leftover `restore-complete` before the next restore (now in [ai-dynamo/snapshot#72](https://github.com/ai-dynamo/snapshot/pull/72); originally the agent-side change on this PR)

The restored workload and kubelet startup probe are independent readers. The workload must not consume completion before kubelet observes it. The snapshot agent remains the owner that invalidates stale completion before a later re-restore.

This PR now carries the Dynamo-side change previously stacked as #13295. The `deploy/snapshot` agent cleanup no longer belongs here after #13177.

## Validation

- same change as #13295: lifecycle keeps `restore-complete` and the unit test expects the stamp to remain