### PR TITLE
fix(frontend): keep completion errors across full aggregation

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -53,6 +53,7 @@ use crate::protocols::common::extensions::{
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::{
+    ParsingOptions,
     audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest},
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
@@ -849,17 +850,6 @@ async fn completions_single(
 
         Ok(sse_stream.into_response())
     } else {
-        // Preserve typed backend errors before the completions aggregator turns
-        // them into strings. In particular, Python ValueError/TypeError arrives
-        // as Backend(InvalidArgument) and must remain an HTTP 400.
-        let stream = check_for_backend_error(stream, None)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?;
-
         // Tap the stream to collect metrics for non-streaming requests without altering items
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
@@ -871,19 +861,10 @@ async fn completions_single(
             );
         });
 
-        let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
+        let response = aggregate_completion_response(stream, parsing_options, &request_id)
             .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
-                );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
-                inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                err_response
+            .inspect_err(|error_response| {
+                inflight_guard.mark_error(extract_error_type_from_response(error_response));
             })?;
 
         inflight_guard.mark_ok();
@@ -976,26 +957,40 @@ fn aggregate_batch_completion_usage(
     }
 }
 
-type BoxedCompletionResponseStream =
-    std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>;
-
-/// Check each prompt stream before merging a non-streaming completion batch.
+/// Fold a non-streaming completion stream into a single response.
 ///
-/// `select_all` cannot safely provide this check after merging because a normal
-/// event from one prompt may arrive before a typed backend error from another.
-/// Poll all streams concurrently so batch startup is not serialized.
-async fn check_completion_batch_streams<S>(
-    streams: Vec<S>,
-) -> Result<Vec<BoxedCompletionResponseStream>, ErrorResponse>
-where
-    S: futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send + 'static,
-{
-    futures::future::try_join_all(
-        streams
-            .into_iter()
-            .map(|stream| check_for_backend_error(stream, None)),
-    )
-    .await
+/// The aggregator reduces a backend error to a string, so the typed error is
+/// captured from the raw events and returned with its own status. Every event
+/// is inspected, so a backend that fails after its first chunk is covered too.
+async fn aggregate_completion_response(
+    stream: impl futures::Stream<Item = Annotated<NvCreateCompletionResponse>>,
+    parsing_options: ParsingOptions,
+    request_id: &str,
+) -> Result<NvCreateCompletionResponse, ErrorResponse> {
+    let backend_error = Arc::new(std::sync::OnceLock::new());
+    let first_error = backend_error.clone();
+    let stream = stream.inspect(move |response| {
+        if let Some(error) = extract_backend_error_if_present(response) {
+            // Keep the first error; it is the one that ended generation.
+            let _ = first_error.set(error);
+        }
+    });
+
+    let aggregated =
+        NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options).await;
+
+    if let Some((message, status)) = backend_error.get() {
+        let error_response = backend_error_response(message.clone(), *status);
+        tracing::warn!(request_id, ?error_response, "Backend error detected");
+        return Err(error_response);
+    }
+
+    aggregated.map_err(|e| {
+        tracing::error!(request_id, "Failed to fold completions stream: {e:?}");
+        ErrorMessage::internal_server_error(&format!(
+            "Failed to fold completions stream for {request_id}"
+        ))
+    })
 }
 
 /// Handle batch prompt completions (multiple prompts with n choices each)
@@ -1100,23 +1095,6 @@ async fn completions_batch(
         all_streams.push(remapped_stream);
     }
 
-    let all_streams: Vec<BoxedCompletionResponseStream> = if streaming {
-        all_streams
-            .into_iter()
-            .map(|stream| Box::pin(stream) as BoxedCompletionResponseStream)
-            .collect()
-    } else {
-        check_completion_batch_streams(all_streams)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?
-    };
-
-    // Merge all streams after every non-streaming prompt has passed its own
-    // backend-error preflight.
     let merged_stream = stream::select_all(all_streams);
     let merged_stream = aggregate_batch_completion_usage(merged_stream, request_id.clone());
 
@@ -1189,19 +1167,10 @@ async fn completions_batch(
             );
         });
 
-        let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
+        let response = aggregate_completion_response(stream, parsing_options, &request_id)
             .await
-            .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
-                );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
-                inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                err_response
+            .inspect_err(|error_response| {
+                inflight_guard.mark_error(extract_error_type_from_response(error_response));
             })?;
 
         inflight_guard.mark_ok();
@@ -5126,82 +5095,6 @@ mod tests {
             assert_eq!(error_response.1.error_type, "Bad Request");
             assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
         }
