### PR TITLE
docs(spica): correct kv_load_ratio support guidance

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
@@ -13,9 +13,10 @@ subtitle: Experimental Spica search for a GLM-5-FP8 Pareto frontier on B200 GPUs
 {/* Separate the adjacent admonitions for Markdown and MDX renderers. */}
 
 > [!IMPORTANT]
-> This experiment uses `kv_load_ratio` and requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. It fails fast before search starts in the default `dynamo-planner`
-> image, which currently retains AI Configurator 0.9.
+> This experiment uses `kv_load_ratio` and the KV-cache estimator from
+> `aiconfigurator_core.sdk.memory`. The default `dynamo-planner` image includes the matching AI
+> Configurator application and core packages. The B200/SGLang target requires a matching AI
+> Configurator performance database.
 
 This replay-backed sweep targets the InferenceX/SemiAnalysis (SA) **GLM-5-FP8 / B200 /
 Dynamo with SGLang / 1k-1k / disaggregated** frontier. It tests whether Spica can discover competitive
@@ -154,17 +155,18 @@ after round 53 consumed about 4 hours 39 minutes for 1.05% additional hypervolum
 
 ## Reproduction Status
 
-This historical experiment cannot currently be reproduced with Dynamo's
-packaged AI Configurator 0.9 dependency. The configuration is retained as a
-reference until Dynamo upgrades to an AI Configurator release that provides
-`aiconfigurator.sdk.memory`.
+The missing memory-estimator dependency no longer blocks this historical configuration. The default
+`dynamo-planner` image imports `estimate_kv_cache` from `aiconfigurator_core.sdk.memory`. When the AI
+Configurator performance database covers `(b200_sxm, sglang)` and `zai-org/GLM-5-FP8`, the search
+reaches the KV-capacity and candidate-concurrency calculations. Reproducing the historical frontier
+still depends on the exact performance database and Replay behavior available in the runtime
+snapshot.
 
 ```bash
-# Reference command; fails fast with the currently packaged dependencies.
 python -m aisimulate.spica \
   --config examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
 ```
 
-The AIConfigurator performance model needs the `aic-forward-pass` binding. Dynamo must include the
-attention-DP KV-capacity fix so replay sees engine capacity as per-rank capacity multiplied by
-attention DP and replicas.
+The AI Configurator performance model needs the `aic-forward-pass` binding. Dynamo's attention-DP
+KV-capacity calculation multiplies per-rank capacity by attention DP and replicas before passing
+engine capacity to Replay.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
@@ -147,12 +147,9 @@ after round 53 consumed about 4 hours 39 minutes for 1.05% additional hypervolum
 
 ## Reproduction Status
 
