### PR TITLE
fix(vllm): read omni realtime multimodal_output via the Mapping API (cherry-pick #12667)

### DIFF
--- a/components/src/dynamo/vllm/omni/realtime_handler.py
+++ b/components/src/dynamo/vllm/omni/realtime_handler.py
@@ -43,6 +43,7 @@ import asyncio
 import base64
 import logging
 import uuid
+from collections.abc import Mapping
 from typing import Any, AsyncGenerator, Callable, Optional, Sequence
 
 import numpy as np
@@ -201,15 +202,18 @@ class Turn:
         """Extract per-step audio deltas from an engine output.
 
         Audio lives in ``output.multimodal_output['audio'|'model_outputs']`` as a
-        float32 waveform (or list of them). Some engine paths emit a growing
-        cumulative waveform; ``waveform_to_deltas`` reconciles both shapes
-        against ``self.audio_ref`` so the client never hears duplicates.
+        float32 waveform (or list of them). The payload is a ``Mapping`` -- a
+        ``MultimodalPayload`` or a plain dict, depending on what the step
+        attached -- so read it through that interface, not a concrete type. Some
+        engine paths emit a growing cumulative waveform; ``waveform_to_deltas``
+        reconciles both shapes against ``self.audio_ref`` so the client never
+        hears duplicates.
         """
         mm = getattr(output, "multimodal_output", None)
-        if mm is None:
+        if not isinstance(mm, Mapping):
             return []
 
-        raw_audio = mm.tensors["audio"] if "audio" in mm.tensors.keys() else None
+        raw_audio = mm.get("audio" if "audio" in mm else "model_outputs")
         if raw_audio is None:
             return []
 
@@ -607,6 +611,11 @@ def tensor_to_numpy(value: Any) -> np.ndarray | None:
             arr = np.asarray(value)
         except Exception:  # noqa: BLE001 - non-array engine payloads are skipped
             return None
+    # ``model_outputs`` is model-defined, so a structured value there survives
+    # np.asarray as an object array; skip it rather than fail the turn on the
+    # astype below. "biuf" is bool/int/uint/float.
+    if arr.dtype.kind not in "biuf":
+        return None
     if arr.ndim > 1:
         arr = arr.reshape(-1)
     return arr.astype(np.float32, copy=False)

--- a/components/src/dynamo/vllm/tests/omni/test_omni_realtime_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_realtime_handler.py
@@ -20,11 +20,9 @@ import pytest
 try:
     # Importing the omni package pulls omni_handler -> vllm_omni; the handler
     # logic itself is vllm-free, but the package import is not.
-    # The handler reads audio off a vLLM-Omni MultimodalPayload (``mm.tensors``),
-    # so the fake engine outputs below must use the real type, not a plain dict.
     from vllm_omni.outputs.mm_outputs import MultimodalPayload
 
-    from dynamo.vllm.omni.realtime_handler import RealtimeOmniHandler
+    from dynamo.vllm.omni.realtime_handler import RealtimeOmniHandler, Turn
 except (ImportError, ModuleNotFoundError):
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
 
@@ -49,22 +47,42 @@ class _FakeContext:
         return self._stopped
 
 
-def _audio_output(samples: np.ndarray, sample_rate: int = 16000):
+# ``OmniRequestOutput.multimodal_output`` is a property that returns whichever
+# shape the step produced: a MultimodalPayload when a stage attached a non-empty
+# one, and the plain-dict fallback field otherwise. Both shapes are Mappings and
+# the handler must read either, so every audio-bearing fixture is parametrized
+# over the two.
+def _payload_obj(tensors: dict, metadata: dict):
+    return MultimodalPayload(tensors=tensors, metadata=metadata)
+
+
+def _payload_dict(tensors: dict, metadata: dict):
+    return {**tensors, **metadata}
+
+
+payload_shapes = pytest.mark.parametrize(
+    "make_payload",
+    [_payload_obj, _payload_dict],
+    ids=["multimodal_payload", "plain_dict"],
+)
+
+
+def _audio_output(samples: np.ndarray, make_payload=_payload_obj, sample_rate=16000):
     return SimpleNamespace(
         stage_id=1,
         outputs=[],
-        multimodal_output=MultimodalPayload(
-            tensors={"audio": samples}, metadata={"sr": sample_rate}
-        ),
+        multimodal_output=make_payload({"audio": samples}, {"sr": sample_rate}),
     )
 
 
 def _text_output(text: str):
+    # Stage-0 steps attach no payload, so the property falls through to its
+    # ``dict`` default -- the shape that reaches the handler on every turn.
     return SimpleNamespace(
         stage_id=0,
         outputs=[SimpleNamespace(text=text, token_ids=[1, 2, 3])],
         prompt_token_ids=[0],
-        multimodal_output=MultimodalPayload(),
+        multimodal_output={},
     )
 
 
@@ -180,6 +198,43 @@ def test_full_turn_event_sequence():
     out_f32 = np.frombuffer(deltas, dtype=np.int16).astype(np.float32) / 32767.0
     assert out_f32.shape == in_f32.shape
     assert np.allclose(out_f32, in_f32, atol=2e-4)
+
+
+def _bare_turn() -> Turn:
+    """A Turn wired to nothing; extract_audio_chunks needs no engine."""
+    return Turn(engine_client=None, streaming_input_factory=None)
+
+
+@payload_shapes
+@pytest.mark.parametrize("key", ["audio", "model_outputs"], ids=["audio", "model_out"])
+def test_extract_audio_chunks_reads_both_payload_shapes(make_payload, key):
+    samples = np.linspace(-1.0, 1.0, 8, dtype=np.float32)
+    output = SimpleNamespace(
+        multimodal_output=make_payload({key: samples}, {"sr": 16000})
+    )
+    chunks = _bare_turn().extract_audio_chunks(output)
+    assert len(chunks) == 1
+    assert np.allclose(chunks[0], samples)
+
+
+@pytest.mark.parametrize(
+    "multimodal_output",
+    [
+        {},  # what a step that attached no payload reports
+        "not-a-mapping",
+    ],
+    ids=["empty_dict", "non_mapping"],
+)
+def test_extract_audio_chunks_without_audio_is_empty(multimodal_output):
+    output = SimpleNamespace(multimodal_output=multimodal_output)
+    assert _bare_turn().extract_audio_chunks(output) == []
+
+
+def test_extract_audio_chunks_skips_non_waveform_model_outputs():
+    # ``model_outputs`` is model-defined; a structured value there survives
+    # np.asarray as an object array and must be skipped, not raised on.
+    output = SimpleNamespace(multimodal_output={"model_outputs": {"logits": [1, 2]}})
+    assert _bare_turn().extract_audio_chunks(output) == []
 
 
 def test_unknown_client_events_are_ignored():

--- a/tests/frontend/realtime_omni_mock_worker.py
+++ b/tests/frontend/realtime_omni_mock_worker.py
@@ -45,9 +45,13 @@ class _MockAsyncOmni:
     """Fake AsyncOmni: drains the streaming audio input, then echoes it back.
 
     Yields a stage-0 text frame (transcript) followed by the accumulated audio
-    as a single multimodal output, matching the fields RealtimeOmniHandler reads
-    off a real ``OmniRequestOutput`` (``stage_id``, ``outputs[].text``, and a
-    ``MultimodalPayload`` whose ``tensors['audio']`` holds the waveform).
+    as a single multimodal output, mirroring the shapes a real
+    ``OmniRequestOutput`` exposes (``stage_id``, ``outputs[].text``, and
+    ``multimodal_output``).
+
+    ``multimodal_output`` is a plain ``dict`` when the step attached no payload
+    and a ``MultimodalPayload`` when it did; the frames below use both so the
+    handler is exercised against either.
     """
 
     default_sampling_params_list: list = []
@@ -61,7 +65,7 @@ class _MockAsyncOmni:
             stage_id=0,
             outputs=[SimpleNamespace(text=MOCK_TRANSCRIPT, token_ids=[1])],
             prompt_token_ids=[0],
-            multimodal_output=MultimodalPayload(),
+            multimodal_output={},
         )
         yield SimpleNamespace(
             stage_id=1,


### PR DESCRIPTION
## Summary

- Cherry-pick of #12667 to `release/1.4.0`
- Every vLLM-Omni realtime turn failed with `AttributeError: 'dict' object has no attribute 'tensors'`, so realtime serving was unusable on this release branch.

Fixes DYN-3745
Fixes https://nvbugs.nvidia.com/6556337

## Original PR

- Main PR: #12667
- Merge commit: `8c00a0a70cdff5af0322984c5e20a2e3cc3892bc`

## What the fix does

`OmniRequestOutput.multimodal_output` returns a `MultimodalPayload` when a stage attached a non-empty one and its plain-dict fallback (`{}`) otherwise. The handler reached for `mm.tensors`, and `run_turn`'s blanket handler turned the `AttributeError` into an `error` event plus `response.done(status=failed)` — so the turn died before any audio.

It now reads through the `Mapping` API, as vLLM-Omni's own `realtime_connection.py` does, and picks up the `model_outputs` key that was documented but never checked.

This is a regression from a dependency bump: vLLM-Omni v0.24.0 split `inter_stage_outputs` out of `multimodal_outputs` and stopped forwarding it to the orchestrator output processor (vLLM-Omni #4527, *"separating inter-stage outputs from client-facing outputs"*). Before that, every step carried a non-empty payload and `mm.tensors` resolved.

## Conflict resolution

One conflict, in the import block. `release/1.4.0` predates the realtime serving refactor (#11830), so it still defines `StreamingInputFactory` locally and needs `Callable` in its `typing` import, which `main` no longer does. Resolved by keeping both:

```python
from collections.abc import Mapping
from typing import Any, AsyncGenerator, Callable, Optional, Sequence
```

Everything else applied cleanly, and both changed functions (`extract_audio_chunks`, `tensor_to_numpy`) landed intact.

## Test plan

- [ ] CI passes
- [ ] Verified fix works on release branch

Because the surrounding file differs from `main` on this branch, the fix was re-verified **against `release/1.4.0`'s own handler** rather than assuming the main result carries over. The real module text was executed before and after the pick, with `MultimodalPayload` copied from the pinned `v0.26.0rc1`:

| case | `release/1.4.0` before | with this pick |
|---|---|---|
| stage-0 step (property fallback `{}`) | `AttributeError: 'dict' object has no attribute 'tensors'` | pass |
| audio via plain dict | `AttributeError` | pass |
| `model_outputs` via plain dict | `AttributeError` | pass |
| `model_outputs` = dict (non-waveform) | `AttributeError` | pass (skipped) |
| non-mapping payload | `AttributeError` | pass |

`pre-commit run --files <changed>` passes clean; all three modules compile.

**Still needed:** an end-to-end run against a real Qwen3-Omni realtime session on GPU with the 1.4.0 image. This is unit-verified only — no test in CI loads a real omni model on the realtime path, which is how the original regression reached a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12717" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->