### PR TITLE
docs(dgdr): correct the unachievable-SLA behavior (adapted cherry-pick #12774)

### DIFF
--- a/docs/fern/kubernetes/dgdr-profiler.md
+++ b/docs/fern/kubernetes/dgdr-profiler.md
@@ -156,7 +156,7 @@ Which parallelization mappings it sweeps depends on the model architecture:
 Beyond the strategy-specific rules covered under [Thorough](#thorough), the profiler enforces these at validation, before any GPUs are used:
 
 - **`sla.e2eLatency` cannot be combined with an explicit `sla.ttft` or `sla.itl`** — provide only one form. The request is rejected otherwise.
-- **An unachievable SLA is not fatal.** The profiler logs a warning, relaxes the SLA to the best achievable value, and continues.
+- **An unachievable SLA is handled per search strategy, and SLA targets are never relaxed.** With `searchStrategy: rapid`, profiling fails and no DGD is generated when no AIC experiment returns an SLA-feasible configuration. With `searchStrategy: thorough`, the profiler selects the closest measured configuration and logs a warning naming the best achievable latency. The generated DGD carries the SLA you submitted. The planner config carries your `sla.ttft` and `sla.itl` unless `features.planner` sets explicit values, which take precedence, and an `sla.e2eLatency` target is not propagated to the planner. See [SLA Cannot Be Met](../components/profiler/profiler-guide.md#sla-cannot-be-met) in the Profiler guide.
 - **A target load that exceeds the GPU budget is not fatal.** The profiler logs a warning and returns its best effort within budget.
 - **A model that spans more GPUs than one node provides needs a gang scheduler** (Grove or LWS); see [Multinode Orchestration](multinode-installation.md).
 


### PR DESCRIPTION
## Summary

Adapted cherry-pick of #12774 (merged to main) onto `release/1.4.0`.

Replaces the false claim in `dgdr-profiler.md` that an unachievable SLA is "relaxed to the best achievable value" with the actual per-strategy behavior: `rapid` fails with no DGD, `thorough` selects the closest measured configuration and warns, SLA targets are never relaxed, and the planner config carries the submitted `sla.ttft`/`sla.itl` unless `features.planner` sets explicit values (an `sla.e2eLatency` target is not propagated).

## Adaptations from the main-side PR

- The docs tree was restructured on main after the 1.4.0 branch cut, so the fix applies to the pre-restructure path `docs/fern/kubernetes/dgdr-profiler.md` and the profiler-guide link is repointed accordingly.
- The main-side sentence about AIC-unsupported architectures falling back to the naive estimator is intentionally omitted: that fallback behaves differently on this branch, so porting the sentence verbatim would misdocument 1.4.0.

The planner-propagation wording was verified against this branch's `components/src/dynamo/profiler/utils/dgd_generation.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12790" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->