-The missing memory-estimator dependency no longer blocks this historical configuration. The default
-`dynamo-planner` image imports `estimate_kv_cache` from `aiconfigurator_core.sdk.memory`. When the AI
-Configurator performance database covers `(b200_sxm, sglang)` and `zai-org/GLM-5-FP8`, the search
-reaches the KV-capacity and candidate-concurrency calculations. Reproducing the historical frontier
-still depends on the exact performance database and Replay behavior available in the runtime
-snapshot.
+The packaged dependencies support this configuration's KV-capacity and candidate-concurrency
+calculations. Reproducing the historical frontier still depends on AI Configurator performance
+database coverage for B200/SGLang/GLM-5-FP8 and on Replay behavior in the runtime snapshot.
 
 ```bash
 python -m aisimulate.spica \

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/glm-5-fp8-pareto-sweep.md
@@ -10,14 +10,6 @@ subtitle: Experimental Spica search for a GLM-5-FP8 Pareto frontier on B200 GPUs
 > treat them as production capacity guidance or a performance commitment. Spica's search behavior
 > and output may change without a standard deprecation period.
 
-{/* Separate the adjacent admonitions for Markdown and MDX renderers. */}
-
-> [!IMPORTANT]
-> This experiment uses `kv_load_ratio` and the KV-cache estimator from
-> `aiconfigurator_core.sdk.memory`. The default `dynamo-planner` image includes the matching AI
-> Configurator application and core packages. The B200/SGLang target requires a matching AI
-> Configurator performance database.
-
 This replay-backed sweep targets the InferenceX/SemiAnalysis (SA) **GLM-5-FP8 / B200 /
 Dynamo with SGLang / 1k-1k / disaggregated** frontier. It tests whether Spica can discover competitive
 deployment mappings without pinning the parallel shape or replica count.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
@@ -60,9 +60,10 @@ Spica source, documentation, and examples were migrated from
 ## Current Limitations
 
 KV-capacity filtering and `kv_load_ratio` require an AI Configurator performance database for the
-target `(hardware_sku, backend)`. Branch enumeration drops targets without one and raises
-`NoViableParallelConfig` only when no backend or deployment mode remains. Spica does not use the
-naive memory-estimation fallback.
+target `(hardware_sku, backend)`. Branch enumeration drops targets without one and backend or
+deployment-mode combinations without a KV-feasible shape within the capacity budget. It raises
+`NoViableParallelConfig` if no viable branch remains. Spica does not use the naive memory-estimation
+fallback.
 
 Treat workloads and search modes not covered by image smoke tests as unsupported experimental paths.
 See [Traffic](traffic.md#kv_load_ratio-candidate-relative-concurrency) for the KV-load contract.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
@@ -34,8 +34,7 @@ Spica's source lives in `aisimulate/src/aisimulate/spica` and is published by th
 distribution in the Dynamo repository. Installing that distribution provides the canonical
 `aisimulate.spica` Python package and its CPU Vizier and JAX dependencies. Runnable configuration
 files and tools live in `examples/aisimulate/spica`. Spica uses AI Configurator's lower-layer
-forward-pass provider and, when available, memory provider, then evaluates candidates with
-Dynamo Replay.
+forward-pass and memory providers, then evaluates candidates with Dynamo Replay.
 
 ## Spica and Replay Optimize
 
@@ -60,16 +59,20 @@ Spica source, documentation, and examples were migrated from
 
 ## Current Limitations
 
-The `dynamo-planner` image currently keeps AI Configurator 0.9 for compatibility with the existing
-Profiler. That release does not provide `aiconfigurator.sdk.memory`:
+The default `dynamo-planner` image installs matching `aiconfigurator` and
+`aiconfigurator-core` packages. Spica imports the KV-cache estimator from
+`aiconfigurator_core.sdk.memory`, so the packaged dependencies support both KV-capacity filtering
+and `kv_load_ratio` workloads:
 
-- Spica emits a warning and skips the pre-search KV-capacity shape filter when the memory estimator
-  is unavailable. Trace workloads and synthetic workloads with fixed `concurrency` remain usable;
-  Replay and the GPU-budget checks still evaluate their candidates.
-- `kv_load_ratio` needs the compatible AI Configurator memory estimator to convert a relative load
-  into candidate-specific concurrency. Spica fails fast before starting the search for this
-  workload mode in the current default `dynamo-planner` image instead of evaluating an unverified
-  load or returning an empty candidate set after the sweep.
+- Spica applies the pre-search KV-capacity shape filter before Replay and the GPU-budget checks
+  evaluate each candidate.
+- `kv_load_ratio` uses the estimator to convert a relative load into candidate-specific
+  concurrency.
+
+KV-capacity calculation requires an AI Configurator performance database for the target
+`(hardware_sku, backend)`. If no database is available, branch enumeration removes that backend and
+continues with any viable backend or deployment mode. If none remain, Spica raises
+`NoViableParallelConfig`. Spica does not use the naive memory-estimation fallback.
 
 Treat workloads and search modes not covered by image smoke tests as unsupported experimental paths.
 See [Traffic](traffic.md#kv_load_ratio-candidate-relative-concurrency) for the KV-load contract.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/overview.md
@@ -59,20 +59,10 @@ Spica source, documentation, and examples were migrated from
 
 ## Current Limitations
 
-The default `dynamo-planner` image installs matching `aiconfigurator` and
-`aiconfigurator-core` packages. Spica imports the KV-cache estimator from
-`aiconfigurator_core.sdk.memory`, so the packaged dependencies support both KV-capacity filtering
-and `kv_load_ratio` workloads:
-
-- Spica applies the pre-search KV-capacity shape filter before Replay and the GPU-budget checks
-  evaluate each candidate.
-- `kv_load_ratio` uses the estimator to convert a relative load into candidate-specific
-  concurrency.
-
-KV-capacity calculation requires an AI Configurator performance database for the target
-`(hardware_sku, backend)`. If no database is available, branch enumeration removes that backend and
-continues with any viable backend or deployment mode. If none remain, Spica raises
-`NoViableParallelConfig`. Spica does not use the naive memory-estimation fallback.
+KV-capacity filtering and `kv_load_ratio` require an AI Configurator performance database for the
+target `(hardware_sku, backend)`. Branch enumeration drops targets without one and raises
+`NoViableParallelConfig` only when no backend or deployment mode remains. Spica does not use the
+naive memory-estimation fallback.
 
 Treat workloads and search modes not covered by image smoke tests as unsupported experimental paths.
 See [Traffic](traffic.md#kv_load_ratio-candidate-relative-concurrency) for the KV-load contract.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-flow.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-flow.md
@@ -101,11 +101,11 @@ backends support each. `context_length` is threaded into KV feasibility.
 - A ranged `workload.kv_load_ratio` (Pareto) becomes a continuous per-trial dimension on the
   branch. A scalar ratio is injected as a constant.
 
-The default `dynamo-planner` image currently uses AI Configurator 0.9, which does not expose
-`aiconfigurator.sdk.memory`. Spica warns and skips the pre-search KV-capacity shape filter in that
-environment. Trace and fixed-concurrency workloads can continue through Replay, but
-`kv_load_ratio` fails fast before branch enumeration because it cannot derive candidate-specific
-concurrency without the memory estimator.
+The default `dynamo-planner` image includes the matching AI Configurator application and core
+packages. Spica uses `aiconfigurator_core.sdk.memory` for both the pre-search KV-capacity filter and
+the candidate-specific concurrency derived from `kv_load_ratio`. A backend with no matching
+performance database follows the failure policy above; Spica does not use the naive memory
+estimator.
 
 ### 5. Per-branch Vizier study loop
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-flow.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-flow.md
@@ -101,12 +101,6 @@ backends support each. `context_length` is threaded into KV feasibility.
 - A ranged `workload.kv_load_ratio` (Pareto) becomes a continuous per-trial dimension on the
   branch. A scalar ratio is injected as a constant.
 
-The default `dynamo-planner` image includes the matching AI Configurator application and core
-packages. Spica uses `aiconfigurator_core.sdk.memory` for both the pre-search KV-capacity filter and
-the candidate-specific concurrency derived from `kv_load_ratio`. A backend with no matching
-performance database follows the failure policy above; Spica does not use the naive memory
-estimator.
-
 ### 5. Per-branch Vizier study loop
 
 For each branch, a `BranchSampler` (`make_branch_sampler`, study id

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-space.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-space.md
@@ -309,19 +309,16 @@ gpu_budget, backend)`:
    - `vllm` forbids `moe_tp > 1 & moe_ep > 1`.
    Large MoE that a node can't hold (`gpus_per_node * vram_per_gpu < 2 * weight_bytes`)
    auto-enables multi-node wideEP.
