### PR TITLE
fix(planner): add optional AIC correction-factor cap

### DIFF
--- a/components/src/dynamo/planner/config/defaults.py
+++ b/components/src/dynamo/planner/config/defaults.py
@@ -85,6 +85,9 @@ class SLAPlannerDefaults(BasePlannerDefaults):
         5  # also controls live FPM tuning frequency for throughput scaling
     )
     max_num_fpm_samples = 64  # max retained FPM observations for tuning/fallback
+    # Optional absolute upper bound on native AIC online correction factors,
+    # enforced on tuning inputs. None keeps the AIC wheel's unbounded behavior.
+    aic_max_correction_factor = None
     fpm_sample_bucket_size = (
         16  # must be a perfect square; total buckets across input axes
     )

--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -562,6 +562,19 @@ class PlannerConfig(BaseModel):
         ),
     )
     max_num_fpm_samples: int = SLAPlannerDefaults.max_num_fpm_samples
+    aic_max_correction_factor: Optional[float] = Field(
+        default=SLAPlannerDefaults.aic_max_correction_factor,
+        ge=1.0,
+        allow_inf_nan=False,
+        description=(
+            "Optional absolute upper bound on native AIC online correction. "
+            "When set, tuning observations are capped at this factor times an "
+            "identical never-tuned native estimate, which bounds AIC's stored "
+            "correction factors. Values below the native estimate are not "
+            "clamped. None preserves the AIC wheel's default unbounded "
+            "correction behavior. Regression fallback is unaffected."
+        ),
+    )
     fpm_sample_bucket_size: int = SLAPlannerDefaults.fpm_sample_bucket_size
     load_scaling_down_sensitivity: int = (
         SLAPlannerDefaults.load_scaling_down_sensitivity

--- a/components/src/dynamo/planner/core/perf_model/aic_adapter.py
+++ b/components/src/dynamo/planner/core/perf_model/aic_adapter.py
@@ -140,6 +140,7 @@ class PlannerEnginePerfModel:
                 limits=limits,
                 options=options,
                 attention_dp_size=self._attention_dp_size() or 1,
+                max_correction_factor=self._config.aic_max_correction_factor,
             )
             diagnostics = self._engine_diagnostics()
             logger.info(
@@ -306,6 +307,7 @@ class PlannerEnginePerfModel:
             self._config.max_num_fpm_samples,
             self._config.load_min_observations,
             self._config.fpm_sample_bucket_size,
+            self._config.aic_max_correction_factor,
             aic_key,
         )
 

--- a/components/src/dynamo/planner/core/perf_model/engine_query.py
+++ b/components/src/dynamo/planner/core/perf_model/engine_query.py
@@ -194,6 +194,8 @@ class AicCoreEnginePerfModel:
         limits: EnginePerfLimits,
         attention_dp_size: int,
         max_observations: int,
+        uncorrected_native_model: Optional[Any] = None,
+        max_correction_factor: Optional[float] = None,
     ) -> None:
         if worker_type not in ("prefill", "decode", "aggregated"):
             raise ValueError(f"invalid worker_type {worker_type!r}")
@@ -201,7 +203,18 @@ class AicCoreEnginePerfModel:
             raise ValueError(
                 f"attention_dp_size must be positive, got {attention_dp_size}"
             )
+        if max_correction_factor is not None and (
+            not math.isfinite(max_correction_factor) or max_correction_factor < 1.0
+        ):
+            raise ValueError(
+                "max_correction_factor must be finite and >= 1.0, "
+                f"got {max_correction_factor}"
+            )
+        if uncorrected_native_model is not None and max_correction_factor is None:
+            raise ValueError("uncorrected_native_model requires max_correction_factor")
         self._model = model
+        self._uncorrected_native_model = uncorrected_native_model
+        self._max_correction_factor = max_correction_factor
         self._worker_type = worker_type
         self._limits = limits
         self._attention_dp_size = attention_dp_size
@@ -216,28 +229,70 @@ class AicCoreEnginePerfModel:
         limits: EnginePerfLimits,
         options: dict[str, int],
         attention_dp_size: int,
+        max_correction_factor: Optional[float] = None,
     ) -> AicCoreEnginePerfModel:
         if aic_config is None:
             model = AicForwardPassPerfModel.from_regression(options)
         else:
             model = AicForwardPassPerfModel.best_available(aic_config, options)
