### PR TITLE
feat(vllm): add reusable in-process ensemble worker

### DIFF
--- a/components/src/dynamo/vllm/embedded_decoder.py
+++ b/components/src/dynamo/vllm/embedded_decoder.py
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Composable native vLLM decoder for in-process Dynamo workers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import AsyncIterator
+from typing import Any, Protocol
+
+from vllm.config import VllmConfig
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+
+from dynamo.common.backend import GenerateChunk, GenerateRequest, LlmRegistration
+from dynamo.llm.exceptions import InvalidArgument
+from dynamo.vllm.handlers import build_sampling_params
+from dynamo.vllm.multimodal_utils.custom_encoder import (
+    CustomEncoderAdapter,
+    VisionEncoderBackend,
+    create_custom_encoder_adapter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DecoderEngine(Protocol):
+    """Native engine operations required by :class:`EmbeddedVllmDecoder`."""
+
+    def generate(
+        self,
+        prompt: Any,
+        sampling_params: SamplingParams,
+        request_id: str,
+    ) -> AsyncIterator[Any]:
+        ...
+
+    async def abort(self, request_id: str) -> None:
+        ...
+
+    def shutdown(self) -> None:
+        ...
+
+
+class EmbeddedVllmDecoder:
+    """Run native vLLM as a child component without registering an endpoint."""
+
+    def __init__(
+        self,
+        *,
+        engine: DecoderEngine,
+        engine_args: AsyncEngineArgs,
+        vllm_config: VllmConfig,
+        default_sampling_params: dict[str, Any],
+    ) -> None:
+        self._engine: DecoderEngine | None = engine
+        self._engine_args = engine_args
+        self._vllm_config = vllm_config
+        self._default_sampling_params = default_sampling_params
+
+    @classmethod
+    def from_engine_args(
+        cls,
+        engine_args: AsyncEngineArgs,
+        *,
+        usage_context: UsageContext = UsageContext.OPENAI_API_SERVER,
+    ) -> EmbeddedVllmDecoder:
+        """Create the vLLM config and native engine without a Dynamo endpoint."""
+
+        os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
+        os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+        vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+        engine = AsyncLLM.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=[],
+            enable_log_requests=engine_args.enable_log_requests,
+            disable_log_stats=engine_args.disable_log_stats,
+        )
+        return cls(
+            engine=engine,
+            engine_args=engine_args,
+            vllm_config=vllm_config,
+            default_sampling_params=(
+                vllm_config.model_config.get_diff_sampling_param()
+            ),
+        )
+
+    def create_prompt_adapter(
+        self,
+        backend: VisionEncoderBackend[Any, Any, Any],
+    ) -> CustomEncoderAdapter[Any]:
+        """Create the Dynamo adapter that maps encoder artifacts to this decoder."""
+
+        return create_custom_encoder_adapter(
+            backend,
+            self._vllm_config.model_config,
+            self._engine_args,
+        )
+
+    def registration(self) -> LlmRegistration:
+        """Return model capacity metadata for the containing Dynamo worker."""
+
+        scheduler_config = self._vllm_config.scheduler_config
+        return LlmRegistration(
+            context_length=self._vllm_config.model_config.max_model_len,
+            kv_cache_block_size=self._vllm_config.cache_config.block_size,
+            max_num_seqs=scheduler_config.max_num_seqs,
+            max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
+            data_parallel_size=1,
+            data_parallel_start_rank=0,
+        )
+
+    async def generate_final(
+        self,
+        request: GenerateRequest,
+        prompt: Any,
+        request_id: str,
+    ) -> GenerateChunk:
+        """Run one non-streaming, single-choice decode and return a terminal chunk."""
+
+        prompt_token_ids = prompt.get("prompt_token_ids")
+        if not isinstance(prompt_token_ids, list):
+            raise InvalidArgument("decoder prompt must contain prompt_token_ids")
+
+        sampling_params = self._build_final_sampling_params(
+            request,
+            prompt_tokens=len(prompt_token_ids),
+        )
+        engine = self._require_engine()
+        completed = False
+        final_output: Any | None = None
+        try:
+            async for request_output in engine.generate(
+                prompt,
+                sampling_params,
+                request_id,
+            ):
+                final_output = request_output
+            if final_output is None or len(final_output.outputs) != 1:
+                count = 0 if final_output is None else len(final_output.outputs)
+                raise RuntimeError(
+                    f"vLLM returned {count} outputs; exactly one is required"
+                )
+
+            output = final_output.outputs[0]
+            if getattr(output, "index", 0) not in (None, 0):
+                raise RuntimeError(
+                    f"vLLM returned unexpected output index {output.index}"
+                )
+            finish_reason = getattr(output, "finish_reason", None)
+            if not finish_reason:
+                raise RuntimeError("vLLM final output did not include a finish reason")
+
+            output_token_ids = list(output.token_ids or [])
+            final_prompt_token_ids = getattr(final_output, "prompt_token_ids", None)
+            prompt_tokens = (
+                len(final_prompt_token_ids)
+                if final_prompt_token_ids is not None
+                else len(prompt_token_ids)
+            )
+            completion_tokens = len(output_token_ids)
+            chunk: GenerateChunk = {
+                "token_ids": output_token_ids,
+                "index": 0,
+                "finish_reason": str(finish_reason),
+                "completion_usage": {
+                    "prompt_tokens": prompt_tokens,
+                    "completion_tokens": completion_tokens,
+                    "total_tokens": prompt_tokens + completion_tokens,
+                },
+            }
+            completed = True
+            return chunk
+        finally:
+            if not completed:
+                try:
+                    await asyncio.shield(engine.abort(request_id))
+                except Exception:
+                    logger.exception("Failed to abort vLLM request %s", request_id)
+
+    async def abort(self, request_id: str) -> None:
+        engine = self._engine
+        if engine is not None:
+            await engine.abort(request_id)
+
+    def shutdown(self) -> None:
+        engine = self._engine
+        self._engine = None
+        if engine is not None:
+            engine.shutdown()
+
+    def _build_final_sampling_params(
+        self,
+        request: GenerateRequest,
+        *,
+        prompt_tokens: int,
+    ) -> SamplingParams:
+        sampling_options = request.get("sampling_options") or {}
+        n = sampling_options.get("n")
+        if n not in (None, 1):
+            raise InvalidArgument(
+                f"EmbeddedVllmDecoder supports exactly one choice; got n={n}"
+            )
+
+        output_options = request.get("output_options") or {}
+        if (
+            output_options.get("logprobs") is not None
+            or output_options.get("prompt_logprobs") is not None
+        ):
+            raise InvalidArgument("EmbeddedVllmDecoder does not support logprobs")
+
+        sampling_params = build_sampling_params(
+            request,
+            self._default_sampling_params,
+            model_max_len=None,
+        )
+        stop_conditions = request.get("stop_conditions") or {}
+        if stop_conditions.get("max_tokens") is None:
+            available = max(
+                1,
+                self._vllm_config.model_config.max_model_len - prompt_tokens,
+            )
+            configured = self._default_sampling_params.get("max_tokens", available)
+            if configured is None:
+                configured = available
+            sampling_params.max_tokens = min(configured, available)
+
+        sampling_params.n = 1
+        sampling_params.detokenize = False
+        sampling_params.output_kind = RequestOutputKind.FINAL_ONLY
+        return sampling_params
+
+    def _require_engine(self) -> DecoderEngine:
+        if self._engine is None:
+            raise RuntimeError("EmbeddedVllmDecoder is shut down")
+        return self._engine

--- a/components/src/dynamo/vllm/embedded_decoder.py
+++ b/components/src/dynamo/vllm/embedded_decoder.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import os
 from collections.abc import AsyncIterator
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -216,7 +216,7 @@ class EmbeddedVllmDecoder:
             raise InvalidArgument("EmbeddedVllmDecoder does not support logprobs")
 
         sampling_params = build_sampling_params(
-            request,
+            cast(dict[str, Any], request),
             self._default_sampling_params,
             model_max_len=None,
         )

