### PR TITLE
fix(frontend): emit SGLang stream role once

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -979,6 +979,7 @@ class SglangStreamingPostProcessor:
         # incomplete byte-fallback sequence.
         self._decode_context_ids = list((prompt_token_ids or [])[-5:])
         self._pending_decode_ids: list[int] = []
+        self._has_emitted_role: bool = False
         # Tool call accumulation.  SGLang's streaming parser returns
         # deltas (name in one chunk, argument fragments across subsequent
         # chunks).  However, the base detector processes at most one event
@@ -1015,6 +1016,12 @@ class SglangStreamingPostProcessor:
             token_ids,
             skip_special_tokens=self._skip_special_tokens,
         )
+
+    def _with_initial_role(self, delta: dict[str, Any]) -> dict[str, Any]:
+        if not self._has_emitted_role:
+            delta["role"] = "assistant"
+            self._has_emitted_role = True
+        return delta
 
     def _incremental_decode(
         self, new_token_ids: list[int], *, flush: bool = False
@@ -1112,14 +1119,14 @@ class SglangStreamingPostProcessor:
             if delta_text:
                 return {
                     "index": 0,
-                    "delta": {"role": "assistant", "content": delta_text},
+                    "delta": self._with_initial_role({"content": delta_text}),
                     "finish_reason": finish_reason,
                     "logprobs": None,
                 }
             elif finish_reason:
                 return {
                     "index": 0,
-                    "delta": {},
+                    "delta": self._with_initial_role({}),
                     "finish_reason": finish_reason,
                     "logprobs": None,
                 }
@@ -1162,7 +1169,7 @@ class SglangStreamingPostProcessor:
                     self._tool_call_args.setdefault(idx, []).append(tc.parameters)
 
         # -- Assemble delta --
-        delta: dict[str, Any] = {"role": "assistant"}
+        delta: dict[str, Any] = {}
         has_content = False
 
         if content_text:
@@ -1336,7 +1343,7 @@ class SglangStreamingPostProcessor:
         if has_content or effective_finish:
             return {
                 "index": 0,
-                "delta": delta if has_content else {},
+                "delta": self._with_initial_role(delta),
                 "finish_reason": effective_finish,
                 "logprobs": None,
             }

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -2949,6 +2949,7 @@ class TestIncrementalDetokenization:  # FRONTEND.6 — token-id stream → text
         choice = post.process_output({"token_ids": [], "finish_reason": "stop"})
         assert choice is not None
         assert choice["finish_reason"] == "stop"
+        assert choice["delta"] == {}
 
     def test_stop_reason_not_emitted_on_choice(self, tokenizer):
         """Backend stop_reason is not part of the OpenAI choice shape."""
@@ -3127,6 +3128,36 @@ class TestFastPlainTextPath:  # FRONTEND.6 — fast path that skips parser when 
         assert choice["index"] == 0
         assert choice["logprobs"] is None
 
+    def test_fast_path_emits_role_only_once(self, tokenizer):
+        """Only the first emitted content delta includes the assistant role."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer, tool_call_parser=None, reasoning_parser=None
+        )
+        token_ids = tokenizer.encode("Hello world again", add_special_tokens=False)
+        assert len(token_ids) >= 2
+
+        first = post.process_output({"token_ids": token_ids[:1], "finish_reason": None})
+        second = post.process_output(
+            {"token_ids": token_ids[1:], "finish_reason": None}
+        )
+
+        assert first is not None
+        assert first["delta"]["role"] == "assistant"
+        assert second is not None
+        assert "role" not in second["delta"]
+
+    def test_finish_only_output_emits_initial_role(self, tokenizer):
+        """An immediate finish still emits the stream's initial role."""
+        post = SglangStreamingPostProcessor(
+            tokenizer=tokenizer, tool_call_parser=None, reasoning_parser=None
+        )
+
+        choice = post.process_output({"token_ids": [], "finish_reason": "stop"})
+
+        assert choice is not None
+        assert choice["delta"] == {"role": "assistant"}
+        assert choice["finish_reason"] == "stop"
+
 
 # ---------------------------------------------------------------------------
 # SglangStreamingPostProcessor: reasoning parsing
@@ -3149,6 +3180,7 @@ class TestReasoningParsing:  # FRONTEND.9 — reasoning ↔ tool-call orchestrat
 
         reasoning = ""
         content = ""
+        roles = []
         for i in range(0, len(token_ids), 5):
             batch = token_ids[i : i + 5]
             is_last = i + 5 >= len(token_ids)
@@ -3157,11 +3189,14 @@ class TestReasoningParsing:  # FRONTEND.9 — reasoning ↔ tool-call orchestrat
             )
             if choice:
                 delta = choice.get("delta", {})
+                if "role" in delta:
+                    roles.append(delta["role"])
                 reasoning += delta.get("reasoning_content", "")
                 content += delta.get("content", "")
 
         assert "think about this" in reasoning
         assert "42" in content
+        assert roles == ["assistant"]
 
     @pytest.mark.parametrize(
         ("parser_name", "reasoning_output", "expected_reasoning"),


### PR DESCRIPTION
## Summary

- Emit `delta.role` only on the first choice produced by the SGLang streaming postprocessor.
- Preserve the initial `assistant` role when generation finishes before producing any content.
- Cover plain-text streams, finish-only streams, and reasoning-parser streams with focused unit tests.

## Background

PR #12639 established the chat-stream contract at the HTTP boundary: the first emitted delta for a choice carries `role: assistant`, while later deltas omit the role. The SGLang Python postprocessor builds streaming choice dictionaries outside the native Rust postprocessing path, so it still attached the role to every content-bearing delta and relied on the HTTP layer to remove the repeats.

That arrangement also left an edge case at the source. When SGLang finishes immediately without generating a token, the postprocessor returns a finish-only choice with an empty delta. The HTTP deduplication logic can remove duplicate roles, but it cannot recover a role that was never emitted.

This change tracks role emission in the per-request SGLang postprocessor and attaches the role only when a choice is actually returned. Buffered UTF-8 sequences and parser-buffered output do not consume the initial role. If the first returned choice is a finish-only choice, it still carries `role: assistant`; any later content or terminal choices omit it.

## Validation

- `black --check` on the modified Python files
- `isort --check-only` on the modified Python files
- `ruff check` on the modified Python files
- `python3 -m py_compile` on the modified Python files
- `git diff --check`

The targeted pytest module was not run locally because the current virtual environment does not include pytest or the SGLang test dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses so the assistant role appears only once, on the first response chunk.
  * Ensured finish-only responses return empty content deltas while preserving the initial assistant role.
  * Corrected role handling for fast text, reasoning, and tool-call streaming responses.

* **Tests**
  * Added coverage for role emission and finish-only streaming behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->