### PR TITLE
test(deploy): retry K8s API calls on vCluster port-forward blips

### DIFF
--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -37,6 +37,65 @@ def _get_workspace_dir() -> str:
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
+# --- Resilience for K8s API calls through the vCluster port-forward ----------
+#
+# Deploy tests reach the (v)cluster API over a local ``kubectl port-forward`` at
+# 127.0.0.1:8443. A watchdog restarts that forward when it drops, but the
+# restart takes a few seconds; a K8s API call that lands in that window fails
+# with a connection error. For post-Ready calls (e.g. get_pods()) that error
+# propagates and fails the whole test even though the deployment is healthy.
+# Retry connection-level errors so a transient tunnel blip does not fail the test.
+def _api_connection_errors() -> tuple[type[BaseException], ...]:
+    # ConnectionError/ConnectionRefusedError/TimeoutError and
+    # aiohttp.ClientConnectorError (kubernetes_asyncio) are all OSError subclasses;
+    # httpx.TransportError (kr8s) is not, so add it explicitly. Built defensively
+    # so a missing optional client library never breaks import.
+    errs: list[type[BaseException]] = [OSError]
+    try:
+        import httpx
+
+        errs.append(httpx.TransportError)
+    except Exception:
+        pass
+    return tuple(errs)
+
+
+_API_CONNECTION_ERRORS = _api_connection_errors()
+
+
+def _retry_api_call(
+    fn,
+    *,
+    what: str,
+    logger: logging.Logger,
+    attempts: int = 5,
+    delay: float = 2.0,
+):
+    """Call ``fn`` and retry only on a vCluster port-forward connection blip.
+
+    Any non-connection exception propagates immediately so real failures are not
+    masked. Re-raises the last connection error if all attempts are exhausted.
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return fn()
+        except _API_CONNECTION_ERRORS as e:
+            last_exc = e
+            logger.warning(
+                "K8s API call (%s) failed on attempt %d/%d "
+                "(vCluster port-forward blip?): %s",
+                what,
+                attempt,
+                attempts,
+                e,
+            )
+            if attempt < attempts:
+                time.sleep(delay)
+    assert last_exc is not None  # loop ran at least once
+    raise last_exc
+
+
 # Supported DynamoGraphDeployment CRD schemas. v1alpha1 uses ``spec.services``
 # (a dict of service name -> ServiceSpec); v1beta1 uses ``spec.components``
 # (a list of components with podTemplate.spec.containers).
@@ -1390,9 +1449,17 @@ class ManagedDeployment:
 
             pods: list[Pod] = []
 
-            for pod in kr8s.get(
-                "pods", namespace=self.namespace, label_selector=label_selector
-            ):
+            # Materialize inside the retry so a dropped 127.0.0.1:8443 tunnel
+            # surfaces as a retryable connection error here rather than partway
+            # through the caller's iteration.
+            fetched = _retry_api_call(
+                lambda ls=label_selector: list(
+                    kr8s.get("pods", namespace=self.namespace, label_selector=ls)
+                ),
+                what=f"list pods for {original_name}",
+                logger=self._logger,
+            )
+            for pod in fetched:
                 pods.append(pod)  # type: ignore[arg-type]
 
             result[original_name] = pods
@@ -1541,13 +1608,23 @@ class ManagedDeployment:
         """
         try:
             # Create port forward - this runs in a background thread
