### PR TITLE
docs(observability): metrics absence semantics + v1.4.0 deprecations (adapted cherry-pick #12775)

### DIFF
--- a/docs/fern/reference/deprecations.mdx
+++ b/docs/fern/reference/deprecations.mdx
@@ -17,6 +17,28 @@ Upgrading? Pick the version you run today to see the dependency migration and th
 
 <UpgradeSelector />
 
+<a id="v140"></a>
+
+## v1.4.0 (upcoming)
+
+4 entries — 2 behavioral changes, 2 removed.
+
+<span className="dynref-badge dynref-badge--blue">Behavioral</span> **Audit subsystem migrated into request trace** (`"log_type":"audit"` records and the `"Audit sinks ready"` readiness marker -> records carrying `"schema":"dynamo.request.trace.v1"` and the `"Request trace sinks ready"` marker); payload logging is unified under the request-trace pipeline and the standalone audit module is gone ([#9390](https://github.com/ai-dynamo/dynamo/pull/9390), [#11180](https://github.com/ai-dynamo/dynamo/pull/11180)).
+
+  > **Migrate:** Update log pipelines that match on the `"Audit sinks ready"` marker or the `"log_type":"audit"` field to the new marker and the `"schema":"dynamo.request.trace.v1"` field. The `DYN_AUDIT_*` environment variables are still honored as legacy aliases of their request-trace replacements (for example `DYN_AUDIT_SINKS` -> `DYN_REQUEST_TRACE_SINKS`, `DYN_AUDIT_FORCE_LOGGING` -> `DYN_REQUEST_TRACE_RECORDS=request_payload`); move configuration to the new names.
+
+<span className="dynref-badge dynref-badge--blue">Behavioral</span> **HTTP header capture in trace records is an explicit fail-closed allowlist**: request headers appear in `request_payload` records only when named in `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST`; when the variable is unset or empty, no headers are captured ([#11386](https://github.com/ai-dynamo/dynamo/pull/11386)).
+
+  > **Migrate:** Set `DYN_REQUEST_TRACE_HTTP_HEADER_CAPTURE_LIST` to the comma-separated header names you need recorded. Captured values are unredacted, so avoid allowlisting credential-bearing headers.
+
+<span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated multimodal worker flags** (`--multimodal-worker` / `--multimodal-encode-worker` -> `--enable-multimodal` with `--disaggregation-mode` / `--dedicated-mm-encoder`) across the vLLM, SGLang, and TensorRT-LLM backends; deprecated in v1.3.0 ([#11887](https://github.com/ai-dynamo/dynamo/pull/11887)).
+
+  > **Migrate:** On vLLM and SGLang, replace the removed flags with `--enable-multimodal` plus the appropriate `--disaggregation-mode` / `--dedicated-mm-encoder` combination. On TensorRT-LLM, use `--modality multimodal`, which remains the supported path.
+
+<span className="dynref-badge dynref-badge--red">Removed</span> **Removed the deprecated vLLM worker role flags** (`--is-prefill-worker` / `--is-decode-worker` -> `--disaggregation-mode`) ([#12089](https://github.com/ai-dynamo/dynamo/pull/12089)).
+
+  > **Migrate:** Pass `--disaggregation-mode prefill` or `--disaggregation-mode decode` instead of the removed boolean flags.
+
 <a id="v130"></a>
 
 ## v1.3.0 — Jul 20, 2026

--- a/docs/fern/reference/observability/metrics-catalog.mdx
+++ b/docs/fern/reference/observability/metrics-catalog.mdx
@@ -92,7 +92,7 @@ sum by (model) (rate(dynamo_frontend_tokenizer_cache_cached_tokens_total[5m]))
 )
 ```
 
-The ratio is defined only when the model has an active L1 cache and observed tokens. Partial hits increment both token counters. The counters remain zero when `DYN_TOKENIZER_CACHE=0`, encoding fails, or the tokenizer has no registered special-token boundaries.
+The ratio is defined only when the model has an active L1 cache and observed tokens. Partial hits increment both token counters. When the cache is disabled with `DYN_TOKENIZER_CACHE=0`, the per-model series are never created, so they are absent from the scrape rather than reported as zero; detect that state with `absent()`, since a `== 0` comparison never matches a missing series. Only the literal value `0` disables the cache; values such as `false` or `off` leave it enabled. With the cache enabled, the counters remain zero when encoding fails or the tokenizer has no registered special-token boundaries.
 
 <ParamField path="dynamo_frontend_inter_token_latency_seconds" type="histogram">
   Inter-token latency in seconds.


### PR DESCRIPTION
## Summary

Adapted cherry-pick of #12775 (merged to main) onto `release/1.4.0`. Two changes:

- `metrics-catalog.mdx`: corrects the tokenizer-cache metric claim — with `DYN_TOKENIZER_CACHE=0` the per-model series are never created (absent from the scrape, detectable only with `absent()`), not reported as zero; only the literal value `0` disables the cache.
- `deprecations.mdx`: adds the v1.4.0 section (4 entries: audit-to-request-trace migration, fail-closed HTTP header capture allowlist, removal of the deprecated multimodal worker flags with per-backend migration guidance, removal of the deprecated vLLM worker role flags).

## Adaptations from the main-side PR

The docs tree was restructured on main after the 1.4.0 branch cut, so the same content applies at the pre-restructure paths `docs/fern/reference/observability/metrics-catalog.mdx` and `docs/fern/reference/deprecations.mdx`. Content is otherwise identical to the merged main-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12791" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->