--- a/components/src/dynamo/vllm/tests/test_vllm_embedded_decoder.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_embedded_decoder.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from vllm.sampling_params import RequestOutputKind
+
+pytest.importorskip(
+    "dynamo._core.backend",
+    reason="dynamo._core.backend not built — run maturin develop first",
+)
+
+from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
+from dynamo.vllm.embedded_decoder import EmbeddedVllmDecoder  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeNativeEngine:
+    def __init__(self) -> None:
+        self.sampling_params: Any = None
+        self.abort_ids: list[str] = []
+        self.shutdown_calls = 0
+        self.failure: Exception | None = None
+
+    async def generate(
+        self,
+        prompt: dict[str, Any],
+        sampling_params: Any,
+        request_id: str,
+    ) -> AsyncIterator[Any]:
+        self.sampling_params = sampling_params
+        if self.failure is not None:
+            raise self.failure
+        yield SimpleNamespace(
+            prompt_token_ids=prompt["prompt_token_ids"],
+            outputs=[SimpleNamespace(index=0, token_ids=[4, 2], finish_reason="stop")],
+        )
+
+    async def abort(self, request_id: str) -> None:
+        self.abort_ids.append(request_id)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+def _vllm_config(max_model_len: int = 128) -> MagicMock:
+    config = MagicMock()
+    config.model_config.max_model_len = max_model_len
+    config.cache_config.block_size = 16
+    config.scheduler_config.max_num_seqs = 32
+    config.scheduler_config.max_num_batched_tokens = 4096
+    return config
+
+
+def _decoder(
+    engine: _FakeNativeEngine,
+    *,
+    max_model_len: int = 128,
+    default_sampling_params: dict[str, Any] | None = None,
+) -> EmbeddedVllmDecoder:
+    return EmbeddedVllmDecoder(
+        engine=engine,
+        engine_args=MagicMock(),
+        vllm_config=_vllm_config(max_model_len),
+        default_sampling_params=default_sampling_params or {},
+    )
+
+
+def _request(*, max_tokens: int | None = 8, n: int | None = 1) -> dict[str, Any]:
+    stop_conditions: dict[str, Any] = {}
+    if max_tokens is not None:
+        stop_conditions["max_tokens"] = max_tokens
+    return {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"n": n, "temperature": 0.25},
+        "stop_conditions": stop_conditions,
+        "output_options": {},
+    }
+
+
+async def test_generate_final_translates_and_normalizes() -> None:
+    engine = _FakeNativeEngine()
+    decoder = _decoder(engine)
+
+    chunk = await decoder.generate_final(
+        _request(),
+        {"prompt_token_ids": [1, 2, 3, 99]},
+        "request-1",
+    )
+
+    assert engine.sampling_params.temperature == 0.25
+    assert engine.sampling_params.max_tokens == 8
+    assert engine.sampling_params.detokenize is False
+    assert engine.sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
+    assert chunk == {
+        "token_ids": [4, 2],
+        "index": 0,
+        "finish_reason": "stop",
+        "completion_usage": {
+            "prompt_tokens": 4,
+            "completion_tokens": 2,
+            "total_tokens": 6,
+        },
+    }
+
+
+async def test_default_output_limit_uses_prepared_prompt_length() -> None:
+    engine = _FakeNativeEngine()
+    decoder = _decoder(
+        engine,
+        max_model_len=10,
+        default_sampling_params={"max_tokens": 20},
+    )
+
+    await decoder.generate_final(
+        _request(max_tokens=None),
+        {"prompt_token_ids": [1, 2, 3, 4]},
+        "request-1",
+    )
+
+    assert engine.sampling_params.max_tokens == 6
+
+
+@pytest.mark.parametrize(
+    ("request_update", "message"),
+    [
+        ({"sampling_options": {"n": 2}}, "exactly one choice"),
+        ({"output_options": {"logprobs": 1}}, "does not support logprobs"),
+    ],
+)
+async def test_rejects_unsupported_final_output_options(
+    request_update: dict[str, Any],
+    message: str,
+) -> None:
+    request = _request()
+    request.update(request_update)
+
+    with pytest.raises(InvalidArgument, match=message):
+        await _decoder(_FakeNativeEngine()).generate_final(
+            request,
+            {"prompt_token_ids": [1]},
+            "request-1",
+        )
+
+
+async def test_failure_aborts_native_request() -> None:
+    engine = _FakeNativeEngine()
+    engine.failure = RuntimeError("decode failed")
+
+    with pytest.raises(RuntimeError, match="decode failed"):
+        await _decoder(engine).generate_final(
+            _request(),
+            {"prompt_token_ids": [1]},
+            "request-1",
+        )
+
+    assert engine.abort_ids == ["request-1"]
+
+
+def test_factory_owns_engine_setup_and_registration() -> None:
+    engine_args = MagicMock()
+    engine_args.enable_log_requests = True
+    engine_args.disable_log_stats = False
+    config = _vllm_config()
+    config.model_config.get_diff_sampling_param.return_value = {"temperature": 0.5}
+    engine_args.create_engine_config.return_value = config
+    native_engine = _FakeNativeEngine()
+
+    with patch(
+        "dynamo.vllm.embedded_decoder.AsyncLLM.from_vllm_config",
+        return_value=native_engine,
+    ):
+        decoder = EmbeddedVllmDecoder.from_engine_args(engine_args)
+
+    registration = decoder.registration()
+    assert registration.context_length == 128
+    assert registration.kv_cache_block_size == 16
+    assert registration.max_num_seqs == 32
+    assert registration.max_num_batched_tokens == 4096
+
+    decoder.shutdown()
+    decoder.shutdown()
+    assert native_engine.shutdown_calls == 1

--- a/components/src/dynamo/vllm/tests/test_vllm_embedded_decoder.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_embedded_decoder.py
@@ -9,12 +9,17 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
-from vllm.sampling_params import RequestOutputKind
 
 pytest.importorskip(
     "dynamo._core.backend",
     reason="dynamo._core.backend not built — run maturin develop first",
 )
+pytest.importorskip(
+    "vllm.engine.arg_utils",
+    reason="a full vLLM installation is required by the embedded decoder",
+)
+
+from vllm.sampling_params import RequestOutputKind  # noqa: E402
 
 from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
 from dynamo.vllm.embedded_decoder import EmbeddedVllmDecoder  # noqa: E402

--- a/examples/custom_backend/user_ensemble/README.md
+++ b/examples/custom_backend/user_ensemble/README.md
@@ -43,6 +43,10 @@ through the user worker, for example
 immediately); batch cost, item caps, and preprocess concurrency remain encoder
 backend policy.
 
+When the decoder shares a GPU with a substantial encoder, reserve room for the
+encoder with `DYN_VLLM_GPU_MEMORY_UTILIZATION` (for example, `0.4`). The default
+is `0.8`, suitable only when the colocated encoder has enough remaining memory.
+
 Then issue a non-streaming request:
 
 ```bash

--- a/examples/custom_backend/user_ensemble/README.md
+++ b/examples/custom_backend/user_ensemble/README.md
@@ -12,7 +12,9 @@ UserEnsembleEngine
        v
 AsyncVisionEncoder -- shared artifacts --> classifier
        |                                  |
-       +---- adapter --> vLLM decoder ----+
+       +---- adapter --> EmbeddedVllmDecoder
+                          |               |
+                          +-- AsyncLLM ---+
                                           |
                                           v
                                   terminal response join
@@ -23,6 +25,12 @@ encoder tensors. The user worker runs the encoder once, passes the same
 in-process artifact objects to the classifier and decoder adapter, waits for
 both branches, and returns one terminal response. Classifier data is attached
 to `nvext.engine_data`; clients must request that optional field.
+
+`EmbeddedVllmDecoder` is a library component, not another serving endpoint. It
+owns native vLLM initialization, request translation, final-output
+normalization, abort, shutdown, and registration metadata. The frontend still
+listens on the only HTTP inference port, and `UserEnsembleEngine` remains the
+only Dynamo backend endpoint for this chain.
 
 The supplied classifier deliberately returns `dummy-classification`. Replace
 `DummyClassifier` with application logic that consumes the encoder artifact.

--- a/examples/custom_backend/user_ensemble/README.md
+++ b/examples/custom_backend/user_ensemble/README.md
@@ -45,12 +45,6 @@ From the repository root:
 ./examples/custom_backend/user_ensemble/launch.sh
 ```
 
-For cross-request encoder coalescing, pass the existing Dynamo batcher policy
-through the user worker, for example
-`--custom-encoder-max-queue-delay-us 1000`. The default is zero (dispatch
-immediately); batch cost, item caps, and preprocess concurrency remain encoder
-backend policy.
-
 When the decoder shares a GPU with a substantial encoder, reserve room for the
 encoder with `DYN_VLLM_GPU_MEMORY_UTILIZATION` (for example, `0.4`). The default
 is `0.8`, suitable only when the colocated encoder has enough remaining memory.

--- a/examples/custom_backend/user_ensemble/README.md
+++ b/examples/custom_backend/user_ensemble/README.md
@@ -1,0 +1,78 @@
+# User Ensemble Worker
+
+This prototype shows that an application can implement an aggregated model
+chain without changing `dynamo.vllm`:
+
+```text
+dynamo.frontend
+       |
+       v
+UserEnsembleEngine
+       |
+       v
+AsyncVisionEncoder -- shared artifacts --> classifier
+       |                                  |
+       +---- adapter --> vLLM decoder ----+
+                                          |
+                                          v
+                                  terminal response join
+```
+
+The frontend sends the ordinary OpenAI request. It does not hold or forward
+encoder tensors. The user worker runs the encoder once, passes the same
+in-process artifact objects to the classifier and decoder adapter, waits for
+both branches, and returns one terminal response. Classifier data is attached
+to `nvext.engine_data`; clients must request that optional field.
+
+The supplied classifier deliberately returns `dummy-classification`. Replace
+`DummyClassifier` with application logic that consumes the encoder artifact.
+This first version accepts exactly one image and one output choice and fails the
+whole request if either branch fails.
+
+## Run
+
+From the repository root:
+
+```bash
+./examples/custom_backend/user_ensemble/launch.sh
+```
+
+Then issue a non-streaming request:
+
+```bash
+curl -sS http://localhost:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen2.5-1.5B-Instruct",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "According to The Hitchhiker’s Guide to the Galaxy, The Answer to"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+        {"type": "text", "text": " is? Reply with only the number."}
+      ]
+    }],
+    "max_tokens": 8,
+    "stream": false,
+    "nvext": {"extra_fields": ["engine_data"]}
+  }'
+```
+
+The generated text should contain `42`, and the response should contain:
+
+```json
+{
+  "nvext": {
+    "engine_data": {
+      "ensemble": {
+        "classifier": "dummy-classification"
+      }
+    }
+  }
+}
+```
+
+The current custom-encoder contract returns CPU-safe artifacts. A future
+in-process contract can add explicitly owned CUDA artifacts; disaggregated
+consumers will require handles and a transfer mechanism such as NIXL rather
+than frontend-mediated tensors.