-    }
-
-    #[tokio::test]
-    async fn test_completion_backend_invalid_argument_surfaces_as_400() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
-        use futures::stream;
-
-        let error_event = Annotated::<NvCreateCompletionResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: None,
-            error: Some(
-                DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
-                    .message("Dynamo's SGLang backend does not currently support logprobs >= 1")
-                    .build(),
-            ),
-        };
-
-        let error_response =
-            match check_for_backend_error(stream::iter(vec![error_event]), None).await {
-                Ok(_) => panic!("typed completion error must fail"),
-                Err(error_response) => error_response,
-            };
-
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
-        assert!(
-            error_response
-                .1
-                .message
-                .contains("does not currently support logprobs >= 1")
-        );
-    }
-
-    #[tokio::test]
-    async fn test_batch_completion_checks_every_stream_for_backend_errors() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
-        use futures::stream;
-
-        let normal_event = Annotated::<NvCreateCompletionResponse> {
-            data: Some(make_completion_chunk("ok", None, None)),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        };
-        let error_event = Annotated::<NvCreateCompletionResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: None,
-            error: Some(
-                DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
-                    .message("invalid second prompt")
-                    .build(),
-            ),
-        };
-
-        let result = check_completion_batch_streams(vec![
-            stream::iter(vec![normal_event]),
-            stream::iter(vec![error_event]),
-        ])
-        .await;
-
-        let error_response = match result {
-            Ok(_) => panic!("an error in any batch prompt must fail the request"),
-            Err(error_response) => error_response,
-        };
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
-        assert_eq!(error_response.1.message, "invalid second prompt");
     }
 
     #[tokio::test]

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -20,6 +20,7 @@ use dynamo_llm::{
         service_v2::HttpService,
     },
     model_card::ModelDeploymentCard,
+    types::openai::completions::OpenAICompletionsStreamingEngine,
 };
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::metrics::prometheus_names::{frontend_service, name_prefix};
@@ -218,6 +219,92 @@ impl
             };
         };
         Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateCompletionRequest>,
+        ManyOut<Annotated<NvCreateCompletionResponse>>,
+        Error,
+    > for InvalidArgumentEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateCompletionResponse>>, Error> {
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield invalid_argument_frame();
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+/// Engine that yields a normal chunk before the `Backend(InvalidArgument)`
+/// frame — modeling a backend that raises after its first decode step.
+struct LateInvalidArgumentEngine {}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateCompletionRequest>,
+        ManyOut<Annotated<NvCreateCompletionResponse>>,
+        Error,
+    > for LateInvalidArgumentEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateCompletionResponse>>, Error> {
+        let (_request, context) = request.transfer(());
+        let ctx = context.context();
+        let stream = stream! {
+            yield Annotated::from_data(completion_chunk("partial"));
+            yield invalid_argument_frame();
+        };
+        Ok(ResponseStream::new(Box::pin(stream), ctx))
+    }
+}
+
+const INVALID_ARGUMENT_MESSAGE: &str =
+    "Dynamo's SGLang backend does not currently support logprobs >= 1";
+
+fn invalid_argument_frame() -> Annotated<NvCreateCompletionResponse> {
+    use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as DynErrorType};
+    Annotated {
+        data: None,
+        id: None,
+        event: Some("error".to_string()),
+        comment: None,
+        error: Some(
+            DynamoError::builder()
+                .error_type(DynErrorType::Backend(BackendError::InvalidArgument))
+                .message(INVALID_ARGUMENT_MESSAGE)
+                .build(),
+        ),
+    }
+}
+
+fn completion_chunk(text: &str) -> NvCreateCompletionResponse {
+    NvCreateCompletionResponse {
+        inner: dynamo_protocols::types::CreateCompletionResponse {
+            id: "cmpl-test".to_string(),
+            choices: vec![dynamo_protocols::types::Choice {
+                text: text.to_string(),
+                index: 0,
+                logprobs: None,
+                finish_reason: None,
+            }],
+            created: 0,
+            model: "test".to_string(),
+            system_fingerprint: None,
+            object: "text_completion".to_string(),
+            usage: None,
+        },
+        nvext: None,
     }
 }
 
