### PR TITLE
docs(spica): correct kv_load_ratio support guidance (cherry-pick #12714)

### DIFF
--- a/docs/fern/components/aisimulate/spica/README.md
+++ b/docs/fern/components/aisimulate/spica/README.md
@@ -34,7 +34,7 @@ Spica's source lives in `aisimulate/src/aisimulate/spica` and is published by th
 distribution in the Dynamo repository. Installing that distribution provides the canonical
 `aisimulate.spica` Python package and its CPU Vizier and JAX dependencies. Runnable configuration
 files and tools live in `examples/aisimulate/spica`. Spica uses AI Configurator's lower-layer
-forward-pass and memory provider, then evaluates candidates with Dynamo Replay.
+forward-pass and memory providers, then evaluates candidates with Dynamo Replay.
 
 ## Spica and Replay Optimize
 
@@ -59,16 +59,11 @@ Spica source, documentation, and examples were migrated from
 
 ## Current Limitations
 
-The `dynamo-planner` image currently keeps AI Configurator 0.9 for compatibility with the existing
-Profiler. That release does not provide `aiconfigurator.sdk.memory`:
-
-- Spica emits a warning and skips the pre-search KV-capacity shape filter when the memory estimator
-  is unavailable. Trace workloads and synthetic workloads with fixed `concurrency` remain usable;
-  Replay and the GPU-budget checks still evaluate their candidates.
-- `kv_load_ratio` needs the compatible AI Configurator memory estimator to convert a relative load
-  into candidate-specific concurrency. Spica fails fast before starting the search for this
-  workload mode in the current default `dynamo-planner` image instead of evaluating an unverified
-  load or returning an empty candidate set after the sweep.
+KV-capacity filtering and `kv_load_ratio` require an AI Configurator performance database for the
+target `(hardware_sku, backend)`. Branch enumeration drops targets without one and backend or
+deployment-mode combinations without a KV-feasible shape within the capacity budget. It raises
+`NoViableParallelConfig` if no viable branch remains. Spica does not use the naive memory-estimation
+fallback.
 
 Treat workloads and search modes not covered by image smoke tests as unsupported experimental paths.
 See [Traffic](traffic.md#kv-load-ratio-candidate-relative-concurrency) for the KV-load contract.

--- a/docs/fern/components/aisimulate/spica/examples/glm5-disagg-pareto-frontier-sweep.md
+++ b/docs/fern/components/aisimulate/spica/examples/glm5-disagg-pareto-frontier-sweep.md
@@ -10,13 +10,6 @@ subtitle: Experimental Spica search for a GLM-5-FP8 Pareto frontier on B200 GPUs
 > treat them as production capacity guidance or a performance commitment. Spica's search behavior
 > and output may change without a standard deprecation period.
 
-{/* Separate the adjacent admonitions for Markdown and MDX renderers. */}
-
-> [!IMPORTANT]
-> This experiment uses `kv_load_ratio` and requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. It fails fast before search starts in the default `dynamo-planner`
-> image, which currently retains AI Configurator 0.9.
-
 This replay-backed sweep targets the InferenceX/SemiAnalysis (SA) **GLM-5-FP8 / B200 /
 Dynamo with SGLang / 1k-1k / disaggregated** frontier. It tests whether Spica can discover competitive
 deployment mappings without pinning the parallel shape or replica count.
@@ -152,13 +145,17 @@ shape of the frontier without treating those near-duplicates as different deploy
 For this workload, 50-55 rounds is the practical quality/runtime point. The final 27 rounds
 after round 53 consumed about 4 hours 39 minutes for 1.05% additional hypervolume.
 
-## Reproduce
+## Reproduction Status
+
+The packaged dependencies support this configuration's KV-capacity and candidate-concurrency
+calculations. Reproducing the historical frontier still depends on AI Configurator performance
+database coverage for B200/SGLang/GLM-5-FP8 and on Replay behavior in the runtime snapshot.
 
 ```bash
 python -m aisimulate.spica \
   --config examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
 ```
 
-The AIConfigurator performance model needs the `aic-forward-pass` binding. Dynamo must include the
-attention-DP KV-capacity fix so replay sees engine capacity as per-rank capacity multiplied by
-attention DP and replicas.
+The AI Configurator performance model needs the `aic-forward-pass` binding. Dynamo's attention-DP
+KV-capacity calculation multiplies per-rank capacity by attention DP and replicas before passing
+engine capacity to Replay.

--- a/docs/fern/components/aisimulate/spica/overview.md
+++ b/docs/fern/components/aisimulate/spica/overview.md
@@ -101,12 +101,6 @@ backends support each. `context_length` is threaded into KV feasibility.
 - A ranged `workload.kv_load_ratio` (Pareto) becomes a continuous per-trial dimension on the
   branch. A scalar ratio is injected as a constant.
 
-The default `dynamo-planner` image currently uses AI Configurator 0.9, which does not expose
-`aiconfigurator.sdk.memory`. Spica warns and skips the pre-search KV-capacity shape filter in that
-environment. Trace and fixed-concurrency workloads can continue through Replay, but
-`kv_load_ratio` fails fast before branch enumeration because it cannot derive candidate-specific
-concurrency without the memory estimator.
-
 ### 5. Per-branch Vizier study loop
 
 For each branch, a `BranchSampler` (`make_branch_sampler`, study id

--- a/docs/fern/components/aisimulate/spica/search-space.md
+++ b/docs/fern/components/aisimulate/spica/search-space.md
@@ -305,19 +305,14 @@ gpu_budget, backend)`:
    - `vllm` forbids `moe_tp > 1 & moe_ep > 1`.
    Large MoE that a node can't hold (`gpus_per_node * vram_per_gpu < 2 * weight_bytes`)
    auto-enables multi-node wideEP.
-5. **KV feasibility** (`aisimulate.spica.kv_estimate.feasible_shape_tokens`, via AI
-   Configurator's `estimate_kv_cache`): when the compatible memory estimator is installed, a shape
-   is kept iff its total KV capacity in tokens (after quantized weights + activation reservations)
-   holds at least one longest sequence —
+5. **KV feasibility** (`aisimulate.spica.kv_estimate.feasible_shape_tokens`, via
+   `aiconfigurator_core.sdk.memory.estimate_kv_cache`): a shape is kept iff its total KV capacity
+   in tokens (after quantized weights + activation reservations) holds at least one longest sequence —
    `total_kv_size_tokens > max_seq_len`, where `max_seq_len` = `context_length` if set, else
    the model's max context. This is per-shape (TEP / DEP / TP differ at the same GPU count)
-   and uses the real (often FP8) weights. SKUs with no perf DB raise `NoPerfDatabase` (no
-   naive fallback). If no shape is feasible within budget, `NoViableParallelConfig` is raised
-   for that branch. The default `dynamo-planner` image retains AI Configurator 0.9, which does not
-   provide `aiconfigurator.sdk.memory`; Spica warns and skips this pre-search filter in that image.
-   Trace and fixed-concurrency workloads still reach Replay, while `kv_load_ratio` fails fast
-   before branch enumeration because candidate-relative concurrency cannot be derived without the
-   estimator.
+   and uses the real (often FP8) weights. The estimator raises `NoPerfDatabase` for a target with no
+   perf DB, and branch enumeration removes that backend. Spica does not use the naive fallback. If
+   no shape is feasible within budget, `NoViableParallelConfig` is raised for that branch.
 6. **Replicas** fill the budget: for each kept worker shape, replica counts
    `r ∈ 1..(gpu_budget // g)` such that `g * r` lies in
    `[min_gpu_budget, gpu_budget]`.

--- a/docs/fern/components/aisimulate/spica/traffic.md
+++ b/docs/fern/components/aisimulate/spica/traffic.md
@@ -71,12 +71,6 @@ shared synthetic knobs threaded into the replay (`ReplayEvaluator._synthetic_kwa
 
 ## `kv_load_ratio` (candidate-relative concurrency)
 
-> [!WARNING]
-> `kv_load_ratio` requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. The default `dynamo-planner` image currently retains AI Configurator
-> 0.9, so this workload mode fails fast before search starts in that image. Use a trace workload
-> or fixed `concurrency` with the default image.
-
 Spica resolves a KV-load trial after the backend, parallel shape, replicas, and batching
 knobs have been selected. For every active role, it asks AI Configurator for the **per-rank** KV token
 capacity using that candidate's `max_num_batched_tokens`, `max_num_seqs`, memory fraction,

--- a/examples/aisimulate/spica/README.md
+++ b/examples/aisimulate/spica/README.md
@@ -40,18 +40,7 @@ python -m aisimulate.spica \
   --config examples/aisimulate/spica/configs/smart_sweep.yaml
 ```
 
-Run the GLM-5-FP8 Pareto-front search:
-
-> [!IMPORTANT]
-> This configuration uses `kv_load_ratio` and requires an AI Configurator release that provides
-> `aiconfigurator.sdk.memory`. It fails closed in the default `dynamo-planner` image, which currently
-> retains AI Configurator 0.9. Trace workloads and fixed `concurrency` workloads remain usable in
-> the default image.
-
-```bash
-python -m aisimulate.spica \
-  --config examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
-```
+The GLM-5-FP8 Pareto-front configuration captures the setup from a previous experiment.
 
 Update `workload.trace_path` before running a trace-backed configuration.
 

--- a/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
+++ b/examples/aisimulate/spica/configs/glm5-disagg-pareto-frontier.yaml
@@ -1,9 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Experimental: this configuration uses kv_load_ratio and requires an AI Configurator release
-# that provides aiconfigurator.sdk.memory. It fails closed in the default dynamo-planner image,
-# which currently retains AI Configurator 0.9.
+# Experimental Spica configuration for the GLM-5-FP8 Pareto sweep.
 
 search_space:
   deployment_mode: [disagg]


### PR DESCRIPTION
## Summary

- Cherry-pick of #12714 to `release/1.4.0`.
- Remove obsolete guidance that the default Planner image uses AI Configurator 0.9 and cannot run `kv_load_ratio`.
- Keep the actual constraints: performance-database coverage, KV-feasible shapes, and Replay behavior for the historical GLM-5-FP8 experiment.

Fixes DYN-3743
Fixes NVBug 6556236

## Original PR

- Main PR: #12714
- Merge commit: `9b63310c5985c586a6521140bc1f19b6dda24067`

## Release adaptation

`release/1.4.0` predates the Fern docs restructure on `main`, so Git mapped the five Spica pages from the new `docs/fern/pages/...` tree to this branch's `docs/fern/components/aisimulate/spica/` tree.

Three content conflicts were resolved while preserving the release layout:

- Applied the corrected current-limit wording to the release Spica landing page and retained its release-specific heading anchor.
- Kept the runnable command on the GLM-5-FP8 page and added the concise reproduction-status constraints from the main PR.
- Replaced the obsolete warning and duplicated GLM command in the examples README with the historical-configuration note from the main PR.

The resulting backport changes the same seven logical documents and examples as #12714.

## Validation

- `git diff --check` passes.
- `fern check` with Node.js 22 reports 0 errors and 2 existing warnings.
- A targeted search finds no remaining references to AI Configurator 0.9 or `aiconfigurator.sdk.memory` under the release Spica docs and examples.
- `fern docs broken-links` could not initialize its Markdown-link rule because the Fern CLI's `rolldown` dependency was missing from the local npx cache. This is the same unrelated Fern tooling failure observed on #12714; the dedicated broken-link checks passed on the main PR.

Documentation-only change; no runtime tests were required.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12724" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->