--- a/examples/custom_backend/user_ensemble/README.md
+++ b/examples/custom_backend/user_ensemble/README.md
@@ -37,6 +37,12 @@ From the repository root:
 ./examples/custom_backend/user_ensemble/launch.sh
 ```
 
+For cross-request encoder coalescing, pass the existing Dynamo batcher policy
+through the user worker, for example
+`--custom-encoder-max-queue-delay-us 1000`. The default is zero (dispatch
+immediately); batch cost, item caps, and preprocess concurrency remain encoder
+backend policy.
+
 Then issue a non-streaming request:
 
 ```bash

--- a/examples/custom_backend/user_ensemble/__init__.py
+++ b/examples/custom_backend/user_ensemble/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""User-authored aggregated model chaining on Dynamo's generic worker."""
+
+from .worker import DummyClassifier, UserEnsembleEngine
+
+__all__ = ["DummyClassifier", "UserEnsembleEngine"]

--- a/examples/custom_backend/user_ensemble/__init__.py
+++ b/examples/custom_backend/user_ensemble/__init__.py
@@ -2,7 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """User-authored aggregated model chaining on Dynamo's generic worker."""
-
-from .worker import DummyClassifier, UserEnsembleEngine
-
-__all__ = ["DummyClassifier", "UserEnsembleEngine"]

--- a/examples/custom_backend/user_ensemble/launch.sh
+++ b/examples/custom_backend/user_ensemble/launch.sh
@@ -17,7 +17,8 @@ WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-4096}"
 GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