@@ -1467,6 +1554,97 @@ async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
         text.contains("Received multimodal data but multimodal processing is not enabled"),
         "expected typed backend error message forwarded to client; got: {text}"
     );
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
+async fn serve_completions_model(
+    name: &str,
+    engine: OpenAICompletionsStreamingEngine,
+) -> (
+    u16,
+    CancellationToken,
+    tokio::task::JoinHandle<Result<(), Error>>,
+) {
+    let (listener, port) = bind_random_port().await;
+    let service = HttpService::builder()
+        .port(port)
+        .enable_cmpl_endpoints(true)
+        .build()
+        .unwrap();
+    let state = service.state_clone();
+    let manager = state.manager();
+
+    let token = CancellationToken::new();
+    let cancel_token = token.clone();
+    let task =
+        tokio::spawn(async move { service.run_with_listener(token.clone(), listener).await });
+    wait_for_service_ready(port).await;
+
+    let card = ModelDeploymentCard::with_name_only(name);
+    manager
+        .add_completions_model(name, card.mdcsum(), engine)
+        .unwrap();
+
+    (port, cancel_token, task)
+}
+
+async fn post_completion(
+    port: u16,
+    model: &str,
+    prompt: &serde_json::Value,
+) -> (StatusCode, String) {
+    let response = reqwest::Client::new()
+        .post(format!("http://localhost:{port}/v1/completions"))
+        .json(&serde_json::json!({ "model": model, "prompt": prompt }))
+        .send()
+        .await
+        .expect("POST /v1/completions");
+    let status = response.status();
+    (status, response.text().await.unwrap_or_default())
+}
+
+/// Single and array prompts take different handlers (`completions_single` vs
+/// `completions_batch`), so both shapes are asserted.
+async fn assert_completions_surface_invalid_argument(model: &str, port: u16) {
+    for prompt in [
+        serde_json::json!("hi"),
+        serde_json::json!(["hi", "bye", "ciao"]),
+    ] {
+        let (status, body) = post_completion(port, model, &prompt).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "prompt {prompt}: typed Backend(InvalidArgument) must reach the client as 400; got {status}, body: {body}"
+        );
+        assert!(
+            body.contains(INVALID_ARGUMENT_MESSAGE),
+            "prompt {prompt}: expected the backend message forwarded to the client; got: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_completions_surface_backend_invalid_argument() {
+    let (port, cancel_token, task) =
+        serve_completions_model("invalid-arg-model", Arc::new(InvalidArgumentEngine {})).await;
+
+    assert_completions_surface_invalid_argument("invalid-arg-model", port).await;
+
+    cancel_token.cancel();
+    task.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn test_completions_surface_backend_invalid_argument_after_first_chunk() {
+    let (port, cancel_token, task) = serve_completions_model(
+        "late-invalid-arg-model",
+        Arc::new(LateInvalidArgumentEngine {}),
+    )
+    .await;
+
+    assert_completions_surface_invalid_argument("late-invalid-arg-model", port).await;
 
     cancel_token.cancel();
     task.await.unwrap().unwrap();


### PR DESCRIPTION
## Overview:

PR #12706 made `/v1/completions` return the backend's own HTTP status for a typed error such as `Backend(InvalidArgument)`. It did this with a preflight that reads only the first stream event, so a backend that emits a normal chunk and *then* fails still returned HTTP 500 with the message replaced by `Failed to fold completions stream`.

This PR removes the preflight and captures the typed error during aggregation instead, so an error at any position keeps its status and its message. The same change removes the batch barrier and the per-prompt boxing that #12706 introduced.

**Repro**

```bash
cargo test -p dynamo-llm --test http-service \
  test_completions_surface_backend_invalid_argument_after_first_chunk
```

The endpoint shape that first showed the bug:

```bash
curl -s localhost:8000/v1/completions -H 'Content-Type: application/json' \
  -d '{"model":"<model>","prompt":"hello","logprobs":2,"max_tokens":16}'
```

**Before**

```
status=500
{"message":"Failed to fold completions stream for c306331a-fe5e-4099-9889-3505ffd59afa","type":"Internal Server Error","code":500}
```

**After**

```
status=400
{"message":"Dynamo's SGLang backend does not currently support logprobs >= 1","type":"Bad Request","code":400}
```

## Details:

**`lib/llm/src/http/service/openai.rs`**

- Adds `aggregate_completion_response`. It taps the raw events on their way into the aggregator, keeps the first typed backend error in a `OnceLock`, and returns that error with its own status. The generic 500 now covers only a fold failure with no typed error. Both `completions_single` and `completions_batch` call it, so the two handlers share one aggregation path.
- Removes `check_completion_batch_streams`. Its `try_join_all` held every prompt stream until the slowest produced its first frame, so a fast prompt could not report metrics or release `http_queue_guard` until the slow prompt answered. `completions_batch` merges with a plain `stream::select_all` again.
- Removes `BoxedCompletionResponseStream`. It only gave the streaming and non-streaming arms the same type, at the cost of one allocation per prompt plus dynamic dispatch on every poll of the streaming path. Streaming is now identical to pre-#12706.
- An expected client 400 logs at `warn` with a structured `error_response` field instead of at `error` with the response formatted into the message.

**`lib/llm/tests/http-service.rs`**

- Adds two tests that drive a real `POST /v1/completions` against a live `HttpService`. One engine emits the typed error as its first frame, the other emits a chunk first. Each test asserts the single-prompt and the array-prompt shape, so both handlers are covered.
- Drops the two unit tests from #12706. They called the helpers directly and stayed green when the production call was removed.

**Trade-off:** without a preflight, a failing batch drains every prompt stream before it answers, as it did before #12706. In exchange, no sibling generation is abandoned mid-flight.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12786" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion error handling so backend errors are detected throughout the entire response, including after output begins.
  * Invalid completion arguments now return clear HTTP 400 responses for single, batch, and streaming requests.
  * Preserved typed status responses while aggregating non-streaming completions.
  * Batch completion responses continue to combine usage information correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->