### PR TITLE
fix(chart): set honorLabels on operator servicemonitor

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml
@@ -40,6 +40,11 @@ spec:
   - port: metrics
     scheme: https
     path: /metrics
+    # honorLabels keeps the namespace label the operator sets on its metrics (the
+    # reconciled resource's namespace); without it Prometheus renames the label to
+    # exported_namespace on collision with the target's namespace, and dashboards
+    # filtering on namespace stop matching. The PodMonitors above already set this.
+    honorLabels: true
     interval: 15s
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:

--- a/deploy/helm/charts/platform/tests/servicemonitor_honorlabels_test.yaml
+++ b/deploy/helm/charts/platform/tests/servicemonitor_honorlabels_test.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: operator ServiceMonitor honorLabels
+templates:
+  - charts/dynamo-operator/templates/operator-servicemonitor.yaml
+tests:
+  - it: should honor metric labels on the metrics endpoint
+    set:
+      dynamo-operator.metricsService.enabled: true
+    asserts:
+      - isKind:
+          of: ServiceMonitor
+      - equal:
+          path: spec.endpoints[0].honorLabels
+          value: true


### PR DESCRIPTION
## Overview:

The operator labels its metrics with `namespace` (the reconciled resource's namespace, per the operator metrics reference). The ServiceMonitor doesn't set `honorLabels`, so Prometheus renames that label to `exported_namespace` when it collides with the scrape target's namespace. Dashboards that filter on `namespace` (including `dynamo-operator.json`) then filter by the operator's install namespace instead of the resource's.

## Details:

Sets `honorLabels: true` on the ServiceMonitor's metrics endpoint, same as the chart's PodMonitors already do. Adds a unit test.

An alternative would be updating the dashboard and docs to use `exported_namespace`, but keeping the metric's own label matches the PodMonitor behavior and the documented label name.

Touches the same file as #12716 but is independent.

## Where should the reviewer start?

`deploy/helm/charts/platform/components/operator/templates/operator-servicemonitor.yaml`

## Related Issues

- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Prometheus metrics scraping to preserve labels supplied by the operator.

* **Tests**
  * Added coverage verifying label preservation when metrics monitoring is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->