### PR TITLE
fix(chart): allow servicemonitor labels

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml
@@ -29,7 +29,9 @@ metadata:
   name: {{ include "dynamo-operator.fullname" . }}-operator
   namespace: {{ .Release.Namespace }}
   labels:
-    release: prometheus
+    {{- with .Values.metricsService.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
     {{- include "dynamo-operator.labels" . | nindent 4 }}
 spec:
   selector:

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -152,6 +152,12 @@ metricsService:
   # true=always create both (use for helm template / GitOps workflows),
   # false=never create either
   enabled: null
+  # -- Labels for the operator ServiceMonitor. Label-selecting Prometheus installs
+  # only discover monitors carrying their release label; the default matches the
+  # release name used by deploy/observability/setup-monitoring.sh. Override when your
+  # Prometheus release is named differently, e.g. {release: kube-prometheus-stack}.
+  labels:
+    release: prometheus
   ports:
   - name: metrics
     port: 8080

--- a/deploy/helm/charts/platform/tests/servicemonitor_labels_test.yaml
+++ b/deploy/helm/charts/platform/tests/servicemonitor_labels_test.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: operator ServiceMonitor labels
+templates:
+  - charts/dynamo-operator/templates/operator-servicemonitor.yaml
+tests:
+  - it: should keep the default release label
+    set:
+      dynamo-operator.metricsService.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: metadata.labels.release
+          value: prometheus
+  - it: should apply configured metricsService.labels
+    set:
+      dynamo-operator.metricsService.enabled: true
+      dynamo-operator.metricsService.labels:
+        release: kube-prometheus-stack
+    asserts:
+      - equal:
+          path: metadata.labels.release
+          value: kube-prometheus-stack


### PR DESCRIPTION
## Overview:

The operator's ServiceMonitor label is hardcoded to `release: prometheus`. That matches the release name used by `deploy/observability/setup-monitoring.sh`, but Prometheus installs under any other release name (e.g. `kube-prometheus-stack`, or GitOps-managed monitoring stacks) can't discover the monitor, so operator metrics go unscraped.

## Details:

Makes the label configurable via `metricsService.labels`. The default keeps `release: prometheus`, so setups following the bundled monitoring script are unaffected; installs with a differently-named Prometheus release override it in values. Adds a helm unit test covering the default and an override.

Same approach as #12094, which makes the generated PodMonitors' labels configurable; together, all generated monitors become discoverable regardless of the Prometheus release name.

## Where should the reviewer start?

`deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml`

## Related Issues

- Relates to #12003

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12716" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable labels for the operator’s metrics monitoring service.
  * Retained `release: prometheus` as the default label while allowing it to be overridden for differently named Prometheus installations.

* **Bug Fixes**
  * Improved compatibility with custom Prometheus deployments by honoring configured monitoring labels.

* **Tests**
  * Added coverage verifying both the default label and custom label overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->