-            # Use 127.0.0.1 (localhost) instead of 0.0.0.0 to prevent port conflicts
-            port_forward = pod.portforward(
-                remote_port=remote_port,
-                local_port=0,  # Auto-assign an available port
-                address="127.0.0.1",  # Use localhost for better isolation and conflict prevention
+            # Use 127.0.0.1 (localhost) instead of 0.0.0.0 to prevent port conflicts.
+            # Opening the forward talks to the K8s API over 127.0.0.1:8443, so retry
+            # if that tunnel is momentarily down rather than giving up (returning None).
+            def _open_port_forward():
+                pf = pod.portforward(
+                    remote_port=remote_port,
+                    local_port=0,  # Auto-assign an available port
+                    address="127.0.0.1",  # localhost for isolation/conflict prevention
+                )
+                pf.start()
+                return pf
+
+            port_forward = _retry_api_call(
+                _open_port_forward,
+                what=f"open port-forward for {pod.name}",
+                logger=self._logger,
             )
-            port_forward.start()
 
             # Try to connect with exponential backoff
             backoff_delay = 0.5  # Start with 500ms

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -10,6 +10,8 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, List, Literal, Optional
 
+import aiohttp
+import httpx
 import kr8s
 import requests
 import yaml
@@ -37,23 +39,14 @@ def _get_workspace_dir() -> str:
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-# The vCluster port-forward (127.0.0.1:8443) can briefly drop mid-test; its
-# watchdog takes a few seconds to restart it. Retry K8s API calls so that window
-# doesn't fail a post-Ready call on a healthy deployment.
-def _api_connection_errors() -> tuple[type[BaseException], ...]:
-    # aiohttp.ClientConnectorError (kubernetes_asyncio) and the builtin connection
-    # errors are OSError subclasses; httpx.TransportError (kr8s) is not.
-    errs: list[type[BaseException]] = [OSError]
-    try:
-        import httpx
-
-        errs.append(httpx.TransportError)
-    except Exception:
-        pass
-    return tuple(errs)
-
-
-_API_CONNECTION_ERRORS = _api_connection_errors()
+# Connection-level errors from the K8s API clients (kr8s -> httpx,
+# kubernetes_asyncio -> aiohttp) when the vCluster port-forward (127.0.0.1:8443)
+# briefly drops mid-test before its watchdog restarts it.
+_API_CONNECTION_ERRORS = (
+    ConnectionError,
+    aiohttp.ClientConnectionError,
+    httpx.TransportError,
+)
 
 
 def _retry_api_call(
@@ -65,24 +58,14 @@ def _retry_api_call(
     delay: float = 2.0,
 ):
     """Retry ``fn`` on a port-forward connection blip; other errors propagate."""
-    last_exc: BaseException | None = None
     for attempt in range(1, attempts + 1):
         try:
             return fn()
         except _API_CONNECTION_ERRORS as e:
-            last_exc = e
-            logger.warning(
-                "K8s API call (%s) failed on attempt %d/%d "
-                "(vCluster port-forward blip?): %s",
-                what,
-                attempt,
-                attempts,
-                e,
-            )
-            if attempt < attempts:
-                time.sleep(delay)
-    assert last_exc is not None  # loop ran at least once
-    raise last_exc
+            if attempt == attempts:
+                raise
+            logger.debug("%s failed (port-forward blip?), retrying: %s", what, e)
+            time.sleep(delay)
 
 
 # Supported DynamoGraphDeployment CRD schemas. v1alpha1 uses ``spec.services``

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -37,19 +37,12 @@ def _get_workspace_dir() -> str:
     return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
-# --- Resilience for K8s API calls through the vCluster port-forward ----------
-#
-# Deploy tests reach the (v)cluster API over a local ``kubectl port-forward`` at
-# 127.0.0.1:8443. A watchdog restarts that forward when it drops, but the
-# restart takes a few seconds; a K8s API call that lands in that window fails
-# with a connection error. For post-Ready calls (e.g. get_pods()) that error
-# propagates and fails the whole test even though the deployment is healthy.
-# Retry connection-level errors so a transient tunnel blip does not fail the test.
+# The vCluster port-forward (127.0.0.1:8443) can briefly drop mid-test; its
+# watchdog takes a few seconds to restart it. Retry K8s API calls so that window
+# doesn't fail a post-Ready call on a healthy deployment.
 def _api_connection_errors() -> tuple[type[BaseException], ...]:
-    # ConnectionError/ConnectionRefusedError/TimeoutError and
-    # aiohttp.ClientConnectorError (kubernetes_asyncio) are all OSError subclasses;
-    # httpx.TransportError (kr8s) is not, so add it explicitly. Built defensively
-    # so a missing optional client library never breaks import.
+    # aiohttp.ClientConnectorError (kubernetes_asyncio) and the builtin connection
+    # errors are OSError subclasses; httpx.TransportError (kr8s) is not.
     errs: list[type[BaseException]] = [OSError]
     try:
         import httpx
@@ -71,11 +64,7 @@ def _retry_api_call(
     attempts: int = 5,
     delay: float = 2.0,
 ):
-    """Call ``fn`` and retry only on a vCluster port-forward connection blip.
-
-    Any non-connection exception propagates immediately so real failures are not
-    masked. Re-raises the last connection error if all attempts are exhausted.
-    """
+    """Retry ``fn`` on a port-forward connection blip; other errors propagate."""
     last_exc: BaseException | None = None
     for attempt in range(1, attempts + 1):
         try:
@@ -1449,9 +1438,8 @@ class ManagedDeployment:
 
             pods: list[Pod] = []
 
-            # Materialize inside the retry so a dropped 127.0.0.1:8443 tunnel
-            # surfaces as a retryable connection error here rather than partway
-            # through the caller's iteration.
+            # Materialize inside the retry so a tunnel drop is retried here, not
+            # partway through the caller's iteration.
             fetched = _retry_api_call(
                 lambda ls=label_selector: list(
                     kr8s.get("pods", namespace=self.namespace, label_selector=ls)
@@ -1607,10 +1595,8 @@ class ManagedDeployment:
         the async cleanup may fail, which is expected and can be safely ignored.
         """
         try:
-            # Create port forward - this runs in a background thread
-            # Use 127.0.0.1 (localhost) instead of 0.0.0.0 to prevent port conflicts.
-            # Opening the forward talks to the K8s API over 127.0.0.1:8443, so retry
-            # if that tunnel is momentarily down rather than giving up (returning None).
+            # Runs in a background thread; 127.0.0.1 avoids port conflicts.
+            # Opening it talks to the K8s API, so retry if the tunnel is briefly down.
             def _open_port_forward():
                 pf = pod.portforward(
                     remote_port=remote_port,

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -1639,14 +1639,12 @@ class ManagedDeployment:
                     self._active_port_forwards.append(port_forward)
                 # Create a fresh portforward object so local_port=0 picks a new
                 # ephemeral port rather than re-binding the previously assigned
-                # port that may still be in TIME_WAIT.
+                # port that may still be in TIME_WAIT. Reuse the retry helper so a
+                # tunnel blip during the reopen is retried, not treated as fatal.
                 try:
-                    port_forward = pod.portforward(
-                        remote_port=remote_port,
-                        local_port=0,
-                        address="127.0.0.1",
+                    port_forward = _retry_api_call(
+                        _open_port_forward, logger=self._logger
                     )
-                    port_forward.start()
                 except Exception as e:
                     self._logger.debug(
                         f"Error restarting port forward for pod {pod.name}: {e}"

--- a/tests/utils/managed_deployment.py
+++ b/tests/utils/managed_deployment.py
@@ -52,7 +52,6 @@ _API_CONNECTION_ERRORS = (
 def _retry_api_call(
     fn,
     *,
-    what: str,
     logger: logging.Logger,
     attempts: int = 5,
     delay: float = 2.0,
@@ -64,7 +63,7 @@ def _retry_api_call(
         except _API_CONNECTION_ERRORS as e:
             if attempt == attempts:
                 raise
-            logger.debug("%s failed (port-forward blip?), retrying: %s", what, e)
+            logger.debug("K8s API call failed (port-forward blip?), retrying: %s", e)
             time.sleep(delay)
 
 
@@ -1427,7 +1426,6 @@ class ManagedDeployment:
                 lambda ls=label_selector: list(
                     kr8s.get("pods", namespace=self.namespace, label_selector=ls)
                 ),
-                what=f"list pods for {original_name}",
                 logger=self._logger,
             )
             for pod in fetched:
@@ -1591,7 +1589,6 @@ class ManagedDeployment:
 
             port_forward = _retry_api_call(
                 _open_port_forward,
-                what=f"open port-forward for {pod.name}",
                 logger=self._logger,
             )
 

--- a/tests/utils/test_managed_deployment.py
+++ b/tests/utils/test_managed_deployment.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the vCluster port-forward retry helper in managed_deployment."""
+
+import logging
+
+import pytest
+
+try:
+    import httpx
+
+    from tests.utils.managed_deployment import _API_CONNECTION_ERRORS, _retry_api_call
+except ImportError:
+    pytest.skip(
+        "managed_deployment client deps (kr8s/httpx/aiohttp) not available",
+        allow_module_level=True,
+    )
+
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit]
+
+_LOG = logging.getLogger(__name__)
+
+
+def test_returns_result_on_success():
+    assert _retry_api_call(lambda: 42, logger=_LOG) == 42
+
+
+def test_retries_then_succeeds_after_connection_blip():
+    """A dropped-tunnel error (e.g. from a replacement port-forward open) is
+    retried, and the call succeeds once the tunnel is back."""
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("tunnel down")
+        return "ok"
+
+    assert _retry_api_call(flaky, logger=_LOG, attempts=5, delay=0) == "ok"
+    assert calls["n"] == 3
+
+
+def test_reraises_after_exhausting_attempts():
+    with pytest.raises(ConnectionRefusedError):
+        _retry_api_call(
+            lambda: (_ for _ in ()).throw(ConnectionRefusedError(111, "refused")),
+            logger=_LOG,
+            attempts=2,
+            delay=0,
+        )
+
+
+def test_does_not_retry_or_mask_non_connection_errors():
+    calls = {"n": 0}
+
+    def real_bug():
+        calls["n"] += 1
+        raise ValueError("real bug")
+
+    with pytest.raises(ValueError):
+        _retry_api_call(real_bug, logger=_LOG, attempts=3, delay=0)
+    assert calls["n"] == 1  # raised immediately, not retried
+
+
+def test_connection_error_set_is_precise():
+    # Covers the errors observed when the 127.0.0.1:8443 tunnel drops...
+    assert issubclass(httpx.ConnectError, _API_CONNECTION_ERRORS)
+    assert issubclass(httpx.RemoteProtocolError, _API_CONNECTION_ERRORS)
+    assert issubclass(ConnectionRefusedError, _API_CONNECTION_ERRORS)
+    # ...without swallowing unrelated OSErrors.
+    assert not issubclass(FileNotFoundError, _API_CONNECTION_ERRORS)


### PR DESCRIPTION
Linear: [OPS-8003](https://linear.app/nvidia/issue/OPS-8003/ops-support-0803-0807)

## Problem

Deploy tests intermittently fail **after the deployment is already healthy** (`Ready=True`), because a post-Ready Kubernetes-API call loses the local `kubectl port-forward` tunnel to the vCluster API (`127.0.0.1:8443`):

```
aiohttp.client_exceptions.ClientConnectorError: Cannot connect to host 127.0.0.1:8443
ConnectionRefusedError(111, "Connect call failed ('127.0.0.1', 8443)")
```

## Root cause (evidence-backed)

Traced to run `31031856982`, job `deploy-test-sglang / agg` (attempt 1):

- `18:04:02` — deployment reaches `Ready` (the readiness poll went through `127.0.0.1:8443` fine).
- `18:04:09` — the next API call fails: `httpx.RemoteProtocolError('Server disconnected…')` → `ConnectionRefused`.
- Cleanup shows the surviving `kubectl` port-forward is a **new pid (624)**, not the original (252) — i.e. the runner's local `kubectl port-forward` process died mid-test and the 5s watchdog restarted it, but a few seconds too late.

This is a **local, transient** port-forward death, **not** a shared vCluster backend problem: a sibling job (`deploy-test-sglang / agg_router`) on a different runner, pointing at the *same* backend, made a **successful** tunnel call in the *same second* (`18:04:09.235`), and no other concurrent job saw any `8443` refusal. The run passed on attempt 2. So it does not warrant raising vCluster memory or splitting the shared control plane — the fix is to make the test ride out a sub-watchdog-recovery-window blip.

The pre-Ready readiness poll already tolerates these blips (it retries); the gap is the **post-Ready** API calls, which had no retry.

## Fix

Add a small `_retry_api_call` helper and wrap the two unguarded post-Ready K8s-API sites in `ManagedDeployment`:

- **`get_pods()`** — the `kr8s.get("pods", …)` list call (the observed failure site), materialized inside the retry so a drop surfaces as a retryable error rather than partway through the caller's iteration.
- **`port_forward()`** — the initial `pod.portforward()/start()`, which opens a stream through the API, so a tunnel blip retries instead of returning `None`.

It retries **only** connection-level errors and re-raises everything else immediately, so real failures are never masked. The caught set covers all three signatures seen in the failure:

- `ConnectionRefusedError` / `aiohttp.ClientConnectorError` — both `OSError` subclasses.
- `httpx.RemoteProtocolError('Server disconnected')` / `httpx.ConnectError` — both `httpx.TransportError` subclasses.

## Validation

- `py_compile` + `ruff` clean.
- Standalone logic check of `_retry_api_call`: passes success through, retries a connection error then succeeds, re-raises after exhausting attempts, and does **not** retry/mask a non-connection error (e.g. `ValueError`).
- Exception-hierarchy coverage verified against `httpx` 0.28.1 (`RemoteProtocolError`/`ConnectError` are `TransportError` subclasses; `ConnectionRefusedError` is an `OSError`).

## Optional follow-up (not included)

Tightening the watchdog poll (`5s → 1-2s`) in `.github/actions/connect-vcluster/action.yml` would shrink the recovery gap further, but given the rarity the in-test retry is sufficient on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12723" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when connecting to Kubernetes through a vCluster port-forward.
  * Automatically retries transient connection failures, reducing interruptions during pod listing and port-forward setup.
  * Non-connection errors continue to surface immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
