### PR TITLE
perf(mocker): optimize replay accounting and SGLang KV events

### DIFF
--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -21,6 +21,10 @@ new_key_type! {
 pub struct KvPageId(usize);
 
 impl KvPageId {
+    pub(crate) fn index(self) -> usize {
+        self.0
+    }
+
     #[cfg(test)]
     pub(crate) fn from_token_index(index: usize, page_size: usize) -> Self {
         Self(index / page_size)
@@ -132,6 +136,7 @@ impl PagePool {
     }
 
     pub fn free_pages(&mut self, pages: &[KvPageId]) {
+        self.free.reserve_exact(pages.len());
         self.free.extend_from_slice(pages);
     }
 

--- a/lib/mocker/src/cache/radix_cache.rs
+++ b/lib/mocker/src/cache/radix_cache.rs
@@ -136,7 +136,6 @@ impl PagePool {
     }
 
     pub fn free_pages(&mut self, pages: &[KvPageId]) {
-        self.free.reserve_exact(pages.len());
         self.free.extend_from_slice(pages);
     }
 

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -118,9 +118,9 @@ pub struct SglangKvManager {
     kv_event_publishers: KvEventPublishers,
     dp_rank: u32,
     next_event_id: u64,
-    /// Maps each physical page to the block hash assigned during Stored
-    /// events, so Removed events can use the same block hash.
-    page_to_block_hash: FxHashMap<KvPageId, ExternalSequenceBlockHash>,
+    /// Maps each dense physical page ID to the block hash assigned during
+    /// Stored events, so Removed events can use the same block hash.
+    page_to_block_hash: Vec<Option<ExternalSequenceBlockHash>>,
     /// Tracks how many live pool slots currently advertise the same logical
     /// block hash so router events reflect logical block visibility, not
     /// transient slot ownership.
@@ -184,7 +184,7 @@ impl SglangKvManager {
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
-            page_to_block_hash: FxHashMap::default(),
+            page_to_block_hash: vec![None; total_tokens / page_size],
             block_hash_refcounts: FxHashMap::default(),
         }
     }
@@ -808,70 +808,60 @@ impl SglangKvManager {
             pages.len()
         );
 
-        let first_block_start = first_new_token / block_size * block_size;
-        let Some(first_unpublished_block) = (first_block_start..complete_len)
-            .step_by(block_size)
-            .find(|&block_start| {
-                let page = pages[block_start / block_size];
-                !self.page_to_block_hash.contains_key(&page)
-            })
+        let first_page = first_new_token / block_size;
+        let Some(first_unpublished_page) = (first_page..complete_pages)
+            .find(|&page_idx| self.page_to_block_hash[pages[page_idx].index()].is_none())
         else {
             return 0;
         };
 
-        let mut computed_blocks = Vec::new();
-        let first_unpublished_page = first_unpublished_block / block_size;
         let local_hashes = &page_hashes[first_unpublished_page..complete_pages];
+        self.block_hash_refcounts.reserve(local_hashes.len());
+        let mut parent_hash = None;
+        let mut blocks = Vec::new();
+        let mut publishing = false;
 
         for (block_idx, tokens_hash) in local_hashes.iter().copied().enumerate() {
-            let block_start = first_unpublished_block + block_idx * block_size;
-            let page_idx = block_start / block_size;
+            let page_idx = first_unpublished_page + block_idx;
             let page = pages[page_idx];
-            if self.page_to_block_hash.contains_key(&page) {
+            let page_slot = page.index();
+            if self.page_to_block_hash[page_slot].is_some() {
                 continue;
             }
 
-            let parent_hash = if block_start == 0 {
+            let block_parent_hash = if page_idx == 0 {
                 None
             } else {
-                self.page_to_block_hash.get(&pages[page_idx - 1]).copied()
+                self.page_to_block_hash[pages[page_idx - 1].index()]
             };
-            let block_hash = match parent_hash {
+            let block_hash = match block_parent_hash {
                 Some(parent_hash) => {
                     ExternalSequenceBlockHash(compute_next_seq_hash(parent_hash.0, tokens_hash))
                 }
                 None => ExternalSequenceBlockHash(tokens_hash.0),
             };
 
-            self.page_to_block_hash.insert(page, block_hash);
+            self.page_to_block_hash[page_slot] = Some(block_hash);
             let refcount = self.block_hash_refcounts.entry(block_hash).or_default();
             *refcount += 1;
-            computed_blocks.push((
-                parent_hash,
-                KvCacheStoredBlockData {
+            if *refcount == 1 && !publishing {
+                publishing = true;
+                parent_hash = block_parent_hash;
+                blocks.reserve_exact(local_hashes.len() - block_idx);
+            }
+            if publishing {
+                blocks.push(KvCacheStoredBlockData {
                     block_hash,
                     tokens_hash,
                     mm_extra_info: None,
-                },
-                *refcount,
-            ));
+                });
+            }
         }
 
         let hashed_blocks = local_hashes.len();
-
-        let first_new = computed_blocks
-            .iter()
-            .position(|(_, _, refcount)| *refcount == 1);
-        let Some(first_new) = first_new else {
+        if blocks.is_empty() {
             return hashed_blocks;
-        };
-
-        let parent_hash = computed_blocks[first_new].0;
-        let blocks = computed_blocks
-            .into_iter()
-            .skip(first_new)
-            .map(|(_, block, _)| block)
-            .collect();
+        }
 
         let event = KvCacheEvent {
             event_id: self.next_event_id,
@@ -897,19 +887,21 @@ impl SglangKvManager {
         }
 
         let mut block_hashes = Vec::new();
+        block_hashes.reserve_exact(evicted_pages.len());
         for &page in evicted_pages {
-            let Some(block_hash) = self.page_to_block_hash.remove(&page) else {
+            let Some(block_hash) = self.page_to_block_hash[page.index()].take() else {
                 continue;
             };
-            let Some(refcount) = self.block_hash_refcounts.get_mut(&block_hash) else {
-                continue;
-            };
-            if *refcount > 1 {
-                *refcount -= 1;
-                continue;
+            if let std::collections::hash_map::Entry::Occupied(mut entry) =
+                self.block_hash_refcounts.entry(block_hash)
+            {
+                if *entry.get() > 1 {
+                    *entry.get_mut() -= 1;
+                } else {
+                    entry.remove();
+                    block_hashes.push(block_hash);
+                }
             }
-            self.block_hash_refcounts.remove(&block_hash);
-            block_hashes.push(block_hash);
         }
 
         if block_hashes.is_empty() {
@@ -1341,6 +1333,40 @@ mod tests {
         assert_eq!(
             store.blocks[0].block_hash,
             ExternalSequenceBlockHash(expected_sequence[0])
+        );
+    }
+
+    #[test]
+    fn reused_physical_page_replaces_dense_event_metadata() {
+        let sink = Arc::new(MockSink::new());
+        let mut mgr =
+            SglangKvManager::new(1, 1, KvEventPublishers::new(Some(sink.clone()), None), 0);
+
+        let first = mgr.allocate_for_request(&[1]).unwrap();
+        let page = first.lease.pages()[0];
+        assert!(mgr.abort(first.lease));
+
+        let second = mgr.allocate_for_request(&[2]).unwrap();
+        assert_eq!(second.lease.pages(), &[page]);
+
+        let events = sink.clone_events();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].event_id, 0);
+        assert_eq!(events[1].event_id, 1);
+        assert_eq!(events[2].event_id, 2);
+        let KvCacheEventData::Stored(first_store) = &events[0].data else {
+            panic!("expected first stored event");
+        };
+        let KvCacheEventData::Removed(remove) = &events[1].data else {
+            panic!("expected removal before page reuse");
+        };
+        let KvCacheEventData::Stored(second_store) = &events[2].data else {
+            panic!("expected replacement stored event");
+        };
+        assert_eq!(remove.block_hashes, vec![first_store.blocks[0].block_hash]);
+        assert_ne!(
+            first_store.blocks[0].block_hash,
+            second_store.blocks[0].block_hash
         );
     }
 

--- a/lib/mocker/src/kv_manager/sglang_backend.rs
+++ b/lib/mocker/src/kv_manager/sglang_backend.rs
@@ -179,14 +179,24 @@ impl SglangKvManager {
         kv_event_publishers: KvEventPublishers,
         dp_rank: u32,
     ) -> Self {
+        let page_to_block_hash = if kv_event_publishers.is_empty() {
+            Vec::new()
+        } else {
+            vec![None; total_tokens / page_size]
+        };
         Self {
             cache: RadixCache::new(total_tokens, page_size),
             kv_event_publishers,
             dp_rank,
             next_event_id: 0,
-            page_to_block_hash: vec![None; total_tokens / page_size],
+            page_to_block_hash,
             block_hash_refcounts: FxHashMap::default(),
         }
+    }
+
+    #[cfg(test)]
+    fn page_metadata_len(&self) -> usize {
+        self.page_to_block_hash.len()
     }
 
     pub fn cache(&self) -> &RadixCache {
@@ -794,6 +804,10 @@ impl SglangKvManager {
         if self.kv_event_publishers.is_empty() {
             return 0;
         }
+        if self.page_to_block_hash.is_empty() {
+            self.page_to_block_hash
+                .resize(self.cache.total_tokens() / self.cache.page_size(), None);
+        }
 
         let block_size = self.cache.page_size();
         let complete_len =
@@ -816,7 +830,6 @@ impl SglangKvManager {
         };
 
         let local_hashes = &page_hashes[first_unpublished_page..complete_pages];
-        self.block_hash_refcounts.reserve(local_hashes.len());
         let mut parent_hash = None;
         let mut blocks = Vec::new();
         let mut publishing = false;
@@ -847,7 +860,6 @@ impl SglangKvManager {
             if *refcount == 1 && !publishing {
                 publishing = true;
                 parent_hash = block_parent_hash;
-                blocks.reserve_exact(local_hashes.len() - block_idx);
             }
             if publishing {
                 blocks.push(KvCacheStoredBlockData {
@@ -887,8 +899,7 @@ impl SglangKvManager {
         }
 
         let mut block_hashes = Vec::new();
-        block_hashes.reserve_exact(evicted_pages.len());
-        for &page in evicted_pages {
+        for (page_idx, &page) in evicted_pages.iter().enumerate() {
             let Some(block_hash) = self.page_to_block_hash[page.index()].take() else {
                 continue;
             };
@@ -899,6 +910,9 @@ impl SglangKvManager {
                     *entry.get_mut() -= 1;
                 } else {
                     entry.remove();
+                    if block_hashes.is_empty() {
+                        block_hashes.reserve_exact(evicted_pages.len() - page_idx);
+                    }
                     block_hashes.push(block_hash);
                 }
             }
@@ -990,6 +1004,16 @@ mod tests {
                 _ => None,
             })
             .sum()
+    }
+
+    #[test]
+    fn dense_page_metadata_is_allocated_only_for_kv_events() {
+        let disabled = SglangKvManager::new(64, 4, KvEventPublishers::default(), 0);
+        assert_eq!(disabled.page_metadata_len(), 0);
+
+        let (_buffer, sink) = capture_router_event_sink(ROUTER_TEST_WORKER_ID);
+        let enabled = SglangKvManager::new(64, 4, KvEventPublishers::new(Some(sink), None), 0);
+        assert_eq!(enabled.page_metadata_len(), 16);
     }
 
     #[test]

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -1127,34 +1127,17 @@ impl TraceCollector {
         }
     }
 
-    /// Move the tokens emitted by one scheduler pass to a shared completion
-    /// boundary. Scheduler cores record their rank-local end time while the
-    /// pass is formed; attention-DP replay then aligns every rank in the group
-    /// to the slowest rank before the pass becomes externally visible.
-    pub(crate) fn align_pass_token_times(
+    /// Record tokens emitted by one scheduler pass at its externally visible
+    /// completion boundary.
+    pub(crate) fn on_output_signals(
         &mut self,
         output_signals: &[OutputSignal],
         completion_time_ms: f64,
     ) {
-        let mut emitted_by_request = FxHashMap::default();
         for signal in output_signals {
             if signal.token_id.is_some() {
-                *emitted_by_request.entry(signal.uuid).or_insert(0usize) += 1;
+                self.on_token(signal.uuid, completion_time_ms);
             }
-        }
-
-        for (uuid, emitted) in emitted_by_request {
-            let Some(stats) = self.requests.get_mut(&uuid) else {
-                continue;
-            };
-            let TokenTimeline::Recording(times) = &mut stats.token_timeline else {
-                continue;
-            };
-            let start = times
-                .len()
-                .checked_sub(emitted)
-                .expect("scheduler emitted more output signals than collector tokens");
-            times[start..].fill(completion_time_ms);
         }
     }
 

--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -9,6 +9,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use uuid::Uuid;
 
 use crate::common::protocols::OutputSignal;
+use crate::scheduler::EnginePassResult;
 
 // 0.1% relative quantile error. The enlarged store covers latency/rate values
 // spanning roughly 10^28 within one sign while remaining bounded (~512 KiB for
@@ -897,6 +898,7 @@ impl TraceCollector {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn on_prefill_admit(
         &mut self,
         uuid: Uuid,
@@ -904,6 +906,15 @@ impl TraceCollector {
         reused_input_tokens: usize,
     ) {
         self.on_admit(uuid, admit_time_ms, reused_input_tokens);
+        self.on_prefill_pool_admit(uuid, admit_time_ms, reused_input_tokens);
+    }
+
+    pub(crate) fn on_prefill_pool_admit(
+        &mut self,
+        uuid: Uuid,
+        admit_time_ms: f64,
+        reused_input_tokens: usize,
+    ) {
         self.on_pool_admission(
             uuid,
             ReplayRequestPool::Prefill,
@@ -921,6 +932,7 @@ impl TraceCollector {
         }
     }
 
+    #[cfg(test)]
     pub(crate) fn on_decode_admit(
         &mut self,
         uuid: Uuid,
@@ -928,6 +940,15 @@ impl TraceCollector {
         reused_input_tokens: usize,
     ) {
         self.on_admit(uuid, admit_time_ms, reused_input_tokens);
+        self.on_decode_pool_admit(uuid, admit_time_ms, reused_input_tokens);
+    }
+
+    pub(crate) fn on_decode_pool_admit(
+        &mut self,
+        uuid: Uuid,
+        admit_time_ms: f64,
+        reused_input_tokens: usize,
+    ) {
         self.on_pool_admission(
             uuid,
             ReplayRequestPool::Decode,
@@ -1127,17 +1148,69 @@ impl TraceCollector {
         }
     }
 
+    /// Record the generic collector effects of one scheduler pass. A hidden
+    /// pass supplies no token boundary but still records admissions at its
+    /// epoch start; topology-specific pool state remains with the caller.
+    #[inline]
+    pub(crate) fn on_scheduler_pass(
+        &mut self,
+        pass: &EnginePassResult,
+        admit_time_ms: f64,
+        token_completion_ms: Option<f64>,
+    ) {
+        for admission in &pass.admissions {
+            self.on_admit(admission.uuid, admit_time_ms, admission.reused_input_tokens);
+        }
+        if let Some(token_completion_ms) = token_completion_ms {
+            self.on_output_signals(
+                &pass.output_signals,
+                token_completion_ms,
+                pass.accept_length_output_tokens > pass.accept_length_decode_forwards,
+            );
+        }
+    }
+
     /// Record tokens emitted by one scheduler pass at its externally visible
     /// completion boundary.
     pub(crate) fn on_output_signals(
         &mut self,
         output_signals: &[OutputSignal],
         completion_time_ms: f64,
+        has_bursts: bool,
     ) {
-        for signal in output_signals {
-            if signal.token_id.is_some() {
-                self.on_token(signal.uuid, completion_time_ms);
+        if !has_bursts {
+            for signal in output_signals {
+                if !signal.rejected && signal.token_id.is_some() {
+                    self.on_token(signal.uuid, completion_time_ms);
+                }
             }
+            return;
+        }
+
+        let mut signal_idx = 0;
+        while signal_idx < output_signals.len() {
+            let uuid = output_signals[signal_idx].uuid;
+            let mut run_end = signal_idx;
+            let mut emitted_tokens = 0;
+            while run_end < output_signals.len() && output_signals[run_end].uuid == uuid {
+                let signal = &output_signals[run_end];
+                emitted_tokens += usize::from(!signal.rejected && signal.token_id.is_some());
+                run_end += 1;
+            }
+            if emitted_tokens == 0 {
+                signal_idx = run_end;
+                continue;
+            }
+            if let Some(stats) = self.requests.get_mut(&uuid)
+                && let TokenTimeline::Recording(times) = &mut stats.token_timeline
+            {
+                if emitted_tokens == 1 {
+                    times.push(completion_time_ms);
+                } else {
+                    times.resize(times.len() + emitted_tokens, completion_time_ms);
+                }
+            }
+            signal_idx = run_end;
         }
     }
 
@@ -1664,6 +1737,75 @@ mod tests {
         assert!((report.throughput.gpu_hours - 0.1 / 3600.0).abs() < 1e-12);
         assert_eq!(report.latency.ttft.mean_ms, 0.0);
         assert_eq!(report.latency.e2e.mean_ms, 0.0);
+    }
+
+    #[test]
+    fn scheduler_output_runs_exclude_rejected_tokens_and_share_the_boundary() {
+        let mut collector = TraceCollector::default();
+        let first = Uuid::from_u128(1);
+        let second = Uuid::from_u128(2);
+        collector.on_arrival(first, 0.0, 4, 3);
+        collector.on_arrival(second, 0.0, 4, 1);
+        let pass = EnginePassResult {
+            end_ms: 42.0,
+            token_completion_ms: 42.0,
+            completed_requests: 2,
+            admissions: vec![
+                crate::scheduler::AdmissionEvent {
+                    uuid: first,
+                    reused_input_tokens: 2,
+                },
+                crate::scheduler::AdmissionEvent {
+                    uuid: second,
+                    reused_input_tokens: 1,
+                },
+            ],
+            output_signals: vec![
+                OutputSignal {
+                    uuid: first,
+                    token_id: Some(10),
+                    completed: false,
+                    rejected: false,
+                    handoff_delay_ms: None,
+                },
+                OutputSignal {
+                    uuid: first,
+                    token_id: Some(11),
+                    completed: false,
+                    rejected: false,
+                    handoff_delay_ms: None,
+                },
+                OutputSignal {
+                    uuid: first,
+                    token_id: Some(12),
+                    completed: true,
+                    rejected: true,
+                    handoff_delay_ms: None,
+                },
+                OutputSignal {
+                    uuid: second,
+                    token_id: Some(20),
+                    completed: true,
+                    rejected: false,
+                    handoff_delay_ms: None,
+                },
+            ],
+            lifecycle_events: Vec::new(),
+            mocker_metrics: crate::scheduler::vllm::MockerMetrics::default(),
+            router_event_visibility: crate::scheduler::RouterEventVisibility::PassEnd,
+            kv_events: Vec::new(),
+            fpm: None,
+            accept_length_output_tokens: 3,
+            accept_length_decode_forwards: 2,
+        };
+        collector.on_scheduler_pass(&pass, 5.0, Some(42.0));
+
+        let first_times = &collector.requests[&first].token_timeline;
+        let second_times = &collector.requests[&second].token_timeline;
+        assert_eq!(collector.requests[&first].first_admit_ms, Some(5.0));
+        assert_eq!(collector.requests[&second].first_admit_ms, Some(5.0));
+        assert!(matches!(first_times, TokenTimeline::Recording(times) if times == &[42.0, 42.0]));
+        assert!(matches!(second_times, TokenTimeline::Recording(times) if times == &[42.0]));
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -754,9 +754,7 @@ where
     fn drive_ready_workers(&mut self) -> anyhow::Result<bool> {
         let mut changed = false;
         loop {
-            let effects = self
-                .engine
-                .drive_ready(self.now_ms, Some(&mut self.collector))?;
+            let effects = self.engine.drive_ready(self.now_ms, &mut self.collector)?;
             attach_pressure_references(&mut self.collector);
             if effects.is_empty() {
                 return Ok(changed);

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -771,6 +771,8 @@ where
         mut effects: EngineEffects<Observation::Batch>,
     ) -> anyhow::Result<()> {
         for admission in effects.admissions.drain(..) {
+            self.collector
+                .on_admit(admission.uuid, self.now_ms, admission.reused_input_tokens);
             self.collector.on_pool_admission(
                 admission.uuid,
                 ReplayRequestPool::Agg,

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -771,8 +771,6 @@ where
         mut effects: EngineEffects<Observation::Batch>,
     ) -> anyhow::Result<()> {
         for admission in effects.admissions.drain(..) {
-            self.collector
-                .on_admit(admission.uuid, self.now_ms, admission.reused_input_tokens);
             self.collector.on_pool_admission(
                 admission.uuid,
                 ReplayRequestPool::Agg,

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -601,14 +601,14 @@ where
         rank_id: usize,
         boundary: PassBoundary,
         mut executed: EnginePassResult,
-        align_collector: Option<&mut TraceCollector>,
+        collector: Option<&mut TraceCollector>,
         effects: &mut EngineEffects<Observation::Batch>,
     ) {
         if let Some(fpm) = executed.fpm.as_mut() {
             fpm.wall_time_secs = boundary.wall_time_secs();
         }
-        if let Some(collector) = align_collector {
-            collector.align_pass_token_times(&executed.output_signals, boundary.end_ms);
+        if let Some(collector) = collector {
+            collector.on_output_signals(&executed.output_signals, boundary.end_ms);
         }
 
         let admitted_requests = !executed.admissions.is_empty();
@@ -720,11 +720,11 @@ where
                     dp_rank,
                     || match self.pass_mode {
                         EnginePassMode::Visible => {
-                            let Some(collector) = collector.as_deref_mut() else {
+                            let Some(_) = collector.as_deref_mut() else {
                                 bail!("offline replay visible engine pass requires a collector");
                             };
                             Self::required_worker_mut(&mut self.workers, rank_id)
-                                .try_execute_pass(collector, now_ms)
+                                .try_execute_pass(now_ms)
                         }
                         EnginePassMode::Hidden => {
                             Self::required_worker_mut(&mut self.workers, rank_id)
@@ -733,7 +733,7 @@ where
                     },
                 )?;
                 let group_end_ms = executed.end_ms.max(now_ms);
-                let align_collector = if self.pass_mode == EnginePassMode::Visible {
+                let pass_collector = if self.pass_mode == EnginePassMode::Visible {
                     Some(
                         collector
                             .as_deref_mut()
@@ -752,7 +752,7 @@ where
                         completion_capacity: 1,
                     },
                     executed,
-                    align_collector,
+                    pass_collector,
                     &mut effects,
                 );
                 group_end_ms
@@ -774,13 +774,13 @@ where
                         dp_rank,
                         || match self.pass_mode {
                             EnginePassMode::Visible => {
-                                let Some(collector) = collector.as_deref_mut() else {
+                                let Some(_) = collector.as_deref_mut() else {
                                     bail!(
                                         "offline replay visible engine pass requires a collector"
                                     );
                                 };
                                 Self::required_worker_mut(&mut self.workers, rank_id)
-                                    .try_execute_pass(collector, now_ms)
+                                    .try_execute_pass(now_ms)
                             }
                             EnginePassMode::Hidden => {
                                 Self::required_worker_mut(&mut self.workers, rank_id)
@@ -831,7 +831,7 @@ where
                         continue;
                     };
 
-                    let align_collector = if self.pass_mode == EnginePassMode::Visible {
+                    let pass_collector = if self.pass_mode == EnginePassMode::Visible {
                         Some(
                             collector
                                 .as_deref_mut()
@@ -846,7 +846,7 @@ where
                         rank_id,
                         boundary,
                         executed,
-                        align_collector,
+                        pass_collector,
                         &mut effects,
                     );
                 }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -45,6 +45,7 @@ struct PassBoundary {
     start_ms: f64,
     end_ms: f64,
     completion_capacity: usize,
+    tokens_visible: bool,
 }
 
 impl PassBoundary {
@@ -608,7 +609,11 @@ where
             fpm.wall_time_secs = boundary.wall_time_secs();
         }
         if let Some(collector) = collector {
-            collector.on_output_signals(&executed.output_signals, boundary.end_ms);
+            collector.on_scheduler_pass(
+                &executed,
+                boundary.start_ms,
+                boundary.tokens_visible.then_some(boundary.end_ms),
+            );
         }
 
         let admitted_requests = !executed.admissions.is_empty();
@@ -675,6 +680,9 @@ where
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects<Observation::Batch>> {
+        if self.pass_mode == EnginePassMode::Visible && collector.is_none() {
+            bail!("offline replay visible engine pass requires a collector");
+        }
         // The serial coordinator may make another component observable at the
         // same virtual timestamp. Match the former full scan by retrying
         // effect-free groups on the next coordinator drive, but not again
@@ -718,30 +726,12 @@ where
                     evidence_pool(self.stage),
                     worker_id,
                     dp_rank,
-                    || match self.pass_mode {
-                        EnginePassMode::Visible => {
-                            let Some(_) = collector.as_deref_mut() else {
-                                bail!("offline replay visible engine pass requires a collector");
-                            };
-                            Self::required_worker_mut(&mut self.workers, rank_id)
-                                .try_execute_pass(now_ms)
-                        }
-                        EnginePassMode::Hidden => {
-                            Self::required_worker_mut(&mut self.workers, rank_id)
-                                .try_execute_hidden_pass(now_ms)
-                        }
+                    || {
+                        Self::required_worker_mut(&mut self.workers, rank_id)
+                            .try_execute_pass(now_ms)
                     },
                 )?;
                 let group_end_ms = executed.end_ms.max(now_ms);
-                let pass_collector = if self.pass_mode == EnginePassMode::Visible {
-                    Some(
-                        collector
-                            .as_deref_mut()
-                            .expect("visible pass collector checked before execution"),
-                    )
-                } else {
-                    None
-                };
                 Self::lower_executed_pass(
                     &mut self.workers,
                     self.stage,
@@ -750,9 +740,10 @@ where
                         start_ms: now_ms,
                         end_ms: group_end_ms,
                         completion_capacity: 1,
+                        tokens_visible: self.pass_mode == EnginePassMode::Visible,
                     },
                     executed,
-                    pass_collector,
+                    collector.as_deref_mut(),
                     &mut effects,
                 );
                 group_end_ms
@@ -772,20 +763,9 @@ where
                         evidence_pool(self.stage),
                         worker_id,
                         dp_rank,
-                        || match self.pass_mode {
-                            EnginePassMode::Visible => {
-                                let Some(_) = collector.as_deref_mut() else {
-                                    bail!(
-                                        "offline replay visible engine pass requires a collector"
-                                    );
-                                };
-                                Self::required_worker_mut(&mut self.workers, rank_id)
-                                    .try_execute_pass(now_ms)
-                            }
-                            EnginePassMode::Hidden => {
-                                Self::required_worker_mut(&mut self.workers, rank_id)
-                                    .try_execute_hidden_pass(now_ms)
-                            }
+                        || {
+                            Self::required_worker_mut(&mut self.workers, rank_id)
+                                .try_execute_pass(now_ms)
                         },
                     )?;
                     executed_by_rank.push(Some(executed));
@@ -800,6 +780,7 @@ where
                     start_ms: now_ms,
                     end_ms: group_end_ms,
                     completion_capacity,
+                    tokens_visible: self.pass_mode == EnginePassMode::Visible,
                 };
 
                 for (&rank_id, executed) in rank_ids.iter().zip(executed_by_rank) {
@@ -831,22 +812,13 @@ where
                         continue;
                     };
 
-                    let pass_collector = if self.pass_mode == EnginePassMode::Visible {
-                        Some(
-                            collector
-                                .as_deref_mut()
-                                .expect("visible pass collector checked before execution"),
-                        )
-                    } else {
-                        None
-                    };
                     Self::lower_executed_pass(
                         &mut self.workers,
                         self.stage,
                         rank_id,
                         boundary,
                         executed,
-                        pass_collector,
+                        collector.as_deref_mut(),
                         &mut effects,
                     );
                 }

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -602,19 +602,17 @@ where
         rank_id: usize,
         boundary: PassBoundary,
         mut executed: EnginePassResult,
-        collector: Option<&mut TraceCollector>,
+        collector: &mut TraceCollector,
         effects: &mut EngineEffects<Observation::Batch>,
     ) {
         if let Some(fpm) = executed.fpm.as_mut() {
             fpm.wall_time_secs = boundary.wall_time_secs();
         }
-        if let Some(collector) = collector {
-            collector.on_scheduler_pass(
-                &executed,
-                boundary.start_ms,
-                boundary.tokens_visible.then_some(boundary.end_ms),
-            );
-        }
+        collector.on_scheduler_pass(
+            &executed,
+            boundary.start_ms,
+            boundary.tokens_visible.then_some(boundary.end_ms),
+        );
 
         let admitted_requests = !executed.admissions.is_empty();
         let had_raw_observations = !executed.kv_events.is_empty();
@@ -678,11 +676,8 @@ where
     pub(in crate::replay::offline) fn drive_ready(
         &mut self,
         now_ms: f64,
-        mut collector: Option<&mut TraceCollector>,
+        collector: &mut TraceCollector,
     ) -> anyhow::Result<EngineEffects<Observation::Batch>> {
-        if self.pass_mode == EnginePassMode::Visible && collector.is_none() {
-            bail!("offline replay visible engine pass requires a collector");
-        }
         // The serial coordinator may make another component observable at the
         // same virtual timestamp. Match the former full scan by retrying
         // effect-free groups on the next coordinator drive, but not again
@@ -743,7 +738,7 @@ where
                         tokens_visible: self.pass_mode == EnginePassMode::Visible,
                     },
                     executed,
-                    collector.as_deref_mut(),
+                    collector,
                     &mut effects,
                 );
                 group_end_ms
@@ -818,7 +813,7 @@ where
                         rank_id,
                         boundary,
                         executed,
-                        collector.as_deref_mut(),
+                        collector,
                         &mut effects,
                     );
                 }
@@ -1070,7 +1065,7 @@ mod tests {
         collector.on_arrival(fast, 0.0, 4, 1);
         collector.on_arrival(slow, 0.0, 8, 1);
 
-        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let effects = engine.drive_ready(0.0, &mut collector).unwrap();
 
         let scheduled = effects.scheduled_completion.as_ref().unwrap();
         assert_eq!(scheduled.payloads.len(), 2);
@@ -1101,7 +1096,7 @@ mod tests {
         let mut collector = TraceCollector::default();
         collector.on_arrival(slow, 0.0, 8, 1);
 
-        let mut first_epoch = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let mut first_epoch = engine.drive_ready(0.0, &mut collector).unwrap();
         let first_scheduled = first_epoch.scheduled_completion.as_ref().unwrap();
         assert_eq!(first_scheduled.payloads.len(), 2);
         assert!(engine.debug_snapshots().iter().all(|rank| rank.busy));
@@ -1121,17 +1116,12 @@ mod tests {
         let mid_epoch = Uuid::from_u128(41);
         collector.on_arrival(mid_epoch, 4.0, 4, 1);
         engine.dispatch(1, timed_request(mid_epoch, 4)).unwrap();
-        assert!(
-            engine
-                .drive_ready(4.0, Some(&mut collector))
-                .unwrap()
-                .is_empty()
-        );
+        assert!(engine.drive_ready(4.0, &mut collector).unwrap().is_empty());
 
         for payload in first_epoch.scheduled_completion.take().unwrap().payloads {
             engine.on_scheduled_completion(payload).unwrap();
         }
-        let second_epoch = engine.drive_ready(9.0, Some(&mut collector)).unwrap();
+        let second_epoch = engine.drive_ready(9.0, &mut collector).unwrap();
         let second_scheduled = second_epoch.scheduled_completion.as_ref().unwrap();
         assert_eq!(second_scheduled.payloads.len(), 2);
         assert!((second_scheduled.at_ms - 14.0).abs() < f64::EPSILON);
@@ -1150,7 +1140,7 @@ mod tests {
 
             let mut now_ms = 0.0;
             while engine.in_flight() > 0 {
-                let effects = engine.drive_ready(now_ms, Some(&mut collector)).unwrap();
+                let effects = engine.drive_ready(now_ms, &mut collector).unwrap();
                 assert!(effects.immediate_completions.is_empty());
                 let scheduled = effects.scheduled_completion.unwrap();
                 assert_eq!(scheduled.payloads.len(), dp_size as usize);
@@ -1211,7 +1201,7 @@ mod tests {
         engine.dispatch(0, timed_request(completed, 4)).unwrap();
         assert_eq!(engine.in_flight(), 1);
         let effects = engine
-            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .drive_ready(0.0, &mut TraceCollector::default())
             .unwrap();
         let completion = take_only_completion(effects);
         assert_eq!(engine.in_flight(), 1);
@@ -1242,14 +1232,14 @@ mod tests {
             .unwrap();
 
         let first = engine
-            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .drive_ready(0.0, &mut TraceCollector::default())
             .unwrap();
         let first = take_only_completion(first);
         assert_eq!(first.worker_idx, 0);
         assert_eq!(engine.ready_groups, BTreeSet::from([1]));
 
         let second = engine
-            .drive_ready(0.0, Some(&mut TraceCollector::default()))
+            .drive_ready(0.0, &mut TraceCollector::default())
             .unwrap();
         let second = take_only_completion(second);
         assert_eq!(second.worker_idx, 1);
@@ -1294,7 +1284,7 @@ mod tests {
         ] {
             let mut engine = make_engine(engine_type);
             engine.dispatch(0, request(uuid)).unwrap();
-            let pass_start = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+            let pass_start = engine.drive_ready(0.0, &mut collector).unwrap();
             assert!(
                 pass_start.pass_start_events.0.is_empty(),
                 "{engine_type:?} exposed KV events before pass completion"
@@ -1400,7 +1390,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let effects = engine.drive_ready(0.0, &mut collector).unwrap();
         assert_eq!(
             effects
                 .scheduled_completion
@@ -1458,13 +1448,13 @@ mod tests {
             .unwrap();
         let mut collector = TraceCollector::default();
 
-        let first = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let first = engine.drive_ready(0.0, &mut collector).unwrap();
         assert_eq!(first.admissions.len(), 1);
         let first = take_only_completion(first);
         assert_eq!(first.completed_requests, 0);
         engine.on_scheduled_completion(first).unwrap();
 
-        let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let second = engine.drive_ready(0.0, &mut collector).unwrap();
         assert!(second.admissions.is_empty());
         assert_eq!(second.immediate_completions.len(), 1);
         assert!(second.scheduled_completion.is_none());
@@ -1476,7 +1466,7 @@ mod tests {
         assert_eq!(engine.ready_groups, BTreeSet::from([0]));
         engine.on_scheduled_completion(second).unwrap();
 
-        let final_pass = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let final_pass = engine.drive_ready(0.0, &mut collector).unwrap();
         let final_pass = take_only_completion(final_pass);
         assert_eq!(final_pass.completed_requests, 1);
         assert!(
@@ -1505,7 +1495,7 @@ mod tests {
             .unwrap();
         let mut collector = TraceCollector::default();
 
-        let first = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let first = engine.drive_ready(0.0, &mut collector).unwrap();
         assert!(first.is_empty());
         assert!(engine.ready_groups.is_empty());
         assert_eq!(engine.deferred_ready_groups, BTreeSet::from([0]));
@@ -1519,7 +1509,7 @@ mod tests {
             }]
         );
 
-        let retry = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let retry = engine.drive_ready(0.0, &mut collector).unwrap();
         assert!(retry.is_empty());
         assert_eq!(engine.deferred_ready_groups, BTreeSet::from([0]));
     }
@@ -1580,7 +1570,7 @@ mod tests {
             )
             .unwrap();
         let mut collector = TraceCollector::default();
-        let mut pass = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let mut pass = engine.drive_ready(0.0, &mut collector).unwrap();
         assert_eq!(
             pass.scheduled_completion.as_ref().unwrap().payloads.len(),
             1
@@ -1680,7 +1670,7 @@ mod tests {
             )
             .unwrap();
         let mut collector = TraceCollector::default();
-        let mut seed = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        let mut seed = engine.drive_ready(0.0, &mut collector).unwrap();
         assert!(
             seed.pass_start_events
                 .0

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -5,6 +5,10 @@ use crate::common::protocols::MockEngineArgs;
 use crate::replay::TraceCollector;
 use crate::scheduler::{EngineCore, EnginePassResult, SglangCore, VllmCore};
 
+fn record_pass(collector: &mut TraceCollector, pass: &EnginePassResult, now_ms: f64) {
+    collector.on_scheduler_pass(pass, now_ms, Some(pass.token_completion_ms));
+}
+
 pub(crate) struct ReplayWorkerCore {
     core: EngineCore,
 }
@@ -71,10 +75,50 @@ impl ReplayWorkerCore {
         now_ms: f64,
     ) -> anyhow::Result<EnginePassResult> {
         let pass = self.core.try_execute_pass(now_ms)?;
-        for admission in &pass.admissions {
-            collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
-        }
-        collector.on_output_signals(&pass.output_signals, pass.end_ms);
+        record_pass(collector, &pass, now_ms);
         Ok(pass)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
+    use crate::scheduler::vllm::MockerMetrics;
+    use crate::scheduler::{AdmissionEvent, RouterEventVisibility};
+    use uuid::Uuid;
+
+    #[test]
+    fn single_worker_records_rank_local_token_completion() {
+        let uuid = Uuid::from_u128(1);
+        let mut collector = TraceCollector::default();
+        collector.on_arrival(uuid, 0.0, 4, 1);
+        let pass = EnginePassResult {
+            end_ms: 20.0,
+            token_completion_ms: 5.0,
+            completed_requests: 1,
+            output_signals: vec![OutputSignal {
+                uuid,
+                token_id: Some(1),
+                completed: true,
+                rejected: false,
+                handoff_delay_ms: None,
+            }],
+            admissions: vec![AdmissionEvent {
+                uuid,
+                reused_input_tokens: 0,
+            }],
+            lifecycle_events: Vec::new(),
+            mocker_metrics: MockerMetrics::default(),
+            router_event_visibility: RouterEventVisibility::PassEnd,
+            kv_events: Vec::new(),
+            fpm: Some(ForwardPassSnapshot::default()),
+            accept_length_output_tokens: 1,
+            accept_length_decode_forwards: 1,
+        };
+
+        record_pass(&mut collector, &pass, 0.0);
+
+        assert_eq!(collector.request_latencies(uuid), Some((5.0, 0.0)));
     }
 }

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -70,6 +70,11 @@ impl ReplayWorkerCore {
         collector: &mut TraceCollector,
         now_ms: f64,
     ) -> anyhow::Result<EnginePassResult> {
-        self.core.try_execute_pass(collector, now_ms)
+        let pass = self.core.try_execute_pass(now_ms)?;
+        for admission in &pass.admissions {
+            collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
+        }
+        collector.on_output_signals(&pass.output_signals, pass.end_ms);
+        Ok(pass)
     }
 }

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -2043,7 +2043,9 @@ where
     fn drive_prefill_workers(&mut self) -> Result<bool> {
         let mut changed = false;
         loop {
-            let effects = self.prefill_engine.drive_ready(self.now_ms, None)?;
+            let effects = self
+                .prefill_engine
+                .drive_ready(self.now_ms, Some(&mut self.collector))?;
             attach_pressure_references(&mut self.collector);
             if effects.is_empty() {
                 return Ok(changed);
@@ -2090,7 +2092,7 @@ where
 
     fn record_prefill_admissions(&mut self, admissions: Vec<AdmissionEvent>) {
         for admission in admissions {
-            self.collector.on_prefill_admit(
+            self.collector.on_prefill_pool_admit(
                 admission.uuid,
                 self.now_ms,
                 admission.reused_input_tokens,
@@ -2100,7 +2102,7 @@ where
 
     fn record_decode_admissions(&mut self, admissions: Vec<AdmissionEvent>) -> Result<()> {
         for admission in admissions {
-            self.collector.on_decode_admit(
+            self.collector.on_decode_pool_admit(
                 admission.uuid,
                 self.now_ms,
                 admission.reused_input_tokens,

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -2045,7 +2045,7 @@ where
         loop {
             let effects = self
                 .prefill_engine
-                .drive_ready(self.now_ms, Some(&mut self.collector))?;
+                .drive_ready(self.now_ms, &mut self.collector)?;
             attach_pressure_references(&mut self.collector);
             if effects.is_empty() {
                 return Ok(changed);
@@ -2061,7 +2061,7 @@ where
         loop {
             let effects = self
                 .decode_engine
-                .drive_ready(self.now_ms, Some(&mut self.collector))?;
+                .drive_ready(self.now_ms, &mut self.collector)?;
             attach_pressure_references(&mut self.collector);
             if effects.is_empty() {
                 #[cfg(test)]

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -436,16 +436,9 @@ impl OfflineWorkerState {
     }
 
     #[cfg(test)]
-    pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
-        self.try_execute_hidden_pass(now_ms)
-            .expect("offline worker hidden scheduler pass failed")
-    }
-
-    pub(crate) fn try_execute_hidden_pass(
-        &mut self,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
-        self.core.try_execute_hidden_pass(now_ms)
+    pub(crate) fn execute_pass_unrecorded(&mut self, now_ms: f64) -> EnginePassResult {
+        self.try_execute_pass(now_ms)
+            .expect("offline worker scheduler pass failed")
     }
 
     #[cfg(feature = "kvbm-offload")]
@@ -577,7 +570,7 @@ mod tests {
             let mut now_ms = 0.0;
             let mut events = Vec::new();
             while !worker.core.is_empty() {
-                let pass = worker.execute_hidden_pass(now_ms);
+                let pass = worker.execute_pass_unrecorded(now_ms);
                 now_ms = pass.end_ms;
                 worker.mark_completed(pass.completed_requests);
                 events.extend(pass.kv_events);
@@ -706,7 +699,7 @@ mod tests {
             assert_eq!(prefill.in_flight(), 1);
             let mut now_ms = 0.0;
             while !prefill.core.is_empty() {
-                let pass = prefill.execute_hidden_pass(now_ms);
+                let pass = prefill.execute_pass_unrecorded(now_ms);
                 now_ms = pass.end_ms;
                 prefill.mark_completed(pass.completed_requests);
             }
@@ -839,7 +832,7 @@ mod tests {
             assert_eq!(completed_decode.in_flight(), 1);
             let mut now_ms = 0.0;
             while !completed_decode.core.is_empty() {
-                let pass = completed_decode.execute_hidden_pass(now_ms);
+                let pass = completed_decode.execute_pass_unrecorded(now_ms);
                 now_ms = pass.end_ms.max(now_ms + 1.0);
                 completed_decode.mark_completed(pass.completed_requests);
             }
@@ -880,7 +873,7 @@ mod tests {
                     .any(|event| matches!(event.event.data, KvCacheEventData::Stored(_)))
             );
 
-            let pass = decode.execute_hidden_pass(0.0);
+            let pass = decode.execute_pass_unrecorded(0.0);
             assert!(
                 pass.kv_events
                     .iter()

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -9,7 +9,6 @@ use crate::common::handoff::{
 use crate::common::protocols::DirectRequest;
 use crate::common::protocols::MockEngineArgs;
 use crate::loadgen::{ReplayRequestHashes, ReplayRequestPayload};
-use crate::replay::TraceCollector;
 use crate::scheduler::{
     EngineCore, EnginePassResult, SchedulerCommand, SchedulerCommandEffects,
     SchedulerCommandResult, SchedulerLifecycleEvent,
@@ -432,12 +431,8 @@ impl OfflineWorkerState {
             .expect("offline worker completed more requests than it owned");
     }
 
-    pub(crate) fn try_execute_pass(
-        &mut self,
-        collector: &mut TraceCollector,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
-        self.core.try_execute_pass(collector, now_ms)
+    pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
+        self.core.try_execute_pass(now_ms)
     }
 
     #[cfg(test)]

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -320,6 +320,14 @@ impl PendingLivePass {
     }
 
     pub(crate) fn suppress_request_outputs(&mut self, request_id: uuid::Uuid) {
+        let removed_output_tokens = self
+            .pass
+            .output_signals
+            .iter()
+            .filter(|signal| {
+                signal.uuid == request_id && !signal.rejected && signal.token_id.is_some()
+            })
+            .count();
         self.pass
             .output_signals
             .retain(|signal| signal.uuid != request_id);
@@ -329,10 +337,18 @@ impl PendingLivePass {
             .iter()
             .filter(|signal| signal.completed)
             .count();
-        let (output_tokens, decode_forwards) =
-            crate::scheduler::accept_length_sample(&self.pass.output_signals);
-        self.pass.accept_length_output_tokens = output_tokens;
-        self.pass.accept_length_decode_forwards = decode_forwards;
+        if removed_output_tokens > 0 {
+            self.pass.accept_length_output_tokens = self
+                .pass
+                .accept_length_output_tokens
+                .checked_sub(removed_output_tokens)
+                .expect("suppressed more output tokens than the pass recorded");
+            self.pass.accept_length_decode_forwards = self
+                .pass
+                .accept_length_decode_forwards
+                .checked_sub(1)
+                .expect("suppressed an unrecorded decode forward");
+        }
     }
 }
 

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -320,14 +320,6 @@ impl PendingLivePass {
     }
 
     pub(crate) fn suppress_request_outputs(&mut self, request_id: uuid::Uuid) {
-        let removed_output_tokens = self
-            .pass
-            .output_signals
-            .iter()
-            .filter(|signal| {
-                signal.uuid == request_id && !signal.rejected && signal.token_id.is_some()
-            })
-            .count();
         self.pass
             .output_signals
             .retain(|signal| signal.uuid != request_id);
@@ -337,18 +329,10 @@ impl PendingLivePass {
             .iter()
             .filter(|signal| signal.completed)
             .count();
-        if removed_output_tokens > 0 {
-            self.pass.accept_length_output_tokens = self
-                .pass
-                .accept_length_output_tokens
-                .checked_sub(removed_output_tokens)
-                .expect("suppressed more output tokens than the pass recorded");
-            self.pass.accept_length_decode_forwards = self
-                .pass
-                .accept_length_decode_forwards
-                .checked_sub(1)
-                .expect("suppressed an unrecorded decode forward");
-        }
+        let (output_tokens, decode_forwards) =
+            crate::scheduler::accept_length_sample(&self.pass.output_signals);
+        self.pass.accept_length_output_tokens = output_tokens;
+        self.pass.accept_length_decode_forwards = decode_forwards;
     }
 }
 

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -233,6 +233,7 @@ async fn midpass_cancellation_is_observed_without_controls_and_suppresses_pendin
     assert!(pending.pass.output_signals.is_empty());
     assert_eq!(pending.pass.completed_requests, 0);
     assert_eq!(pending.pass.accept_length_output_tokens, 0);
+    assert_eq!(pending.pass.accept_length_decode_forwards, 0);
 }
 
 #[tokio::test]
@@ -243,6 +244,7 @@ async fn explicit_discard_suppresses_pending_output_after_noop_cancellation() {
     assert!(pending.pass.output_signals.is_empty());
     assert_eq!(pending.pass.completed_requests, 0);
     assert_eq!(pending.pass.accept_length_output_tokens, 0);
+    assert_eq!(pending.pass.accept_length_decode_forwards, 0);
 }
 
 #[tokio::test]

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -120,6 +120,7 @@ fn pass() -> EnginePassResult {
     let request_id = Uuid::from_u128(1);
     EnginePassResult {
         end_ms: 1.0,
+        token_completion_ms: 1.0,
         completed_requests: 1,
         output_signals: vec![OutputSignal {
             uuid: request_id,
@@ -245,6 +246,48 @@ async fn explicit_discard_suppresses_pending_output_after_noop_cancellation() {
     assert_eq!(pending.pass.completed_requests, 0);
     assert_eq!(pending.pass.accept_length_output_tokens, 0);
     assert_eq!(pending.pass.accept_length_decode_forwards, 0);
+}
+
+#[test]
+fn output_suppression_repairs_stale_accept_length_counters() {
+    let mut pass = pass();
+    let surviving = Uuid::from_u128(2);
+    pass.output_signals.extend([
+        OutputSignal {
+            uuid: surviving,
+            token_id: Some(2),
+            completed: false,
+            rejected: false,
+            handoff_delay_ms: None,
+        },
+        OutputSignal {
+            uuid: surviving,
+            token_id: Some(3),
+            completed: true,
+            rejected: false,
+            handoff_delay_ms: None,
+        },
+        OutputSignal {
+            uuid: surviving,
+            token_id: Some(4),
+            completed: true,
+            rejected: true,
+            handoff_delay_ms: None,
+        },
+    ]);
+    pass.accept_length_output_tokens = 0;
+    pass.accept_length_decode_forwards = 0;
+    let mut pending = PendingLivePass {
+        pass,
+        kv_events: Vec::new(),
+        admissions_published: false,
+        pass_start_kv_published: false,
+    };
+
+    pending.suppress_request_outputs(Uuid::from_u128(1));
+
+    assert_eq!(pending.pass.accept_length_output_tokens, 2);
+    assert_eq!(pending.pass.accept_length_decode_forwards, 1);
 }
 
 #[tokio::test]

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -123,9 +123,9 @@ pub(crate) fn build_fpm_snapshot(
     }
 }
 
-/// Return (visible output tokens, request-forwards) for accept-length
-/// accounting. A signal with a token corresponds to one visible token; multiple
-/// token signals with the same UUID in a pass are an MTP/spec-decode burst.
+/// Recompute (visible output tokens, request-forwards) for debug/test
+/// validation. Release builds carry these counters directly from decode.
+#[cfg(any(test, debug_assertions))]
 pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, usize) {
     let visible_tokens = output_signals
         .iter()
@@ -142,6 +142,22 @@ pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, u
         .collect::<std::collections::HashSet<_>>()
         .len();
     (visible_tokens, request_forwards)
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AcceptLengthSample {
+    pub(crate) output_tokens: usize,
+    pub(crate) decode_forwards: usize,
+}
+
+impl AcceptLengthSample {
+    pub(crate) fn record_forward(&mut self, output_tokens: usize) {
+        if output_tokens == 0 {
+            return;
+        }
+        self.output_tokens += output_tokens;
+        self.decode_forwards += 1;
+    }
 }
 
 pub(crate) use sglang::SglangCore;
@@ -712,6 +728,17 @@ mod tests {
         ];
 
         assert_eq!(accept_length_sample(&signals), (2, 1));
+    }
+
+    #[test]
+    fn accept_length_counters_count_tokens_and_forwards() {
+        let mut sample = AcceptLengthSample::default();
+        sample.record_forward(3);
+        sample.record_forward(0);
+        sample.record_forward(1);
+
+        assert_eq!(sample.output_tokens, 4);
+        assert_eq!(sample.decode_forwards, 2);
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -192,6 +192,18 @@ pub(crate) struct EnginePassResult {
     pub(crate) accept_length_decode_forwards: usize,
 }
 
+#[cfg(test)]
+pub(crate) fn record_test_pass(
+    collector: &mut crate::replay::TraceCollector,
+    pass: &EnginePassResult,
+    start_ms: f64,
+) {
+    for admission in &pass.admissions {
+        collector.on_admit(admission.uuid, start_ms, admission.reused_input_tokens);
+    }
+    collector.on_output_signals(&pass.output_signals, pass.end_ms);
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RouterEventVisibility {
     /// Expose buffered KV events when the pass starts, before the modeled sleep.
@@ -302,14 +314,10 @@ impl EngineCore {
         }
     }
 
-    pub(crate) fn try_execute_pass(
-        &mut self,
-        collector: &mut crate::replay::TraceCollector,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
+    pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
         match self {
-            Self::Vllm(core) => core.try_execute_pass(collector, now_ms),
-            Self::Sglang(core) => core.try_execute_pass(collector, now_ms),
+            Self::Vllm(core) => core.try_execute_pass(now_ms),
+            Self::Sglang(core) => core.try_execute_pass(now_ms),
         }
     }
 

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use kv_event_sink::{CapturedRouterEventBuffer, capture_router_event_s
 pub(crate) use live_boundary::{
     LiveBoundaryCore, LivePassExecution, LiveSchedulerState, spawn_live_scheduler,
 };
+use rustc_hash::FxHashSet;
 pub(crate) use source_holds::{
     ActiveHandoffRequests, DestinationHolds, PendingDestinations, RemovedSource, SourceCompletion,
     SourceHolds,
@@ -123,9 +124,9 @@ pub(crate) fn build_fpm_snapshot(
     }
 }
 
-/// Recompute (visible output tokens, request-forwards) for debug/test
-/// validation. Release builds carry these counters directly from decode.
-#[cfg(any(test, debug_assertions))]
+/// Recompute (visible output tokens, request-forwards) for debug validation
+/// and the cold live-output suppression path. Ordinary pass execution carries
+/// these counters directly from decode.
 pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, usize) {
     let visible_tokens = output_signals
         .iter()
@@ -139,7 +140,7 @@ pub(crate) fn accept_length_sample(output_signals: &[OutputSignal]) -> (usize, u
         .iter()
         .filter(|signal| !signal.rejected && signal.token_id.is_some())
         .map(|signal| signal.uuid)
-        .collect::<std::collections::HashSet<_>>()
+        .collect::<FxHashSet<_>>()
         .len();
     (visible_tokens, request_forwards)
 }
@@ -174,6 +175,9 @@ pub(crate) struct AdmissionEvent {
 #[derive(Debug, Clone)]
 pub(crate) struct EnginePassResult {
     pub(crate) end_ms: f64,
+    /// Rank-local token completion boundary before non-model wakeups (such as
+    /// KVBM stall-advance) can extend `end_ms`.
+    pub(crate) token_completion_ms: f64,
     pub(crate) completed_requests: usize,
     pub(crate) output_signals: Vec<OutputSignal>,
     pub(crate) admissions: Vec<AdmissionEvent>,
@@ -190,18 +194,6 @@ pub(crate) struct EnginePassResult {
     pub(crate) accept_length_output_tokens: usize,
     /// Number of request decode forwards that emitted those visible tokens.
     pub(crate) accept_length_decode_forwards: usize,
-}
-
-#[cfg(test)]
-pub(crate) fn record_test_pass(
-    collector: &mut crate::replay::TraceCollector,
-    pass: &EnginePassResult,
-    start_ms: f64,
-) {
-    for admission in &pass.admissions {
-        collector.on_admit(admission.uuid, start_ms, admission.reused_input_tokens);
-    }
-    collector.on_output_signals(&pass.output_signals, pass.end_ms);
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -322,19 +314,9 @@ impl EngineCore {
     }
 
     #[cfg(test)]
-    pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
-        self.try_execute_hidden_pass(now_ms)
-            .expect("engine hidden scheduler pass failed")
-    }
-
-    pub(crate) fn try_execute_hidden_pass(
-        &mut self,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
-        match self {
-            Self::Vllm(core) => core.try_execute_hidden_pass(now_ms),
-            Self::Sglang(core) => core.try_execute_hidden_pass(now_ms),
-        }
+    pub(crate) fn execute_pass_unrecorded(&mut self, now_ms: f64) -> EnginePassResult {
+        self.try_execute_pass(now_ms)
+            .expect("engine scheduler pass failed")
     }
 
     #[cfg(feature = "kvbm-offload")]
@@ -668,7 +650,7 @@ mod tests {
             let mut running_request = request(running_id, (100..108).collect());
             running_request.max_output_tokens = 32;
             core.receive(running_request);
-            core.execute_hidden_pass(0.0);
+            core.execute_pass_unrecorded(0.0);
             assert_eq!(request_metrics(&core).running_requests, 1);
             let active_blocks_before_cancel = request_metrics(&core).active_decode_blocks;
             assert!(
@@ -823,7 +805,7 @@ mod tests {
                 .unwrap();
             let mut now_ms = 0.0;
             for _ in 0..8 {
-                let pass = source.execute_hidden_pass(now_ms);
+                let pass = source.execute_pass_unrecorded(now_ms);
                 now_ms = pass.end_ms;
                 if source.is_empty() {
                     break;
@@ -977,13 +959,13 @@ mod tests {
             assert!(blocked.lifecycle_events.is_empty());
             assert!(destination.is_empty());
             assert!(!destination.is_drained());
-            let pending_only = destination.execute_hidden_pass(0.0);
+            let pending_only = destination.execute_pass_unrecorded(0.0);
             assert_eq!(pending_only.end_ms, 0.0);
             assert!(pending_only.admissions.is_empty());
             assert!(pending_only.output_signals.is_empty());
 
             destination.receive(request(fresh_request, (300..304).collect()));
-            let pass = destination.execute_hidden_pass(0.0);
+            let pass = destination.execute_pass_unrecorded(0.0);
             assert!(pass.admissions.is_empty());
             assert!(pass.output_signals.is_empty());
             assert_eq!(pass.end_ms, 0.0);
@@ -1002,7 +984,7 @@ mod tests {
                     .unwrap(),
                 SchedulerCommandResult::Applied
             );
-            let materialized = destination.execute_hidden_pass(0.0);
+            let materialized = destination.execute_pass_unrecorded(0.0);
             assert!(
                 materialized
                     .admissions
@@ -1032,7 +1014,7 @@ mod tests {
                     .unwrap(),
                 SchedulerCommandResult::Applied
             );
-            let fresh = destination.execute_hidden_pass(1.0);
+            let fresh = destination.execute_pass_unrecorded(1.0);
             assert!(
                 fresh
                     .admissions
@@ -1155,7 +1137,7 @@ mod tests {
             .unwrap();
         assert!(pending.lifecycle_events.is_empty());
 
-        let first_pass = destination.execute_hidden_pass(0.0);
+        let first_pass = destination.execute_pass_unrecorded(0.0);
         assert!(
             first_pass
                 .admissions
@@ -1171,7 +1153,7 @@ mod tests {
 
         let mut reservation_events = Vec::new();
         for now_ms in 1..=4 {
-            destination.execute_hidden_pass(f64::from(now_ms));
+            destination.execute_pass_unrecorded(f64::from(now_ms));
             reservation_events.extend(destination.retry_pending_destinations());
             if !reservation_events.is_empty() {
                 break;
@@ -1226,7 +1208,7 @@ mod tests {
                 uuid: Some(Uuid::from_u128(38_200 + case as u128)),
                 ..Default::default()
             });
-            let pass = destination.execute_hidden_pass(0.0);
+            let pass = destination.execute_pass_unrecorded(0.0);
             assert_eq!(pass.admissions.len(), 1);
             let before_activation = match &destination {
                 EngineCore::Vllm(core) => core.mocker_metrics().active_decode_blocks,

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -15,6 +15,7 @@ use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional
 use crate::common::utils::prefill_handoff_transfer_timing;
 use crate::kv_manager::SglangKvManager;
 use crate::kv_manager::sglang_backend::SglangDestinationReservation;
+#[cfg(test)]
 use crate::replay::TraceCollector;
 use crate::replay::offline::evidence::record_pressure_readmission;
 
@@ -603,16 +604,15 @@ impl SglangCore {
         collector: &mut TraceCollector,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.try_execute_pass(collector, now_ms)
-            .expect("SGLang scheduler pass failed")
+        let pass = self
+            .try_execute_pass(now_ms)
+            .expect("SGLang scheduler pass failed");
+        crate::scheduler::record_test_pass(collector, &pass, now_ms);
+        pass
     }
 
-    pub(crate) fn try_execute_pass(
-        &mut self,
-        collector: &mut TraceCollector,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
-        self.try_execute_pass_internal(Some(collector), now_ms)
+    pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
+        self.try_execute_pass_internal(now_ms)
     }
 
     #[cfg(test)]
@@ -625,22 +625,17 @@ impl SglangCore {
         &mut self,
         now_ms: f64,
     ) -> anyhow::Result<EnginePassResult> {
-        self.try_execute_pass_internal(None, now_ms)
+        self.try_execute_pass_internal(now_ms)
     }
 
     #[cfg(test)]
-    pub(super) fn execute_pass_internal(
-        &mut self,
-        collector: Option<&mut TraceCollector>,
-        now_ms: f64,
-    ) -> EnginePassResult {
-        self.try_execute_pass_internal(collector, now_ms)
+    pub(super) fn execute_pass_internal(&mut self, now_ms: f64) -> EnginePassResult {
+        self.try_execute_pass_internal(now_ms)
             .expect("SGLang scheduler pass failed")
     }
 
     pub(super) fn try_execute_pass_internal(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
     ) -> anyhow::Result<EnginePassResult> {
         let mut admissions = self.promote_prebuilt_ready();
@@ -668,9 +663,6 @@ impl SglangCore {
         admissions.append(&mut admit.admissions);
         for admission in &admissions {
             record_pressure_readmission(admission.uuid, now_ms);
-            if let Some(collector) = collector.as_deref_mut() {
-                collector.on_admit(admission.uuid, now_ms, admission.reused_input_tokens);
-            }
         }
 
         // Capture per-request prefill FPM data before dispersing can_run.
@@ -711,14 +703,6 @@ impl SglangCore {
 
         for request in decode.completed_requests.drain(..) {
             self.complete_source(request);
-        }
-
-        if let Some(collector) = collector {
-            for signal in &decode.output_signals {
-                if signal.token_id.is_some() {
-                    collector.on_token(signal.uuid, decode.end_ms);
-                }
-            }
         }
 
         for req in decode.requests.drain(..).rev() {

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -607,24 +607,11 @@ impl SglangCore {
         let pass = self
             .try_execute_pass(now_ms)
             .expect("SGLang scheduler pass failed");
-        crate::scheduler::record_test_pass(collector, &pass, now_ms);
+        collector.on_scheduler_pass(&pass, now_ms, Some(pass.token_completion_ms));
         pass
     }
 
     pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
-        self.try_execute_pass_internal(now_ms)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn execute_hidden_pass(&mut self, now_ms: f64) -> EnginePassResult {
-        self.try_execute_hidden_pass(now_ms)
-            .expect("SGLang hidden scheduler pass failed")
-    }
-
-    pub(crate) fn try_execute_hidden_pass(
-        &mut self,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
         self.try_execute_pass_internal(now_ms)
     }
 
@@ -785,6 +772,7 @@ impl SglangCore {
         debug_assert_sglang_scheduler_state(&self.waiting, &self.running, self.config.block_size);
         Ok(EnginePassResult {
             end_ms: decode.end_ms,
+            token_completion_ms: decode.end_ms,
             completed_requests: decode
                 .output_signals
                 .iter()

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -29,8 +29,8 @@ use crate::scheduler::{
     ActiveHandoffRequests, AdmissionInvariant, AdmissionStage, CapturedRouterEventBuffer,
     DestinationHolds, EnginePassResult, MockerMetrics, PendingDestinations, RemovedSource,
     RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult,
-    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, accept_length_sample,
-    build_fpm_snapshot, capture_router_event_sink,
+    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, build_fpm_snapshot,
+    capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
@@ -792,8 +792,12 @@ impl SglangCore {
             (decode.end_ms - now_ms) / 1000.0,
         );
 
-        let (accept_length_output_tokens, accept_length_decode_forwards) =
-            accept_length_sample(&decode.output_signals);
+        let accept_length = decode.accept_length;
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            (accept_length.output_tokens, accept_length.decode_forwards),
+            crate::scheduler::accept_length_sample(&decode.output_signals)
+        );
         debug_assert_sglang_scheduler_state(&self.waiting, &self.running, self.config.block_size);
         Ok(EnginePassResult {
             end_ms: decode.end_ms,
@@ -814,8 +818,8 @@ impl SglangCore {
                 .map(CapturedRouterEventBuffer::drain)
                 .unwrap_or_default(),
             fpm: Some(fpm),
-            accept_length_output_tokens,
-            accept_length_decode_forwards,
+            accept_length_output_tokens: accept_length.output_tokens,
+            accept_length_decode_forwards: accept_length.decode_forwards,
         })
     }
 

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -14,12 +14,14 @@ use crate::replay::offline::evidence::{
 
 use super::config::{SglangConfig, floor_to_block};
 use super::request::SglangRequest;
+use crate::scheduler::AcceptLengthSample;
 
 #[derive(Default)]
 pub(super) struct DecodeResult {
     pub(super) requests: Vec<SglangRequest>,
     pub(super) completed_requests: Vec<SglangRequest>,
     pub(super) output_signals: Vec<OutputSignal>,
+    pub(super) accept_length: AcceptLengthSample,
     pub(super) retracted_any: bool,
     pub(super) end_ms: f64,
 }
@@ -281,6 +283,7 @@ pub(super) fn simulate_decode_step_with_sampler(
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
+            ..DecodeResult::default()
         });
     }
 
@@ -317,13 +320,16 @@ pub(super) fn simulate_decode_step_with_sampler(
             requests: retracted,
             retracted_any,
             end_ms: current_time_ms,
+            ..DecodeResult::default()
         });
     };
 
     output_signals.reserve(running.len());
     let mut completed_indices = Vec::new();
+    let mut accept_length = AcceptLengthSample::default();
 
     for (idx, req) in running.iter_mut().enumerate() {
+        let output_signals_before = output_signals.len();
         let remaining = req.remaining_output_tokens();
         let burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
             remaining.min(1)
@@ -365,6 +371,7 @@ pub(super) fn simulate_decode_step_with_sampler(
             cache_materialized_prefix(req, kv_manager, config);
             req.debug_assert_invariants(config.block_size);
         }
+        accept_length.record_forward(output_signals.len() - output_signals_before);
     }
 
     debug_assert!(reservation.len() <= reserved_pages);
@@ -381,6 +388,7 @@ pub(super) fn simulate_decode_step_with_sampler(
         requests: retracted,
         completed_requests,
         output_signals,
+        accept_length,
         retracted_any,
         end_ms: current_time_ms + total_time.as_secs_f64() * 1000.0,
     })

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -329,7 +329,7 @@ pub(super) fn simulate_decode_step_with_sampler(
     let mut accept_length = AcceptLengthSample::default();
 
     for (idx, req) in running.iter_mut().enumerate() {
-        let output_signals_before = output_signals.len();
+        let mut emitted_tokens = 0usize;
         let remaining = req.remaining_output_tokens();
         let burst = if config.worker_type == crate::common::protocols::WorkerType::Prefill {
             remaining.min(1)
@@ -362,6 +362,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                     config.kv_bytes_per_token,
                 ),
             });
+            emitted_tokens += 1;
 
             if is_complete {
                 completed_indices.push(idx);
@@ -371,7 +372,7 @@ pub(super) fn simulate_decode_step_with_sampler(
             cache_materialized_prefix(req, kv_manager, config);
             req.debug_assert_invariants(config.block_size);
         }
-        accept_length.record_forward(output_signals.len() - output_signals_before);
+        accept_length.record_forward(emitted_tokens);
     }
 
     debug_assert!(reservation.len() <= reserved_pages);

--- a/lib/mocker/src/scheduler/sglang/live.rs
+++ b/lib/mocker/src/scheduler/sglang/live.rs
@@ -148,7 +148,7 @@ impl LiveBoundaryCore for SglangCore {
         &mut self,
         _scheduler_start: &Instant,
     ) -> anyhow::Result<LivePassExecution> {
-        let pass = self.try_execute_pass_internal(None, 0.0)?;
+        let pass = self.try_execute_pass_internal(0.0)?;
         let duration = std::time::Duration::from_secs_f64(pass.end_ms / 1000.0);
         Ok(LivePassExecution { pass, duration })
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -2339,7 +2339,7 @@ mod forward_pass_metrics {
         // Submit and fully drain a request first so the core isn't empty
         // (empty core blocks in receive_requests in live mode, but
         // execute_pass_internal works fine on an empty core).
-        let pass = core.execute_hidden_pass(0.0);
+        let pass = core.execute_pass_internal(0.0);
         let fpm = pass.fpm.expect("FPM should be present even for empty pass");
 
         assert_eq!(fpm.num_prefill_requests, 0);
@@ -2596,7 +2596,7 @@ mod forward_pass_metrics {
         // just verify we always get Some(fpm).
         if !saw_queued_decode {
             // Verify the requests completed or are still running with valid FPM
-            let pass = core.execute_hidden_pass(10.0);
+            let pass = core.execute_pass_internal(10.0);
             assert!(pass.fpm.is_some(), "FPM should always be present");
         }
     }

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -1583,6 +1583,8 @@ mod core_behavior {
         let mut collector = crate::replay::TraceCollector::default();
         let first = core.execute_pass(&mut collector, 0.0);
         assert_eq!(first.output_signals.len(), 9);
+        assert_eq!(first.accept_length_output_tokens, 9);
+        assert_eq!(first.accept_length_decode_forwards, 3);
         let second = core.execute_pass(&mut collector, first.end_ms);
         let ordered = second
             .output_signals
@@ -1608,6 +1610,8 @@ mod core_behavior {
         assert_eq!(core.running[1].uuid, longer);
         assert_eq!(core.running[1].output_len(), 6);
         assert_eq!(second.fpm.unwrap().num_decode_requests, 3);
+        assert_eq!(second.accept_length_output_tokens, 8);
+        assert_eq!(second.accept_length_decode_forwards, 3);
 
         let third = core.execute_pass(&mut collector, second.end_ms);
         assert_eq!(
@@ -1618,6 +1622,8 @@ mod core_behavior {
                 .collect::<Vec<_>>(),
             vec![long, long, longer, longer],
         );
+        assert_eq!(third.accept_length_output_tokens, 4);
+        assert_eq!(third.accept_length_decode_forwards, 2);
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -176,7 +176,7 @@ fn zero_output_request_completes_after_prefill() {
     let mut core = SglangCore::new(test_args(32, 4, 16));
     let uuid = core.receive(direct_request(vec![1, 2, 3, 4], 0));
 
-    let pass = core.execute_pass_internal(None, 0.0);
+    let pass = core.execute_pass_internal(0.0);
 
     assert!(core.is_empty());
     assert_eq!(pass.completed_requests, 1);
@@ -1540,7 +1540,7 @@ mod core_behavior {
             ..Default::default()
         });
 
-        let pass = core.execute_pass_internal(None, 0.0);
+        let pass = core.execute_pass_internal(0.0);
         assert_eq!(pass.completed_requests, 0);
         assert_eq!(pass.mocker_metrics.active_decode_blocks, 2);
     }
@@ -1631,7 +1631,7 @@ mod core_behavior {
         let mut core = SglangCore::new_with_kv_capture(test_args(32, 4, 4), ROUTER_TEST_WORKER_ID);
         core.receive(direct_request(vec![1, 2, 3, 4], 1));
 
-        let pass = core.execute_pass_internal(None, 0.0);
+        let pass = core.execute_pass_internal(0.0);
 
         assert_eq!(pass.router_event_visibility, RouterEventVisibility::PassEnd);
         assert!(!pass.kv_events.is_empty());
@@ -1754,16 +1754,16 @@ mod router_events {
         let mut core = SglangCore::new_with_kv_capture(test_args(32, 4, 4), ROUTER_TEST_WORKER_ID);
         core.receive(direct_request(vec![1, 2, 3, 4, 5, 6], 2));
 
-        let pass1 = core.execute_pass_internal(None, 0.0);
+        let pass1 = core.execute_pass_internal(0.0);
         let mut prompt_hashes = stored_hashes(&pass1.kv_events);
         assert_eq!(prompt_hashes.len(), 1);
         harness.apply_events(pass1.kv_events).await;
 
-        let pass2 = core.execute_pass_internal(None, pass1.end_ms);
+        let pass2 = core.execute_pass_internal(pass1.end_ms);
         prompt_hashes.extend(nth_stored_hashes(&pass2.kv_events, 0));
         harness.apply_events(pass2.kv_events).await;
 
-        let pass3 = core.execute_pass_internal(None, pass2.end_ms);
+        let pass3 = core.execute_pass_internal(pass2.end_ms);
         prompt_hashes.extend(nth_stored_hashes(&pass3.kv_events, 0));
         harness.apply_events(pass3.kv_events).await;
 
@@ -1779,13 +1779,13 @@ mod router_events {
         let mut core = SglangCore::new_with_kv_capture(test_args(32, 4, 16), ROUTER_TEST_WORKER_ID);
         core.receive(direct_request(vec![7, 8, 9, 10], 5));
 
-        let pass1 = core.execute_pass_internal(None, 0.0);
+        let pass1 = core.execute_pass_internal(0.0);
         let mut full_hashes = stored_hashes(&pass1.kv_events);
         harness.apply_events(pass1.kv_events).await;
 
         let mut now_ms = pass1.end_ms;
         for _ in 0..3 {
-            let pass = core.execute_pass_internal(None, now_ms);
+            let pass = core.execute_pass_internal(now_ms);
             now_ms = pass.end_ms;
             full_hashes.extend(stored_hashes(&pass.kv_events));
             harness.apply_events(pass.kv_events).await;
@@ -1828,7 +1828,7 @@ mod router_events {
         let mut now_ms = 0.0;
         let mut hashes = Vec::new();
         while !core.is_empty() {
-            let pass = core.execute_pass_internal(None, now_ms);
+            let pass = core.execute_pass_internal(now_ms);
             now_ms = pass.end_ms;
             hashes.extend(stored_hashes(&pass.kv_events));
         }
@@ -1885,16 +1885,16 @@ mod router_events {
         let mut core = SglangCore::new_with_kv_capture(test_args(32, 4, 16), ROUTER_TEST_WORKER_ID);
         core.receive(direct_request(vec![11, 12, 13, 14], 3));
 
-        let pass1 = core.execute_pass_internal(None, 0.0);
+        let pass1 = core.execute_pass_internal(0.0);
         let prompt_hashes = nth_stored_hashes(&pass1.kv_events, 0);
         let mut full_hashes = stored_hashes(&pass1.kv_events);
         harness.apply_events(pass1.kv_events).await;
 
-        let pass2 = core.execute_pass_internal(None, pass1.end_ms);
+        let pass2 = core.execute_pass_internal(pass1.end_ms);
         full_hashes.extend(stored_hashes(&pass2.kv_events));
         harness.apply_events(pass2.kv_events).await;
 
-        let pass3 = core.execute_pass_internal(None, pass2.end_ms);
+        let pass3 = core.execute_pass_internal(pass2.end_ms);
         assert_eq!(removed_event_count(&pass3.kv_events), 0);
         full_hashes.extend(stored_hashes(&pass3.kv_events));
         harness.apply_events(pass3.kv_events).await;

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1149,18 +1149,11 @@ impl VllmCore {
         let pass = self
             .try_execute_pass(now_ms)
             .expect("vLLM scheduler pass failed");
-        crate::scheduler::record_test_pass(collector, &pass, now_ms);
+        collector.on_scheduler_pass(&pass, now_ms, Some(pass.token_completion_ms));
         pass
     }
 
     pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
-        self.execute_pass_internal(now_ms, None)
-    }
-
-    pub(crate) fn try_execute_hidden_pass(
-        &mut self,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
         self.execute_pass_internal(now_ms, None)
     }
 
@@ -1635,8 +1628,9 @@ impl VllmCore {
             (accept_length.output_tokens, accept_length.decode_forwards),
             crate::scheduler::accept_length_sample(&output_signals)
         );
+        let token_completion_ms = decode_start_ms + decode_time.as_secs_f64() * 1000.0;
         #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
-        let mut end_ms = decode_start_ms + decode_time.as_secs_f64() * 1000.0;
+        let mut end_ms = token_completion_ms;
 
         // Stall-advance for pending offload work: if the pass did no
         // model work but either (a) requests are parked on G2→G1 swap-ins
@@ -1657,6 +1651,7 @@ impl VllmCore {
         self.state.debug_assert_invariants();
         Ok(EnginePassResult {
             end_ms,
+            token_completion_ms,
             completed_requests: requests_before.saturating_sub(self.state.requests.len()),
             output_signals,
             admissions,
@@ -2524,7 +2519,7 @@ impl VllmCore {
             Vec::with_capacity(sampled_bursts.iter().map(|(_, burst)| *burst).sum());
         let mut accept_length = AcceptLengthSample::default();
         for (uuid, burst) in sampled_bursts {
-            let output_signals_before = output_signals.len();
+            let mut emitted_tokens = 0usize;
             let mut completed = false;
             let mut deferred_deref = Vec::new();
             for _ in 0..burst {
@@ -2607,13 +2602,14 @@ impl VllmCore {
                         self.args.kv_bytes_per_token,
                     ),
                 });
+                emitted_tokens += 1;
                 if is_complete {
                     completed = true;
                     deferred_deref = effects.cleanup;
                     break;
                 }
             }
-            accept_length.record_forward(output_signals.len() - output_signals_before);
+            accept_length.record_forward(emitted_tokens);
 
             if completed {
                 self.complete_source(uuid, deferred_deref);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -31,11 +31,11 @@ use crate::replay::offline::evidence::{
 use crate::scheduler::vllm::policy::{self, AdmissionDecision, PolicySequence};
 use crate::scheduler::vllm::request::RequestKvState;
 use crate::scheduler::{
-    ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
+    AcceptLengthSample, ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
     CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, ForwardPassSnapshot,
     MockerMetrics, PendingDestinations, RemovedSource, RouterEventVisibility, SchedulerCommand,
     SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion,
-    SourceHolds, accept_length_sample, build_fpm_snapshot, capture_router_event_sink,
+    SourceHolds, build_fpm_snapshot, capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1633,7 +1633,7 @@ impl VllmCore {
         let prefill_time =
             predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args)?;
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let (decode_time, mut output_signals) =
+        let (decode_time, mut output_signals, accept_length) =
             self.emit_ready_tokens(collector, decode_start_ms)?;
         // Emit the terminal signals for the requests the gate rejected above
         // (see the gate comment for why this can't be done inline).
@@ -1646,6 +1646,11 @@ impl VllmCore {
                 handoff_delay_ms: None,
             });
         }
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            (accept_length.output_tokens, accept_length.decode_forwards),
+            crate::scheduler::accept_length_sample(&output_signals)
+        );
         #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
         let mut end_ms = decode_start_ms + decode_time.as_secs_f64() * 1000.0;
 
@@ -1665,8 +1670,6 @@ impl VllmCore {
         }
 
         let fpm = self.compute_fpm(&scheduled, (end_ms - now_ms) / 1000.0);
-        let (accept_length_output_tokens, accept_length_decode_forwards) =
-            accept_length_sample(&output_signals);
         self.state.debug_assert_invariants();
         Ok(EnginePassResult {
             end_ms,
@@ -1682,8 +1685,8 @@ impl VllmCore {
                 .map(CapturedRouterEventBuffer::drain)
                 .unwrap_or_default(),
             fpm: Some(fpm),
-            accept_length_output_tokens,
-            accept_length_decode_forwards,
+            accept_length_output_tokens: accept_length.output_tokens,
+            accept_length_decode_forwards: accept_length.decode_forwards,
         })
     }
 
@@ -2195,7 +2198,7 @@ impl VllmCore {
         &mut self,
         mut collector: Option<&mut TraceCollector>,
         decode_start_ms: f64,
-    ) -> anyhow::Result<(Duration, Vec<OutputSignal>)> {
+    ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
         let mut ready = Vec::with_capacity(self.state.running.len());
         let mut already_complete = Vec::new();
         let mut total_length = 0usize;
@@ -2241,7 +2244,11 @@ impl VllmCore {
             if !output_signals.is_empty() {
                 self.state.compact_running();
             }
-            return Ok((Duration::ZERO, output_signals));
+            return Ok((
+                Duration::ZERO,
+                output_signals,
+                AcceptLengthSample::default(),
+            ));
         }
 
         if self.speculative_sampler.is_some() {
@@ -2250,10 +2257,10 @@ impl VllmCore {
             }
 
             self.state.compact_running();
-            let (decode_time, mut speculative_signals) =
+            let (decode_time, mut speculative_signals, accept_length) =
                 self.emit_speculative_ready_tokens(ready, collector, decode_start_ms)?;
             output_signals.append(&mut speculative_signals);
-            return Ok((decode_time, output_signals));
+            return Ok((decode_time, output_signals, accept_length));
         }
 
         // For prefill workers, the first decode token is produced as part of
@@ -2275,6 +2282,7 @@ impl VllmCore {
         };
 
         let mut running_changed = !output_signals.is_empty();
+        let mut accept_length = AcceptLengthSample::default();
         for uuid in ready {
             let mut emitted = false;
             let mut emitted_token_id = None;
@@ -2384,19 +2392,20 @@ impl VllmCore {
                 collector.on_token(uuid, decode_end_ms);
             }
             output_signals.push(output_signal);
+            accept_length.record_forward(1);
         }
 
         if output_signals.is_empty() {
             if running_changed {
                 self.state.compact_running();
             }
-            return Ok((Duration::ZERO, output_signals));
+            return Ok((Duration::ZERO, output_signals, accept_length));
         }
 
         if running_changed {
             self.state.compact_running();
         }
-        Ok((decode_time, output_signals))
+        Ok((decode_time, output_signals, accept_length))
     }
 
     fn emit_speculative_ready_tokens(
@@ -2404,7 +2413,7 @@ impl VllmCore {
         mut ready: Vec<Uuid>,
         collector: Option<&mut TraceCollector>,
         decode_start_ms: f64,
-    ) -> anyhow::Result<(Duration, Vec<OutputSignal>)> {
+    ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
         let max_burst = if self.args.worker_type == WorkerType::Prefill {
             1
         } else {
@@ -2415,7 +2424,7 @@ impl VllmCore {
         };
         for uuid in ready.iter().copied() {
             if self.refresh_request_offload_dependency(uuid).is_some() {
-                return Ok((Duration::ZERO, Vec::new()));
+                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
             }
         }
         let mut running_changed = false;
@@ -2454,7 +2463,7 @@ impl VllmCore {
                             .expect("speculative dependency request must remain active");
                         request.offload_dependency = dependency;
                     }
-                    return Ok((Duration::ZERO, Vec::new()));
+                    return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
                 }
                 G1Acquire::RetryNow { .. } => {
                     panic!("speculative reservation must consume bounded RetryNow internally")
@@ -2466,7 +2475,7 @@ impl VllmCore {
                 if running_changed {
                     self.state.compact_running();
                 }
-                return Ok((Duration::ZERO, Vec::new()));
+                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
             };
             running_changed = true;
             self.finish_preemption(preempted);
@@ -2484,7 +2493,7 @@ impl VllmCore {
             }
             if ready.is_empty() {
                 self.state.compact_running();
-                return Ok((Duration::ZERO, Vec::new()));
+                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
             }
         };
 
@@ -2538,7 +2547,9 @@ impl VllmCore {
 
         let mut output_signals =
             Vec::with_capacity(sampled_bursts.iter().map(|(_, burst)| *burst).sum());
+        let mut accept_length = AcceptLengthSample::default();
         for (uuid, burst) in sampled_bursts {
+            let output_signals_before = output_signals.len();
             let mut completed = false;
             let mut deferred_deref = Vec::new();
             for _ in 0..burst {
@@ -2627,6 +2638,7 @@ impl VllmCore {
                     break;
                 }
             }
+            accept_length.record_forward(output_signals.len() - output_signals_before);
 
             if completed {
                 self.complete_source(uuid, deferred_deref);
@@ -2659,7 +2671,7 @@ impl VllmCore {
         if running_changed {
             self.state.compact_running();
         }
-        Ok((decode_time, output_signals))
+        Ok((decode_time, output_signals, accept_length))
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -23,6 +23,7 @@ use crate::kv_manager::kvbm_backend::SwapInRegistrationBlock;
 use crate::kv_manager::{DestinationReservation, G1Acquire, OffloadDependency};
 #[cfg(feature = "kvbm-offload")]
 use crate::kvbm_offload::coordinator::SwapInTerminal;
+#[cfg(test)]
 use crate::replay::TraceCollector;
 use crate::replay::offline::evidence::{
     EnginePressureState, PressureKind, canonical_evidence_capture_active, record_pressure,
@@ -1145,23 +1146,22 @@ impl VllmCore {
         collector: &mut TraceCollector,
         now_ms: f64,
     ) -> EnginePassResult {
-        self.try_execute_pass(collector, now_ms)
-            .expect("vLLM scheduler pass failed")
+        let pass = self
+            .try_execute_pass(now_ms)
+            .expect("vLLM scheduler pass failed");
+        crate::scheduler::record_test_pass(collector, &pass, now_ms);
+        pass
     }
 
-    pub(crate) fn try_execute_pass(
-        &mut self,
-        collector: &mut TraceCollector,
-        now_ms: f64,
-    ) -> anyhow::Result<EnginePassResult> {
-        self.execute_pass_internal(Some(collector), now_ms, None)
+    pub(crate) fn try_execute_pass(&mut self, now_ms: f64) -> anyhow::Result<EnginePassResult> {
+        self.execute_pass_internal(now_ms, None)
     }
 
     pub(crate) fn try_execute_hidden_pass(
         &mut self,
         now_ms: f64,
     ) -> anyhow::Result<EnginePassResult> {
-        self.execute_pass_internal(None, now_ms, None)
+        self.execute_pass_internal(now_ms, None)
     }
 
     /// Drive the offload engine forward to `now_ms` and promote any
@@ -1436,7 +1436,6 @@ impl VllmCore {
     #[cfg_attr(feature = "profile", inline(never))]
     pub(super) fn execute_pass_internal(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
         now_ms: f64,
         admission_tx: Option<&mpsc::UnboundedSender<AdmissionEvent>>,
     ) -> anyhow::Result<EnginePassResult> {
@@ -1475,13 +1474,6 @@ impl VllmCore {
                 ScheduleOutcome::Scheduled { admission, .. } => {
                     if let Some(admission) = admission {
                         record_pressure_readmission(admission.uuid, now_ms);
-                        if let Some(collector) = collector.as_deref_mut() {
-                            collector.on_admit(
-                                admission.uuid,
-                                now_ms,
-                                admission.reused_input_tokens,
-                            );
-                        }
                         if let Some(admission_tx) = admission_tx {
                             let _ = admission_tx.send(admission.clone());
                         }
@@ -1608,13 +1600,6 @@ impl VllmCore {
                 } => {
                     if let Some(admission) = admission {
                         record_pressure_readmission(admission.uuid, now_ms);
-                        if let Some(collector) = collector.as_deref_mut() {
-                            collector.on_admit(
-                                admission.uuid,
-                                now_ms,
-                                admission.reused_input_tokens,
-                            );
-                        }
                         if let Some(admission_tx) = admission_tx {
                             let _ = admission_tx.send(admission.clone());
                         }
@@ -1633,8 +1618,7 @@ impl VllmCore {
         let prefill_time =
             predict_prefill_duration(batch_count, batch_total_isl, batch_total_prefix, &self.args)?;
         let decode_start_ms = now_ms + prefill_time.as_secs_f64() * 1000.0;
-        let (decode_time, mut output_signals, accept_length) =
-            self.emit_ready_tokens(collector, decode_start_ms)?;
+        let (decode_time, mut output_signals, accept_length) = self.emit_ready_tokens()?;
         // Emit the terminal signals for the requests the gate rejected above
         // (see the gate comment for why this can't be done inline).
         for uuid in rejected_uuids {
@@ -2196,8 +2180,6 @@ impl VllmCore {
     #[cfg_attr(feature = "profile", inline(never))]
     fn emit_ready_tokens(
         &mut self,
-        mut collector: Option<&mut TraceCollector>,
-        decode_start_ms: f64,
     ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
         let mut ready = Vec::with_capacity(self.state.running.len());
         let mut already_complete = Vec::new();
@@ -2253,20 +2235,20 @@ impl VllmCore {
 
         if self.speculative_sampler.is_some() {
             if output_signals.is_empty() {
-                return self.emit_speculative_ready_tokens(ready, collector, decode_start_ms);
+                return self.emit_speculative_ready_tokens(ready);
             }
 
             self.state.compact_running();
             let (decode_time, mut speculative_signals, accept_length) =
-                self.emit_speculative_ready_tokens(ready, collector, decode_start_ms)?;
+                self.emit_speculative_ready_tokens(ready)?;
             output_signals.append(&mut speculative_signals);
             return Ok((decode_time, output_signals, accept_length));
         }
 
         // For prefill workers, the first decode token is produced as part of
         // the prefill forward pass — no separate decode iteration needed.
-        let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
-            (Duration::ZERO, decode_start_ms)
+        let decode_time = if self.args.worker_type == WorkerType::Prefill {
+            Duration::ZERO
         } else {
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
             let active_kv_tokens = total_length;
@@ -2277,8 +2259,7 @@ impl VllmCore {
                 context_length,
                 total_kv_tokens,
             )?;
-            let dt = scale_decode_time(decode_ms, &self.args);
-            (dt, decode_start_ms + dt.as_secs_f64() * 1000.0)
+            scale_decode_time(decode_ms, &self.args)
         };
 
         let mut running_changed = !output_signals.is_empty();
@@ -2388,9 +2369,6 @@ impl VllmCore {
                 self.complete_source(uuid, deferred_deref);
                 running_changed = true;
             }
-            if let Some(collector) = collector.as_deref_mut() {
-                collector.on_token(uuid, decode_end_ms);
-            }
             output_signals.push(output_signal);
             accept_length.record_forward(1);
         }
@@ -2411,8 +2389,6 @@ impl VllmCore {
     fn emit_speculative_ready_tokens(
         &mut self,
         mut ready: Vec<Uuid>,
-        collector: Option<&mut TraceCollector>,
-        decode_start_ms: f64,
     ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
         let max_burst = if self.args.worker_type == WorkerType::Prefill {
             1
@@ -2502,8 +2478,8 @@ impl VllmCore {
             .filter_map(|uuid| self.state.requests.get(uuid))
             .map(|request| request.sequence.len())
             .sum::<usize>();
-        let (decode_time, decode_end_ms) = if self.args.worker_type == WorkerType::Prefill {
-            (Duration::ZERO, decode_start_ms)
+        let decode_time = if self.args.worker_type == WorkerType::Prefill {
+            Duration::ZERO
         } else {
             let total_kv_tokens = self.args.num_gpu_blocks * self.args.block_size;
             let active_kv_tokens = total_length;
@@ -2514,8 +2490,7 @@ impl VllmCore {
                 context_length,
                 total_kv_tokens,
             )?;
-            let duration = scale_decode_time(decode_ms, &self.args);
-            (duration, decode_start_ms + duration.as_secs_f64() * 1000.0)
+            scale_decode_time(decode_ms, &self.args)
         };
 
         let sampled_bursts = {
@@ -2661,12 +2636,6 @@ impl VllmCore {
         }
 
         self.kv_manager.release_decode_reservation(reservation);
-
-        if let Some(collector) = collector {
-            for signal in &output_signals {
-                collector.on_token(signal.uuid, decode_end_ms);
-            }
-        }
 
         if running_changed {
             self.state.compact_running();

--- a/lib/mocker/src/scheduler/vllm/live.rs
+++ b/lib/mocker/src/scheduler/vllm/live.rs
@@ -222,7 +222,7 @@ impl LiveBoundaryCore for VllmCore {
         // Wall-clock elapsed time drives the PS bandwidth models across
         // vLLM passes; SGLang reports a duration directly from each pass.
         let now_ms = scheduler_start.elapsed().as_secs_f64() * 1000.0;
-        let pass = self.execute_pass_internal(None, now_ms, None)?;
+        let pass = self.execute_pass_internal(now_ms, None)?;
         let duration = std::time::Duration::from_secs_f64((pass.end_ms - now_ms).max(0.0) / 1000.0);
         Ok(LivePassExecution { pass, duration })
     }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -4163,6 +4163,12 @@ mod offload {
         // request, schedules nothing.
         let mut collector = crate::replay::TraceCollector::default();
         let pass1 = core.execute_pass(&mut collector, 0.0);
+        let stall_deadline = core
+            .earliest_offload_deadline()
+            .expect("parked swap-in must expose a stall-advance deadline");
+        assert_eq!(pass1.token_completion_ms, 0.0);
+        assert_eq!(pass1.end_ms, stall_deadline);
+        assert!(pass1.end_ms > pass1.token_completion_ms);
         assert_eq!(
             core.requests_awaiting_swap_in.len(),
             1,


### PR DESCRIPTION
## Overview

This PR removes three allocation- and hash-heavy paths from offline replay: decode accept-length rescans, per-pass token-timeline alignment, and hash-indexed SGLang physical-page metadata.

## Summary

- Count visible decode tokens and participating requests while scheduler outputs are emitted instead of rescanning `OutputSignal`s through a `HashSet`.
- Record replay token timestamps once at the final pass boundary, including the shared slowest-rank boundary for attention DP.
- Index SGLang physical-page metadata directly by page ID and reduce temporary allocation while publishing stored and removed KV events.
- Keep ordinary decode accounting scan-free while recomputing counters from surviving signals only on the rare live-output suppression path.
- Preserve public APIs, configuration, event formats, and simulation behavior.

## Details

The three commits are intentionally kept as independent benchmark points:

1. `perf(mocker): count accept-length samples during decode`
2. `perf(mocker): record replay tokens at pass completion`
3. `perf(mocker): index SGLang pages directly`

Review feedback is addressed in one follow-up commit:

4. `fix(mocker): address replay review feedback`

The token-accounting change retains a debug-only reference scan. Live cancellation uses the same scan only when suppressing buffered outputs so stale counters self-heal without adding work to ordinary passes. Admissions remain recorded at pass start, while accepted token-bearing outputs are recorded at the existing completion boundary. Single-worker vLLM keeps its rank-local model-completion timestamp across KVBM stall advance; aggregated and attention-DP replay retain their shared completion boundary. The SGLang KV-event path preserves duplicate logical hashes, parent chaining, event IDs, page reuse, and final-copy removal semantics.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/mod.rs` and the SGLang/vLLM scheduler implementations for direct accept-length accounting.
- `lib/mocker/src/replay/collector.rs` and `lib/mocker/src/replay/offline/components/engine.rs` for final-boundary token recording.
- `lib/mocker/src/kv_manager/sglang_backend.rs` for dense physical-page metadata and KV-event construction.

## Performance

Single unprofiled point per commit, no warm-ups. The workload was the deterministic 2x Astra trace (`806487947000d49d4e8a817112e479a8b7282ffb3f388259cb921cf13bc3ff1b`) with 12 aggregated SGLang/B200 workers, KV routing/events, 64-token pages, and the benchmark-only AIC Moka build. Every point completed 187,906 requests and 2,580,832,264 processed tokens.

| Point | Wall time | Processed tokens/s | Incremental throughput | Versus baseline |
| --- | ---: | ---: | ---: | ---: |
| Baseline `e026f9a654` | 84.756 s | 30.450 M | — | — |
| C1 `9d1d72b201` | 76.304 s | 33.823 M | +11.08% | +11.08% |
| C2 `11ce174953` | 71.594 s | 36.048 M | +6.58% | +18.38% |
| C3 `80ad0e77de` | 64.936 s | 39.745 M | +10.25% | +30.52% |
| Review-fix head `f2ce225849` | 65.989 s | 39.110 M | -1.60% | +28.44% |

The final review-fix row is compared with the preserved C3 result; C3 was not rerun. It completed the same 187,906 requests, 2,401,594,588 input tokens, 179,237,676 output tokens, and 2,580,832,264 processed tokens, with prefix-cache reuse 0.920969. Its 1.60% throughput regression versus C3 misses the requested 1% point gate, while the fully reviewed head remains 28.44% faster than baseline. These are point comparisons, not statistical claims. The deterministic canonical replay validation below establishes exact behavioral parity.

## Validation

The full offline replay correctness-parity protocol passed between exact baseline `e026f9a6544f28032f0ce0e070b05ba3a5e5bea6` and final review-fix head `f2ce22584985120dcc3a953851a716b9b8d904d6`.

- Exact 5,000-request Mooncake fixture, SHA-256 `3892ae19ae480b643155f0c6b9d798591cbe2e73bec6a0fa5ae3d3bc0332fb8a`.
- Two independent processes per revision for all four canonical rows.
- Byte-identical canonical reports for aggregated and disaggregated SGLang.
- Byte-identical canonical reports for aggregated and disaggregated native-vLLM KVBM stress.
- Every report completed all 5,000 requests; disaggregated rows exercised 5,000 handoffs.
- KVBM rows exercised offload/host-pinned lifecycles and bounded preemption (2 aggregated, 1 disaggregated).

Additional checks:

- `cargo test -p dynamo-mocker` (716 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` (192 passed; two failures reproduced unchanged at the exact baseline)
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --features aic-forward-pass`
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The baseline-reproduced KVBM failures are:

- `busy_worker_advances_offload_without_destination_admission`
- `aggregated_canonical_evidence_covers_real_kvbm_lifecycle`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cache event reporting when physical pages are reused, ensuring removals and replacements receive distinct identifiers.
  * Improved cancellation handling so token and decode-forward metrics remain accurate.
  * Corrected token timing records to reflect scheduler pass completion.

* **Improvements**
  * Improved acceptance-length metrics for standard and speculative decoding.
  * Added validation and coverage for cache events, cancellation behavior, and acceptance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
