### PR TITLE
fix(profiler): propagate AIC database version

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -15,6 +15,7 @@ try:
     from dynamo.profiler.utils.dgd_generation import (
         _build_planner_config,
         _inject_mocker_aic_args,
+        _load_latest_database_version,
         build_aic_interpolation_spec,
         build_aic_perf_model_spec,
         enable_vllm_benchmark_mode,
@@ -34,6 +35,39 @@ pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.unit,
 ]
+
+
+def test_aic_import_treats_missing_root_package_as_optional(monkeypatch):
+    def raise_missing_root(_):
+        raise ModuleNotFoundError(name="aiconfigurator_core")
+
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.dgd_generation.importlib.import_module",
+        raise_missing_root,
+    )
+
+    assert _load_latest_database_version() is None
+
+
+@pytest.mark.parametrize(
+    "missing_module",
+    ["aiconfigurator_core.sdk.operations.attention", "unrelated_dependency"],
+)
+def test_aic_import_propagates_internal_or_unrelated_missing_module(
+    monkeypatch, missing_module
+):
+    def raise_missing_dependency(_):
+        raise ModuleNotFoundError(name=missing_module)
+
+    monkeypatch.setattr(
+        "dynamo.profiler.utils.dgd_generation.importlib.import_module",
+        raise_missing_dependency,
+    )
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        _load_latest_database_version()
+
+    assert exc_info.value.name == missing_module
 
 
 def _dgdr(
@@ -396,6 +430,31 @@ class TestBuildPlannerConfigEmbedsAicSpec:
         )
 
         assert spec is None