-[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization 0.8"
+[[ -z "$GPU_MEM_ARGS" ]] && \
+    GPU_MEM_ARGS="--gpu-memory-utilization ${DYN_VLLM_GPU_MEMORY_UTILIZATION:-0.8}"
 
 print_launch_banner --no-curl "User Ensemble Worker" "$MODEL" "$HTTP_PORT" \
     "Worker GPU: $WORKER_GPU" \

--- a/examples/custom_backend/user_ensemble/launch.sh
+++ b/examples/custom_backend/user_ensemble/launch.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(readlink -f "$SCRIPT_DIR/../../..")"
+source "$REPO_ROOT/examples/common/gpu_utils.sh"
+source "$REPO_ROOT/examples/common/launch_utils.sh"
+
+MODEL="${DYN_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
+ENCODER_CLASS="${DYN_ENCODER_CLASS:-examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder}"
+CUSTOM_JINJA_TEMPLATE="${DYN_CUSTOM_JINJA_TEMPLATE:-$REPO_ROOT/examples/custom_encoder/templates/qwen_vl.jinja}"
+WORKER_GPU="${DYN_WORKER_GPU:-${CUDA_VISIBLE_DEVICES:-0}}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-4096}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+[[ -z "$GPU_MEM_ARGS" ]] && GPU_MEM_ARGS="--gpu-memory-utilization 0.8"
+
+print_launch_banner --no-curl "User Ensemble Worker" "$MODEL" "$HTTP_PORT" \
+    "Worker GPU: $WORKER_GPU" \
+    "Encoder:    $ENCODER_CLASS"
+
+export DYN_REQUEST_PLANE=tcp
+export DYN_TCP_MAX_MESSAGE_SIZE=209715200
+export DYN_HTTP_BODY_LIMIT_MB=200
+
+python -m dynamo.frontend &
+
+CUDA_VISIBLE_DEVICES=$WORKER_GPU \
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+python -m examples.custom_backend.user_ensemble.worker \
+    --model "$MODEL" \
+    --encoder-class "$ENCODER_CLASS" \
+    --custom-jinja-template "$CUSTOM_JINJA_TEMPLATE" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --disable-kv-routing \
+    $GPU_MEM_ARGS \
+    "$@" &
+
+wait_any_exit

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -19,6 +19,7 @@ from dynamo.llm.exceptions import InvalidArgument
 
 from examples.custom_backend.user_ensemble.worker import (
     UserEnsembleEngine,
+    _served_model_name,
 )
 
 pytestmark = [
@@ -251,3 +252,18 @@ async def test_abort_and_cleanup_delegate_and_cleanup_is_idempotent():
     assert decoder.abort_ids == ["cancel-me"]
     assert decoder.shutdown_calls == 1
     assert encoder.shutdown_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("configured", "fallback", "expected"),
+    [
+        (None, "public/model-id", "public/model-id"),
+        ([], "public/model-id", "public/model-id"),
+        (["served", "alias"], "public/model-id", "served"),
+        ("served", "public/model-id", "served"),
+    ],
+)
+def test_served_model_name_preserves_public_cli_identity(
+    configured, fallback: str, expected: str
+):
+    assert _served_model_name(configured, fallback) == expected

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -205,9 +205,11 @@ async def test_classifier_failure_cancels_and_aborts_decoder():
     engine._adapter = _FakeAdapter()
     engine._decoder = decoder
 
-    with pytest.raises(Exception, match="classifier failed"):
+    with pytest.raises(Exception) as exc_info:
         await _collect(engine, _request())
 
+    nested_errors = getattr(exc_info.value, "exceptions", ())
+    assert any("classifier failed" in str(error) for error in nested_errors)
     assert decoder.abort_ids == ["request-1"]
 
 

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -14,6 +14,7 @@ pytest.importorskip(
     "dynamo._core.backend",
     reason="dynamo._core.backend not built — run maturin develop first",
 )
+pytest.importorskip("vllm", reason="vLLM is required by the ensemble worker")
 
 from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
 from examples.custom_backend.user_ensemble.worker import (  # noqa: E402

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -98,6 +98,29 @@ def _engine(classifier=None):
     return engine
 
 
+def test_encoder_queue_delay_is_configured_on_engine():
+    engine = UserEnsembleEngine(
+        model_name="test-model",
+        served_model_name="test-model",
+        engine_args=MagicMock(),
+        encoder_backend_type=MagicMock(),
+        custom_encoder_max_queue_delay_us=1_000,
+    )
+
+    assert engine._custom_encoder_max_queue_delay_us == 1_000
+
+
+def test_encoder_queue_delay_rejects_negative_values():
+    with pytest.raises(ValueError, match="non-negative"):
+        UserEnsembleEngine(
+            model_name="test-model",
+            served_model_name="test-model",
+            engine_args=MagicMock(),
+            encoder_backend_type=MagicMock(),
+            custom_encoder_max_queue_delay_us=-1,
+        )
+
+
 def _context(request_id: str = "request-1") -> MagicMock:
     context = MagicMock()
     context.id.return_value = request_id

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip(
+    "dynamo._core.backend",
+    reason="dynamo._core.backend not built — run maturin develop first",
+)
+
+from dynamo.llm.exceptions import InvalidArgument
+
+from examples.custom_backend.user_ensemble.worker import (
+    UserEnsembleEngine,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+class _FakeEncoder:
+    def __init__(self, artifacts: list[Any]) -> None:
+        self.artifacts = artifacts
+        self.calls: list[list[str]] = []
+        self.shutdown_calls = 0
+
+    async def encode(self, raws: list[str]) -> list[Any]:
+        self.calls.append(raws)
+        return self.artifacts
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.artifacts: Any = None
+
+    def prepare_prompt(self, token_ids: list[int], artifacts: list[Any]) -> dict:
+        self.artifacts = artifacts
+        return {"prompt_token_ids": token_ids + [99]}
+
+
+class _FakeDecoder:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.abort_ids: list[str] = []
+        self.shutdown_calls = 0
+
+    async def generate(self, prompt, sampling_params, request_id):
+        self.started.set()
+        yield SimpleNamespace(
+            prompt_token_ids=prompt["prompt_token_ids"],
+            outputs=[SimpleNamespace(index=0, token_ids=[4, 2], finish_reason="stop")],
+        )
+
+    async def abort(self, request_id: str) -> None:
+        self.abort_ids.append(request_id)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+
+class _RecordingClassifier:
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+        self.artifacts: Any = None
+
+    async def classify(self, artifacts) -> str:
+        self.artifacts = artifacts
+        self.started.set()
+        return "category-a"
+
+
+def _engine(classifier=None):
+    engine = object.__new__(UserEnsembleEngine)
+    engine.model_name = "test-model"
+    engine.served_model_name = "test-model"
+    engine._classifier = classifier or _RecordingClassifier()
+    engine._default_sampling_params = {}
+    engine._model_max_len = 128
+    engine._encoder = None
+    engine._adapter = None
+    engine._decoder = None
+    return engine
+
+
+def _context(request_id: str = "request-1") -> MagicMock:
+    context = MagicMock()
+    context.id.return_value = request_id
+    return context
+
+
+def _request(image_count: int = 1) -> dict:
+    return {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"n": 1},
+        "stop_conditions": {"max_tokens": 8},
+        "output_options": {},
+        "multi_modal_data": {
+            "image_url": [
+                {"Url": f"data:image/png;base64,image-{index}"}
+                for index in range(image_count)
+            ]
+        },
+    }
+
+
+async def _collect(engine: UserEnsembleEngine, request: dict) -> list[dict]:
+    return [chunk async for chunk in engine.generate(request, _context())]
+
+
+async def test_encoder_artifacts_fan_out_once_and_join_on_terminal():
+    artifact = object()
+    artifacts = [artifact]
+    classifier = _RecordingClassifier()
+    encoder = _FakeEncoder(artifacts)
+    adapter = _FakeAdapter()
+    decoder = _FakeDecoder()
+    engine = _engine(classifier)
+    engine._encoder = encoder
+    engine._adapter = adapter
+    engine._decoder = decoder
+
+    chunks = await _collect(engine, _request())
+
+    assert encoder.calls == [["data:image/png;base64,image-0"]]
+    assert classifier.artifacts is artifacts
+    assert adapter.artifacts is artifacts
+    assert chunks == [
+        {
+            "token_ids": [4, 2],
+            "index": 0,
+            "finish_reason": "stop",
+            "completion_usage": {
+                "prompt_tokens": 4,
+                "completion_tokens": 2,
+                "total_tokens": 6,
+            },
+            "engine_data": {"ensemble": {"classifier": "category-a"}},
+        }
+    ]
+
+
+async def test_classifier_and_decoder_run_concurrently():
+    classifier_started = asyncio.Event()
+    decoder_started = asyncio.Event()
+
+    class BarrierClassifier:
+        async def classify(self, artifacts) -> str:
+            classifier_started.set()
+            await asyncio.wait_for(decoder_started.wait(), timeout=1)
+            return "joined"
+
+    class BarrierDecoder(_FakeDecoder):
+        async def generate(self, prompt, sampling_params, request_id):
+            decoder_started.set()
+            await asyncio.wait_for(classifier_started.wait(), timeout=1)
+            yield SimpleNamespace(
+                prompt_token_ids=prompt["prompt_token_ids"],
+                outputs=[
+                    SimpleNamespace(index=0, token_ids=[42], finish_reason="stop")
+                ],
+            )
+
+    engine = _engine(BarrierClassifier())
+    engine._encoder = _FakeEncoder([object()])
+    engine._adapter = _FakeAdapter()
+    engine._decoder = BarrierDecoder()
+
+    [terminal] = await _collect(engine, _request())
+
+    assert terminal["engine_data"]["ensemble"]["classifier"] == "joined"
+
+
+async def test_classifier_failure_cancels_and_aborts_decoder():
+    decoder_started = asyncio.Event()
+
+    class FailingClassifier:
+        async def classify(self, artifacts) -> str:
+            await asyncio.wait_for(decoder_started.wait(), timeout=1)
+            raise RuntimeError("classifier failed")
+
+    class BlockingDecoder(_FakeDecoder):
+        async def generate(self, prompt, sampling_params, request_id):
+            decoder_started.set()
+            await asyncio.Future()
+            yield
+
+    decoder = BlockingDecoder()
+    engine = _engine(FailingClassifier())
+    engine._encoder = _FakeEncoder([object()])
+    engine._adapter = _FakeAdapter()
+    engine._decoder = decoder
+
+    with pytest.raises(Exception, match="classifier failed"):
+        await _collect(engine, _request())
+
+    assert decoder.abort_ids == ["request-1"]
+
+
+@pytest.mark.parametrize("image_count", [0, 2])
+async def test_rejects_non_single_image_requests(image_count: int):
+    engine = _engine()
+    engine._encoder = _FakeEncoder([object()])
+    engine._adapter = _FakeAdapter()
+    engine._decoder = _FakeDecoder()
+
+    with pytest.raises(InvalidArgument, match="exactly one image"):
+        await _collect(engine, _request(image_count))
+
+
+async def test_rejects_multiple_choices():
+    engine = _engine()
+    engine._encoder = _FakeEncoder([object()])
+    engine._adapter = _FakeAdapter()
+    engine._decoder = _FakeDecoder()
+    request = _request()
+    request["sampling_options"]["n"] = 2
+
+    with pytest.raises(InvalidArgument, match="exactly one choice"):
+        await _collect(engine, request)
+
+
+async def test_abort_and_cleanup_delegate_and_cleanup_is_idempotent():
+    encoder = _FakeEncoder([object()])
+    decoder = _FakeDecoder()
+    engine = _engine()
+    engine._encoder = encoder
+    engine._adapter = _FakeAdapter()
+    engine._decoder = decoder
+
+    await engine.abort(_context("cancel-me"))
+    await engine.cleanup()
+    await engine.cleanup()
+
+    assert decoder.abort_ids == ["cancel-me"]
+    assert decoder.shutdown_calls == 1
+    assert encoder.shutdown_calls == 1

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -60,12 +59,23 @@ class _FakeDecoder:
         self.abort_ids: list[str] = []
         self.shutdown_calls = 0
 
-    async def generate(self, prompt, sampling_params, request_id):
+    async def generate_final(
+        self,
+        request: dict[str, Any],
+        prompt: dict[str, Any],
+        request_id: str,
+    ) -> dict[str, Any]:
         self.started.set()
-        yield SimpleNamespace(
-            prompt_token_ids=prompt["prompt_token_ids"],
-            outputs=[SimpleNamespace(index=0, token_ids=[4, 2], finish_reason="stop")],
-        )
+        return {
+            "token_ids": [4, 2],
+            "index": 0,
+            "finish_reason": "stop",
+            "completion_usage": {
+                "prompt_tokens": len(prompt["prompt_token_ids"]),
+                "completion_tokens": 2,
+                "total_tokens": len(prompt["prompt_token_ids"]) + 2,
+            },
+        }
 
     async def abort(self, request_id: str) -> None:
         self.abort_ids.append(request_id)
@@ -90,8 +100,6 @@ def _engine(classifier=None):
     engine.model_name = "test-model"
     engine.served_model_name = "test-model"
     engine._classifier = classifier or _RecordingClassifier()
-    engine._default_sampling_params = {}
-    engine._model_max_len = 128
     engine._encoder = None
     engine._adapter = None
     engine._decoder = None
@@ -189,15 +197,24 @@ async def test_classifier_and_decoder_run_concurrently():
             return "joined"
 
     class BarrierDecoder(_FakeDecoder):
-        async def generate(self, prompt, sampling_params, request_id):
+        async def generate_final(
+            self,
+            request: dict[str, Any],
+            prompt: dict[str, Any],
+            request_id: str,
+        ) -> dict[str, Any]:
             decoder_started.set()
             await asyncio.wait_for(classifier_started.wait(), timeout=1)
-            yield SimpleNamespace(
-                prompt_token_ids=prompt["prompt_token_ids"],
-                outputs=[
-                    SimpleNamespace(index=0, token_ids=[42], finish_reason="stop")
-                ],
-            )
+            return {
+                "token_ids": [42],
+                "index": 0,
+                "finish_reason": "stop",
+                "completion_usage": {
+                    "prompt_tokens": len(prompt["prompt_token_ids"]),
+                    "completion_tokens": 1,
+                    "total_tokens": len(prompt["prompt_token_ids"]) + 1,
+                },
+            }
 
     engine = _engine(BarrierClassifier())
     engine._encoder = _FakeEncoder([object()])
@@ -218,10 +235,17 @@ async def test_classifier_failure_cancels_and_aborts_decoder():
             raise RuntimeError("classifier failed")
 
     class BlockingDecoder(_FakeDecoder):
-        async def generate(self, prompt, sampling_params, request_id):
-            decoder_started.set()
-            await asyncio.Future()
-            yield
+        async def generate_final(
+            self,
+            request: dict[str, Any],
+            prompt: dict[str, Any],
+            request_id: str,
+        ) -> dict[str, Any]:
+            try:
+                decoder_started.set()
+                await asyncio.Future()
+            finally:
+                await self.abort(request_id)
 
     decoder = BlockingDecoder()
     engine = _engine(FailingClassifier())
@@ -246,31 +270,6 @@ async def test_rejects_non_single_image_requests(image_count: int):
 
     with pytest.raises(InvalidArgument, match="exactly one image"):
         await _collect(engine, _request(image_count))
-
-
-async def test_rejects_multiple_choices():
-    engine = _engine()
-    engine._encoder = _FakeEncoder([object()])
-    engine._adapter = _FakeAdapter()
-    engine._decoder = _FakeDecoder()
-    request = _request()
-    request["sampling_options"]["n"] = 2
-
-    with pytest.raises(InvalidArgument, match="exactly one choice"):
-        await _collect(engine, request)
-
-
-async def test_accepts_null_choice_count_as_single_choice():
-    engine = _engine()
-    engine._encoder = _FakeEncoder([object()])
-    engine._adapter = _FakeAdapter()
-    engine._decoder = _FakeDecoder()
-    request = _request()
-    request["sampling_options"]["n"] = None
-
-    chunks = await _collect(engine, request)
-
-    assert chunks[-1]["finish_reason"] == "stop"
 
 
 async def test_abort_and_cleanup_delegate_and_cleanup_is_idempotent():

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -109,29 +109,6 @@ def _engine(classifier=None):
     return engine
 
 
-def test_encoder_queue_delay_is_configured_on_engine():
-    engine = UserEnsembleEngine(
-        model_name="test-model",
-        served_model_name="test-model",
-        engine_args=MagicMock(),
-        encoder_backend_type=MagicMock(),
-        custom_encoder_max_queue_delay_us=1_000,
-    )
-
-    assert engine._custom_encoder_max_queue_delay_us == 1_000
-
-
-def test_encoder_queue_delay_rejects_negative_values():
-    with pytest.raises(ValueError, match="non-negative"):
-        UserEnsembleEngine(
-            model_name="test-model",
-            served_model_name="test-model",
-            engine_args=MagicMock(),
-            encoder_backend_type=MagicMock(),
-            custom_encoder_max_queue_delay_us=-1,
-        )
-
-
 def _context(request_id: str = "request-1") -> MagicMock:
     context = MagicMock()
     context.id.return_value = request_id

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -15,9 +15,8 @@ pytest.importorskip(
     reason="dynamo._core.backend not built — run maturin develop first",
 )
 
-from dynamo.llm.exceptions import InvalidArgument
-
-from examples.custom_backend.user_ensemble.worker import (
+from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
+from examples.custom_backend.user_ensemble.worker import (  # noqa: E402
     UserEnsembleEngine,
     _served_model_name,
 )

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -13,7 +13,10 @@ pytest.importorskip(
     "dynamo._core.backend",
     reason="dynamo._core.backend not built — run maturin develop first",
 )
-pytest.importorskip("vllm", reason="vLLM is required by the ensemble worker")
+pytest.importorskip(
+    "vllm.engine.arg_utils",
+    reason="a full vLLM installation is required by the ensemble worker",
+)
 
 from dynamo.llm.exceptions import InvalidArgument  # noqa: E402
 from examples.custom_backend.user_ensemble.worker import (  # noqa: E402

--- a/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
+++ b/examples/custom_backend/user_ensemble/tests/test_user_ensemble_worker.py
@@ -237,6 +237,19 @@ async def test_rejects_multiple_choices():
         await _collect(engine, request)
 
 
+async def test_accepts_null_choice_count_as_single_choice():
+    engine = _engine()
+    engine._encoder = _FakeEncoder([object()])
+    engine._adapter = _FakeAdapter()
+    engine._decoder = _FakeDecoder()
+    request = _request()
+    request["sampling_options"]["n"] = None
+
+    chunks = await _collect(engine, request)
+
+    assert chunks[-1]["finish_reason"] == "stop"
+
+
 async def test_abort_and_cleanup_delegate_and_cleanup_is_idempotent():
     encoder = _FakeEncoder([object()])
     decoder = _FakeDecoder()

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -128,16 +128,12 @@ class UserEnsembleEngine(LLMEngine):
         served_model_name: str,
         engine_args: AsyncEngineArgs,
         encoder_backend_type: type[VisionEncoderBackend[Any, Any, Any]],
-        custom_encoder_max_queue_delay_us: int = 0,
         classifier: Classifier | None = None,
     ) -> None:
-        if custom_encoder_max_queue_delay_us < 0:
-            raise ValueError("custom encoder queue delay must be non-negative")
         self.model_name = model_name
         self.served_model_name = served_model_name
         self._engine_args = engine_args
         self._encoder_backend_type = encoder_backend_type
-        self._custom_encoder_max_queue_delay_us = custom_encoder_max_queue_delay_us
         self._classifier = classifier or DummyClassifier()
 
         self._decoder: Decoder | None = None
@@ -165,7 +161,6 @@ class UserEnsembleEngine(LLMEngine):
         parser.add_argument("--event-plane", choices=("nats", "zmq"), default=None)
         parser.add_argument("--custom-jinja-template", default=None)
         parser.add_argument("--encoder-class", required=True)
-        parser.add_argument("--custom-encoder-max-queue-delay-us", type=int, default=0)
         parser.add_argument("--disable-kv-routing", action="store_true")
         AsyncEngineArgs.add_cli_args(parser, async_args_only=False)
         args = parser.parse_args(argv)
@@ -193,7 +188,6 @@ class UserEnsembleEngine(LLMEngine):
             served_model_name=served_model_name,
             engine_args=engine_args,
             encoder_backend_type=backend_type,
-            custom_encoder_max_queue_delay_us=(args.custom_encoder_max_queue_delay_us),
         )
         worker_config = WorkerConfig(
             namespace=args.namespace,
@@ -220,7 +214,6 @@ class UserEnsembleEngine(LLMEngine):
         self._encoder = AsyncVisionEncoder(
             backend,
             name="ensemble-vision-encoder",
-            max_queue_delay_us=self._custom_encoder_max_queue_delay_us,
         )
         self._encoder.load(self.model_name)
 

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -137,12 +137,16 @@ class UserEnsembleEngine(LLMEngine):
         served_model_name: str,
         engine_args: AsyncEngineArgs,
         encoder_backend_type: type[VisionEncoderBackend[Any, Any, Any]],
+        custom_encoder_max_queue_delay_us: int = 0,
         classifier: Classifier | None = None,
     ) -> None:
+        if custom_encoder_max_queue_delay_us < 0:
+            raise ValueError("custom encoder queue delay must be non-negative")
         self.model_name = model_name
         self.served_model_name = served_model_name
         self._engine_args = engine_args
         self._encoder_backend_type = encoder_backend_type
+        self._custom_encoder_max_queue_delay_us = custom_encoder_max_queue_delay_us
         self._classifier = classifier or DummyClassifier()
 
         self._decoder: Decoder | None = None
@@ -172,6 +176,7 @@ class UserEnsembleEngine(LLMEngine):
         parser.add_argument("--event-plane", choices=("nats", "zmq"), default=None)
         parser.add_argument("--custom-jinja-template", default=None)
         parser.add_argument("--encoder-class", required=True)
+        parser.add_argument("--custom-encoder-max-queue-delay-us", type=int, default=0)
         parser.add_argument("--disable-kv-routing", action="store_true")
         AsyncEngineArgs.add_cli_args(parser, async_args_only=False)
         args = parser.parse_args(argv)
@@ -199,6 +204,7 @@ class UserEnsembleEngine(LLMEngine):
             served_model_name=served_model_name,
             engine_args=engine_args,
             encoder_backend_type=backend_type,
+            custom_encoder_max_queue_delay_us=(args.custom_encoder_max_queue_delay_us),
         )
         worker_config = WorkerConfig(
             namespace=args.namespace,
@@ -243,7 +249,11 @@ class UserEnsembleEngine(LLMEngine):
             vllm_config.model_config,
             self._engine_args,
         )
-        self._encoder = AsyncVisionEncoder(backend, name="ensemble-vision-encoder")
+        self._encoder = AsyncVisionEncoder(
+            backend,
+            name="ensemble-vision-encoder",
+            max_queue_delay_us=self._custom_encoder_max_queue_delay_us,
+        )
         self._encoder.load(self.model_name)
 
         scheduler_config = vllm_config.scheduler_config

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -347,7 +347,9 @@ class UserEnsembleEngine(LLMEngine):
         self, request: GenerateRequest, prompt_tokens: int
     ) -> SamplingParams:
         sampling_options = request.get("sampling_options") or {}
