### PR TITLE
feat(mocker): report admission cache truth as first-chunk completion_usage

### DIFF
--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -34,6 +34,7 @@ use dynamo_mocker::services::bootstrap::{
     ParticipantRegistration, connect_to_prefill,
 };
 use dynamo_mocker::services::zmq_events::ZmqKvEventSink;
+use dynamo_protocols::types::{CompletionUsage, PromptTokensDetails};
 use dynamo_runtime::DistributedRuntime;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::protocols::annotated::Annotated;
@@ -188,6 +189,29 @@ impl KvCacheEventSink for KvEventSinkAdapter {
         self.0
             .publish_batch_with_storage_tiers(events)
             .map_err(|e| anyhow::anyhow!("Failed to send KV event batch: {}", e))
+    }
+}
+
+/// Cumulative usage snapshot carrying the scheduler's admission cache truth
+/// in `prompt_tokens_details.cached_tokens`.
+fn usage_with_cached_tokens(
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    cached_tokens: usize,
+) -> CompletionUsage {
+    // Saturate rather than panic on pathological token counts.
+    fn to_u32(value: usize) -> u32 {
+        value.try_into().unwrap_or(u32::MAX)
+    }
+    CompletionUsage {
+        prompt_tokens: to_u32(prompt_tokens),
+        completion_tokens: to_u32(completion_tokens),
+        total_tokens: to_u32(prompt_tokens.saturating_add(completion_tokens)),
+        prompt_tokens_details: Some(PromptTokensDetails {
+            audio_tokens: None,
+            cached_tokens: Some(to_u32(cached_tokens)),
+        }),
+        completion_tokens_details: None,
     }
 }
 
@@ -845,6 +869,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             .request_timing(&request.model, dp_rank, is_prefill, request_start)
             .await;
 
+        let prompt_tokens_count = request.token_ids.len();
         // Convert PreprocessedRequest to DirectRequest for scheduler
         let direct_request = DirectRequest {
             tokens: request.token_ids.clone(),
@@ -1004,6 +1029,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // Spawn a task to handle the complex async logic
         let response_task = async move {
             let mut token_count = 0;
+            let mut cached_prefix_tokens: Option<usize> = None;
             let mut source_completion_rx = source_completion_rx;
             let mut source_handoff_complete = source_completion_rx.is_none();
             let mut destination_error_rx = destination_error_rx;
@@ -1092,6 +1118,10 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                             break;
                         }
 
+                        if let Some(cached) = signal.cached_tokens {
+                            cached_prefix_tokens = Some(cached);
+                        }
+
                         // Generate a token (with thinking boundaries if configured)
                         let token_id = if has_planned_output_tokens {
                             signal.token_id.unwrap_or_else(generate_random_token)
@@ -1104,9 +1134,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                         };
                         token_count += 1;
 
+                        // The first chunk carries the admission cache truth; the
+                        // final chunk repeats cumulative totals (OpenAI convention).
                         let output = LLMEngineOutput {
                             token_ids: vec![token_id],
                             disaggregated_params: is_prefill.then(|| serde_json::json!("dummy")),
+                            completion_usage: signal.cached_tokens.map(|cached| {
+                                usage_with_cached_tokens(prompt_tokens_count, token_count, cached)
+                            }),
                             ..Default::default()
                         };
 
@@ -1186,13 +1221,15 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
                                 }
                             }
 