-5. **KV feasibility** (`aisimulate.spica.kv_estimate.feasible_shape_tokens`, via AI
-   Configurator's `estimate_kv_cache`): when the compatible memory estimator is installed, a shape
-   is kept iff its total KV capacity in tokens (after quantized weights + activation reservations)
-   holds at least one longest sequence —
+5. **KV feasibility** (`aisimulate.spica.kv_estimate.feasible_shape_tokens`, via
+   `aiconfigurator_core.sdk.memory.estimate_kv_cache`): a shape is kept iff its total KV capacity
+   in tokens (after quantized weights + activation reservations) holds at least one longest sequence —
    `total_kv_size_tokens > max_seq_len`, where `max_seq_len` = `context_length` if set, else
    the model's max context. This is per-shape (TEP / DEP / TP differ at the same GPU count)
-   and uses the real (often FP8) weights. SKUs with no perf DB raise `NoPerfDatabase` (no
-   naive fallback). If no shape is feasible within budget, `NoViableParallelConfig` is raised
-   for that branch. The default `dynamo-planner` image retains AI Configurator 0.9, which does not
-   provide `aiconfigurator.sdk.memory`; Spica warns and skips this pre-search filter in that image.
-   Trace and fixed-concurrency workloads still reach Replay, while `kv_load_ratio` fails fast
-   before branch enumeration because candidate-relative concurrency cannot be derived without the
-   estimator.
+   and uses the real (often FP8) weights. The estimator raises `NoPerfDatabase` for a target with no
+   perf DB, and branch enumeration removes that backend. Spica does not use the naive fallback. If
+   no shape is feasible within budget, `NoViableParallelConfig` is raised for that branch. The
+   default `dynamo-planner` image includes the matching AI Configurator application and core
+   packages required by this path and by `kv_load_ratio`.
 6. **Replicas** fill the budget: for each kept worker shape, replica counts
    `r ∈ 1..(gpu_budget // g)` such that `g * r` lies in
    `[min_gpu_budget, gpu_budget]`.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-space.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/search-space.md
@@ -316,9 +316,7 @@ gpu_budget, backend)`:
    the model's max context. This is per-shape (TEP / DEP / TP differ at the same GPU count)
    and uses the real (often FP8) weights. The estimator raises `NoPerfDatabase` for a target with no
    perf DB, and branch enumeration removes that backend. Spica does not use the naive fallback. If
-   no shape is feasible within budget, `NoViableParallelConfig` is raised for that branch. The
-   default `dynamo-planner` image includes the matching AI Configurator application and core
-   packages required by this path and by `kv_load_ratio`.
+   no shape is feasible within budget, `NoViableParallelConfig` is raised for that branch.
 6. **Replicas** fill the budget: for each kept worker shape, replica counts
    `r ∈ 1..(gpu_budget // g)` such that `g * r` lies in
    `[min_gpu_budget, gpu_budget]`.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/traffic.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/traffic.md
@@ -71,11 +71,13 @@ shared synthetic knobs threaded into the replay (`ReplayEvaluator._synthetic_kwa
 
 ## `kv_load_ratio` (candidate-relative concurrency)
 
-> [!WARNING]
-> `kv_load_ratio` requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. The default `dynamo-planner` image currently retains AI Configurator
-> 0.9, so this workload mode fails fast before search starts in that image. Use a trace workload
-> or fixed `concurrency` with the default image.
+> [!IMPORTANT]
+> The default `dynamo-planner` image includes the matching AI Configurator application and core
+> packages. Spica loads the KV-cache estimator from `aiconfigurator_core.sdk.memory`.
+> `kv_load_ratio` requires a performance database for the target `(hardware_sku, backend)`. If no
+> database is available, branch enumeration removes that backend and continues with any viable
+> backend or deployment mode; if none remain, Spica raises `NoViableParallelConfig`. Spica does not
+> use the naive memory estimator.
 
 Spica resolves a KV-load trial after the backend, parallel shape, replicas, and batching
 knobs have been selected. For every active role, it asks AI Configurator for the **per-rank** KV token

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/traffic.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/ai-simulate-experimental/spica-experimental/traffic.md
@@ -71,14 +71,6 @@ shared synthetic knobs threaded into the replay (`ReplayEvaluator._synthetic_kwa
 
 ## `kv_load_ratio` (candidate-relative concurrency)
 
-> [!IMPORTANT]
-> The default `dynamo-planner` image includes the matching AI Configurator application and core
-> packages. Spica loads the KV-cache estimator from `aiconfigurator_core.sdk.memory`.
-> `kv_load_ratio` requires a performance database for the target `(hardware_sku, backend)`. If no
-> database is available, branch enumeration removes that backend and continues with any viable
-> backend or deployment mode; if none remain, Spica raises `NoViableParallelConfig`. Spica does not
-> use the naive memory estimator.
-
 Spica resolves a KV-load trial after the backend, parallel shape, replicas, and batching
 knobs have been selected. For every active role, it asks AI Configurator for the **per-rank** KV token
 capacity using that candidate's `max_num_batched_tokens`, `max_num_seqs`, memory fraction,

--- a/examples/aisimulate/spica/README.md
+++ b/examples/aisimulate/spica/README.md
@@ -40,13 +40,7 @@ python -m aisimulate.spica \
   --config examples/aisimulate/spica/configs/smart_sweep.yaml
 ```
 
-The GLM-5-FP8 Pareto-front configuration captures the setup from a previous experiment:
-
-> [!IMPORTANT]
-> This configuration uses `kv_load_ratio` and the KV-cache estimator from
-> `aiconfigurator_core.sdk.memory`. The default `dynamo-planner` image includes the matching AI
-> Configurator application and core packages. Candidate enumeration requires an AI Configurator
-> performance database for the B200/SGLang target.
+The GLM-5-FP8 Pareto-front configuration captures the setup from a previous experiment.
 
 Update `workload.trace_path` before running a trace-backed configuration.
 

--- a/examples/aisimulate/spica/README.md
+++ b/examples/aisimulate/spica/README.md
@@ -40,14 +40,13 @@ python -m aisimulate.spica \
   --config examples/aisimulate/spica/configs/smart_sweep.yaml
 ```
 
-The GLM-5-FP8 Pareto-front configuration is retained as a reference for a
-previous experiment:
+The GLM-5-FP8 Pareto-front configuration captures the setup from a previous experiment:
 
 > [!IMPORTANT]
-> This configuration uses `kv_load_ratio` and requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. It fails closed in the default `dynamo-planner` image, which currently
-> retains AI Configurator 0.9. It is not runnable with the repository's packaged dependencies.
-> Use `smart_sweep.yaml` with a trace or fixed `concurrency` workload for a runnable search.
+> This configuration uses `kv_load_ratio` and the KV-cache estimator from
+> `aiconfigurator_core.sdk.memory`. The default `dynamo-planner` image includes the matching AI
+> Configurator application and core packages. Candidate enumeration requires an AI Configurator
+> performance database for the B200/SGLang target.
 
 Update `workload.trace_path` before running a trace-backed configuration.
 

--- a/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
+++ b/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Experimental: this configuration uses kv_load_ratio and requires an AI Configurator release
-# that provides aiconfigurator.sdk.memory. It fails closed in the default dynamo-planner image,
-# which currently retains AI Configurator 0.9.
+# Experimental: this configuration uses kv_load_ratio and the KV-cache estimator from
+# aiconfigurator_core.sdk.memory. The default dynamo-planner image includes the matching AI
+# Configurator application and core packages. The B200/SGLang target requires a matching
+# performance database.
 
 search_space:
   deployment_mode: [disagg]

--- a/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
+++ b/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
@@ -1,10 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Experimental: this configuration uses kv_load_ratio and the KV-cache estimator from
-# aiconfigurator_core.sdk.memory. The default dynamo-planner image includes the matching AI
-# Configurator application and core packages. The B200/SGLang target requires a matching
-# performance database.
+# Experimental Spica configuration for the GLM-5-FP8 Pareto sweep.
 
 search_space:
   deployment_mode: [disagg]


### PR DESCRIPTION
## Summary

- Correct Spica documentation and examples that still described the default `dynamo-planner` image as using AI Configurator 0.9.
- Document the packaged `aiconfigurator_core.sdk.memory` estimator and supported `kv_load_ratio` path.
- Preserve the real performance-database failure policy: branch enumeration removes unsupported backends and raises `NoViableParallelConfig` only when no viable mode remains.
- Clarify that reproducing the historical GLM-5 frontier still depends on the exact performance database and Replay behavior in the runtime snapshot.

## Root Cause

The AI Configurator 0.11 migration updated the Planner dependencies and Spica import path, but the earlier AIC 0.9 limitation remained in five Fern pages and two example files.

## User Impact

Users are no longer directed away from the packaged `kv_load_ratio` path or toward the removed `aiconfigurator.sdk.memory` namespace.

Tracks [DYN-3743](https://linear.app/nvidia/issue/DYN-3743/dynamorelease140spica-documentation-still-says-the-default-planner).

## Validation

- `NODE_OPTIONS=--experimental-global-webcrypto fern check --warnings` — 0 errors; two unrelated warnings for unauthenticated redirect checks and existing accent-color contrast.
- `git diff --check`
- Three independent agentic review passes covering technical accuracy, documentation style, and PR scope; no remaining findings.
- `fern docs broken-links` could not initialize locally because the Node 18/rolldown environment is missing its bundled dependency. This change does not add or modify links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Spica guidance to reflect current KV-capacity and concurrency calculations.
  * Clarified that KV-feasibility filtering requires matching performance data and removes unsupported configurations.
  * Documented failure behavior when no feasible deployment configuration remains.
  * Refreshed GLM-5-FP8 experimental reproduction notes and configuration descriptions.
  * Removed outdated compatibility warnings and fallback-behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->