-        n = sampling_options.get("n", 1)
+        n = sampling_options.get("n")
+        if n is None:
+            n = 1
         if n != 1:
             raise InvalidArgument(
                 f"UserEnsembleEngine supports exactly one choice; got n={n}"

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -60,7 +60,8 @@ logger = logging.getLogger(__name__)
 class Classifier(Protocol):
     """User-supplied asynchronous classifier over encoder artifacts."""
 
-    async def classify(self, artifacts: Sequence[Any]) -> str: ...
+    async def classify(self, artifacts: Sequence[Any]) -> str:
+        ...
 
 
 class Decoder(Protocol):
@@ -71,19 +72,24 @@ class Decoder(Protocol):
         prompt: Any,
         sampling_params: SamplingParams,
         request_id: str,
-    ) -> AsyncIterator[Any]: ...
+    ) -> AsyncIterator[Any]:
+        ...
 
-    async def abort(self, request_id: str) -> None: ...
+    async def abort(self, request_id: str) -> None:
+        ...
 
-    def shutdown(self) -> None: ...
+    def shutdown(self) -> None:
+        ...
 
 
 class Encoder(Protocol):
     """Subset of ``AsyncVisionEncoder`` used on the request path."""
 
-    async def encode(self, raws: list[str]) -> list[Any]: ...
+    async def encode(self, raws: list[str]) -> list[Any]:
+        ...
 
