### PR TITLE
fix(vllm): declare entry-stage engine_input_source in GLM-Image NIXL config (cherry-pick #12709)

### DIFF
--- a/examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml
+++ b/examples/backends/vllm/launch/stage_configs/glm_image_nixl.yaml
@@ -35,6 +35,10 @@ stage_args:
       distributed_executor_backend: "mp"
       enable_prefix_caching: false
       max_num_batched_tokens: 32768
+    # Entry stage: input comes from the request, not from another stage.
+    # Declared explicitly because the stage_args format applies no schema
+    # defaults, and vLLM-Omni reads this field unconditionally.
+    engine_input_source: []
     # Explicit connector mapping for AR -> DiT
     output_connectors:
       to_stage_1: ar_to_dit_nixl


### PR DESCRIPTION
## Summary

- Cherry-pick of #12709 to `release/1.4.0`
- The AR stage (stage 0) of the GLM-Image NIXL pipeline died at orchestrator init with `Missing key engine_input_source`, so `disagg_omni_glm_image_nixl.sh` could not start and `/v1/images/generations` never became ready.

Fixes DYN-3746

## Original PR

- Main PR: #12709
- Merge commit: `0c4fabc26b1baea86846eb2e3bd4dc89e4e9dc0c`

## What the fix does

Declares `engine_input_source: []` on the entry stage. The `stage_args` format applies no schema defaults and vLLM-Omni reads the field unconditionally, so omegaconf raised `ConfigAttributeError` at `stage_args[0].engine_input_source`, killing the orchestrator thread.

Applied to `release/1.4.0` with no conflicts — the config file is identical to `main` on this branch.

## Test plan

- [ ] CI passes
- [ ] Verified fix works on release branch

Verified after the pick: the file parses, and the entry stage now declares the field while stage 1 keeps its existing source.

```
stage 0: engine_input_source = []
stage 1: engine_input_source = [0]
```

Byte-identical to the merged state on `main`. `pre-commit run --files <changed>` passes clean.

**Not verified end-to-end.** This needs a two-GPU H100 run of `disagg_omni_glm_image_nixl.sh` on the 1.4.0 image to confirm the AR stage now reaches ready — the reproduction in DYN-3746.

> [!NOTE]
> DYN-3746's write-up argues the config needs a fuller migration than this one field (`stage_args` → `stages`, plus the `engine_args:` / `runtime:` nesting and the connector declaration form). The ticket was closed against this PR, so that analysis may have been superseded — but if it still holds, `release/1.4.0` will need the follow-up too, and this pick only clears the first failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12719" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->