+
+        # The AIC wheel exposes corrected estimates and aggregate correction
+        # diagnostics, but it cannot cap or return the matching region's raw
+        # native estimate. When a cap is requested and native AIC is available,
+        # keep a second, never-tuned native model as the absolute tuning
+        # baseline. A cap relative to the already-corrected estimate would
+        # compound across repeated outliers (for example 2x -> 4x -> 8x).
+        uncorrected_native_model = None
+        if max_correction_factor is not None and aic_config is not None:
+            diagnostics = model.diagnostics()
+            if diagnostics.get("source") == "aic":
+                uncorrected_native_model = AicForwardPassPerfModel.from_native(
+                    aic_config, options
+                )
         return cls(
             model=model,
             worker_type=worker_type,
             limits=limits,
             attention_dp_size=attention_dp_size,
             max_observations=options["max_observations"],
+            uncorrected_native_model=uncorrected_native_model,
+            max_correction_factor=max_correction_factor,
         )
 
     def tune_with_fpms(self, iterations: list[list[ForwardPassMetrics]]) -> None:
         for metrics_by_rank in iterations:
             self._validate_metrics_by_rank(metrics_by_rank)
-        self._model.tune_with_fpms(
-            [
-                [_fpm_to_aic_dict(metrics) for metrics in metrics_by_rank]
-                for metrics_by_rank in iterations
-            ]
-        )
+        payload_iterations = [
+            [_fpm_to_aic_dict(metrics) for metrics in metrics_by_rank]
+            for metrics_by_rank in iterations
+        ]
+        if self._uncorrected_native_model is not None:
+            max_correction_factor = self._max_correction_factor
+            if max_correction_factor is None:
+                raise RuntimeError(
+                    "native AIC correction baseline is missing its configured cap"
+                )
+            for payload in payload_iterations:
+                native_ms = self._estimate_forward_pass_ms(
+                    self._uncorrected_native_model,
+                    payload,
+                    label="uncorrected native AIC forward-pass estimate",
+                )
+                if native_ms is None:
+                    raise ValueError(
+                        "uncorrected native AIC forward-pass estimate is unavailable"
+                    )
+                if native_ms < 0.0:
+                    raise ValueError(
+                        "uncorrected native AIC forward-pass estimate must be "
+                        f"non-negative, got {native_ms}"
+                    )
+                max_wall_time_s = native_ms * max_correction_factor / 1000.0
+                for metrics in payload:
+                    wall_time = metrics["wall_time"]
+                    if wall_time > max_wall_time_s:
+                        metrics["wall_time"] = max_wall_time_s
+        self._model.tune_with_fpms(payload_iterations)
         self._load_averages.observe_iterations(iterations)
 
     def diagnostics(self) -> dict[str, Any]:
@@ -247,6 +302,19 @@ class AicCoreEnginePerfModel:
                 "aiconfigurator-core diagnostics must be a mapping, "
                 f"got {type(diagnostics).__name__}"
             )
