### PR TITLE
fix(operator): run Dynamo + Grove operators HA to stop webhook-flap CI failures

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -32,7 +32,18 @@ metadata:
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
   strategy:
+    {{- if gt (int .Values.controllerManager.replicas) 1 }}
+    # With >1 replica, roll one pod at a time and never drop below the desired
+    # count so the admission webhook always has a serving endpoint during updates.
+    # Leader election (see operator-config.yaml) keeps only one active manager;
+    # the webhook is stateless, so multiple serving replicas do not conflict.
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+    {{- else }}
     type: Recreate
+    {{- end }}
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/deploy/helm/charts/platform/components/operator/templates/poddisruptionbudget.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/poddisruptionbudget.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Keep at least one operator pod (and therefore one serving admission-webhook
+# endpoint) available during voluntary disruptions such as node drains and
+# upgrades. Only rendered when running >1 replica; with a single replica a
+# minAvailable:1 budget would block node drains entirely.
+{{- if gt (int .Values.controllerManager.replicas) 1 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "dynamo-operator.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: manager
+    {{- include "dynamo-operator.labels" . | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      {{- include "dynamo-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -92,7 +92,13 @@ controllerManager:
       requests:
         cpu: 512m
         memory: 1Gi
-  replicas: 1
+  # Run 2 replicas so a single pod restart/reschedule never leaves the admission
+  # webhook without a serving endpoint (the cause of intermittent
+  # "dial tcp ...:443: connect: connection refused" DGD-admission failures).
+  # Safe with >1 replica: leader election elects one active manager; the webhook
+  # is stateless and served by all replicas. Paired with a PodDisruptionBudget
+  # (poddisruptionbudget.yaml) and a RollingUpdate strategy (deployment.yaml).
+  replicas: 2
   serviceAccount:
     annotations: {}
 

--- a/deploy/helm/charts/platform/templates/grove-poddisruptionbudget.yaml
+++ b/deploy/helm/charts/platform/templates/grove-poddisruptionbudget.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The upstream Grove chart ships no PodDisruptionBudget, so define one here to
+# keep at least one grove-operator pod (and its PodCliqueSet admission webhook)
+# available during voluntary disruptions. Only rendered when Grove is installed
+# and running >1 replica (see the `grove:` block in values.yaml).
+{{- $grove := .Values.grove | default dict }}
+{{- $groveInstalled := and .Values.global .Values.global.grove (or .Values.global.grove.install .Values.global.grove.enabled) }}
+{{- if and $groveInstalled (gt (int ($grove.replicaCount | default 1)) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: grove-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: grove-operator
+    app.kubernetes.io/part-of: dynamo-platform
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grove-operator
+{{- end }}

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -282,6 +282,12 @@ dynamo-operator:
 # Grove component - distributed inference orchestration
 # Installation is controlled by global.grove.install above.
 grove:
+  # -- Run 2 Grove operator replicas so a single pod restart (e.g. the expected
+  # cert-resync restart, grove issue #701) never leaves the PodCliqueSet webhook
+  # without a serving endpoint. Grove enables leader election by default, so only
+  # one replica reconciles; the webhook is stateless and served by all replicas.
+  # Paired with a PodDisruptionBudget (templates/grove-poddisruptionbudget.yaml).
+  replicaCount: 2
   # -- Node tolerations for Grove pods
   tolerations: []
   # -- Affinity for Grove pods


### PR DESCRIPTION
## Problem

Deploy jobs (`deploy-test-*`, `DynamoCheckpoint Deploy`, etc.) intermittently fail at `DynamoGraphDeployment` admission with:

```
Internal error occurred: failed calling webhook "mdynamographdeployment.kb.io":
Post "https://dynamo-platform-dynamo-operator-webhook-service.default.svc:443/mutate-...":
dial tcp <ip>:443: connect: connection refused
```

or the equivalent on the Grove operator:

```
failed calling webhook "pcs.defaulting.webhooks.grove.io":
Post "https://grove-operator.default.svc:9443/...": dial tcp <ip>:9443: connect: connection refused
```

## Root cause

Both operators run a **single replica** with a **fail-closed** (`failurePolicy: Fail`) admission webhook. When that one pod's webhook is momentarily unavailable — the expected cert-resync restart (Grove [issue #701](https://github.com/ai-dynamo/grove/issues/701)), a node/reschedule event, an OOM, or a transient not-ready — the webhook Service's EndpointSlice drops its only endpoint, so the API server gets `connection refused` and the fail-closed webhook rejects the admission. Prior work reduced *some* triggers (#12255 readiness gating, #12279 vCluster version alignment), but with one replica any brief blip is still a full outage window.

## Fix

Run both operators with **2 replicas + a PodDisruptionBudget (`minAvailable: 1`)** so a single pod restart never leaves the webhook without a serving endpoint.

- **Dynamo operator**: `controllerManager.replicas` 1 → 2; switch `Recreate` → `RollingUpdate` (`maxUnavailable: 0`, `maxSurge: 1`) so upgrades also keep a serving endpoint; new `PodDisruptionBudget`.
- **Grove operator**: `grove.replicaCount` 1 → 2 (upstream subchart override); new `PodDisruptionBudget` in the parent chart (Grove ships none).

**Safe with >1 replica** — both operators enable leader election (Dynamo: `operator-config.yaml` `leaderElection.enabled: true`; Grove: chart default `leaderElection.enabled: true`), so exactly one replica reconciles while the **stateless** webhook is served by all replicas.

Both PDBs and the `RollingUpdate` switch are **gated on `replicas > 1`**, so single-replica installs are unchanged (still `Recreate`, no PDB — avoids blocking node drains).

## Validation

- `helm template` — both PDBs render, Dynamo `replicas: 2` + `RollingUpdate`, Grove `replicas: 2`; single-replica path degrades cleanly (0 PDBs, `Recreate`).
- `helm lint` — 0 failures.

## Note / tradeoff

This sets `replicas: 2` as the **chart default**, so it fixes CI *and* makes the operators HA in production — at the cost of a second operator pod per install (roughly doubles each operator's resource reservations). If a smaller blast radius is preferred, the replica bump could instead be scoped to CI via `--set` in the `setup-dynamo-operator` step, leaving the chart default at 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Operator components now run with two replicas by default for improved availability.
  - Added disruption protection to keep at least one operator pod available during voluntary maintenance or node disruptions.

- **Reliability Improvements**
  - Multi-replica deployments now use rolling updates with no planned downtime.
  - Single-replica deployments retain their existing replacement strategy.
  - Webhook services remain available during upgrades through leader election and redundant replicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->