### PR TITLE
fix(router): account for replica event delivery age

### DIFF
--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -718,6 +718,9 @@ pub struct ActiveSequenceEvent {
     pub router_id: u64,
     #[serde(default)]
     pub lora_name: Option<String>,
+    /// Populated locally from the transport envelope; skipped for wire compatibility.
+    #[serde(skip)]
+    pub delivery_age: Duration,
 }
 
 /// Active-sequence lifecycle events carried in publisher-queue arrival order.

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -1176,6 +1176,7 @@ mod tests {
                 data: ActiveSequenceEventData::MarkPrefillCompleted,
                 router_id: 1,
                 lora_name: None,
+                delivery_age: Duration::ZERO,
             })
             .unwrap();
 
@@ -1261,6 +1262,7 @@ mod tests {
                 data: ActiveSequenceEventData::Free,
                 router_id: 1,
                 lora_name: None,
+                delivery_age: Duration::ZERO,
             })
             .unwrap();
 
@@ -1345,6 +1347,7 @@ mod tests {
                 data: ActiveSequenceEventData::Free,
                 router_id: 1,
                 lora_name: None,
+                delivery_age: Duration::ZERO,
             })
             .unwrap();
 

--- a/lib/kv-router/src/sequences/README.md
+++ b/lib/kv-router/src/sequences/README.md
@@ -82,13 +82,15 @@ modeled durations. If any active prefill lacks an expected duration, token load 
 anchor-only decay so unmodeled no-AIC/default requests do not decay. A zero-duration anchor is treated
 as completing its own tokens immediately without inventing token spillover into later requests.
 This token-load approximation assumes active modeled prefills have roughly uniform tokens/sec.
+Replica-synced events translate event-envelope delivery age into a local monotonic anchor, so
+transport delay does not extend modeled prefill load or stale-request expiry. Non-event-plane
+subscribers retain the zero-age receive-time fallback.
 
 If a modeled non-anchor prefill is removed before the anchor, the tracker credits that completed work
 by shifting the effective anchor forward by the removed request's modeled duration, capped at the
 removal time. This keeps completed non-anchor work from also counting as elapsed progress against the
 remaining modeled backlog. `Free` keeps its existing implicit prefill-completion cleanup behavior and
-applies the same credit when the prefill is still tracked. Replica-synced state remains advisory and
-receive-time anchored.
+applies the same credit when the prefill is still tracked. Replica-synced state remains advisory.
 
 When any active prefill for a worker lacks an expected duration, the modeled-time read returns
 `Err(MissingExpectedDuration)`. That is the normal default/no-AIC or prediction-failed state, and the

--- a/lib/kv-router/src/sequences/README.md
+++ b/lib/kv-router/src/sequences/README.md
@@ -82,15 +82,13 @@ modeled durations. If any active prefill lacks an expected duration, token load 
 anchor-only decay so unmodeled no-AIC/default requests do not decay. A zero-duration anchor is treated
 as completing its own tokens immediately without inventing token spillover into later requests.
 This token-load approximation assumes active modeled prefills have roughly uniform tokens/sec.
-Replica-synced events translate event-envelope delivery age into a local monotonic anchor, so
-transport delay does not extend modeled prefill load or stale-request expiry. Non-event-plane
-subscribers retain the zero-age receive-time fallback.
 
 If a modeled non-anchor prefill is removed before the anchor, the tracker credits that completed work
 by shifting the effective anchor forward by the removed request's modeled duration, capped at the
 removal time. This keeps completed non-anchor work from also counting as elapsed progress against the
 remaining modeled backlog. `Free` keeps its existing implicit prefill-completion cleanup behavior and
-applies the same credit when the prefill is still tracked. Replica-synced state remains advisory.
+applies the same credit when the prefill is still tracked. Replica-synced state remains advisory and
+uses event-envelope delivery age as its decay and expiry anchor.
 
 When any active prefill for a worker lacks an expected duration, the modeled-time read returns
 `Err(MissingExpectedDuration)`. That is the normal default/no-AIC or prediction-failed state, and the

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -777,6 +777,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             },
             router_id: self.router_id,
             lora_name: req.lora_name.clone(),
