### PR TITLE
fix(vllm): preserve decode handoff on cancellation

### DIFF
--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -67,6 +67,8 @@ pool. Override them with `--grpc-connect-attempt-timeout-secs`,
 `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or with the
 corresponding `DYN_SIDECAR_GRPC_*` environment variables.
 
+Each request owns its response stream but borrows a channel from the shared pool. Aggregate and prefill cancellation drops only that request's stream. Decode cancellation first submits the decode request and retains its stream through the first output token so a NIXL receiver can complete and release the transferred KV; it then drops the stream. vLLM automatically aborts the corresponding engine request while the pooled HTTP/2 connection remains available to other requests. The sidecar does not call the Control `Abort` RPC.
+
 ## Test without vLLM or a GPU
 
 Use the CPU-only `dynamo-vllm-mocker-server` to exercise the same Inference, Control, and health contracts:

--- a/lib/sidecar/vllm/README.md
+++ b/lib/sidecar/vllm/README.md
@@ -67,7 +67,7 @@ pool. Override them with `--grpc-connect-attempt-timeout-secs`,
 `--grpc-retry-interval-secs`, and `--grpc-startup-deadline-secs`, or with the
 corresponding `DYN_SIDECAR_GRPC_*` environment variables.
 
-Each request owns its response stream but borrows a channel from the shared pool. Aggregate and prefill cancellation drops only that request's stream. Decode cancellation first submits the decode request and retains its stream through the first output token so a NIXL receiver can complete and release the transferred KV; it then drops the stream. vLLM automatically aborts the corresponding engine request while the pooled HTTP/2 connection remains available to other requests. The sidecar does not call the Control `Abort` RPC.
+Each request owns its response stream but borrows a channel from the shared pool. Aggregate and prefill cancellation drops only that request's stream. Decode cancellation first submits the decode request and retains its stream until the first output token or a response containing `finish_info`, so a NIXL receiver can complete and release the transferred KV; it then drops the stream. If the stream ends early, returns a gRPC error, or produces an invalid response after cancellation, the sidecar logs the failure and reports the request as cancelled. vLLM automatically aborts the corresponding engine request while the pooled HTTP/2 connection remains available to other requests. The sidecar does not call the Control `Abort` RPC.
 
 ## Test without vLLM or a GPU
 

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -271,16 +271,39 @@ impl LLMEngine for VllmSidecarEngine {
                                 }
                             }
                             Ok(None) => {}
+                            Err(error) if request_cancelled => {
+                                tracing::warn!(
+                                    %error,
+                                    "vLLM response conversion failed after request cancellation"
+                                );
+                                yield Ok(cancelled(&state));
+                                break;
+                            }
                             Err(error) => {
                                 yield Err(error);
                                 break;
                             }
                         }
                     }
+                    Ok(None) if request_cancelled => {
+                        tracing::warn!(
+                            "vLLM GenerateStream ended before transfer completion after request cancellation"
+                        );
+                        yield Ok(cancelled(&state));
+                        break;
+                    }
                     Ok(None) => {
                         yield Err(client::protocol_error(
                             "GenerateStream ended before a terminal response",
                         ));
+                        break;
+                    }
+                    Err(status) if request_cancelled => {
+                        tracing::warn!(
+                            %status,
+                            "vLLM GenerateStream failed before transfer completion after request cancellation"
+                        );
+                        yield Ok(cancelled(&state));
                         break;
                     }
                     Err(status) => {

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -191,18 +191,25 @@ impl LLMEngine for VllmSidecarEngine {
         let mut state = ResponseState::new(&request, self.mode);
         let mut proto_request = build_generate_request(request, request_id, self.mode)?;
         proto_request.model.clone_from(&self.model.served_name);
+        let defer_request_cancellation = self.mode.is_decode();
         let stopped_ctx = ctx.inner_arc();
         let shutdown = self.cancel.clone();
-        let mut cancellation = Box::pin(async move {
+        let mut request_cancellation = Box::pin(async move { stopped_ctx.stopped().await });
+        let mut shutdown_cancellation = Box::pin(async move { shutdown.cancelled().await });
+        let stream = if defer_request_cancellation {
+            // Decode must reach vLLM so NIXL can release transferred KV.
             tokio::select! {
-                _ = stopped_ctx.stopped() => {}
-                _ = shutdown.cancelled() => {}
+                biased;
+                _ = shutdown_cancellation.as_mut() => None,
+                result = client.generate_stream(proto_request) => Some(result?),
             }
-        });
-        let stream = tokio::select! {
-            biased;
-            _ = cancellation.as_mut() => None,
-            result = client.generate_stream(proto_request) => Some(result?),
+        } else {
+            tokio::select! {
+                biased;
+                _ = shutdown_cancellation.as_mut() => None,
+                _ = request_cancellation.as_mut() => None,
+                result = client.generate_stream(proto_request) => Some(result?),
+            }
         };
         let Some(mut stream) = stream else {
             let output = cancelled(&state);
@@ -210,40 +217,75 @@ impl LLMEngine for VllmSidecarEngine {
         };
 
         Ok(Box::pin(async_stream::stream! {
+            let mut request_cancelled = false;
+            let mut first_token_observed = false;
             loop {
-                tokio::select! {
-                    biased;
-                    _ = cancellation.as_mut() => {
-                        yield Ok(cancelled(&state));
-                        break;
+                let message = if request_cancelled {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown_cancellation.as_mut() => None,
+                        message = stream.message() => Some(message),
                     }
-                    message = stream.message() => {
-                        match message {
-                            Ok(Some(response)) => match state.convert(response) {
-                                Ok(Some(output)) => {
-                                    let terminal = output.finish_reason.is_some();
-                                    yield Ok(output);
-                                    if terminal {
-                                        break;
+                } else {
+                    tokio::select! {
+                        biased;
+                        _ = shutdown_cancellation.as_mut() => None,
+                        _ = request_cancellation.as_mut() => {
+                            if defer_request_cancellation && !first_token_observed {
+                                request_cancelled = true;
+                                continue;
+                            }
+                            None
+                        }
+                        message = stream.message() => Some(message),
+                    }
+                };
+
+                let Some(message) = message else {
+                    yield Ok(cancelled(&state));
+                    break;
+                };
+                match message {
+                    Ok(Some(response)) => {
+                        let response_has_token = response
+                            .outputs
+                            .as_ref()
+                            .is_some_and(|output| output.num_tokens > 0);
+                        let transfer_completed = response.outputs.as_ref().is_some_and(|output| {
+                            output.num_tokens > 0 || output.finish_info.is_some()
+                        });
+                        match state.convert(response) {
+                            Ok(Some(output)) => {
+                                first_token_observed |= response_has_token;
+                                if request_cancelled && transfer_completed {
+                                    if first_token_observed {
+                                        ctx.notify_first_token();
                                     }
-                                }
-                                Ok(None) => {}
-                                Err(error) => {
-                                    yield Err(error);
+                                    yield Ok(cancelled(&state));
                                     break;
                                 }
-                            },
-                            Ok(None) => {
-                                yield Err(client::protocol_error(
-                                    "GenerateStream ended before a terminal response",
-                                ));
-                                break;
+                                let terminal = output.finish_reason.is_some();
+                                yield Ok(output);
+                                if terminal {
+                                    break;
+                                }
                             }
-                            Err(status) => {
-                                yield Err(client::status_to_dynamo("GenerateStream", status));
+                            Ok(None) => {}
+                            Err(error) => {
+                                yield Err(error);
                                 break;
                             }
                         }
+                    }
+                    Ok(None) => {
+                        yield Err(client::protocol_error(
+                            "GenerateStream ended before a terminal response",
+                        ));
+                        break;
+                    }
+                    Err(status) => {
+                        yield Err(client::status_to_dynamo("GenerateStream", status));
+                        break;
                     }
                 }
             }

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -38,6 +38,9 @@ struct FakeVllm {
     hang_before_headers: Arc<AtomicBool>,
     headers_pending: Arc<AtomicBool>,
     release_headers: Arc<Notify>,
+    hold_before_first_token: Arc<AtomicBool>,
+    first_token_pending: Arc<AtomicBool>,
+    release_first_token: Arc<Notify>,
     server_stream_dropped: Arc<AtomicBool>,
 }
 
@@ -120,6 +123,9 @@ impl pb::inference_server::Inference for FakeVllm {
             "nested": {"flags": [true, null, "opaque"]},
         });
         let hang = self.hang.load(Ordering::SeqCst);
+        let hold_before_first_token = self.hold_before_first_token.load(Ordering::SeqCst);
+        let first_token_pending = self.first_token_pending.clone();
+        let release_first_token = self.release_first_token.clone();
         let dropped = self.server_stream_dropped.clone();
 
         let stream = async_stream::try_stream! {
@@ -146,6 +152,12 @@ impl pb::inference_server::Inference for FakeVllm {
                 prompt_info: Some(prompt_info),
                 outputs: None,
             };
+
+            if hold_before_first_token {
+                first_token_pending.store(true, Ordering::SeqCst);
+                release_first_token.notified().await;
+                first_token_pending.store(false, Ordering::SeqCst);
+            }
 
             if hang {
                 loop {
@@ -813,6 +825,90 @@ async fn cancellation_interrupts_pending_response_headers() {
     let terminal = stream.next().await.unwrap().unwrap();
     assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
     server.service.release_headers.notify_waiters();
+}
+
+#[tokio::test]
+async fn decode_cancellation_waits_for_submission_and_first_token() {
+    let service = FakeVllm::default();
+    service.hang_before_headers.store(true, Ordering::SeqCst);
+    service
+        .hold_before_first_token
+        .store(true, Ordering::SeqCst);
+    let server = FakeServer::start(service).await;
+    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    engine.start(0).await.expect("start");
+
+    let mut decode_request = request();
+    decode_request.prefill_result = Some(PrefillResult {
+        disaggregated_params: json!({
+            "do_remote_decode": false,
+            "do_remote_prefill": true,
+            "remote_engine_id": "prefill-0",
+            "remote_host": "127.0.0.1",
+            "remote_port": 20097,
+            "remote_block_ids": [7, 8],
+        }),
+        prompt_tokens_details: None,
+    });
+    let context = dynamo_backend_common::testing::mock_context();
+    let generate = engine.generate(decode_request, GenerateContext::new(context.clone(), None));
+    tokio::pin!(generate);
+
+    tokio::select! {
+        _ = &mut generate => panic!("decode returned before response headers were gated"),
+        _ = async {
+            while !server.service.headers_pending.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        } => {}
+    }
+    assert_eq!(server.service.requests.lock().await.len(), 1);
+    context.stop_generating();
+    tokio::select! {
+        _ = &mut generate => panic!("decode cancellation returned before response headers"),
+        _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+    }
+
+    server.service.release_headers.notify_one();
+    let mut stream = tokio::time::timeout(std::time::Duration::from_secs(2), &mut generate)
+        .await
+        .expect("decode response headers")
+        .expect("decode stream");
+    let next = stream.next();
+    tokio::pin!(next);
+    tokio::select! {
+        _ = &mut next => panic!("decode returned before the first token was gated"),
+        _ = async {
+            while !server.service.first_token_pending.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        } => {}
+    }
+    assert!(
+        !server.service.server_stream_dropped.load(Ordering::SeqCst),
+        "decode stream dropped before the first token"
+    );
+    tokio::select! {
+        _ = &mut next => panic!("decode cancellation completed before the first token"),
+        _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {}
+    }
+
+    server.service.release_first_token.notify_one();
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), &mut next)
+        .await
+        .expect("first token did not release decode cancellation")
+        .expect("cancelled terminal")
+        .expect("cancelled output");
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
+    drop(stream);
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while !server.service.server_stream_dropped.load(Ordering::SeqCst) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("server stream dropped after first token");
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -28,15 +28,6 @@ use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
 
-#[derive(Clone, Copy, Default)]
-enum BeforeFirstTokenFailure {
-    #[default]
-    None,
-    Eof,
-    GrpcStatus,
-    InvalidResponse,
-}
-
 #[derive(Clone, Default)]
 struct FakeVllm {
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
@@ -48,7 +39,7 @@ struct FakeVllm {
     headers_pending: Arc<AtomicBool>,
     release_headers: Arc<Notify>,
     hold_before_first_token: Arc<AtomicBool>,
-    before_first_token_failure: BeforeFirstTokenFailure,
+    close_before_first_token: Arc<AtomicBool>,
     first_token_pending: Arc<AtomicBool>,
     release_first_token: Arc<Notify>,
     server_stream_dropped: Arc<AtomicBool>,
@@ -134,7 +125,7 @@ impl pb::inference_server::Inference for FakeVllm {
         });
         let hang = self.hang.load(Ordering::SeqCst);
         let hold_before_first_token = self.hold_before_first_token.load(Ordering::SeqCst);
-        let before_first_token_failure = self.before_first_token_failure;
+        let close_before_first_token = self.close_before_first_token.load(Ordering::SeqCst);
         let first_token_pending = self.first_token_pending.clone();
         let release_first_token = self.release_first_token.clone();
         let dropped = self.server_stream_dropped.clone();
@@ -169,18 +160,8 @@ impl pb::inference_server::Inference for FakeVllm {
                 release_first_token.notified().await;
                 first_token_pending.store(false, Ordering::SeqCst);
             }
-            match before_first_token_failure {
-                BeforeFirstTokenFailure::None => {}
-                BeforeFirstTokenFailure::Eof => return,
-                BeforeFirstTokenFailure::GrpcStatus => {
-                    Err(Status::internal("failed before first token"))?;
-                }
-                BeforeFirstTokenFailure::InvalidResponse => {
-                    let mut response = sequence_response(false, wants_logprobs, None);
-                    response.outputs.as_mut().expect("sequence output").num_tokens = 2;
-                    yield response;
-                    return;
-                }
+            if close_before_first_token {
+                return;
             }
 
             if hang {
@@ -943,36 +924,30 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
 }
 
 #[tokio::test]
-async fn decode_cancellation_maps_stream_failures_to_cancelled() {
-    for (failure, case) in [
-        (BeforeFirstTokenFailure::Eof, "premature EOF"),
-        (BeforeFirstTokenFailure::GrpcStatus, "gRPC failure"),
-        (BeforeFirstTokenFailure::InvalidResponse, "invalid response"),
-    ] {
-        let service = FakeVllm {
-            before_first_token_failure: failure,
-            ..Default::default()
-        };
-        let server = FakeServer::start(service).await;
-        let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
-        engine.start(0).await.expect("start");
+async fn decode_cancellation_maps_premature_eof_to_cancelled() {
+    let service = FakeVllm::default();
+    service
+        .close_before_first_token
+        .store(true, Ordering::SeqCst);
+    let server = FakeServer::start(service).await;
+    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    engine.start(0).await.expect("start");
 
-        let context = dynamo_backend_common::testing::mock_context();
-        let mut stream = engine
-            .generate(
-                decode_request(),
-                GenerateContext::new(context.clone(), None),
-            )
-            .await
-            .expect("decode stream");
-        context.stop_generating();
-        let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
-            .await
-            .unwrap_or_else(|_| panic!("{case} did not release decode cancellation"))
-            .expect("cancelled terminal")
-            .expect("cancelled output");
-        assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
-    }
+    let context = dynamo_backend_common::testing::mock_context();
+    let mut stream = engine
+        .generate(
+            decode_request(),
+            GenerateContext::new(context.clone(), None),
+        )
+        .await
+        .expect("decode stream");
+    context.stop_generating();
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+        .await
+        .expect("premature EOF did not release decode cancellation")
+        .expect("cancelled terminal")
+        .expect("cancelled output");
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -39,6 +39,7 @@ struct FakeVllm {
     headers_pending: Arc<AtomicBool>,
     release_headers: Arc<Notify>,
     hold_before_first_token: Arc<AtomicBool>,
+    close_before_first_token: Arc<AtomicBool>,
     first_token_pending: Arc<AtomicBool>,
     release_first_token: Arc<Notify>,
     server_stream_dropped: Arc<AtomicBool>,
@@ -124,6 +125,7 @@ impl pb::inference_server::Inference for FakeVllm {
         });
         let hang = self.hang.load(Ordering::SeqCst);
         let hold_before_first_token = self.hold_before_first_token.load(Ordering::SeqCst);
+        let close_before_first_token = self.close_before_first_token.load(Ordering::SeqCst);
         let first_token_pending = self.first_token_pending.clone();
         let release_first_token = self.release_first_token.clone();
         let dropped = self.server_stream_dropped.clone();
@@ -157,6 +159,9 @@ impl pb::inference_server::Inference for FakeVllm {
                 first_token_pending.store(true, Ordering::SeqCst);
                 release_first_token.notified().await;
                 first_token_pending.store(false, Ordering::SeqCst);
+            }
+            if close_before_first_token {
+                return;
             }
 
             if hang {
@@ -492,6 +497,22 @@ fn request() -> PreprocessedRequest {
         })))
         .build()
         .expect("request")
+}
+
+fn decode_request() -> PreprocessedRequest {
+    let mut request = request();
+    request.prefill_result = Some(PrefillResult {
+        disaggregated_params: json!({
+            "do_remote_decode": false,
+            "do_remote_prefill": true,
+            "remote_engine_id": "prefill-0",
+            "remote_host": "127.0.0.1",
+            "remote_port": 20097,
+            "remote_block_ids": [7, 8],
+        }),
+        prompt_tokens_details: None,
+    });
+    request
 }
 
 fn engine(endpoint: &str, mode: DisaggregationMode, connections: usize) -> VllmSidecarEngine {
@@ -838,20 +859,11 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
     let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
     engine.start(0).await.expect("start");
 
-    let mut decode_request = request();
-    decode_request.prefill_result = Some(PrefillResult {
-        disaggregated_params: json!({
-            "do_remote_decode": false,
-            "do_remote_prefill": true,
-            "remote_engine_id": "prefill-0",
-            "remote_host": "127.0.0.1",
-            "remote_port": 20097,
-            "remote_block_ids": [7, 8],
-        }),
-        prompt_tokens_details: None,
-    });
     let context = dynamo_backend_common::testing::mock_context();
-    let generate = engine.generate(decode_request, GenerateContext::new(context.clone(), None));
+    let generate = engine.generate(
+        decode_request(),
+        GenerateContext::new(context.clone(), None),
+    );
     tokio::pin!(generate);
 
     tokio::select! {
@@ -909,6 +921,33 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
     })
     .await
     .expect("server stream dropped after first token");
+}
+
+#[tokio::test]
+async fn decode_cancellation_maps_premature_eof_to_cancelled() {
+    let service = FakeVllm::default();
+    service
+        .close_before_first_token
+        .store(true, Ordering::SeqCst);
+    let server = FakeServer::start(service).await;
+    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+    engine.start(0).await.expect("start");
+
+    let context = dynamo_backend_common::testing::mock_context();
+    let mut stream = engine
+        .generate(
+            decode_request(),
+            GenerateContext::new(context.clone(), None),
+        )
+        .await
+        .expect("decode stream");
+    context.stop_generating();
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+        .await
+        .expect("premature EOF did not release decode cancellation")
+        .expect("cancelled terminal")
+        .expect("cancelled output");
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -28,6 +28,15 @@ use crate::json::{json_to_struct, struct_to_json};
 use crate::model::DiscoveredModel;
 use crate::proto as pb;
 
+#[derive(Clone, Copy, Default)]
+enum BeforeFirstTokenFailure {
+    #[default]
+    None,
+    Eof,
+    GrpcStatus,
+    InvalidResponse,
+}
+
 #[derive(Clone, Default)]
 struct FakeVllm {
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
@@ -39,7 +48,7 @@ struct FakeVllm {
     headers_pending: Arc<AtomicBool>,
     release_headers: Arc<Notify>,
     hold_before_first_token: Arc<AtomicBool>,
-    close_before_first_token: Arc<AtomicBool>,
+    before_first_token_failure: BeforeFirstTokenFailure,
     first_token_pending: Arc<AtomicBool>,
     release_first_token: Arc<Notify>,
     server_stream_dropped: Arc<AtomicBool>,
@@ -125,7 +134,7 @@ impl pb::inference_server::Inference for FakeVllm {
         });
         let hang = self.hang.load(Ordering::SeqCst);
         let hold_before_first_token = self.hold_before_first_token.load(Ordering::SeqCst);
-        let close_before_first_token = self.close_before_first_token.load(Ordering::SeqCst);
+        let before_first_token_failure = self.before_first_token_failure;
         let first_token_pending = self.first_token_pending.clone();
         let release_first_token = self.release_first_token.clone();
         let dropped = self.server_stream_dropped.clone();
@@ -160,8 +169,18 @@ impl pb::inference_server::Inference for FakeVllm {
                 release_first_token.notified().await;
                 first_token_pending.store(false, Ordering::SeqCst);
             }
-            if close_before_first_token {
-                return;
+            match before_first_token_failure {
+                BeforeFirstTokenFailure::None => {}
+                BeforeFirstTokenFailure::Eof => return,
+                BeforeFirstTokenFailure::GrpcStatus => {
+                    Err(Status::internal("failed before first token"))?;
+                }
+                BeforeFirstTokenFailure::InvalidResponse => {
+                    let mut response = sequence_response(false, wants_logprobs, None);
+                    response.outputs.as_mut().expect("sequence output").num_tokens = 2;
+                    yield response;
+                    return;
+                }
             }
 
             if hang {
@@ -924,30 +943,36 @@ async fn decode_cancellation_waits_for_submission_and_first_token() {
 }
 
 #[tokio::test]
-async fn decode_cancellation_maps_premature_eof_to_cancelled() {
-    let service = FakeVllm::default();
-    service
-        .close_before_first_token
-        .store(true, Ordering::SeqCst);
-    let server = FakeServer::start(service).await;
-    let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
-    engine.start(0).await.expect("start");
+async fn decode_cancellation_maps_stream_failures_to_cancelled() {
+    for (failure, case) in [
+        (BeforeFirstTokenFailure::Eof, "premature EOF"),
+        (BeforeFirstTokenFailure::GrpcStatus, "gRPC failure"),
+        (BeforeFirstTokenFailure::InvalidResponse, "invalid response"),
+    ] {
+        let service = FakeVllm {
+            before_first_token_failure: failure,
+            ..Default::default()
+        };
+        let server = FakeServer::start(service).await;
+        let engine = engine(&server.endpoint, DisaggregationMode::Decode, 1);
+        engine.start(0).await.expect("start");
 
-    let context = dynamo_backend_common::testing::mock_context();
-    let mut stream = engine
-        .generate(
-            decode_request(),
-            GenerateContext::new(context.clone(), None),
-        )
-        .await
-        .expect("decode stream");
-    context.stop_generating();
-    let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
-        .await
-        .expect("premature EOF did not release decode cancellation")
-        .expect("cancelled terminal")
-        .expect("cancelled output");
-    assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
+        let context = dynamo_backend_common::testing::mock_context();
+        let mut stream = engine
+            .generate(
+                decode_request(),
+                GenerateContext::new(context.clone(), None),
+            )
+            .await
+            .expect("decode stream");
+        context.stop_generating();
+        let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+            .await
+            .unwrap_or_else(|_| panic!("{case} did not release decode cancellation"))
+            .expect("cancelled terminal")
+            .expect("cancelled output");
+        assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Overview:

Part 2 of a 4-PR stack. This layer preserves disaggregated NIXL handoff completion when a client cancels a decode request.

## Details:

- Submit decode requests even when client cancellation wins the initial race.
- Keep the decode response stream alive until the first token or terminal transfer signal so the receiver can complete and release transferred KV.
- After cancellation, map premature EOF, gRPC failure, or response-conversion failure to a `Cancelled` terminal while logging the underlying failure.
- Continue cancelling aggregate and prefill requests by dropping only their per-request gRPC response stream.
- Do not call vLLM `Abort` or close the shared pooled channel.

The post-cancellation wait intentionally has no arbitrary timeout; safe bounded cleanup requires a protocol-level transfer-completion or cleanup signal.

### Stack

1. [#12734 — split gRPC services and Control discovery](https://github.com/ai-dynamo/dynamo/pull/12734)
2. [#12736 — preserve decode handoff on cancellation](https://github.com/ai-dynamo/dynamo/pull/12736)
3. [#12735 — deterministic DP and KV routing](https://github.com/ai-dynamo/dynamo/pull/12735)
4. [#12214 — multimodal sidecar requests](https://github.com/ai-dynamo/dynamo/pull/12214)

Base: [#12734](https://github.com/ai-dynamo/dynamo/pull/12734)

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-vllm-sidecar` — 17 tests passed
- `cargo clippy -p dynamo-vllm-sidecar --all-targets -- -D warnings`

## Where should the reviewer start?

- `lib/sidecar/vllm/src/engine.rs` for the cancellation race and stream-lifetime behavior.
- `lib/sidecar/vllm/src/tests.rs` for first-token deferral and premature-EOF regression coverage.

## Related Issues

**This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling for streaming requests.
  * Decode requests now complete necessary handoff and receive the first output token before cancellation takes effect.
  * Premature stream closure and cancellation-related errors now produce a clear cancelled result.
  * Shutdown cancellation remains immediate.

* **Documentation**
  * Clarified cancellation behavior for aggregate, prefill, and decode requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->