### PR TITLE
feat(epp): run custom selection services through standard bootstrap

### DIFF
--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -13,7 +13,7 @@ description = "Envoy ext_proc gRPC server for Dynamo inference routing"
 
 [[bin]]
 name = "dynamo-ext-proc"
-path = "src/main.rs"
+path = "src/bin/dynamo-ext-proc.rs"
 
 [dependencies]
 dynamo-kv-router = { workspace = true, features = [

--- a/deploy/inference-gateway/ext-proc/src/bin/dynamo-ext-proc.rs
+++ b/deploy/inference-gateway/ext-proc/src/bin/dynamo-ext-proc.rs
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    dynamo_ext_proc::run().await
+}

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -22,6 +22,7 @@ pub mod peer_discovery;
 pub mod picker;
 pub mod pod_discovery;
 pub mod proto;
+mod runner;
 pub mod selector;
 pub mod server;
 pub mod topology_adapter;
@@ -33,6 +34,7 @@ pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol}
 pub use inference_pool::PoolState;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo, ResponseUsage};
 pub use pod_discovery::{PodDiscovery, RawWorker};
+pub use runner::{run, run_with_selection_service};
 pub use selector::{OverlapSummary, SelectRequest, SelectResponse, Selector, WorkerRegistration};
 pub use server::ExtProcServer;
 pub use topology_adapter::{RegistrationDefaults, TopologyAdapter};

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -118,26 +118,27 @@ fn create_tls_acceptor() -> Result<TlsAcceptor> {
 
 /// Run the stock EPP until it exits.
 pub async fn run() -> Result<()> {
-    run_inner(None).await
+    init_tracing();
+    run_inner(EppMode::from_env()?, None).await
 }
 
 /// Run the standalone EPP around a caller-built selection service.
 pub async fn run_with_selection_service(service: SelectionService) -> Result<()> {
-    run_inner(Some(service)).await
+    init_tracing();
+    run_inner(EppMode::Standalone, Some(service)).await
 }
 
-async fn run_inner(selection_service: Option<SelectionService>) -> Result<()> {
-    tracing_subscriber::fmt()
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
-        .init();
+        .try_init();
+}
 
-    let standalone = matches!(EppMode::from_env()?, EppMode::Standalone);
-    if selection_service.is_some() && !standalone {
-        anyhow::bail!("a custom selection service requires DYN_EPP_MODE=standalone");
-    }
+async fn run_inner(mode: EppMode, selection_service: Option<SelectionService>) -> Result<()> {
+    let standalone = matches!(mode, EppMode::Standalone);
 
     let config = Config::from_env();
 

--- a/deploy/inference-gateway/ext-proc/src/runner.rs
+++ b/deploy/inference-gateway/ext-proc/src/runner.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Standalone Rust EPP binary.
+//! Standard Rust EPP process bootstrap.
 //!
 //! Replaces the Go EPP + CGO bridge with a single native Rust binary that
 //! implements the Envoy ext_proc gRPC service and uses Dynamo's KV-aware
@@ -13,9 +13,11 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use dynamo_ext_proc::{EppMode, EppStandaloneConfig, ExtProcServer, Router, metrics};
+use dynamo_kv_router::services::selection::SelectionService;
 use tokio::net::TcpListener;
 use tokio_rustls::TlsAcceptor;
+
+use crate::{EppMode, EppStandaloneConfig, ExtProcServer, Router, metrics};
 
 const GRPC_PORT: u16 = 9002;
 const HEALTH_PORT: u16 = 9003;
@@ -114,8 +116,17 @@ fn create_tls_acceptor() -> Result<TlsAcceptor> {
     Ok(TlsAcceptor::from(Arc::new(tls_config)))
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+/// Run the stock EPP until it exits.
+pub async fn run() -> Result<()> {
+    run_inner(None).await
+}
+
+/// Run the standalone EPP around a caller-built selection service.
+pub async fn run_with_selection_service(service: SelectionService) -> Result<()> {
+    run_inner(Some(service)).await
+}
+
+async fn run_inner(selection_service: Option<SelectionService>) -> Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -124,6 +135,9 @@ async fn main() -> Result<()> {
         .init();
 
     let standalone = matches!(EppMode::from_env()?, EppMode::Standalone);
+    if selection_service.is_some() && !standalone {
+        anyhow::bail!("a custom selection service requires DYN_EPP_MODE=standalone");
+    }
 
     let config = Config::from_env();
 
@@ -172,7 +186,12 @@ async fn main() -> Result<()> {
             "Initializing standalone selector mode (no Dynamo runtime)..."
         );
         metrics::set_served_model(&selector_cfg.model_name);
-        let router = Arc::new(dynamo_ext_proc::EppRouter::from_selector(selector_cfg).await?);
+        let router = Arc::new(match selection_service {
+            Some(service) => {
+                crate::EppRouter::from_selection_service(selector_cfg, service).await?
+            }
+            None => crate::EppRouter::from_selector(selector_cfg).await?,
+        });
         let ready_router = router.clone();
         serve(router, move || ready_router.is_ready(), health_reporter).await
     } else {
@@ -191,7 +210,7 @@ async fn main() -> Result<()> {
 
 /// Mirror the picker's live readiness onto the gRPC health status, then serve
 /// the ext_proc endpoint. Shared by both Dynamo-discovery and standalone modes.
-async fn serve<P: dynamo_ext_proc::EndpointPicker>(
+async fn serve<P: crate::EndpointPicker>(
     picker: Arc<P>,
     is_ready: impl Fn() -> bool + Send + 'static,
     health_reporter: tonic_health::server::HealthReporter,
@@ -203,7 +222,7 @@ async fn serve<P: dynamo_ext_proc::EndpointPicker>(
     // (set SERVING once) would strand those states, so a background task tracks
     // transitions and moves the health status in lock-step, dropping out of
     // SERVING when readiness drops and recovering when it returns. Health starts
-    // NOT_SERVING (set in `main`); the mirror polls a cheap closure (atomic loads).
+    // NOT_SERVING (set during startup); the mirror polls a cheap closure (atomic loads).
     {
         let health_reporter = health_reporter.clone();
         tokio::spawn(async move {

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
@@ -132,7 +132,7 @@ let service = SelectionServiceBuilder::new(kv_router_config)
 dynamo_ext_proc::run_with_selection_service(service).await?;
 ```
 
-The runner uses the stock TLS, health, metrics, discovery, and readiness bootstrap. It requires `DYN_EPP_MODE=standalone` and takes ownership of the service so its workers, peer membership, and background tasks share the EPP lifecycle. The standard EPP binary calls the same runner without a prebuilt service.
+The runner uses the stock TLS, health, metrics, discovery, and readiness bootstrap. Supplying a prebuilt service selects standalone mode and transfers ownership of the service so its workers, peer membership, and background tasks share the EPP lifecycle. The standard EPP binary calls the same runner without a prebuilt service.
 
 ## Policy Contract
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
@@ -121,7 +121,7 @@ Build and run that binary in the custom image. `python3 -m dynamo.frontend` star
 
 ## Link a Custom EPP
 
-Build a `SelectionService` with the same factory and move it into `EppRouter`:
+Build a `SelectionService` with the same factory and pass it to the standard EPP runner:
 
 ```rust
 let service = SelectionServiceBuilder::new(kv_router_config)
@@ -129,11 +129,10 @@ let service = SelectionServiceBuilder::new(kv_router_config)
     .build()
     .await?;
 
-let epp_config = EppStandaloneConfig::from_env()?;
-let router = EppRouter::from_selection_service(epp_config, service).await?;
+dynamo_ext_proc::run_with_selection_service(service).await?;
 ```
 
-`EppRouter` takes exclusive ownership of the service so its workers, peer membership, and background tasks share the EPP lifecycle. The standard EPP path remains unchanged when the caller does not supply a prebuilt service.
+The runner uses the stock TLS, health, metrics, discovery, and readiness bootstrap. It requires `DYN_EPP_MODE=standalone` and takes ownership of the service so its workers, peer membership, and background tasks share the EPP lifecycle. The standard EPP binary calls the same runner without a prebuilt service.
 
 ## Policy Contract
 

--- a/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
+++ b/docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md
@@ -124,6 +124,8 @@ Build and run that binary in the custom image. `python3 -m dynamo.frontend` star
 Build a `SelectionService` with the same factory and pass it to the standard EPP runner:
 
 ```rust
+use dynamo_kv_router::services::selection::SelectionServiceBuilder;
+
 let service = SelectionServiceBuilder::new(kv_router_config)
     .worker_selection_policy_factory(active_request_policy)
     .build()


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Moves the existing Rust EPP process bootstrap into the `dynamo-ext-proc` library and exposes it as a reusable runner. This lets custom linked policies pass a prebuilt `SelectionService` without copying Dynamo's TLS, health, metrics, discovery, readiness, or server setup.

CLOSES: DYN-3775

### How This Was Implemented
- Move the stock EPP bootstrap from the binary entrypoint into library-owned `run()` and `run_with_selection_service(...)` functions.
- Keep `dynamo-ext-proc` as a seven-line binary that calls the same default runner.
- Route a supplied service through the existing `EppRouter::from_selection_service` constructor in standalone EPP mode.
- Document the custom EPP invocation.

<details>
<summary>Walkthrough</summary>

#### Mental model

The stock and custom binaries now differ only in how the selection service is supplied. Both enter the same process bootstrap and the same ext-proc request path.

```mermaid
flowchart LR
    D["Stock binary"] --> R["run()"]
    P["Custom policy crate"] --> S["Prebuilt SelectionService"]
    S --> C["run_with_selection_service()"]
    R --> B["Standard EPP bootstrap"]
    C --> B
    B --> E["EppRouter"]
    E --> X["ExtProcServer"]
```

#### State and ordering

`run()` preserves the existing environment-driven mode selection: standalone mode builds the default embedded selector, while Dynamo runtime mode uses discovery. `run_with_selection_service(...)` explicitly selects standalone mode and moves the caller-owned service into `EppRouter`; callers do not need to set `DYN_EPP_MODE` for the custom path.

#### Request lifecycle

Startup still initializes tracing, health reporting, metrics, standalone pod discovery or Dynamo discovery, readiness mirroring, TLS, and the ext-proc server in the existing order. After construction, requests follow the existing `EppRouter` and `SelectionService` paths for tokenization, eligibility, scheduling, validation, accounting, reservations, and completion callbacks.

#### Boundaries and limitations

This PR does not change the Python frontend, `HttpFrontend`, worker-selection traits, default selection behavior, or request hot path. It adds no macro, runtime policy loading, C ABI, policy registry, or frontend configuration surface; custom policies remain statically linked into a Rust EPP image.

</details>

### Validation
- `cargo test -p dynamo-ext-proc --lib` (117 passed)
- `cargo check -p dynamo-ext-proc --all-targets`
- `cargo clippy -p dynamo-ext-proc --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `pre-commit run --files deploy/inference-gateway/ext-proc/Cargo.toml deploy/inference-gateway/ext-proc/src/bin/dynamo-ext-proc.rs deploy/inference-gateway/ext-proc/src/lib.rs deploy/inference-gateway/ext-proc/src/runner.rs docs/fern/pages/developer-guide/advanced-customizations/custom-worker-selection.md`
- `fern check`
- `fern docs broken-links`
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running the inference gateway with a caller-provided selection service.
  * Standardized standalone gateway startup and health initialization.

* **Documentation**
  * Updated custom worker-selection guidance to explain service ownership and standalone mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->