-                            if !send_response(
-                                &stream_tx,
-                                LLMEngineOutput::length(),
-                                &async_context,
-                            )
-                            .await
-                            {
+                            let mut final_output = LLMEngineOutput::length();
+                            if let Some(cached) = cached_prefix_tokens {
+                                final_output.completion_usage = Some(usage_with_cached_tokens(
+                                    prompt_tokens_count,
+                                    token_count,
+                                    cached,
+                                ));
+                            }
+                            if !send_response(&stream_tx, final_output, &async_context).await {
                                 break;
                             }
                             native_timing.record_normal_completion();
@@ -1381,10 +1418,9 @@ mod tests {
         let token = stream.next().await.unwrap().data.unwrap();
         assert_eq!(token.token_ids.len(), 1);
         assert!(token.finish_reason.is_none());
-        assert_eq!(
-            stream.next().await.unwrap().data.unwrap(),
-            LLMEngineOutput::length()
-        );
+        let mut expected_finish = LLMEngineOutput::length();
+        expected_finish.completion_usage = Some(usage_with_cached_tokens(3, 1, 0));
+        assert_eq!(stream.next().await.unwrap().data.unwrap(), expected_finish);
         assert!(stream.next().await.is_none());
     }
 

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -1418,6 +1418,19 @@ mod tests {
         let token = stream.next().await.unwrap().data.unwrap();
         assert_eq!(token.token_ids.len(), 1);
         assert!(token.finish_reason.is_none());
+        assert_eq!(
+            token.completion_usage,
+            Some(CompletionUsage {
+                prompt_tokens: 3,
+                completion_tokens: 1,
+                total_tokens: 4,
+                prompt_tokens_details: Some(PromptTokensDetails {
+                    audio_tokens: None,
+                    cached_tokens: Some(0),
+                }),
+                completion_tokens_details: None,
+            })
+        );
         let mut expected_finish = LLMEngineOutput::length();
         expected_finish.completion_usage = Some(usage_with_cached_tokens(3, 1, 0));
         assert_eq!(stream.next().await.unwrap().data.unwrap(), expected_finish);

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -350,6 +350,10 @@ pub struct OutputSignal {
     pub rejected: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub handoff_delay_ms: Option<f64>,
+    /// Prompt tokens served from KV cache at admission (scheduler truth,
+    /// post-eviction). Set once, on the request's first output signal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cached_tokens: Option<usize>,
 }
 
 /// Preemption policy for evicting decode requests under memory pressure

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -1766,6 +1766,7 @@ mod tests {
                     token_id: Some(10),
                     completed: false,
                     rejected: false,
+                    cached_tokens: None,
                     handoff_delay_ms: None,
                 },
                 OutputSignal {
@@ -1773,6 +1774,7 @@ mod tests {
                     token_id: Some(11),
                     completed: false,
                     rejected: false,
+                    cached_tokens: None,
                     handoff_delay_ms: None,
                 },
                 OutputSignal {
@@ -1780,6 +1782,7 @@ mod tests {
                     token_id: Some(12),
                     completed: true,
                     rejected: true,
+                    cached_tokens: None,
                     handoff_delay_ms: None,
                 },
                 OutputSignal {
@@ -1787,6 +1790,7 @@ mod tests {
                     token_id: Some(20),
                     completed: true,
                     rejected: false,
+                    cached_tokens: None,
                     handoff_delay_ms: None,
                 },
             ],

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -102,6 +102,7 @@ mod tests {
                 token_id: Some(1),
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             }],
             admissions: vec![AdmissionEvent {

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -294,6 +294,7 @@ mod tests {
                 token_id: None,
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             }],
             lifecycle_events: Vec::new(),

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -127,6 +127,7 @@ fn pass() -> EnginePassResult {
             token_id: Some(1),
             completed: true,
             rejected: false,
+            cached_tokens: None,
             handoff_delay_ms: None,
         }],
         admissions: vec![AdmissionEvent {
@@ -258,6 +259,7 @@ fn output_suppression_repairs_stale_accept_length_counters() {
             token_id: Some(2),
             completed: false,
             rejected: false,
+            cached_tokens: None,
             handoff_delay_ms: None,
         },
         OutputSignal {
@@ -265,6 +267,7 @@ fn output_suppression_repairs_stale_accept_length_counters() {
             token_id: Some(3),
             completed: true,
             rejected: false,
+            cached_tokens: None,
             handoff_delay_ms: None,
         },
         OutputSignal {
@@ -272,6 +275,7 @@ fn output_suppression_repairs_stale_accept_length_counters() {
             token_id: Some(4),
             completed: true,
             rejected: true,
+            cached_tokens: None,
             handoff_delay_ms: None,
         },
     ]);

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -126,6 +126,7 @@ fn pass() -> EnginePassResult {
             token_id: Some(1),
             completed: true,
             rejected: false,
+            cached_tokens: None,
             handoff_delay_ms: None,
         }],
         admissions: vec![AdmissionEvent {

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -692,6 +692,7 @@ mod tests {
                 token_id: None,
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -699,6 +700,7 @@ mod tests {
                 token_id: Some(7),
                 completed: false,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -706,6 +708,7 @@ mod tests {
                 token_id: Some(8),
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -713,6 +716,7 @@ mod tests {
                 token_id: Some(9),
                 completed: true,
                 rejected: true,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
         ];

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -686,6 +686,7 @@ mod tests {
                 token_id: None,
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -693,6 +694,7 @@ mod tests {
                 token_id: Some(7),
                 completed: false,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -700,6 +702,7 @@ mod tests {
                 token_id: Some(8),
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
             OutputSignal {
@@ -707,6 +710,7 @@ mod tests {
                 token_id: Some(9),
                 completed: true,
                 rejected: true,
+                cached_tokens: None,
                 handoff_delay_ms: None,
             },
         ];

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -241,6 +241,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 token_id: None,
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: compute_prefill_handoff_delay_ms(
                     config.worker_type,
                     true,
@@ -354,6 +355,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 token_id: Some(token_id),
                 completed: is_complete,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: compute_prefill_handoff_delay_ms(
                     config.worker_type,
                     is_complete,

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -239,6 +239,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 token_id: None,
                 completed: true,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: compute_prefill_handoff_delay_ms(
                     config.worker_type,
                     true,
@@ -348,6 +349,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 token_id: Some(token_id),
                 completed: is_complete,
                 rejected: false,
+                cached_tokens: None,
                 handoff_delay_ms: compute_prefill_handoff_delay_ms(
                     config.worker_type,
                     is_complete,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -53,9 +53,25 @@ pub(crate) struct VllmRequestState {
     pub(crate) num_computed_tokens: usize,
     pub(crate) num_preemptions: usize,
     pub(crate) offload_dependency: Option<OffloadDependency>,
+    /// Prefix tokens found cached at first admission (set once: a preempted
+    /// request re-probes against a cache warmed by its own blocks, which
+    /// would inflate the value).
+    pub(crate) cached_prefix_tokens: Option<usize>,
+    /// Whether the admission cache truth was already attached to a signal.
+    pub(crate) cached_tokens_signaled: bool,
 }
 
 impl VllmRequestState {
+    /// Admission cache truth rides the request's first signal only.
+    fn take_cached_tokens_for_signal(&mut self) -> Option<usize> {
+        if self.cached_tokens_signaled {
+            None
+        } else {
+            self.cached_tokens_signaled = true;
+            self.cached_prefix_tokens
+        }
+    }
+
     fn prompt_is_prebuilt(&self) -> bool {
         self.num_computed_tokens >= self.sequence.num_input_tokens()
             && self.sequence.num_allocated_tokens() >= self.sequence.num_input_tokens()
@@ -939,6 +955,8 @@ impl VllmCore {
             num_computed_tokens: 0,
             num_preemptions: 0,
             offload_dependency: None,
+            cached_prefix_tokens: None,
+            cached_tokens_signaled: false,
         }
     }
 
@@ -1621,6 +1639,7 @@ impl VllmCore {
                 completed: true,
                 rejected: true,
                 handoff_delay_ms: None,
+                cached_tokens: None,
             });
         }
         #[cfg(debug_assertions)]
@@ -2159,6 +2178,12 @@ impl VllmCore {
         *token_budget = token_budget.saturating_sub(tokens_used);
 
         let admission = if from_waiting {
+            self.state
+                .requests
+                .get_mut(&uuid)
+                .unwrap_or_else(|| panic!("schedule_request: {uuid} removed mid-pass (admission)"))
+                .cached_prefix_tokens
+                .get_or_insert(cached_prefix_tokens);
             Some(AdmissionEvent {
                 uuid,
                 reused_input_tokens: cached_prefix_tokens,
@@ -2207,6 +2232,12 @@ impl VllmCore {
         // without manufacturing an output token.
         let mut output_signals = Vec::with_capacity(already_complete.len() + ready.len());
         for (uuid, handoff_delay_ms, cleanup) in already_complete {
+            // The request's only signal; read before complete_source drops the state.
+            let cached_tokens = self
+                .state
+                .requests
+                .get_mut(&uuid)
+                .and_then(VllmRequestState::take_cached_tokens_for_signal);
             self.complete_source(uuid, cleanup);
             output_signals.push(OutputSignal {
                 uuid,
@@ -2214,6 +2245,7 @@ impl VllmCore {
                 completed: true,
                 rejected: false,
                 handoff_delay_ms,
+                cached_tokens,
             });
         }
 
@@ -2343,22 +2375,30 @@ impl VllmCore {
                 continue;
             }
 
-            let handoff_delay_ms = self.state.requests.get(&uuid).and_then(|request| {
-                request.debug_assert_progress(uuid);
-                compute_prefill_handoff_delay_ms(
-                    self.args.worker_type,
-                    completed,
-                    request.sequence.num_input_tokens(),
-                    self.args.kv_transfer_bandwidth,
-                    self.args.kv_bytes_per_token,
-                )
-            });
+            let worker_type = self.args.worker_type;
+            let kv_transfer_bandwidth = self.args.kv_transfer_bandwidth;
+            let kv_bytes_per_token = self.args.kv_bytes_per_token;
+            let (handoff_delay_ms, cached_tokens) = match self.state.requests.get_mut(&uuid) {
+                Some(request) => {
+                    request.debug_assert_progress(uuid);
+                    let handoff_delay_ms = compute_prefill_handoff_delay_ms(
+                        worker_type,
+                        completed,
+                        request.sequence.num_input_tokens(),
+                        kv_transfer_bandwidth,
+                        kv_bytes_per_token,
+                    );
+                    (handoff_delay_ms, request.take_cached_tokens_for_signal())
+                }
+                None => (None, None),
+            };
             let output_signal = OutputSignal {
                 uuid,
                 token_id: emitted_token_id,
                 completed,
                 rejected: false,
                 handoff_delay_ms,
+                cached_tokens,
             };
             if completed {
                 self.complete_source(uuid, deferred_deref);
@@ -2578,7 +2618,7 @@ impl VllmCore {
                     );
                 }
 
-                let prompt_tokens = {
+                let (prompt_tokens, cached_tokens) = {
                     let request = self
                         .state
                         .requests
@@ -2587,13 +2627,15 @@ impl VllmCore {
                     if !is_complete && let RequestKvState::Kvbm(sequence) = &mut request.sequence {
                         sequence.commit_allocation(sequence.len());
                     }
-                    request.sequence.num_input_tokens()
+                    let cached_tokens = request.take_cached_tokens_for_signal();
+                    (request.sequence.num_input_tokens(), cached_tokens)
                 };
                 output_signals.push(OutputSignal {
                     uuid,
                     token_id: Some(token_id),
                     completed: is_complete,
                     rejected: false,
+                    cached_tokens,
                     handoff_delay_ms: compute_prefill_handoff_delay_ms(
                         self.args.worker_type,
                         is_complete,

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -52,9 +52,25 @@ pub(crate) struct VllmRequestState {
     pub(crate) num_computed_tokens: usize,
     pub(crate) num_preemptions: usize,
     pub(crate) offload_dependency: Option<OffloadDependency>,
+    /// Prefix tokens found cached at first admission (set once: a preempted
+    /// request re-probes against a cache warmed by its own blocks, which
+    /// would inflate the value).
+    pub(crate) cached_prefix_tokens: Option<usize>,
+    /// Whether the admission cache truth was already attached to a signal.
+    pub(crate) cached_tokens_signaled: bool,
 }
 
 impl VllmRequestState {
+    /// Admission cache truth rides the request's first signal only.
+    fn take_cached_tokens_for_signal(&mut self) -> Option<usize> {
+        if self.cached_tokens_signaled {
+            None
+        } else {
+            self.cached_tokens_signaled = true;
+            self.cached_prefix_tokens
+        }
+    }
+
     fn prompt_is_prebuilt(&self) -> bool {
         self.num_computed_tokens >= self.sequence.num_input_tokens()
             && self.sequence.num_allocated_tokens() >= self.sequence.num_input_tokens()
@@ -938,6 +954,8 @@ impl VllmCore {
             num_computed_tokens: 0,
             num_preemptions: 0,
             offload_dependency: None,
+            cached_prefix_tokens: None,
+            cached_tokens_signaled: false,
         }
     }
 
@@ -1644,6 +1662,7 @@ impl VllmCore {
                 completed: true,
                 rejected: true,
                 handoff_delay_ms: None,
+                cached_tokens: None,
             });
         }
         #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
@@ -2177,6 +2196,12 @@ impl VllmCore {
         *token_budget = token_budget.saturating_sub(tokens_used);
 
         let admission = if from_waiting {
+            self.state
+                .requests
+                .get_mut(&uuid)
+                .unwrap_or_else(|| panic!("schedule_request: {uuid} removed mid-pass (admission)"))
+                .cached_prefix_tokens
+                .get_or_insert(cached_prefix_tokens);
             Some(AdmissionEvent {
                 uuid,
                 reused_input_tokens: cached_prefix_tokens,
@@ -2227,6 +2252,12 @@ impl VllmCore {
         // without manufacturing an output token.
         let mut output_signals = Vec::with_capacity(already_complete.len() + ready.len());
         for (uuid, handoff_delay_ms, cleanup) in already_complete {
+            // The request's only signal; read before complete_source drops the state.
+            let cached_tokens = self
+                .state
+                .requests
+                .get_mut(&uuid)
+                .and_then(VllmRequestState::take_cached_tokens_for_signal);
             self.complete_source(uuid, cleanup);
             output_signals.push(OutputSignal {
                 uuid,
@@ -2234,6 +2265,7 @@ impl VllmCore {
                 completed: true,
                 rejected: false,
                 handoff_delay_ms,
+                cached_tokens,
             });
         }
 
@@ -2359,22 +2391,30 @@ impl VllmCore {
                 continue;
             }
 
-            let handoff_delay_ms = self.state.requests.get(&uuid).and_then(|request| {
-                request.debug_assert_progress(uuid);
-                compute_prefill_handoff_delay_ms(
-                    self.args.worker_type,
-                    completed,
-                    request.sequence.num_input_tokens(),
-                    self.args.kv_transfer_bandwidth,
-                    self.args.kv_bytes_per_token,
-                )
-            });
+            let worker_type = self.args.worker_type;
+            let kv_transfer_bandwidth = self.args.kv_transfer_bandwidth;
+            let kv_bytes_per_token = self.args.kv_bytes_per_token;
+            let (handoff_delay_ms, cached_tokens) = match self.state.requests.get_mut(&uuid) {
+                Some(request) => {
+                    request.debug_assert_progress(uuid);
+                    let handoff_delay_ms = compute_prefill_handoff_delay_ms(
+                        worker_type,
+                        completed,
+                        request.sequence.num_input_tokens(),
+                        kv_transfer_bandwidth,
+                        kv_bytes_per_token,
+                    );
+                    (handoff_delay_ms, request.take_cached_tokens_for_signal())
+                }
+                None => (None, None),
+            };
             let output_signal = OutputSignal {
                 uuid,
                 token_id: emitted_token_id,
                 completed,
                 rejected: false,
                 handoff_delay_ms,
+                cached_tokens,
             };
             if completed {
                 self.complete_source(uuid, deferred_deref);
@@ -2597,7 +2637,7 @@ impl VllmCore {
                     );
                 }
 
-                let prompt_tokens = {
+                let (prompt_tokens, cached_tokens) = {
                     let request = self
                         .state
                         .requests
@@ -2606,13 +2646,15 @@ impl VllmCore {
                     if !is_complete && let RequestKvState::Kvbm(sequence) = &mut request.sequence {
                         sequence.commit_allocation(sequence.len());
                     }
-                    request.sequence.num_input_tokens()
+                    let cached_tokens = request.take_cached_tokens_for_signal();
+                    (request.sequence.num_input_tokens(), cached_tokens)
                 };
                 output_signals.push(OutputSignal {
                     uuid,
                     token_id: Some(token_id),
                     completed: is_complete,
                     rejected: false,
+                    cached_tokens,
                     handoff_delay_ms: compute_prefill_handoff_delay_ms(
                         self.args.worker_type,
                         is_complete,

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1620,6 +1620,8 @@ mod core_behavior {
                 num_computed_tokens: 9,
                 num_preemptions: 1,
                 offload_dependency: None,
+                cached_prefix_tokens: None,
+                cached_tokens_signaled: false,
             },
         );
 
@@ -3147,6 +3149,8 @@ mod offload {
                 num_computed_tokens,
                 num_preemptions: 0,
                 offload_dependency: None,
+                cached_prefix_tokens: None,
+                cached_tokens_signaled: false,
             },
         );
     }
@@ -4464,4 +4468,80 @@ mod offload {
         assert!(core.destination_is_held(handoff_id));
         assert_eq!(core.destination_block_count(handoff_id), 2);
     }
+}
+
+#[test]
+fn test_first_signal_carries_admission_cache_truth() {
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Vllm)
+        .block_size(4)
+        .num_gpu_blocks(16)
+        .max_num_batched_tokens(Some(16))
+        .max_num_seqs(Some(3))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(true)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    // 9 tokens = two full blocks (cacheable) + one partial.
+    let tokens: Vec<u32> = (0..9).collect();
+
+    fn drive_to_completion(core: &mut VllmCore, uuid: Uuid) -> Vec<OutputSignal> {
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut signals = Vec::new();
+        for step in 0..100 {
+            let pass = core.execute_pass(&mut collector, step as f64);
+            signals.extend(
+                pass.output_signals
+                    .iter()
+                    .filter(|signal| signal.uuid == uuid)
+                    .cloned(),
+            );
+            if signals.iter().any(|signal| signal.completed) {
+                return signals;
+            }
+        }
+        panic!("request {uuid} never completed");
+    }
+
+    let cold = Uuid::from_u128(90);
+    core.receive(DirectRequest {
+        tokens: tokens.clone(),
+        max_output_tokens: 3,
+        uuid: Some(cold),
+        ..Default::default()
+    });
+    let cold_signals = drive_to_completion(&mut core, cold);
+    assert_eq!(
+        cold_signals[0].cached_tokens,
+        Some(0),
+        "cold request must report zero admission cache hits"
+    );
+    assert!(
+        cold_signals[1..]
+            .iter()
+            .all(|signal| signal.cached_tokens.is_none()),
+        "cache truth must ride the first signal only"
+    );
+
+    let warm = Uuid::from_u128(91);
+    core.receive(DirectRequest {
+        tokens: tokens.clone(),
+        max_output_tokens: 3,
+        uuid: Some(warm),
+        ..Default::default()
+    });
+    let warm_signals = drive_to_completion(&mut core, warm);
+    assert_eq!(
+        warm_signals[0].cached_tokens,
+        Some(8),
+        "repeat of the same prompt must report its two full blocks as admission cache hits"
+    );
+    assert!(
+        warm_signals[1..]
+            .iter()
+            .all(|signal| signal.cached_tokens.is_none()),
+        "cache truth must ride the first signal only"
+    );
 }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1620,6 +1620,8 @@ mod core_behavior {
                 num_computed_tokens: 9,
                 num_preemptions: 1,
                 offload_dependency: None,
+                cached_prefix_tokens: None,
+                cached_tokens_signaled: false,
             },
         );
 
@@ -3147,6 +3149,8 @@ mod offload {
                 num_computed_tokens,
                 num_preemptions: 0,
                 offload_dependency: None,
+                cached_prefix_tokens: None,
+                cached_tokens_signaled: false,
             },
         );
     }
@@ -4470,4 +4474,80 @@ mod offload {
         assert!(core.destination_is_held(handoff_id));
         assert_eq!(core.destination_block_count(handoff_id), 2);
     }
+}
+
+#[test]
+fn test_first_signal_carries_admission_cache_truth() {
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Vllm)
+        .block_size(4)
+        .num_gpu_blocks(16)
+        .max_num_batched_tokens(Some(16))
+        .max_num_seqs(Some(3))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(true)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    // 9 tokens = two full blocks (cacheable) + one partial.
+    let tokens: Vec<u32> = (0..9).collect();
+
+    fn drive_to_completion(core: &mut VllmCore, uuid: Uuid) -> Vec<OutputSignal> {
+        let mut collector = crate::replay::TraceCollector::default();
+        let mut signals = Vec::new();
+        for step in 0..100 {
+            let pass = core.execute_pass(&mut collector, step as f64);
+            signals.extend(
+                pass.output_signals
+                    .iter()
+                    .filter(|signal| signal.uuid == uuid)
+                    .cloned(),
+            );
+            if signals.iter().any(|signal| signal.completed) {
+                return signals;
+            }
+        }
+        panic!("request {uuid} never completed");
+    }
+
+    let cold = Uuid::from_u128(90);
+    core.receive(DirectRequest {
+        tokens: tokens.clone(),
+        max_output_tokens: 3,
+        uuid: Some(cold),
+        ..Default::default()
+    });
+    let cold_signals = drive_to_completion(&mut core, cold);
+    assert_eq!(
+        cold_signals[0].cached_tokens,
+        Some(0),
+        "cold request must report zero admission cache hits"
+    );
+    assert!(
+        cold_signals[1..]
+            .iter()
+            .all(|signal| signal.cached_tokens.is_none()),
+        "cache truth must ride the first signal only"
+    );
+
+    let warm = Uuid::from_u128(91);
+    core.receive(DirectRequest {
+        tokens: tokens.clone(),
+        max_output_tokens: 3,
+        uuid: Some(warm),
+        ..Default::default()
+    });
+    let warm_signals = drive_to_completion(&mut core, warm);
+    assert_eq!(
+        warm_signals[0].cached_tokens,
+        Some(8),
+        "repeat of the same prompt must report its two full blocks as admission cache hits"
+    );
+    assert!(
+        warm_signals[1..]
+            .iter()
+            .all(|signal| signal.cached_tokens.is_none()),
+        "cache truth must ride the first signal only"
+    );
 }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -287,6 +287,7 @@ fn zero_output_request_completes_after_prefill(#[case] engine_type: EngineType) 
             token_id: None,
             completed: true,
             rejected: false,
+            cached_tokens: Some(0),
             ..
         }] if *signal_uuid == uuid
     ));
@@ -327,6 +328,7 @@ fn fully_cached_zero_output_request_is_not_decode_fpm_work() {
             token_id: None,
             completed: true,
             rejected: false,
+            cached_tokens: Some(4),
             ..
         }] if *signal_uuid == uuid
     ));
@@ -1125,18 +1127,27 @@ mod core_behavior {
         });
 
         let mut collector = crate::replay::TraceCollector::default();
-        let mut emitted = Vec::new();
+        let mut signals = Vec::new();
         for step in 0..planned.len() {
             let pass = core.execute_pass(&mut collector, step as f64);
-            emitted.extend(
+            signals.extend(
                 pass.output_signals
                     .into_iter()
-                    .filter(|signal| signal.uuid == uuid)
-                    .map(|signal| signal.token_id.expect("planned token should be present")),
+                    .filter(|signal| signal.uuid == uuid),
             );
         }
 
+        let emitted: Vec<_> = signals
+            .iter()
+            .map(|signal| signal.token_id.expect("planned token should be present"))
+            .collect();
         assert_eq!(emitted, planned);
+        assert_eq!(signals[0].cached_tokens, Some(0));
+        assert!(
+            signals[1..]
+                .iter()
+                .all(|signal| signal.cached_tokens.is_none())
+        );
         assert!(core.is_empty());
     }
 
@@ -4549,5 +4560,100 @@ fn test_first_signal_carries_admission_cache_truth() {
             .iter()
             .all(|signal| signal.cached_tokens.is_none()),
         "cache truth must ride the first signal only"
+    );
+}
+
+#[test]
+fn test_preempted_request_keeps_original_admission_cache_truth() {
+    let args = MockEngineArgs::builder()
+        .engine_type(EngineType::Vllm)
+        .block_size(4)
+        .num_gpu_blocks(6)
+        .max_num_batched_tokens(Some(16))
+        .max_num_seqs(Some(2))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(true)
+        .preemption_mode(PreemptionMode::Lifo)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+    let mut core = VllmCore::new(args);
+    let mut collector = crate::replay::TraceCollector::default();
+    let mut now_ms = 0.0;
+
+    // Warm one block so the victim's first admission sees a genuine hit.
+    let warm = Uuid::from_u128(70);
+    core.receive(DirectRequest {
+        tokens: (0..4).collect(),
+        max_output_tokens: 1,
+        uuid: Some(warm),
+        ..Default::default()
+    });
+    for _ in 0..8 {
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        if core.state.requests.is_empty() {
+            break;
+        }
+    }
+    assert!(
+        core.state.requests.is_empty(),
+        "warm request never completed"
+    );
+
+    // The filler is admitted first; the victim (warm prefix + unique tail) is
+    // newest, so Lifo preempts it under KV pressure before its first output.
+    let filler = Uuid::from_u128(71);
+    let victim = Uuid::from_u128(72);
+    core.receive(DirectRequest {
+        tokens: (100..108).collect(),
+        max_output_tokens: 8,
+        uuid: Some(filler),
+        ..Default::default()
+    });
+    core.receive(DirectRequest {
+        tokens: (0..4).chain(200..212).collect(),
+        max_output_tokens: 4,
+        uuid: Some(victim),
+        ..Default::default()
+    });
+
+    let mut victim_signals = Vec::new();
+    let mut preempted = false;
+    for _ in 0..64 {
+        let pass = core.execute_pass(&mut collector, now_ms);
+        now_ms = pass.end_ms.max(now_ms + 1.0);
+        victim_signals.extend(
+            pass.output_signals
+                .iter()
+                .filter(|signal| signal.uuid == victim)
+                .cloned(),
+        );
+        if !preempted && pass.mocker_metrics.vllm_preemptions_total > 0 {
+            preempted = true;
+            assert!(
+                victim_signals.is_empty(),
+                "victim must be preempted before its first output"
+            );
+            assert_eq!(core.state.requests.get(&victim).unwrap().num_preemptions, 1);
+        }
+        if victim_signals.iter().any(|signal| signal.completed) {
+            break;
+        }
+    }
+    assert!(preempted, "victim was never preempted");
+    assert!(
+        victim_signals.iter().any(|signal| signal.completed),
+        "victim never completed after readmission"
+    );
+    assert_eq!(
+        victim_signals[0].cached_tokens,
+        Some(4),
+        "first signal must retain the original admission count, not a post-preemption re-probe"
+    );
+    assert!(
+        victim_signals[1..]
+            .iter()
+            .all(|signal| signal.cached_tokens.is_none())
     );
 }


### PR DESCRIPTION
## Overview:

The vLLM-mode mocker scheduler computes each request's admission-time cached-prefix tokens (`PrefillCost.cached_tokens` — post-eviction truth) but never reports it: every mocker stream chunk carries `completion_usage: None`. Downstream, every cache-hit surface — including the frontend's cached-tokens usage histogram — therefore falls back to the KV router's radix **estimate**. The estimate structurally over-credits after eviction (the radix tree cannot see blocks the scheduler dropped), and with no engine-side measurement the estimator's error is unobservable — measured and estimated cache-hit metrics are the same number by construction.

This PR carries the scheduler's truth out on the stream, so anyone simulating fleets with the mocker (router-heuristic scoring, capacity studies) can compare the router's overlap estimate against what the scheduler actually reused, per request.

## Details:

- `OutputSignal` gains `cached_tokens: Option<usize>` (`serde` default + skip-if-none, so serialized replay artifacts stay compatible). The scheduler sets it **once, on the request's first output signal** — including the terminal-without-token signal for requests that are already complete after prefill, which is their only signal.
- The value is captured in `schedule_request` alongside the existing `AdmissionEvent.reused_input_tokens` — one canonical computation, so the signal and the admission event can never disagree (including the disagg prebuilt-prompt case, where both report 0 rather than claiming a KV-handoff arrival as a cache hit). Set-once semantics: a preempted request re-probes against a cache warmed by its own blocks, which would inflate the truth. `VllmRequestState::take_cached_tokens_for_signal` guards all emission paths (both token paths and the terminal-after-prefill signal, which is such a request's only one); the reject path reports `None` (the request never ran).
- `lib/llm/src/mocker.rs` relays it as `LLMEngineOutput.completion_usage.prompt_tokens_details.cached_tokens` on the **first chunk** and repeats cumulative totals on the **final chunk** (OpenAI streaming convention — the frontend propagation path is already covered by `test_streaming_usage.rs`).
- sglang mode reports `None` explicitly: it tracks cache hits only in aggregate.

New test: `scheduler::vllm::tests::test_first_signal_carries_admission_cache_truth` — a cold request reports `Some(0)`, an identical repeat reports its two full blocks (`Some(8)` at block_size 4), and the truth rides the first signal only. Full `dynamo-mocker` suite passes (711 tests); `cargo fmt`/`clippy` clean.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/vllm/core.rs` — the set-once capture after `AdmissionDecision::Admit`, and the first-signal attach in the two emission paths.
- `lib/llm/src/mocker.rs` — the stream-side relay (first + final chunk).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

cc @PeaBrane @jthomson04 — mocker area; suggested by our team as the right reviewers.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cache-usage reporting to streaming completion responses.
  * First output now includes tokens served from the prompt cache when available.
  * Final responses include cumulative prompt and completion token totals.

* **Bug Fixes**
  * Cache metadata is reported only once and remains accurate across request interruptions.
  * Token counts safely handle values exceeding supported limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