-    def shutdown(self) -> None: ...
+    def shutdown(self) -> None:
+        ...
 
 
 class DummyClassifier:

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -121,11 +121,10 @@ def _load_encoder_backend(class_path: str) -> type[VisionEncoderBackend[Any, Any
     return cast(type[VisionEncoderBackend[Any, Any, Any]], backend_type)
 
 
-def _served_model_name(engine_args: AsyncEngineArgs) -> str:
-    configured = engine_args.served_model_name
+def _served_model_name(configured: str | list[str] | None, fallback: str) -> str:
     if isinstance(configured, list):
-        return configured[0] if configured else engine_args.model
-    return configured or engine_args.model
+        return configured[0] if configured else fallback
+    return configured or fallback
 
 
 class UserEnsembleEngine(LLMEngine):
@@ -177,9 +176,13 @@ class UserEnsembleEngine(LLMEngine):
         AsyncEngineArgs.add_cli_args(parser, async_args_only=False)
         args = parser.parse_args(argv)
 
+        requested_model = args.model
         engine_args = AsyncEngineArgs.from_cli_args(args)
         engine_args.enable_prompt_embeds = True
-        served_model_name = _served_model_name(engine_args)
+        served_model_name = _served_model_name(
+            args.served_model_name,
+            requested_model,
+        )
         backend_type = _load_encoder_backend(args.encoder_class)
         custom_template = (
             os.path.abspath(os.path.expanduser(args.custom_jinja_template))
@@ -192,7 +195,7 @@ class UserEnsembleEngine(LLMEngine):
             )
 
         engine = cls(
-            model_name=engine_args.model,
+            model_name=requested_model,
             served_model_name=served_model_name,
             engine_args=engine_args,
             encoder_backend_type=backend_type,
@@ -201,7 +204,7 @@ class UserEnsembleEngine(LLMEngine):
             namespace=args.namespace,
             component=args.component,
             endpoint=args.endpoint,
-            model_name=engine_args.model,
+            model_name=requested_model,
             served_model_name=served_model_name,
             endpoint_types=args.endpoint_types,
             discovery_backend=args.discovery_backend,

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -14,16 +14,11 @@ from __future__ import annotations
 
 import asyncio
 import importlib
-import logging
 import os
-from collections.abc import AsyncGenerator, AsyncIterator, Sequence
-from dataclasses import dataclass
+from collections.abc import AsyncGenerator, Sequence
 from typing import Any, Protocol, cast
 
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.sampling_params import RequestOutputKind, SamplingParams
-from vllm.usage.usage_lib import UsageContext
-from vllm.v1.engine.async_llm import AsyncLLM
 
 try:
     from vllm.utils import FlexibleArgumentParser
@@ -36,15 +31,14 @@ from dynamo.common.backend import (
     GenerateChunk,
     GenerateRequest,
     LLMEngine,
-    LlmRegistration,
     WorkerConfig,
 )
 from dynamo.common.backend.run import run
 from dynamo.llm.exceptions import InvalidArgument
+from dynamo.vllm.embedded_decoder import EmbeddedVllmDecoder
 from dynamo.vllm.multimodal_utils.custom_encoder import (
     AsyncVisionEncoder,
     VisionEncoderBackend,
-    create_custom_encoder_adapter,
 )
 from dynamo.vllm.multimodal_utils.custom_encoder.adapter.base import (
     CustomEncoderAdapter,
@@ -53,8 +47,6 @@ from dynamo.vllm.multimodal_utils.request_processor import (
     IMAGE_URL_KEY,
     URL_VARIANT_KEY,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class Classifier(Protocol):
@@ -65,14 +57,14 @@ class Classifier(Protocol):
 
 
 class Decoder(Protocol):
-    """Subset of ``AsyncLLM`` used by the ensemble engine."""
+    """Embedded decoder operations used by the ensemble engine."""
 
-    def generate(
+    async def generate_final(
         self,
+        request: GenerateRequest,
         prompt: Any,
-        sampling_params: SamplingParams,
         request_id: str,
-    ) -> AsyncIterator[Any]:
+    ) -> GenerateChunk:
         ...
 
     async def abort(self, request_id: str) -> None:
@@ -102,13 +94,6 @@ class DummyClassifier:
             )
         await asyncio.sleep(0)
         return "dummy-classification"
-
-
-@dataclass(frozen=True)
-class _DecodedResult:
-    token_ids: list[int]
-    finish_reason: str
-    prompt_tokens: int
 
 
 def _load_encoder_backend(class_path: str) -> type[VisionEncoderBackend[Any, Any, Any]]:
@@ -158,8 +143,6 @@ class UserEnsembleEngine(LLMEngine):
         self._decoder: Decoder | None = None
         self._encoder: Encoder | None = None
         self._adapter: CustomEncoderAdapter[Any] | None = None
-        self._default_sampling_params: dict[str, Any] = {}
-        self._model_max_len: int | None = None
 
     @classmethod
     async def from_args(
@@ -229,32 +212,11 @@ class UserEnsembleEngine(LLMEngine):
 
     async def start(self, worker_id: int) -> EngineConfig:
         del worker_id
-        os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
-        os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
-
-        usage_context = UsageContext.OPENAI_API_SERVER
-        vllm_config = self._engine_args.create_engine_config(
-            usage_context=usage_context
-        )
-        self._default_sampling_params = (
-            vllm_config.model_config.get_diff_sampling_param()
-        )
-        self._model_max_len = vllm_config.model_config.max_model_len
-
-        self._decoder = AsyncLLM.from_vllm_config(
-            vllm_config=vllm_config,
-            usage_context=usage_context,
-            stat_loggers=[],
-            enable_log_requests=self._engine_args.enable_log_requests,
-            disable_log_stats=self._engine_args.disable_log_stats,
-        )
+        decoder = EmbeddedVllmDecoder.from_engine_args(self._engine_args)
+        self._decoder = decoder
 
         backend = self._encoder_backend_type()
-        self._adapter = create_custom_encoder_adapter(
-            backend,
-            vllm_config.model_config,
-            self._engine_args,
-        )
+        self._adapter = decoder.create_prompt_adapter(backend)
         self._encoder = AsyncVisionEncoder(
             backend,
             name="ensemble-vision-encoder",
@@ -262,52 +224,31 @@ class UserEnsembleEngine(LLMEngine):
         )
         self._encoder.load(self.model_name)
 
-        scheduler_config = vllm_config.scheduler_config
         return EngineConfig(
             model=self.model_name,
             served_model_name=self.served_model_name,
-            llm=LlmRegistration(
-                context_length=self._model_max_len,
-                kv_cache_block_size=vllm_config.cache_config.block_size,
-                max_num_seqs=scheduler_config.max_num_seqs,
-                max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
-                data_parallel_size=1,
-                data_parallel_start_rank=0,
-            ),
+            llm=decoder.registration(),
         )
 
     async def generate(
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
-        encoder, adapter = self._request_resources()
+        encoder, adapter, decoder = self._request_resources()
         request_id = context.id()
         image_url = self._single_image_url(request)
 
         artifacts = await encoder.encode([image_url])
         prompt = adapter.prepare_prompt(list(request["token_ids"]), artifacts)
-        sampling_params = self._sampling_params(
-            request, len(prompt["prompt_token_ids"])
-        )
 
         async with asyncio.TaskGroup() as group:
             classification = group.create_task(self._classifier.classify(artifacts))
             decoding = group.create_task(
-                self._decode(prompt, sampling_params, request_id)
+                decoder.generate_final(request, prompt, request_id)
             )
 
         decoded = decoding.result()
-        completion_tokens = len(decoded.token_ids)
-        yield {
-            "token_ids": decoded.token_ids,
-            "index": 0,
-            "finish_reason": decoded.finish_reason,
-            "completion_usage": {
-                "prompt_tokens": decoded.prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": decoded.prompt_tokens + completion_tokens,
-            },
-            "engine_data": {"ensemble": {"classifier": classification.result()}},
-        }
+        decoded["engine_data"] = {"ensemble": {"classifier": classification.result()}}
+        yield decoded
 
     async def abort(self, context: Context) -> None:
         decoder = self._decoder
@@ -326,10 +267,12 @@ class UserEnsembleEngine(LLMEngine):
         if decoder is not None:
             decoder.shutdown()
 
-    def _request_resources(self) -> tuple[Encoder, CustomEncoderAdapter[Any]]:
+    def _request_resources(
+        self,
+    ) -> tuple[Encoder, CustomEncoderAdapter[Any], Decoder]:
         if self._encoder is None or self._adapter is None or self._decoder is None:
             raise RuntimeError("UserEnsembleEngine.generate() called before start()")
-        return self._encoder, self._adapter
+        return self._encoder, self._adapter, self._decoder
 
     @staticmethod
     def _single_image_url(request: GenerateRequest) -> str:
@@ -358,116 +301,6 @@ class UserEnsembleEngine(LLMEngine):
                 "image_url item must contain a non-empty 'Url' string"
             )
         return image_url
-
-    def _sampling_params(
-        self, request: GenerateRequest, prompt_tokens: int
-    ) -> SamplingParams:
-        sampling_options = request.get("sampling_options") or {}
-        n = sampling_options.get("n")
-        if n is None:
-            n = 1
-        if n != 1:
-            raise InvalidArgument(
-                f"UserEnsembleEngine supports exactly one choice; got n={n}"
-            )
-
-        output_options = request.get("output_options") or {}
-        if (
-            output_options.get("logprobs") is not None
-            or output_options.get("prompt_logprobs") is not None
-        ):
-            raise InvalidArgument("UserEnsembleEngine does not support logprobs")
-
-        sampling_params = SamplingParams(**self._default_sampling_params)
-        for key in (
-            "presence_penalty",
-            "frequency_penalty",
-            "repetition_penalty",
-            "temperature",
-            "top_p",
-            "top_k",
-            "min_p",
-            "seed",
-        ):
-            value = sampling_options.get(key)
-            if value is not None:
-                setattr(sampling_params, key, value)
-
-        stop_conditions = request.get("stop_conditions") or {}
-        for key in ("max_tokens", "min_tokens", "ignore_eos", "stop_token_ids"):
-            value = stop_conditions.get(key)
-            if value is not None:
-                setattr(sampling_params, key, value)
-        hidden_stop_ids = stop_conditions.get("stop_token_ids_hidden")
-        if hidden_stop_ids:
-            sampling_params.stop_token_ids = list(
-                set(sampling_params.stop_token_ids or []).union(hidden_stop_ids)
-            )
-
-        if (
-            stop_conditions.get("max_tokens") is None
-            and self._model_max_len is not None
-        ):
-            available = max(1, self._model_max_len - prompt_tokens)
-            configured = self._default_sampling_params.get("max_tokens", available)
-            sampling_params.max_tokens = min(configured, available)
-
-        sampling_params.n = 1
-        sampling_params.detokenize = False
-        sampling_params.output_kind = RequestOutputKind.FINAL_ONLY
-        return sampling_params
-
-    async def _decode(
-        self,
-        prompt: Any,
-        sampling_params: SamplingParams,
-        request_id: str,
-    ) -> _DecodedResult:
-        decoder = self._decoder
-        if decoder is None:
-            raise RuntimeError("decoder is not initialized")
-
-        completed = False
-        final_output: Any | None = None
-        try:
-            async for request_output in decoder.generate(
-                prompt, sampling_params, request_id
-            ):
-                final_output = request_output
-            if final_output is None or len(final_output.outputs) != 1:
-                count = 0 if final_output is None else len(final_output.outputs)
-                raise RuntimeError(
-                    f"vLLM returned {count} outputs; exactly one is required"
-                )
-
-            output = final_output.outputs[0]
-            if getattr(output, "index", 0) not in (None, 0):
-                raise RuntimeError(
-                    f"vLLM returned unexpected output index {output.index}"
-                )
-            finish_reason = getattr(output, "finish_reason", None)
-            if not finish_reason:
-                raise RuntimeError("vLLM final output did not include a finish reason")
-
-            prompt_token_ids = getattr(final_output, "prompt_token_ids", None)
-            prompt_tokens = (
-                len(prompt_token_ids)
-                if prompt_token_ids is not None
-                else len(prompt["prompt_token_ids"])
-            )
-            result = _DecodedResult(
-                token_ids=list(output.token_ids or []),
-                finish_reason=str(finish_reason),
-                prompt_tokens=prompt_tokens,
-            )
-            completed = True
-            return result
-        finally:
-            if not completed:
-                try:
-                    await asyncio.shield(decoder.abort(request_id))
-                except Exception:
-                    logger.exception("Failed to abort vLLM request %s", request_id)
 
 
 def main() -> None:

--- a/examples/custom_backend/user_ensemble/worker.py
+++ b/examples/custom_backend/user_ensemble/worker.py
@@ -1,0 +1,457 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Aggregated encoder -> classifier + decoder -> join worker.
+
+The module intentionally builds on public Dynamo worker contracts instead of
+specializing ``dynamo.vllm``. One encoder result is shared by two in-process
+consumers. The decoder consumes an adapter-produced vLLM prompt, while the
+classifier consumes the same artifact objects and contributes data to the final
+``engine_data`` payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from dataclasses import dataclass
+from typing import Any, Protocol, cast
+
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.async_llm import AsyncLLM
+
+try:
+    from vllm.utils import FlexibleArgumentParser
+except ImportError:
+    from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+from dynamo._core import Context
+from dynamo.common.backend import (
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+    LlmRegistration,
+    WorkerConfig,
+)
+from dynamo.common.backend.run import run
+from dynamo.llm.exceptions import InvalidArgument
+from dynamo.vllm.multimodal_utils.custom_encoder import (
+    AsyncVisionEncoder,
+    VisionEncoderBackend,
+    create_custom_encoder_adapter,
+)
+from dynamo.vllm.multimodal_utils.custom_encoder.adapter.base import (
+    CustomEncoderAdapter,
+)
+from dynamo.vllm.multimodal_utils.request_processor import (
+    IMAGE_URL_KEY,
+    URL_VARIANT_KEY,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class Classifier(Protocol):
+    """User-supplied asynchronous classifier over encoder artifacts."""
+
+    async def classify(self, artifacts: Sequence[Any]) -> str: ...
+
+
+class Decoder(Protocol):
+    """Subset of ``AsyncLLM`` used by the ensemble engine."""
+
+    def generate(
+        self,
+        prompt: Any,
+        sampling_params: SamplingParams,
+        request_id: str,
+    ) -> AsyncIterator[Any]: ...
+
+    async def abort(self, request_id: str) -> None: ...
+
+    def shutdown(self) -> None: ...
+
+
+class Encoder(Protocol):
+    """Subset of ``AsyncVisionEncoder`` used on the request path."""
+
+    async def encode(self, raws: list[str]) -> list[Any]: ...
+
+    def shutdown(self) -> None: ...
+
+
+class DummyClassifier:
+    """Small replaceable classification branch used by the runnable smoke."""
+
+    async def classify(self, artifacts: Sequence[Any]) -> str:
+        if len(artifacts) != 1:
+            raise InvalidArgument(
+                f"DummyClassifier requires one encoder artifact; got {len(artifacts)}"
+            )
+        await asyncio.sleep(0)
+        return "dummy-classification"
+
+
+@dataclass(frozen=True)
+class _DecodedResult:
+    token_ids: list[int]
+    finish_reason: str
+    prompt_tokens: int
+
+
+def _load_encoder_backend(class_path: str) -> type[VisionEncoderBackend[Any, Any, Any]]:
+    module_name, separator, class_name = class_path.rpartition(".")
+    if not separator:
+        raise ValueError(
+            "--encoder-class must be a dotted module.ClassName path; "
+            f"got {class_path!r}"
+        )
+    module = importlib.import_module(module_name)
+    backend_type = getattr(module, class_name)
+    if not isinstance(backend_type, type) or not issubclass(
+        backend_type, VisionEncoderBackend
+    ):
+        raise TypeError(f"{class_path} must name a VisionEncoderBackend subclass")
+    return cast(type[VisionEncoderBackend[Any, Any, Any]], backend_type)
+
+
+def _served_model_name(engine_args: AsyncEngineArgs) -> str:
+    configured = engine_args.served_model_name
+    if isinstance(configured, list):
+        return configured[0] if configured else engine_args.model
+    return configured or engine_args.model
+
+
+class UserEnsembleEngine(LLMEngine):
+    """One-request aggregate chain with a fan-out and terminal response join."""
+
+    def __init__(
+        self,
+        *,
+        model_name: str,
+        served_model_name: str,
+        engine_args: AsyncEngineArgs,
+        encoder_backend_type: type[VisionEncoderBackend[Any, Any, Any]],
+        classifier: Classifier | None = None,
+    ) -> None:
+        self.model_name = model_name
+        self.served_model_name = served_model_name
+        self._engine_args = engine_args
+        self._encoder_backend_type = encoder_backend_type
+        self._classifier = classifier or DummyClassifier()
+
+        self._decoder: Decoder | None = None
+        self._encoder: Encoder | None = None
+        self._adapter: CustomEncoderAdapter[Any] | None = None
+        self._default_sampling_params: dict[str, Any] = {}
+        self._model_max_len: int | None = None
+
+    @classmethod
+    async def from_args(
+        cls, argv: list[str] | None = None
+    ) -> tuple[UserEnsembleEngine, WorkerConfig]:
+        parser = FlexibleArgumentParser(
+            description="Aggregated user ensemble worker",
+            allow_abbrev=False,
+        )
+        parser.add_argument("--namespace", default="dynamo")
+        parser.add_argument("--component", default="backend")
+        parser.add_argument("--endpoint", default="generate")
+        parser.add_argument("--endpoint-types", default="chat,completions")
+        parser.add_argument(
+            "--discovery-backend",
+            choices=("kubernetes", "etcd", "file", "mem"),
+            default="etcd",
+        )
+        parser.add_argument("--request-plane", choices=("tcp", "nats"), default="tcp")
+        parser.add_argument("--event-plane", choices=("nats", "zmq"), default=None)
+        parser.add_argument("--custom-jinja-template", default=None)
+        parser.add_argument("--encoder-class", required=True)
+        parser.add_argument("--disable-kv-routing", action="store_true")
+        AsyncEngineArgs.add_cli_args(parser, async_args_only=False)
+        args = parser.parse_args(argv)
+
+        engine_args = AsyncEngineArgs.from_cli_args(args)
+        engine_args.enable_prompt_embeds = True
+        served_model_name = _served_model_name(engine_args)
+        backend_type = _load_encoder_backend(args.encoder_class)
+        custom_template = (
+            os.path.abspath(os.path.expanduser(args.custom_jinja_template))
+            if args.custom_jinja_template
+            else None
+        )
+        if custom_template is not None and not os.path.isfile(custom_template):
+            raise FileNotFoundError(
+                f"Custom Jinja template file not found: {custom_template}"
+            )
+
+        engine = cls(
+            model_name=engine_args.model,
+            served_model_name=served_model_name,
+            engine_args=engine_args,
+            encoder_backend_type=backend_type,
+        )
+        worker_config = WorkerConfig(
+            namespace=args.namespace,
+            component=args.component,
+            endpoint=args.endpoint,
+            model_name=engine_args.model,
+            served_model_name=served_model_name,
+            endpoint_types=args.endpoint_types,
+            discovery_backend=args.discovery_backend,
+            request_plane=args.request_plane,
+            event_plane=args.event_plane,
+            custom_jinja_template=custom_template,
+            enable_kv_routing=not args.disable_kv_routing,
+        )
+        return engine, worker_config
+
+    async def start(self, worker_id: int) -> EngineConfig:
+        del worker_id
+        os.environ.setdefault("VLLM_NO_USAGE_STATS", "1")
+        os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+        usage_context = UsageContext.OPENAI_API_SERVER
+        vllm_config = self._engine_args.create_engine_config(
+            usage_context=usage_context
+        )
+        self._default_sampling_params = (
+            vllm_config.model_config.get_diff_sampling_param()
+        )
+        self._model_max_len = vllm_config.model_config.max_model_len
+
+        self._decoder = AsyncLLM.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=[],
+            enable_log_requests=self._engine_args.enable_log_requests,
+            disable_log_stats=self._engine_args.disable_log_stats,
+        )
+
+        backend = self._encoder_backend_type()
+        self._adapter = create_custom_encoder_adapter(
+            backend,
+            vllm_config.model_config,
+            self._engine_args,
+        )
+        self._encoder = AsyncVisionEncoder(backend, name="ensemble-vision-encoder")
+        self._encoder.load(self.model_name)
+
+        scheduler_config = vllm_config.scheduler_config
+        return EngineConfig(
+            model=self.model_name,
+            served_model_name=self.served_model_name,
+            llm=LlmRegistration(
+                context_length=self._model_max_len,
+                kv_cache_block_size=vllm_config.cache_config.block_size,
+                max_num_seqs=scheduler_config.max_num_seqs,
+                max_num_batched_tokens=scheduler_config.max_num_batched_tokens,
+                data_parallel_size=1,
+                data_parallel_start_rank=0,
+            ),
+        )
+
+    async def generate(
+        self, request: GenerateRequest, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
+        encoder, adapter = self._request_resources()
+        request_id = context.id()
+        image_url = self._single_image_url(request)
+
+        artifacts = await encoder.encode([image_url])
+        prompt = adapter.prepare_prompt(list(request["token_ids"]), artifacts)
+        sampling_params = self._sampling_params(
+            request, len(prompt["prompt_token_ids"])
+        )
+
+        async with asyncio.TaskGroup() as group:
+            classification = group.create_task(self._classifier.classify(artifacts))
+            decoding = group.create_task(
+                self._decode(prompt, sampling_params, request_id)
+            )
+
+        decoded = decoding.result()
+        completion_tokens = len(decoded.token_ids)
+        yield {
+            "token_ids": decoded.token_ids,
+            "index": 0,
+            "finish_reason": decoded.finish_reason,
+            "completion_usage": {
+                "prompt_tokens": decoded.prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": decoded.prompt_tokens + completion_tokens,
+            },
+            "engine_data": {"ensemble": {"classifier": classification.result()}},
+        }
+
+    async def abort(self, context: Context) -> None:
+        decoder = self._decoder
+        if decoder is not None:
+            await decoder.abort(context.id())
+
+    async def cleanup(self) -> None:
+        encoder = self._encoder
+        decoder = self._decoder
+        self._encoder = None
+        self._decoder = None
+        self._adapter = None
+
+        if encoder is not None:
+            encoder.shutdown()
+        if decoder is not None:
+            decoder.shutdown()
+
+    def _request_resources(self) -> tuple[Encoder, CustomEncoderAdapter[Any]]:
+        if self._encoder is None or self._adapter is None or self._decoder is None:
+            raise RuntimeError("UserEnsembleEngine.generate() called before start()")
+        return self._encoder, self._adapter
+
+    @staticmethod
+    def _single_image_url(request: GenerateRequest) -> str:
+        multimodal = request.get("multi_modal_data") or {}
+        unsupported = sorted(
+            key for key, value in multimodal.items() if key != IMAGE_URL_KEY and value
+        )
+        if unsupported:
+            raise InvalidArgument(
+                "UserEnsembleEngine supports image inputs only; got "
+                f"unsupported multimodal data: {unsupported}"
+            )
+
+        image_items = multimodal.get(IMAGE_URL_KEY) or []
+        if len(image_items) != 1:
+            raise InvalidArgument(
+                "UserEnsembleEngine requires exactly one image per request; "
+                f"got {len(image_items)}"
+            )
+        image_item = image_items[0]
+        if not isinstance(image_item, dict):
+            raise InvalidArgument("image_url item must be an object with a 'Url' field")
+        image_url = image_item.get(URL_VARIANT_KEY)
+        if not isinstance(image_url, str) or not image_url:
+            raise InvalidArgument(
+                "image_url item must contain a non-empty 'Url' string"
+            )
+        return image_url
+
+    def _sampling_params(
+        self, request: GenerateRequest, prompt_tokens: int
+    ) -> SamplingParams:
+        sampling_options = request.get("sampling_options") or {}
+        n = sampling_options.get("n", 1)
+        if n != 1:
+            raise InvalidArgument(
+                f"UserEnsembleEngine supports exactly one choice; got n={n}"
+            )
+
+        output_options = request.get("output_options") or {}
+        if (
+            output_options.get("logprobs") is not None
+            or output_options.get("prompt_logprobs") is not None
+        ):
+            raise InvalidArgument("UserEnsembleEngine does not support logprobs")
+
+        sampling_params = SamplingParams(**self._default_sampling_params)
+        for key in (
+            "presence_penalty",
+            "frequency_penalty",
+            "repetition_penalty",
+            "temperature",
+            "top_p",
+            "top_k",
+            "min_p",
+            "seed",
+        ):
+            value = sampling_options.get(key)
+            if value is not None:
+                setattr(sampling_params, key, value)
+
+        stop_conditions = request.get("stop_conditions") or {}
+        for key in ("max_tokens", "min_tokens", "ignore_eos", "stop_token_ids"):
+            value = stop_conditions.get(key)
+            if value is not None:
+                setattr(sampling_params, key, value)
+        hidden_stop_ids = stop_conditions.get("stop_token_ids_hidden")
+        if hidden_stop_ids:
+            sampling_params.stop_token_ids = list(
+                set(sampling_params.stop_token_ids or []).union(hidden_stop_ids)
+            )
+
+        if (
+            stop_conditions.get("max_tokens") is None
+            and self._model_max_len is not None
+        ):
+            available = max(1, self._model_max_len - prompt_tokens)
+            configured = self._default_sampling_params.get("max_tokens", available)
+            sampling_params.max_tokens = min(configured, available)
+
+        sampling_params.n = 1
+        sampling_params.detokenize = False
+        sampling_params.output_kind = RequestOutputKind.FINAL_ONLY
+        return sampling_params
+
+    async def _decode(
+        self,
+        prompt: Any,
+        sampling_params: SamplingParams,
+        request_id: str,
+    ) -> _DecodedResult:
+        decoder = self._decoder
+        if decoder is None:
+            raise RuntimeError("decoder is not initialized")
+
+        completed = False
+        final_output: Any | None = None
+        try:
+            async for request_output in decoder.generate(
+                prompt, sampling_params, request_id
+            ):
+                final_output = request_output
+            if final_output is None or len(final_output.outputs) != 1:
+                count = 0 if final_output is None else len(final_output.outputs)
+                raise RuntimeError(
+                    f"vLLM returned {count} outputs; exactly one is required"
+                )
+
+            output = final_output.outputs[0]
+            if getattr(output, "index", 0) not in (None, 0):
+                raise RuntimeError(
+                    f"vLLM returned unexpected output index {output.index}"
+                )
+            finish_reason = getattr(output, "finish_reason", None)
+            if not finish_reason:
+                raise RuntimeError("vLLM final output did not include a finish reason")
+
+            prompt_token_ids = getattr(final_output, "prompt_token_ids", None)
+            prompt_tokens = (
+                len(prompt_token_ids)
+                if prompt_token_ids is not None
+                else len(prompt["prompt_token_ids"])
+            )
+            result = _DecodedResult(
+                token_ids=list(output.token_ids or []),
+                finish_reason=str(finish_reason),
+                prompt_tokens=prompt_tokens,
+            )
+            completed = True
+            return result
+        finally:
+            if not completed:
+                try:
+                    await asyncio.shield(decoder.abort(request_id))
+                except Exception:
+                    logger.exception("Failed to abort vLLM request %s", request_id)
+
+
+def main() -> None:
+    run(UserEnsembleEngine)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

Dynamo applications need to compose a custom vision encoder with additional inference branches without specializing the generic `dynamo.vllm` worker, running the encoder twice, or routing intermediate tensors through the frontend. Existing components expose the required primitives, but custom workers otherwise reproduce native vLLM initialization, sampling translation, request cleanup, and registration metadata. This provides a reusable in-process decoder boundary while leaving orchestration and response joining under application control.

## Effect

`OpenAI request → frontend → UserEnsembleEngine → encoder → {classifier, EmbeddedVllmDecoder} → joined response`

## What Change

- Add reusable embedded vLLM lifecycle, sampling, and output normalization.
- Fan shared encoder artifacts to concurrent classifier and decoder branches.
- Document launch, batching, GPU headroom, and joined-response behavior.

## Test Plan

- Run 18 focused decoder and ensemble tests on one H100.
- Complete a real encoder-decoder frontend request with joined classifier metadata.
