### PR TITLE
feat(request-trace): Hive-partitioned S3 keys and concurrent uploads

### DIFF
--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -329,11 +329,15 @@ See [Forward Pass Metrics Trace Reference](forward-pass-metrics-traces.mdx) for 
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_PREFIX" type="string">
-  Object key prefix for the `s3` sink. When unset, records land at the bucket root. Keys are `{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`.
+  Object key prefix for the `s3` sink. When unset, the parent `DynamoGraphDeployment` qualified by its namespace (`DYN_PARENT_DGD_K8S_NAMESPACE/DYN_PARENT_DGD_K8S_NAME`, both injected by the operator) is used, so each deployment lands under its own prefix without configuration; DGD names are unique only within a namespace. Setting this variable overrides that default. With neither set, records land at the bucket root. Keys are `{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`.
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES" type="integer" default="67108864">
   Batch roll threshold for the `s3` sink in uncompressed bytes. When the pending batch reaches this size it is gzipped and uploaded as one object.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS" type="integer" default="4">
+  Maximum concurrent `PutObject` calls for the `s3` sink. Finished batches upload on separate tasks so a slow `PutObject` cannot stall record ingestion; batches admitted beyond this limit wait in a bounded queue behind the in-flight uploads. Once both fill, further batches are dropped and counted.
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS" type="integer" default="10000">

--- a/docs/fern/pages/reference/observability/environment-variables.mdx
+++ b/docs/fern/pages/reference/observability/environment-variables.mdx
@@ -323,11 +323,15 @@ See [Forward Pass Metrics Trace Reference](forward-pass-metrics-traces.mdx) for 
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_PREFIX" type="string">
-  Object key prefix for the `s3` sink. When unset, records land at the bucket root. Keys are `{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`.
+  Object key prefix for the `s3` sink. When unset, the parent `DynamoGraphDeployment` qualified by its namespace (`DYN_PARENT_DGD_K8S_NAMESPACE/DYN_PARENT_DGD_K8S_NAME`, both injected by the operator) is used, so each deployment lands under its own prefix without configuration; DGD names are unique only within a namespace. Setting this variable overrides that default. With neither set, records land at the bucket root. Keys are `{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`.
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES" type="integer" default="67108864">
   Batch roll threshold for the `s3` sink in uncompressed bytes. When the pending batch reaches this size it is gzipped and uploaded as one object.
+</ParamField>
+
+<ParamField path="DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS" type="integer" default="4">
+  Maximum concurrent `PutObject` calls for the `s3` sink. Finished batches upload on separate tasks so a slow `PutObject` cannot stall record ingestion; batches admitted beyond this limit wait in a bounded queue behind the in-flight uploads. Once both fill, further batches are dropped and counted.
 </ParamField>
 
 <ParamField path="DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS" type="integer" default="10000">

