### PR TITLE
fix(snapshot): guard restores against pod replacement

### DIFF
--- a/deploy/snapshot/internal/controller/controller.go
+++ b/deploy/snapshot/internal/controller/controller.go
@@ -356,7 +356,7 @@ func restoreContainerIDFromStatus(pod *corev1.Pod, containerName string) string 
 	return ""
 }
 
-func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName string) (*corev1.Pod, bool) {
+func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *corev1.Pod, podKey, containerName, checkpointID string) (*corev1.Pod, bool) {
 	livePod, err := w.clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -372,6 +372,9 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		)
 		return nil, false
 	}
+	if w.maybeSkipRestore(pod, livePod, podKey, containerName, checkpointID) {
+		return nil, false
+	}
 	if livePod.DeletionTimestamp != nil ||
 		(livePod.Status.Phase != corev1.PodPending && livePod.Status.Phase != corev1.PodRunning) {
 		w.log.V(1).Info("Skipping restore; pod became ineligible while polling runtime",
@@ -382,6 +385,58 @@ func (w *NodeController) refreshRestorePodForStart(ctx context.Context, pod *cor
 		return nil, false
 	}
 	return livePod, true
+}
+
+func (w *NodeController) maybeSkipRestore(observedPod, livePod *corev1.Pod, podKey, containerName, checkpointID string) bool {
+	if observedPod.UID == "" || livePod.UID != observedPod.UID {
+		w.log.Info("Skipping restore; pod identity changed while polling runtime",
+			"pod", podKey,
+			"container", containerName,
+			"observed_uid", observedPod.UID,
+			"live_uid", livePod.UID,
+		)
+		return true
+	}
+	if livePod.Spec.NodeName != w.config.NodeName {
+		w.log.Info("Skipping restore; pod is no longer assigned to this node",
+			"pod", podKey,
+			"container", containerName,
+			"node", livePod.Spec.NodeName,
+		)
+		return true
+	}
+	if livePod.Labels[snapshotprotocol.CheckpointIDLabel] != checkpointID {
+		w.log.Info("Skipping restore; pod checkpoint identity changed while polling runtime",
+			"pod", podKey,
+			"container", containerName,
+			"checkpoint_id", checkpointID,
+			"live_checkpoint_id", livePod.Labels[snapshotprotocol.CheckpointIDLabel],
+		)
+		return true
+	}
+	targets, err := snapshotprotocol.TargetContainersFromAnnotations(livePod.Annotations, 1, 0)
+	if err != nil {
+		w.log.Error(err, "Skipping restore; live pod has invalid target-container metadata",
+			"pod", podKey,
+			"container", containerName,
+		)
+		return true
+	}
+	stillTargeted := false
+	for _, target := range targets {
+		if target == containerName {
+			stillTargeted = true
+			break
+		}
+	}
+	if !stillTargeted {
+		w.log.Info("Skipping restore; container is no longer a restore target",
+			"pod", podKey,
+			"container", containerName,
+		)
+		return true
+	}
+	return false
 }
 
 func (w *NodeController) pollForContainerID(
@@ -400,7 +455,7 @@ func (w *NodeController) pollForContainerID(
 		containerID, err := w.runtime.ResolveContainerIDByPod(resolveCtx, pod.Name, pod.Namespace, containerName)
 		cancel()
 		if err == nil && containerID != "" {
-			livePod, ok := w.refreshRestorePodForStart(ctx, pod, podKey, containerName)
+			livePod, ok := w.refreshRestorePodForStart(ctx, pod, podKey, containerName, checkpointID)
 			if !ok {
 				return
 			}

--- a/deploy/snapshot/internal/controller/controller_test.go
+++ b/deploy/snapshot/internal/controller/controller_test.go
@@ -112,6 +112,7 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   namespace,
+			UID:         "test-pod-uid",
 			Labels:      labels,
 			Annotations: merged,
 		},
@@ -129,6 +130,51 @@ func makePod(name, namespace, nodeName string, phase corev1.PodPhase, ready bool
 			},
 		},
 	}
+}
+
+func TestAnnotatePodUsesUIDPrecondition(t *testing.T) {
+	statusKey := snapshotprotocol.RestoreStatusAnnotationPrefix + "main"
+	annotations := map[string]string{statusKey: snapshotprotocol.RestoreStatusInProgress}
+
+	t.Run("matching UID updates only requested annotations", func(t *testing.T) {
+		pod := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, nil, nil)
+		clientset := fake.NewClientset(pod.DeepCopy())
+
+		if err := annotatePod(context.Background(), clientset, testr.New(t), pod, annotations); err != nil {
+			t.Fatalf("annotatePod() error = %v", err)
+		}
+
+		updated, err := clientset.CoreV1().Pods(pod.Namespace).Get(context.Background(), pod.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get updated pod: %v", err)
+		}
+		if got := updated.Annotations[statusKey]; got != snapshotprotocol.RestoreStatusInProgress {
+			t.Fatalf("restore status annotation = %q, want %q", got, snapshotprotocol.RestoreStatusInProgress)
+		}
+		if got := updated.Annotations[snapshotprotocol.TargetContainersAnnotation]; got != "main" {
+			t.Fatalf("target-container annotation = %q, want main", got)
+		}
+	})
+
+	t.Run("recreated pod is not modified", func(t *testing.T) {
+		observed := makePod("test-pod", "default", testNodeName, corev1.PodRunning, false, nil, nil)
+		observed.UID = "observed-uid"
+		live := observed.DeepCopy()
+		live.UID = "replacement-uid"
+		clientset := fake.NewClientset(live)
+
+		if err := annotatePod(context.Background(), clientset, testr.New(t), observed, annotations); err == nil {
+			t.Fatal("annotatePod() succeeded for a same-named replacement pod")
+		}
+
+		unchanged, err := clientset.CoreV1().Pods(live.Namespace).Get(context.Background(), live.Name, metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("get replacement pod: %v", err)
+		}
+		if _, ok := unchanged.Annotations[statusKey]; ok {
+			t.Fatalf("replacement pod received restore status: %#v", unchanged.Annotations)
+		}
+	})
 }
 
 func TestCheckpointLocationsFromPod(t *testing.T) {
@@ -637,6 +683,83 @@ func TestReconcileRestorePodPollsRuntimeBeforePodRunning(t *testing.T) {
 	t.Fatalf("expected RestoreRequested event from runtime polling before PodRunning; actions=%#v", clientset.Actions())
 }
 
+func TestRefreshRestorePodForStartRevalidatesIdentityAndMetadata(t *testing.T) {
+	const checkpointID = "abc123"
+	tests := []struct {
+		name           string
+		mutateObserved func(*corev1.Pod)
+		mutateLive     func(*corev1.Pod)
+		wantEligible   bool
+	}{
+		{name: "unchanged pod", wantEligible: true},
+		{
+			name: "same-named replacement pod",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.UID = "replacement-uid"
+			},
+		},
+		{
+			name: "missing observed UID",
+			mutateObserved: func(pod *corev1.Pod) {
+				pod.UID = ""
+			},
+		},
+		{
+			name: "checkpoint identity changed",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Labels[snapshotprotocol.CheckpointIDLabel] = "other-checkpoint"
+			},
+		},
+		{
+			name: "container no longer targeted",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Annotations[snapshotprotocol.TargetContainersAnnotation] = "sidecar"
+			},
+		},
+		{
+			name: "pod moved off node",
+			mutateLive: func(pod *corev1.Pod) {
+				pod.Spec.NodeName = "other-node"
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := makePod(
+				"test-pod",
+				"default",
+				testNodeName,
+				corev1.PodRunning,
+				false,
+				map[string]string{snapshotprotocol.CheckpointIDLabel: checkpointID},
+				nil,
+			)
+			live := observed.DeepCopy()
+			if tc.mutateObserved != nil {
+				tc.mutateObserved(observed)
+			}
+			if tc.mutateLive != nil {
+				tc.mutateLive(live)
+			}
+			w := makeTestController(t, live)
+
+			got, eligible := w.refreshRestorePodForStart(
+				context.Background(), observed, "default/test-pod", "main", checkpointID,
+			)
+			if eligible != tc.wantEligible {
+				t.Fatalf("eligible = %v, want %v", eligible, tc.wantEligible)
+			}
+			if eligible && got == nil {
+				t.Fatal("eligible refresh returned a nil pod")
+			}
+			if !eligible && got != nil {
+				t.Fatalf("ineligible refresh returned pod UID %q", got.UID)
+			}
+		})
+	}
+}
+
 func TestPollForContainerIDSkipsTerminalLivePod(t *testing.T) {
 	checkpointID := "abc123"
 	labels := map[string]string{
@@ -713,4 +836,3 @@ func TestPollForContainerIDSkipsWhenRestoreAttemptAlreadyHeld(t *testing.T) {
 		}
 	}
 }
