### PR TITLE
chore: update Aiconfigurator release source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=7564a73006c1af79f6034e3671fa7b16836ef137#7564a73006c1af79f6034e3671fa7b16836ef137"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=c80c1875e1e623dc89bbe150d9d763a3a8d232df#c80c1875e1e623dc89bbe150d9d763a3a8d232df"
 dependencies = [
  "bincode 1.3.3",
  "parquet",
@@ -7331,7 +7331,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7351,7 +7351,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 rustls-pemfile = { version = "2" }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "7564a73006c1af79f6034e3671fa7b16836ef137" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "c80c1875e1e623dc89bbe150d9d763a3a8d232df" }
 
 [profile.dev.package]
 insta.opt-level = 3

--- a/aisimulate/pyproject.toml
+++ b/aisimulate/pyproject.toml
@@ -29,8 +29,8 @@ classifiers = [
 ]
 dependencies = [
     "ai-dynamo>=1.3.0,<2.0.0",
-    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137",
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
+    "aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
     "chex==0.1.87",
     "filterpy==1.4.5",
     "flax==0.10.0",

--- a/benchmarks/pyproject.toml
+++ b/benchmarks/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
     "aiperf==0.10.0",
     "matplotlib",
     "networkx",

--- a/container/deps/requirements.frontend.txt
+++ b/container/deps/requirements.frontend.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Required by experimental KV router --router-prefill-load-model=aic.
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core
 
 # tritonclient<=2.62.0 requires grpcio<1.68 and protobuf<6.0dev; pin here so the
 # resolver picks compatible versions when installed alongside runtime deps.

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -4,9 +4,9 @@
 # Dependencies required by the planner, profiler, and global_planner services.
 
 # Keep both layers on the same immutable AIC source revision.
-aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137
+aiconfigurator @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df
 
-aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core
+aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -35,7 +35,7 @@ dependencies = [
 [[package]]
 name = "aiconfigurator-core"
 version = "0.11.0"
-source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=7564a73006c1af79f6034e3671fa7b16836ef137#7564a73006c1af79f6034e3671fa7b16836ef137"
+source = "git+https://github.com/ai-dynamo/aiconfigurator.git?rev=c80c1875e1e623dc89bbe150d9d763a3a8d232df#c80c1875e1e623dc89bbe150d9d763a3a8d232df"
 dependencies = [
  "bincode 1.3.3",
  "parquet",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -120,7 +120,7 @@ opentelemetry_sdk = { version = "0.31.0", features = ["trace"] }
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 
 [patch.crates-io]
-aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "7564a73006c1af79f6034e3671fa7b16836ef137" }
+aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "c80c1875e1e623dc89bbe150d9d763a3a8d232df" }
 
 [profile.profiling]
 inherits = "release"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ sglang = [
 ]
 
 mocker = [
-    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@7564a73006c1af79f6034e3671fa7b16836ef137#subdirectory=aic-core",
+    "aiconfigurator-core @ git+https://github.com/ai-dynamo/aiconfigurator.git@c80c1875e1e623dc89bbe150d9d763a3a8d232df#subdirectory=aic-core",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
Update every Python and Rust source pin for aiconfigurator and aiconfigurator-core from 7564a73006c1af79f6034e3671fa7b16836ef137 to c80c1875e1e623dc89bbe150d9d763a3a8d232df, keeping release/1.4.0 aligned with the tip of Aiconfigurator release/0.11.0. Picks up the naive-mode sizing fix for unsupported architectures (ai-dynamo/aiconfigurator#1493) and a docs clarification (#1494).



<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12726" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->