### PR TITLE
docs(observability): correct tokenizer-cache metric absence and add the v1.4.0 deprecations section

### DIFF
--- a/docs/fern/pages/reference/general/releases/deprecations.mdx
+++ b/docs/fern/pages/reference/general/releases/deprecations.mdx
@@ -17,6 +17,28 @@ Upgrading? Pick the version you run today to see the dependency migration and th
 
 <UpgradeSelector />
 
+<a id="v140"></a>
+
+## v1.4.0 (upcoming)
+
+4 entries: 2 behavioral changes, 2 removed.
+
+<span className="dynref-badge dynref-badge--blue">Behavioral</span> **Audit subsystem migrated into request trace** (`"log_type":"audit"` records and the `"Audit sinks ready"` readiness marker -> records carrying `"schema":"dynamo.request.trace.v1"` and the `"Request trace sinks ready"` marker); payload logging is unified under the request-trace pipeline and the standalone audit module is gone ([#9390](https://github.com/ai-dynamo/dynamo/pull/9390), [#11180](https://github.com/ai-dynamo/dynamo/pull/11180)).
+
+  > **Migrate:** Update log pipelines that match on the `"Audit sinks ready"` marker or the `"log_type":"audit"` field to the new marker and the `"schema":"dynamo.request.trace.v1"` field. The `DYN_AUDIT_*` environment variables are still honored as legacy aliases of their request-trace replacements (for example `DYN_AUDIT_SINKS` -> `DYN_REQUEST_TRACE_SINKS`, `DYN_AUDIT_FORCE_LOGGING` -> `DYN_REQUEST_TRACE_RECORDS=request_payload`); move configuration to the new names.
+
+<span className="dynref-badge dynref-badge--blue">Behavioral</span> **HTTP header capture in trace records is an explicit fail-closed allowlist**: request headers appear in `request_payload` records only when named in `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST`; when the variable is unset or empty, no headers are captured ([#11386](https://github.com/ai-dynamo/dynamo/pull/11386)).
+
+  > **Migrate:** Set `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` to the comma-separated header names you need recorded. Captured values are unredacted, so avoid allowlisting credential-bearing headers.
+
+<span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated multimodal worker flags** (`--multimodal-worker` / `--multimodal-encode-worker` -> `--enable-multimodal` with `--disaggregation-mode` / `--dedicated-mm-encoder`) across the vLLM, SGLang, and TensorRT-LLM backends; deprecated in v1.3.0 ([#11887](https://github.com/ai-dynamo/dynamo/pull/11887)).
+
+  > **Migrate:** Replace the removed flags with `--enable-multimodal` plus the appropriate `--disaggregation-mode` / `--dedicated-mm-encoder` combination.
+
+<span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated vLLM worker role flags** (`--is-prefill-worker` / `--is-decode-worker` -> `--disaggregation-mode`) ([#12089](https://github.com/ai-dynamo/dynamo/pull/12089)).
+
+  > **Migrate:** Pass `--disaggregation-mode prefill` or `--disaggregation-mode decode` instead of the removed boolean flags.
+
 <a id="v130"></a>
 
 ## v1.3.0 — Jul 20, 2026

--- a/docs/fern/pages/reference/general/releases/deprecations.mdx
+++ b/docs/fern/pages/reference/general/releases/deprecations.mdx
@@ -21,7 +21,7 @@ Upgrading? Pick the version you run today to see the dependency migration and th
 
 ## v1.4.0 (upcoming)
 
-4 entries: 2 behavioral changes, 2 removed.
+4 entries — 2 behavioral changes, 2 removed.
 
 <span className="dynref-badge dynref-badge--blue">Behavioral</span> **Audit subsystem migrated into request trace** (`"log_type":"audit"` records and the `"Audit sinks ready"` readiness marker -> records carrying `"schema":"dynamo.request.trace.v1"` and the `"Request trace sinks ready"` marker); payload logging is unified under the request-trace pipeline and the standalone audit module is gone ([#9390](https://github.com/ai-dynamo/dynamo/pull/9390), [#11180](https://github.com/ai-dynamo/dynamo/pull/11180)).
 
@@ -33,7 +33,7 @@ Upgrading? Pick the version you run today to see the dependency migration and th
 
 <span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated multimodal worker flags** (`--multimodal-worker` / `--multimodal-encode-worker` -> `--enable-multimodal` with `--disaggregation-mode` / `--dedicated-mm-encoder`) across the vLLM, SGLang, and TensorRT-LLM backends; deprecated in v1.3.0 ([#11887](https://github.com/ai-dynamo/dynamo/pull/11887)).
 
-  > **Migrate:** Replace the removed flags with `--enable-multimodal` plus the appropriate `--disaggregation-mode` / `--dedicated-mm-encoder` combination.
+  > **Migrate:** On vLLM and SGLang, replace the removed flags with `--enable-multimodal` plus the appropriate `--disaggregation-mode` / `--dedicated-mm-encoder` combination. On TensorRT-LLM, use `--modality multimodal`, which remains the supported path.
 
 <span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated vLLM worker role flags** (`--is-prefill-worker` / `--is-decode-worker` -> `--disaggregation-mode`) ([#12089](https://github.com/ai-dynamo/dynamo/pull/12089)).
 

--- a/docs/fern/pages/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/pages/reference/observability/metrics-catalog.mdx
@@ -93,7 +93,7 @@ sum by (model) (rate(dynamo_frontend_tokenizer_cache_cached_tokens_total[5m]))
 )
 ```
 
-The ratio is defined only when the model has an active L1 cache and observed tokens. Partial hits increment both token counters. The counters remain zero when `DYN_TOKENIZER_CACHE=0`, encoding fails, or the tokenizer has no registered special-token boundaries.
+The ratio is defined only when the model has an active L1 cache and observed tokens. Partial hits increment both token counters. When the cache is disabled with `DYN_TOKENIZER_CACHE=0`, the per-model series are never created, so they are absent from the scrape rather than reported as zero; detect that state with `absent()`, since a `== 0` comparison never matches a missing series. Only the literal value `0` disables the cache; values such as `false` or `off` leave it enabled. With the cache enabled, the counters remain zero when encoding fails or the tokenizer has no registered special-token boundaries.
 
 <ParamField path="dynamo_frontend_inter_token_latency_seconds" type="histogram">
   Inter-token latency in seconds.


### PR DESCRIPTION
Fixes NVBug [6556256](https://nvbugs.nvidia.com/6556256) / DYN-3744 (P1, 1.4.0 QA).

Two documentation gaps from the 1.4.0 observability work:

## Tokenizer-cache counters: absent, not zero

`metrics-catalog.mdx` claimed the tokenizer-cache token counters "remain zero" when `DYN_TOKENIZER_CACHE=0`. In code the series is never created: with the cache disabled the raw tokenizer is returned and `instrumented_tokenizer_cache` is never called (`lib/llm/src/model_card.rs:1319`), and the counters are `IntCounterVec`s labeled by model whose per-model children only instantiate inside that path (`model_card.rs:72`, `lib/runtime/src/metrics/frontend_perf.rs:144`). An un-instantiated vec exports no time series, so a `== 0` alert never fires; `absent()` is required. The page now says so, and also documents that only the literal `0` disables the cache (`false`/`off` leave it enabled, per `model_card.rs:61`).

## v1.4.0 deprecations section

`deprecations.mdx` had no v1.4.0 section. Added one with 4 sourced entries: the audit-to-request-trace migration (#9390, #11180) including the still-honored `DYN_AUDIT_*` legacy aliases, the fail-closed HTTP header-capture allowlist (#11386), and the removed multimodal worker flags (#11887) and vLLM worker-role flags (#12089). Each entry carries a Migrate note; PRs verified in the 1.4.0 cycle by ancestry.

## Verification

`docs/fern/scripts/check_reference.sh` broken-links step reports 0 errors in `reference/`. Its absolute-href nav check fails with a pre-existing `StopIteration` on clean `origin/main` as well; reported separately, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12775" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added v1.4.0 deprecation guidance covering audit logging, HTTP header capture, and deprecated worker configuration flags.
  * Clarified tokenizer cache metrics behavior, including cache disabling, series detection, accepted configuration values, and encoding failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->