+        diagnostics = dict(diagnostics)
+        observed_aic_max_factor = None
+        if str(diagnostics.get("source", "")).startswith("aic"):
+            observed_aic_max_factor = self._model.get_max_correction_factor()
+        diagnostics["planner_correction_cap"] = {
+            "configured_max_factor": self._max_correction_factor,
+            "enabled": self._uncorrected_native_model is not None,
+            "scope": "aic_tuning_input",
+            "observed_aic_max_factor": observed_aic_max_factor,
+            "stored_aic_corrections_capped": (
+                self._uncorrected_native_model is not None
+            ),
+        }
         return diagnostics
 
     def get_queued_prefill_time(
@@ -616,19 +684,30 @@ class AicCoreEnginePerfModel:
     def _estimate_forward_pass_seconds(
         self, metrics_by_rank: list[ForwardPassMetrics]
     ) -> Optional[float]:
-        estimate_ms = self._model.estimate_forward_pass_time_ms(
-            [_fpm_to_aic_dict(metrics) for metrics in metrics_by_rank]
+        payload = [_fpm_to_aic_dict(metrics) for metrics in metrics_by_rank]
+        estimate_ms = self._estimate_forward_pass_ms(
+            self._model,
+            payload,
+            label="AIC forward-pass estimate",
         )
         if estimate_ms is None:
             return None
-        if not math.isfinite(estimate_ms):
-            raise ValueError(
-                f"AIC forward-pass estimate must be finite, got {estimate_ms}"
-            )
         return _checked_duration_seconds(
             max(0.0, estimate_ms) / 1000.0,
             "AIC forward-pass estimate",
         )
+
+    @staticmethod
+    def _estimate_forward_pass_ms(
+        model: Any,
+        payload: list[dict[str, Any]],
+        *,
+        label: str,
+    ) -> Optional[float]:
+        estimate_ms = model.estimate_forward_pass_time_ms(payload)
+        if estimate_ms is not None and not math.isfinite(estimate_ms):
+            raise ValueError(f"{label} must be finite, got {estimate_ms}")
+        return estimate_ms
 
 
 def _fpm_to_aic_dict(metrics: ForwardPassMetrics) -> dict[str, Any]:

--- a/components/src/dynamo/planner/tests/integration/test_aic_native_estimator.py
+++ b/components/src/dynamo/planner/tests/integration/test_aic_native_estimator.py
@@ -33,7 +33,7 @@ def _offline_aic(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
 
 
-def _config() -> PlannerConfig:
+def _config(*, max_correction_factor: float | None = None) -> PlannerConfig:
     pick = PickedParallelConfig()
     return PlannerConfig.model_construct(
         aic_perf_model=AICPerfModelSpec.model_construct(
@@ -46,6 +46,7 @@ def _config() -> PlannerConfig:
         ),
         max_num_fpm_samples=16,
         load_min_observations=5,
+        aic_max_correction_factor=max_correction_factor,
         fpm_sample_bucket_size=16,
         ttft_ms=500.0,
         itl_ms=50.0,
@@ -166,3 +167,51 @@ def test_planner_uses_real_aic_regression_fallback_after_tuning() -> None:
         add_next_request=False,
     )
     assert itl_s == pytest.approx(0.01, rel=1e-6)
+
+
+def test_native_aic_correction_cap_stays_absolute_after_repeated_outliers() -> None:
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(max_correction_factor=2.0),
+        capabilities=_capabilities(),
+    )
+    query = ForwardPassMetrics(
+        worker_id="decode-0",
+        scheduled_requests=ScheduledRequestMetrics(
+            num_decode_requests=2,
+            sum_decode_kv_tokens=16_773,
+        ),
+    )
+    native_itl_s = model.estimate_scheduled_decode_itl(
+        [query],
+        add_next_request=False,
+    )
+    assert native_itl_s is not None and native_itl_s > 0.0
+
+    for counter_id in range(1, 13):
+        model.add_observations(
+            {
+                ("decode-0", 0): ForwardPassMetrics(
+                    worker_id="decode-0",
+                    counter_id=counter_id,
+                    wall_time=1.2,
+                    scheduled_requests=query.scheduled_requests,
+                )
+            }
+        )
+
+    corrected_itl_s = model.estimate_scheduled_decode_itl(
+        [query],
+        add_next_request=False,
+    )
+    diagnostics = model._engine_diagnostics()
+
+    assert diagnostics["source"] == "aic_with_correction"
+    correction_cap = diagnostics["planner_correction_cap"]
+    assert correction_cap["configured_max_factor"] == 2.0
+    assert correction_cap["enabled"] is True
+    assert correction_cap["scope"] == "aic_tuning_input"
+    assert correction_cap["observed_aic_max_factor"] == pytest.approx(2.0)
+    assert correction_cap["stored_aic_corrections_capped"] is True
+    assert diagnostics["retained_observations"] == 12
+    assert corrected_itl_s == pytest.approx(2.0 * native_itl_s, rel=1e-6)

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -235,6 +235,20 @@ def test_planner_metadata_identifies_custom_plugins_without_secrets():
     )
 
 
+def test_replay_metadata_tracks_aic_correction_cap_as_decision_config():
+    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+    adapter._benchmark_granularity = 8
+    adapter._bootstrap_metadata = {"status": "not_required"}
+    adapter._capture_details = False
+
+    adapter._config = PlannerConfig(mode="agg", aic_max_correction_factor=None)
+    disabled_digest = adapter._planner_metadata()["planner_config_digest"]
+    adapter._config = PlannerConfig(mode="agg", aic_max_correction_factor=2.0)
+    capped_digest = adapter._planner_metadata()["planner_config_digest"]
+
+    assert capped_digest != disabled_digest
+
+
 def test_build_tick_input_maps_replay_accept_length():
     # The Rust simulation drains the per-tick traffic window into
     # ``result["traffic"]``; a need_traffic_metrics tick maps it onto

--- a/components/src/dynamo/planner/tests/unit/test_aic_perf_adapter.py
+++ b/components/src/dynamo/planner/tests/unit/test_aic_perf_adapter.py
@@ -106,6 +106,7 @@ def _config(
     dp: int = 1,
     min_observations: int = 5,
     speculative_nextn: int = 0,
+    max_correction_factor: float | None = None,
 ) -> PlannerConfig:
     pick = PickedParallelConfig(dp=dp)
     return PlannerConfig.model_construct(
@@ -118,6 +119,7 @@ def _config(
         ),
         max_num_fpm_samples=16,
         load_min_observations=min_observations,
+        aic_max_correction_factor=max_correction_factor,
         fpm_sample_bucket_size=16,
         ttft_ms=500.0,
         itl_ms=50.0,
@@ -195,6 +197,46 @@ def test_aic_diagnostics_gate_sufficient_data(fake_engine_factory):
 
     fake._diagnostics["readiness"] = "ready"
     assert model.has_sufficient_data()
+
+
+def test_aic_correction_cap_is_forwarded_to_engine_factory(fake_engine_factory):
+    fake = _FakeEngineModel(
+        diagnostics={
+            "source": "aic",
+            "readiness": "ready",
+            "retained_observations": 0,
+        }
+    )
+    _install_fake_engine(fake_engine_factory, fake)
+
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(max_correction_factor=2.0),
+        capabilities=_caps(),
+    )
+
+    assert fake_engine_factory.last_kwargs is not None
+    assert fake_engine_factory.last_kwargs["max_correction_factor"] == 2.0
+    assert 2.0 in model._model_key()
+
+
+def test_aic_correction_cap_fails_closed_when_native_baseline_init_fails(
+    monkeypatch,
+):
+    class _FailingEngineFactory:
+        @classmethod
+        def best_available(cls, **_kwargs):
+            raise RuntimeError("native correction baseline unavailable")
+
+    monkeypatch.setattr(aic_adapter, "AicCoreEnginePerfModel", _FailingEngineFactory)
+    model = PlannerEnginePerfModel(
+        worker_type="decode",
+        config=_config(max_correction_factor=2.0),
+        capabilities=_caps(),
+    )
+
+    assert model._engine_model is None
+    assert not model.has_sufficient_data()
 
 
 def test_missing_capability_fields_use_engine_query_defaults(fake_engine_factory):

--- a/components/src/dynamo/planner/tests/unit/test_engine_query.py
+++ b/components/src/dynamo/planner/tests/unit/test_engine_query.py
@@ -33,8 +33,13 @@ class _FakeForwardPassModel:
     def __init__(
         self,
         estimate: Callable[[list[dict[str, Any]]], Optional[float]],
+        *,
+        source: str = "fallback_regression",
+        max_correction_factor: Optional[float] = None,
     ) -> None:
         self._estimate = estimate
+        self._source = source
+        self._max_correction_factor = max_correction_factor
         self.estimate_calls: list[list[dict[str, Any]]] = []
         self.tuned_iterations: list[list[dict[str, Any]]] = []
 
@@ -49,10 +54,13 @@ class _FakeForwardPassModel:
 
     def diagnostics(self) -> dict[str, Any]:
         return {
-            "source": "fallback_regression",
+            "source": self._source,
             "readiness": "ready",
             "retained_observations": len(self.tuned_iterations),
         }
+
+    def get_max_correction_factor(self) -> Optional[float]:
+        return self._max_correction_factor
 
 
 def _model(
@@ -124,6 +132,314 @@ def test_best_available_uses_aic_core_wheel_facade(monkeypatch):
     assert _FakeAicFacade.last_config is config
     assert _FakeAicFacade.last_options is options
     assert model.diagnostics()["readiness"] == "ready"
+
+
+def test_best_available_builds_never_tuned_native_baseline_only_when_cap_enabled(
+    monkeypatch,
+):
+    corrected = _FakeForwardPassModel(lambda _metrics: 80.0, source="aic")
+    native = _FakeForwardPassModel(lambda _metrics: 10.0, source="aic")
+
+    class _FakeAicFacade:
+        best_available_calls = 0
+        from_native_calls = 0
+
+        @classmethod
+        def best_available(cls, _config, _options):
+            cls.best_available_calls += 1
+            return corrected
+
+        @classmethod
+        def from_native(cls, _config, _options):
+            cls.from_native_calls += 1
+            return native
+
+    monkeypatch.setattr(engine_query, "AicForwardPassPerfModel", _FakeAicFacade)
+    model = AicCoreEnginePerfModel.best_available(
+        aic_config={"schema_version": 1},
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        options={
+            "max_observations": 8,
+            "min_observations": 2,
+            "bucket_count": 4,
+            "max_num_tokens": 128,
+            "max_batch_size": 16,
+            "max_kv_tokens": 10_000,
+        },
+        attention_dp_size=1,
+        max_correction_factor=2.0,
+    )
+    outlier = ForwardPassMetrics(
+        wall_time=1.0,
+        scheduled_requests=ScheduledRequestMetrics(
+            num_decode_requests=1,
+            sum_decode_kv_tokens=100,
+        ),
+    )
+    model.tune_with_fpms([[outlier]])
+    native_tuning_calls = len(native.estimate_calls)
+    estimate_s = model.get_scheduled_decode_itl([outlier])
+
+    assert corrected.tuned_iterations[0][0]["wall_time"] == pytest.approx(0.02)
+    assert estimate_s == pytest.approx(0.08)
+    assert len(native.estimate_calls) == native_tuning_calls
+    assert _FakeAicFacade.best_available_calls == 1
+    assert _FakeAicFacade.from_native_calls == 1
+    assert model.diagnostics()["planner_correction_cap"] == {
+        "configured_max_factor": 2.0,
+        "enabled": True,
+        "scope": "aic_tuning_input",
+        "observed_aic_max_factor": None,
+        "stored_aic_corrections_capped": True,
+    }
+
+
+def test_best_available_does_not_build_native_baseline_for_regression_fallback(
+    monkeypatch,
+):
+    class _FallbackWithoutCorrectionGetter:
+        def estimate_forward_pass_time_ms(self, _metrics):
+            return 80.0
+
+        def tune_with_fpms(self, _iterations):
+            return None
+
+        def diagnostics(self):
+            return {
+                "source": "fallback_regression",
+                "readiness": "ready",
+                "retained_observations": 0,
+            }
+
+    fallback = _FallbackWithoutCorrectionGetter()
+
+    class _FakeAicFacade:
+        @classmethod
+        def best_available(cls, _config, _options):
+            return fallback
+
+        @classmethod
+        def from_native(cls, _config, _options):
+            raise AssertionError("regression fallback must not build a native baseline")
+
+    monkeypatch.setattr(engine_query, "AicForwardPassPerfModel", _FakeAicFacade)
+    model = AicCoreEnginePerfModel.best_available(
+        aic_config={"schema_version": 1},
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        options={
+            "max_observations": 8,
+            "min_observations": 2,
+            "bucket_count": 4,
+            "max_num_tokens": 128,
+            "max_batch_size": 16,
+            "max_kv_tokens": 10_000,
+        },
+        attention_dp_size=1,
+        max_correction_factor=2.0,
+    )
+
+    assert model.diagnostics()["planner_correction_cap"]["enabled"] is False
+
+
+def test_native_correction_cap_fails_closed_when_baseline_construction_fails(
+    monkeypatch,
+):
+    corrected = _FakeForwardPassModel(lambda _metrics: 80.0, source="aic")
+
+    class _FakeAicFacade:
+        @classmethod
+        def best_available(cls, _config, _options):
+            return corrected
+
+        @classmethod
+        def from_native(cls, _config, _options):
+            raise RuntimeError("native baseline unavailable")
+
+    monkeypatch.setattr(engine_query, "AicForwardPassPerfModel", _FakeAicFacade)
+
+    with pytest.raises(RuntimeError, match="native baseline unavailable"):
+        AicCoreEnginePerfModel.best_available(
+            aic_config={"schema_version": 1},
+            worker_type="decode",
+            limits=EnginePerfLimits(128, 16, 10_000),
+            options={
+                "max_observations": 8,
+                "min_observations": 2,
+                "bucket_count": 4,
+                "max_num_tokens": 128,
+                "max_batch_size": 16,
+                "max_kv_tokens": 10_000,
+            },
+            attention_dp_size=1,
+            max_correction_factor=2.0,
+        )
+
+
+def test_native_correction_cap_is_absolute_across_repeated_outliers():
+    corrected = _FakeForwardPassModel(lambda _metrics: 10.0)
+    native = _FakeForwardPassModel(lambda _metrics: 10.0)
+    model = AicCoreEnginePerfModel(
+        model=corrected,
+        uncorrected_native_model=native,
+        max_correction_factor=2.0,
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        attention_dp_size=1,
+        max_observations=8,
+    )
+    for wall_time in (0.02, 0.04, 0.08):
+        model.tune_with_fpms(
+            [
+                [
+                    ForwardPassMetrics(
+                        wall_time=wall_time,
+                        scheduled_requests=ScheduledRequestMetrics(
+                            num_decode_requests=1,
+                            sum_decode_kv_tokens=100,
+                        ),
+                    )
+                ]
+            ]
+        )
+
+    tuned_wall_times = [
+        iteration[0]["wall_time"] for iteration in corrected.tuned_iterations
+    ]
+    assert tuned_wall_times == pytest.approx([0.02, 0.02, 0.02])
+
+
+def test_native_correction_cap_preserves_attention_dp_max_wall_semantics():
+    corrected = _FakeForwardPassModel(lambda _metrics: 10.0)
+    model = AicCoreEnginePerfModel(
+        model=corrected,
+        uncorrected_native_model=_FakeForwardPassModel(lambda _metrics: 10.0),
+        max_correction_factor=2.0,
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        attention_dp_size=2,
+        max_observations=8,
+    )
+
+    model.tune_with_fpms(
+        [
+            [
+                ForwardPassMetrics(
+                    dp_rank=0,
+                    wall_time=0.01,
+                    scheduled_requests=ScheduledRequestMetrics(
+                        num_decode_requests=1,
+                        sum_decode_kv_tokens=100,
+                    ),
+                ),
+                ForwardPassMetrics(
+                    dp_rank=1,
+                    wall_time=1.0,
+                    scheduled_requests=ScheduledRequestMetrics(
+                        num_decode_requests=1,
+                        sum_decode_kv_tokens=100,
+                    ),
+                ),
+            ]
+        ]
+    )
+
+    tuned = corrected.tuned_iterations[0]
+    assert [metrics["wall_time"] for metrics in tuned] == pytest.approx([0.01, 0.02])
+
+
+def test_native_correction_cap_does_not_clamp_downward_correction():
+    corrected = _FakeForwardPassModel(lambda _metrics: 10.0)
+    model = AicCoreEnginePerfModel(
+        model=corrected,
+        uncorrected_native_model=_FakeForwardPassModel(lambda _metrics: 10.0),
+        max_correction_factor=2.0,
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        attention_dp_size=1,
+        max_observations=8,
+    )
+
+    model.tune_with_fpms(
+        [
+            [
+                ForwardPassMetrics(
+                    wall_time=0.005,
+                    scheduled_requests=ScheduledRequestMetrics(
+                        num_decode_requests=1,
+                        sum_decode_kv_tokens=100,
+                    ),
+                )
+            ]
+        ]
+    )
+
+    assert corrected.tuned_iterations[0][0]["wall_time"] == pytest.approx(0.005)
+
+
+def test_native_correction_cap_disabled_preserves_corrected_estimate():
+    corrected = _FakeForwardPassModel(lambda _metrics: 80.0)
+    model = AicCoreEnginePerfModel(
+        model=corrected,
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        attention_dp_size=1,
+        max_observations=8,
+    )
+
+    observation = ForwardPassMetrics(
+        wall_time=1.0,
+        scheduled_requests=ScheduledRequestMetrics(
+            num_decode_requests=1,
+            sum_decode_kv_tokens=100,
+        ),
+    )
+    model.tune_with_fpms([[observation]])
+    estimate_s = model.get_scheduled_decode_itl([observation])
+
+    assert corrected.tuned_iterations[0][0]["wall_time"] == 1.0
+    assert estimate_s == pytest.approx(0.08)
+
+
+def test_native_correction_cap_fails_closed_when_baseline_estimate_is_unavailable():
+    model = AicCoreEnginePerfModel(
+        model=_FakeForwardPassModel(lambda _metrics: 80.0),
+        uncorrected_native_model=_FakeForwardPassModel(lambda _metrics: None),
+        max_correction_factor=2.0,
+        worker_type="decode",
+        limits=EnginePerfLimits(128, 16, 10_000),
+        attention_dp_size=1,
+        max_observations=8,
+    )
+
+    with pytest.raises(ValueError, match="native AIC.*unavailable"):
+        model.tune_with_fpms(
+            [
+                [
+                    ForwardPassMetrics(
+                        wall_time=1.0,
+                        scheduled_requests=ScheduledRequestMetrics(
+                            num_decode_requests=1,
+                            sum_decode_kv_tokens=100,
+                        ),
+                    )
+                ]
+            ]
+        )
+
+
+@pytest.mark.parametrize("factor", [0.0, 0.5, float("inf"), float("nan")])
+def test_native_correction_cap_rejects_invalid_values(factor):
+    with pytest.raises(ValueError, match="must be finite and >= 1.0"):
+        AicCoreEnginePerfModel(
+            model=_FakeForwardPassModel(lambda _metrics: 10.0),
+            max_correction_factor=factor,
+            worker_type="decode",
+            limits=EnginePerfLimits(128, 16, 10_000),
+            attention_dp_size=1,
+            max_observations=8,
+        )
 
 
 def test_queued_prefill_uses_full_chunks_plus_tail():

--- a/components/src/dynamo/planner/tests/unit/test_planner_config.py
+++ b/components/src/dynamo/planner/tests/unit/test_planner_config.py
@@ -177,6 +177,26 @@ def test_max_num_fpm_samples_field():
     assert config.max_num_fpm_samples == 100
 
 
+def test_aic_max_correction_factor_default_is_disabled():
+    config = PlannerConfig(namespace="test-ns")
+    assert config.aic_max_correction_factor is None
+
+
+@pytest.mark.parametrize("factor", [1.0, 2.5])
+def test_aic_max_correction_factor_accepts_finite_values_at_least_one(factor):
+    config = PlannerConfig(namespace="test-ns", aic_max_correction_factor=factor)
+    assert config.aic_max_correction_factor == factor
+
+
+@pytest.mark.parametrize(
+    "factor",
+    [0.0, 0.99, float("inf"), float("-inf"), float("nan")],
+)
+def test_aic_max_correction_factor_rejects_invalid_values(factor):
+    with pytest.raises(ValidationError):
+        PlannerConfig(namespace="test-ns", aic_max_correction_factor=factor)
+
+
 def test_speculative_nextn_default_and_positive_value():
     config = PlannerConfig(namespace="test-ns")
     assert config.speculative_nextn == 0

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/overview.md
@@ -178,6 +178,7 @@ DGDR planner features and generated ConfigMaps are materialized into these
 | `enable_load_scaling` | `false` | Enable load-based scaling |
 | `load_adjustment_interval_seconds` | `5` | Seconds between FPM tuning updates and load-based scaling decisions |
 | `max_num_fpm_samples` | `64` | Maximum retained FPM observations for online tuning or regression |
+| `aic_max_correction_factor` | `null` | Optional absolute upper bound on native AIC correction factors, enforced by clipping tuning observations against a never-tuned native estimate; `null` preserves unbounded AIC correction |
 | `fpm_sample_bucket_size` | `16` | Number of buckets for observation retirement (must be perfect square) |
 | `load_scaling_down_sensitivity` | `80` | Scale-down sensitivity 0-100 (0=never, 100=aggressive) |
 | `load_min_observations` | `5` | Minimum observations before regression activates |

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/planner/planner-guide.md
@@ -128,6 +128,7 @@ spec:
 |-------|------|---------|-------------|
 | `load_adjustment_interval_seconds` | int | `5` | Seconds between FPM tuning updates and load-based scaling decisions. Even when only throughput scaling is enabled, live FPM observations are fed into the perf model at this interval. Must be shorter than `throughput_adjustment_interval_seconds`. |
 | `max_num_fpm_samples` | int | `64` | Maximum retained FPM observations for online tuning or regression. |
+| `aic_max_correction_factor` | float or null | `null` | Absolute upper bound on native AIC online correction. Set a finite value greater than or equal to `1.0`; `null` preserves unbounded AIC correction. The Planner bounds each tuning observation against an identical never-tuned native estimate, so the bound applies only to native AIC and does not clamp downward corrections. Enabling it maintains a second native model and runs one native estimate per tuned FPM iteration. The second model adds memory and can add one-time latency to the first capped Planner tuning tick; it does not run on the inference engine thread. |
 | `fpm_sample_bucket_size` | int | `16` | Number of buckets for observation retirement (must be a perfect square). |
 | `load_scaling_down_sensitivity` | int | `80` | Scale-down sensitivity 0–100 (0=never, 100=aggressive). |
 | `load_min_observations` | int | `5` | Minimum observations before making scaling decisions. |

--- a/docs/fern/pages/reference/components/planner-configuration.mdx
+++ b/docs/fern/pages/reference/components/planner-configuration.mdx
@@ -205,6 +205,10 @@ When `optimization_target` is `throughput`, `latency`, or `load`, the Planner fo
   Maximum retained ForwardPassMetrics observations for online tuning and regression fallback.
 </ParamField>
 
+<ParamField path="aic_max_correction_factor" type="number | null" default="null">
+  Absolute upper bound on native AIC online correction. When set, the Planner caps each tuning observation at this factor times an identical never-tuned native estimate, which bounds AIC's stored correction factors. The value must be finite and greater than or equal to `1.0`. The bound does not clamp observations below the native baseline and does not affect regression fallback. `null` preserves the AIC wheel's unbounded correction behavior. Enabling the bound maintains a second native model and runs one native estimate per tuned FPM iteration. The second model adds memory and can add one-time latency to the first capped Planner tuning tick; it does not run on the inference engine thread.
+</ParamField>
+
 <ParamField path="fpm_sample_bucket_size" type="integer" default="16">
   Number of buckets for observation retirement. Must be a perfect square.
 </ParamField>
@@ -597,6 +601,7 @@ The Planner enforces these cross-field rules at startup and rejects a config tha
 
 - `ttft_ms` must be greater than 0.
 - `report_interval_hours` must be a positive finite number or `null`.
+- `aic_max_correction_factor` must be `null` or a finite number greater than or equal to `1.0`.
 - `fpm_sample_bucket_size` must be a perfect square.
 - `global_planner_namespace` is required when `environment` is `global-planner`.
 - Under `optimization_target: load`, prefill modes require `prefill_scale_up_queue_tokens` > `prefill_scale_down_queue_tokens`, and decode modes require `decode_scale_up_kv_rate` > `decode_scale_down_kv_rate`.

--- a/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
+++ b/docs/fern/pages/reference/kubernetes-api/dynamo-graph-deployment-request.mdx
@@ -372,6 +372,10 @@ service.
   Maximum retained ForwardPassMetrics observations for online tuning and regression fallback.
 </ParamField>
 
+<ParamField path="aic_max_correction_factor" type="number | null" default="null">
+  Absolute upper bound on native AIC online correction. When set, the Planner caps each tuning observation at this factor times an identical never-tuned native estimate, which bounds AIC's stored correction factors. The value must be finite and greater than or equal to `1.0`. The bound does not clamp observations below the native baseline and does not affect regression fallback. `null` preserves the AIC wheel's unbounded correction behavior. Enabling the bound maintains a second native model and runs one native estimate per tuned FPM iteration. The second model adds memory and can add one-time latency to the first capped Planner tuning tick; it does not run on the inference engine thread.
+</ParamField>
+
 <ParamField path="fpm_sample_bucket_size" type="integer" default="16">
   Number of buckets for observation retirement. Must be a perfect square.
 </ParamField>


### PR DESCRIPTION
## What

- Add an opt-in `aic_max_correction_factor` Planner setting (`>= 1.0`, disabled by default).
- When native AIC is active and the cap is configured, retain an identical never-tuned native model as the correction baseline.
- Clamp only upward FPM wall-time observations before they reach AIC tuning; downward corrections remain unchanged.
- Report the configured cap, whether it is active, and AIC's observed maximum correction in diagnostics.
- Document the new setting and cover configuration, fallback, adapter, native-AIC, replay-digest, and repeated-outlier behavior.

## Why

Related to #12430.

A transient forward-pass outlier can otherwise teach native AIC a very large correction for the matching workload region, which depresses the Planner's capacity estimate long after the stall has passed. This is especially damaging when several similar outliers arrive in sequence.

The cap is computed from a separate never-tuned native estimate. Using the already-corrected estimate as the baseline would compound the bound across observations (for example, 2x -> 4x -> 8x) and would not provide an absolute ceiling.

This is intentionally a mitigation rather than a universal default: deployments can choose a factor appropriate to their tolerance for genuine performance shifts. Regression fallback and the existing unbounded behavior are unchanged when the setting is unset.

## Validation

- `99 passed in 15.55s` across:
  - Planner AIC adapter unit tests
  - engine-query unit tests
  - Planner config unit tests
  - offline replay FPM tests
  - native AIC integration tests
- Ruff formatting/checks passed for all touched Python files.
- `git diff --check` passed.
- Controlled replay of 12 matching outliers learned an approximately 90.76x correction without a cap; configured 1.25x, 1.5x, and 2.0x caps bounded the stored correction at the configured factor.

## Runtime impact

The extra native model and baseline estimate are created and used only when the cap is configured and native AIC is available. Normal capacity/latency queries do not query the baseline model; capped tuning adds one native estimate per FPM iteration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Planner setting to cap native AIC online correction factors.
  * Supports finite values of at least 1.0; leaving it unset preserves uncapped behavior.
  * Planner diagnostics now report correction-cap configuration and observed correction factors.
  * Configuration changes trigger updated model initialization.

* **Documentation**
  * Documented the new setting, validation rules, defaults, behavior, and runtime considerations.

* **Tests**
  * Added coverage for correction caps, validation, fallback behavior, diagnostics, and configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->