### PR TITLE
fix(runtime): type TCP connect failures as CannotConnect

### DIFF
--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -1537,9 +1537,12 @@ where
             Err(err) => {
                 if self.fault_detection_enabled {
                     if is_inhibited(err.as_ref()) {
-                        tracing::debug!(
-                            "Reporting instance {instance_id} down due to error: {err}"
-                        );
+                        // Quarantining a worker is a fault event, not routine
+                        // bookkeeping: at debug it is invisible in production,
+                        // so a pool silently shrinking to zero looks identical
+                        // to "no workers registered". Matches the warn! the
+                        // response-timeout quarantine below already uses.
+                        tracing::warn!("Reporting instance {instance_id} down due to error: {err}");
                         self.client.report_instance_down(instance_id);
                     } else if match_error_chain(err.as_ref(), &[ErrorType::ResourceExhausted], &[])
                     {
@@ -1569,7 +1572,7 @@ where
             if let Some(err) = res.err()
                 && is_inhibited(&err)
             {
-                tracing::debug!(
+                tracing::warn!(
                     "Reporting instance {instance_id} down due to migratable error: {err}"
                 );
                 client.report_instance_down(instance_id);

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1500,8 +1500,29 @@ impl RequestPlaneClient for TcpRequestClient {
             headers.insert("x-endpoint-path".to_string(), endpoint_name.clone());
         }
 
-        // Get shared connection from pool (Arc, not exclusive borrow)
-        let conn = self.pool.get_connection(addr).await?;
+        // Get shared connection from pool (Arc, not exclusive borrow).
+        //
+        // A connect failure means the worker is gone (ECONNREFUSED) or
+        // unreachable. Type it the same way the post-connect failure arms below
+        // do: `PushRouter::is_inhibited` matches `DynamoError` variants through
+        // `match_error_chain`, and a bare `std::io::Error` matches nothing, so
+        // leaving this untyped means the router never quarantines a dead
+        // instance and keeps dispatching to it until discovery expires it.
+        let conn = self.pool.get_connection(addr).await.map_err(|e| {
+            self.stats.errors.fetch_add(1, Ordering::Relaxed);
+            TCP_ERRORS_TOTAL.inc();
+            tracing::warn!(%addr, error = %e, "TCP connect failed; instance unreachable");
+            let cause = crate::error::DynamoError::from(
+                e.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
+            );
+            anyhow::anyhow!(
+                crate::error::DynamoError::builder()
+                    .error_type(crate::error::ErrorType::CannotConnect)
+                    .message(format!("TCP connect to {addr} failed"))
+                    .cause(cause)
+                    .build()
+            )
+        })?;
 
         let result = tokio::time::timeout(
             self.config.request_timeout,
@@ -2831,6 +2852,82 @@ mod tests {
             conn_count.load(Ordering::SeqCst),
             1,
             "Should use only 1 connection"
+        );
+    }
+
+    /// Bind then drop, yielding a port the OS will refuse connections on.
+    async fn closed_port() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        drop(listener);
+        addr
+    }
+
+    /// A worker that is *gone* (process dead, port refusing) must surface a
+    /// `CannotConnect`-typed error.
+    ///
+    /// `PushRouter::is_inhibited` matches on `DynamoError` variants via
+    /// `match_error_chain`; a bare `std::io::Error` matches nothing, so an
+    /// untyped ECONNREFUSED means `report_instance_down` never fires and the
+    /// router keeps dispatching to the dead instance for the full discovery
+    /// liveness window.
+    #[tokio::test]
+    async fn connect_refused_is_typed_cannot_connect() {
+        let addr = closed_port().await;
+        let client = TcpRequestClient::default();
+
+        let err = client
+            .send_request(
+                format!("{addr}/test_endpoint"),
+                Bytes::from("ping"),
+                Headers::new(),
+            )
+            .await
+            .expect_err("connecting to a closed port must fail");
+
+        assert!(
+            crate::error::match_error_chain(
+                err.as_ref(),
+                &[crate::error::ErrorType::CannotConnect],
+                &[]
+            ),
+            "ECONNREFUSED must be typed CannotConnect so the router quarantines the dead \
+             worker; got untyped error: {err:?}"
+        );
+    }
+
+    /// Contrast case, and the reason the gap is easy to miss: a worker that dies
+    /// *mid-request* (connection established, then reset) is already typed
+    /// correctly by the `Ok(Err(_))` arm of `send_request`. Same fault class as
+    /// the test above, opposite classification.
+    #[tokio::test]
+    async fn established_connection_failure_is_typed_cannot_connect() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // Accept, then drop immediately without responding -> peer reset.
+        tokio::spawn(async move {
+            if let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+            }
+        });
+
+        let client = TcpRequestClient::default();
+        let err = client
+            .send_request(
+                format!("{addr}/test_endpoint"),
+                Bytes::from("ping"),
+                Headers::new(),
+            )
+            .await
+            .expect_err("a reset connection must fail the request");
+
+        assert!(
+            crate::error::match_error_chain(
+                err.as_ref(),
+                &[crate::error::ErrorType::CannotConnect],
+                &[]
+            ),
+            "mid-request failure should already be typed CannotConnect: {err:?}"
         );
     }
 }

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1087,7 +1087,32 @@ impl HostPool {
                     }
                     Err(e) => {
                         self.connect_notify.notify_waiters();
-                        return Err(e);
+                        // Only an actual socket-connect failure means the peer is
+                        // gone or unreachable, so only this branch is typed
+                        // `CannotConnect` — the same type the post-connect failure
+                        // arms in `send_request` use. `PushRouter::is_inhibited`
+                        // treats that as a fault and quarantines the instance, so
+                        // the other error exits from this function (pool at
+                        // capacity, limiter closed, waiter exhausted its retries)
+                        // must stay untyped: they are local coordination failures
+                        // and would otherwise take a healthy worker out of
+                        // rotation under a cold-start burst.
+                        TCP_ERRORS_TOTAL.inc();
+                        tracing::warn!(
+                            addr = %self.addr,
+                            error = %e,
+                            "TCP connect failed; instance unreachable"
+                        );
+                        let cause = crate::error::DynamoError::from(
+                            e.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
+                        );
+                        return Err(anyhow::anyhow!(
+                            crate::error::DynamoError::builder()
+                                .error_type(crate::error::ErrorType::CannotConnect)
+                                .message(format!("TCP connect to {} failed", self.addr))
+                                .cause(cause)
+                                .build()
+                        ));
                     }
                 }
             }
