### PR TITLE
fix(docs): stop Fern bundling commented-out component imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,6 +111,20 @@ repos:
       language: system
       files: ^docs/fern/scripts/check_published_styles\.py$
       pass_filenames: false
+    - id: check-component-imports
+      name: Check mdx-components carry no unbundleable specifiers
+      entry: python3 docs/fern/scripts/check_component_imports.py
+      language: system
+      # Scan the whole components/ tree, not just the staged files: Fern
+      # bundles them together and reports whichever it reaches first.
+      files: ^docs/fern/(components/|scripts/check_component_imports\.py$)
+      pass_filenames: false
+    - id: check-component-imports-selftest
+      name: Self-test the component specifier matcher
+      entry: python3 docs/fern/scripts/check_component_imports.py --test
+      language: system
+      files: ^docs/fern/scripts/check_component_imports\.py$
+      pass_filenames: false
     - id: pytest-marker-report
       name: Report pytest markers (static + inherited)
       entry: python3 tests/report_pytest_markers.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -117,7 +117,8 @@ repos:
       language: system
       # Scan the whole components/ tree, not just the staged files: Fern
       # bundles them together and reports whichever it reaches first.
-      files: ^docs/fern/(components/|scripts/check_component_imports\.py$)
+      # fern.config.json is in scope so a CLI bump trips the matcher-drift check.
+      files: ^docs/fern/(components/|fern\.config\.json$|scripts/check_component_imports\.py$)
       pass_filenames: false
     - id: check-component-imports-selftest
       name: Self-test the component specifier matcher

--- a/docs/fern/components/RecipeStyles.tsx
+++ b/docs/fern/components/RecipeStyles.tsx
@@ -11,12 +11,21 @@
  * constraint, CSS injected this exact way.
  *
  * Server component (no "use client"); registered via docs.yml
- * `experimental.mdx-components: ./components`. IMPORT it (ambient use is
- * unsupported — renders "Unsupported JSX tag"); the @/ prefix resolves to the
- * fern/ root and is rewritten to a relative path at publish time:
- *   import { RecipeStyles } from "@/components/RecipeStyles";
- * Then place <RecipeStyles /> once, right after the frontmatter, on every
+ * `experimental.mdx-components: ./components`. Every page must pull in the
+ * named RecipeStyles export from the specifier `@/components/RecipeStyles`
+ * (ambient use is unsupported — renders "Unsupported JSX tag"); the @/ prefix
+ * resolves to the fern/ root and is rewritten to a relative path at publish
+ * time. Then place <RecipeStyles /> once, right after the frontmatter, on every
  * recipe/benchmark page (and the two landing READMEs).
