### PR TITLE
fix(thunderagent): recover sessions after worker replacement

### DIFF
--- a/components/src/dynamo/thunderagent_router/__main__.py
+++ b/components/src/dynamo/thunderagent_router/__main__.py
@@ -150,7 +150,8 @@ class ThunderAgentRouterHandler:
             aic_perf_config=build_aic_perf_config(self._config),
         )
 
-        self._capacity = WorkerCapacityProvider(worker_endpoint)
+        worker_client = await worker_endpoint.client()
+        self._capacity = WorkerCapacityProvider(worker_endpoint, worker_client)
         self._capacity.start()
 
         self._scheduler = ThunderAgentScheduler(

--- a/components/src/dynamo/thunderagent_router/capacity.py
+++ b/components/src/dynamo/thunderagent_router/capacity.py
@@ -16,16 +16,17 @@ from typing import Optional
 
 from dynamo.common.native_offloading import get_native_offloading_capacity_tokens
 from dynamo.llm import FpmEventSubscriber
-from dynamo.runtime import Endpoint
+from dynamo.runtime import Client, Endpoint
 
 logger = logging.getLogger(__name__)
 
 
 class WorkerCapacityProvider:
-    """Maps ``worker_id -> program-retention tokens`` from each worker's MDC."""
+    """Tracks live workers and their MDC program-retention capacity."""
 
-    def __init__(self, endpoint: Endpoint) -> None:
+    def __init__(self, endpoint: Endpoint, client: Client) -> None:
         self._endpoint = endpoint
+        self._client = client
         self._subscriber: Optional[FpmEventSubscriber] = None
         # Cache parsed cards keyed on the raw JSON string so a subsequent
         # snapshot() call avoids re-parsing on the request hot path.
@@ -66,6 +67,14 @@ class WorkerCapacityProvider:
             if retention_tokens is not None:
                 out[worker_id] = retention_tokens
         return out
+
+    def live_worker_ids(self) -> set[int]:
+        """Return workers currently registered for the generate endpoint."""
+        try:
+            return set(self._client.instance_ids())
+        except Exception as exc:
+            logger.debug("WorkerCapacityProvider liveness snapshot error: %s", exc)
+            return set()
 
     def _parse_pool_tokens(self, card_json: str) -> Optional[int]:
         if card_json in self._parsed:

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -174,18 +174,46 @@ class ThunderAgentScheduler:
             program.waiting = program.waiting or asyncio.Event()
             return program.waiting, True
 
-        if not (was_new and program.assigned_worker_id is None):
+        needs_assignment = was_new and program.assigned_worker_id is None
+        stale_replacement = False
+        live_worker_ids: set[int] = set()
+        if program.assigned_worker_id is not None:
+            live_worker_ids = self._capacity.live_worker_ids()
+            if not live_worker_ids or program.assigned_worker_id in live_worker_ids:
+                return None, False
+            stale_worker_id = program.assigned_worker_id
+            program.assigned_worker_id = None
+            needs_assignment = True
+            stale_replacement = True
+            logger.info(
+                "thunderagent.worker stale_pin program=%s old_worker=%s "
+                "available_workers=%s",
+                program_id,
+                stale_worker_id,
+                sorted(live_worker_ids),
+            )
+
+        if not needs_assignment:
             return None, False
 
         capacities = self._capacity.snapshot()
+        if stale_replacement:
+            capacities = {
+                worker_id: capacity
+                for worker_id, capacity in capacities.items()
+                if worker_id in live_worker_ids
+            }
+
         if not capacities:
             # Cold start: MDC hasn't published yet. Let the request flow
             # through with no pin; the chunk-loop callback will populate
             # ``assigned_worker_id`` once the engine picks a worker, and
             # subsequent turns get the sticky pin.
             return None, False
-        worker_id = self._select_worker_for_new_program_locked(
-            capacities, program.token_total
+        worker_id = self._select_worker_for_admission_locked(
+            capacities,
+            program.token_total,
+            queue_behind_paused=not stale_replacement,
         )
         if worker_id is not None:
             program.assigned_worker_id = worker_id
@@ -305,13 +333,15 @@ class ThunderAgentScheduler:
             key=lambda w: capacities[w] - self._worker_used(w, decayed=True),
         )
 
-    def _select_worker_for_new_program_locked(
+    def _select_worker_for_admission_locked(
         self,
         capacities: dict[int, int],
         estimated_tokens: int,
+        *,
+        queue_behind_paused: bool,
     ) -> Optional[int]:
         # Fairness: new programs queue behind any existing paused program.
-        if self._table.paused:
+        if queue_behind_paused and self._table.paused:
             return None
         buffer = self._cfg.buffer_per_program
         required = estimated_tokens + buffer

--- a/components/src/dynamo/thunderagent_router/router.py
+++ b/components/src/dynamo/thunderagent_router/router.py
@@ -174,10 +174,27 @@ class ThunderAgentScheduler:
             program.waiting = program.waiting or asyncio.Event()
             return program.waiting, True
 
-        if not (was_new and program.assigned_worker_id is None):
+        capacities = self._capacity.snapshot()
+        needs_assignment = was_new and program.assigned_worker_id is None
+        if (
+            program.assigned_worker_id is not None
+            and capacities
+            and program.assigned_worker_id not in capacities
+        ):
+            stale_worker_id = program.assigned_worker_id
+            program.assigned_worker_id = None
+            needs_assignment = True
+            logger.info(
+                "thunderagent.worker stale_pin program=%s old_worker=%s "
+                "available_workers=%s",
+                program_id,
+                stale_worker_id,
+                sorted(capacities),
+            )
+
+        if not needs_assignment:
             return None, False
 
-        capacities = self._capacity.snapshot()
         if not capacities:
             # Cold start: MDC hasn't published yet. Let the request flow
             # through with no pin; the chunk-loop callback will populate

--- a/components/src/dynamo/thunderagent_router/tests/test_capacity.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_capacity.py
@@ -25,10 +25,21 @@ class _FakeSubscriber:
         return self._cards
 
 
+class _FakeClient:
+    def __init__(self, worker_ids: list[int] | None = None) -> None:
+        self._worker_ids = worker_ids or []
+
+    def instance_ids(self) -> list[int]:
+        return list(self._worker_ids)
+
+
 def _make_provider(
     cards: dict[str, str],
 ) -> tuple[WorkerCapacityProvider, _FakeSubscriber]:
-    provider = WorkerCapacityProvider(endpoint=None)  # type: ignore[arg-type]
+    provider = WorkerCapacityProvider(  # type: ignore[arg-type]
+        endpoint=None,
+        client=_FakeClient(),
+    )
     subscriber = _FakeSubscriber(cards)
     provider._subscriber = subscriber  # type: ignore[assignment]
     return provider, subscriber
@@ -103,5 +114,16 @@ def test_parsed_cards_cache_hits_on_repeat_snapshot():
 
 
 def test_snapshot_returns_empty_when_subscriber_unset():
-    provider = WorkerCapacityProvider(endpoint=None)  # type: ignore[arg-type]
+    provider = WorkerCapacityProvider(  # type: ignore[arg-type]
+        endpoint=None,
+        client=_FakeClient(),
+    )
     assert provider.snapshot() == {}
+
+
+def test_live_worker_ids_uses_endpoint_client():
+    provider = WorkerCapacityProvider(  # type: ignore[arg-type]
+        endpoint=None,
+        client=_FakeClient([1, 2]),
+    )
+    assert provider.live_worker_ids() == {1, 2}

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -20,12 +20,18 @@ pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
 
 @dataclass
 class FakeCapacity:
-    """Stand-in for WorkerCapacityProvider that returns a fixed snapshot."""
+    """Stand-in for WorkerCapacityProvider with configurable worker state."""
 
     workers: dict[int, int] = field(default_factory=dict)
+    live_workers: Optional[set[int]] = None
 
     def snapshot(self) -> dict[int, int]:
         return dict(self.workers)
+
+    def live_worker_ids(self) -> set[int]:
+        if self.live_workers is not None:
+            return set(self.live_workers)
+        return set(self.workers)
 
 
 def make_router(
@@ -128,6 +134,50 @@ async def test_assigned_worker_hint_reflects_sticky_assignment():
     await router.assign_worker("p1", 3)
     decision = await router.before_request("p1", estimated_prompt_tokens=100)
     assert decision.assigned_worker_hint == 3
+
+
+@pytest.mark.asyncio
+async def test_stale_worker_assignment_moves_to_replacement():
+    router, capacity = make_router(capacity_workers={1: 1000})
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    capacity.workers = {}
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    capacity.workers = {2: 1000}
+    capacity.live_workers = {1, 2}
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    capacity.live_workers = {2}
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 2
+    assert router._stat_worker_assignments == 2
+
+
+@pytest.mark.asyncio
+async def test_stale_replacement_bypasses_new_program_fairness_gate():
+    router, capacity = make_router(capacity_workers={1: 300})
+    decision = await router.before_request("active", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    waiter = asyncio.create_task(
+        router.before_request("waiting", estimated_prompt_tokens=100)
+    )
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(waiter), timeout=0.05)
+    assert router._table.programs["waiting"].lifecycle == ProgramLifecycle.PAUSED
+
+    capacity.workers = {2: 1000}
+    capacity.live_workers = {2}
+    decision = await router.before_request("active", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 2
+
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/thunderagent_router/tests/test_router.py
+++ b/components/src/dynamo/thunderagent_router/tests/test_router.py
@@ -131,6 +131,22 @@ async def test_assigned_worker_hint_reflects_sticky_assignment():
 
 
 @pytest.mark.asyncio
+async def test_stale_worker_assignment_moves_to_replacement():
+    router, capacity = make_router(capacity_workers={1: 1000})
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    capacity.workers = {}
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 1
+
+    capacity.workers = {2: 1000}
+    decision = await router.before_request("p1", estimated_prompt_tokens=100)
+    assert decision.assigned_worker_hint == 2
+    assert router._stat_worker_assignments == 2
+
+
+@pytest.mark.asyncio
 async def test_pause_acting_then_before_request_blocks_until_resume():
     cfg = ThunderAgentConfig(
         scheduler_interval_seconds=0.05,


### PR DESCRIPTION
## Overview:

ThunderAgent keeps a sticky backend worker assignment for each program. When that worker is replaced, its runtime instance ID changes, but existing programs retain the removed worker ID. Their next request is then pinned to an endpoint that no longer exists and returns HTTP 500 even after the replacement worker is fully ready.

This change detects a stale assignment during admission and moves the existing program to a currently available worker, allowing the session to continue without a session-final request or router restart.

## Details:

- Compare an existing program's assigned worker with the generate endpoint's live instance set from `Client.instance_ids()`.
- Keep MDC-derived capacity metadata separate from worker liveness, so a healthy worker with missing or incomplete capacity fields is not treated as removed.
- Preserve the existing pin while the live instance set is empty, avoiding reassignment during transient discovery gaps.
- Read the capacity cards only for a new assignment or confirmed stale replacement, keeping MDC parsing off established-session requests.
- Let confirmed stale-session recovery bypass the new-program fairness gate when a replacement has capacity; ordinary new programs still queue behind paused work.
- Filter stale capacity entries before selecting a replacement, and retain the existing pause behavior when no replacement has room.
- Count the replacement as a worker assignment and log the old and available worker IDs.

## Where should the reviewer start?

Start with `ThunderAgentScheduler._admit_locked` in `components/src/dynamo/thunderagent_router/router.py`, then `WorkerCapacityProvider.live_worker_ids` in `capacity.py`. The two focused regressions are in the existing scheduler test file.

## Validation

The core worker-replacement behavior was validated end to end on AKS in `westus2` using:

- Dynamo Platform 1.3.0 with Dynamo `main` at `f4625cde5c` plus the scheduler change mounted into the router pod.
- `Qwen/Qwen3.5-4B` with vLLM 0.24.0.
- Two `Standard_NC48ads_A100_v4` nodes, forcing the backend replacement across nodes in both directions.

Baseline current-main result:

- Session `qwen35-stale-baseline` was pinned to worker `8722798920968502` on the first A100 node.
- The backend was replaced on the second node with worker `5661459964659526`.
- After the replacement worker and DGD were Ready, the existing session returned HTTP 500.
- A fresh control session returned HTTP 200 through worker `5661459964659526`.

Patched result:

- Session `qwen35-stale-patched` was pinned to worker `5661459964659526` on the second A100 node.
- The backend was replaced on the first node with worker `3642907851597554`.
- The same session returned HTTP 200, moved to worker `3642907851597554`, and remained pinned there on the following turn.
- The router logged `thunderagent.worker stale_pin` with the old and replacement worker IDs.

Review follow-up validation:

- Mounted the exact amended scheduler, capacity provider, and focused tests into the AKS Dynamo runtime: `25 passed`.
- Repeated the two-node 4B replacement with session `qwen35-final-e2e`: it moved from worker `8259452763909662` on the second A100 to worker `1127939156566991` on the first A100, returned HTTP 200, and retained the new pin on the following request.
- The router logged `thunderagent.worker stale_pin` for the same old and replacement IDs.
- Repository-pinned Ruff formatting and lint checks passed for all five changed files after rebasing onto current `main`.
- `git diff --check` passed.
- The amended commit remains DCO-signed.

## Related Issues

Fixes #13100


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worker assignment handling when a previously assigned worker is no longer available.
  * Automatically reassigns work to an available worker when capacity returns under a different worker.
  * Preserves valid existing assignments without unnecessary reassignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
