### PR TITLE
docs(operator): align rolling update status field

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/rolling-update.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/rolling-update.md
@@ -285,7 +285,7 @@ The rolling update progress is tracked in `.status.rollingUpdate` with the follo
 The status also tracks:
 - `startTime` — When the rolling update began.
 - `endTime` — When the rolling update completed.
-- `updatedServices` — List of worker services that have completed the transition.
+- `updatedComponents` - List of worker components that have completed the transition.
 
 ### Configuring maxSurge and maxUnavailable
 


### PR DESCRIPTION
## Summary

- replace the v1alpha1 `updatedServices` rolling update status field with the v1beta1 `updatedComponents` field
- describe the tracked entries as worker components to match the API contract

## Validation

- `python3 docs/fern/scripts/check_asset_paths.py`
- `git diff --check`
- commit hooks
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12744" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated rolling-update status documentation to refer to completed worker components instead of services.
  * Clarified that `updatedComponents` lists worker components that have completed the transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->