### PR TITLE
fix(metrics): sync prometheus_names.py

### DIFF
--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -59,6 +59,14 @@ class frontend_perf:
     TOKENIZE_SECONDS = "tokenize_seconds"
     # Template application time in preprocessor
     TEMPLATE_SECONDS = "template_seconds"
+    # L1 tokenizer cache hits (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
+    TOKENIZER_CACHE_HITS_TOTAL = "tokenizer_cache_hits_total"
+    # L1 tokenizer cache misses (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
+    TOKENIZER_CACHE_MISSES_TOTAL = "tokenizer_cache_misses_total"
+    # Tokens returned from the L1 tokenizer prefix cache (cumulative, labeled by model)
+    TOKENIZER_CACHE_CACHED_TOKENS_TOTAL = "tokenizer_cache_cached_tokens_total"
+    # Tokens freshly encoded after an L1 tokenizer prefix-cache lookup (cumulative, labeled by model)
+    TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL = "tokenizer_cache_uncached_tokens_total"
     # Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
     DETOKENIZE_TOTAL_US = "detokenize_total_us"
     # Total tokens detokenized; use rate(total_us)/rate(count) for per-token average
@@ -98,6 +106,10 @@ class frontend_service:
     KV_HIT_RATE = "kv_hit_rate"
     # Upper-bound estimation of KV cache transfer latency in disaggregated serving (seconds)
     KV_TRANSFER_ESTIMATED_LATENCY_SECONDS = "kv_transfer_estimated_latency_seconds"
+    # Shared cache hit rate (0.0-1.0): fraction of request blocks found in shared cache
+    SHARED_CACHE_HIT_RATE = "shared_cache_hit_rate"
+    # Shared cache blocks beyond device overlap for the selected worker
+    SHARED_CACHE_BEYOND_BLOCKS = "shared_cache_beyond_blocks"
     # Scheduler selections with less overlap than another eligible worker
     NON_MAX_OVERLAP_SELECTIONS_TOTAL = "non_max_overlap_selections_total"
     # Effective KV overlap blocks lost by non-max-overlap selections
@@ -116,9 +128,7 @@ class frontend_service:
     # Separate from `REQUEST_DURATION_SECONDS` so its buckets can be sized for
     # pooling-model latencies (sub-second) without sacrificing resolution.
     EMBEDDING_LATENCY_SECONDS = "embedding_latency_seconds"
-    # Number of `image_url` content parts per request (histogram). Named
-    # `images_per_request` so the auto-emitted `_sum` (cumulative image volume),
-    # `_count` (requests observed), and `_bucket` all read naturally.
+    # Number of `image_url` content parts per request (histogram)
     IMAGES_PER_REQUEST = "images_per_request"
     # Number of `video_url` content parts per request (histogram)
     VIDEOS_PER_REQUEST = "videos_per_request"
@@ -170,7 +180,7 @@ class frontend_service:
     WORKER_LAST_INTER_TOKEN_LATENCY_SECONDS = "worker_last_inter_token_latency_seconds"
     # Number of requests pending in the router's scheduler queue (gauge per worker_type)
     ROUTER_QUEUE_PENDING_REQUESTS = "router_queue_pending_requests"
-    # Number of replicas allocated for a LoRA adapter
+    # Number of replicas allocated for a LoRA adapter (gauge per LoRA)
     LORA_REPLICA_FACTOR = "lora_replica_factor"
     # Whether a LoRA adapter is actively receiving traffic (1=active, 0=inactive)
     LORA_IS_ACTIVE = "lora_is_active"
@@ -271,14 +281,6 @@ class kvstats:
     KV_CACHE_HIT_RATE = "kv_cache_hit_rate"
 
 
-class lifecycle:
-    """Worker-lifecycle timing gauges. Set once per worker run by the
-    framework, not by the engine."""
-
-    CLEANUP_TIME_SECONDS = "cleanup_time_seconds"
-    DRAIN_TIME_SECONDS = "drain_time_seconds"
-
-
 class labels:
     """Automatically inserted Prometheus label names used across the metrics system"""
 
@@ -309,6 +311,11 @@ class labels:
     ROUTER_ID = "router_id"
 
 
+class lifecycle:
+    CLEANUP_TIME_SECONDS = "cleanup_time_seconds"
+    DRAIN_TIME_SECONDS = "drain_time_seconds"
+
+
 class model_info:
     # Model load time in seconds
     LOAD_TIME_SECONDS = "model_load_time_seconds"
@@ -334,6 +341,9 @@ class name_prefix:
     TRANSPORT = "dynamo_transport"
     # Prefix for work-handler transport breakdown metrics (backend side)
     WORK_HANDLER = "dynamo_work_handler"
+    # Prefix for request admission/rejection control metrics (e.g.
+    # `dynamo_rejection_request_total`).
+    REJECTION = "dynamo_rejection"
     # Prefix for tokio runtime metrics (poll times, queue depths, stalls).
     TOKIO = "dynamo_tokio"
     # Prefix for per-phase routing overhead latency (hashing, scheduling).
@@ -377,6 +387,10 @@ class router:
     OUTPUT_SEQUENCE_TOKENS = "router_output_sequence_tokens"
     # Predicted KV cache hit rate at routing time (0.0-1.0)
     KV_HIT_RATE = "router_kv_hit_rate"
