### PR TITLE
test(router): budget shared-GPU sglang workers by token cap instead of memory fraction

### DIFF
--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -39,12 +39,17 @@ pytestmark = [
 ]
 PAGE_SIZE = 16  # SGLang uses "page_size" instead of "block_size"
 
-# Shared SGLang configuration for all tests
-# mem_fraction_static limits actual VRAM allocation (required for multi-worker on same GPU)
+# Shared SGLang configuration for all tests.
+# Memory is budgeted with the token-cap form (--max-total-tokens +
+# --mem-fraction-static 0.9, see tests/README.md "SGLang KV tokens") instead
+# of a fractional split: a fraction is measured against memory that moves
+# while a sibling worker on the same GPU is still allocating, so
+# multi-worker-per-GPU launches can fail the pool-admission check by a hair.
+# The token cap keeps the allocation small and deterministic.
 SGLANG_ARGS: Dict[str, Any] = {
     "page_size": PAGE_SIZE,
     "model": MODEL_NAME,
-    "mem_fraction_static": 0.4,  # Limit VRAM allocation per worker (equivalent to vLLM's gpu_memory_utilization)
+    "max_total_tokens": 2048,  # matches the requested_sglang_kv_tokens(2048) markers
     "context_length": 1024,  # Limit context length to reduce KV cache size (equivalent to vLLM's max_model_len)
     "disable_cuda_graph": True,  # Disable CUDA graphs for faster startup & lower memory (equivalent to vLLM's enforce_eager)
 }
@@ -125,6 +130,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
         page_size = sglang_args.get("page_size", PAGE_SIZE)
         model = sglang_args.get("model", MODEL_NAME)
         mem_fraction_static = sglang_args.get("mem_fraction_static")
+        max_total_tokens = sglang_args.get("max_total_tokens")
         context_length = sglang_args.get("context_length")
         disable_cuda_graph = sglang_args.get("disable_cuda_graph", False)
 
@@ -166,8 +172,18 @@ class SGLangProcess(ManagedEngineProcessMixin):
                 command.append("--disable-cuda-graph")
                 command.append("--disable-piecewise-cuda-graph")
 
-            # Limit VRAM allocation (required for multi-worker on same GPU)
-            if mem_fraction_static is not None:
+            # Limit VRAM allocation (required for multi-worker on same GPU).
+            # Prefer the token-cap form; see the SGLANG_ARGS comment.
+            if max_total_tokens is not None:
+                command.extend(
+                    [
+                        "--max-total-tokens",
+                        str(max_total_tokens),
+                        "--mem-fraction-static",
+                        "0.9",
+                    ]
+                )
+            elif mem_fraction_static is not None:
                 command.extend(["--mem-fraction-static", str(mem_fraction_static)])
 
             # Add optional context_length if specified

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -41,11 +41,7 @@ PAGE_SIZE = 16  # SGLang uses "page_size" instead of "block_size"
 
 # Shared SGLang configuration for all tests.
 # Memory is budgeted with the token-cap form (--max-total-tokens +
-# --mem-fraction-static 0.9, see tests/README.md "SGLang KV tokens") instead
-# of a fractional split: a fraction is measured against memory that moves
-# while a sibling worker on the same GPU is still allocating, so
-# multi-worker-per-GPU launches can fail the pool-admission check by a hair.
-# The token cap keeps the allocation small and deterministic.
+# --mem-fraction-static 0.9, see tests/README.md "SGLang KV tokens").
 SGLANG_ARGS: Dict[str, Any] = {
     "page_size": PAGE_SIZE,
     "model": MODEL_NAME,
@@ -86,6 +82,9 @@ class SGLangProcess(ManagedEngineProcessMixin):
                 - page_size: KV cache page size (default: 16)
                 - model: Model name/path (default: TinyLlama-1.1B)
                 - mem_fraction_static: Fraction of GPU memory to allocate (optional)
+                - max_total_tokens: Max KV cache tokens; takes precedence over
+                  mem_fraction_static and is emitted with --mem-fraction-static 0.9
+                  (see tests/README.md "SGLang KV tokens")
                 - context_length: Maximum sequence length (optional)
                 - disable_cuda_graph: Disable CUDA graphs (default: False)
             num_workers: Number of SGLang worker processes
@@ -133,6 +132,12 @@ class SGLangProcess(ManagedEngineProcessMixin):
         max_total_tokens = sglang_args.get("max_total_tokens")
         context_length = sglang_args.get("context_length")
         disable_cuda_graph = sglang_args.get("disable_cuda_graph", False)
+        # Resolved memory budget, for startup logs (mirrors the command flags).
+        mem_budget = (
+            f"max_total_tokens={max_total_tokens}, mem_frac=0.9"
+            if max_total_tokens is not None
+            else f"mem_frac={mem_fraction_static}"
+        )
 
         self.model_name = model
 
@@ -250,13 +255,13 @@ class SGLangProcess(ManagedEngineProcessMixin):
             if data_parallel_size is not None:
                 logger.info(
                     f"Created {data_parallel_size} DP ranks per worker on GPU(s) {gpu_device} "
-                    f"(mem_frac={mem_fraction_static}, system_port={system_port}, kv_port={kv_events_port}) "
+                    f"({mem_budget}, system_port={system_port}, kv_port={kv_events_port}) "
                     f"with endpoint: {self.endpoint}"
                 )
             else:
                 logger.info(
                     f"Created SGLang worker {worker_idx} on GPU {gpu_device} "
-                    f"(mem_frac={mem_fraction_static}, system_port={system_port}, kv_port={kv_events_port}) "
+                    f"({mem_budget}, system_port={system_port}, kv_port={kv_events_port}) "
                     f"with endpoint: {self.endpoint}"
                 )
 


### PR DESCRIPTION
## Summary

The shared `SGLANG_ARGS` used a fixed `--mem-fraction-static=0.4` per worker for the two-workers-on-one-GPU router tests. That fractional form is not launch-order-safe: SGLang's pool-admission check compares the fraction against the memory that disappeared between the worker's pre-load snapshot and its post-load measurement, so a sibling worker still materializing its own pool lands in that window and the check can reject by a hair. 

This switches the shared config to the parallel-safe token-cap form documented in `tests/README.md` ("SGLang KV tokens"): `--max-total-tokens 2048` — matching the tests' existing `requested_sglang_kv_tokens(2048)` markers — plus `--mem-fraction-static 0.9` to keep the admission gate open. The actual allocation becomes small and deterministic regardless of GPU size or sibling startup timing.

Backward-compatible on both paths:
- `mem_fraction_static` stays supported for configs that still pass it (token cap takes precedence when both are set).
- The VRAM-aware parallel scheduler still overrides via `_PROFILE_OVERRIDE_SGLANG_MAX_TOTAL_TOKENS`: `build_gpu_mem_args` appends its flags after these, and the last occurrence wins.

## Validation

- Emitted worker command now carries `--max-total-tokens 2048 --mem-fraction-static 0.9`; with the scheduler env set, its appended flags still win (argparse last-occurrence semantics).
- Two-worker single-GPU launches no longer depend on sibling startup timing for pool admission; verified on internal CI where the fractional form failed the second worker's launch deterministically and the token-cap form starts both workers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12782" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime configuration for SGLang-backed workloads.
  - Token limits are now applied more consistently, helping provide predictable response lengths.
  - Memory allocation settings are handled more reliably when a token limit is not specified.

- **Tests**
  - Updated end-to-end coverage to validate the revised SGLang configuration and resource behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->