+            delivery_age: Duration::ZERO,
         });
         self.add_request_local(req, decay_now, lazily_register_worker)?;
         if let Some(event) = event {
@@ -1286,6 +1287,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             data: event_data,
             router_id: self.router_id,
             lora_name,
+            delivery_age: Duration::ZERO,
         });
         Ok(())
     }
@@ -1311,6 +1313,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             data: event_data,
             router_id: self.router_id,
             lora_name,
+            delivery_age: Duration::ZERO,
         });
         Ok(())
     }
@@ -1723,6 +1726,7 @@ mod tests {
             },
             router_id: 99,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 
@@ -1736,6 +1740,7 @@ mod tests {
             data: ActiveSequenceEventData::Free,
             router_id: 99,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 
@@ -1749,7 +1754,16 @@ mod tests {
             data: ActiveSequenceEventData::MarkPrefillCompleted,
             router_id: 99,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
+    }
+
+    fn delivered_after(
+        mut event: ActiveSequenceEvent,
+        delivery_age: Duration,
+    ) -> ActiveSequenceEvent {
+        event.delivery_age = delivery_age;
+        event
     }
 
     fn local_sequence_request(request_id: &str, worker: WorkerWithDpRank) -> SequenceRequest {
@@ -2758,6 +2772,7 @@ mod tests {
                     },
                     router_id: 99,
                     lora_name: None,
+                    delivery_age: Duration::ZERO,
                 }),
                 Ok(ActiveSequenceEvent {
                     request_id: "req-1".to_string(),
@@ -2765,6 +2780,7 @@ mod tests {
                     data: ActiveSequenceEventData::Free,
                     router_id: 99,
                     lora_name: None,
+                    delivery_age: Duration::ZERO,
                 }),
             ]),
         };
@@ -2781,7 +2797,115 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn replica_sync_modeled_remaining_prefill_time_uses_receive_time_and_clears() {
+    async fn replica_delivery_age_preserves_absolute_prefill_decay() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let make_sequences = || {
+            ActiveSequencesMultiWorker::new(
+                NoopSequencePublisher,
+                4,
+                HashMap::from([(1_u64, (0_u32, 1_u32))]),
+                true,
+                0,
+                "test",
+            )
+        };
+        let event = |request_id: &str| ActiveSequenceEvent {
+            request_id: request_id.to_string(),
+            worker,
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(vec![1, 2, 3]),
+                track_prefill_tokens: true,
+                expected_output_tokens: None,
+                prefill_load_hint: modeled_hint(12, 10),
+            },
+            router_id: 99,
+            lora_name: None,
+            delivery_age: Duration::ZERO,
+        };
+        let first = make_sequences();
+        let second = make_sequences();
+
+        first.apply_replica_batch(vec![delivered_after(
+            event("first"),
+            Duration::from_secs(2),
+        )]);
+        tokio::time::advance(Duration::from_secs(3)).await;
+        second.apply_replica_batch(vec![delivered_after(
+            event("second"),
+            Duration::from_secs(5),
+        )]);
+
+        let now = Instant::now();
+        assert_eq!(
+            modeled_time_loads_by_worker(&first, now)
+                .get(&worker)
+                .copied(),
+            Some(Ok(5_000))
+        );
+        assert_eq!(
+            modeled_time_loads_by_worker(&second, now)
+                .get(&worker)
+                .copied(),
+            Some(Ok(5_000))
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_delivery_age_advances_stale_request_expiry() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let sequences = ActiveSequencesMultiWorker::new_with_expiry_duration(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+            Duration::from_secs(35),
+        );
+
+        sequences.apply_replica_batch(vec![delivered_after(
+            replica_add("aged", worker, vec![1, 2, 3]),
+            Duration::from_secs(10),
+        )]);
+        tokio::time::advance(Duration::from_secs(30)).await;
+        sequences.force_expire_requests_across_all_workers();
+
+        assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[test]
+    fn replica_add_expired_on_arrival_is_dropped_and_cleanup_stays_idempotent() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let sequences = ActiveSequencesMultiWorker::new_with_expiry_duration(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+            Duration::from_secs(5),
+        );
+
+        sequences.apply_replica_batch(vec![delivered_after(
+            replica_add("expired", worker, vec![1, 2, 3]),
+            Duration::from_secs(5),
+        )]);
+        assert_eq!(active_request_count(&sequences, worker), 0);
+
+        sequences.apply_replica_batch(vec![replica_add("cleanup", worker, vec![4, 5, 6])]);
+        sequences.apply_replica_batch(vec![delivered_after(
+            replica_free("cleanup", worker),
+            Duration::from_secs(60),
+        )]);
+        sequences.apply_replica_batch(vec![delivered_after(
+            replica_free("cleanup", worker),
+            Duration::from_secs(60),
+        )]);
+        assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn replica_sync_modeled_remaining_prefill_time_uses_zero_age_fallback_and_clears() {
         let sequences = ActiveSequencesMultiWorker::new(
             NoopSequencePublisher,
             4,
@@ -2806,6 +2930,7 @@ mod tests {
                         },
                         router_id: 99,
                         lora_name: None,
+                        delivery_age: Duration::ZERO,
                     })]),
                 },
                 CancellationToken::new(),
