### PR TITLE
fix(multimodal): own NVDEC frame memory and CUDA-gate PyNvVideoCodec in the SGLang image (OPS-8040)

### DIFF
--- a/components/src/dynamo/common/multimodal/nvdec_decoder.py
+++ b/components/src/dynamo/common/multimodal/nvdec_decoder.py
@@ -156,11 +156,16 @@ def _gpu_id() -> int:
 
 
 def _frame_to_rgb_hwc(frame) -> np.ndarray:
-    """Copy a decoded (device) RGB frame to a host ``(H, W, 3)`` uint8 array.
+    """Copy a decoded RGB frame into an owned host ``(H, W, 3)`` uint8 array.
 
-    A 2.x ``DecodedFrame`` (``output_color_type=RGB``) holds a CUDA buffer and
-    supports the DLPack protocol, so torch wraps it zero-copy on the GPU and
-    ``.cpu()`` copies to host. Validated on PyNvVideoCodec 2.1.1 for H.264/H.265.
+    A 2.x ``DecodedFrame`` (``output_color_type=RGB``) supports the DLPack
+    protocol, so torch wraps its buffer zero-copy. The decoder is constructed
+    with ``use_device_memory=False``, so that buffer is already host memory:
+    ``.cpu()`` is a no-op and ``.numpy()`` would keep aliasing decoder-owned
+    memory, which the decoder is free to recycle for the next indexed read.
+    The explicit ``np.array(..., copy=True)`` is what guarantees every
+    collected frame owns its pixels (and normalizes dtype in the same step).
+    Validated on PyNvVideoCodec 2.1.1 for H.264/H.265.
     """
     import torch
 
@@ -168,10 +173,7 @@ def _frame_to_rgb_hwc(frame) -> np.ndarray:
         tensor = torch.from_dlpack(frame)
     except Exception:  # noqa: BLE001 - fall back to the CUDA-array-interface path
         tensor = torch.as_tensor(frame, device="cuda")
-    arr = tensor.cpu().numpy()
-    if arr.dtype != np.uint8:
-        arr = arr.astype(np.uint8)
-    return arr
+    return np.array(tensor.cpu().numpy(), dtype=np.uint8, copy=True)
 
 
 def _source_fps(decoder) -> float:

--- a/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder.py
+++ b/components/src/dynamo/common/tests/multimodal/test_nvdec_decoder.py
@@ -163,6 +163,23 @@ def test_should_use_nvdec_false_when_unavailable(monkeypatch):
     assert nd.should_use_nvdec("h264") is False
 
 
+def test_frame_to_rgb_hwc_copies_out_of_decoder_memory():
+    """The decoder hands over host frames (``use_device_memory=False``) and is
+    free to recycle the underlying buffer between indexed reads, so the
+    conversion must copy. numpy arrays export DLPack exactly like a
+    ``DecodedFrame`` does: without the copy, torch wraps the buffer zero-copy
+    and mutating the source would corrupt the already-collected frame.
+    """
+    source = np.full((4, 6, 3), 7, dtype=np.uint8)
+
+    converted = nd._frame_to_rgb_hwc(source)
+    source[:] = 99  # the decoder reuses its buffer for the next frame
+
+    assert converted.dtype == np.uint8
+    assert converted.shape == (4, 6, 3)
+    np.testing.assert_array_equal(converted, np.full((4, 6, 3), 7, dtype=np.uint8))
+
+
 def test_decode_matches_frame_contract(monkeypatch):
     monkeypatch.setitem(
         sys.modules, "PyNvVideoCodec", _fake_pynv(num_frames=10, h=4, w=6)

--- a/container/templates/sglang_runtime.Dockerfile
+++ b/container/templates/sglang_runtime.Dockerfile
@@ -139,11 +139,29 @@ RUN --mount=type=bind,source=./container/deps/requirements.common.txt,target=/tm
 # Install SGLang-specific runtime dependencies without changing the upstream
 # dependency solution. imageio-ffmpeg is installed from source (no bundled
 # binary) for the VP9 video-encode path; see requirements.sglang.txt.
+{% if device == "cuda" %}
 RUN --mount=type=bind,source=./container/deps/requirements.sglang.txt,target=/tmp/requirements.sglang.txt \
     --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     export PIP_CACHE_DIR=/root/.cache/pip && \
     pip install --break-system-packages --force-reinstall --no-deps \
         --requirement /tmp/requirements.sglang.txt
+{% else %}
+# PyNvVideoCodec decodes on NVDEC through libnvcuvid, so it is inert on a
+# non-NVIDIA device. Drop it from the shared requirements rather than ship an
+# unusable NVIDIA codec wheel in the Intel XPU image. The pattern is anchored
+# to the line start so it cannot match inside another requirement, and the
+# import check fails the build if the package arrives by another route -- a
+# filter that silently stopped matching would otherwise look like success.
+# Whole-RUN branches rather than a conditional inside one RUN, for the reasons
+# documented at the equivalent block in vllm_runtime.Dockerfile.
+RUN --mount=type=bind,source=./container/deps/requirements.sglang.txt,target=/tmp/requirements.sglang.txt \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    export PIP_CACHE_DIR=/root/.cache/pip && \
+    grep -v '^PyNvVideoCodec' /tmp/requirements.sglang.txt > /tmp/requirements.sglang.nonvidia.txt && \
+    pip install --break-system-packages --force-reinstall --no-deps \
+        --requirement /tmp/requirements.sglang.nonvidia.txt && \
+    ! python3 -c "import PyNvVideoCodec" 2>/dev/null
+{% endif %}
 
 # Remove the codec-bearing video-DECODE components from the upstream SGLang image
 # (PyAV, decord, OpenCV, torchcodec + any base ffmpeg/libav*), then copy the


### PR DESCRIPTION
## Summary

Two hardening items surfaced by automated review on the release cherry-pick #12703. Both target code that merged in #11836, so they land on main first.

- `components/src/dynamo/common/multimodal/nvdec_decoder.py`: `_frame_to_rgb_hwc` now copies each decoded frame into memory it owns. The decoder is constructed with `use_device_memory=False`, so the DLPack-wrapped frame is already host memory: `.cpu()` was a no-op and `.numpy()` aliased decoder-owned buffers — correctness relied on PyNvVideoCodec (undocumented) handing each `DecodedFrame` its own buffer. The copy removes that dependency and covers both call sites (`decode_video_nvdec` and the SGLang `NvdecVideoDecoder.get_frames_as_tensor` convert through this helper). The docstring still described the device-memory path, so it is rewritten. Raised in [this review thread](https://github.com/ai-dynamo/dynamo/pull/12703#discussion_r3722550730).
- `container/templates/sglang_runtime.Dockerfile`: drop `PyNvVideoCodec` from the non-CUDA (Intel XPU) SGLang image, mirroring the existing device branch in `vllm_runtime.Dockerfile`: line-anchored `grep -v '^PyNvVideoCodec'` over the shared requirements plus a negative import check so a silently broken filter fails the build. The wheel is inert without libnvcuvid; this stops shipping it where it can never run. Raised in [this review thread](https://github.com/ai-dynamo/dynamo/pull/12703#discussion_r3722550063).

## Validation

- New CPU regression test `test_frame_to_rgb_hwc_copies_out_of_decoder_memory` drives the helper with a numpy source (numpy exports DLPack exactly like a `DecodedFrame`): it **fails on the previous code** (mutating the source corrupts the collected frame) and passes with the copy. Full `test_nvdec_decoder.py`: 33 passed.
- Rendered the `sglang` template for both devices with `container/render.py`: the CUDA output is functionally unchanged (same unfiltered install; blank-line-only diff from the template branch markers), the XPU output gains exactly the filter block and import check.
- `pre-commit run --all-files`: all hooks pass.

Linear: OPS-8040 (sub-issue of OPS-7665)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12733" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame handling to ensure decoded RGB data remains stable when source buffers are reused or changed.
  * Added regression coverage for frame data preservation.

* **Chores**
  * Updated runtime image dependency installation based on device type.
  * Non-CUDA images now exclude unsupported video decoding components and validate the resulting installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