@@ -1502,26 +1527,13 @@ impl RequestPlaneClient for TcpRequestClient {
 
         // Get shared connection from pool (Arc, not exclusive borrow).
         //
-        // A connect failure means the worker is gone (ECONNREFUSED) or
-        // unreachable. Type it the same way the post-connect failure arms below
-        // do: `PushRouter::is_inhibited` matches `DynamoError` variants through
-        // `match_error_chain`, and a bare `std::io::Error` matches nothing, so
-        // leaving this untyped means the router never quarantines a dead
-        // instance and keeps dispatching to it until discovery expires it.
-        let conn = self.pool.get_connection(addr).await.map_err(|e| {
+        // Errors are propagated as-is: the pool types a genuine socket-connect
+        // failure as `CannotConnect` at the connect site, and deliberately
+        // leaves its local coordination failures untyped so they cannot
+        // quarantine a healthy worker. Do not wrap here — this boundary cannot
+        // tell the two apart.
+        let conn = self.pool.get_connection(addr).await.inspect_err(|_| {
             self.stats.errors.fetch_add(1, Ordering::Relaxed);
-            TCP_ERRORS_TOTAL.inc();
-            tracing::warn!(%addr, error = %e, "TCP connect failed; instance unreachable");
-            let cause = crate::error::DynamoError::from(
-                e.into_boxed_dyn_error() as Box<dyn std::error::Error + 'static>
-            );
-            anyhow::anyhow!(
-                crate::error::DynamoError::builder()
-                    .error_type(crate::error::ErrorType::CannotConnect)
-                    .message(format!("TCP connect to {addr} failed"))
-                    .cause(cause)
-                    .build()
-            )
         })?;
 
         let result = tokio::time::timeout(
@@ -2893,6 +2905,52 @@ mod tests {
             ),
             "ECONNREFUSED must be typed CannotConnect so the router quarantines the dead \
              worker; got untyped error: {err:?}"
+        );
+    }
+
+    /// Local pool-coordination failures must NOT classify as `CannotConnect`.
+    ///
+    /// `HostPool::get_connection` has four error exits and only one of them —
+    /// the `TcpConnection::connect` branch — says anything about the peer. The
+    /// other three (pool at capacity, connect limiter closed, waiter exhausted
+    /// its retries) are frontend-local. Typing those as `CannotConnect` would
+    /// make `is_inhibited` quarantine a *healthy* worker, and it would do so
+    /// precisely when contention is highest (a cold-start burst), which is
+    /// self-amplifying: contention quarantines workers, and quarantine
+    /// concentrates load on the survivors.
+    ///
+    /// A closed limiter is the deterministic representative of that class — it
+    /// fails before any socket is dialed. The retry-exhaustion exit has the same
+    /// requirement but is only reachable by a CAS-gate loser, so it needs a race
+    /// to construct and is not asserted here.
+    #[tokio::test]
+    async fn pool_coordination_failure_is_not_typed_cannot_connect() {
+        let config = TcpRequestConfig {
+            request_timeout: Duration::from_secs(1),
+            connect_timeout: Duration::from_millis(50),
+            pool_size: 2,
+            channel_buffer: 10,
+        };
+        // Address is never dialed: the closed limiter fails the acquire first.
+        let pool = HostPool::new(closed_port().await, &config);
+
+        let limiter = tokio::sync::Semaphore::new(1);
+        limiter.close();
+
+        // `expect_err` needs `T: Debug`; `Arc<TcpConnection>` is not.
+        let err = match pool.get_connection(&limiter).await {
+            Ok(_) => panic!("a closed connect limiter must fail"),
+            Err(e) => e,
+        };
+
+        assert!(
+            !crate::error::match_error_chain(
+                err.as_ref(),
+                &[crate::error::ErrorType::CannotConnect],
+                &[]
+            ),
+            "local pool failure must not be typed CannotConnect — it would quarantine a \
+             healthy worker: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Overview:

`TcpRequestClient::send_request` wraps its two post-connect failure arms in `DynamoError{CannotConnect}`, but a connect failure propagated a bare `std::io::Error`. `match_error_chain` matches only a `DynamoError`, so every consumer of that classification silently declined to act. When a worker dies ungracefully the frontend keeps routing to its dead address, returning `500 Failed to generate completions` for the whole discovery liveness window (~10s on etcd, 30s+ on Kubernetes) with nothing retried and no trace in logs or metrics.

## Details:

One missing type tag disabled three mechanisms:

| mechanism | gate | consequence |
|---|---|---|
| router quarantine | `is_inhibited` (`push_router.rs:41`) | `report_instance_down` never fires; dead instance stays in `routable_ids` |
| request migration | `is_migratable` (`migration.rs:59`) | request never retried on a healthy worker |
| observability | — | no `tracing::` line, no `TCP_ERRORS_TOTAL` increment |

The typing is applied at the `TcpConnection::connect` failure branch, **not** at the `get_connection` boundary. That distinction matters: `HostPool::get_connection` has four error exits and only one says anything about the peer.

| exit | classified |
|---|---|
| pool at capacity, no healthy connection | untyped (local) |
| global connect limiter closed | untyped (local) |
| `TcpConnection::connect` failed | **`CannotConnect`** |
| waiter exhausted `MAX_CONNECT_RETRIES` | untyped (local) |

`CannotConnect` is an inhibited error, so typing the local exits would make the router quarantine a *healthy* worker — and would do it exactly when contention is highest, since during a cold-start burst a CAS-gate loser can exhaust its waits without ever dialing a socket. That is self-amplifying: contention quarantines workers, quarantine concentrates load on the survivors. The local exits stay untyped, which already means non-inhibiting; no new error enum is needed.

Changes:
1. `tcp_client.rs` — type the `TcpConnection::connect` failure as `CannotConnect` and instrument it (`TCP_ERRORS_TOTAL` + `warn!`). `send_request` propagates pool errors as-is.
2. `tcp_client.rs` — three tests: a refused connect must be `CannotConnect`; a mid-request reset must be too (passes today, documents the behaviour being matched); a local pool failure must **not** be, using a closed limiter as the deterministic representative of that class.
3. `push_router.rs` — raise the two `report_instance_down` logs from `debug!` to `warn!`. At debug, a pool shrinking to zero looks identical to "no workers registered". Matches the `warn!` the response-timeout quarantine already uses.

Not a regression: `CannotConnect` entered this file in #6303, which covered the request path and `nats_client.rs` but missed the connect path (from #4246). NATS, `addressed_router.rs`, and `push_router.rs` are all typed — TCP-on-connect was the sole holdout.

**Validation.** `cargo test -p dynamo-runtime --lib -- --test-threads=8` → 526 passed, 0 failed; clippy and fmt clean. End-to-end with two `dynamo.mocker` workers, one `SIGKILL`ed, 60 requests, healthy peer alive throughout:

| typing fix | migration | 200 | 500 |
|---|---|---|---|
| ✗ | off (default) | 30 | **30** |
| ✗ | `--migration-limit 1` | 30 | **30** |
| ✓ | off (default) | 58 | 2 |
| ✓ | `--migration-limit 1` | **60** | **0** |

Rows 1–2 are identical — migration is inert without the typing fix. `migration_limit` defaults to `0`, so the row-3 gain comes from the quarantine: once typed, the dead instance is evicted from the candidate set and round-robin stops selecting it. The residual 2 are one per reconcile cycle, where `reconcile_discovered` rebuilds `routable_ids := discovered_ids` and re-admits the instance; left alone deliberately, since eager restoration is the intended behaviour for transient faults.

## Where should the reviewer start?

1. `tcp_client.rs` — the `Err(e)` branch after `TcpConnection::connect` in `ensure_capacity_or_heal`. Read it against the `Ok(Err(e))` / `Err(_)` arms in `send_request`; the point is that all three now agree, and that the sibling exits in the same function deliberately do not.
2. `tcp_client.rs` tests — the three are a set: two assert what must be typed, one asserts what must not. All run in ~0s, no etcd or GPU.
3. `push_router.rs` — log-level change only.


## Related Issues
**🔗 This PR is linked to an issue:**

- Closes  #12776 

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12780" target="_blank">
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
  <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
</picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Improved visibility for quarantined instances by elevating relevant fault-detection messages.
* TCP connection failures are now consistently classified as connection errors.
* Added error metrics and warning logs when connections fail or reset during requests.
* Improved handling of backend connection failures without changing instance reporting behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