+ *
+ * Do NOT spell that out as a literal ES module statement here, not even inside
+ * a comment. Fern collects a component's third-party dependencies with a
+ * plain-text regex over the whole source file, so a commented-out example reads
+ * as a real dependency on `@/components`, which is outside Fern's allowlist
+ * (react, react-dom, @mdx-js/react, next). Fern then shells out to
+ * `npx rolldown` to bundle it and the docs build dies with "Failed to bundle
+ * third-party imports". docs/fern/scripts/check_component_imports.py enforces
+ * this.
  */
 const RECIPE_CSS = `
 /* Dark-mode variable re-bind.

--- a/docs/fern/components/ReferenceStyles.tsx
+++ b/docs/fern/components/ReferenceStyles.tsx
@@ -17,12 +17,16 @@
  * constraint, CSS injected this exact way.
  *
  * Server component (no "use client"); registered via docs.yml
- * `experimental.mdx-components: ./components`. IMPORT it (ambient use is
- * unsupported — renders "Unsupported JSX tag"); the @/ prefix resolves to the
- * fern/ root and is rewritten to a relative path at publish time:
- *   import { ReferenceStyles } from "@/components/ReferenceStyles";
- * Then place <ReferenceStyles /> once, right after the frontmatter, on every
- * Reference page that uses these components.
+ * `experimental.mdx-components: ./components`. Every page must pull in the
+ * named ReferenceStyles export from the specifier `@/components/ReferenceStyles`
+ * (ambient use is unsupported — renders "Unsupported JSX tag"); the @/ prefix
+ * resolves to the fern/ root and is rewritten to a relative path at publish
+ * time. Then place <ReferenceStyles /> once, right after the frontmatter, on
+ * every Reference page that uses these components.
+ *
+ * Do NOT spell that out as a literal ES module statement here, not even inside
+ * a comment — see the header of RecipeStyles.tsx for why it breaks the docs
+ * build. docs/fern/scripts/check_component_imports.py enforces this.
  */
 const REFERENCE_CSS = `
 /* Dark-mode variable re-bind.

--- a/docs/fern/components/TerminalDemo.tsx
+++ b/docs/fern/components/TerminalDemo.tsx
@@ -12,9 +12,12 @@
  *   This repo ships NO package.json alongside fern/, and neither existing
  *   custom component (CustomFooter, RecipeStyles) pulls an external npm dep —
  *   the build-safe pattern here is self-contained, dependency-free components.
- *   So instead of `import "asciinema-player"` (which Fern's mdx-components
- *   bundling can't resolve without a declared dep), we inject the player's JS +
- *   CSS from jsDelivr at runtime and call the global AsciinemaPlayer.create().
+ *   So rather than depending on the asciinema-player package directly (which
+ *   Fern's mdx-components bundling can't resolve without a declared dep, and
+ *   which it cannot even see named here as a literal ES module statement
+ *   without failing the build — see the header of RecipeStyles.tsx), we inject
+ *   the player's JS + CSS from jsDelivr at runtime and call the global
+ *   AsciinemaPlayer.create().
  *   The site already loads third-party JS (adobedtm) and iframes (ghbtns), so
  *   an external <script>/<link> is consistent with the page's existing origins.
  *
@@ -24,8 +27,10 @@
  *   DOM access is inside useEffect and guarded, so SSR renders an empty frame
  *   and hydration wires up the player. dispose() runs on unmount.
  *
- * USAGE (import — ambient JSX is unsupported, per the RecipeStyles note):
- *   import { TerminalDemo } from "@/components/TerminalDemo";
+ * USAGE (ambient JSX is unsupported, per the RecipeStyles note): pull in the
+ * named TerminalDemo export from the specifier `@/components/TerminalDemo`,
+ * then render it. docs/fern/scripts/check_component_imports.py enforces the
+ * no-literal-statement rule.
  *
  *   <TerminalDemo
  *     src="../../assets/dynamo-demo.cast"   // relative, so Fern rewrites it

--- a/docs/fern/scripts/check_component_imports.py
+++ b/docs/fern/scripts/check_component_imports.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Guard against module specifiers Fern would try to bundle with rolldown.
+
+docs.yml registers docs/fern/components via `experimental.mdx-components`. When
+Fern publishes, it scans each component source for module specifiers that are
+neither relative nor allowlisted, and treats what it finds as third-party
+dependencies to bundle -- shelling out to `npx rolldown@<pin>` with the
+component's directory as cwd. The docs-website branch ships no package.json
+next to fern/, so that bundle cannot resolve anything and the build fails with:
+
+    Failed to bundle third-party imports in fern/components/<file>.tsx:
+    rolldown exited with code 127 ... sh: 1: rolldown: not found
+
+The trap is that Fern's scan is a plain-text regex over the whole file -- it
+does not parse the source, so it does not skip comments. A usage example in a
+component's doc header, such as
+
+    * <the ES module keyword> { RecipeStyles } from "@/components/RecipeStyles";
+
+is collected as a real dependency on `@/components` and sends the publish down
+the rolldown path. That is what broke the "Preview or publish docs" job: the
+failing component rotated between RecipeStyles, ReferenceStyles and
+TerminalDemo depending on which one Fern reached first, and none of the three
+had an actual npm dependency. Document the specifier in prose instead.
+
+The regex and allowlist below mirror the Fern CLI's own implementation
+(cli.cjs, the helper behind "Failed to bundle third-party imports"); keep them
+in sync when the pinned CLI in fern.config.json moves.
+
+Usage: python3 check_component_imports.py [files...]
+With no arguments, checks every source file under docs/fern/components.
+Run with --test to self-test the matcher.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]  # docs/fern
+REPO = ROOT.parents[1]  # repo root, for readable paths
+COMPONENTS = ROOT / "components"
+
+# Fern only scans these extensions.
+SOURCE_SUFFIXES = (".js", ".jsx", ".ts", ".tsx")
+
+# Specifiers Fern resolves itself; everything else is "third party".
+ALLOWLIST = ("react", "react-dom", "@mdx-js/react", "next")
+
+# Fern's own specifier regex, verbatim. Note it is applied to raw text, which is
+# why comments count.
+SPECIFIER = re.compile(
+    r"""(?:^|[^\w.])(?:import|export)\s+(?:[\w*\s{},$]*?from\s+)?["']([^"'\n]+)["']"""
+    r"""|import\(\s*["']([^"'\n]+)["']\s*\)"""
+    r"""|require\(\s*["']([^"'\n]+)["']\s*\)""",
+    re.M,
+)
+
+
+def package_root(specifier: str) -> str:
+    """Reduce a specifier to the package Fern would have to install."""
+    parts = specifier.split("/")
+    if specifier.startswith("@"):
+        return "/".join(parts[:2])
+    return parts[0] if parts else specifier
+
+
+def is_relative(specifier: str) -> bool:
+    return specifier.startswith(("./", "../")) or specifier in (".", "..")
+
+
+def third_party(contents: str) -> list[tuple[int, str]]:
+    """Return (line number, specifier) for everything Fern would bundle."""
+    found: list[tuple[int, str]] = []
+    seen: set[str] = set()
+    for match in SPECIFIER.finditer(contents):
+        specifier = match.group(1) or match.group(2) or match.group(3)
+        if specifier is None or is_relative(specifier):
+            continue
+        if package_root(specifier) in ALLOWLIST or specifier in seen:
+            continue
+        seen.add(specifier)
+        found.append((contents[: match.start()].count("\n") + 1, specifier))
+    return found
+
+
+def display(path: Path) -> str:
+    """Repo-relative when possible; a caller may pass a path from anywhere."""
+    try:
+        return str(path.resolve().relative_to(REPO))
+    except ValueError:
+        return str(path)
+
+
+def check(path: Path) -> list[str]:
+    text = path.read_text()
+    return [
+        f"{display(path)}:{line}: {specifier}\n"
+        f"      Fern reads this as a third-party dependency and bundles the file"
+        f" with rolldown, which fails the docs publish.\n"
+        f"      If it is a usage example or a comment, describe the specifier in"
+        f" prose instead of writing a literal statement."
+        for line, specifier in third_party(text)
+    ]
+
+
+def selftest() -> int:
+    cases: list[tuple[str, bool]] = [
+        ('import { useState } from "react";', False),
+        ('import ReactDOM from "react-dom/client";', False),
+        ('import { useMDXComponents } from "@mdx-js/react";', False),
+        ('import { CURRENT_TAG } from "./releases.data";', False),
+        ('import { X } from "../shared/x";', False),
+        # The regression this script exists for: an example inside a comment.
+        (' *   import { RecipeStyles } from "@/components/RecipeStyles";', True),
+        ('So instead of `import "asciinema-player"` we load it from a CDN.', True),
+        ('export { Foo } from "@/components/Foo";', True),
+        ('const mod = await import("chart.js");', True),
+        ('const lodash = require("lodash");', True),
+        # Prose that merely contains the word must not trip the matcher.
+        ('* fails with "Failed to bundle third-party imports" at publish.', False),
+        ("* Every page must pull in the named export from `@/components/Foo`.", False),
+    ]
+    failures = 0
+    for source, should_flag in cases:
+        flagged = bool(third_party(source))
+        if flagged != should_flag:
+            failures += 1
+            verb = "flagged" if flagged else "missed"
+            print(f"selftest: {verb} unexpectedly: {source!r}", file=sys.stderr)
+    if failures:
+        print(f"{failures} selftest case(s) failed", file=sys.stderr)
+        return 1
+    print(f"selftest: {len(cases)} case(s) passed")
+    return 0
+
+
+def main() -> int:
+    if "--test" in sys.argv[1:]:
+        return selftest()
+
+    args = [Path(a) for a in sys.argv[1:]]
+    targets = args or sorted(
+        p for p in COMPONENTS.rglob("*") if p.suffix in SOURCE_SUFFIXES
+    )
+    targets = [t for t in targets if t.suffix in SOURCE_SUFFIXES and t.is_file()]
+
+    problems: list[str] = []
+    for target in targets:
+        problems.extend(check(target))
+
+    if problems:
+        print("module specifiers Fern cannot bundle:\n", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        print(
+            "\n  Fern resolves only "
+            + ", ".join(ALLOWLIST)
+            + " and relative paths. A component that genuinely needs an npm"
+            " package also needs a package.json on the docs-website branch,"
+            " which does not exist -- load it from a CDN at runtime instead"
+            " (see docs/fern/components/TerminalDemo.tsx).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"checked {len(targets)} component source(s): no unbundleable specifiers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/fern/scripts/check_component_imports.py
+++ b/docs/fern/scripts/check_component_imports.py
@@ -120,7 +120,7 @@ def check_pin_drift() -> list[str]:
     """Report when fern.config.json has moved past the ported-from release."""
     config_path = ROOT / "fern.config.json"
     try:
-        pinned = json.loads(config_path.read_text()).get("version", "")
+        pinned = json.loads(config_path.read_text(encoding="utf-8")).get("version", "")
     except (OSError, ValueError) as exc:
         return [
             f"{display(config_path)}: could not read the pinned Fern version: {exc}"
@@ -144,7 +144,9 @@ def display(path: Path) -> str:
 
 
 def check(path: Path) -> list[str]:
-    text = path.read_text()
+    # Explicit encoding: most component sources carry non-ASCII (em dashes in
+    # the doc headers), and the locale default is not UTF-8 everywhere.
+    text = path.read_text(encoding="utf-8")
     return [
         f"{display(path)}:{line}: {specifier}\n"
         f"      Fern reads this as a third-party dependency and bundles the file"

--- a/docs/fern/scripts/check_component_imports.py
+++ b/docs/fern/scripts/check_component_imports.py
@@ -37,17 +37,20 @@ failing component rotated between RecipeStyles, ReferenceStyles and
 TerminalDemo depending on which one Fern reached first, and none of the three
 had an actual npm dependency. Document the specifier in prose instead.
 
-The regex and allowlist below mirror the Fern CLI's own implementation
-(cli.cjs, the helper behind "Failed to bundle third-party imports"); keep them
-in sync when the pinned CLI in fern.config.json moves.
+The regex and allowlist below mirror the Fern CLI's own implementation (cli.cjs,
+the helper behind "Failed to bundle third-party imports"). That copy can drift,
+so a full scan also fails when fern.config.json is bumped past PORTED_FROM --
+re-read the bundler in the new CLI, reconcile the two constants, then move
+PORTED_FROM.
 
 Usage: python3 check_component_imports.py [files...]
-With no arguments, checks every source file under docs/fern/components.
-Run with --test to self-test the matcher.
+With no arguments, checks every source file under docs/fern/components and
+verifies the Fern pin. Run with --test to self-test the matcher.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -55,6 +58,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]  # docs/fern
 REPO = ROOT.parents[1]  # repo root, for readable paths
 COMPONENTS = ROOT / "components"
+
+# The Fern CLI release SPECIFIER and ALLOWLIST below were read out of. Nothing
+# makes the CLI keep that shape, so a bump that widens the allowlist -- or
+# replaces the text scan with a real parser that skips comments -- would leave
+# this check silently over- or under-reporting. Under-reporting is the costly
+# direction: it breaks the docs publish exactly the way this script exists to
+# prevent. Fail on the bump instead, while someone is already looking at Fern.
+PORTED_FROM = "5.80.2"
 
 # Fern only scans these extensions.
 SOURCE_SUFFIXES = (".js", ".jsx", ".ts", ".tsx")
@@ -89,14 +100,39 @@ def third_party(contents: str) -> list[tuple[int, str]]:
     found: list[tuple[int, str]] = []
     seen: set[str] = set()
     for match in SPECIFIER.finditer(contents):
-        specifier = match.group(1) or match.group(2) or match.group(3)
-        if specifier is None or is_relative(specifier):
+        group = next((i for i in (1, 2, 3) if match.group(i) is not None), None)
+        if group is None:
+            continue
+        specifier = match.group(group)
+        if is_relative(specifier):
             continue
         if package_root(specifier) in ALLOWLIST or specifier in seen:
             continue
         seen.add(specifier)
-        found.append((contents[: match.start()].count("\n") + 1, specifier))
+        # Anchor on the specifier, not on match.start(): the first alternation
+        # opens with (?:^|[^\w.]), which consumes the preceding newline for a
+        # statement at column 0 and would report the line above.
+        found.append((contents[: match.start(group)].count("\n") + 1, specifier))
     return found
+
+
+def check_pin_drift() -> list[str]:
+    """Report when fern.config.json has moved past the ported-from release."""
+    config_path = ROOT / "fern.config.json"
+    try:
+        pinned = json.loads(config_path.read_text()).get("version", "")
+    except (OSError, ValueError) as exc:
+        return [
+            f"{display(config_path)}: could not read the pinned Fern version: {exc}"
+        ]
+    if pinned == PORTED_FROM:
+        return []
+    return [
+        f"{display(config_path)}: pins Fern {pinned}, but this check's matcher was"
+        f" ported from {PORTED_FROM}.\n"
+        f"      Re-read the third-party-import bundler in {pinned}, reconcile"
+        f" SPECIFIER and ALLOWLIST, then update PORTED_FROM."
+    ]
 
 
 def display(path: Path) -> str:
@@ -120,29 +156,50 @@ def check(path: Path) -> list[str]:
 
 
 def selftest() -> int:
-    cases: list[tuple[str, bool]] = [
-        ('import { useState } from "react";', False),
-        ('import ReactDOM from "react-dom/client";', False),
-        ('import { useMDXComponents } from "@mdx-js/react";', False),
-        ('import { CURRENT_TAG } from "./releases.data";', False),
-        ('import { X } from "../shared/x";', False),
+    # (source, should_flag, expected line number or None to skip the check)
+    cases: list[tuple[str, bool, int | None]] = [
+        ('import { useState } from "react";', False, None),
+        ('import ReactDOM from "react-dom/client";', False, None),
+        ('import { useMDXComponents } from "@mdx-js/react";', False, None),
+        ('import { CURRENT_TAG } from "./releases.data";', False, None),
+        ('import { X } from "../shared/x";', False, None),
         # The regression this script exists for: an example inside a comment.
-        (' *   import { RecipeStyles } from "@/components/RecipeStyles";', True),
-        ('So instead of `import "asciinema-player"` we load it from a CDN.', True),
-        ('export { Foo } from "@/components/Foo";', True),
-        ('const mod = await import("chart.js");', True),
-        ('const lodash = require("lodash");', True),
+        (' *   import { RecipeStyles } from "@/components/RecipeStyles";', True, 1),
+        ('So instead of `import "asciinema-player"` we load it from a CDN.', True, 1),
+        ('export { Foo } from "@/components/Foo";', True, 1),
+        ('const mod = await import("chart.js");', True, 1),
+        ('const lodash = require("lodash");', True, 1),
+        # A statement at column 0 must report its own line, not the one above:
+        # the leading (?:^|[^\w.]) alternation eats the previous newline.
+        ('header\nimport { X } from "@/components/X";\n', True, 2),
+        ('a\nb\nexport { Y } from "@/components/Y";\n', True, 3),
         # Prose that merely contains the word must not trip the matcher.
-        ('* fails with "Failed to bundle third-party imports" at publish.', False),
-        ("* Every page must pull in the named export from `@/components/Foo`.", False),
+        (
+            '* fails with "Failed to bundle third-party imports" at publish.',
+            False,
+            None,
+        ),
+        (
+            "* Every page must pull in the named export from `@/components/Foo`.",
+            False,
+            None,
+        ),
     ]
     failures = 0
-    for source, should_flag in cases:
-        flagged = bool(third_party(source))
-        if flagged != should_flag:
+    for source, should_flag, expected_line in cases:
+        hits = third_party(source)
+        if bool(hits) != should_flag:
             failures += 1
-            verb = "flagged" if flagged else "missed"
+            verb = "flagged" if hits else "missed"
             print(f"selftest: {verb} unexpectedly: {source!r}", file=sys.stderr)
+            continue
+        if expected_line is not None and hits[0][0] != expected_line:
+            failures += 1
+            print(
+                f"selftest: reported line {hits[0][0]}, expected {expected_line}:"
+                f" {source!r}",
+                file=sys.stderr,
+            )
     if failures:
         print(f"{failures} selftest case(s) failed", file=sys.stderr)
         return 1
@@ -178,6 +235,16 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    # Only on a full scan: an explicit file list is a targeted call, and the pin
+    # is a property of the tree rather than of any one component.
+    if not args:
+        drift = check_pin_drift()
+        if drift:
+            print("Fern CLI pin has moved past this check:\n", file=sys.stderr)
+            for problem in drift:
+                print(f"  - {problem}", file=sys.stderr)
+            return 1
 
     print(f"checked {len(targets)} component source(s): no unbundleable specifiers")
     return 0


### PR DESCRIPTION
## Summary

The `Preview or publish docs` job has been failing on `main` and on every docs-touching PR with:

```
Failed to bundle third-party imports in fern/components/RecipeStyles.tsx:
rolldown exited with code 127 ... sh: 1: rolldown: not found
```

The named component rotated run to run — `RecipeStyles.tsx`, `ReferenceStyles.tsx`, `TerminalDemo.tsx` — and **none of the three has an npm dependency**. That is the tell: the trigger was not a real import.

**Root cause.** Fern collects a component's third-party dependencies with a plain-text regex over the whole source file. It does not parse the source, so it does not skip comments. Each of the three headers documented its own usage with a literal example statement naming `@/components/<Name>`. Fern read that comment as a real dependency; `@/components` is outside its allowlist (`react`, `react-dom`, `@mdx-js/react`, `next`), so it shelled out to `npx rolldown` to bundle it.

The `docs-website` branch ships no `package.json` next to `fern/`, so that bundle could never resolve. It surfaced two ways, which is what made it look flaky rather than broken:

- exit `127` — `rolldown: not found`
- exit `1` — `ERR_MODULE_NOT_FOUND` on a half-unpacked `~/.npm/_npx/…/rolldown/dist/shared/binding-*.mjs`

Fern bundles the components concurrently, so several `npx` invocations race on one shared cache directory. A retry that happens to win the race goes green, which is why re-runs sometimes "fixed" it.

**Fix.** Document the specifier in prose in all three headers instead of writing a literal statement, and add `docs/fern/scripts/check_component_imports.py` — a port of Fern's own matcher (regex, allowlist, and package-root reduction taken from the pinned CLI) — wired into pre-commit so a re-added example is caught before merge instead of on the publish.

No page content, CSS, or component behaviour changes; the edits are comment-only.

## Validation

- Ported Fern's detector and ran it against `docs/fern/components` at `main`: flagged exactly `RecipeStyles.tsx:17`, `ReferenceStyles.tsx:23`, `TerminalDemo.tsx:15,28` — the same three files CI named, and no others.
- After the fix: `checked 33 component source(s): no unbundleable specifiers`.
- Replayed the workflow's components sync (`fern-docs.yml`, the `rm -rf` + `cp -r` into `docs-checkout/fern/components`) against a real `origin/docs-website` worktree and re-ran the check on the composed tree — clean, 33/33. Confirmed `docs-website` carries exactly these 33 files, so the branch copy cannot drift.
- Guard verified in both directions: it exits 1 with a located finding on the pre-fix `RecipeStyles.tsx`, and 0 on the fixed tree.
- `--test` self-test covers 12 cases, including allowlisted, scoped-allowlisted, subpath, relative, dynamic `import()`, `require()`, re-export, the commented-example regression, and prose that merely contains the word.
- `pre-commit run --files …` green on all five changed files.

Not fixed here, and tracked separately: `main` is also red on the later `Verify published pages carry their component CSS` step, which 404s on `/dynamo/dev/recipes/feature-benchmarks/llama-3-3-70b-topology`. That is a different failure in a different step — `Publish Docs` itself succeeds on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/12753" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how to use styling and terminal demonstration components in applicable pages.
  * Added guidance for component imports, page placement, and runtime asset loading.

* **Quality Improvements**
  * Added automated validation to detect unsupported component dependencies and provide actionable error details.
  * Included self-checks to help ensure dependency validation remains reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->