-

--- a/deploy/snapshot/internal/controller/util.go
+++ b/deploy/snapshot/internal/controller/util.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -61,18 +63,48 @@ func isContainerReady(pod *corev1.Pod, containerName string) bool {
 	return false
 }
 
-func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, annotations map[string]string) error {
-	patchBytes, err := json.Marshal(map[string]any{
-		"metadata": map[string]any{
-			"annotations": annotations,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to build annotation patch payload: %w", err)
+func getPatchPodAnnotations(pod *corev1.Pod, annotations map[string]string) ([]byte, error) {
+	if pod.UID == "" {
+		return nil, fmt.Errorf("pod %s/%s has no UID", pod.Namespace, pod.Name)
+	}
+	if pod.Annotations == nil {
+		return nil, fmt.Errorf("pod %s/%s has no annotations map", pod.Namespace, pod.Name)
 	}
 
+	// Test the immutable UID in the same API request as the annotation writes. A
+	// namespace/name Get followed by a merge patch has a TOCTOU window where a
+	// deleted Pod can be replaced by a same-named Pod between the two requests.
+	patch := []map[string]any{{
+		"op":    "test",
+		"path":  "/metadata/uid",
+		"value": string(pod.UID),
+	}}
+	keys := make([]string, 0, len(annotations))
+	for key := range annotations {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		patch = append(patch, map[string]any{
+			"op":    "add",
+			"path":  "/metadata/annotations/" + escapeJSONPointerToken(key),
+			"value": annotations[key],
+		})
+	}
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build annotation patch payload: %w", err)
+	}
+	return patchBytes, nil
+}
+
+func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.Logger, pod *corev1.Pod, annotations map[string]string) error {
+	patchBytes, err := getPatchPodAnnotations(pod, annotations)
+	if err != nil {
+		return err
+	}
 	_, err = clientset.CoreV1().Pods(pod.Namespace).Patch(
-		ctx, pod.Name, ktypes.MergePatchType, patchBytes, metav1.PatchOptions{},
+		ctx, pod.Name, ktypes.JSONPatchType, patchBytes, metav1.PatchOptions{},
 	)
 	if err != nil {
 		log.Error(err, "Failed to annotate pod",
@@ -81,6 +113,10 @@ func annotatePod(ctx context.Context, clientset kubernetes.Interface, log logr.L
 		)
 	}
 	return err
+}
+
+func escapeJSONPointerToken(value string) string {
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(value)
 }
 
 // checkpointLeaseName returns the Lease guarding the artifact identified by checkpointID. The


### PR DESCRIPTION
## Overview:

### Summary

Prevent the snapshot agent from annotating or starting restore work for a recreated Pod that reused the original namespace and name.

## Details:

- build restore-status updates as JSON Patch operations with an atomic test of the immutable Pod UID
- re-fetch and validate the live Pod UID, node assignment, checkpoint ID, and target-container metadata before starting a restore resolved through runtime polling
- add regression coverage for same-named replacement Pods and changed restore metadata

The previous merge patch addressed a Pod only by namespace and name. If the observed Pod was deleted and replaced before the patch, restore annotations could land on the replacement. Runtime polling had the same identity gap because its final API refresh only checked deletion and phase.

Unchanged eligible Pods continue through the existing restore path. Pods whose identity or restore metadata changed are skipped without mutation.

## Where should the reviewer start?

Start with `deploy/snapshot/internal/controller/util.go` for the atomic UID-preconditioned patch construction, then `deploy/snapshot/internal/controller/controller.go` for the live restore eligibility checks.

## Validation:

- `go test ./internal/controller` in a Linux container
- `git diff --check`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restore operations now verify pod identity, node assignment, checkpoint details, and target-container metadata before starting.
  * Prevents restores or annotation updates from affecting replacement pods with the same name.
  * Ensures restore polling uses the correct checkpoint.

* **Tests**
  * Added coverage for pod identity and metadata validation during restore and annotation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->