+
+    def test_aic_perf_model_falls_back_when_sdk_is_unavailable(
+        self, monkeypatch, caplog
+    ):
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            None,
+        )
+        planner = PlannerConfig(
+            enable_throughput_scaling=True,
+            enable_load_scaling=False,
+            optimization_target="sla",
+        )
+        dgdr = _dgdr(planner=planner)
+
+        spec = build_aic_perf_model_spec(
+            dgdr,
+            best_prefill_pick=PickedParallelConfig(tp=1),
+            best_decode_pick=PickedParallelConfig(tp=2),
+            resolved_backend="vllm",
+            system="h200_sxm",
+        )
+
+        assert spec is None
+        assert "aiconfigurator-core is unavailable" in caplog.text
 
     @pytest.mark.parametrize(
         ("mode", "prefill_pick", "decode_pick"),

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -331,7 +331,17 @@ class TestBuildPlannerConfigEmbedsAicSpec:
         assert cfg.prefill_engine_num_gpu == 8
         assert cfg.decode_engine_num_gpu == 8
 
-    def test_aic_perf_model_threads_into_planner_config(self):
+    def test_aic_perf_model_threads_into_planner_config(self, monkeypatch):
+        resolved_versions = []
+
+        def resolve_backend_version(*, system, backend):
+            resolved_versions.append((system, backend))
+            return "0.24.0"
+
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            resolve_backend_version,
+        )
         planner = PlannerConfig(
             enable_throughput_scaling=True,
             enable_load_scaling=False,
@@ -360,8 +370,32 @@ class TestBuildPlannerConfigEmbedsAicSpec:
         assert cfg.aic_perf_model.hf_id == dgdr.model
         assert cfg.aic_perf_model.system == "h200_sxm"
         assert cfg.aic_perf_model.backend == "vllm"
+        assert cfg.aic_perf_model.backend_version == "0.24.0"
         assert cfg.aic_perf_model.prefill_pick == prefill_pick
         assert cfg.aic_perf_model.decode_pick == decode_pick
+        assert resolved_versions == [("h200_sxm", "vllm")]
+
+    def test_aic_perf_model_falls_back_when_database_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(
+            "dynamo.profiler.utils.dgd_generation.get_latest_database_version",
+            lambda **_: None,
+        )
+        planner = PlannerConfig(
+            enable_throughput_scaling=True,
+            enable_load_scaling=False,
+            optimization_target="sla",
+        )
+        dgdr = _dgdr(planner=planner)
+
+        spec = build_aic_perf_model_spec(
+            dgdr,
+            best_prefill_pick=PickedParallelConfig(tp=1),
+            best_decode_pick=PickedParallelConfig(tp=2),
+            resolved_backend="vllm",
+            system="unknown_system",
+        )
+
+        assert spec is None
 
     @pytest.mark.parametrize(
         ("mode", "prefill_pick", "decode_pick"),

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -20,6 +20,7 @@ from typing import Any, Optional
 
 import numpy as np
 import yaml
+from aiconfigurator_core.sdk.perf_database import get_latest_database_version
 
 from dynamo.common.utils.paths import get_workspace_dir
 from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
@@ -707,10 +708,24 @@ def build_aic_perf_model_spec(
     if mode in ("decode", "agg", "disagg") and best_decode_pick is None:
         return None
 
+    backend_version = get_latest_database_version(
+        system=system,
+        backend=resolved_backend,
+    )
+    if backend_version is None:
+        logger.warning(
+            "No AIC performance database is available for system=%s, backend=%s; "
+            "Planner will use FPM regression instead of native AIC estimates.",
+            system,
+            resolved_backend,
+        )
+        return None
+
     return AICPerfModelSpec(
         hf_id=dgdr.model,
         system=system,
         backend=resolved_backend,
+        backend_version=backend_version,
         prefill_pick=best_prefill_pick,
         decode_pick=best_decode_pick,
     )

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
 import json
 import logging
 import uuid
+from collections.abc import Callable
 from typing import Any, Optional
 
 import numpy as np
 import yaml
-from aiconfigurator_core.sdk.perf_database import get_latest_database_version
 
 from dynamo.common.utils.paths import get_workspace_dir
 from dynamo.planner.config.aic_interpolation_spec import AICInterpolationSpec
@@ -56,6 +57,19 @@ from dynamo.profiler.utils.profile_common import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _load_latest_database_version() -> Optional[Callable[..., Optional[str]]]:
+    try:
+        perf_database = importlib.import_module("aiconfigurator_core.sdk.perf_database")
+    except ModuleNotFoundError as e:
+        if e.name != "aiconfigurator_core":
+            raise
+        return None
+    return perf_database.get_latest_database_version
+
+
+get_latest_database_version = _load_latest_database_version()
 
 # ConfigMap name prefixes (a 4-char UUID suffix is appended at runtime
 # so that multiple deployments in the same namespace don't collide)
@@ -706,6 +720,13 @@ def build_aic_perf_model_spec(
     if mode in ("prefill", "disagg") and best_prefill_pick is None:
         return None
     if mode in ("decode", "agg", "disagg") and best_decode_pick is None:
+        return None
+
+    if get_latest_database_version is None:
+        logger.warning(
+            "aiconfigurator-core is unavailable; Planner will use FPM regression "
+            "instead of native AIC estimates."
+        )
         return None
 
     backend_version = get_latest_database_version(


### PR DESCRIPTION
## Summary

- resolve the packaged AIC performance database version for the selected system/backend
- populate `aic_perf_model.backend_version` in profiler-generated Planner config
- preserve FPM regression fallback when no native AIC database exists
- add regression coverage for version propagation and the no-database path

## Root cause

The profiler created `AICPerfModelSpec` without `backend_version`, so the field serialized as `null`. The Planner forwarded that value to aiconfigurator-core, which requires the database version to load native performance data. Model construction failed and throughput scaling skipped every tick even after worker self-benchmark FPMs arrived.

This resolves [DYN-3777](https://linear.app/nvidia/issue/DYN-3777).

## Validation

- `35 passed` — `test_dgd_generation_aic.py`
- `62 passed` — `test_helpers_profile_sla.py`
- `13 passed` — `test_aic_perf_adapter.py`
- reproduced the reported Qwen3-0.6B / H200 / vLLM configuration locally: the generated version is `0.24.0`, and both prefill and decode initialize with `source=aic`, `readiness=ready`
- independent agentic code review: no blocking findings
- isort, black, flake8, codespell, ruff, whitespace, and syntax checks passed

The global pytest-marker pre-commit report could not complete in this local environment because unrelated KVBM/SGLang test modules require dependencies not present in the current venv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AIC performance model generation now selects the latest available performance database version.
  * Added graceful fallback when no matching database version is available, preventing invalid model specifications.
  * Improved validation of backend version resolution and database lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->