--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -49,12 +49,42 @@ Setting `DYN_REQUEST_TRACE_SINKS=stderr` does not enable OTLP export. Include `o
 The `s3` sink writes records directly to an S3 bucket as gzipped JSONL objects, one object per rolled
 batch. Records are batched in-process and uploaded when the batch reaches
 `DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES` or when `DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS`
-elapses. Object keys are `{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`, where
-`run_id` is a per-process UUID that keeps container restarts and hostname collisions from overwriting
-earlier batches. Credentials come from the shared object-store client's provider chain (environment
-variables, IMDS, IRSA, and Pod Identity). Shared AWS config and credential profiles are not loaded;
-how the frontend pod is credentialed is a deployment concern. On terminal upload failure the batch
-is dropped and a warning is logged; no on-disk retry queue is kept.
+elapses. Object keys use Hive-style time partitions,
+`{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`, so Athena and Glue can
+prune by day and hour. Time is the only partition column: a batch can hold records for several models,
+and every row carries its own `model` field, so query that column instead of partitioning on it.
+
+The prefix defaults to the parent `DynamoGraphDeployment`, qualified by its namespace as
+`{namespace}/{name}` (the operator injects `DYN_PARENT_DGD_K8S_NAMESPACE` and
+`DYN_PARENT_DGD_K8S_NAME`), so each deployment writes under its own prefix with no configuration.
+The namespace is included because DGD names are unique only within a namespace.
+Set `DYN_REQUEST_TRACE_S3_PREFIX` to override that — for example to nest traces under an
+organizational path or to reserve a prefix in a bucket shared with other data.
+
+In the filename, `MMSS` is the minute and second the batch was flushed, ordering objects within the
+hour partition, and `seq` is a per-process counter that keeps two batches flushed in the same second
+distinct. `pod` identifies the writing pod (`POD_NAME`, falling back to the hostname), and
+`run_id` is a per-process UUID that keeps container restarts and pod-name collisions from overwriting
+earlier batches. Per-record timing lives in each row's `event_time_unix_ms`. Credentials come from the shared
+object-store client's provider chain (environment variables, IMDS, IRSA, and Pod Identity). Shared AWS
+config and credential profiles are not loaded; how the frontend pod is credentialed is a deployment
+concern.
+
+Uploads run on separate tasks. At most `DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS` `PutObject` calls
+are in flight, with a queue of ready batches behind them, so a slow `PutObject` does not stall record
+ingestion. Loss is
+bounded and always counted: if S3 stays slow long enough to fill both the in-flight set and the queue,
+further batches are discarded, and if the record channel fills first, individual records are dropped.
+Either way the sink warns on the first drop and logs the running total at shutdown rather than one line
+per record. On terminal upload failure the batch is dropped and a warning is logged; no on-disk retry
+queue is kept.
+
+To query the objects with Athena, declare the two partition keys and let partition projection or
+`MSCK REPAIR TABLE` discover them:
+
+```sql
+PARTITIONED BY (`date` string, `hour` string)
+```
 
 ```bash
 export DYN_REQUEST_TRACE=1

--- a/docs/fern/pages/reference/observability/request-traces.mdx
+++ b/docs/fern/pages/reference/observability/request-traces.mdx
@@ -49,12 +49,41 @@ Setting `DYN_REQUEST_TRACE_SINKS=stderr` does not enable OTLP export. Include `o
 The `s3` sink writes records directly to an S3 bucket as gzipped JSONL objects, one object per rolled
 batch. Records are batched in-process and uploaded when the batch reaches
 `DYN_REQUEST_TRACE_S3_ROLL_UNCOMPRESSED_BYTES` or when `DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS`
-elapses. Object keys are `{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`, where
-`run_id` is a per-process UUID that keeps container restarts and hostname collisions from overwriting
-earlier batches. Credentials come from the AWS SDK default provider chain (environment variables,
+elapses. Object keys use Hive-style time partitions,
+`{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`, so Athena and Glue can
+prune by day and hour. Time is the only partition column: a batch can hold records for several models,
+and every row carries its own `model` field, so query that column instead of partitioning on it.
+
+The prefix defaults to the parent `DynamoGraphDeployment`, qualified by its namespace as
+`{namespace}/{name}` (the operator injects `DYN_PARENT_DGD_K8S_NAMESPACE` and
+`DYN_PARENT_DGD_K8S_NAME`), so each deployment writes under its own prefix with no configuration.
+The namespace is included because DGD names are unique only within a namespace.
+Set `DYN_REQUEST_TRACE_S3_PREFIX` to override that — for example to nest traces under an
+organizational path or to reserve a prefix in a bucket shared with other data.
+
+In the filename, `MMSS` is the minute and second the batch was flushed, ordering objects within the
+hour partition, and `seq` is a per-process counter that keeps two batches flushed in the same second
+distinct. `pod` identifies the writing pod (`POD_NAME`, falling back to the hostname), and
+`run_id` is a per-process UUID that keeps container restarts and pod-name collisions from overwriting
+earlier batches. Per-record timing lives in each row's `event_time_unix_ms`. Credentials come from the AWS SDK default provider chain (environment variables,
 IMDS, IRSA, Pod Identity, shared profiles); how the frontend pod is credentialed is a deployment
-concern. On terminal upload failure the batch is dropped and a warning is logged; no on-disk retry
+concern.
+
+Uploads run on separate tasks. At most `DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS` `PutObject` calls
+are in flight, with a queue of ready batches behind them, so a slow `PutObject` does not stall record
+ingestion. Loss is
+bounded and always counted: if S3 stays slow long enough to fill both the in-flight set and the queue,
+further batches are discarded, and if the record channel fills first, individual records are dropped.
+Either way the sink warns on the first drop and logs the running total at shutdown rather than one line
+per record. On terminal upload failure the batch is dropped and a warning is logged; no on-disk retry
 queue is kept.
+
+To query the objects with Athena, declare the two partition keys and let partition projection or
+`MSCK REPAIR TABLE` discover them:
+
+```sql
+PARTITIONED BY (`date` string, `hour` string)
+```
 
 ```bash
 export DYN_REQUEST_TRACE=1

--- a/lib/llm/src/request_trace/config.rs
+++ b/lib/llm/src/request_trace/config.rs
@@ -23,6 +23,7 @@ const DEFAULT_LEGACY_AUDIT_NATS_SUBJECT: &str = "dynamo.audit.v1";
 const DEFAULT_OTEL_MAX_PAYLOAD_BYTES: usize = 4 * 1024 * 1024;
 const DEFAULT_S3_ROLL_UNCOMPRESSED_BYTES: u64 = 64 * 1024 * 1024;
 const DEFAULT_S3_FLUSH_INTERVAL_MS: u64 = 10_000;
+const DEFAULT_S3_MAX_CONCURRENT_UPLOADS: usize = 4;
 
 const CAPTURE_UNINITIALIZED: u8 = 0;
 const CAPTURE_ACTIVE: u8 = 1;
@@ -103,6 +104,7 @@ pub struct RequestTracePolicy {
     pub s3_prefix: Option<String>,
     pub s3_roll_uncompressed_bytes: u64,
     pub s3_flush_interval_ms: u64,
+    pub s3_max_concurrent_uploads: usize,
 }
 
 impl RequestTracePolicy {
@@ -234,6 +236,10 @@ fn load_from_env() -> RequestTracePolicy {
         env_u64(&[env_request_trace::DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS])
             .filter(|value| *value > 0)
             .unwrap_or(DEFAULT_S3_FLUSH_INTERVAL_MS);
+    let s3_max_concurrent_uploads =
+        env_usize(&[env_request_trace::DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS])
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_S3_MAX_CONCURRENT_UPLOADS);
 
     RequestTracePolicy {
         enabled,
@@ -256,6 +262,7 @@ fn load_from_env() -> RequestTracePolicy {
         s3_prefix,
         s3_roll_uncompressed_bytes,
         s3_flush_interval_ms,
+        s3_max_concurrent_uploads,
     }
 }
 

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -4,10 +4,12 @@
 //! S3 destination for request trace records.
 //!
 //! Records are batched in-process as gzipped JSONL, and each finished batch is
-//! uploaded as one object via `PutObject`. Object keys use a simple time-based
-//! layout for PR 1
-//! (`{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`);
-//! richer partitioning ships in a follow-up.
+//! uploaded as one object via `PutObject`. Object keys use Hive-style time
+//! partitions
+//! (`{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`)
+//! so Athena and Glue can prune by day and hour. Time is the only partition
+//! column; every row carries its own `model` field, so consumers filter on
+//! that column rather than on the key.
 //!
 //! Credentials come from the shared `object_store` S3 client — environment
 //! variables, IMDS, IRSA, and Pod Identity are supported. Shared AWS config and
@@ -16,14 +18,19 @@
 //!
 //! # Upload concurrency
 //!
-//! A single worker task drains the record channel and uploads each finished
-//! batch inline (same shape as the OpenTelemetry Rust `BatchLogProcessor` and
-//! the local `telemetry::jsonl_gz` writer). While an upload is in flight the
-//! worker is not draining, so a slow `PutObject` applies backpressure and
-//! `emit` drops records once the channel fills. Drops are counted and surfaced
-//! (see [`S3RequestTraceSink::emit`]). Overlapping uploads with a bounded
-//! concurrency pool so the drain never stalls is a follow-up; it belongs with
-//! the object-layout work where the sink is restructured to carry more context.
+//! One worker task drains the record channel and batches records; finished
+//! batches are uploaded on separate tasks, so a slow `PutObject` never stops
+//! the worker from draining. Two semaphores bound the work: at most
+//! `DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS` `PutObject` calls are in
+//! flight, and behind them a queue holds up to that many times
+//! [`UPLOAD_QUEUE_DEPTH_MULTIPLIER`] finalized batches waiting their turn.
+//!
+//! Loss is bounded and always counted, never silent. If S3 stays slow long
+//! enough to fill both the in-flight set and the queue, further batches are
+//! discarded; if the record channel itself fills first, `emit` drops records.
+//! Both paths increment one counter, warn on the first drop, and report the
+//! running total at shutdown (the OpenTelemetry Rust `BatchLogProcessor`
+//! drop-accounting pattern), so a degraded endpoint cannot flood the log.
 
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -38,10 +45,11 @@ use object_store::{
     aws::{AmazonS3Builder, AmazonS3ConfigKey},
     path::Path as ObjectPath,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use dynamo_runtime::config::environment_names::kubernetes as env_kubernetes;
 use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
 
 use super::RequestTraceRecord;
@@ -57,14 +65,20 @@ const DEFAULT_BUFFER_INITIAL_BYTES: usize = 256 * 1024;
 // a warning; a persistent retry queue is deferred to a follow-up PR.
 const S3_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
 const S3_OPERATION_TIMEOUT: Duration = Duration::from_secs(90);
+/// Ready batches queued behind the in-flight uploads, as a multiple of the
+/// concurrency limit. Batches roll about once per flush interval per pod, so a
+/// small queue rides out a multi-minute S3 slowdown before anything is dropped.
+const UPLOAD_QUEUE_DEPTH_MULTIPLIER: usize = 2;
 
 pub struct S3RequestTraceSink {
     tx: mpsc::Sender<RequestTraceRecord>,
     shutdown: CancellationToken,
     worker: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    /// Count of records dropped by `emit` because the batcher channel was full
-    /// or closed. Surfaced once on the first drop and again as a summary at
-    /// shutdown, so a slow S3 does not produce one log line per dropped record.
+    /// Records lost, from either path: `emit` finding the batcher channel full
+    /// or closed, or the worker discarding a batch because the upload queue was
+    /// saturated. Shared with the worker task. Surfaced once on the first drop
+    /// and again as a summary at shutdown, so a slow S3 does not produce one
+    /// log line per dropped record.
     dropped: Arc<AtomicU64>,
 }
 
@@ -74,9 +88,8 @@ struct S3UploadOptions {
     prefix: String,
     host: String,
     /// Per-process UUID mixed into every object key so that a pod restart
-    /// (which reuses hostname and can land within the same second) can't
-    /// overwrite a previous batch, and two frontends sharing a hostname
-    /// stay disjoint.
+    /// (which reuses the pod name and can land within the same second) can't
+    /// overwrite a previous batch, and two pods sharing a name stay disjoint.
     run_id: String,
 }
 
@@ -89,11 +102,12 @@ impl S3RequestTraceSink {
                 env_request_trace::DYN_REQUEST_TRACE_SINKS,
             )
         })?;
-        let prefix = policy.s3_prefix.clone().unwrap_or_default();
-        let host = hostname_or_fallback();
+        let prefix = resolve_prefix(policy.s3_prefix.as_deref());
+        let host = pod_identity();
         let run_id = Uuid::new_v4().simple().to_string();
         let roll_uncompressed_bytes = policy.s3_roll_uncompressed_bytes;
         let flush_interval = Duration::from_millis(policy.s3_flush_interval_ms.max(1));
+        let max_concurrent_uploads = policy.s3_max_concurrent_uploads.max(1);
 
         let store: Arc<dyn ObjectStore> = Arc::new(
             request_trace_s3_builder(&bucket, policy.s3_region.as_deref())
@@ -110,6 +124,8 @@ impl S3RequestTraceSink {
             run_id,
         };
         let worker_shutdown = shutdown.clone();
+        let dropped = Arc::new(AtomicU64::new(0));
+        let worker_dropped = dropped.clone();
         let worker = tokio::spawn(async move {
             run_worker(
                 store,
@@ -118,6 +134,8 @@ impl S3RequestTraceSink {
                 worker_shutdown,
                 roll_uncompressed_bytes,
                 flush_interval,
+                max_concurrent_uploads,
+                worker_dropped,
             )
             .await;
         });
@@ -126,7 +144,7 @@ impl S3RequestTraceSink {
             tx,
             shutdown,
             worker: Mutex::new(Some(worker)),
-            dropped: Arc::new(AtomicU64::new(0)),
+            dropped,
         })
     }
 
@@ -191,12 +209,13 @@ impl RequestTraceSink for S3RequestTraceSink {
             tracing::warn!(
                 target: "dynamo_llm::request_trace",
                 dropped,
-                "request trace s3: dropped records during the run (batcher backpressure)"
+                "request trace s3: records lost during the run (batcher backpressure or saturated upload queue)"
             );
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_worker(
     store: Arc<dyn ObjectStore>,
     options: S3UploadOptions,
@@ -204,10 +223,22 @@ async fn run_worker(
     shutdown: CancellationToken,
     roll_uncompressed_bytes: u64,
     flush_interval: Duration,
+    max_concurrent_uploads: usize,
+    dropped: Arc<AtomicU64>,
 ) {
-    let uploader = Arc::new(S3Uploader { store, options });
+    let uploader = Arc::new(S3Uploader::new(store, options));
+    // Two tiers. `admission_slots` caps how much work is outstanding at all:
+    // the uploads in flight plus the bounded queue of ready batches behind
+    // them. Handing a batch to a spawned task means a slow `PutObject` never
+    // stalls the drain loop below.
+    let admission_slots = max_concurrent_uploads * (1 + UPLOAD_QUEUE_DEPTH_MULTIPLIER);
+    let upload_slots = Arc::new(Semaphore::new(admission_slots));
+    // `in_flight_slots` is what actually bounds concurrent `PutObject` calls to
+    // `max_concurrent_uploads`. Without this second gate every admitted batch
+    // would upload immediately and the extra admission permits would multiply
+    // real concurrency instead of forming a queue.
+    let in_flight_slots = Arc::new(Semaphore::new(max_concurrent_uploads));
     let mut batch = JsonlBatch::new();
-    let mut seq: u64 = 0;
     let mut flush_tick = tokio::time::interval(flush_interval);
     flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // Skip the immediate tick that `interval` fires at t=0.
@@ -232,17 +263,18 @@ async fn run_worker(
                         // Enforce the roll threshold during shutdown too, so a
                         // full channel can't collapse into one oversized PUT
                         // that loses everything on a single upload failure.
-                        upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                        upload_ready_batch(&uploader, &mut batch).await;
                     }
                 }
                 if !batch.is_empty() {
-                    upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                    upload_ready_batch(&uploader, &mut batch).await;
                 }
+                drain_uploads(&upload_slots, admission_slots).await;
                 return;
             }
             _ = flush_tick.tick() => {
                 if !batch.is_empty() {
-                    upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                    spawn_upload(&uploader, &mut batch, &upload_slots, &in_flight_slots, &dropped).await;
                 }
             }
             message = rx.recv() => {
@@ -255,13 +287,14 @@ async fn run_worker(
                                 "request trace s3: serialize failed; dropping record"
                             );
                         } else if batch.uncompressed_bytes() >= roll_uncompressed_bytes {
-                            upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                            spawn_upload(&uploader, &mut batch, &upload_slots, &in_flight_slots, &dropped).await;
                         }
                     }
                     None => {
                         if !batch.is_empty() {
-                            upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                            upload_ready_batch(&uploader, &mut batch).await;
                         }
+                        drain_uploads(&upload_slots, admission_slots).await;
                         return;
                     }
                 }
@@ -270,7 +303,98 @@ async fn run_worker(
     }
 }
 
-async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, seq: &mut u64) {
+/// Wait for every spawned upload to finish before the worker returns.
+///
+/// Acquiring the semaphore's *total* permit count is only possible once no
+/// upload task holds one, which drains the in-flight set without tracking task
+/// handles. The count must be the fixed total: `available_permits()` reports
+/// only the currently free permits, so acquiring that many would succeed
+/// immediately and abandon the in-flight uploads.
+async fn drain_uploads(upload_slots: &Arc<Semaphore>, admission_slots: usize) {
+    let _ = upload_slots.acquire_many(admission_slots as u32).await;
+}
+
+/// Finalize the batch and upload it on its own task, so a slow `PutObject`
+/// never stalls the drain loop.
+///
+/// Admission is bounded in two tiers: `upload_slots` caps the total outstanding
+/// work (uploads in flight plus the queue behind them), while `in_flight_slots`
+/// caps how many spawned tasks may call `PutObject` at once. When every
+/// admission permit is taken — S3 is degraded and the queue has filled — the
+/// batch is dropped and counted rather than blocking ingestion, which is the
+/// whole point of moving uploads off this task.
+async fn spawn_upload(
+    uploader: &Arc<S3Uploader>,
+    batch: &mut JsonlBatch,
+    upload_slots: &Arc<Semaphore>,
+    in_flight_slots: &Arc<Semaphore>,
+    dropped: &Arc<AtomicU64>,
+) {
+    let lines = batch.lines();
+    let Ok(permit) = upload_slots.clone().try_acquire_owned() else {
+        // Discard the batch so the buffer resets; keeping it would only grow
+        // unboundedly while S3 stays unavailable.
+        let discarded = batch.discard();
+        let total = dropped.fetch_add(discarded, Ordering::Relaxed) + discarded;
+        tracing::warn!(
+            target: "dynamo_llm::request_trace",
+            records = discarded,
+            total_dropped = total,
+            "request trace s3: upload queue full (S3 slow or unavailable); batch discarded"
+        );
+        return;
+    };
+
+    let ready = match batch.take_finished().await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let total = dropped.fetch_add(lines, Ordering::Relaxed) + lines;
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                %error,
+                records = lines,
+                total_dropped = total,
+                "request trace s3: finalize gzip batch failed; discarding"
+            );
+            return;
+        }
+    };
+
+    // Stamp the key from when the batch was flushed, not from when its upload
+    // eventually starts. A queued batch can wait behind the in-flight limit for
+    // an unbounded time while S3 is slow, and stamping later would file those
+    // records under a `date=`/`hour=` partition after the one they belong to —
+    // so a time-pruned Athena query over the correct partition would miss them.
+    let flushed_at = SystemTime::now();
+    let uploader = uploader.clone();
+    let dropped = dropped.clone();
+    let in_flight_slots = in_flight_slots.clone();
+    tokio::spawn(async move {
+        // Hold the admission permit for the whole upload; dropping it on
+        // completion frees a slot for the next queued batch.
+        let _permit = permit;
+        // Queue here until an in-flight slot frees up, so at most
+        // `max_concurrent_uploads` `PutObject` calls are ever outstanding. This
+        // await is what turns the surplus admission permits into a real queue.
+        let _in_flight = in_flight_slots.acquire().await;
+        let key = uploader.object_key(flushed_at);
+        let batch_bytes = ready.len();
+        if let Err(error) = uploader.put_object(key.clone(), ready).await {
+            let total = dropped.fetch_add(lines, Ordering::Relaxed) + lines;
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                key = %key,
+                batch_bytes,
+                records = lines,
+                total_dropped = total,
+                %error,
+                "request trace s3: put_object failed after SDK retries; batch discarded"
+            );
+        }
+    });
+}
+
+async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch) {
     let ready = match batch.take_finished().await {
         Ok(bytes) => bytes,
         Err(error) => {
@@ -282,9 +406,7 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
             return;
         }
     };
-    let this_seq = *seq;
-    *seq = seq.saturating_add(1);
-    let key = uploader.object_key(SystemTime::now(), this_seq);
+    let key = uploader.object_key(SystemTime::now());
     let batch_bytes = ready.len();
     if let Err(error) = uploader.put_object(key.clone(), ready).await {
         // The client exhausted its retries (three total attempts, bounded by
@@ -304,16 +426,28 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
 struct S3Uploader {
     store: Arc<dyn ObjectStore>,
     options: S3UploadOptions,
+    /// Monotonic per-process batch counter, mixed into every key. `MMSS` is only
+    /// second-granular, so a size roll under load or several rolls during
+    /// shutdown can flush twice within one second; without this the second
+    /// object would overwrite the first.
+    sequence: AtomicU64,
 }
 
 impl S3Uploader {
-    fn object_key(&self, at: SystemTime, seq: u64) -> String {
-        // Simple time-based layout for PR 1. Richer partitioning
-        // (model=/date=/hour= Hive style) lands in the follow-up.
-        //
-        // `run_id` guarantees per-process uniqueness so that a pod restart
-        // within the same second (or two frontends sharing a hostname)
-        // cannot overwrite each other's objects.
+    fn new(store: Arc<dyn ObjectStore>, options: S3UploadOptions) -> Self {
+        Self {
+            store,
+            options,
+            sequence: AtomicU64::new(0),
+        }
+    }
+
+    fn object_key(&self, at: SystemTime) -> String {
+        // Hive-style time partitions (`date=`/`hour=`) so Athena and Glue can
+        // prune by day and hour instead of scanning the whole prefix. Time is
+        // the only partition column: a batch can hold records for several
+        // models, and every row already carries its own `model` field, so
+        // consumers filter on that column rather than the key.
         let secs = at
             .duration_since(UNIX_EPOCH)
             .map(|dur| dur.as_secs())
@@ -325,9 +459,15 @@ impl S3Uploader {
             key.push_str(prefix);
             key.push('/');
         }
+        // `MMSS` orders objects within the hour partition, `seq` separates two
+        // batches that flush in the same second, `pod` identifies the writing
+        // pod without opening the object, and the per-process `run_id` keeps two
+        // pods (or a pod and its restart) that flush in the same second from
+        // overwriting each other.
+        let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
         key.push_str(&format!(
-            "{yyyy:04}/{mm:02}/{dd:02}/{host}-{hh:02}{mi:02}{ss:02}-{run_id}-{seq:06}.jsonl.gz",
-            host = self.options.host,
+            "date={yyyy:04}-{mm:02}-{dd:02}/hour={hh:02}/{mi:02}{ss:02}-{seq:04}-{pod}-{run_id}.jsonl.gz",
+            pod = self.options.host,
             run_id = self.options.run_id,
         ));
         key
@@ -399,6 +539,19 @@ impl JsonlBatch {
         self.raw.len() as u64
     }
 
+    /// Records currently buffered, used to attribute drops to a record count.
+    fn lines(&self) -> u64 {
+        self.lines
+    }
+
+    /// Throw the buffered records away and reset, returning how many were lost.
+    fn discard(&mut self) -> u64 {
+        let lost = self.lines;
+        self.raw.clear();
+        self.lines = 0;
+        lost
+    }
+
     fn push(&mut self, record: &RequestTraceRecord) -> Result<()> {
         let mut line = serde_json::to_vec(record).context("serializing request trace record")?;
         line.push(b'\n');
@@ -432,11 +585,55 @@ impl JsonlBatch {
     }
 }
 
-fn hostname_or_fallback() -> String {
-    std::env::var("HOSTNAME")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+/// Resolve the leading key segment.
+///
+/// An explicitly configured `DYN_REQUEST_TRACE_S3_PREFIX` always wins: setting
+/// it is a deliberate choice to control the bucket layout (nesting under
+/// `org/team/env`, or reserving a prefix in a bucket shared with other data).
+/// Otherwise the parent `DynamoGraphDeployment` is used, so each deployment
+/// lands under its own prefix without any configuration. DGD names are only
+/// unique within a namespace, so the namespace is included as
+/// `{namespace}/{name}` to keep same-named deployments in different namespaces
+/// from writing into one prefix. The operator injects
+/// `DYN_PARENT_DGD_K8S_NAME` and `DYN_PARENT_DGD_K8S_NAMESPACE` on every
+/// component container, so on Kubernetes both are available; the name alone is
+/// used if the namespace is missing, and off-cluster runs with neither set write
+/// to the bucket root.
+fn resolve_prefix(configured: Option<&str>) -> String {
+    if let Some(prefix) = configured.map(str::trim).filter(|value| !value.is_empty()) {
+        return prefix.to_string();
+    }
+    let Some(name) = env_non_empty(env_kubernetes::DYN_PARENT_DGD_K8S_NAME) else {
+        return String::new();
+    };
+    match env_non_empty(env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE) {
+        Some(namespace) => format!("{namespace}/{name}"),
+        None => name,
+    }
+}
+
+/// Identify the writing pod, following the same precedence the runtime's
+/// Kubernetes discovery uses (`POD_NAME` first; see
+/// `runtime::discovery::kube::utils`). The operator injects `POD_NAME` from
+/// `metadata.name`, so it is the authoritative source on-cluster; the
+/// remaining steps cover non-operator and bare-metal runs.
+fn pod_identity() -> String {
+    env_non_empty(env_kubernetes::POD_NAME)
+        .or_else(|| env_non_empty("HOSTNAME"))
+        .or_else(|| {
+            std::fs::read_to_string("/etc/hostname")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 /// Convert unix seconds to UTC (year, month, day, hour, minute, second).
@@ -488,31 +685,114 @@ mod tests {
     }
 
     #[test]
-    fn object_key_includes_prefix_date_run_and_seq() {
+    fn object_key_includes_prefix_partitions_time_pod_and_run_id() {
         let uploader = test_uploader("traces/");
         let at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
-        let key = uploader.object_key(at, 42);
+        let key = uploader.object_key(at);
         assert_eq!(
             key,
-            "traces/2026/07/15/frontend-0-123456-cafebabe-000042.jsonl.gz"
+            "traces/date=2026-07-15/hour=12/3456-0000-frontend-0-cafebabe.jsonl.gz"
         );
+    }
+
+    #[test]
+    fn object_keys_stay_distinct_within_the_same_second() {
+        // A size roll under load, or several rolls during shutdown, can flush
+        // twice inside one wall-clock second. `MMSS` alone would collide and the
+        // second upload would overwrite the first, so the sequence must advance.
+        let uploader = test_uploader("");
+        let at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
+        let keys: Vec<String> = (0..3).map(|_| uploader.object_key(at)).collect();
+        assert!(keys[0].contains("3456-0000-"), "{}", keys[0]);
+        assert!(keys[1].contains("3456-0001-"), "{}", keys[1]);
+        assert!(keys[2].contains("3456-0002-"), "{}", keys[2]);
+        let unique: std::collections::HashSet<&String> = keys.iter().collect();
+        assert_eq!(unique.len(), 3, "keys collided: {keys:?}");
     }
 
     #[test]
     fn object_key_omits_leading_slash_when_prefix_empty() {
         let uploader = test_uploader("");
-        let key = uploader.object_key(UNIX_EPOCH, 0);
+        let key = uploader.object_key(UNIX_EPOCH);
         assert!(!key.starts_with('/'));
-        assert!(key.starts_with("1970/01/01/frontend-0-"));
+        assert!(key.starts_with("date=1970-01-01/hour=00/0000-0000-frontend-0-"));
+    }
+
+    #[test]
+    fn object_key_partitions_by_the_supplied_flush_time() {
+        // A queued batch can wait behind the in-flight limit for an unbounded
+        // time while S3 is slow. The key must come from when the batch was
+        // flushed, not from when its upload finally starts, or the records land
+        // in a later `date=`/`hour=` partition than they belong to and a
+        // time-pruned query over the correct partition misses them.
+        let uploader = test_uploader("");
+        // 2026-07-15 12:34:56 UTC, one second before the hour partition rolls
+        // would be misleading, so use a moment whose hour is unambiguous.
+        let flushed_at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
+        // An upload that starts an hour later must still be keyed by `flushed_at`.
+        let started_later = flushed_at + Duration::from_secs(3600);
+        assert!(uploader.object_key(flushed_at).contains("hour=12/3456-"));
+        assert!(uploader.object_key(started_later).contains("hour=13/3456-"));
+    }
+
+    #[tokio::test]
+    async fn drain_uploads_waits_for_an_in_flight_upload_to_finish() {
+        // Regression test: draining must acquire the semaphore's *total* permit
+        // count. Using `available_permits()` returns the free count, so the
+        // acquire would succeed instantly and abandon in-flight uploads.
+        let admission_slots = 4;
+        let slots = Arc::new(Semaphore::new(admission_slots));
+        let held = slots.clone().acquire_owned().await.unwrap();
+
+        // With one permit held, the drain must not complete.
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                drain_uploads(&slots, admission_slots)
+            )
+            .await
+            .is_err(),
+            "drain returned while an upload still held a permit"
+        );
+
+        // Releasing it (as a finished upload does) lets the drain complete.
+        drop(held);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                drain_uploads(&slots, admission_slots)
+            )
+            .await
+            .is_ok(),
+            "drain did not complete after every permit was released"
+        );
+    }
+
+    #[tokio::test]
+    async fn admitted_batches_queue_behind_the_in_flight_limit() {
+        // The admission semaphore is deliberately larger than the in-flight
+        // limit, so admission alone must not permit an upload to start;
+        // otherwise the configured concurrency would be exceeded.
+        let max_concurrent_uploads = 1;
+        let admission_slots = max_concurrent_uploads * (1 + UPLOAD_QUEUE_DEPTH_MULTIPLIER);
+        assert!(admission_slots > max_concurrent_uploads);
+
+        let in_flight = Arc::new(Semaphore::new(max_concurrent_uploads));
+        let busy = in_flight.clone().acquire_owned().await.unwrap();
+        // Every in-flight slot is taken, so a newly admitted batch waits here
+        // rather than issuing a concurrent `PutObject`.
+        assert!(
+            in_flight.clone().try_acquire_owned().is_err(),
+            "an extra upload started while the in-flight limit was saturated"
+        );
+        drop(busy);
+        assert!(in_flight.try_acquire_owned().is_ok());
     }
 
     #[tokio::test]
     async fn put_object_writes_body_and_content_type() {
         let store = Arc::new(InMemory::new());
-        let uploader = S3Uploader {
-            store: store.clone(),
-            options: test_options(""),
-        };
+        let uploader = S3Uploader::new(store.clone(), test_options(""));
         let key = "traces/batch.jsonl.gz";
         let body = vec![1, 2, 3, 4];
 
@@ -535,10 +815,7 @@ mod tests {
     #[tokio::test]
     async fn put_object_preserves_percent_encoded_key() {
         let store = Arc::new(InMemory::new());
-        let uploader = S3Uploader {
-            store: store.clone(),
-            options: test_options(""),
-        };
+        let uploader = S3Uploader::new(store.clone(), test_options(""));
         let key = "traces/%2F/batch.jsonl.gz";
         let body = vec![1, 2, 3, 4];
 
@@ -594,10 +871,7 @@ mod tests {
     }
 
     fn test_uploader(prefix: &str) -> S3Uploader {
-        S3Uploader {
-            store: Arc::new(InMemory::new()),
-            options: test_options(prefix),
-        }
+        S3Uploader::new(Arc::new(InMemory::new()), test_options(prefix))
     }
 
     fn test_options(prefix: &str) -> S3UploadOptions {
@@ -651,6 +925,124 @@ mod tests {
 
         let dropped = sink.dropped.load(Ordering::Relaxed);
         assert_eq!(dropped, (total - capacity) as u64);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_falls_back_to_the_parent_dgd_name() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd"))],
+            || {
+                assert_eq!(resolve_prefix(None), "my-dgd");
+                assert_eq!(resolve_prefix(Some("   ")), "my-dgd");
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_qualifies_the_dgd_name_with_its_namespace() {
+        // DGD names are unique only within a namespace, so two same-named
+        // deployments in different namespaces must not share one prefix.
+        temp_env::with_vars(
+            [
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd")),
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE, Some("team-a")),
+            ],
+            || assert_eq!(resolve_prefix(None), "team-a/my-dgd"),
+        );
+        temp_env::with_vars(
+            [
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd")),
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE, Some("team-b")),
+            ],
+            || assert_eq!(resolve_prefix(None), "team-b/my-dgd"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn explicit_prefix_wins_over_the_parent_dgd_name() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd"))],
+            || assert_eq!(resolve_prefix(Some("traces/prod")), "traces/prod"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_is_empty_off_cluster_without_configuration() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, None::<&str>)],
+            || assert_eq!(resolve_prefix(None), ""),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pod_identity_prefers_pod_name_over_hostname() {
+        temp_env::with_vars(
+            [
+                (env_kubernetes::POD_NAME, Some("frontend-abc123")),
+                ("HOSTNAME", Some("some-host")),
+            ],
+            || assert_eq!(pod_identity(), "frontend-abc123"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pod_identity_falls_back_to_hostname() {
+        temp_env::with_vars(
+            [
+                (env_kubernetes::POD_NAME, None::<&str>),
+                ("HOSTNAME", Some("some-host")),
+            ],
+            || assert_eq!(pod_identity(), "some-host"),
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_upload_discards_and_counts_when_queue_is_saturated() {
+        let uploader = Arc::new(test_uploader(""));
+        // A semaphore with no permits available stands in for "every upload
+        // slot and every queue slot is taken".
+        let slots = Arc::new(Semaphore::new(1));
+        let held = slots.clone().acquire_owned().await.unwrap();
+        let in_flight = Arc::new(Semaphore::new(1));
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let mut batch = JsonlBatch::new();
+        for _ in 0..3 {
+            batch.push(&sample_record()).unwrap();
+        }
+        assert_eq!(batch.lines(), 3);
+
+        spawn_upload(&uploader, &mut batch, &slots, &in_flight, &dropped).await;
+
+        // The batch is discarded, its records counted, and the buffer reset so
+        // it does not grow while S3 stays unavailable.
+        assert_eq!(dropped.load(Ordering::Relaxed), 3);
+        assert!(batch.is_empty());
+        assert_eq!(batch.uncompressed_bytes(), 0);
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn spawn_upload_takes_a_slot_when_capacity_is_available() {
+        let uploader = Arc::new(test_uploader(""));
+        let slots = Arc::new(Semaphore::new(2));
+        let in_flight = Arc::new(Semaphore::new(1));
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let mut batch = JsonlBatch::new();
+        batch.push(&sample_record()).unwrap();
+        spawn_upload(&uploader, &mut batch, &slots, &in_flight, &dropped).await;
+
+        // The batch was handed off (buffer reset) rather than discarded. The
+        // spawned upload fails against the no-network client, which counts the
+        // records, so only assert the hand-off drained the batch here.
+        assert!(batch.is_empty());
     }
 
     #[test]

--- a/lib/llm/src/request_trace/s3_sink.rs
+++ b/lib/llm/src/request_trace/s3_sink.rs
@@ -4,10 +4,12 @@
 //! S3 destination for request trace records.
 //!
 //! Records are batched in-process as gzipped JSONL, and each finished batch is
-//! uploaded as one object via `PutObject`. Object keys use a simple time-based
-//! layout for PR 1
-//! (`{prefix}/{yyyy}/{mm}/{dd}/{host}-{HHMMSS}-{run_id}-{seq}.jsonl.gz`);
-//! richer partitioning ships in a follow-up.
+//! uploaded as one object via `PutObject`. Object keys use Hive-style time
+//! partitions
+//! (`{prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz`)
+//! so Athena and Glue can prune by day and hour. Time is the only partition
+//! column; every row carries its own `model` field, so consumers filter on
+//! that column rather than on the key.
 //!
 //! Credentials come from the AWS SDK default provider chain — env vars, IMDS,
 //! IRSA, Pod Identity, and shared profiles are all handled by the SDK. How the
@@ -15,14 +17,19 @@
 //!
 //! # Upload concurrency
 //!
-//! A single worker task drains the record channel and uploads each finished
-//! batch inline (same shape as the OpenTelemetry Rust `BatchLogProcessor` and
-//! the local `telemetry::jsonl_gz` writer). While an upload is in flight the
-//! worker is not draining, so a slow `PutObject` applies backpressure and
-//! `emit` drops records once the channel fills. Drops are counted and surfaced
-//! (see [`S3RequestTraceSink::emit`]). Overlapping uploads with a bounded
-//! concurrency pool so the drain never stalls is a follow-up; it belongs with
-//! the object-layout work where the sink is restructured to carry more context.
+//! One worker task drains the record channel and batches records; finished
+//! batches are uploaded on separate tasks, so a slow `PutObject` never stops
+//! the worker from draining. Two semaphores bound the work: at most
+//! `DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS` `PutObject` calls are in
+//! flight, and behind them a queue holds up to that many times
+//! [`UPLOAD_QUEUE_DEPTH_MULTIPLIER`] finalized batches waiting their turn.
+//!
+//! Loss is bounded and always counted, never silent. If S3 stays slow long
+//! enough to fill both the in-flight set and the queue, further batches are
+//! discarded; if the record channel itself fills first, `emit` drops records.
+//! Both paths increment one counter, warn on the first drop, and report the
+//! running total at shutdown (the OpenTelemetry Rust `BatchLogProcessor`
+//! drop-accounting pattern), so a degraded endpoint cannot flood the log.
 
 use std::io::Write;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -34,10 +41,11 @@ use async_trait::async_trait;
 use aws_config::{BehaviorVersion, Region, timeout::TimeoutConfig};
 use aws_sdk_s3::primitives::ByteStream;
 use flate2::{Compression, write::GzEncoder};
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use dynamo_runtime::config::environment_names::kubernetes as env_kubernetes;
 use dynamo_runtime::config::environment_names::llm::request_trace as env_request_trace;
 
 use super::RequestTraceRecord;
@@ -53,14 +61,20 @@ const DEFAULT_BUFFER_INITIAL_BYTES: usize = 256 * 1024;
 // a warning; a persistent retry queue is deferred to a follow-up PR.
 const S3_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(30);
 const S3_OPERATION_TIMEOUT: Duration = Duration::from_secs(90);
+/// Ready batches queued behind the in-flight uploads, as a multiple of the
+/// concurrency limit. Batches roll about once per flush interval per pod, so a
+/// small queue rides out a multi-minute S3 slowdown before anything is dropped.
+const UPLOAD_QUEUE_DEPTH_MULTIPLIER: usize = 2;
 
 pub struct S3RequestTraceSink {
     tx: mpsc::Sender<RequestTraceRecord>,
     shutdown: CancellationToken,
     worker: Mutex<Option<tokio::task::JoinHandle<()>>>,
-    /// Count of records dropped by `emit` because the batcher channel was full
-    /// or closed. Surfaced once on the first drop and again as a summary at
-    /// shutdown, so a slow S3 does not produce one log line per dropped record.
+    /// Records lost, from either path: `emit` finding the batcher channel full
+    /// or closed, or the worker discarding a batch because the upload queue was
+    /// saturated. Shared with the worker task. Surfaced once on the first drop
+    /// and again as a summary at shutdown, so a slow S3 does not produce one
+    /// log line per dropped record.
     dropped: Arc<AtomicU64>,
 }
 
@@ -70,9 +84,8 @@ struct S3UploadOptions {
     prefix: String,
     host: String,
     /// Per-process UUID mixed into every object key so that a pod restart
-    /// (which reuses hostname and can land within the same second) can't
-    /// overwrite a previous batch, and two frontends sharing a hostname
-    /// stay disjoint.
+    /// (which reuses the pod name and can land within the same second) can't
+    /// overwrite a previous batch, and two pods sharing a name stay disjoint.
     run_id: String,
 }
 
@@ -85,11 +98,12 @@ impl S3RequestTraceSink {
                 env_request_trace::DYN_REQUEST_TRACE_SINKS,
             )
         })?;
-        let prefix = policy.s3_prefix.clone().unwrap_or_default();
-        let host = hostname_or_fallback();
+        let prefix = resolve_prefix(policy.s3_prefix.as_deref());
+        let host = pod_identity();
         let run_id = Uuid::new_v4().simple().to_string();
         let roll_uncompressed_bytes = policy.s3_roll_uncompressed_bytes;
         let flush_interval = Duration::from_millis(policy.s3_flush_interval_ms.max(1));
+        let max_concurrent_uploads = policy.s3_max_concurrent_uploads.max(1);
 
         let timeout_config = TimeoutConfig::builder()
             .operation_attempt_timeout(S3_ATTEMPT_TIMEOUT)
@@ -112,6 +126,8 @@ impl S3RequestTraceSink {
             run_id,
         };
         let worker_shutdown = shutdown.clone();
+        let dropped = Arc::new(AtomicU64::new(0));
+        let worker_dropped = dropped.clone();
         let worker = tokio::spawn(async move {
             run_worker(
                 client,
@@ -120,6 +136,8 @@ impl S3RequestTraceSink {
                 worker_shutdown,
                 roll_uncompressed_bytes,
                 flush_interval,
+                max_concurrent_uploads,
+                worker_dropped,
             )
             .await;
         });
@@ -128,7 +146,7 @@ impl S3RequestTraceSink {
             tx,
             shutdown,
             worker: Mutex::new(Some(worker)),
-            dropped: Arc::new(AtomicU64::new(0)),
+            dropped,
         })
     }
 
@@ -193,12 +211,13 @@ impl RequestTraceSink for S3RequestTraceSink {
             tracing::warn!(
                 target: "dynamo_llm::request_trace",
                 dropped,
-                "request trace s3: dropped records during the run (batcher backpressure)"
+                "request trace s3: records lost during the run (batcher backpressure or saturated upload queue)"
             );
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_worker(
     client: aws_sdk_s3::Client,
     options: S3UploadOptions,
@@ -206,10 +225,22 @@ async fn run_worker(
     shutdown: CancellationToken,
     roll_uncompressed_bytes: u64,
     flush_interval: Duration,
+    max_concurrent_uploads: usize,
+    dropped: Arc<AtomicU64>,
 ) {
-    let uploader = Arc::new(S3Uploader { client, options });
+    let uploader = Arc::new(S3Uploader::new(client, options));
+    // Two tiers. `admission_slots` caps how much work is outstanding at all:
+    // the uploads in flight plus the bounded queue of ready batches behind
+    // them. Handing a batch to a spawned task means a slow `PutObject` never
+    // stalls the drain loop below.
+    let admission_slots = max_concurrent_uploads * (1 + UPLOAD_QUEUE_DEPTH_MULTIPLIER);
+    let upload_slots = Arc::new(Semaphore::new(admission_slots));
+    // `in_flight_slots` is what actually bounds concurrent `PutObject` calls to
+    // `max_concurrent_uploads`. Without this second gate every admitted batch
+    // would upload immediately and the extra admission permits would multiply
+    // real concurrency instead of forming a queue.
+    let in_flight_slots = Arc::new(Semaphore::new(max_concurrent_uploads));
     let mut batch = JsonlBatch::new();
-    let mut seq: u64 = 0;
     let mut flush_tick = tokio::time::interval(flush_interval);
     flush_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
     // Skip the immediate tick that `interval` fires at t=0.
@@ -234,17 +265,18 @@ async fn run_worker(
                         // Enforce the roll threshold during shutdown too, so a
                         // full channel can't collapse into one oversized PUT
                         // that loses everything on a single upload failure.
-                        upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                        upload_ready_batch(&uploader, &mut batch).await;
                     }
                 }
                 if !batch.is_empty() {
-                    upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                    upload_ready_batch(&uploader, &mut batch).await;
                 }
+                drain_uploads(&upload_slots, admission_slots).await;
                 return;
             }
             _ = flush_tick.tick() => {
                 if !batch.is_empty() {
-                    upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                    spawn_upload(&uploader, &mut batch, &upload_slots, &in_flight_slots, &dropped).await;
                 }
             }
             message = rx.recv() => {
@@ -257,13 +289,14 @@ async fn run_worker(
                                 "request trace s3: serialize failed; dropping record"
                             );
                         } else if batch.uncompressed_bytes() >= roll_uncompressed_bytes {
-                            upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                            spawn_upload(&uploader, &mut batch, &upload_slots, &in_flight_slots, &dropped).await;
                         }
                     }
                     None => {
                         if !batch.is_empty() {
-                            upload_ready_batch(&uploader, &mut batch, &mut seq).await;
+                            upload_ready_batch(&uploader, &mut batch).await;
                         }
+                        drain_uploads(&upload_slots, admission_slots).await;
                         return;
                     }
                 }
@@ -272,7 +305,98 @@ async fn run_worker(
     }
 }
 
-async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, seq: &mut u64) {
+/// Wait for every spawned upload to finish before the worker returns.
+///
+/// Acquiring the semaphore's *total* permit count is only possible once no
+/// upload task holds one, which drains the in-flight set without tracking task
+/// handles. The count must be the fixed total: `available_permits()` reports
+/// only the currently free permits, so acquiring that many would succeed
+/// immediately and abandon the in-flight uploads.
+async fn drain_uploads(upload_slots: &Arc<Semaphore>, admission_slots: usize) {
+    let _ = upload_slots.acquire_many(admission_slots as u32).await;
+}
+
+/// Finalize the batch and upload it on its own task, so a slow `PutObject`
+/// never stalls the drain loop.
+///
+/// Admission is bounded in two tiers: `upload_slots` caps the total outstanding
+/// work (uploads in flight plus the queue behind them), while `in_flight_slots`
+/// caps how many spawned tasks may call `PutObject` at once. When every
+/// admission permit is taken — S3 is degraded and the queue has filled — the
+/// batch is dropped and counted rather than blocking ingestion, which is the
+/// whole point of moving uploads off this task.
+async fn spawn_upload(
+    uploader: &Arc<S3Uploader>,
+    batch: &mut JsonlBatch,
+    upload_slots: &Arc<Semaphore>,
+    in_flight_slots: &Arc<Semaphore>,
+    dropped: &Arc<AtomicU64>,
+) {
+    let lines = batch.lines();
+    let Ok(permit) = upload_slots.clone().try_acquire_owned() else {
+        // Discard the batch so the buffer resets; keeping it would only grow
+        // unboundedly while S3 stays unavailable.
+        let discarded = batch.discard();
+        let total = dropped.fetch_add(discarded, Ordering::Relaxed) + discarded;
+        tracing::warn!(
+            target: "dynamo_llm::request_trace",
+            records = discarded,
+            total_dropped = total,
+            "request trace s3: upload queue full (S3 slow or unavailable); batch discarded"
+        );
+        return;
+    };
+
+    let ready = match batch.take_finished().await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            let total = dropped.fetch_add(lines, Ordering::Relaxed) + lines;
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                %error,
+                records = lines,
+                total_dropped = total,
+                "request trace s3: finalize gzip batch failed; discarding"
+            );
+            return;
+        }
+    };
+
+    // Stamp the key from when the batch was flushed, not from when its upload
+    // eventually starts. A queued batch can wait behind the in-flight limit for
+    // an unbounded time while S3 is slow, and stamping later would file those
+    // records under a `date=`/`hour=` partition after the one they belong to —
+    // so a time-pruned Athena query over the correct partition would miss them.
+    let flushed_at = SystemTime::now();
+    let uploader = uploader.clone();
+    let dropped = dropped.clone();
+    let in_flight_slots = in_flight_slots.clone();
+    tokio::spawn(async move {
+        // Hold the admission permit for the whole upload; dropping it on
+        // completion frees a slot for the next queued batch.
+        let _permit = permit;
+        // Queue here until an in-flight slot frees up, so at most
+        // `max_concurrent_uploads` `PutObject` calls are ever outstanding. This
+        // await is what turns the surplus admission permits into a real queue.
+        let _in_flight = in_flight_slots.acquire().await;
+        let key = uploader.object_key(flushed_at);
+        let batch_bytes = ready.len();
+        if let Err(error) = uploader.put_object(key.clone(), ready).await {
+            let total = dropped.fetch_add(lines, Ordering::Relaxed) + lines;
+            tracing::warn!(
+                target: "dynamo_llm::request_trace",
+                key = %key,
+                batch_bytes,
+                records = lines,
+                total_dropped = total,
+                %error,
+                "request trace s3: put_object failed after SDK retries; batch discarded"
+            );
+        }
+    });
+}
+
+async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch) {
     let ready = match batch.take_finished().await {
         Ok(bytes) => bytes,
         Err(error) => {
@@ -284,9 +408,7 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
             return;
         }
     };
-    let this_seq = *seq;
-    *seq = seq.saturating_add(1);
-    let key = uploader.object_key(SystemTime::now(), this_seq);
+    let key = uploader.object_key(SystemTime::now());
     let batch_bytes = ready.len();
     if let Err(error) = uploader.put_object(key.clone(), ready).await {
         // The SDK exhausted its retries (three total attempts by default,
@@ -306,16 +428,28 @@ async fn upload_ready_batch(uploader: &Arc<S3Uploader>, batch: &mut JsonlBatch, 
 struct S3Uploader {
     client: aws_sdk_s3::Client,
     options: S3UploadOptions,
+    /// Monotonic per-process batch counter, mixed into every key. `MMSS` is only
+    /// second-granular, so a size roll under load or several rolls during
+    /// shutdown can flush twice within one second; without this the second
+    /// object would overwrite the first.
+    sequence: AtomicU64,
 }
 
 impl S3Uploader {
-    fn object_key(&self, at: SystemTime, seq: u64) -> String {
-        // Simple time-based layout for PR 1. Richer partitioning
-        // (model=/date=/hour= Hive style) lands in the follow-up.
-        //
-        // `run_id` guarantees per-process uniqueness so that a pod restart
-        // within the same second (or two frontends sharing a hostname)
-        // cannot overwrite each other's objects.
+    fn new(client: aws_sdk_s3::Client, options: S3UploadOptions) -> Self {
+        Self {
+            client,
+            options,
+            sequence: AtomicU64::new(0),
+        }
+    }
+
+    fn object_key(&self, at: SystemTime) -> String {
+        // Hive-style time partitions (`date=`/`hour=`) so Athena and Glue can
+        // prune by day and hour instead of scanning the whole prefix. Time is
+        // the only partition column: a batch can hold records for several
+        // models, and every row already carries its own `model` field, so
+        // consumers filter on that column rather than the key.
         let secs = at
             .duration_since(UNIX_EPOCH)
             .map(|dur| dur.as_secs())
@@ -327,9 +461,15 @@ impl S3Uploader {
             key.push_str(prefix);
             key.push('/');
         }
+        // `MMSS` orders objects within the hour partition, `seq` separates two
+        // batches that flush in the same second, `pod` identifies the writing
+        // pod without opening the object, and the per-process `run_id` keeps two
+        // pods (or a pod and its restart) that flush in the same second from
+        // overwriting each other.
+        let seq = self.sequence.fetch_add(1, Ordering::Relaxed);
         key.push_str(&format!(
-            "{yyyy:04}/{mm:02}/{dd:02}/{host}-{hh:02}{mi:02}{ss:02}-{run_id}-{seq:06}.jsonl.gz",
-            host = self.options.host,
+            "date={yyyy:04}-{mm:02}-{dd:02}/hour={hh:02}/{mi:02}{ss:02}-{seq:04}-{pod}-{run_id}.jsonl.gz",
+            pod = self.options.host,
             run_id = self.options.run_id,
         ));
         key
@@ -373,6 +513,19 @@ impl JsonlBatch {
         self.raw.len() as u64
     }
 
+    /// Records currently buffered, used to attribute drops to a record count.
+    fn lines(&self) -> u64 {
+        self.lines
+    }
+
+    /// Throw the buffered records away and reset, returning how many were lost.
+    fn discard(&mut self) -> u64 {
+        let lost = self.lines;
+        self.raw.clear();
+        self.lines = 0;
+        lost
+    }
+
     fn push(&mut self, record: &RequestTraceRecord) -> Result<()> {
         let mut line = serde_json::to_vec(record).context("serializing request trace record")?;
         line.push(b'\n');
@@ -406,11 +559,55 @@ impl JsonlBatch {
     }
 }
 
-fn hostname_or_fallback() -> String {
-    std::env::var("HOSTNAME")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
+/// Resolve the leading key segment.
+///
+/// An explicitly configured `DYN_REQUEST_TRACE_S3_PREFIX` always wins: setting
+/// it is a deliberate choice to control the bucket layout (nesting under
+/// `org/team/env`, or reserving a prefix in a bucket shared with other data).
+/// Otherwise the parent `DynamoGraphDeployment` is used, so each deployment
+/// lands under its own prefix without any configuration. DGD names are only
+/// unique within a namespace, so the namespace is included as
+/// `{namespace}/{name}` to keep same-named deployments in different namespaces
+/// from writing into one prefix. The operator injects
+/// `DYN_PARENT_DGD_K8S_NAME` and `DYN_PARENT_DGD_K8S_NAMESPACE` on every
+/// component container, so on Kubernetes both are available; the name alone is
+/// used if the namespace is missing, and off-cluster runs with neither set write
+/// to the bucket root.
+fn resolve_prefix(configured: Option<&str>) -> String {
+    if let Some(prefix) = configured.map(str::trim).filter(|value| !value.is_empty()) {
+        return prefix.to_string();
+    }
+    let Some(name) = env_non_empty(env_kubernetes::DYN_PARENT_DGD_K8S_NAME) else {
+        return String::new();
+    };
+    match env_non_empty(env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE) {
+        Some(namespace) => format!("{namespace}/{name}"),
+        None => name,
+    }
+}
+
+/// Identify the writing pod, following the same precedence the runtime's
+/// Kubernetes discovery uses (`POD_NAME` first; see
+/// `runtime::discovery::kube::utils`). The operator injects `POD_NAME` from
+/// `metadata.name`, so it is the authoritative source on-cluster; the
+/// remaining steps cover non-operator and bare-metal runs.
+fn pod_identity() -> String {
+    env_non_empty(env_kubernetes::POD_NAME)
+        .or_else(|| env_non_empty("HOSTNAME"))
+        .or_else(|| {
+            std::fs::read_to_string("/etc/hostname")
+                .ok()
+                .map(|value| value.trim().to_string())
+                .filter(|value| !value.is_empty())
+        })
         .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn env_non_empty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 /// Convert unix seconds to UTC (year, month, day, hour, minute, second).
@@ -461,38 +658,140 @@ mod tests {
     }
 
     #[test]
-    fn object_key_includes_prefix_date_run_and_seq() {
-        let uploader = S3Uploader {
-            client: dummy_client(),
-            options: S3UploadOptions {
+    fn object_key_includes_prefix_partitions_time_pod_and_run_id() {
+        let uploader = S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
                 bucket: "b".to_string(),
                 prefix: "traces/".to_string(),
                 host: "frontend-0".to_string(),
                 run_id: "cafebabe".to_string(),
             },
-        };
+        );
         let at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
-        let key = uploader.object_key(at, 42);
+        let key = uploader.object_key(at);
         assert_eq!(
             key,
-            "traces/2026/07/15/frontend-0-123456-cafebabe-000042.jsonl.gz"
+            "traces/date=2026-07-15/hour=12/3456-0000-frontend-0-cafebabe.jsonl.gz"
         );
     }
 
     #[test]
-    fn object_key_omits_leading_slash_when_prefix_empty() {
-        let uploader = S3Uploader {
-            client: dummy_client(),
-            options: S3UploadOptions {
+    fn object_keys_stay_distinct_within_the_same_second() {
+        // A size roll under load, or several rolls during shutdown, can flush
+        // twice inside one wall-clock second. `MMSS` alone would collide and the
+        // second upload would overwrite the first, so the sequence must advance.
+        let uploader = S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
                 bucket: "b".to_string(),
                 prefix: String::new(),
                 host: "h".to_string(),
                 run_id: "abc".to_string(),
             },
-        };
-        let key = uploader.object_key(UNIX_EPOCH, 0);
+        );
+        let at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
+        let keys: Vec<String> = (0..3).map(|_| uploader.object_key(at)).collect();
+        assert!(keys[0].contains("3456-0000-"), "{}", keys[0]);
+        assert!(keys[1].contains("3456-0001-"), "{}", keys[1]);
+        assert!(keys[2].contains("3456-0002-"), "{}", keys[2]);
+        let unique: std::collections::HashSet<&String> = keys.iter().collect();
+        assert_eq!(unique.len(), 3, "keys collided: {keys:?}");
+    }
+
+    #[test]
+    fn object_key_omits_leading_slash_when_prefix_empty() {
+        let uploader = S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
+                bucket: "b".to_string(),
+                prefix: String::new(),
+                host: "h".to_string(),
+                run_id: "abc".to_string(),
+            },
+        );
+        let key = uploader.object_key(UNIX_EPOCH);
         assert!(!key.starts_with('/'));
-        assert!(key.starts_with("1970/01/01/h-"));
+        assert!(key.starts_with("date=1970-01-01/hour=00/0000-0000-h-"));
+    }
+
+    #[test]
+    fn object_key_partitions_by_the_supplied_flush_time() {
+        // A queued batch can wait behind the in-flight limit for an unbounded
+        // time while S3 is slow. The key must come from when the batch was
+        // flushed, not from when its upload finally starts, or the records land
+        // in a later `date=`/`hour=` partition than they belong to and a
+        // time-pruned query over the correct partition misses them.
+        let uploader = S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
+                bucket: "b".to_string(),
+                prefix: String::new(),
+                host: "h".to_string(),
+                run_id: "abc".to_string(),
+            },
+        );
+        // 2026-07-15 12:34:56 UTC, one second before the hour partition rolls
+        // would be misleading, so use a moment whose hour is unambiguous.
+        let flushed_at = UNIX_EPOCH + Duration::from_secs(1_784_118_896);
+        // An upload that starts an hour later must still be keyed by `flushed_at`.
+        let started_later = flushed_at + Duration::from_secs(3600);
+        assert!(uploader.object_key(flushed_at).contains("hour=12/3456-"));
+        assert!(uploader.object_key(started_later).contains("hour=13/3456-"));
+    }
+
+    #[tokio::test]
+    async fn drain_uploads_waits_for_an_in_flight_upload_to_finish() {
+        // Regression test: draining must acquire the semaphore's *total* permit
+        // count. Using `available_permits()` returns the free count, so the
+        // acquire would succeed instantly and abandon in-flight uploads.
+        let admission_slots = 4;
+        let slots = Arc::new(Semaphore::new(admission_slots));
+        let held = slots.clone().acquire_owned().await.unwrap();
+
+        // With one permit held, the drain must not complete.
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                drain_uploads(&slots, admission_slots)
+            )
+            .await
+            .is_err(),
+            "drain returned while an upload still held a permit"
+        );
+
+        // Releasing it (as a finished upload does) lets the drain complete.
+        drop(held);
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(50),
+                drain_uploads(&slots, admission_slots)
+            )
+            .await
+            .is_ok(),
+            "drain did not complete after every permit was released"
+        );
+    }
+
+    #[tokio::test]
+    async fn admitted_batches_queue_behind_the_in_flight_limit() {
+        // The admission semaphore is deliberately larger than the in-flight
+        // limit, so admission alone must not permit an upload to start;
+        // otherwise the configured concurrency would be exceeded.
+        let max_concurrent_uploads = 1;
+        let admission_slots = max_concurrent_uploads * (1 + UPLOAD_QUEUE_DEPTH_MULTIPLIER);
+        assert!(admission_slots > max_concurrent_uploads);
+
+        let in_flight = Arc::new(Semaphore::new(max_concurrent_uploads));
+        let busy = in_flight.clone().acquire_owned().await.unwrap();
+        // Every in-flight slot is taken, so a newly admitted batch waits here
+        // rather than issuing a concurrent `PutObject`.
+        assert!(
+            in_flight.clone().try_acquire_owned().is_err(),
+            "an extra upload started while the in-flight limit was saturated"
+        );
+        drop(busy);
+        assert!(in_flight.try_acquire_owned().is_ok());
     }
 
     fn dummy_client() -> aws_sdk_s3::Client {
@@ -547,6 +846,140 @@ mod tests {
 
         let dropped = sink.dropped.load(Ordering::Relaxed);
         assert_eq!(dropped, (total - capacity) as u64);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_falls_back_to_the_parent_dgd_name() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd"))],
+            || {
+                assert_eq!(resolve_prefix(None), "my-dgd");
+                assert_eq!(resolve_prefix(Some("   ")), "my-dgd");
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_qualifies_the_dgd_name_with_its_namespace() {
+        // DGD names are unique only within a namespace, so two same-named
+        // deployments in different namespaces must not share one prefix.
+        temp_env::with_vars(
+            [
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd")),
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE, Some("team-a")),
+            ],
+            || assert_eq!(resolve_prefix(None), "team-a/my-dgd"),
+        );
+        temp_env::with_vars(
+            [
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd")),
+                (env_kubernetes::DYN_PARENT_DGD_K8S_NAMESPACE, Some("team-b")),
+            ],
+            || assert_eq!(resolve_prefix(None), "team-b/my-dgd"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn explicit_prefix_wins_over_the_parent_dgd_name() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, Some("my-dgd"))],
+            || assert_eq!(resolve_prefix(Some("traces/prod")), "traces/prod"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn prefix_is_empty_off_cluster_without_configuration() {
+        temp_env::with_vars(
+            [(env_kubernetes::DYN_PARENT_DGD_K8S_NAME, None::<&str>)],
+            || assert_eq!(resolve_prefix(None), ""),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pod_identity_prefers_pod_name_over_hostname() {
+        temp_env::with_vars(
+            [
+                (env_kubernetes::POD_NAME, Some("frontend-abc123")),
+                ("HOSTNAME", Some("some-host")),
+            ],
+            || assert_eq!(pod_identity(), "frontend-abc123"),
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn pod_identity_falls_back_to_hostname() {
+        temp_env::with_vars(
+            [
+                (env_kubernetes::POD_NAME, None::<&str>),
+                ("HOSTNAME", Some("some-host")),
+            ],
+            || assert_eq!(pod_identity(), "some-host"),
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_upload_discards_and_counts_when_queue_is_saturated() {
+        let uploader = Arc::new(S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
+                bucket: "b".to_string(),
+                prefix: String::new(),
+                host: "h".to_string(),
+                run_id: "abc".to_string(),
+            },
+        ));
+        // A semaphore with no permits available stands in for "every upload
+        // slot and every queue slot is taken".
+        let slots = Arc::new(Semaphore::new(1));
+        let held = slots.clone().acquire_owned().await.unwrap();
+        let in_flight = Arc::new(Semaphore::new(1));
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let mut batch = JsonlBatch::new();
+        for _ in 0..3 {
+            batch.push(&sample_record()).unwrap();
+        }
+        assert_eq!(batch.lines(), 3);
+
+        spawn_upload(&uploader, &mut batch, &slots, &in_flight, &dropped).await;
+
+        // The batch is discarded, its records counted, and the buffer reset so
+        // it does not grow while S3 stays unavailable.
+        assert_eq!(dropped.load(Ordering::Relaxed), 3);
+        assert!(batch.is_empty());
+        assert_eq!(batch.uncompressed_bytes(), 0);
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn spawn_upload_takes_a_slot_when_capacity_is_available() {
+        let uploader = Arc::new(S3Uploader::new(
+            dummy_client(),
+            S3UploadOptions {
+                bucket: "b".to_string(),
+                prefix: String::new(),
+                host: "h".to_string(),
+                run_id: "abc".to_string(),
+            },
+        ));
+        let slots = Arc::new(Semaphore::new(2));
+        let in_flight = Arc::new(Semaphore::new(1));
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let mut batch = JsonlBatch::new();
+        batch.push(&sample_record()).unwrap();
+        spawn_upload(&uploader, &mut batch, &slots, &in_flight, &dropped).await;
+
+        // The batch was handed off (buffer reset) rather than discarded. The
+        // spawned upload fails against the no-network client, which counts the
+        // records, so only assert the hand-off drained the batch here.
+        assert!(batch.is_empty());
     }
 
     #[test]

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -605,6 +605,14 @@ pub mod llm {
         /// still land in S3. Default `10000` (10 s).
         pub const DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS: &str =
             "DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS";
+
+        /// Maximum S3 uploads in flight concurrently. Finished batches are
+        /// uploaded on separate tasks so a slow `PutObject` cannot stall record
+        /// ingestion. A bounded queue holds a few more ready batches behind
+        /// these; once both fill, further batches are dropped and counted.
+        /// Default `4`.
+        pub const DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS: &str =
+            "DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS";
     }
 }
 
@@ -771,6 +779,25 @@ pub mod discovery {
 
     /// Kube discovery mode: "pod" (default) or "container" (each container registers independently)
     pub const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
+}
+
+/// Pod metadata injected by the Dynamo operator.
+///
+/// The operator sets these on every component container, so they are always
+/// present on operator-managed Kubernetes deployments and absent elsewhere
+/// (local runs, plain Docker, bare metal).
+pub mod kubernetes {
+    /// Kubernetes name of the parent `DynamoGraphDeployment` resource.
+    pub const DYN_PARENT_DGD_K8S_NAME: &str = "DYN_PARENT_DGD_K8S_NAME";
+
+    /// Kubernetes namespace of the parent `DynamoGraphDeployment` resource.
+    pub const DYN_PARENT_DGD_K8S_NAMESPACE: &str = "DYN_PARENT_DGD_K8S_NAMESPACE";
+
+    /// Pod name, injected from `metadata.name`.
+    pub const POD_NAME: &str = "POD_NAME";
+
+    /// Pod namespace, injected from `metadata.namespace`.
+    pub const POD_NAMESPACE: &str = "POD_NAMESPACE";
 }
 
 /// CUDA and GPU environment variables

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -601,6 +601,14 @@ pub mod llm {
         /// still land in S3. Default `10000` (10 s).
         pub const DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS: &str =
             "DYN_REQUEST_TRACE_S3_FLUSH_INTERVAL_MS";
+
+        /// Maximum S3 uploads in flight concurrently. Finished batches are
+        /// uploaded on separate tasks so a slow `PutObject` cannot stall record
+        /// ingestion. A bounded queue holds a few more ready batches behind
+        /// these; once both fill, further batches are dropped and counted.
+        /// Default `4`.
+        pub const DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS: &str =
+            "DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS";
     }
 }
 
@@ -766,6 +774,25 @@ pub mod discovery {
 
     /// Kube discovery mode: "pod" (default) or "container" (each container registers independently)
     pub const DYN_KUBE_DISCOVERY_MODE: &str = "DYN_KUBE_DISCOVERY_MODE";
+}
+
+/// Pod metadata injected by the Dynamo operator.
+///
+/// The operator sets these on every component container, so they are always
+/// present on operator-managed Kubernetes deployments and absent elsewhere
+/// (local runs, plain Docker, bare metal).
+pub mod kubernetes {
+    /// Kubernetes name of the parent `DynamoGraphDeployment` resource.
+    pub const DYN_PARENT_DGD_K8S_NAME: &str = "DYN_PARENT_DGD_K8S_NAME";
+
+    /// Kubernetes namespace of the parent `DynamoGraphDeployment` resource.
+    pub const DYN_PARENT_DGD_K8S_NAMESPACE: &str = "DYN_PARENT_DGD_K8S_NAMESPACE";
+
+    /// Pod name, injected from `metadata.name`.
+    pub const POD_NAME: &str = "POD_NAME";
+
+    /// Pod namespace, injected from `metadata.namespace`.
+    pub const POD_NAMESPACE: &str = "POD_NAMESPACE";
 }
 
 /// CUDA and GPU environment variables


### PR DESCRIPTION
## Summary

Follow-up to #11806 for native S3 support in the request-trace sink (#11768).
Makes trace objects queryable by partition-aware engines, and stops a slow
`PutObject` from stalling record ingestion.

> [!NOTE]
> Rebased onto #13002, which moved the sink from `aws-sdk-s3` to the shared
> `object_store` client. This PR now builds its uploader on that client and keeps
> the shared `test_uploader` helper, so the layout and concurrency work here is
> independent of the credential/transport layer.

### Hive-partitioned object keys

    {prefix}/date=YYYY-MM-DD/hour=HH/{MMSS}-{seq}-{pod}-{run_id}.jsonl.gz

Athena and Glue prune on `date`/`hour` and pick up partitions via
`MSCK REPAIR TABLE`. Design notes:

- **Time is the only partition column**, so a batch is always single-valued —
  no per-key batching, eviction, or small-object fan-out.
- **Model is deliberately not in the key.** Every row already carries `model`,
  so consumers filter on the column and one in-process batch suffices.
- **`MMSS`** orders objects in the hour partition, **`seq`** (a monotonic
  per-process counter) separates two batches flushed in the same second, and
  **`run_id`** (per-process UUID) keeps restarts and pod-name reuse disjoint.
  **`pod`** identifies the writer without opening the object.
- **Prefix defaults to the parent DGD, namespace-qualified** as
  `{namespace}/{name}` (`DYN_PARENT_DGD_K8S_NAMESPACE`/`DYN_PARENT_DGD_K8S_NAME`)
  when `DYN_REQUEST_TRACE_S3_PREFIX` is unset, so deployments separate themselves
  in a shared bucket — DGD names are unique only within a namespace. An explicit
  prefix always wins; off-cluster runs write to the bucket root.
- **Pod identity** resolves `POD_NAME` → `HOSTNAME` → `/etc/hostname` →
  `unknown`, matching existing runtime convention.

> [!NOTE]
> The prefix default changes behavior merged in #11806, where the prefix
> defaulted to the bucket root. Flagging for reviewer input — happy to revert if
> bucket-root is preferred.

### Concurrent uploads

Closes the deferred review comment on #11806: the inline `.await` on
`PutObject` blocked the drain loop, so a degraded S3 backed up the record
channel and caused correlated drops.

- Uploads are `tokio::spawn`ed; the drain loop never awaits S3.
- Two semaphores: `in_flight_slots` (N) caps concurrent `PutObject` calls to
  the configured limit, and `upload_slots` (3N) caps total admitted work, so the
  surplus permits form a bounded queue of finalized batches rather than
  multiplying real concurrency.
- On saturation the batch is discarded and counted in a shared `AtomicU64`,
  warning with `records` and `total_dropped`. Loss is bounded and observable
  instead of silently stalling ingestion.
- Shutdown drains in-flight uploads before returning.
- New `DYN_REQUEST_TRACE_S3_MAX_CONCURRENT_UPLOADS` (default 4).

Also adds a `kubernetes` module to `environment_names` for the
operator-injected pod and DGD variables, which had no Rust constants.

## Validation

### Unit

    cargo fmt --check
    cargo clippy -p dynamo-llm --lib --features request-trace-s3 -- -D warnings
    cargo test -p dynamo-llm --lib --features request-trace-s3 request_trace::s3_sink

22 tests pass in `request_trace::s3_sink` (18 from this PR plus the 4 `object_store`
tests already on main), covering key composition, same-second key distinctness,
flush-time partitioning,
prefix precedence including namespace qualification, pod-identity fallback, both
saturation branches of the upload pool, the shutdown drain barrier, and the
in-flight upload cap.

### Integration (live EKS + S3)

vLLM aggregated, 1×p5en, `RedHatAI/Qwen3.6-35B-A3B-NVFP4`, 550 requests at
concurrency 64 (ISL 1600 / OSL ~1160).

| Records enabled | Objects | Records | Distinct ids | Matched both | Bytes |
|---|---|---|---|---|---|
| `request_payload,request_end` | 14 | 550 + 550 | 550 | 550 | 1,653,498 |
| `request_end` | 14 | 550 | 550 | — | 36,391 |
| _(trace disabled)_ | 0 | — | — | — | 0 |

- **Zero loss, duplication, or orphans** — every `request_id` appears in both
  record types. No malformed lines; all records `schema:
  dynamo.request.trace.v1`.
- **Zero dropped batches** (`total_dropped` = 0) and no S3 errors: the bounded
  queue was never saturated at this rate.
- Objects landed exactly 10 s apart under sustained load, confirming the flush
  interval drives cadence rather than the 64 MiB size roll.
- With tracing disabled the same image wrote nothing and never initialized the
  sink.

Example key, with the prefix defaulting to the DGD name:

    reqtrace-s3-test/date=2026-08-06/hour=04/1016-reqtrace-s3-test-frontend-56f88966f6-n68jj-356c5e20975e42f6bd02e2b343d5d923.jsonl.gz

(Captured before review; keys now also carry the `seq` segment and the prefix is
namespace-qualified.)

Compressed volume is **66 B/request** for `request_end` alone versus
**3,006 B/request** with `request_payload` (~45×) — worth knowing when choosing
which records to enable.

### Request-path overhead

Same deployment and load, three arms, streaming:

| Metric | Disabled | `request_end` | `request_payload,request_end` |
|---|---|---|---|
| TTFT avg (ms) | 419.4 | 383.1 (−8.7%) | 377.8 (−9.9%) |
| TTFT p99 (ms) | 2234.3 | 2230.7 (−0.2%) | 2225.5 (−0.4%) |
| ITL avg (ms) | 12.30 | 12.52 (+1.8%) | 12.59 (+2.4%) |
| Request latency avg (ms) | 14715 | 14961 (+1.7%) | 14970 (+1.7%) |
| Output tok/s | 4925 | 4851 (−1.5%) | 4823 (−2.1%) |

**No measurable overhead.** Every delta is ≤2.4% and inconsistent in direction —
average TTFT *improves* with tracing enabled, which cannot be a real effect of
doing more work — so these are run-to-run noise. That matches the design: the
hot path is one record clone plus a bounded `try_send`, gzip runs on
`spawn_blocking`, and uploads are now off-task.

Caveat: at concurrency 64 on a single GPU serving a 35B model, latency is
GPU-queue-dominated (~15 s average), so this bounds overhead rather than
resolving it precisely — it cannot detect a sub-millisecond per-request cost.
One run per arm.

## Related

- Issue #11768 · PR1 #11806 (merged)

A Prometheus counter for dropped records is left to a follow-up: the
`AtomicU64` with warn-once plus shutdown summary already makes loss observable,
and threading a metrics registry touches the sink-init path shared by all five
sink kinds.

