### PR TITLE
fix(vllm): declare entry-stage engine_input_source in GLM-Image NIXL config

### DIFF
--- a/examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml
+++ b/examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml
@@ -35,6 +35,10 @@ stage_args:
       distributed_executor_backend: "mp"
       enable_prefix_caching: false
       max_num_batched_tokens: 32768
+    # Entry stage: input comes from the request, not from another stage.
+    # Declared explicitly because the stage_args format applies no schema
+    # defaults, and vLLM-Omni reads this field unconditionally.
+    engine_input_source: []
     # Explicit connector mapping for AR -> DiT
     output_connectors:
       to_stage_1: ar_to_dit_nixl


### PR DESCRIPTION
## Overview:

The GLM-Image AR→DiT NIXL disaggregation launch script
(`examples/backends/vllm/launch/disagg_omni_glm_image_nixl.sh`) cannot start on
vllm-omni v0.26.0rc1. The AR stage exits with code 1 and the frontend never
becomes ready:

    RuntimeError: Orchestrator initialization failed: Missing key
    engine_input_source (full_key: stage_args[0].engine_input_source)

## Summary

Stage 0 of `stage_configs/glm_image_nixl.yaml` is the pipeline's entry stage and
omitted `engine_input_source`. That was valid through v0.25.0rc1, where
vllm-omni defaulted the field to `[]`. Upstream removed the default in
v0.26.0rc1 (`fb4dd41d`, "[Refactor]: Remove unnecessary config getattr" #5199),
so stage metadata extraction now reads it unconditionally. The legacy
`stage_args` config format applies no schema defaults, so the field is simply
absent and the orchestrator thread dies during engine creation.

Stage 1 already declares `engine_input_source: [0]`, which is why only the AR
half crashed. The SHM variant is unaffected because it consumes vllm-omni's own
packaged config in the `stages` format, whose parser supplies the default.

This declares the field explicitly as an empty list — the value upstream itself
supplied until v0.26.0rc1, and the one its deploy parser still produces for an
entry stage (a stage with empty `input_sources`).

## Details:

Fixing the config rather than `_stage_config_to_dict` in `stage_worker.py`:
that file ships in the wheel and is on the path of every omni deployment,
including the SHM path that currently works, whereas this change touches one
example config. Re-adding in Dynamo a default upstream deliberately removed
would also diverge from the engine's contract.

## Where should the reviewer start?

Single file, four added lines:
`examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml`

## Validation

- Reproduced the original failure against a `v0.26.0rc1` checkout, matching the
  reported `ConfigAttributeError` exactly including `full_key` and
  `object_type`; confirmed it no longer raises after this change.
- Verified the field survives Dynamo's whitelist copy into the synthesized
  single-stage config that is handed to `AsyncOmni`.
- `pre-commit run --files examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml` passes.
- **Not yet validated:** end-to-end image generation over NIXL on a two-GPU
  host. This config has no CI lane, and the AR stage previously died before any
  transfer occurred, so the NIXL data path has not executed on this pin.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12709" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the GLM image stage configuration to explicitly define an empty engine input source, improving configuration clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->