@@ -2825,6 +2950,7 @@ mod tests {
                         data: ActiveSequenceEventData::MarkPrefillCompleted,
                         router_id: 99,
                         lora_name: None,
+                        delivery_age: Duration::ZERO,
                     })]),
                 },
                 CancellationToken::new(),
@@ -2849,6 +2975,7 @@ mod tests {
                         },
                         router_id: 99,
                         lora_name: None,
+                        delivery_age: Duration::ZERO,
                     })]),
                 },
                 CancellationToken::new(),
@@ -2868,6 +2995,7 @@ mod tests {
                         data: ActiveSequenceEventData::Free,
                         router_id: 99,
                         lora_name: None,
+                        delivery_age: Duration::ZERO,
                     })]),
                 },
                 CancellationToken::new(),
@@ -2907,6 +3035,7 @@ mod tests {
                             },
                             router_id: 99,
                             lora_name: None,
+                            delivery_age: Duration::ZERO,
                         }),
                         Ok(ActiveSequenceEvent {
                             request_id: later.clone(),
@@ -2919,6 +3048,7 @@ mod tests {
                             },
                             router_id: 99,
                             lora_name: None,
+                            delivery_age: Duration::ZERO,
                         }),
                     ]),
                 },
@@ -2945,6 +3075,7 @@ mod tests {
                         data: ActiveSequenceEventData::Free,
                         router_id: 99,
                         lora_name: None,
+                        delivery_age: Duration::ZERO,
                     })]),
                 },
                 CancellationToken::new(),
@@ -2983,6 +3114,7 @@ mod tests {
                 },
                 router_id: 99,
                 lora_name: None,
+                delivery_age: Duration::ZERO,
             })]),
         };
 

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -2856,7 +2856,7 @@ mod tests {
         let sequences = ActiveSequencesMultiWorker::new_with_expiry_duration(
             NoopSequencePublisher,
             4,
-            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            HashMap::new(),
             true,
             0,
             "test",
@@ -2868,6 +2868,7 @@ mod tests {
             Duration::from_secs(35),
         )]);
         assert_eq!(active_request_count(&sequences, worker), 0);
