### PR TITLE
fix(frontend): guard tokenizer.chat_template for MistralTokenizer (#12659) [cherry-pick release/1.4.0]

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -1104,3 +1104,59 @@ def test_runtime_config_context_length(vllm_processor_module, runtime_config, ex
     mdc = SimpleNamespace(runtime_config=lambda: runtime_config)
 
     assert vllm_processor_module._runtime_config_context_length(mdc) == expected
+
+
+# Regression: MistralTokenizer (--tokenizer-mode mistral) has no chat_template
+# attribute; a direct read used to crash vLLM preprocessing.
+
+
+def _make_mistral_tokenizer():
+    # Bare instance: these tests only touch attribute access, not tokenization.
+    from vllm.tokenizers.mistral import MistralTokenizer
+
+    return MistralTokenizer.__new__(MistralTokenizer)
+
+
+def test_mistral_tokenizer_has_no_chat_template_attribute():
+    """Direct read raises; getattr is safe; the attribute is assignable."""
+    tok = _make_mistral_tokenizer()
+
+    with pytest.raises(AttributeError):
+        _ = tok.chat_template
+
+    assert getattr(tok, "chat_template", None) is None
+    tok.chat_template = "x"
+    assert tok.chat_template == "x"
+
+
+def test_ensure_chat_template_mistral_no_crash(vllm_processor_module, tmp_path):
+    """_ensure_chat_template leaves a MistralTokenizer untouched (no attribute)."""
+    tok = _make_mistral_tokenizer()
+
+    vllm_processor_module._ensure_chat_template(tok, str(tmp_path), None)
+
+    assert not hasattr(tok, "chat_template")
+
+
+def test_ensure_chat_template_mistral_ignores_on_disk_template(
+    vllm_processor_module, tmp_path
+):
+    """A chat_template.jinja beside a Mistral model is not attached to it."""
+    (tmp_path / "chat_template.jinja").write_text("{{ messages }}")
+    tok = _make_mistral_tokenizer()
+
+    vllm_processor_module._ensure_chat_template(tok, str(tmp_path), None)
+
+    assert not hasattr(tok, "chat_template")
+
+
+def test_ensure_chat_template_preserves_existing_hf_template(
+    vllm_processor_module, tokenizer, tmp_path
+):
+    """An HF tokenizer's existing chat_template is left untouched."""
+    existing = tokenizer.chat_template
+    assert existing is not None
+
+    vllm_processor_module._ensure_chat_template(tokenizer, str(tmp_path), None)
+
+    assert tokenizer.chat_template == existing

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -88,6 +88,23 @@ def _runtime_config_context_length(mdc: ModelDeploymentCard) -> int | None:
     return context_length
 
 
+def _ensure_chat_template(
+    tokenizer: Any, local_dir: str, chat_template_flag: str | None
+) -> None:
+    """Set tokenizer.chat_template so vLLM's renderer handles tool calls.
+
+    Skipped for MistralTokenizer (--tokenizer-mode mistral): it has no
+    chat_template attribute and renders via mistral_common, so leave it
+    untouched rather than attach an HF template it never uses.
+    """
+    if not hasattr(tokenizer, "chat_template"):
+        return
+    if tokenizer.chat_template is None:
+        tokenizer.chat_template = resolve_chat_template(local_dir, backend="vllm")
+    if chat_template_flag:
+        tokenizer.chat_template = load_chat_template(chat_template_flag)
+
+
 def _mm_feature_modality(feature: Any) -> str:
     return getattr(feature, "modality", None) or "image"
 
@@ -981,16 +998,9 @@ class EngineFactory:
         input_processor = InputProcessor(vllm_config)
         tokenizer = input_processor.get_tokenizer()
 
-        # vLLM's renderer skips its AutoProcessor fallback when tools are present,
-        # so tool calls crash unless tokenizer.chat_template is set; load from disk.
-        if tokenizer.chat_template is None:
-            tokenizer.chat_template = resolve_chat_template(local_dir, backend="vllm")
-
-        # --chat-template overrides; load_chat_template accepts either a file path
-        # or an inline Jinja template string.
-        chat_template_flag = getattr(self.flags, "chat_template", None)
-        if chat_template_flag:
-            tokenizer.chat_template = load_chat_template(chat_template_flag)
+        _ensure_chat_template(
+            tokenizer, local_dir, getattr(self.flags, "chat_template", None)
+        )
 
         # Resolve stream_interval: env var override > backend config > default (20)
         stream_interval = self.stream_interval


### PR DESCRIPTION
## Overview:

Cherry-pick of #12659 onto `release/1.4.0`.

Fixes an `AttributeError` that prevents Mistral models from registering on the
vLLM chat-processor path (`--dyn-chat-processor vllm --tokenizer-mode mistral`).

## Details:

`EngineFactory.chat_engine_factory` read `tokenizer.chat_template` directly. With
`--tokenizer-mode mistral`, vLLM returns a `MistralTokenizer` (`vllm.tokenizers.mistral`)
which has **no** `chat_template` attribute, so the read raised
`AttributeError: 'MistralTokenizer' object has no attribute 'chat_template'`. The
`chat_engine_factory` callback failed, the model never registered, and every chat
request returned HTTP 404.

The fix extracts a `_ensure_chat_template` helper that **skips** the block entirely
when the tokenizer has no `chat_template` attribute — a `MistralTokenizer` renders via
`mistral_common` and never consults an HF chat template, so it is left untouched.
Regression tests exercise the real `MistralTokenizer`, including a case where a
`chat_template.jinja` sits beside the model.

Cherry-picked cleanly from `2d959b9`; no code changes relative to the merged commit.

## Where should the reviewer start?

- `components/src/dynamo/frontend/vllm_processor.py` — `_ensure_chat_template` helper
  and its call site in `EngineFactory.chat_engine_factory`.
- `components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — regression tests.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — cherry-pick of #12659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12705" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->