+    # Shared cache hit rate (0.0-1.0): fraction of request blocks found in shared cache
+    SHARED_CACHE_HIT_RATE = "router_shared_cache_hit_rate"
+    # Shared cache blocks beyond device overlap for the selected worker
+    SHARED_CACHE_BEYOND_BLOCKS = "router_shared_cache_beyond_blocks"
     # Scheduler selections with less overlap than another eligible worker
     NON_MAX_OVERLAP_SELECTIONS_TOTAL = "router_non_max_overlap_selections_total"
     # Effective KV overlap blocks lost by non-max-overlap selections
@@ -406,6 +420,10 @@ class routing_overhead:
     SCHEDULING_MS = "overhead_scheduling_ms"
     # Total routing overhead per request
     TOTAL_MS = "overhead_total_ms"
+    # Time spent querying the shared KV cache (Mooncake)
+    SHARED_CACHE_QUERY_MS = "overhead_shared_cache_query_ms"
+    # Total shared cache failures (query and subscriber failures)
+    SHARED_CACHE_ERRORS_TOTAL = "shared_cache_errors_total"
 
 
 class task_tracker:
@@ -498,8 +516,9 @@ class work_handler:
     # Configured capacity of the bounded work queue (gauge, static)
     QUEUE_CAPACITY = "queue_capacity"
     # Total times enqueuing work failed because the dispatcher channel was closed.
-    # tokio bounded mpsc applies backpressure on full — saturation shows up as
-    # rising QUEUE_DEPTH toward QUEUE_CAPACITY.
+    # A full queue is shed via try_reserve() and counted under
+    # `dynamo_rejection_request_total`. Saturation shows up as rising `QUEUE_DEPTH`
+    # toward `QUEUE_CAPACITY`.
     ENQUEUE_REJECTED_TOTAL = "enqueue_rejected_total"
     # Time spent waiting to acquire a worker-pool permit (histogram)
     PERMIT_WAIT_SECONDS = "permit_wait_seconds"

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -446,8 +446,9 @@ pub mod work_handler {
     pub const QUEUE_CAPACITY: &str = "queue_capacity";
 
     /// Total times enqueuing work failed because the dispatcher channel was closed.
-    /// Note: tokio bounded mpsc applies backpressure on full — it does NOT increment
-    /// this counter. Saturation shows up as rising `QUEUE_DEPTH` toward `QUEUE_CAPACITY`.
+    /// A full queue is shed via try_reserve() and counted under
+    /// `dynamo_rejection_request_total`. Saturation shows up as rising `QUEUE_DEPTH`
+    /// toward `QUEUE_CAPACITY`.
     pub const ENQUEUE_REJECTED_TOTAL: &str = "enqueue_rejected_total";
 
     /// Time spent waiting to acquire a worker-pool permit (histogram)
@@ -824,12 +825,22 @@ pub mod kvstats {
 
     /// GPU cache usage as a percentage (0.0-1.0)
     pub const GPU_CACHE_USAGE_PERCENT: &str = "gpu_cache_usage_percent";
+
+    /// Prefix cache hit rate (0.0-1.0), portable across vLLM / SGLang / TRT-LLM
+    pub const KV_CACHE_HIT_RATE: &str = "kv_cache_hit_rate";
 }
 
 // Model information metrics
 pub mod model_info {
     /// Model load time in seconds
     pub const LOAD_TIME_SECONDS: &str = "model_load_time_seconds";
+}
+
+// Worker-lifecycle timing gauges. Set once per worker run by the framework, not by the engine.
+pub mod lifecycle {
+    pub const CLEANUP_TIME_SECONDS: &str = "cleanup_time_seconds";
+
+    pub const DRAIN_TIME_SECONDS: &str = "drain_time_seconds";
 }
 
 // Shared regex patterns for Prometheus sanitization


### PR DESCRIPTION
## Overview:

Synchronize `lib/bindings/python/src/dynamo/prometheus_names.py` with`lib/runtime/src/metrics/prometheus_names.rs` by adding the missing `lifecycle` module to Rust and regenerating the Python file. The primary bug is that codegen removed the lifecycle class; the PR also includes the expected drift that surfaces when running codegen on an out-of-sync file.

## Details:

Rust changes (`lib/runtime/src/metrics/prometheus_names.rs`):

Added mod `lifecycle` with `CLEANUP_TIME_SECONDS` and `DRAIN_TIME_SECONDS`.

Python changes from codegen (`lib/bindings/python/src/dynamo/prometheus_names.py`):

Restored / added (already present in Rust but missing in Python):
`TOKENIZER_CACHE_HITS_TOTAL`, `TOKENIZER_CACHE_MISSES_TOTAL`, `TOKENIZER_CACHE_CACHED_TOKENS_TOTAL`,etc.

Removed (no longer present in Rust): `kvstats.KV_CACHE_HIT_RATE`

## Where should the reviewer start?

1.`lib/runtime/src/metrics/prometheus_names.rs `— verify the new lifecycle module.
2.`lib/bindings/python/src/dynamo/prometheus_names.py` — verify the regenerated file matches Rust and that class `lifecycle` is restored.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #12742 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitoring metrics for tokenizer cache hits, misses, and token counts.
  * Added shared-cache performance metrics, including hit rates, cache coverage, query duration, and errors.
  * Added rejection and routing-overhead metrics for improved request observability.
  * Added worker lifecycle timing metrics for cleanup and drain operations.

* **Improvements**
  * Reorganized cache and lifecycle metrics for clearer monitoring and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->