+        assert_eq!(sequences.num_workers(), 0);
 
         sequences.apply_replica_batch(vec![delivered_after(
             replica_add("aged", worker, vec![1, 2, 3]),
@@ -2888,6 +2889,51 @@ mod tests {
         sequences.force_expire_requests_across_all_workers();
 
         assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn delayed_replica_free_does_not_backdate_newer_prefill() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let sequences = ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            4,
+            HashMap::from([(1_u64, (0_u32, 1_u32))]),
+            true,
+            0,
+            "test",
+        );
+        let older = ActiveSequenceEvent {
+            request_id: "older".to_string(),
+            worker,
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(vec![1, 2, 3]),
+                track_prefill_tokens: true,
+                expected_output_tokens: None,
+                prefill_load_hint: modeled_hint(100, 10),
+            },
+            router_id: 99,
+            lora_name: None,
+            delivery_age: Duration::ZERO,
+        };
+        sequences.apply_replica_batch(vec![older]);
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+        let mut newer = local_sequence_request("newer", worker);
+        newer.prefill_load_hint = modeled_hint(100, 10);
+        sequences.add_request(newer, Instant::now()).unwrap();
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        sequences.apply_replica_batch(vec![delivered_after(
+            replica_free("older", worker),
+            Duration::from_secs(4),
+        )]);
+
+        assert_eq!(
+            modeled_time_loads_by_worker(&sequences, Instant::now())
+                .get(&worker)
+                .copied(),
+            Some(Ok(10_000))
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -2851,7 +2851,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn replica_delivery_age_advances_stale_request_expiry() {
+    async fn replica_delivery_age_drives_expiry_and_preserves_cleanup() {
         let worker = WorkerWithDpRank::new(1, 0);
         let sequences = ActiveSequencesMultiWorker::new_with_expiry_duration(
             NoopSequencePublisher,
@@ -2864,34 +2864,15 @@ mod tests {
         );
 
         sequences.apply_replica_batch(vec![delivered_after(
+            replica_add("expired", worker, vec![1, 2, 3]),
+            Duration::from_secs(35),
+        )]);
+        assert_eq!(active_request_count(&sequences, worker), 0);
+
+        sequences.apply_replica_batch(vec![delivered_after(
             replica_add("aged", worker, vec![1, 2, 3]),
             Duration::from_secs(10),
         )]);
-        tokio::time::advance(Duration::from_secs(30)).await;
-        sequences.force_expire_requests_across_all_workers();
-
-        assert_eq!(active_request_count(&sequences, worker), 0);
-    }
-
-    #[test]
-    fn replica_add_expired_on_arrival_is_dropped_and_cleanup_stays_idempotent() {
-        let worker = WorkerWithDpRank::new(1, 0);
-        let sequences = ActiveSequencesMultiWorker::new_with_expiry_duration(
-            NoopSequencePublisher,
-            4,
-            HashMap::from([(1_u64, (0_u32, 1_u32))]),
-            true,
-            0,
-            "test",
-            Duration::from_secs(5),
-        );
-
-        sequences.apply_replica_batch(vec![delivered_after(
-            replica_add("expired", worker, vec![1, 2, 3]),
-            Duration::from_secs(5),
-        )]);
-        assert_eq!(active_request_count(&sequences, worker), 0);
-
         sequences.apply_replica_batch(vec![replica_add("cleanup", worker, vec![4, 5, 6])]);
         sequences.apply_replica_batch(vec![delivered_after(
             replica_free("cleanup", worker),
@@ -2901,6 +2882,11 @@ mod tests {
             replica_free("cleanup", worker),
             Duration::from_secs(60),
         )]);
+        assert_eq!(active_request_count(&sequences, worker), 1);
+
+        tokio::time::advance(Duration::from_secs(30)).await;
+        sequences.force_expire_requests_across_all_workers();
+
         assert_eq!(active_request_count(&sequences, worker), 0);
     }
 

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -169,13 +169,6 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         }
 
         let receive_now = Instant::now();
-        let decay_now = receive_now.checked_sub(delivery_age).unwrap_or_else(|| {
-            tracing::debug!(
-                delivery_age_ms = delivery_age.as_millis(),
-                "Replica event age exceeds the local monotonic clock range; using receive time"
-            );
-            receive_now
-        });
 
         match data {
             ActiveSequenceEventData::AddRequest {
@@ -184,10 +177,14 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 expected_output_tokens,
                 prefill_load_hint,
             } => {
-                if self.replica_worker_policy == ReplicaWorkerPolicy::LazyRegister {
-                    self.ensure_worker_registered(event_worker);
-                }
-                let table = self.workers.read();
+                let decay_now = receive_now.checked_sub(delivery_age).unwrap_or_else(|| {
+                    tracing::debug!(
+                        delivery_age_ms = delivery_age.as_millis(),
+                        "Replica event age exceeds the local monotonic clock range; using receive time"
+                    );
+                    receive_now
+                });
+                let mut table = self.workers.read();
                 if table
                     .expiry_duration()
                     .is_some_and(|expiry_duration| delivery_age >= expiry_duration)
@@ -198,6 +195,13 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                         "Dropping replica AddRequest that expired before arrival"
                     );
                     return;
+                }
+                if self.replica_worker_policy == ReplicaWorkerPolicy::LazyRegister
+                    && !table.index.contains_key(&event_worker)
+                {
+                    drop(table);
+                    self.ensure_worker_registered(event_worker);
+                    table = self.workers.read();
                 }
                 let Some(&idx) = table.index.get(&event_worker) else {
                     tracing::debug!(
@@ -246,7 +250,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 let load = {
                     let slot = &table.slots[idx];
                     let mut seq = slot.sequences.write();
-                    let delta = seq.free(&request_id, decay_now);
+                    let delta = seq.free(&request_id, receive_now);
                     let load = seq.worker_load_snapshot();
                     self.prompt_registry
                         .apply_membership_delta_and_load_without_cleanup(worker, delta, load);
@@ -267,7 +271,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 };
                 let load = {
                     let mut seq = table.slots[idx].sequences.write();
-                    seq.mark_prefill_completed(&request_id, decay_now);
+                    seq.mark_prefill_completed(&request_id, receive_now);
                     let load = seq.worker_load_snapshot();
                     self.prompt_registry.replace_worker_load_state(worker, load);
                     load

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -161,15 +161,21 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             data,
             router_id,
             lora_name,
+            delivery_age,
         } = event;
 
         if router_id == self.router_id {
             return;
         }
 
-        // ActiveSequenceEvent does not carry prompt-load decay timestamps yet.
-        // Peer routers still approximate decay anchoring with local receive time.
-        let decay_now = Instant::now();
+        let receive_now = Instant::now();
+        let decay_now = receive_now.checked_sub(delivery_age).unwrap_or_else(|| {
+            tracing::debug!(
+                delivery_age_ms = delivery_age.as_millis(),
+                "Replica event age exceeds the local monotonic clock range; using receive time"
+            );
+            receive_now
+        });
 
         match data {
             ActiveSequenceEventData::AddRequest {
@@ -182,6 +188,17 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                     self.ensure_worker_registered(event_worker);
                 }
                 let table = self.workers.read();
+                if table
+                    .expiry_duration()
+                    .is_some_and(|expiry_duration| delivery_age >= expiry_duration)
+                {
+                    tracing::trace!(
+                        request_id,
+                        delivery_age_ms = delivery_age.as_millis(),
+                        "Dropping replica AddRequest that expired before arrival"
+                    );
+                    return;
+                }
                 let Some(&idx) = table.index.get(&event_worker) else {
                     tracing::debug!(
                         worker = ?event_worker,

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -197,7 +197,7 @@ impl ActiveSequences {
         }
 
         let mut outcome = self.force_expiry();
-        let started_at = Instant::now();
+        let started_at = decay_now;
 
         let prompt_hashes = token_sequence.unwrap_or_default();
         let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -168,6 +168,10 @@ impl WorkerTable {
         self.slots.iter().map(|slot| slot.worker)
     }
 
+    pub(super) fn expiry_duration(&self) -> Option<Duration> {
+        self.expiry_duration
+    }
+
     pub(super) fn register_worker(
         &mut self,
         block_size: usize,

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -569,6 +569,7 @@ mod tests {
                 data: ActiveSequenceEventData::Free,
                 router_id: 42,
                 lora_name: None,
+                delivery_age: std::time::Duration::ZERO,
             },
         }
     }

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -537,6 +537,7 @@ mod tests {
                 },
                 router_id,
                 lora_name: None,
+                delivery_age: std::time::Duration::ZERO,
             },
         }
     }

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -29,6 +29,7 @@ use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -304,6 +305,25 @@ pub struct RuntimeSequenceSubscriber {
     pending: VecDeque<ActiveSequenceEvent>,
 }
 
+fn envelope_delivery_age(published_at: u64) -> Duration {
+    let received_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or(0);
+    envelope_delivery_age_at(published_at, received_at)
+}
+
+fn envelope_delivery_age_at(published_at: u64, received_at: u64) -> Duration {
+    let Some(age_ms) = received_at.checked_sub(published_at) else {
+        tracing::debug!(
+            clock_skew_ms = published_at - received_at,
+            "Replica event publication time is ahead of the subscriber clock; clamping age to zero"
+        );
+        return Duration::ZERO;
+    };
+    Duration::from_millis(age_ms)
+}
+
 impl RuntimeSequenceSubscriber {
     pub(crate) async fn for_endpoint(endpoint: &Endpoint) -> Result<Self> {
         let transport_kind = endpoint.drt().default_event_transport_kind();
@@ -326,10 +346,8 @@ impl RuntimeSequenceSubscriber {
             pending: VecDeque::new(),
         })
     }
-}
 
-impl SequenceSubscriber for RuntimeSequenceSubscriber {
-    async fn next_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
+    async fn next_sequence_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
         loop {
             if let Some(event) = self.pending.pop_front() {
                 return Some(Ok(event));
@@ -337,19 +355,29 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
             match &mut self.inner {
                 ActiveSequenceEventSubscriber::Nats(subscriber) => {
                     return match subscriber.next().await? {
-                        Ok((_envelope, event)) => Some(Ok(event)),
+                        Ok((envelope, mut event)) => {
+                            event.delivery_age = envelope_delivery_age(envelope.published_at);
+                            Some(Ok(event))
+                        }
                         Err(error) => Some(Err(error)),
                     };
                 }
                 ActiveSequenceEventSubscriber::Zmq(subscriber) => match subscriber.next().await? {
-                    Ok((_envelope, batch)) => self.pending.extend(batch.events),
+                    Ok((envelope, batch)) => {
+                        let delivery_age = envelope_delivery_age(envelope.published_at);
+                        self.pending
+                            .extend(batch.events.into_iter().map(|mut event| {
+                                event.delivery_age = delivery_age;
+                                event
+                            }));
+                    }
                     Err(error) => return Some(Err(error)),
                 },
             }
         }
     }
 
-    fn poll_next_event(
+    fn poll_next_sequence_event(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
@@ -360,20 +388,45 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
             match &mut self.inner {
                 ActiveSequenceEventSubscriber::Nats(subscriber) => {
                     return match subscriber.poll_next(cx) {
-                        Poll::Ready(Some(Ok((_envelope, event)))) => Poll::Ready(Some(Ok(event))),
+                        Poll::Ready(Some(Ok((envelope, mut event)))) => {
+                            event.delivery_age = envelope_delivery_age(envelope.published_at);
+                            Poll::Ready(Some(Ok(event)))
+                        }
                         Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
                         Poll::Ready(None) => Poll::Ready(None),
                         Poll::Pending => Poll::Pending,
                     };
                 }
                 ActiveSequenceEventSubscriber::Zmq(subscriber) => match subscriber.poll_next(cx) {
-                    Poll::Ready(Some(Ok((_envelope, batch)))) => self.pending.extend(batch.events),
+                    Poll::Ready(Some(Ok((envelope, batch)))) => {
+                        let delivery_age = envelope_delivery_age(envelope.published_at);
+                        self.pending
+                            .extend(batch.events.into_iter().map(|mut event| {
+                                event.delivery_age = delivery_age;
+                                event
+                            }));
+                    }
                     Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
                     Poll::Ready(None) => return Poll::Ready(None),
                     Poll::Pending => return Poll::Pending,
                 },
             }
         }
+    }
+}
+
+impl SequenceSubscriber for RuntimeSequenceSubscriber {
+    fn next_event(
+        &mut self,
+    ) -> impl Future<Output = Option<anyhow::Result<ActiveSequenceEvent>>> + Send {
+        self.next_sequence_event()
+    }
+
+    fn poll_next_event(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
+        self.poll_next_sequence_event(cx)
     }
 }
 
@@ -490,6 +543,15 @@ mod tests {
         })
     }
 
+    #[test]
+    fn envelope_age_uses_delivery_lag_and_clamps_future_publication() {
+        assert_eq!(
+            envelope_delivery_age_at(1_000, 1_250),
+            Duration::from_millis(250)
+        );
+        assert_eq!(envelope_delivery_age_at(1_250, 1_000), Duration::ZERO);
+    }
+
     fn free_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
         ActiveSequenceEvent {
             request_id: request_id.into(),
@@ -497,6 +559,7 @@ mod tests {
             data: ActiveSequenceEventData::Free,
             router_id: 7,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 
@@ -512,6 +575,7 @@ mod tests {
             },
             router_id: 7,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 
@@ -522,6 +586,7 @@ mod tests {
             data: ActiveSequenceEventData::MarkPrefillCompleted,
             router_id: 7,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 
@@ -752,11 +817,13 @@ mod tests {
             ActiveSequenceEventWireFormat::Batch
         );
 
-        let event = free_event("request");
+        let mut event = free_event("request");
+        event.delivery_age = Duration::from_secs(5);
         let singleton_payload = MsgpackCodec.encode_payload(&event).unwrap();
         let decoded_singleton: ActiveSequenceEvent =
             MsgpackCodec.decode_payload(&singleton_payload).unwrap();
         assert_eq!(decoded_singleton.request_id, "request");
+        assert_eq!(decoded_singleton.delivery_age, Duration::ZERO);
         assert!(
             MsgpackCodec
                 .decode_payload::<ActiveSequenceEventBatch>(&singleton_payload)
@@ -771,6 +838,7 @@ mod tests {
         let decoded_batch: ActiveSequenceEventBatch =
             MsgpackCodec.decode_payload(&batch_payload).unwrap();
         assert_eq!(decoded_batch.events[0].request_id, "request");
+        assert_eq!(decoded_batch.events[0].delivery_age, Duration::ZERO);
         assert!(
             MsgpackCodec
                 .decode_payload::<ActiveSequenceEvent>(&batch_payload)

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -346,8 +346,10 @@ impl RuntimeSequenceSubscriber {
             pending: VecDeque::new(),
         })
     }
+}
 
-    async fn next_sequence_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
+impl SequenceSubscriber for RuntimeSequenceSubscriber {
+    async fn next_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
         loop {
             if let Some(event) = self.pending.pop_front() {
                 return Some(Ok(event));
@@ -377,7 +379,7 @@ impl RuntimeSequenceSubscriber {
         }
     }
 
-    fn poll_next_sequence_event(
+    fn poll_next_event(
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
@@ -412,21 +414,6 @@ impl RuntimeSequenceSubscriber {
                 },
             }
         }
-    }
-}
-
-impl SequenceSubscriber for RuntimeSequenceSubscriber {
-    fn next_event(
-        &mut self,
-    ) -> impl Future<Output = Option<anyhow::Result<ActiveSequenceEvent>>> + Send {
-        self.next_sequence_event()
-    }
-
-    fn poll_next_event(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
-        self.poll_next_sequence_event(cx)
     }
 }
 

--- a/lib/llm/src/kv_router/sequence/direct_zmq.rs
+++ b/lib/llm/src/kv_router/sequence/direct_zmq.rs
@@ -98,7 +98,7 @@ pub(super) async fn start<P: SequencePublisher + 'static>(
     let handler_metrics = metrics.clone();
     let handler = move |envelope: dynamo_runtime::transports::event_plane::ValidatedEnvelope| {
         let codec = Codec::default();
-        let batch = codec
+        let mut batch = codec
             .decode_payload::<ActiveSequenceEventBatch>(&envelope.payload)
             .inspect_err(|_| {
                 handler_metrics.record_payload_decode_error();
@@ -110,6 +110,10 @@ pub(super) async fn start<P: SequencePublisher + 'static>(
                 batch.events.len(),
                 MAX_REPLICA_BATCH_EVENTS
             );
+        }
+        let delivery_age = super::envelope_delivery_age(envelope.published_at);
+        for event in &mut batch.events {
+            event.delivery_age = delivery_age;
         }
         tracker.apply_replica_batch(batch.events);
         Ok(())
@@ -215,6 +219,7 @@ mod tests {
             },
             router_id: 99,
             lora_name: None,
+            delivery_age: Duration::ZERO,
         }
     }
 

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -761,6 +761,7 @@ mod tests {
             data,
             router_id: 7,
             lora_name: lora_name.map(str::to_string),
+            delivery_age: Duration::ZERO,
         }
     }
 


### PR DESCRIPTION
## Summary

- preserve event-envelope delivery age when decoding active-sequence events from NATS and ZMQ
- translate wall-clock delivery age into a local monotonic anchor for prefill decay and stale-request expiry
- drop replicated `AddRequest` events whose configured TTL is exhausted on arrival while keeping delayed `Free` idempotent
- keep `delivery_age` local-only with `#[serde(skip)]`, preserving the active-sequence payload format for rolling upgrades and replay

## Where are opportunities for >10ms lag
- nats supercluster (100s of ms)
- nats jetstream (120s+ for old events)
- weird stuff happening in workload-plane on zmq/nats regular (~usually only 10s of milliseconds -> smaller effect)
- > cpu nodes far apart -> definetly possible, in my feeling inside datacenter is often 1-3ms, but i have seen also 10-15ms, e.g. when frontends placed on gpu nodes vs cpu essential nodes in the same region, different vms etc.

## Where does it not lag: 
- inside runtime -> us lag negligble.

## Root cause

Typed sequence subscribers discarded the event envelope. Replica application therefore anchored state to local receive time, extending its effective lifetime by event-bus delay and treating replayed events as fresh.

## Behavior

The existing envelope `published_at` timestamp is converted to delivery age at receipt. Publication timestamps ahead of the subscriber clock are clamped to zero age. This makes delayed delivery and JetStream-style replay consume the correct remaining lifetime without changing the serialized event payload.

This PR uses publication time as the compatibility-safe anchor. Time spent in the local asynchronous publication queue before `published_at` is assigned remains outside this change. Michael's words: You wanna still rollout restart the routers, so would be nice if the envolove age not needed.

Fixes #12777

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved accuracy of replicated request and prefill tracking by accounting for event delivery time.
* Prevented stale requests from being retained beyond the configured expiry period.
* Improved cleanup and expiration behavior for synchronized workloads.
* Added safe handling for delayed, future-dated, or unusually old events.
* Ensured delayed updates do not incorrectly affect newer prefills.

## Compatibility

* Preserved existing event serialization formats while supporting delivery-age tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->