### PR TITLE
fix(frontend): unify validation error handling

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -475,7 +475,7 @@ def _render_deepseek_v4_prompt_token_ids(
     try:
         from sglang.srt.entrypoints.openai.encoding_dsv4 import encode_messages
     except ImportError as exc:
-        raise ValueError(
+        raise ImportError(
             "DeepSeek-V4 preprocessing requires SGLang's "
             "sglang.srt.entrypoints.openai.encoding_dsv4 encoder. "
             "Install an SGLang build that includes the DeepSeek-V4 integration."
@@ -755,7 +755,7 @@ def preprocess_chat_request(
         chosen_name = tool_choice["function"]["name"]
         available_names = {t.function.name for t in (sglang_tools or [])}
         if chosen_name not in available_names:
-            raise ValueError(
+            raise PreprocessError(
                 f"tool_choice names function {chosen_name!r}, but it is not "
                 f"present in tools (available: {sorted(available_names) or 'none'})"
             )

--- a/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_sglang_processor_unit.py
@@ -58,6 +58,7 @@ from dynamo.frontend.utils import (
     random_call_id,
     random_uuid,
 )
+from dynamo.llm.exceptions import InvalidArgument
 
 # Needs sglang packages (gpu_1 container), but does not allocate GPU VRAM.
 pytestmark = [
@@ -1923,7 +1924,7 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
         ), "tool_choice=none with flag off should keep tools in template"
 
     def test_named_tool_choice_missing_function_raises(self, tokenizer):
-        """Named tool_choice referencing a function absent from tools raises ValueError."""
+        """A named tool_choice absent from tools is client validation."""
         request = {
             "model": MODEL,
             "messages": [{"role": "user", "content": "Hello"}],
@@ -1945,13 +1946,27 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
                 "function": {"name": "does_not_exist"},
             },
         }
-        with pytest.raises(ValueError, match="does_not_exist"):
+        with pytest.raises(PreprocessError, match="does_not_exist"):
             preprocess_chat_request(
                 request,
                 tokenizer=tokenizer,
                 tool_call_parser_name="hermes",
                 reasoning_parser_name=None,
             )
+
+        processor = SglangProcessor(
+            tokenizer=tokenizer,
+            routed_engine=FakeRoutedEngine(items=[]),
+            tool_call_parser_name="hermes",
+            reasoning_parser_name=None,
+            eos_token_ids=None,
+        )
+
+        async def collect():
+            return [item async for item in processor.generator(request)]
+
+        with pytest.raises(InvalidArgument, match="does_not_exist"):
+            asyncio.run(collect())
 
     def test_chat_template_override_helpers(self, tmp_path):
         """Chat template overrides can be supplied as a Jinja file path."""
@@ -2133,6 +2148,31 @@ class TestPreprocessChatRequest:  # FRONTEND.1 — chat-template input preproces
         assert captured["messages"][0]["role"] == "system"
         assert captured["messages"][0]["tools"][0]["function"]["name"] == "get_weather"
         assert captured["messages"][1]["role"] == "user"
+
+    def test_deepseek_v4_missing_sglang_encoder_is_import_error(self, monkeypatch):
+        """A missing server-side integration is not invalid client input."""
+        monkeypatch.setitem(
+            sys.modules,
+            "sglang.srt.entrypoints.openai.encoding_dsv4",
+            None,
+        )
+
+        class NoTemplateTokenizer:
+            chat_template = None
+
+        with pytest.raises(
+            ImportError,
+            match="DeepSeek-V4 preprocessing requires SGLang's",
+        ):
+            preprocess_chat_request(
+                {
+                    "model": "deepseek-ai/DeepSeek-V4-Pro",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                },
+                tokenizer=NoTemplateTokenizer(),
+                tool_call_parser_name=None,
+                reasoning_parser_name="deepseek-v4",
+            )
 
     def test_deepseek_v4_tool_call_arguments_reach_encoder_as_json_string(
         self, monkeypatch

--- a/lib/bindings/python/rust/llm/frontend_routes.rs
+++ b/lib/bindings/python/rust/llm/frontend_routes.rs
@@ -241,7 +241,7 @@ async fn call_python_frontend_route(
     if extension_executor().try_send(job).is_err() {
         tracing::warn!("frontend extension pool saturated; shedding request");
         return extension_error_response(
-            dynamo_llm::http::service::error::SanitizedError::Overloaded.status(),
+            dynamo_llm::http::service::error::overload_status_code(),
             "frontend route extension busy",
         );
     }

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -30,7 +30,9 @@ use tracing::Instrument;
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_rendered_errors,
+    },
     metrics::{
         CancellationLabels, Endpoint,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
@@ -39,9 +41,9 @@ use super::{
 };
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
-    AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
-    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse,
-    AnthropicMessageContent, SystemContent, chat_completion_to_anthropic_response,
+    AnthropicCountTokensRequest, AnthropicCountTokensResponse, AnthropicCreateMessageRequest,
+    AnthropicErrorBody, AnthropicErrorResponse, SystemContent,
+    chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -56,9 +58,7 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::{
-    HttpErrorClassification, SanitizedError, classify_http_error, invalid_argument,
-};
+use super::error::{HttpProblem, HttpProblemKind, invalid_argument};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
 use crate::engines::ValidateRequest;
@@ -135,54 +135,12 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
-fn validate_anthropic_content_blocks(
-    request: &AnthropicCreateMessageRequest,
-) -> Result<(), dynamo_runtime::error::DynamoError> {
-    for (message_index, message) in request.messages.iter().enumerate() {
-        let AnthropicMessageContent::Blocks { content } = &message.content else {
-            continue;
-        };
-        for (block_index, block) in content.iter().enumerate() {
-            if let AnthropicContentBlock::Other(value) = block
-                && !value.is_object()
-            {
-                return Err(invalid_argument(format!(
-                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
-                )));
-            }
-        }
-    }
-    Ok(())
-}
-
 /// Top-level HTTP handler for POST /v1/messages.
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
     headers: HeaderMap,
     Json(mut request): Json<AnthropicCreateMessageRequest>,
 ) -> Result<Response, Response> {
-    // Validate required fields
-    if request.messages.is_empty() {
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "messages: field required",
-        ));
-    }
-    if request.max_tokens == 0 {
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            "max_tokens: must be greater than 0",
-        ));
-    }
-    if let Err(error) = validate_anthropic_content_blocks(&request) {
-        return Err(anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            error.message(),
-        ));
-    }
     gate_anthropic_nvext(&mut request, state.nvext_enabled());
 
     // Create request context
@@ -229,10 +187,11 @@ async fn handler_anthropic_messages(
     )
     .await
     .map_err(|e| {
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
+        anthropic_problem(HttpProblem::internal(
+            "Internal server error",
             format!("Failed to await Anthropic messages task: {e:?}"),
-        )
+        ))
+        .0
     })?;
 
     connection_handle.disarm();
@@ -283,28 +242,6 @@ async fn anthropic_messages(
 
     tracing::trace!("Received Anthropic messages request: {:?}", &*request);
 
-    // Look up engine and parsing options early so we know whether a reasoning
-    // parser is configured before converting the request.
-    let (engine, parsing_options) = state
-        .manager()
-        .get_chat_completions_engine_with_parsing(&model)
-        .map_err(|e| match e {
-            // Registered but not ready to serve yet → retryable 503 (mapped to
-            // "overloaded_error" by `anthropic_error`). Reuses the OpenAI path's
-            // canonical, customer-facing message so both APIs report the same
-            // text. Anything else is a genuine missing model → 404.
-            crate::discovery::ModelManagerError::ModelUnavailable(_) => anthropic_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "overloaded_error",
-                &super::openai::model_not_ready_message(&model),
-            ),
-            _ => anthropic_error(
-                StatusCode::NOT_FOUND,
-                "not_found_error",
-                &format!("Model '{}' not found", model),
-            ),
-        })?;
-
     let (orig_request, context) = request.into_parts();
     let model_for_resp = orig_request.model.clone();
 
@@ -343,6 +280,24 @@ async fn anthropic_messages(
         )
         .0);
     }
+
+    // Resolve the engine only after the single conversion + validation
+    // pipeline succeeds, so invalid requests do not depend on model state.
+    let (engine, parsing_options) = state
+        .manager()
+        .get_chat_completions_engine_with_parsing(&model)
+        .map_err(|e| match e {
+            crate::discovery::ModelManagerError::ModelUnavailable(_) => anthropic_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "overloaded_error",
+                &super::openai::model_not_ready_message(&model),
+            ),
+            _ => anthropic_error(
+                StatusCode::NOT_FOUND,
+                "not_found_error",
+                &format!("Model '{}' not found", model),
+            ),
+        })?;
     // When a reasoning parser is configured and the client hasn't explicitly
     // disabled thinking, assume the model's chat template will inject `<think>`.
     //
@@ -438,14 +393,9 @@ async fn anthropic_messages(
         let engine_stream = match super::openai::pre_commit_error_peek_timeout() {
             Some(duration) => super::openai::check_for_backend_error(engine_stream, Some(duration))
                 .await
-                .map_err(|(status, error)| {
-                    inflight_guard.mark_error(metric_error_type_for_status(status));
-                    let fallback_type = if status.is_client_error() {
-                        "invalid_request_error"
-                    } else {
-                        "api_error"
-                    };
-                    anthropic_error(status, fallback_type, error.message())
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    anthropic_problem(problem).0
                 })?,
             None => engine_stream,
         };
@@ -472,7 +422,6 @@ async fn anthropic_messages(
                 yield event.map_err(axum::Error::new);
             }
 
-            let mut backend_error = None;
             let mut cancelled = false;
 
             // Keep a single cancellation future alive across chunks — recreating
@@ -495,13 +444,19 @@ async fn anthropic_messages(
                             &mut http_queue_guard,
                         );
 
-                        if let Some((message, status)) =
-                            super::openai::extract_backend_error_if_present(&annotated_chunk)
-                        {
-                            backend_error.get_or_insert_with(|| {
-                                anthropic_inline_error(message, status)
-                            });
-                            continue;
+                        if let Some(problem) = HttpProblem::from_annotated(&annotated_chunk) {
+                            converter.append_error_events(
+                                anthropic_problem_body(&problem),
+                                &mut events,
+                            );
+                            for event in events.drain(..) {
+                                yield event.map_err(axum::Error::new);
+                            }
+                            // The native error event is terminal. Return the
+                            // classification to the monitor for metrics without
+                            // waiting for the backend transport to close.
+                            yield Err(axum::Error::new(problem));
+                            return;
                         }
 
                         let Some(stream_resp) = annotated_chunk.data else {
@@ -524,11 +479,7 @@ async fn anthropic_messages(
                 }
             }
 
-            if let Some(error) = backend_error {
-                converter.append_error_events(error, &mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -542,7 +493,12 @@ async fn anthropic_messages(
             }
         };
 
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -865,94 +821,48 @@ fn apply_anthropic_header_routing_overrides(
     }
 }
 
-/// Build an Anthropic-formatted error response from a canonical
-/// [`SanitizedError`] variant. The status, public message, and Anthropic
-/// `error_type` all come from the variant; `details` are logged
-/// server-side but never reach the client.
-fn anthropic_sanitized_error_with_details(
-    err: SanitizedError,
-    details: impl std::fmt::Display,
-) -> Response {
-    let status = err.status();
-    if err.log_as_error() {
-        tracing::error!(status = %status, "Anthropic {err}: {details}");
-    } else {
-        tracing::debug!(status = %status, "Anthropic {err}: {details}");
-    }
-    (
-        status,
-        Json(AnthropicErrorResponse {
-            object_type: "error".to_string(),
-            error: AnthropicErrorBody {
-                error_type: err.anthropic_type().to_string(),
-                message: err.to_string(),
-            },
-        }),
-    )
-        .into_response()
-}
-
 fn anthropic_error_from_anyhow(
     err: anyhow::Error,
     fallback: &str,
 ) -> (Response, super::metrics::ErrorType) {
-    match classify_http_error(err.as_ref()) {
-        HttpErrorClassification::QueueRejection(rejection) => (
-            anthropic_sanitized_error_with_details(SanitizedError::Overloaded, rejection),
-            super::metrics::ErrorType::Overload,
-        ),
-        HttpErrorClassification::Client { status, message } => {
-            let error_type = match status {
-                StatusCode::NOT_FOUND => super::metrics::ErrorType::NotFound,
-                StatusCode::TOO_MANY_REQUESTS => super::metrics::ErrorType::Overload,
-                _ => super::metrics::ErrorType::Validation,
-            };
-            (
-                anthropic_error(status, "invalid_request_error", message),
-                error_type,
-            )
-        }
-        HttpErrorClassification::Sanitized(error) => {
-            let error_type = match error {
-                SanitizedError::Cancelled => super::metrics::ErrorType::Cancelled,
-                SanitizedError::Overloaded => super::metrics::ErrorType::Overload,
-                SanitizedError::Unavailable => super::metrics::ErrorType::Unavailable,
-                SanitizedError::Internal | SanitizedError::PreserveServerError(_) => {
-                    super::metrics::ErrorType::Internal
-                }
-            };
-            (
-                anthropic_sanitized_error_with_details(error, format!("{err:#}")),
-                error_type,
-            )
-        }
-        HttpErrorClassification::Internal => (
-            anthropic_sanitized_error_with_details(
-                SanitizedError::Internal,
-                format!("{fallback}: {err:#}"),
-            ),
-            super::metrics::ErrorType::Internal,
-        ),
-    }
+    anthropic_problem(HttpProblem::from_error(err.as_ref(), fallback))
 }
 
-fn anthropic_inline_error(message: String, status: StatusCode) -> AnthropicErrorBody {
-    match SanitizedError::for_backend_status(status) {
-        Some(error) => {
-            if error.log_as_error() {
-                tracing::error!(%status, "Anthropic stream error: {message}");
-            } else {
-                tracing::debug!(%status, "Anthropic stream error: {message}");
-            }
-            AnthropicErrorBody {
-                error_type: error.anthropic_type().to_string(),
-                message: error.to_string(),
-            }
-        }
-        None => AnthropicErrorBody {
-            error_type: anthropic_error_type(status, "invalid_request_error").to_string(),
-            message,
-        },
+fn anthropic_problem(problem: HttpProblem) -> (Response, super::metrics::ErrorType) {
+    let metric_type = problem.metric_type();
+    let body = anthropic_problem_body(&problem);
+    (
+        (
+            problem.status(),
+            Json(AnthropicErrorResponse {
+                object_type: "error".to_string(),
+                error: body,
+            }),
+        )
+            .into_response(),
+        metric_type,
+    )
+}
+
+fn anthropic_problem_body(problem: &HttpProblem) -> AnthropicErrorBody {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
+    } else if problem.status().as_u16() == 499 {
+        tracing::debug!(status = %problem.status(), "Anthropic error: {}", problem.diagnostic());
+    }
+    let error_type = match problem.kind() {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "overloaded_error",
+        HttpProblemKind::NotImplemented | HttpProblemKind::Internal => "api_error",
+    };
+    AnthropicErrorBody {
+        error_type: error_type.to_string(),
+        message: problem.message().to_string(),
     }
 }
 
@@ -965,19 +875,6 @@ fn anthropic_error_type(status: StatusCode, fallback: &str) -> &str {
         429 => "rate_limit_error",
         503 | 529 => "overloaded_error",
         _ => fallback,
-    }
-}
-
-fn metric_error_type_for_status(status: StatusCode) -> super::metrics::ErrorType {
-    match status {
-        StatusCode::BAD_REQUEST => super::metrics::ErrorType::Validation,
-        StatusCode::NOT_FOUND => super::metrics::ErrorType::NotFound,
-        StatusCode::TOO_MANY_REQUESTS => super::metrics::ErrorType::Overload,
-        StatusCode::SERVICE_UNAVAILABLE => super::metrics::ErrorType::Unavailable,
-        status if status.as_u16() == 499 => super::metrics::ErrorType::Cancelled,
-        status if status.as_u16() == 529 => super::metrics::ErrorType::Overload,
-        status if status.is_client_error() => super::metrics::ErrorType::Validation,
-        _ => super::metrics::ErrorType::Internal,
     }
 }
 

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -39,9 +39,9 @@ use super::{
 };
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
-    AnthropicCountTokensRequest, AnthropicCountTokensResponse, AnthropicCreateMessageRequest,
-    AnthropicErrorBody, AnthropicErrorResponse, SystemContent,
-    chat_completion_to_anthropic_response,
+    AnthropicContentBlock, AnthropicCountTokensRequest, AnthropicCountTokensResponse,
+    AnthropicCreateMessageRequest, AnthropicErrorBody, AnthropicErrorResponse,
+    AnthropicMessageContent, SystemContent, chat_completion_to_anthropic_response,
 };
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
@@ -56,9 +56,12 @@ use crate::request_template::{RequestTemplate, resolve_request_model};
 use crate::types::Annotated;
 
 // Re-use helpers from the openai module (sibling under service/)
-use super::error::SanitizedError;
+use super::error::{
+    HttpErrorClassification, SanitizedError, classify_http_error, invalid_argument,
+};
 use super::metadata::{attach_x_request_id, extract_metadata_from_http};
 use super::openai::{get_body_limit, get_or_create_request_id};
+use crate::engines::ValidateRequest;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -132,6 +135,26 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
+fn validate_anthropic_content_blocks(
+    request: &AnthropicCreateMessageRequest,
+) -> Result<(), dynamo_runtime::error::DynamoError> {
+    for (message_index, message) in request.messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block
+                && !value.is_object()
+            {
+                return Err(invalid_argument(format!(
+                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Top-level HTTP handler for POST /v1/messages.
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
@@ -151,6 +174,13 @@ async fn handler_anthropic_messages(
             StatusCode::BAD_REQUEST,
             "invalid_request_error",
             "max_tokens: must be greater than 0",
+        ));
+    }
+    if let Err(error) = validate_anthropic_content_blocks(&request) {
+        return Err(anthropic_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_request_error",
+            error.message(),
         ));
     }
     gate_anthropic_nvext(&mut request, state.nvext_enabled());
@@ -219,7 +249,6 @@ async fn anthropic_messages(
     mut stream_handle: ConnectionHandle,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
-    let request_id = request.id().to_string();
 
     // Apply template defaults before capturing model (must happen first so
     // engine lookup and metrics use the resolved model name).
@@ -297,16 +326,8 @@ async fn anthropic_messages(
 
     // Convert Anthropic request -> UnifiedRequest -> Chat Completion request
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
-        tracing::error!(
-            request_id,
-            error = %e,
-            "Failed to convert AnthropicCreateMessageRequest to UnifiedRequest",
-        );
-        anthropic_error(
-            StatusCode::BAD_REQUEST,
-            "invalid_request_error",
-            &format!("Failed to convert request: {}", e),
-        )
+        let error = invalid_argument(format!("Failed to convert request: {e}"));
+        anthropic_error_from_anyhow(error.into(), "Failed to convert Anthropic request").0
     })?;
 
     // Extract the API context before consuming the UnifiedRequest — this
@@ -315,6 +336,13 @@ async fn anthropic_messages(
     let anthropic_ctx = unified_request.anthropic_context().cloned();
     let mut chat_request = unified_request.into_inner();
     apply_anthropic_header_routing_overrides(&mut chat_request, &headers, state.nvext_enabled());
+    if let Err(error) = chat_request.validate() {
+        return Err(anthropic_error_from_anyhow(
+            invalid_argument(error.to_string()).into(),
+            "Invalid Anthropic request",
+        )
+        .0);
+    }
     // When a reasoning parser is configured and the client hasn't explicitly
     // disabled thinking, assume the model's chat template will inject `<think>`.
     //
@@ -377,40 +405,11 @@ async fn anthropic_messages(
             state
                 .metrics_clone()
                 .inc_rejection(&model, super::metrics::Endpoint::AnthropicMessages);
-            inflight_guard.mark_error(super::metrics::ErrorType::Overload);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Overloaded,
-                format!("{e:#}"),
-            );
         }
-        if super::metrics::request_was_unavailable(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Unavailable);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Unavailable,
-                format!("{e:#}"),
-            );
-        }
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Validation);
-            return anthropic_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_request_error",
-                dynamo_err.message(),
-            );
-        }
-        // Check for cancelled request (client disconnected before response was sent)
-        if super::metrics::request_was_cancelled(e.as_ref()) {
-            inflight_guard.mark_error(super::metrics::ErrorType::Cancelled);
-            return anthropic_sanitized_error_with_details(
-                SanitizedError::Cancelled,
-                format!("{e:#}"),
-            );
-        }
-        inflight_guard.mark_error(super::metrics::ErrorType::Internal);
-        anthropic_sanitized_error_with_details(
-            SanitizedError::Internal,
-            format!("Failed to generate Anthropic completions: {e}"),
-        )
+        let (response, error_type) =
+            anthropic_error_from_anyhow(e, "Failed to generate Anthropic completions");
+        inflight_guard.mark_error(error_type);
+        response
     })?;
 
     let ctx = engine_stream.context();
@@ -436,6 +435,21 @@ async fn anthropic_messages(
     > = Box::pin(engine_stream);
 
     if streaming {
+        let engine_stream = match super::openai::pre_commit_error_peek_timeout() {
+            Some(duration) => super::openai::check_for_backend_error(engine_stream, Some(duration))
+                .await
+                .map_err(|(status, error)| {
+                    inflight_guard.mark_error(metric_error_type_for_status(status));
+                    let fallback_type = if status.is_client_error() {
+                        "invalid_request_error"
+                    } else {
+                        "api_error"
+                    };
+                    anthropic_error(status, fallback_type, error.message())
+                })?,
+            None => engine_stream,
+        };
+
         stream_handle.arm();
 
         let mut converter = match anthropic_ctx {
@@ -458,7 +472,7 @@ async fn anthropic_messages(
                 yield event.map_err(axum::Error::new);
             }
 
-            let mut saw_error = false;
+            let mut backend_error = None;
             let mut cancelled = false;
 
             // Keep a single cancellation future alive across chunks — recreating
@@ -481,10 +495,16 @@ async fn anthropic_messages(
                             &mut http_queue_guard,
                         );
 
+                        if let Some((message, status)) =
+                            super::openai::extract_backend_error_if_present(&annotated_chunk)
+                        {
+                            backend_error.get_or_insert_with(|| {
+                                anthropic_inline_error(message, status)
+                            });
+                            continue;
+                        }
+
                         let Some(stream_resp) = annotated_chunk.data else {
-                            if annotated_chunk.event.as_deref() == Some("error") {
-                                saw_error = true;
-                            }
                             continue;
                         };
 
@@ -504,8 +524,8 @@ async fn anthropic_messages(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
+            if let Some(error) = backend_error {
+                converter.append_error_events(error, &mut events);
             } else {
                 converter.append_end_events(&mut events);
             }
@@ -532,38 +552,8 @@ async fn anthropic_messages(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors using the openai helper
-        let stream_with_check = super::openai::check_for_backend_error(engine_stream, None)
-            .await
-            .map_err(|(status, _json_err)| {
-                // check_for_backend_error has already sanitized the body and
-                // logged the backend detail; preserve its status when
-                // re-wrapping in Anthropic format. Status classification is
-                // delegated to SanitizedError::for_backend_status so the
-                // openai and anthropic surfaces stay aligned.
-                let details = format!("backend error event (status {})", status.as_u16());
-                match SanitizedError::for_backend_status(status) {
-                    Some(variant) => anthropic_sanitized_error_with_details(variant, details),
-                    // 4xx (non-499): preserve the client-error status; the
-                    // message is the canonical reason so we don't smuggle
-                    // backend text through. The "invalid_request_error"
-                    // argument is a fallback — anthropic_error remaps
-                    // 401/403/404/429 to their spec-correct types from the
-                    // status code itself.
-                    None => {
-                        tracing::error!(%status, "Anthropic backend error event");
-                        anthropic_error(
-                            status,
-                            "invalid_request_error",
-                            status.canonical_reason().unwrap_or("Client error"),
-                        )
-                    }
-                }
-            })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -575,10 +565,10 @@ async fn anthropic_messages(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    anthropic_sanitized_error_with_details(
-                        SanitizedError::Internal,
-                        format!("Failed to fold messages stream: {e:?}"),
-                    )
+                    let (response, error_type) =
+                        anthropic_error_from_anyhow(e.into(), "Failed to fold messages stream");
+                    inflight_guard.mark_error(error_type);
+                    response
                 })?;
 
         let response = chat_completion_to_anthropic_response(
@@ -902,44 +892,99 @@ fn anthropic_sanitized_error_with_details(
         .into_response()
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()` anywhere in the
-/// error chain. Request validation surfaces `InvalidArgument`, while backends
-/// that reject bad input (e.g. Python `ValueError`/`TypeError` wrapped by
-/// `py_err_to_dynamo`) surface `Backend(InvalidArgument)`; both are client
-/// input errors and warrant an HTTP 400 rather than a generic 500.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(dynamo_error) = error.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
+fn anthropic_error_from_anyhow(
+    err: anyhow::Error,
+    fallback: &str,
+) -> (Response, super::metrics::ErrorType) {
+    match classify_http_error(err.as_ref()) {
+        HttpErrorClassification::QueueRejection(rejection) => (
+            anthropic_sanitized_error_with_details(SanitizedError::Overloaded, rejection),
+            super::metrics::ErrorType::Overload,
+        ),
+        HttpErrorClassification::Client { status, message } => {
+            let error_type = match status {
+                StatusCode::NOT_FOUND => super::metrics::ErrorType::NotFound,
+                StatusCode::TOO_MANY_REQUESTS => super::metrics::ErrorType::Overload,
+                _ => super::metrics::ErrorType::Validation,
+            };
+            (
+                anthropic_error(status, "invalid_request_error", message),
+                error_type,
             )
-        {
-            return Some(dynamo_error);
         }
-        current = error.source();
+        HttpErrorClassification::Sanitized(error) => {
+            let error_type = match error {
+                SanitizedError::Cancelled => super::metrics::ErrorType::Cancelled,
+                SanitizedError::Overloaded => super::metrics::ErrorType::Overload,
+                SanitizedError::Unavailable => super::metrics::ErrorType::Unavailable,
+                SanitizedError::Internal | SanitizedError::PreserveServerError(_) => {
+                    super::metrics::ErrorType::Internal
+                }
+            };
+            (
+                anthropic_sanitized_error_with_details(error, format!("{err:#}")),
+                error_type,
+            )
+        }
+        HttpErrorClassification::Internal => (
+            anthropic_sanitized_error_with_details(
+                SanitizedError::Internal,
+                format!("{fallback}: {err:#}"),
+            ),
+            super::metrics::ErrorType::Internal,
+        ),
     }
-    None
 }
 
-/// Build an Anthropic-formatted error response.
-/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
-fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
-    let mapped_type = match status.as_u16() {
+fn anthropic_inline_error(message: String, status: StatusCode) -> AnthropicErrorBody {
+    match SanitizedError::for_backend_status(status) {
+        Some(error) => {
+            if error.log_as_error() {
+                tracing::error!(%status, "Anthropic stream error: {message}");
+            } else {
+                tracing::debug!(%status, "Anthropic stream error: {message}");
+            }
+            AnthropicErrorBody {
+                error_type: error.anthropic_type().to_string(),
+                message: error.to_string(),
+            }
+        }
+        None => AnthropicErrorBody {
+            error_type: anthropic_error_type(status, "invalid_request_error").to_string(),
+            message,
+        },
+    }
+}
+
+fn anthropic_error_type(status: StatusCode, fallback: &str) -> &str {
+    match status.as_u16() {
         400 => "invalid_request_error",
         401 => "authentication_error",
         403 => "permission_error",
         404 => "not_found_error",
         429 => "rate_limit_error",
         503 | 529 => "overloaded_error",
-        // Use the caller-provided type for other codes (e.g. 500 → "api_error")
-        _ => error_type,
-    };
+        _ => fallback,
+    }
+}
+
+fn metric_error_type_for_status(status: StatusCode) -> super::metrics::ErrorType {
+    match status {
+        StatusCode::BAD_REQUEST => super::metrics::ErrorType::Validation,
+        StatusCode::NOT_FOUND => super::metrics::ErrorType::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => super::metrics::ErrorType::Overload,
+        StatusCode::SERVICE_UNAVAILABLE => super::metrics::ErrorType::Unavailable,
+        status if status.as_u16() == 499 => super::metrics::ErrorType::Cancelled,
+        status if status.as_u16() == 529 => super::metrics::ErrorType::Overload,
+        status if status.is_client_error() => super::metrics::ErrorType::Validation,
+        _ => super::metrics::ErrorType::Internal,
+    }
+}
+
+/// Build an Anthropic-formatted error response.
+/// Maps HTTP status codes to Anthropic error types following the Anthropic API spec.
+fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Response {
+    let mapped_type = anthropic_error_type(status, error_type);
 
     (
         status,
@@ -1035,23 +1080,5 @@ mod tests {
 
         assert_eq!(nvext.backend_instance_id, None);
         assert_eq!(nvext.decode_worker_id, None);
-    }
-
-    #[test]
-    fn anthropic_invalid_argument_is_found_through_error_context() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
-
-        let error = anyhow::Error::new(
-            DynamoError::builder()
-                .error_type(ErrorType::InvalidArgument)
-                .message("invalid request")
-                .build(),
-        )
-        .context("request validation failed");
-
-        assert_eq!(
-            find_invalid_argument_in_chain(error.as_ref()).map(|error| error.message()),
-            Some("invalid request")
-        );
     }
 }

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -31,10 +31,11 @@
 use axum::response::sse::Event;
 use dynamo_runtime::engine::AsyncEngineContext;
 use futures::{Stream, StreamExt};
+use std::error::Error as _;
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::http::service::error::SanitizedError;
+use crate::http::service::error::{HttpProblem, HttpProblemKind};
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
 
 use dynamo_runtime::config::environment_names::llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS as BACKEND_STREAM_TIMEOUT_ENV;
@@ -208,12 +209,63 @@ pub fn monitor_for_disconnects(
     )
 }
 
+/// Monitor a protocol stream that renders its own terminal error event before
+/// returning the classified [`HttpProblem`]. The monitor still owns metrics and
+/// stream finalization, but does not append an OpenAI error envelope.
+pub fn monitor_for_disconnects_with_rendered_errors(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        backend_stream_timeout(),
+        false,
+    )
+}
+
+fn openai_stream_error_type(kind: HttpProblemKind) -> &'static str {
+    match kind {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "service_unavailable",
+        HttpProblemKind::NotImplemented => "not_implemented",
+        HttpProblemKind::Internal => "internal_server_error",
+    }
+}
+
 fn monitor_for_disconnects_with_timeout(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+    inactivity_timeout: Option<Duration>,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_impl(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        inactivity_timeout,
+        true,
+    )
+}
+
+fn monitor_for_disconnects_impl(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
     context: Arc<dyn AsyncEngineContext>,
     mut inflight_guard: InflightGuard,
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
+    render_openai_error: bool,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -242,27 +294,38 @@ fn monitor_for_disconnects_with_timeout(
                             yield event;
                         }
                         Some(Err(err)) => {
-                            // Mark error as internal since it's a streaming error
-                            inflight_guard.mark_error(ErrorType::Internal);
+                            let problem = err
+                                .source()
+                                .and_then(|source| source.downcast_ref::<HttpProblem>())
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    HttpProblem::internal("Internal server error", err.to_string())
+                                });
+                            inflight_guard.mark_error(problem.metric_type());
                             // We're terminating the stream intentionally here with a
                             // structured error + [DONE]; disarm so the stream handle
                             // doesn't later record this as ClosedUnexpectedly (which
                             // would mis-attribute the fault as a client disconnect).
                             stream_handle.disarm();
-                            tracing::error!("Streaming error: {err}");
-                            // Emit a structured OpenAI-style error frame + `data: [DONE]`
-                            // so naive `data:`-line parsers see both the error and a
-                            // stream terminator. Body derived from SanitizedError so
-                            // the sanitized message + status live in one place.
-                            let sanitized = SanitizedError::Internal;
-                            let err_json = serde_json::json!({
-                                "error": {
-                                    "message": sanitized.to_string(),
-                                    "type": sanitized.openai_type_slug(),
-                                    "code": sanitized.status().as_u16(),
-                                }
-                            });
-                            yield Event::default().data(err_json.to_string());
+                            if problem.status().is_server_error() {
+                                tracing::error!("Streaming error: {}", problem.diagnostic());
+                            } else {
+                                tracing::debug!("Streaming error: {}", problem.diagnostic());
+                            }
+                            if render_openai_error {
+                                // HTTP status is already committed, so carry the
+                                // classification in an OpenAI inline envelope.
+                                let err_json = serde_json::json!({
+                                    "error": {
+                                        "message": problem.message(),
+                                        "type": openai_stream_error_type(problem.kind()),
+                                        "code": problem.status().as_u16(),
+                                    }
+                                });
+                                yield Event::default().data(err_json.to_string());
+                            }
+                            // Preserve the frontend's common SSE terminator after
+                            // either the default or protocol-native error frame.
                             yield Event::default().data("[DONE]");
                             // Break to prevent any subsequent mark_ok() from overwriting the error
                             break;
@@ -713,8 +776,8 @@ mod tests {
             .get("error")
             .and_then(|v| v.as_object())
             .unwrap_or_else(|| panic!("[{case}] `error` field is not an object. Body:\n{text}"));
-        let expected = SanitizedError::Internal;
-        let expected_message = expected.to_string();
+        let expected = HttpProblem::internal("Internal server error", "test diagnostic");
+        let expected_message = expected.message().to_string();
         assert_eq!(
             error.get("message").and_then(|v| v.as_str()),
             Some(expected_message.as_str()),
@@ -722,7 +785,7 @@ mod tests {
         );
         assert_eq!(
             error.get("type").and_then(|v| v.as_str()),
-            Some(expected.openai_type_slug()),
+            Some(openai_stream_error_type(expected.kind())),
             "[{case}] structured error `type` mismatch. Body:\n{text}"
         );
         assert_eq!(

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -5,13 +5,19 @@ use std::sync::LazyLock;
 
 use axum::http::StatusCode;
 use dynamo_runtime::config::environment_names::llm as env_llm;
-use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+use dynamo_runtime::error::{BackendError, DynamoError, ErrorType as DynamoErrorType};
+use serde_json::Value;
 use thiserror::Error;
+
+use super::metrics::ErrorType as MetricErrorType;
+use crate::types::Annotated;
+
+pub(crate) const INTERNAL_ERROR_MESSAGE: &str = "Internal server error";
 
 /// Overload / admission-control rejection status. Reads
 /// `DYN_HTTP_OVERLOAD_STATUS_CODE` (default 529); cached since env is fixed at
 /// runtime and this is on the rejection path.
-pub(crate) fn overload_status_code() -> StatusCode {
+pub fn overload_status_code() -> StatusCode {
     static CODE: LazyLock<StatusCode> = LazyLock::new(|| {
         let default = StatusCode::from_u16(529).expect("529 is a valid HTTP status code");
         std::env::var(env_llm::DYN_HTTP_OVERLOAD_STATUS_CODE)
@@ -33,278 +39,427 @@ pub struct HttpError {
     pub message: String,
 }
 
-/// Protocol-neutral result of classifying an error at the HTTP boundary.
-/// OpenAI and Anthropic render this classification in their own envelopes.
-pub(crate) enum HttpErrorClassification<'a> {
-    /// Admission-control rejection with structured details available to the
-    /// OpenAI response renderer.
-    QueueRejection(&'a dynamo_kv_router::scheduling::QueueRejection),
-    /// A client-visible status and safe message.
-    Client {
-        status: StatusCode,
-        message: &'a str,
-    },
-    /// A server-side or cancellation category whose details must be sanitized.
-    Sanitized(SanitizedError),
-    /// An otherwise-unclassified internal error. Protocol renderers may use
-    /// their endpoint-specific safe fallback text.
+/// Protocol-neutral error categories used for metrics and protocol rendering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HttpProblemKind {
+    Validation,
+    Authentication,
+    Permission,
+    NotFound,
+    RateLimit,
+    Cancelled,
+    Overloaded,
+    Unavailable,
+    NotImplemented,
     Internal,
+}
+
+/// A fully classified HTTP failure.
+///
+/// Classification owns the status, public message, metrics category, and
+/// diagnostic. Protocol modules only translate this model into their wire
+/// envelope; they do not re-classify errors.
+#[derive(Debug, Clone)]
+pub(crate) struct HttpProblem {
+    kind: HttpProblemKind,
+    status: StatusCode,
+    message: String,
+    diagnostic: String,
+    details: Option<Box<Value>>,
 }
 
 /// Construct a typed invalid-argument error for validation performed at an
 /// HTTP protocol adapter boundary.
 pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
     DynamoError::builder()
-        .error_type(ErrorType::InvalidArgument)
+        .error_type(DynamoErrorType::InvalidArgument)
         .message(message)
         .build()
 }
 
-/// Classify an error once, independently of the public protocol envelope.
-///
-/// Typed invalid arguments are the only backend messages exposed by default.
-/// Explicit [`HttpError`] 4xx statuses retain their messages. All other
-/// failures are mapped to a sanitized category.
-pub(crate) fn classify_http_error<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> HttpErrorClassification<'a> {
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(rejection) =
-            error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
-        {
-            return HttpErrorClassification::QueueRejection(rejection);
-        }
-        current = error.source();
-    }
-
-    if super::metrics::request_was_rejected(err) {
-        return HttpErrorClassification::Sanitized(SanitizedError::Overloaded);
-    }
-    if super::metrics::request_was_unavailable(err) {
-        return HttpErrorClassification::Sanitized(SanitizedError::Unavailable);
-    }
-
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(dynamo_error) = error.downcast_ref::<DynamoError>()
-            && matches!(
-                dynamo_error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return HttpErrorClassification::Client {
-                status: StatusCode::BAD_REQUEST,
-                message: dynamo_error.message(),
-            };
-        }
-        current = error.source();
-    }
-
-    if super::metrics::request_was_cancelled(err) {
-        return HttpErrorClassification::Sanitized(SanitizedError::Cancelled);
-    }
-
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(http_error) = error.downcast_ref::<HttpError>() {
-            if http_error.code == 499 {
-                return HttpErrorClassification::Sanitized(SanitizedError::Cancelled);
-            }
-            if let Ok(status) = StatusCode::from_u16(http_error.code)
-                && status.is_client_error()
+impl HttpProblem {
+    pub(crate) fn from_error(
+        err: &(dyn std::error::Error + 'static),
+        internal_message: &str,
+    ) -> Self {
+        let diagnostic = format_error_chain(err);
+        let mut current = Some(err);
+        while let Some(error) = current {
+            if let Some(rejection) =
+                error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
             {
-                return HttpErrorClassification::Client {
-                    status,
-                    message: &http_error.message,
+                return Self {
+                    kind: HttpProblemKind::Overloaded,
+                    status: overload_status_code(),
+                    message: rejection.to_string(),
+                    diagnostic,
+                    details: serde_json::to_value(rejection).ok().map(Box::new),
                 };
             }
-            return HttpErrorClassification::Sanitized(SanitizedError::Internal);
+            current = error.source();
+        }
+
+        // For typed failures, the outermost category owns classification; an
+        // invalid-argument cause must not downgrade an outer unavailable error.
+        let mut current = Some(err);
+        while let Some(error) = current {
+            if let Some(dynamo_error) = error.downcast_ref::<DynamoError>() {
+                return Self::from_dynamo_error(dynamo_error, internal_message, diagnostic);
+            }
+            if let Some(http_error) = error.downcast_ref::<HttpError>() {
+                return Self::from_explicit_http_error(http_error, diagnostic);
+            }
+            current = error.source();
+        }
+
+        Self::internal(internal_message, diagnostic)
+    }
+
+    /// Classify a backend stream event without exposing server-side details.
+    pub(crate) fn from_annotated<T>(event: &Annotated<T>) -> Option<Self> {
+        #[derive(serde::Deserialize)]
+        struct ErrorPayload {
+            message: Option<String>,
+            code: Option<u16>,
+        }
+
+        if event.is_error() {
+            // A typed error is authoritative. Its message is data, not another
+            // envelope to inspect: parsing JSON-looking text here could leak an
+            // unknown failure as a client error or override InvalidArgument.
+            if let Some(error) = event.error.as_ref() {
+                return Some(Self::from_dynamo_error(
+                    error,
+                    INTERNAL_ERROR_MESSAGE,
+                    format_error_chain(error),
+                ));
+            }
+
+            let diagnostic = event
+                .comment
+                .as_ref()
+                .map(|comments| comments.join(", "))
+                .filter(|message| !message.trim().is_empty())
+                .unwrap_or_else(|| "unspecified error".to_string());
+
+            // Compatibility for legacy error events that carried a JSON body
+            // in their comment instead of the structured `error` field.
+            if let Ok(payload) = serde_json::from_str::<ErrorPayload>(&diagnostic) {
+                let status = payload
+                    .code
+                    .and_then(|code| StatusCode::from_u16(code).ok())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                let message = payload.message.unwrap_or_else(|| diagnostic.clone());
+                return Some(Self::from_backend_status(status, message, diagnostic));
+            }
+
+            return Some(Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic));
+        }
+
+        // Legacy backends used a comment-only, otherwise empty annotation as
+        // an error marker. Preserve that signal, but never expose or interpret
+        // the untyped comment as a client-safe status/message.
+        if event.data.is_none()
+            && event.event.is_none()
+            && let Some(comments) = event.comment.as_ref()
+            && !comments.is_empty()
+        {
+            return Some(Self::internal(INTERNAL_ERROR_MESSAGE, comments.join(", ")));
+        }
+
+        None
+    }
+
+    pub(crate) fn from_backend_status(
+        status: StatusCode,
+        message: impl Into<String>,
+        diagnostic: impl Into<String>,
+    ) -> Self {
+        let message = message.into();
+        let diagnostic = diagnostic.into();
+        match status {
+            status if status.as_u16() == 499 => Self::classified(
+                HttpProblemKind::Cancelled,
+                status,
+                "Request cancelled",
+                diagnostic,
+            ),
+            status if status.is_client_error() => Self {
+                kind: kind_for_status(status),
+                status,
+                message,
+                diagnostic,
+                details: None,
+            },
+            status if status.is_server_error() => Self::classified(
+                kind_for_status(status),
+                status,
+                INTERNAL_ERROR_MESSAGE,
+                diagnostic,
+            ),
+            _ => Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic),
+        }
+    }
+
+    pub(crate) fn internal(message: impl Into<String>, diagnostic: impl Into<String>) -> Self {
+        Self {
+            kind: HttpProblemKind::Internal,
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+            diagnostic: diagnostic.into(),
+            details: None,
+        }
+    }
+
+    fn from_dynamo_error(error: &DynamoError, internal_message: &str, diagnostic: String) -> Self {
+        match error.error_type() {
+            DynamoErrorType::InvalidArgument
+            | DynamoErrorType::Backend(BackendError::InvalidArgument) => Self {
+                kind: HttpProblemKind::Validation,
+                status: StatusCode::BAD_REQUEST,
+                message: error.message().to_string(),
+                diagnostic,
+                details: None,
+            },
+            DynamoErrorType::ResourceExhausted => Self::classified(
+                HttpProblemKind::Overloaded,
+                overload_status_code(),
+                "Service temporarily overloaded",
+                diagnostic,
+            ),
+            DynamoErrorType::Unavailable => Self::classified(
+                HttpProblemKind::Unavailable,
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service temporarily unavailable",
+                diagnostic,
+            ),
+            DynamoErrorType::Cancelled | DynamoErrorType::Backend(BackendError::Cancelled) => {
+                Self::classified(
+                    HttpProblemKind::Cancelled,
+                    StatusCode::from_u16(499).expect("499 is a valid HTTP status code"),
+                    "Request cancelled",
+                    diagnostic,
+                )
+            }
+            _ => Self::internal(internal_message, diagnostic),
+        }
+    }
+
+    fn from_explicit_http_error(error: &HttpError, diagnostic: String) -> Self {
+        let Ok(status) = StatusCode::from_u16(error.code) else {
+            return Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic);
+        };
+        if status.as_u16() == 499 {
+            Self::classified(
+                HttpProblemKind::Cancelled,
+                status,
+                "Request cancelled",
+                diagnostic,
+            )
+        } else if status.is_client_error() {
+            Self {
+                kind: kind_for_status(status),
+                status,
+                message: error.message.clone(),
+                diagnostic,
+                details: None,
+            }
+        } else {
+            Self::internal(INTERNAL_ERROR_MESSAGE, diagnostic)
+        }
+    }
+
+    fn classified(
+        kind: HttpProblemKind,
+        status: StatusCode,
+        message: impl Into<String>,
+        diagnostic: String,
+    ) -> Self {
+        Self {
+            kind,
+            status,
+            message: message.into(),
+            diagnostic,
+            details: None,
+        }
+    }
+
+    pub(crate) fn kind(&self) -> HttpProblemKind {
+        self.kind
+    }
+
+    pub(crate) fn status(&self) -> StatusCode {
+        self.status
+    }
+
+    pub(crate) fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub(crate) fn diagnostic(&self) -> &str {
+        &self.diagnostic
+    }
+
+    pub(crate) fn details(&self) -> Option<Box<Value>> {
+        self.details.clone()
+    }
+
+    pub(crate) fn metric_type(&self) -> MetricErrorType {
+        metric_type_for_kind(self.kind)
+    }
+
+    pub(crate) fn metric_type_for_status(status: StatusCode) -> MetricErrorType {
+        metric_type_for_kind(kind_for_status(status))
+    }
+}
+
+fn metric_type_for_kind(kind: HttpProblemKind) -> MetricErrorType {
+    match kind {
+        HttpProblemKind::Validation
+        | HttpProblemKind::Authentication
+        | HttpProblemKind::Permission => MetricErrorType::Validation,
+        HttpProblemKind::NotFound => MetricErrorType::NotFound,
+        HttpProblemKind::RateLimit | HttpProblemKind::Overloaded => MetricErrorType::Overload,
+        HttpProblemKind::Unavailable => MetricErrorType::Unavailable,
+        HttpProblemKind::Cancelled => MetricErrorType::Cancelled,
+        HttpProblemKind::NotImplemented => MetricErrorType::NotImplemented,
+        HttpProblemKind::Internal => MetricErrorType::Internal,
+    }
+}
+
+impl std::fmt::Display for HttpProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for HttpProblem {}
+
+fn kind_for_status(status: StatusCode) -> HttpProblemKind {
+    match status {
+        StatusCode::UNAUTHORIZED => HttpProblemKind::Authentication,
+        StatusCode::FORBIDDEN => HttpProblemKind::Permission,
+        StatusCode::NOT_FOUND => HttpProblemKind::NotFound,
+        StatusCode::TOO_MANY_REQUESTS => HttpProblemKind::RateLimit,
+        StatusCode::NOT_IMPLEMENTED => HttpProblemKind::NotImplemented,
+        StatusCode::SERVICE_UNAVAILABLE => HttpProblemKind::Unavailable,
+        status if status.as_u16() == 499 => HttpProblemKind::Cancelled,
+        status if status.as_u16() == 529 => HttpProblemKind::Overloaded,
+        status if status.is_client_error() => HttpProblemKind::Validation,
+        _ => HttpProblemKind::Internal,
+    }
+}
+
+fn format_error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut parts = Vec::new();
+    let mut current = Some(err);
+    while let Some(error) = current {
+        if let Some(error) = error.downcast_ref::<DynamoError>() {
+            parts.push(error.message().to_string());
+        } else {
+            parts.push(error.to_string());
         }
         current = error.source();
     }
-
-    HttpErrorClassification::Internal
-}
-
-/// Canonical sanitized error responses returned at the HTTP boundary.
-///
-/// Each variant fixes the `(status, public message, protocol error_type)`
-/// triple so call sites stop duplicating literals. The protocol-specific
-/// mappings (OpenAI `error_type` string, Anthropic `error_type`) and the
-/// `Display` impl that produces the user-safe message all live on this
-/// enum — clients see exactly what the enum says, never a backend error
-/// chain, file path, or panic stack.
-#[derive(Debug, Clone, Copy)]
-pub enum SanitizedError {
-    /// 499 Client Closed Request.
-    Cancelled,
-    /// 529 Site Is Overloaded.
-    Overloaded,
-    /// 503 Service Unavailable.
-    Unavailable,
-    /// 500 Internal Server Error.
-    Internal,
-    /// Preserve a backend-reported 5xx status code while replacing the
-    /// body with the generic internal-error message. Clients still see
-    /// the original status (so 503 retry semantics survive); only the
-    /// payload is sanitized.
-    ///
-    /// Invariant: the inner status MUST be in the 500–599 range. Construct
-    /// via [`SanitizedError::for_backend_status`] to enforce this.
-    PreserveServerError(StatusCode),
-}
-
-impl SanitizedError {
-    /// Classify a backend-supplied HTTP status into the right sanitized
-    /// variant. Returns `None` to mean "forward this 4xx (non-499)
-    /// message as-is" — that case is the protocol contract for client
-    /// errors and is the caller's responsibility to handle.
-    ///
-    /// The single source of truth for the status → variant mapping;
-    /// every site that triages a backend status code should call this
-    /// instead of inlining the if-chain.
-    pub fn for_backend_status(status: StatusCode) -> Option<Self> {
-        if status.as_u16() == 499 {
-            Some(SanitizedError::Cancelled)
-        } else if status.is_client_error() {
-            // 4xx (non-499) is the protocol contract; caller forwards.
-            None
-        } else if status.is_server_error() {
-            Some(SanitizedError::PreserveServerError(status))
-        } else {
-            // 1xx/2xx/3xx asserted by a backend payload — coerce to 500.
-            Some(SanitizedError::Internal)
-        }
-    }
-
-    pub fn status(self) -> StatusCode {
-        match self {
-            // 499 is not IANA-registered but is widely used (nginx).
-            SanitizedError::Cancelled => StatusCode::from_u16(499).unwrap(),
-            SanitizedError::Overloaded => overload_status_code(),
-            SanitizedError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
-            SanitizedError::Internal => StatusCode::INTERNAL_SERVER_ERROR,
-            SanitizedError::PreserveServerError(code) => {
-                debug_assert!(
-                    code.is_server_error(),
-                    "PreserveServerError requires a 5xx status; got {code}"
-                );
-                code
-            }
-        }
-    }
-
-    /// Anthropic `error.type` for this category. For `PreserveServerError`
-    /// the inner status is consulted so a backend 503/529 is reported as
-    /// `overloaded_error` (matching the Anthropic spec) rather than the
-    /// generic `api_error`.
-    pub fn anthropic_type(self) -> &'static str {
-        match self {
-            SanitizedError::Cancelled => "request_cancelled",
-            SanitizedError::Overloaded => "overloaded_error",
-            SanitizedError::Unavailable => "overloaded_error",
-            SanitizedError::Internal => "api_error",
-            SanitizedError::PreserveServerError(status) => match status.as_u16() {
-                503 | 529 => "overloaded_error",
-                _ => "api_error",
-            },
-        }
-    }
-
-    /// OpenAI-style snake_case `type` field used in inline error frames.
-    pub fn openai_type_slug(self) -> &'static str {
-        match self {
-            SanitizedError::Cancelled => "request_cancelled",
-            SanitizedError::Overloaded => "service_unavailable",
-            SanitizedError::Unavailable => "service_unavailable",
-            SanitizedError::Internal => "internal_server_error",
-            SanitizedError::PreserveServerError(status) => match status.as_u16() {
-                503 | 529 => "service_unavailable",
-                _ => "internal_server_error",
-            },
-        }
-    }
-
-    /// Whether to log this category at `error!` (true) or `debug!` (false).
-    /// Cancellations are client-driven and routinely fire on disconnect, so
-    /// they stay at debug to avoid drowning real errors.
-    pub fn log_as_error(self) -> bool {
-        !matches!(self, SanitizedError::Cancelled)
-    }
-}
-
-impl std::fmt::Display for SanitizedError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SanitizedError::Cancelled => f.write_str("Request cancelled"),
-            SanitizedError::Overloaded => f.write_str("Service temporarily overloaded"),
-            SanitizedError::Unavailable => f.write_str("Service temporarily unavailable"),
-            SanitizedError::Internal | SanitizedError::PreserveServerError(_) => {
-                f.write_str("Internal server error")
-            }
-        }
-    }
+    parts.join(": ")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_runtime::protocols::maybe_error::MaybeError;
+
+    #[test]
+    fn typed_validation_is_safe_and_unknown_errors_are_sanitized() {
+        for error_type in [
+            DynamoErrorType::InvalidArgument,
+            DynamoErrorType::Backend(BackendError::InvalidArgument),
+        ] {
+            let error = DynamoError::builder()
+                .error_type(error_type)
+                .message("temperature must be between 0 and 2")
+                .build();
+            let problem = HttpProblem::from_error(&error, "request failed");
+            assert_eq!(problem.kind(), HttpProblemKind::Validation);
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem.message(), "temperature must be between 0 and 2");
+        }
+
+        let error = DynamoError::builder()
+            .error_type(DynamoErrorType::Backend(BackendError::Unknown))
+            .message("panic at /srv/worker.py:42")
+            .build();
+        let problem = HttpProblem::from_error(&error, "request failed");
+        assert_eq!(problem.kind(), HttpProblemKind::Internal);
+        assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.message(), "request failed");
+        assert!(!problem.message().contains("/srv/worker.py"));
+    }
 
     #[test]
     fn local_statuses_distinguish_overload_from_unavailable() {
-        assert_eq!(SanitizedError::Overloaded.status().as_u16(), 529);
-        assert_eq!(
-            SanitizedError::Unavailable.status(),
-            StatusCode::SERVICE_UNAVAILABLE
+        let overloaded = HttpProblem::from_dynamo_error(
+            &DynamoError::builder()
+                .error_type(DynamoErrorType::ResourceExhausted)
+                .message("busy")
+                .build(),
+            INTERNAL_ERROR_MESSAGE,
+            "busy".to_string(),
         );
+        assert_eq!(overloaded.status().as_u16(), 529);
+        assert_eq!(overloaded.kind(), HttpProblemKind::Overloaded);
+        let unavailable = HttpProblem::from_dynamo_error(
+            &DynamoError::builder()
+                .error_type(DynamoErrorType::Unavailable)
+                .message("down")
+                .build(),
+            INTERNAL_ERROR_MESSAGE,
+            "down".to_string(),
+        );
+        assert_eq!(unavailable.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(unavailable.kind(), HttpProblemKind::Unavailable);
     }
 
     #[test]
-    fn preserve_server_error_503_maps_to_overload_types() {
-        // Backend-asserted 503 must surface as the spec-correct overload
-        // type on both protocols, not as a generic api_error /
-        // internal_server_error.
-        let err = SanitizedError::PreserveServerError(StatusCode::SERVICE_UNAVAILABLE);
-        assert_eq!(err.anthropic_type(), "overloaded_error");
-        assert_eq!(err.openai_type_slug(), "service_unavailable");
+    fn backend_statuses_forward_client_messages_and_sanitize_everything_else() {
+        let client =
+            HttpProblem::from_backend_status(StatusCode::BAD_REQUEST, "bad prompt", "bad prompt");
+        assert_eq!(client.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(client.message(), "bad prompt");
+
+        let server = HttpProblem::from_backend_status(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "worker host leaked",
+            "worker host leaked",
+        );
+        assert_eq!(server.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(server.message(), INTERNAL_ERROR_MESSAGE);
+
+        let invalid_status = HttpProblem::from_backend_status(
+            StatusCode::from_u16(399).unwrap(),
+            "not an error",
+            "not an error",
+        );
+        assert_eq!(invalid_status.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(invalid_status.message(), INTERNAL_ERROR_MESSAGE);
     }
 
     #[test]
-    fn preserve_server_error_529_maps_to_overload_types() {
-        // Anthropic uses 529 as an alternative overload signal; mirror
-        // the 503 mapping so clients can apply the same backoff.
-        let err = SanitizedError::PreserveServerError(StatusCode::from_u16(529).unwrap());
-        assert_eq!(err.anthropic_type(), "overloaded_error");
-        assert_eq!(err.openai_type_slug(), "service_unavailable");
-    }
+    fn typed_annotated_errors_ignore_json_shaped_messages() {
+        let invalid = DynamoError::builder()
+            .error_type(DynamoErrorType::InvalidArgument)
+            .message(r#"{"code":500,"message":"wrong"}"#)
+            .build();
+        let problem = HttpProblem::from_annotated(&Annotated::<()>::from_err(invalid)).unwrap();
+        assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(problem.message(), r#"{"code":500,"message":"wrong"}"#);
 
-    #[test]
-    fn preserve_server_error_500_remains_generic() {
-        let err = SanitizedError::PreserveServerError(StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(err.anthropic_type(), "api_error");
-        assert_eq!(err.openai_type_slug(), "internal_server_error");
-    }
-
-    #[test]
-    fn for_backend_status_classifies_correctly() {
-        // 499 → Cancelled
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(499).unwrap()),
-            Some(SanitizedError::Cancelled)
-        ));
-        // 5xx → PreserveServerError preserving the code
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::SERVICE_UNAVAILABLE),
-            Some(SanitizedError::PreserveServerError(s)) if s == StatusCode::SERVICE_UNAVAILABLE
-        ));
-        // Non-499 4xx → None (forward as-is)
-        assert!(SanitizedError::for_backend_status(StatusCode::BAD_REQUEST).is_none());
-        assert!(SanitizedError::for_backend_status(StatusCode::NOT_FOUND).is_none());
-        // 1xx/2xx/3xx asserted by backend → Internal
-        assert!(matches!(
-            SanitizedError::for_backend_status(StatusCode::from_u16(399).unwrap()),
-            Some(SanitizedError::Internal)
-        ));
+        let unknown = DynamoError::builder()
+            .error_type(DynamoErrorType::Backend(BackendError::Unknown))
+            .message(r#"{"code":400,"message":"secret /srv/worker"}"#)
+            .build();
+        let problem = HttpProblem::from_annotated(&Annotated::<()>::from_err(unknown)).unwrap();
+        assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.message(), INTERNAL_ERROR_MESSAGE);
     }
 }

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -5,6 +5,7 @@ use std::sync::LazyLock;
 
 use axum::http::StatusCode;
 use dynamo_runtime::config::environment_names::llm as env_llm;
+use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
 use thiserror::Error;
 
 /// Overload / admission-control rejection status. Reads
@@ -30,6 +31,100 @@ pub(crate) fn overload_status_code() -> StatusCode {
 pub struct HttpError {
     pub code: u16,
     pub message: String,
+}
+
+/// Protocol-neutral result of classifying an error at the HTTP boundary.
+/// OpenAI and Anthropic render this classification in their own envelopes.
+pub(crate) enum HttpErrorClassification<'a> {
+    /// Admission-control rejection with structured details available to the
+    /// OpenAI response renderer.
+    QueueRejection(&'a dynamo_kv_router::scheduling::QueueRejection),
+    /// A client-visible status and safe message.
+    Client {
+        status: StatusCode,
+        message: &'a str,
+    },
+    /// A server-side or cancellation category whose details must be sanitized.
+    Sanitized(SanitizedError),
+    /// An otherwise-unclassified internal error. Protocol renderers may use
+    /// their endpoint-specific safe fallback text.
+    Internal,
+}
+
+/// Construct a typed invalid-argument error for validation performed at an
+/// HTTP protocol adapter boundary.
+pub(crate) fn invalid_argument(message: impl Into<String>) -> DynamoError {
+    DynamoError::builder()
+        .error_type(ErrorType::InvalidArgument)
+        .message(message)
+        .build()
+}
+
+/// Classify an error once, independently of the public protocol envelope.
+///
+/// Typed invalid arguments are the only backend messages exposed by default.
+/// Explicit [`HttpError`] 4xx statuses retain their messages. All other
+/// failures are mapped to a sanitized category.
+pub(crate) fn classify_http_error<'a>(
+    err: &'a (dyn std::error::Error + 'static),
+) -> HttpErrorClassification<'a> {
+    let mut current = Some(err);
+    while let Some(error) = current {
+        if let Some(rejection) =
+            error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
+        {
+            return HttpErrorClassification::QueueRejection(rejection);
+        }
+        current = error.source();
+    }
+
+    if super::metrics::request_was_rejected(err) {
+        return HttpErrorClassification::Sanitized(SanitizedError::Overloaded);
+    }
+    if super::metrics::request_was_unavailable(err) {
+        return HttpErrorClassification::Sanitized(SanitizedError::Unavailable);
+    }
+
+    let mut current = Some(err);
+    while let Some(error) = current {
+        if let Some(dynamo_error) = error.downcast_ref::<DynamoError>()
+            && matches!(
+                dynamo_error.error_type(),
+                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
+            )
+        {
+            return HttpErrorClassification::Client {
+                status: StatusCode::BAD_REQUEST,
+                message: dynamo_error.message(),
+            };
+        }
+        current = error.source();
+    }
+
+    if super::metrics::request_was_cancelled(err) {
+        return HttpErrorClassification::Sanitized(SanitizedError::Cancelled);
+    }
+
+    let mut current = Some(err);
+    while let Some(error) = current {
+        if let Some(http_error) = error.downcast_ref::<HttpError>() {
+            if http_error.code == 499 {
+                return HttpErrorClassification::Sanitized(SanitizedError::Cancelled);
+            }
+            if let Ok(status) = StatusCode::from_u16(http_error.code)
+                && status.is_client_error()
+            {
+                return HttpErrorClassification::Client {
+                    status,
+                    message: &http_error.message,
+                };
+            }
+            return HttpErrorClassification::Sanitized(SanitizedError::Internal);
+        }
+        current = error.source();
+    }
+
+    HttpErrorClassification::Internal
 }
 
 /// Canonical sanitized error responses returned at the HTTP boundary.

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -25,6 +25,7 @@ use serde::Serialize;
 use tracing::Instrument;
 
 use super::disconnect::create_connection_monitor;
+use super::error::{HttpProblem, HttpProblemKind};
 use super::metrics::{CancellationLabels, ErrorType};
 use super::openai::{
     check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
@@ -90,6 +91,24 @@ fn generate_error_response(code: StatusCode, error_type: &str, message: String) 
         }),
     )
         .into_response()
+}
+
+fn generate_problem(problem: HttpProblem) -> Response {
+    if problem.status().is_server_error() {
+        tracing::error!(status = %problem.status(), "Generate error: {}", problem.diagnostic());
+    }
+    let error_type = match problem.kind() {
+        HttpProblemKind::Validation => "invalid_request_error",
+        HttpProblemKind::Authentication => "authentication_error",
+        HttpProblemKind::Permission => "permission_error",
+        HttpProblemKind::NotFound => "not_found_error",
+        HttpProblemKind::RateLimit => "rate_limit_error",
+        HttpProblemKind::Cancelled => "request_cancelled",
+        HttpProblemKind::Overloaded | HttpProblemKind::Unavailable => "service_unavailable",
+        HttpProblemKind::NotImplemented => "not_implemented",
+        HttpProblemKind::Internal => "internal_error",
+    };
+    generate_error_response(problem.status(), error_type, problem.message().to_string())
 }
 
 /// Resolve the request metadata that vLLM keeps outside the public JSON body.
@@ -423,32 +442,16 @@ async fn generate_dispatch(
     let stream = match generate_result {
         Ok(stream) => stream,
         Err(error) => {
-            let was_cancelled = request_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref());
             let was_rejected = super::metrics::request_was_rejected(error.as_ref());
-            inflight_guard.mark_error(if was_cancelled {
-                ErrorType::Cancelled
-            } else if was_rejected {
-                ErrorType::Unavailable
-            } else {
-                ErrorType::Internal
-            });
-            if was_cancelled {
-                return generate_cancelled_response();
-            }
             if was_rejected {
                 tracing::warn!(%request_id, error = %format!("{error:#}"), "engine rejected generate request");
                 state
                     .metrics_clone()
                     .inc_rejection(&model, super::metrics::Endpoint::Generate);
-                return generate_error_response(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "service_unavailable",
-                    "engine rejected the request".to_string(),
-                );
             }
-            tracing::error!(%request_id, error = %format!("{error:#}"), "engine generate call failed");
-            return generate_internal_error_response();
+            let problem = HttpProblem::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            return generate_problem(problem);
         }
     };
 
@@ -484,16 +487,13 @@ async fn generate_dispatch(
             Json(response).into_response()
         }
         Err(error) => {
-            if request_context.is_killed()
-                || engine_context.is_killed()
-                || super::metrics::request_was_cancelled(error.as_ref())
-            {
+            if request_context.is_killed() || engine_context.is_killed() {
                 inflight_guard.mark_error(ErrorType::Cancelled);
                 return generate_cancelled_response();
             }
-            inflight_guard.mark_error(ErrorType::Internal);
-            tracing::error!(%request_id, %error, "failed to fold generate stream");
-            generate_internal_error_response()
+            let problem = HttpProblem::from_error(error.as_ref(), "internal server error");
+            inflight_guard.mark_error(problem.metric_type());
+            generate_problem(problem)
         }
     }
 }
@@ -588,6 +588,44 @@ mod tests {
     struct TerminalEngine(crate::protocols::common::FinishReason);
 
     struct CancelledEngine;
+
+    struct InvalidArgumentEngine {
+        during_stream: bool,
+    }
+
+    fn backend_invalid_argument() -> dynamo_runtime::error::DynamoError {
+        dynamo_runtime::error::DynamoError::builder()
+            .error_type(dynamo_runtime::error::ErrorType::Backend(
+                dynamo_runtime::error::BackendError::InvalidArgument,
+            ))
+            .message("unsupported generate option")
+            .build()
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for InvalidArgumentEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            if !self.during_stream {
+                return Err(backend_invalid_argument().into());
+            }
+            let event = Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(backend_invalid_argument()),
+            };
+            Ok(ResponseStream::new(
+                Box::pin(futures::stream::iter([event])),
+                request.context(),
+            ))
+        }
+    }
 
     #[async_trait::async_trait]
     impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
@@ -1129,6 +1167,47 @@ mod tests {
 
         assert_eq!(response.status().as_u16(), 499);
         assert_cancelled_dispatch_metrics(state.as_ref());
+    }
+
+    #[tokio::test]
+    async fn typed_validation_from_generate_or_stream_returns_400() {
+        for during_stream in [false, true] {
+            let engine: crate::types::openai::generate::GenerateStreamingEngine =
+                Arc::new(InvalidArgumentEngine { during_stream });
+            let service = HttpService::builder().build().unwrap();
+            let state = service.state_clone();
+            let response = generate_dispatch(
+                engine,
+                dispatch_test_context(),
+                "req-invalid-generate".to_string(),
+                "test-model".to_string(),
+                state.clone(),
+                GenerateResponseOptions::default(),
+            )
+            .await;
+
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read validation response");
+            let body: serde_json::Value =
+                serde_json::from_slice(&body).expect("parse validation response");
+            assert_eq!(body["error"]["type"], "invalid_request_error");
+            assert_eq!(body["error"]["message"], "unsupported generate option");
+
+            let metric_model = state.manager().metric_model_for("test-model");
+            assert_eq!(state.metrics_clone().get_inflight_count(metric_model), 0);
+            assert_eq!(
+                state.metrics_clone().get_request_counter(
+                    metric_model,
+                    &Endpoint::Generate,
+                    &RequestType::Unary,
+                    &Status::Error,
+                    &ErrorType::Validation,
+                ),
+                1
+            );
+        }
     }
 
     #[test]

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -58,6 +58,7 @@ pub fn request_was_cancelled(err: &(dyn std::error::Error + 'static)) -> bool {
 pub use prometheus::Registry;
 
 use super::RouteDoc;
+use super::error::HttpProblem;
 
 /// Worker type label values for Prometheus timing metrics
 pub use crate::discovery::{WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL};
@@ -2033,6 +2034,10 @@ fn observe_annotation_metrics<T>(
 fn annotated_to_sse_event<T: Serialize>(
     annotated: crate::types::Annotated<T>,
 ) -> Result<Option<Event>, axum::Error> {
+    if let Some(problem) = HttpProblem::from_annotated(&annotated) {
+        return Err(axum::Error::new(problem));
+    }
+
     let mut event = Event::default();
 
     if let Some(ref data) = annotated.data {
@@ -2040,23 +2045,6 @@ fn annotated_to_sse_event<T: Serialize>(
     }
 
     if let Some(ref msg) = annotated.event {
-        if msg == "error" {
-            let error_message = if let Some(ref dynamo_err) = annotated.error
-                && !dynamo_err.message().is_empty()
-            {
-                dynamo_err.message().to_string()
-            } else if let Some(ref comments) = annotated.comment {
-                let joined = comments.join(" -- ");
-                if joined.trim().is_empty() {
-                    "unspecified error".to_string()
-                } else {
-                    joined
-                }
-            } else {
-                "unspecified error".to_string()
-            };
-            return Err(axum::Error::new(error_message));
-        }
         event = event.event(msg);
     }
 
@@ -3769,6 +3757,22 @@ mod tests {
         }
     }
 
+    fn assert_internal_problem(
+        result: Result<Option<Event>, axum::Error>,
+        expected_diagnostic: &str,
+    ) {
+        use std::error::Error as _;
+
+        let error = result.expect_err("error annotation must fail conversion");
+        let problem = error
+            .source()
+            .and_then(|source| source.downcast_ref::<HttpProblem>())
+            .expect("converter must preserve the classified HTTP problem");
+        assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(problem.message(), "Internal server error");
+        assert!(problem.diagnostic().contains(expected_diagnostic));
+    }
+
     #[test]
     fn test_error_event_uses_dynamo_error_message() {
         use dynamo_runtime::error::DynamoError;
@@ -3776,30 +3780,26 @@ mod tests {
             Some(DynamoError::msg("image load failed: 403 Forbidden")),
             None,
         ));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("403 Forbidden"));
+        assert_internal_problem(result, "403 Forbidden");
     }
 
     #[test]
     fn test_error_event_falls_back_to_comment() {
         let result =
             run_event_converter(error_annotated(None, Some(vec!["connection lost".into()])));
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("connection lost"));
+        assert_internal_problem(result, "connection lost");
     }
 
     #[test]
     fn test_error_event_unspecified_when_no_message() {
         let result = run_event_converter(error_annotated(None, None));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]
     fn test_error_event_empty_comment_falls_through() {
         let result = run_event_converter(error_annotated(None, Some(vec!["".into()])));
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err().to_string(), "unspecified error");
+        assert_internal_problem(result, "unspecified error");
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -33,8 +33,11 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::{HttpError, HttpErrorClassification, classify_http_error, invalid_argument},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
+        monitor_for_disconnects_with_rendered_errors,
+    },
+    error::{HttpError, HttpProblem, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -91,8 +94,6 @@ const BATCH_OUTPUT_RETRIEVAL_NOT_IMPLEMENTED: &str =
 static FORCE_INCLUDE_USAGE: LazyLock<bool> =
     LazyLock::new(|| env_is_truthy(env_llm::DYN_ENABLE_FORCE_INCLUDE_USAGE));
 
-use super::error::{SanitizedError, overload_status_code};
-
 pub(super) fn rl_router(
     drt: Arc<dynamo_runtime::DistributedRuntime>,
 ) -> anyhow::Result<axum::Router> {
@@ -122,6 +123,9 @@ pub(crate) struct ErrorMessage {
     code: u16,
     #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<Box<serde_json::Value>>,
+    /// Preserve canonical classification for metrics without putting it on the wire.
+    #[serde(skip)]
+    classification: Option<ErrorType>,
 }
 
 fn map_error_code_to_error_type(code: StatusCode) -> String {
@@ -135,25 +139,13 @@ fn map_error_code_to_error_type(code: StatusCode) -> String {
     }
 }
 
-/// Classify error for metrics based on status code and message
-fn classify_error_for_metrics(code: StatusCode, _message: &str) -> ErrorType {
-    match code {
-        StatusCode::BAD_REQUEST => ErrorType::Validation, // 400
-        StatusCode::NOT_FOUND => ErrorType::NotFound,     // 404
-        StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented, // 501
-        StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
-        StatusCode::SERVICE_UNAVAILABLE => ErrorType::Unavailable, // 503
-        StatusCode::INTERNAL_SERVER_ERROR => ErrorType::Internal, // 500
-        _ if code.as_u16() == 529 => ErrorType::Overload, // 529
-        _ if code.as_u16() == 499 => ErrorType::Cancelled, // 499 Client Closed Request
-        _ if code.is_client_error() => ErrorType::Validation, // other 4xx
-        _ => ErrorType::Internal,                         // everything else
-    }
-}
-
 /// Extract ErrorType from ErrorResponse for metrics
 fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
-    classify_error_for_metrics(response.0, &response.1.message)
+    response
+        .1
+        .classification
+        .clone()
+        .unwrap_or_else(|| HttpProblem::metric_type_for_status(response.0))
 }
 
 fn responses_error_code(status: StatusCode) -> &'static str {
@@ -165,10 +157,6 @@ fn responses_error_code(status: StatusCode) -> &'static str {
 }
 
 impl ErrorMessage {
-    pub(super) fn message(&self) -> &str {
-        &self.message
-    }
-
     /// Not Found Error
     pub fn model_not_found() -> ErrorResponse {
         let code = StatusCode::NOT_FOUND;
@@ -180,6 +168,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
@@ -212,6 +201,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
@@ -229,6 +219,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
@@ -248,6 +239,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
@@ -271,32 +263,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
-            }),
-        )
-    }
-
-    /// Build a sanitized error response from a [`SanitizedError`] variant.
-    /// The status, public message, and protocol error_type all come from
-    /// the variant — call sites do not pass any of them as literals.
-    /// Server-side `details` are logged alongside the canonical category;
-    /// the client only ever sees the variant's public message.
-    pub fn sanitized_with_details(
-        err: SanitizedError,
-        details: impl std::fmt::Display,
-    ) -> ErrorResponse {
-        let status = err.status();
-        if err.log_as_error() {
-            tracing::error!(status = %status, "{err}: {details}");
-        } else {
-            tracing::debug!(status = %status, "{err}: {details}");
-        }
-        (
-            status,
-            Json(ErrorMessage {
-                message: err.to_string(),
-                error_type: map_error_code_to_error_type(status),
-                code: status.as_u16(),
-                details: None,
+                classification: None,
             }),
         )
     }
@@ -315,6 +282,7 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
@@ -329,84 +297,39 @@ impl ErrorMessage {
                 error_type,
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
     }
 
-    /// The OAI endpoints call an [`dynamo.runtime::engine::AsyncEngine`] which are specialized to return
-    /// an [`anyhow::Error`]. This method will convert the [`anyhow::Error`] into an [`HttpError`].
-    /// If successful, it will return the [`HttpError`] as an [`ErrorMessage::internal_server_error`]
-    /// with the details of the error.
+    pub(super) fn from_problem(problem: HttpProblem) -> ErrorResponse {
+        let status = problem.status();
+        let classification = problem.metric_type();
+        if status.is_server_error() {
+            tracing::error!(status = %status, "{}", problem.diagnostic());
+        } else if status.as_u16() == 499 {
+            tracing::debug!(status = %status, "{}", problem.diagnostic());
+        }
+        (
+            status,
+            Json(ErrorMessage {
+                message: problem.message().to_string(),
+                error_type: map_error_code_to_error_type(status),
+                code: status.as_u16(),
+                details: problem.details(),
+                classification: Some(classification),
+            }),
+        )
+    }
+
+    /// Convert an engine error into an OpenAI error envelope.
     pub fn from_anyhow(err: anyhow::Error, alt_msg: &str) -> ErrorResponse {
-        match classify_http_error(err.as_ref()) {
-            HttpErrorClassification::QueueRejection(rejection) => {
-                let code = overload_status_code();
-                (
-                    code,
-                    Json(ErrorMessage {
-                        message: rejection.to_string(),
-                        error_type: map_error_code_to_error_type(code),
-                        code: code.as_u16(),
-                        details: serde_json::to_value(rejection).ok().map(Box::new),
-                    }),
-                )
-            }
-            HttpErrorClassification::Client { status, message } => (
-                status,
-                Json(ErrorMessage {
-                    message: message.to_string(),
-                    error_type: map_error_code_to_error_type(status),
-                    code: status.as_u16(),
-                    details: None,
-                }),
-            ),
-            HttpErrorClassification::Sanitized(error) => {
-                ErrorMessage::sanitized_with_details(error, format!("{err:#}"))
-            }
-            HttpErrorClassification::Internal => {
-                ErrorMessage::internal_server_error_with_details(alt_msg, format!("{err:#}"))
-            }
-        }
+        Self::from_problem(HttpProblem::from_error(err.as_ref(), alt_msg))
     }
 
-    /// Implementers should only be able to throw 400-499 errors.
+    /// Implementers may explicitly return safe 4xx errors.
     pub fn from_http_error(err: HttpError) -> ErrorResponse {
-        // 499 is part of the 4xx range but its body can carry cancellation
-        // context (queue paths, context IDs) — sanitize separately.
-        if err.code == 499 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Cancelled, err.message);
-        }
-        // Backend-supplied messages are only forwarded for the documented 4xx
-        // range; for 5xx or codes outside the HTTP space the message may
-        // contain internal paths/details and is kept server-side only.
-        if err.code < 400 || err.code >= 500 {
-            return ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message);
-        }
-        match StatusCode::from_u16(err.code) {
-            Ok(code) => (
-                code,
-                Json(ErrorMessage {
-                    message: err.message,
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: None,
-                }),
-            ),
-            Err(_) => ErrorMessage::sanitized_with_details(SanitizedError::Internal, err.message),
-        }
-    }
-}
-
-impl From<HttpError> for ErrorMessage {
-    fn from(err: HttpError) -> Self {
-        ErrorMessage {
-            message: err.message,
-            error_type: map_error_code_to_error_type(
-                StatusCode::from_u16(err.code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
-            ),
-            code: err.code,
-            details: None,
-        }
+        Self::from_problem(HttpProblem::from_error(&err, "Internal server error"))
     }
 }
 
@@ -429,6 +352,7 @@ pub async fn smart_json_error_middleware(request: Request<Body>, next: Next) -> 
                 error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
                 code: StatusCode::BAD_REQUEST.as_u16(),
                 details: None,
+                classification: None,
             }),
         )
             .into_response()
@@ -760,14 +684,12 @@ async fn completions_single(
         // immediately available typed validation failures a bounded chance to
         // become an HTTP 4xx first.
         let stream = match pre_commit_error_peek_timeout() {
-            Some(dur) => {
-                check_for_backend_error(stream, Some(dur))
-                    .await
-                    .map_err(|err_response| {
-                        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                        err_response
-                    })?
-            }
+            Some(dur) => check_for_backend_error(stream, Some(dur))
+                .await
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
+                })?,
             None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
         };
 
@@ -1051,9 +973,9 @@ async fn completions_batch(
         let merged_stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(merged_stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
             None => {
                 Box::pin(merged_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
@@ -1424,6 +1346,7 @@ fn json_deserialize_error(error: serde_json::Error) -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
+            classification: None,
         }),
     )
 }
@@ -1452,6 +1375,7 @@ fn unsupported_media_type_error() -> ErrorResponse {
             error_type: map_error_code_to_error_type(code),
             code: code.as_u16(),
             details: None,
+            classification: None,
         }),
     )
 }
@@ -1505,128 +1429,6 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
     changed.then_some(out)
 }
 
-/// Checks if an Annotated event represents a backend error and extracts error information.
-/// Returns Some((message, status_code)) if it's an error, None otherwise.
-pub(super) fn extract_backend_error_if_present<T: serde::Serialize>(
-    event: &Annotated<T>,
-) -> Option<(String, StatusCode)> {
-    #[derive(serde::Deserialize)]
-    struct ErrorPayload {
-        message: Option<String>,
-        code: Option<u16>,
-    }
-
-    // Check if event type is "error" (from postprocessor when FinishReason::Error is encountered)
-    if let Some(event_type) = &event.event
-        && event_type == "error"
-    {
-        use dynamo_runtime::error::{BackendError, ErrorType};
-
-        // Classify only this event's error, not its causes. An inner invalid
-        // argument must not override an outer unavailable or internal error.
-        let invalid_argument = event.error.as_ref().filter(|error| {
-            matches!(
-                error.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        });
-
-        // Extract error string: prefer DynamoError field, fallback to legacy comment.
-        // Use message() instead of to_string() for DynamoError to avoid prefixing
-        // the ErrorType (e.g., "Unknown: {...}"), which would break JSON parsing.
-        let error_str = if let Some(ref dynamo_err) = event.error {
-            let mut parts = Vec::new();
-            let mut current: Option<&dyn std::error::Error> = Some(dynamo_err);
-            while let Some(e) = current {
-                if let Some(de) = e.downcast_ref::<dynamo_runtime::error::DynamoError>() {
-                    parts.push(de.message().to_string());
-                } else {
-                    parts.push(e.to_string());
-                }
-                current = e.source();
-            }
-            parts.join(", ")
-        } else {
-            event
-                .comment
-                .as_ref()
-                .map(|c| c.join(", "))
-                .unwrap_or_else(|| "Unknown error".to_string())
-        };
-
-        // Parse the status-bearing node's own message. The diagnostic string
-        // above includes its causes and therefore is not necessarily JSON.
-        let status_message = event
-            .error
-            .as_ref()
-            .map(|error| error.message())
-            .unwrap_or(&error_str);
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(status_message) {
-            // Preserve explicit HTTP-like statuses (for example 415); Python
-            // 4xx exceptions share the Backend(InvalidArgument) category.
-            let code = match error_payload.code {
-                Some(code) => {
-                    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
-                }
-                None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
-                None => StatusCode::INTERNAL_SERVER_ERROR,
-            };
-            let message = error_payload
-                .message
-                .unwrap_or_else(|| status_message.to_string());
-            return Some((message, code));
-        }
-
-        if let Some(invalid_argument) = invalid_argument {
-            return Some((
-                invalid_argument.message().to_string(),
-                StatusCode::BAD_REQUEST,
-            ));
-        }
-
-        return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
-    }
-
-    // Check if the data payload itself contains an error structure with code >= 400
-    if let Some(data) = &event.data
-        && let Ok(json_value) = serde_json::to_value(data)
-        && let Ok(error_payload) = serde_json::from_value::<ErrorPayload>(json_value.clone())
-        && let Some(code_num) = error_payload.code
-        && code_num >= 400
-    {
-        let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let message = error_payload
-            .message
-            .unwrap_or_else(|| json_value.to_string());
-        return Some((message, code));
-    }
-
-    // Check if comment contains error information (without event: error)
-    if let Some(comments) = &event.comment
-        && !comments.is_empty()
-    {
-        let comment_str = comments.join(", ");
-
-        // Try to parse comment as error JSON with code >= 400
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(&comment_str)
-            && let Some(code_num) = error_payload.code
-            && code_num >= 400
-        {
-            let code = StatusCode::from_u16(code_num).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let message = error_payload.message.unwrap_or(comment_str);
-            return Some((message, code));
-        }
-
-        // Comments present with no data AND no event type indicates error
-        // (events with event types like "request_id" or "event.dynamo.test.sentinel" are annotations)
-        if event.data.is_none() && event.event.is_none() {
-            return Some((comment_str, StatusCode::INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    None
-}
-
 /// Returns true for events that only carry an annotation tag (e.g. the
 /// `request_id` frame prepended to every stream): no data, no error, and
 /// an `event` field that is *not* the `"error"` marker. Annotations may
@@ -1658,12 +1460,12 @@ const MAX_LEADING_ANNOTATIONS: usize = 16;
 /// non-annotation event arrives, return the buffered annotations chained with
 /// the remaining stream so downstream sees the original ordering.
 ///
-/// Returns `Err(ErrorResponse)` if the first non-annotation event is a backend
+/// Returns `Err(HttpProblem)` if the first non-annotation event is a backend
 /// error, `Ok(stream)` otherwise.
 pub(super) async fn check_for_backend_error<T>(
     stream: impl futures::Stream<Item = Annotated<T>> + Send + 'static,
     timeout: Option<std::time::Duration>,
-) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, ErrorResponse>
+) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<T>> + Send>>, HttpProblem>
 where
     T: serde::Serialize + Send + 'static,
 {
@@ -1697,8 +1499,8 @@ where
             continue;
         }
 
-        if let Some((error_msg, status_code)) = extract_backend_error_if_present(&event) {
-            return Err(backend_error_response(error_msg, status_code));
+        if let Some(problem) = HttpProblem::from_annotated(&event) {
+            return Err(problem);
         }
 
         // First non-annotation, non-error event — hand back for downstream
@@ -1708,29 +1510,10 @@ where
     }
 }
 
-/// Convert an `(error_msg, status_code)` pair from `extract_backend_error_if_present`
-/// into the wire `ErrorResponse` used by streaming pre-commit checks.
-fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorResponse {
-    match SanitizedError::for_backend_status(status_code) {
-        Some(variant) => ErrorMessage::sanitized_with_details(variant, error_msg),
-        // 4xx (non-499): protocol contract — forward backend message as-is.
-        None => (
-            status_code,
-            Json(ErrorMessage {
-                message: error_msg,
-                error_type: map_error_code_to_error_type(status_code),
-                code: status_code.as_u16(),
-                details: None,
-            }),
-        ),
-    }
-}
-
 /// Read the pre-commit peek window from the environment.
 ///
 /// `Some(dur)` — poll for that duration before committing SSE.
-/// `None` — the peek is disabled entirely (default; matches pre-fix behavior
-/// where all backend errors surface as SSE frames post-HTTP-200).
+/// `None` — the peek is explicitly disabled with a value of `0`.
 ///
 /// Read live per streaming request. Reading `std::env::var` is a hashmap
 /// lookup — sub-microsecond, negligible next to the peek window
@@ -1739,12 +1522,14 @@ fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorRe
 // FIXME: unify env-var initialization with the rest of `env_llm::*` once that
 // module gets a standard reader.
 pub(super) fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+    const DEFAULT_MS: u64 = 500;
     match std::env::var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS)
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_MS)
     {
-        Some(0) | None => None,
-        Some(ms) => Some(std::time::Duration::from_millis(ms)),
+        0 => None,
+        ms => Some(std::time::Duration::from_millis(ms)),
     }
 }
 
@@ -2101,18 +1886,12 @@ async fn chat_completions(
         let stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately (pre-fix
-            // behavior). Backend errors will surface as SSE error frames via
-            // monitor_for_disconnects.
-            None => Box::pin(stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
         };
 
         let mut http_queue_guard = Some(http_queue_guard);
@@ -2609,16 +2388,14 @@ async fn responses(
         let engine_stream = match pre_commit_error_peek_timeout() {
             Some(dur) => check_for_backend_error(engine_stream, Some(dur))
                 .await
-                .map_err(|err_response| {
-                    tracing::error!(request_id = %request_id, "Backend error detected: {:?}", err_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-                    err_response
+                .map_err(|problem| {
+                    inflight_guard.mark_error(problem.metric_type());
+                    ErrorMessage::from_problem(problem)
                 })?,
-            // Env var unset → skip peek, commit HTTP 200 immediately.
-            None => Box::pin(engine_stream)
-                as std::pin::Pin<
-                    Box<dyn futures::Stream<Item = _> + Send>,
-                >,
+            // Explicit `0` skips the peek and commits HTTP 200 immediately.
+            None => {
+                Box::pin(engine_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
         };
 
         // Streaming path: convert chat completion stream chunks to Responses API SSE events.
@@ -2641,9 +2418,6 @@ async fn responses(
                 yield event.map_err(axum::Error::new);
             }
 
-            // Track whether the backend sent an error event during the stream.
-            let mut backend_error = None;
-
             while let Some(annotated_chunk) = engine_stream.next().await {
                 process_chat_response_and_observe_metrics(
                     &annotated_chunk,
@@ -2651,13 +2425,21 @@ async fn responses(
                     &mut http_queue_guard,
                 );
 
-                if let Some((message, status)) = extract_backend_error_if_present(&annotated_chunk) {
-                    let response = backend_error_response(message, status);
-                    backend_error.get_or_insert_with(|| ErrorObject {
-                        code: responses_error_code(response.0).to_string(),
-                        message: response.1.message.clone(),
-                    });
-                    continue;
+                if let Some(problem) = HttpProblem::from_annotated(&annotated_chunk) {
+                    converter.append_error_events(
+                        ErrorObject {
+                            code: responses_error_code(problem.status()).to_string(),
+                            message: problem.message().to_string(),
+                        },
+                        &mut events,
+                    );
+                    for event in events.drain(..) {
+                        yield event.map_err(axum::Error::new);
+                    }
+                    // response.failed is terminal. Return the classification to
+                    // the monitor for metrics without waiting for backend EOF.
+                    yield Err(axum::Error::new(problem));
+                    return;
                 }
 
                 let Some(stream_resp) = annotated_chunk.data else {
@@ -2670,11 +2452,7 @@ async fn responses(
                 }
             }
 
-            if let Some(error) = backend_error {
-                converter.append_error_events(error, &mut events);
-            } else {
-                converter.append_end_events(&mut events);
-            }
+            converter.append_end_events(&mut events);
             for event in events.drain(..) {
                 yield event.map_err(axum::Error::new);
             }
@@ -2682,7 +2460,12 @@ async fn responses(
 
         // Wrap with disconnect monitoring: detects client disconnects, cancels generation,
         // and defers inflight_guard.mark_ok() until the stream completes.
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let stream = monitor_for_disconnects_with_rendered_errors(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+        );
 
         let mut sse_stream = Sse::new(stream);
         if let Some(keep_alive) = state.sse_keep_alive() {
@@ -3303,6 +3086,7 @@ async fn images_edits(
                 error_type: map_error_code_to_error_type(code),
                 code: code.as_u16(),
                 details: None,
+                classification: None,
             }),
         ));
     }
@@ -4092,14 +3876,14 @@ mod tests {
 
     #[test]
     fn test_resource_exhausted_error_response_from_anyhow() {
-        use dynamo_runtime::error::{DynamoError, ErrorType};
+        use dynamo_runtime::error::{DynamoError, ErrorType as DynamoErrorType};
         use dynamo_runtime::pipeline::error::PipelineError;
 
         let cause = PipelineError::ServiceOverloaded(
             "All workers are busy, please retry later".to_string(),
         );
         let err: anyhow::Error = DynamoError::builder()
-            .error_type(ErrorType::ResourceExhausted)
+            .error_type(DynamoErrorType::ResourceExhausted)
             .message("All workers are busy, please retry later")
             .cause(cause)
             .build()
@@ -4109,6 +3893,10 @@ mod tests {
         assert_eq!(response.1.code, 529);
         assert_eq!(response.1.error_type, "Overloaded");
         assert_eq!(response.1.message, "Service temporarily overloaded");
+        assert_eq!(
+            extract_error_type_from_response(&response),
+            ErrorType::Overload
+        );
         assert!(
             !response.1.message.contains("All workers are busy"),
             "client response must not include the underlying engine message"
@@ -4243,8 +4031,7 @@ mod tests {
     #[test]
     fn test_cancelled_error_metrics_classification() {
         // HTTP 499 should be classified as Cancelled for metrics
-        let error_type =
-            classify_error_for_metrics(StatusCode::from_u16(499).unwrap(), "cancelled request");
+        let error_type = HttpProblem::metric_type_for_status(StatusCode::from_u16(499).unwrap());
         assert_eq!(
             error_type,
             ErrorType::Cancelled,
@@ -4959,16 +4746,11 @@ mod tests {
 
         // Should return an error
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend-supplied 5xx text must not be forwarded to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(
-                !error_response
-                    .1
-                    .message
-                    .contains("Backend service unavailable")
-            );
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Backend service unavailable"));
         }
     }
 
@@ -4997,14 +4779,16 @@ mod tests {
 
             let result = check_for_backend_error(stream::iter(vec![error_event]), None).await;
 
-            let error_response = match result {
-                Err(error_response) => error_response,
+            let problem = match result {
+                Err(problem) => problem,
                 Ok(_) => panic!("typed invalid argument must fail"),
             };
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-            assert_eq!(error_response.1.error_type, "Bad Request");
-            assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                problem.kind(),
+                crate::http::service::error::HttpProblemKind::Validation
+            );
+            assert_eq!(problem.message(), "unsupported JSON schema keyword");
         }
     }
 
@@ -5026,19 +4810,15 @@ mod tests {
             ),
         };
 
-        let error_response =
-            match check_for_backend_error(stream::iter(vec![error_event]), None).await {
-                Ok(_) => panic!("typed completion error must fail"),
-                Err(error_response) => error_response,
-            };
+        let problem = match check_for_backend_error(stream::iter(vec![error_event]), None).await {
+            Ok(_) => panic!("typed completion error must fail"),
+            Err(problem) => problem,
+        };
 
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
+        assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
         assert!(
-            error_response
-                .1
-                .message
+            problem
+                .message()
                 .contains("does not currently support logprobs >= 1")
         );
     }
@@ -5064,13 +4844,12 @@ mod tests {
 
         // Should return an error with correct status code extracted from JSON
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // 500 backend JSON messages are sanitized to a static client
             // message; the raw payload is only logged server-side.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert_eq!(error_response.1.code, 500);
-            assert!(!error_response.1.message.contains("prompt > max_seq_len"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("prompt > max_seq_len"));
         }
     }
 
@@ -5096,12 +4875,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
-            assert_eq!(error_response.1.code, 500);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("/srv/model.py"));
-            assert!(!error_response.1.message.contains("panic"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("/srv/model.py"));
+            assert!(!problem.message().contains("panic"));
         }
     }
 
@@ -5125,12 +4903,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::SERVICE_UNAVAILABLE);
-            assert_eq!(error_response.1.code, 503);
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("engine pool"));
-            assert!(!error_response.1.message.contains("/srv/engine.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("engine pool"));
+            assert!(!problem.message().contains("/srv/engine.py"));
         }
     }
 
@@ -5155,12 +4932,11 @@ mod tests {
         let result = check_for_backend_error(test_stream, None).await;
 
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0.as_u16(), 499);
-            assert_eq!(error_response.1.code, 499);
-            assert_eq!(error_response.1.message, "Request cancelled");
-            assert!(!error_response.1.message.contains("abc-123"));
-            assert!(!error_response.1.message.contains("/srv/queue.py"));
+        if let Err(problem) = result {
+            assert_eq!(problem.status().as_u16(), 499);
+            assert_eq!(problem.message(), "Request cancelled");
+            assert!(!problem.message().contains("abc-123"));
+            assert!(!problem.message().contains("/srv/queue.py"));
         }
     }
 
@@ -5195,10 +4971,9 @@ mod tests {
             result.is_err(),
             "annotation followed by an error event must still be detected as an error"
         );
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-            assert_eq!(error_response.1.code, 400);
-            assert_eq!(error_response.1.message, "bad input from client");
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(problem.message(), "bad input from client");
         }
     }
 
@@ -5328,64 +5103,13 @@ mod tests {
 
         // Should return an error based on is_backend_error_event logic
         assert!(result.is_err());
-        if let Err(error_response) = result {
-            assert_eq!(error_response.0, StatusCode::INTERNAL_SERVER_ERROR);
+        if let Err(problem) = result {
+            assert_eq!(problem.status(), StatusCode::INTERNAL_SERVER_ERROR);
             // Backend comment text falls under the 5xx default — must be
             // sanitized so it cannot leak internals to the client.
-            assert_eq!(error_response.1.message, "Internal server error");
-            assert!(!error_response.1.message.contains("Connection timeout"));
+            assert_eq!(problem.message(), "Internal server error");
+            assert!(!problem.message().contains("Connection timeout"));
         }
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_validation() {
-        let error_type =
-            classify_error_for_metrics(StatusCode::BAD_REQUEST, "Validation: Invalid parameter");
-        assert_eq!(error_type, ErrorType::Validation);
-
-        let error_type = classify_error_for_metrics(StatusCode::BAD_REQUEST, "Some other error");
-        assert_eq!(error_type, ErrorType::Validation);
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_status_codes() {
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_FOUND, "Model not found"),
-            ErrorType::NotFound
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::NOT_IMPLEMENTED, "Feature not supported"),
-            ErrorType::NotImplemented
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::TOO_MANY_REQUESTS, "Rate limit exceeded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::SERVICE_UNAVAILABLE, "Unavailable"),
-            ErrorType::Unavailable
-        );
-        assert_eq!(
-            classify_error_for_metrics(overload_status_code(), "Overloaded"),
-            ErrorType::Overload
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::INTERNAL_SERVER_ERROR, "Panic"),
-            ErrorType::Internal
-        );
-    }
-
-    #[test]
-    fn test_classify_error_for_metrics_client_errors() {
-        // Other 4xx errors should be classified as validation
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::UNAUTHORIZED, "Unauthorized"),
-            ErrorType::Validation
-        );
-        assert_eq!(
-            classify_error_for_metrics(StatusCode::FORBIDDEN, "Forbidden"),
-            ErrorType::Validation
-        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -34,7 +34,7 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use super::{
     RouteDoc,
     disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
-    error::HttpError,
+    error::{HttpError, HttpErrorClassification, classify_http_error, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
         CancellationLabels, Endpoint, ErrorType, EventConverter,
@@ -72,6 +72,7 @@ use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
 use dynamo_protocols::types::Choice;
+use dynamo_protocols::types::responses::ErrorObject;
 use dynamo_runtime::logging::get_distributed_tracing_context;
 use tracing::Instrument;
 
@@ -135,17 +136,10 @@ fn map_error_code_to_error_type(code: StatusCode) -> String {
 }
 
 /// Classify error for metrics based on status code and message
-fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
+fn classify_error_for_metrics(code: StatusCode, _message: &str) -> ErrorType {
     match code {
-        StatusCode::BAD_REQUEST => {
-            // 400
-            if message.starts_with("Validation:") {
-                ErrorType::Validation
-            } else {
-                ErrorType::Internal
-            }
-        }
-        StatusCode::NOT_FOUND => ErrorType::NotFound, // 404
+        StatusCode::BAD_REQUEST => ErrorType::Validation, // 400
+        StatusCode::NOT_FOUND => ErrorType::NotFound,     // 404
         StatusCode::NOT_IMPLEMENTED => ErrorType::NotImplemented, // 501
         StatusCode::TOO_MANY_REQUESTS => ErrorType::Overload, // 429
         StatusCode::SERVICE_UNAVAILABLE => ErrorType::Unavailable, // 503
@@ -153,7 +147,7 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
         _ if code.as_u16() == 529 => ErrorType::Overload, // 529
         _ if code.as_u16() == 499 => ErrorType::Cancelled, // 499 Client Closed Request
         _ if code.is_client_error() => ErrorType::Validation, // other 4xx
-        _ => ErrorType::Internal,                     // everything else
+        _ => ErrorType::Internal,                         // everything else
     }
 }
 
@@ -162,44 +156,19 @@ fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     classify_error_for_metrics(response.0, &response.1.message)
 }
 
-/// Match `InvalidArgument` at top-level OR under `Backend()`.
-/// `py_err_to_dynamo` wraps Python `ValueError`/`TypeError` as
-/// `Backend(InvalidArgument)`; both variants are 400-worthy.
-fn find_invalid_argument_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_runtime::error::DynamoError> {
-    use dynamo_runtime::error::{BackendError, ErrorType};
-    let mut current = Some(err);
-    while let Some(e) = current {
-        if let Some(dynamo_err) = e.downcast_ref::<dynamo_runtime::error::DynamoError>()
-            && matches!(
-                dynamo_err.error_type(),
-                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
-            )
-        {
-            return Some(dynamo_err);
-        }
-        current = e.source();
+fn responses_error_code(status: StatusCode) -> &'static str {
+    match status {
+        StatusCode::TOO_MANY_REQUESTS => "rate_limit_exceeded",
+        status if status.is_client_error() => "invalid_prompt",
+        _ => "server_error",
     }
-    None
-}
-
-fn find_queue_rejection_in_chain<'a>(
-    err: &'a (dyn std::error::Error + 'static),
-) -> Option<&'a dynamo_kv_router::scheduling::QueueRejection> {
-    let mut current = Some(err);
-    while let Some(error) = current {
-        if let Some(rejection) =
-            error.downcast_ref::<dynamo_kv_router::scheduling::QueueRejection>()
-        {
-            return Some(rejection);
-        }
-        current = error.source();
-    }
-    None
 }
 
 impl ErrorMessage {
+    pub(super) fn message(&self) -> &str {
+        &self.message
+    }
+
     /// Not Found Error
     pub fn model_not_found() -> ErrorResponse {
         let code = StatusCode::NOT_FOUND;
@@ -369,60 +338,32 @@ impl ErrorMessage {
     /// If successful, it will return the [`HttpError`] as an [`ErrorMessage::internal_server_error`]
     /// with the details of the error.
     pub fn from_anyhow(err: anyhow::Error, alt_msg: &str) -> ErrorResponse {
-        if let Some(rejection) = find_queue_rejection_in_chain(err.as_ref()) {
-            let code = overload_status_code();
-            return (
-                code,
+        match classify_http_error(err.as_ref()) {
+            HttpErrorClassification::QueueRejection(rejection) => {
+                let code = overload_status_code();
+                (
+                    code,
+                    Json(ErrorMessage {
+                        message: rejection.to_string(),
+                        error_type: map_error_code_to_error_type(code),
+                        code: code.as_u16(),
+                        details: serde_json::to_value(rejection).ok().map(Box::new),
+                    }),
+                )
+            }
+            HttpErrorClassification::Client { status, message } => (
+                status,
                 Json(ErrorMessage {
-                    message: rejection.to_string(),
-                    error_type: map_error_code_to_error_type(code),
-                    code: code.as_u16(),
-                    details: serde_json::to_value(rejection).ok().map(Box::new),
-                }),
-            );
-        }
-
-        // Check for ResourceExhausted anywhere in the error chain → HTTP 529
-        if super::metrics::request_was_rejected(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Overloaded,
-                format!("{err:#}"),
-            );
-        }
-
-        // No backend workers are currently routable → HTTP 503.
-        if super::metrics::request_was_unavailable(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Unavailable,
-                format!("{err:#}"),
-            );
-        }
-
-        // InvalidArgument (top-level OR Backend) → 400.
-        if let Some(dynamo_err) = find_invalid_argument_in_chain(err.as_ref()) {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorMessage {
-                    message: dynamo_err.message().to_string(),
-                    error_type: map_error_code_to_error_type(StatusCode::BAD_REQUEST),
-                    code: StatusCode::BAD_REQUEST.as_u16(),
+                    message: message.to_string(),
+                    error_type: map_error_code_to_error_type(status),
+                    code: status.as_u16(),
                     details: None,
                 }),
-            );
-        }
-
-        // Check for Cancelled anywhere in the error chain → HTTP 499 (Client Closed Request)
-        if super::metrics::request_was_cancelled(err.as_ref()) {
-            return ErrorMessage::sanitized_with_details(
-                SanitizedError::Cancelled,
-                format!("{err:#}"),
-            );
-        }
-
-        // Then check for HttpError
-        match err.downcast::<HttpError>() {
-            Ok(http_error) => ErrorMessage::from_http_error(http_error),
-            Err(err) => {
+            ),
+            HttpErrorClassification::Sanitized(error) => {
+                ErrorMessage::sanitized_with_details(error, format!("{err:#}"))
+            }
+            HttpErrorClassification::Internal => {
                 ErrorMessage::internal_server_error_with_details(alt_msg, format!("{err:#}"))
             }
         }
@@ -815,6 +756,21 @@ async fn completions_single(
     let stream = stream::iter(annotations).chain(stream);
 
     if streaming {
+        // Preserve streaming semantics after headers are committed, but give
+        // immediately available typed validation failures a bounded chance to
+        // become an HTTP 4xx first.
+        let stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => {
+                check_for_backend_error(stream, Some(dur))
+                    .await
+                    .map_err(|err_response| {
+                        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+                        err_response
+                    })?
+            }
+            None => Box::pin(stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>,
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream
@@ -849,17 +805,6 @@ async fn completions_single(
 
         Ok(sse_stream.into_response())
     } else {
-        // Preserve typed backend errors before the completions aggregator turns
-        // them into strings. In particular, Python ValueError/TypeError arrives
-        // as Backend(InvalidArgument) and must remain an HTTP 400.
-        let stream = check_for_backend_error(stream, None)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?;
-
         // Tap the stream to collect metrics for non-streaming requests without altering items
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = stream.inspect(move |response| {
@@ -874,14 +819,10 @@ async fn completions_single(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -974,28 +915,6 @@ fn aggregate_batch_completion_usage(
             yield response;
         }
     }
-}
-
-type BoxedCompletionResponseStream =
-    std::pin::Pin<Box<dyn futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send>>;
-
-/// Check each prompt stream before merging a non-streaming completion batch.
-///
-/// `select_all` cannot safely provide this check after merging because a normal
-/// event from one prompt may arrive before a typed backend error from another.
-/// Poll all streams concurrently so batch startup is not serialized.
-async fn check_completion_batch_streams<S>(
-    streams: Vec<S>,
-) -> Result<Vec<BoxedCompletionResponseStream>, ErrorResponse>
-where
-    S: futures::Stream<Item = Annotated<NvCreateCompletionResponse>> + Send + 'static,
-{
-    futures::future::try_join_all(
-        streams
-            .into_iter()
-            .map(|stream| check_for_backend_error(stream, None)),
-    )
-    .await
 }
 
 /// Handle batch prompt completions (multiple prompts with n choices each)
@@ -1100,23 +1019,8 @@ async fn completions_batch(
         all_streams.push(remapped_stream);
     }
 
-    let all_streams: Vec<BoxedCompletionResponseStream> = if streaming {
-        all_streams
-            .into_iter()
-            .map(|stream| Box::pin(stream) as BoxedCompletionResponseStream)
-            .collect()
-    } else {
-        check_completion_batch_streams(all_streams)
-            .await
-            .map_err(|error_response| {
-                tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                error_response
-            })?
-    };
-
-    // Merge all streams after every non-streaming prompt has passed its own
-    // backend-error preflight.
+    // Merge all prompt streams. The unary aggregator preserves any typed error
+    // regardless of which prompt produces data first.
     let merged_stream = stream::select_all(all_streams);
     let merged_stream = aggregate_batch_completion_usage(merged_stream, request_id.clone());
 
@@ -1144,6 +1048,18 @@ async fn completions_batch(
     let merged_stream = stream::iter(annotations_vec).chain(merged_stream);
 
     if streaming {
+        let merged_stream = match pre_commit_error_peek_timeout() {
+            Some(dur) => check_for_backend_error(merged_stream, Some(dur))
+                .await
+                .map_err(|err_response| {
+                    inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+                    err_response
+                })?,
+            None => {
+                Box::pin(merged_stream) as std::pin::Pin<Box<dyn futures::Stream<Item = _> + Send>>
+            }
+        };
+
         // For streaming, we'll drop the http_queue_guard on the first token
         let mut http_queue_guard = Some(http_queue_guard);
         let stream = merged_stream
@@ -1192,14 +1108,10 @@ async fn completions_batch(
         let response = NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options)
             .await
             .map_err(|e| {
-                tracing::error!(
-                    "Failed to fold completions stream for {}: {:?}",
-                    request_id,
-                    e
+                let err_response = ErrorMessage::from_anyhow(
+                    e.into(),
+                    &format!("Failed to fold completions stream for {request_id}"),
                 );
-                let err_response = ErrorMessage::internal_server_error(&format!(
-                    "Failed to fold completions stream for {request_id}"
-                ));
                 inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -1320,13 +1232,8 @@ async fn embeddings(
     let mut response = NvCreateEmbeddingResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!(
-                "Failed to fold embeddings stream for {}: {:?}",
-                request_id,
-                e
-            );
             let err_response =
-                ErrorMessage::internal_server_error("Failed to fold embeddings stream");
+                ErrorMessage::from_anyhow(e.into(), "Failed to fold embeddings stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -1600,7 +1507,7 @@ fn escape_json_string_control_chars(body: &[u8]) -> Option<Vec<u8>> {
 
 /// Checks if an Annotated event represents a backend error and extracts error information.
 /// Returns Some((message, status_code)) if it's an error, None otherwise.
-fn extract_backend_error_if_present<T: serde::Serialize>(
+pub(super) fn extract_backend_error_if_present<T: serde::Serialize>(
     event: &Annotated<T>,
 ) -> Option<(String, StatusCode)> {
     #[derive(serde::Deserialize)]
@@ -1745,7 +1652,7 @@ const MAX_LEADING_ANNOTATIONS: usize = 16;
 
 /// Inspect the first non-annotation event in the stream for a backend error.
 ///
-/// `timeout = None` — await stream events indefinitely (non-streaming preflight).
+/// `timeout = None` — await stream events indefinitely.
 /// `timeout = Some(dur)` — race against a single deadline captured at function
 /// entry (streaming pre-commit peek). If the deadline elapses before a
 /// non-annotation event arrives, return the buffered annotations chained with
@@ -1802,9 +1709,7 @@ where
 }
 
 /// Convert an `(error_msg, status_code)` pair from `extract_backend_error_if_present`
-/// into the wire `ErrorResponse`. Shared between the non-streaming preflight
-/// (`check_for_backend_error`) and the streaming preflight so both paths speak
-/// the same sanitization + status contract to the client.
+/// into the wire `ErrorResponse` used by streaming pre-commit checks.
 fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorResponse {
     match SanitizedError::for_backend_status(status_code) {
         Some(variant) => ErrorMessage::sanitized_with_details(variant, error_msg),
@@ -1833,7 +1738,7 @@ fn backend_error_response(error_msg: String, status_code: StatusCode) -> ErrorRe
 /// process restart.
 // FIXME: unify env-var initialization with the rest of `env_llm::*` once that
 // module gets a standard reader.
-fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
+pub(super) fn pre_commit_error_peek_timeout() -> Option<std::time::Duration> {
     match std::env::var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS)
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
@@ -2298,18 +2203,8 @@ async fn chat_completions(
 
         Ok(sse_stream.into_response())
     } else {
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = stream.inspect(move |response| {
             // Calls observe_response() on each token - drops http_queue_guard on first token
             process_chat_response_and_observe_metrics(
                 response,
@@ -2322,12 +2217,8 @@ async fn chat_completions(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(
-                        request_id,
-                        "Failed to parse chat completion response: {:?}",
-                        e
-                    );
-                    let err_response = ErrorMessage::internal_server_error(
+                    let err_response = ErrorMessage::from_anyhow(
+                        e.into(),
                         "Failed to parse chat completion response",
                     );
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
@@ -2631,15 +2522,9 @@ async fn responses(
     let (orig_request, context) = request.into_parts();
 
     let unified_request: UnifiedRequest = orig_request.try_into().map_err(|e: anyhow::Error| {
-        tracing::error!(
-            request_id,
-            error = %e,
-            "Failed to convert NvCreateResponse to UnifiedRequest",
-        );
-        let err_response = ErrorMessage::not_implemented_error(
-            VALIDATION_PREFIX.to_string()
-                + "Failed to convert responses request: "
-                + &e.to_string(),
+        let err_response = ErrorMessage::from_anyhow(
+            invalid_argument(format!("Failed to convert responses request: {e}")).into(),
+            "Failed to convert responses request",
         );
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         err_response
@@ -2650,6 +2535,14 @@ async fn responses(
     let responses_ctx = unified_request.responses_context().cloned();
     let mut chat_request = unified_request.into_inner();
     if let Err(err_response) = normalize_chat_reasoning_template_args(&mut chat_request) {
+        inflight_guard.mark_error(extract_error_type_from_response(&err_response));
+        return Err(err_response);
+    }
+    if let Err(error) = chat_request.validate() {
+        let err_response = ErrorMessage::from_anyhow(
+            invalid_argument(error.to_string()).into(),
+            "Invalid responses request",
+        );
         inflight_guard.mark_error(extract_error_type_from_response(&err_response));
         return Err(err_response);
     }
@@ -2749,7 +2642,7 @@ async fn responses(
             }
 
             // Track whether the backend sent an error event during the stream.
-            let mut saw_error = false;
+            let mut backend_error = None;
 
             while let Some(annotated_chunk) = engine_stream.next().await {
                 process_chat_response_and_observe_metrics(
@@ -2758,8 +2651,12 @@ async fn responses(
                     &mut http_queue_guard,
                 );
 
-                if extract_backend_error_if_present(&annotated_chunk).is_some() {
-                    saw_error = true;
+                if let Some((message, status)) = extract_backend_error_if_present(&annotated_chunk) {
+                    let response = backend_error_response(message, status);
+                    backend_error.get_or_insert_with(|| ErrorObject {
+                        code: responses_error_code(response.0).to_string(),
+                        message: response.1.message.clone(),
+                    });
                     continue;
                 }
 
@@ -2773,8 +2670,8 @@ async fn responses(
                 }
             }
 
-            if saw_error {
-                converter.append_error_events(&mut events);
+            if let Some(error) = backend_error {
+                converter.append_error_events(error, &mut events);
             } else {
                 converter.append_end_events(&mut events);
             }
@@ -2795,19 +2692,8 @@ async fn responses(
         Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
-
-        // Check first event for backend errors before aggregating (non-streaming only)
-        let stream_with_check =
-            check_for_backend_error(engine_stream, None)
-                .await
-                .map_err(|error_response| {
-                    tracing::error!(request_id, "Backend error detected: {:?}", error_response);
-                    inflight_guard.mark_error(extract_error_type_from_response(&error_response));
-                    error_response
-                })?;
-
         let mut http_queue_guard = Some(http_queue_guard);
-        let stream = stream_with_check.inspect(move |response| {
+        let stream = engine_stream.inspect(move |response| {
             process_chat_response_and_observe_metrics(
                 response,
                 &mut response_collector,
@@ -2819,9 +2705,8 @@ async fn responses(
             NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options.clone())
                 .await
                 .map_err(|e| {
-                    tracing::error!(request_id, "Failed to fold responses stream: {:?}", e);
                     let err_response =
-                        ErrorMessage::internal_server_error("Failed to fold responses stream");
+                        ErrorMessage::from_anyhow(e.into(), "Failed to fold responses stream");
                     inflight_guard.mark_error(extract_error_type_from_response(&err_response));
                     err_response
                 })?;
@@ -3394,8 +3279,7 @@ async fn images(
     let response = NvImagesResponse::from_annotated_stream(stream)
         .await
         .map_err(|e| {
-            tracing::error!("Failed to fold images stream for {}: {:?}", request_id, e);
-            let err_response = ErrorMessage::internal_server_error("Failed to fold images stream");
+            let err_response = ErrorMessage::from_anyhow(e.into(), "Failed to fold images stream");
             inflight.mark_error(extract_error_type_from_response(&err_response));
             err_response
         })?;
@@ -3548,9 +3432,8 @@ async fn videos(
         let response = NvVideosResponse::from_annotated_stream(stream)
             .await
             .map_err(|e| {
-                tracing::error!("Failed to fold videos stream for {}: {:?}", request_id, e);
                 let err_response =
-                    ErrorMessage::internal_server_error("Failed to fold videos stream");
+                    ErrorMessage::from_anyhow(e.into(), "Failed to fold videos stream");
                 inflight.mark_error(extract_error_type_from_response(&err_response));
                 err_response
             })?;
@@ -3800,10 +3683,7 @@ async fn audio_speech(
 
     let response = NvAudioSpeechResponse::from_annotated_stream(stream)
         .await
-        .map_err(|e| {
-            tracing::error!("Failed to fold audio stream for {}: {:?}", request_id, e);
-            ErrorMessage::internal_server_error("Failed to fold audio stream")
-        })?;
+        .map_err(|e| ErrorMessage::from_anyhow(e.into(), "Failed to fold audio stream"))?;
 
     // Check for failure before marking success
     if response.status == "failed" {
@@ -5164,47 +5044,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_batch_completion_checks_every_stream_for_backend_errors() {
-        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
-        use futures::stream;
-
-        let normal_event = Annotated::<NvCreateCompletionResponse> {
-            data: Some(make_completion_chunk("ok", None, None)),
-            id: None,
-            event: None,
-            comment: None,
-            error: None,
-        };
-        let error_event = Annotated::<NvCreateCompletionResponse> {
-            data: None,
-            id: None,
-            event: Some("error".to_string()),
-            comment: None,
-            error: Some(
-                DynamoError::builder()
-                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
-                    .message("invalid second prompt")
-                    .build(),
-            ),
-        };
-
-        let result = check_completion_batch_streams(vec![
-            stream::iter(vec![normal_event]),
-            stream::iter(vec![error_event]),
-        ])
-        .await;
-
-        let error_response = match result {
-            Ok(_) => panic!("an error in any batch prompt must fail the request"),
-            Err(error_response) => error_response,
-        };
-        assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
-        assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
-        assert_eq!(error_response.1.error_type, "Bad Request");
-        assert_eq!(error_response.1.message, "invalid second prompt");
-    }
-
-    #[tokio::test]
     async fn test_check_for_backend_error_with_json_error_and_code() {
         use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
         use futures::stream;
@@ -5500,14 +5339,12 @@ mod tests {
 
     #[test]
     fn test_classify_error_for_metrics_validation() {
-        // 400 with "Validation:" prefix to validation
         let error_type =
             classify_error_for_metrics(StatusCode::BAD_REQUEST, "Validation: Invalid parameter");
         assert_eq!(error_type, ErrorType::Validation);
 
-        // 400 WITHOUT "Validation:" to internal (fallback)
         let error_type = classify_error_for_metrics(StatusCode::BAD_REQUEST, "Some other error");
-        assert_eq!(error_type, ErrorType::Internal);
+        assert_eq!(error_type, ErrorType::Validation);
     }
 
     #[test]

--- a/lib/llm/src/http/service/realtime.rs
+++ b/lib/llm/src/http/service/realtime.rs
@@ -61,7 +61,7 @@ const REQUEST_CHANNEL_CAPACITY: usize = 64;
 /// half-broken peer from parking the connection indefinitely.
 const CLOSE_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
-use super::{RouteDoc, error::SanitizedError, service_v2};
+use super::{RouteDoc, error::INTERNAL_ERROR_MESSAGE, service_v2};
 use crate::discovery::ModelManagerError;
 use crate::types::RealtimeBidirectionalEngine;
 use dynamo_protocols::types::realtime::{
@@ -169,10 +169,7 @@ async fn handle_socket(
         Ok(s) => s,
         Err(err) => {
             tracing::error!(%err, "/v1/realtime engine.generate() failed");
-            *close_reason.lock() = Some(close_message(
-                close_code::ERROR,
-                &SanitizedError::Internal.to_string(),
-            ));
+            *close_reason.lock() = Some(close_message(close_code::ERROR, INTERNAL_ERROR_MESSAGE));
             return;
         }
     };
@@ -190,13 +187,12 @@ async fn handle_socket(
                 event
             } else if let Some(err) = annotated.error {
                 tracing::error!("/v1/realtime engine error: {err}");
-                let sanitized = SanitizedError::Internal;
                 RealtimeServerEvent::Error(RealtimeServerEventError {
                     event_id: format!("event_{}", Uuid::new_v4()),
                     error: RealtimeAPIError {
                         r#type: "server_error".to_string(),
                         code: None,
-                        message: sanitized.to_string(),
+                        message: INTERNAL_ERROR_MESSAGE.to_string(),
                         param: None,
                         event_id: None,
                     },
@@ -485,7 +481,7 @@ where
                 send_error_event(
                     ws_tx,
                     "server_error",
-                    &SanitizedError::Internal.to_string(),
+                    INTERNAL_ERROR_MESSAGE,
                     Some(model_param),
                 )
                 .await;

--- a/lib/llm/src/protocols/anthropic/stream_converter.rs
+++ b/lib/llm/src/protocols/anthropic/stream_converter.rs
@@ -574,20 +574,22 @@ impl AnthropicStreamConverter {
     }
 
     /// Emit error events when the stream ends due to a backend error.
-    pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+    pub fn emit_error_events(
+        &mut self,
+        error: AnthropicErrorBody,
+    ) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::with_capacity(1);
-        self.append_error_events(&mut events);
+        self.append_error_events(error, &mut events);
         events
     }
 
     /// Append error events when the stream ends due to a backend error.
-    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
-        let error_event = AnthropicStreamEvent::Error {
-            error: AnthropicErrorBody {
-                error_type: "api_error".to_string(),
-                message: "An internal error occurred during generation.".to_string(),
-            },
-        };
+    pub fn append_error_events(
+        &mut self,
+        error: AnthropicErrorBody,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        let error_event = AnthropicStreamEvent::Error { error };
         events.push(make_sse_event("error", &error_event));
     }
 }
@@ -1000,7 +1002,13 @@ mod tests {
         assert!(events.iter().all(Result::is_ok));
 
         events.clear();
-        conv.append_error_events(&mut events);
+        conv.append_error_events(
+            AnthropicErrorBody {
+                error_type: "api_error".to_string(),
+                message: "Internal server error".to_string(),
+            },
+            &mut events,
+        );
         assert_eq!(events.len(), 1);
         assert_eq!(events.capacity(), capacity);
         assert!(events.iter().all(Result::is_ok));

--- a/lib/llm/src/protocols/anthropic/types.rs
+++ b/lib/llm/src/protocols/anthropic/types.rs
@@ -55,10 +55,37 @@ fn system_message_content(content: &AnthropicMessageContent) -> String {
             .join("\n"),
     }
 }
+
+fn validate_request(req: &AnthropicCreateMessageRequest) -> anyhow::Result<()> {
+    if req.messages.is_empty() {
+        anyhow::bail!("messages: field required");
+    }
+    if req.max_tokens == 0 {
+        anyhow::bail!("max_tokens: must be greater than 0");
+    }
+
+    for (message_index, message) in req.messages.iter().enumerate() {
+        let AnthropicMessageContent::Blocks { content } = &message.content else {
+            continue;
+        };
+        for (block_index, block) in content.iter().enumerate() {
+            if let AnthropicContentBlock::Other(value) = block
+                && !value.is_object()
+            {
+                anyhow::bail!(
+                    "messages[{message_index}].content[{block_index}]: content blocks must be objects"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
 impl TryFrom<AnthropicCreateMessageRequest> for NvCreateChatCompletionRequest {
     type Error = anyhow::Error;
 
     fn try_from(req: AnthropicCreateMessageRequest) -> Result<Self, Self::Error> {
+        validate_request(&req)?;
         let mut messages = Vec::new();
 
         // Prepend system message if present
@@ -1276,6 +1303,22 @@ mod tests {
             }
             other => panic!("expected assistant message, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_scalar_content_block_is_rejected_during_conversion() {
+        let req: AnthropicCreateMessageRequest = serde_json::from_value(serde_json::json!({
+            "model": "test",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": ["hello"]}]
+        }))
+        .unwrap();
+
+        let error = NvCreateChatCompletionRequest::try_from(req).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "messages[0].content[0]: content blocks must be objects"
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvAudioSpeechResponse;
 
@@ -22,7 +23,7 @@ impl NvAudioSpeechResponse {
     /// Aggregates an annotated stream of audio responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
+    ) -> Result<NvAudioSpeechResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use std::collections::{BTreeMap, HashMap};
 
 use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
@@ -43,8 +43,6 @@ pub struct DeltaAggregator {
     system_fingerprint: Option<String>,
     /// Map of incremental response choices, keyed by index.
     choices: HashMap<u32, DeltaChoice>,
-    /// Optional structured error if an error occurs during aggregation.
-    error: Option<DynamoError>,
     /// Optional service tier information for the response.
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Aggregated nvext field from stream responses
@@ -200,7 +198,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             service_tier: None,
             nvext: None,
         }
@@ -220,19 +217,9 @@ impl DeltaAggregator {
         parsing_options: ParsingOptions,
     ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let mut aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok_typed() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     aggregator.id = delta.inner.id;
                     aggregator.model = delta.inner.model;
                     aggregator.created = delta.inner.created;
@@ -340,14 +327,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
+            .await?;
 
         // #8640: finalize the per-index tool-call chunk accumulator into the
         // choice's `tool_calls` vector. Chunks missing id or name across the

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -17,6 +17,7 @@ use crate::protocols::{
 
 use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::error::DynamoError;
 
 fn is_harmony_parser(parser: &str) -> bool {
     parser == "harmony"
@@ -42,8 +43,8 @@ pub struct DeltaAggregator {
     system_fingerprint: Option<String>,
     /// Map of incremental response choices, keyed by index.
     choices: HashMap<u32, DeltaChoice>,
-    /// Optional error message if an error occurs during aggregation.
-    error: Option<String>,
+    /// Optional structured error if an error occurs during aggregation.
+    error: Option<DynamoError>,
     /// Optional service tier information for the response.
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Aggregated nvext field from stream responses
@@ -213,15 +214,15 @@ impl DeltaAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation is successful.
-    /// * `Err(String)` if an error occurs during processing.
+    /// * `Err(DynamoError)` if an error occurs during processing.
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let mut aggregator = stream
             .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
                 // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
+                let delta = match delta.ok_typed() {
                     Ok(delta) => delta,
                     Err(error) => {
                         aggregator.error = Some(error);
@@ -523,11 +524,11 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 
     /// Converts an SSE stream into a [`NvCreateChatCompletionResponse`].
     ///
@@ -536,25 +537,25 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 }
 
 impl ChatCompletionAggregator for NvCreateChatCompletionResponse {
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateChatCompletionStreamResponse>(stream);
         NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -1825,5 +1826,42 @@ mod tests {
             "content key must be serialized as null when absent"
         );
         assert!(json.get("reasoning_content").is_some());
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let partial = create_test_delta(
+            0,
+            "partial",
+            Some(dynamo_protocols::types::Role::Assistant),
+            None,
+            None,
+            None,
+        );
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid sampling parameter")
+            .build();
+        let stream = stream::iter(vec![
+            partial,
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid sampling parameter");
     }
 }

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -6,7 +6,7 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
-    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
 use dynamo_runtime::{engine::DataStream, error::DynamoError};
@@ -48,7 +48,7 @@ impl NvCreateClassifyResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
     ) -> Result<NvCreateClassifyResponse, DynamoError> {
-        aggregate_typed_stream(stream).await
+        aggregate_stream(stream).await
     }
 }
 

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 
 use dynamo_runtime::error::DynamoError;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 
 use super::NvCreateCompletionResponse;
 use crate::protocols::{
@@ -23,7 +23,6 @@ pub struct DeltaAggregator {
     usage: Option<dynamo_protocols::types::CompletionUsage>,
     system_fingerprint: Option<String>,
     choices: HashMap<u32, DeltaChoice>,
-    error: Option<DynamoError>,
     nvext: Option<serde_json::Value>,
 }
 
@@ -49,7 +48,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             nvext: None,
         }
     }
@@ -61,18 +59,9 @@ impl DeltaAggregator {
     ) -> Result<NvCreateCompletionResponse, DynamoError> {
         tracing::debug!("Tool Call Parser: {:?}", parsing_options.tool_call_parser); // TODO: remove this once completion has tool call support
         let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                let delta = match delta.ok_typed() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     // TODO(#14) - Aggregate Annotation
 
                     // these are cheap to move so we do it every time since we are consuming the delta
@@ -137,16 +126,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // If we have an error, return it
-        let aggregator = if let Some(error) = aggregator.error {
-            return Err(error);
-        } else {
-            aggregator
-        };
+            .await?;
 
         // extra the aggregated deltas and sort by index
         let mut choices: Vec<_> = aggregator

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
+use dynamo_runtime::error::DynamoError;
 use futures::{Stream, StreamExt};
 
 use super::NvCreateCompletionResponse;
@@ -23,7 +23,7 @@ pub struct DeltaAggregator {
     usage: Option<dynamo_protocols::types::CompletionUsage>,
     system_fingerprint: Option<String>,
     choices: HashMap<u32, DeltaChoice>,
-    error: Option<String>,
+    error: Option<DynamoError>,
     nvext: Option<serde_json::Value>,
 }
 
@@ -58,11 +58,11 @@ impl DeltaAggregator {
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         tracing::debug!("Tool Call Parser: {:?}", parsing_options.tool_call_parser); // TODO: remove this once completion has tool call support
         let aggregator = stream
             .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                let delta = match delta.ok() {
+                let delta = match delta.ok_typed() {
                     Ok(delta) => delta,
                     Err(error) => {
                         aggregator.error = Some(error);
@@ -143,7 +143,7 @@ impl DeltaAggregator {
 
         // If we have an error, return it
         let aggregator = if let Some(error) = aggregator.error {
-            return Err(anyhow::anyhow!(error));
+            return Err(error);
         } else {
             aggregator
         };
@@ -193,7 +193,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateCompletionResponse>(stream);
         NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -201,7 +201,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 }
@@ -462,5 +462,34 @@ mod tests {
             choice1.finish_reason,
             Some(dynamo_protocols::types::CompletionFinishReason::Stop)
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("unsupported logprobs")
+            .build();
+        let stream = stream::iter(vec![
+            create_test_delta(0, "partial", None, None),
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "unsupported logprobs");
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -9,7 +9,7 @@ use crate::protocols::{
     openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
-use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
 use futures::Stream;
 
 impl StreamAggregable for NvCreateEmbeddingResponse {
@@ -28,7 +28,7 @@ impl NvCreateEmbeddingResponse {
     /// Converts an SSE stream into a [`NvCreateEmbeddingResponse`].
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateEmbeddingResponse>(stream);
         NvCreateEmbeddingResponse::from_annotated_stream(stream).await
     }
@@ -36,7 +36,7 @@ impl NvCreateEmbeddingResponse {
     /// Aggregates an annotated stream of embedding responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }
@@ -44,6 +44,7 @@ impl NvCreateEmbeddingResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_runtime::error::{BackendError, ErrorType};
     use futures::stream;
 
     fn create_test_embedding_response(
@@ -141,7 +142,40 @@ mod tests {
         let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Test error"));
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn test_typed_error_after_data_is_preserved() {
+        let embedding = dynamo_protocols::types::Embedding {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: dynamo_protocols::types::EmbeddingVector::Float(vec![0.1]),
+        };
+        let response = create_test_embedding_response(vec![embedding], 1, 1);
+        let error = Annotated::<NvCreateEmbeddingResponse> {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                    .message("invalid embedding request")
+                    .build(),
+            ),
+        };
+
+        let result =
+            NvCreateEmbeddingResponse::from_annotated_stream(stream::iter(vec![response, error]))
+                .await;
+
+        let error = result.expect_err("typed error must win over partial data");
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid embedding request");
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -569,8 +569,7 @@ impl GenerateAggregator {
         let mut aggregator = GenerateAggregator::new(request_id);
         pin_mut!(stream);
         while let Some(delta) = stream.next().await {
-            let delta = delta.ok().map_err(anyhow::Error::msg)?;
-            if let Some(output) = delta.data {
+            if let Some(output) = delta.into_data().map_err(anyhow::Error::new)? {
                 aggregator.apply_output(output, options)?;
             }
         }

--- a/lib/llm/src/protocols/openai/images/aggregator.rs
+++ b/lib/llm/src/protocols/openai/images/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvImagesResponse;
 
@@ -22,7 +23,7 @@ impl NvImagesResponse {
     /// Aggregates an annotated stream of image responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvImagesResponse>>,
-    ) -> Result<NvImagesResponse, String> {
+    ) -> Result<NvImagesResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/pooling/aggregator.rs
+++ b/lib/llm/src/protocols/openai/pooling/aggregator.rs
@@ -6,7 +6,7 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
-    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
 use dynamo_runtime::{engine::DataStream, error::DynamoError};
@@ -48,7 +48,7 @@ impl NvCreatePoolingResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreatePoolingResponse>>,
     ) -> Result<NvCreatePoolingResponse, DynamoError> {
-        aggregate_typed_stream(stream).await
+        aggregate_stream(stream).await
     }
 }
 

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -14,8 +14,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::response::sse::Event;
 use dynamo_protocols::types::responses::{
-    AssistantRole, FunctionToolCall, IncompleteDetails, InputTokenDetails, Instructions,
-    OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
+    AssistantRole, ErrorObject, FunctionToolCall, IncompleteDetails, InputTokenDetails,
+    Instructions, OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
     OutputTextContent, OutputTokenDetails, ReasoningItem, Response, ResponseCompletedEvent,
     ResponseContentPartAddedEvent, ResponseContentPartDoneEvent, ResponseCreatedEvent,
     ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
@@ -779,17 +779,23 @@ impl ResponseStreamConverter {
     }
 
     /// Emit error events when the stream ends due to a backend error.
-    pub fn emit_error_events(&mut self) -> Vec<Result<Event, anyhow::Error>> {
+    pub fn emit_error_events(&mut self, error: ErrorObject) -> Vec<Result<Event, anyhow::Error>> {
         let mut events = Vec::new();
-        self.append_error_events(&mut events);
+        self.append_error_events(error, &mut events);
         events
     }
 
     /// Append error events when the stream ends due to a backend error.
-    pub fn append_error_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
+    pub fn append_error_events(
+        &mut self,
+        error: ErrorObject,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        let mut response = self.make_response(Status::Failed, vec![]);
+        response.error = Some(error);
         let failed = ResponseStreamEvent::ResponseFailed(ResponseFailedEvent {
             sequence_number: self.next_seq(),
-            response: self.make_response(Status::Failed, vec![]),
+            response,
         });
         events.push(self.make_sse_event(&failed));
     }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -28,8 +28,7 @@ where
     let mut response: Option<T> = None;
 
     while let Some(delta) = stream.next().await {
-        let delta = delta.ok_typed()?;
-        if let Some(data) = delta.data {
+        if let Some(data) = delta.into_data()? {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),
                 None => response = Some(data),
@@ -38,14 +37,4 @@ where
     }
 
     Ok(response.unwrap_or_else(T::empty))
-}
-
-/// Backwards-compatible name for callers that adopted typed aggregation before
-/// it became the default.
-pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
-where
-    T: StreamAggregable,
-    S: Stream<Item = Annotated<T>>,
-{
-    aggregate_stream(stream).await
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -19,7 +19,7 @@ pub trait StreamAggregable: Sized {
 /// Aggregate a stream of [`Annotated<T>`] into a single `T`. The first error
 /// encountered short-circuits further merging and is returned; the remainder
 /// of the stream is dropped.
-pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, String>
+pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
     S: Stream<Item = Annotated<T>>,
@@ -28,7 +28,7 @@ where
     let mut response: Option<T> = None;
 
     while let Some(delta) = stream.next().await {
-        let delta = delta.ok()?;
+        let delta = delta.ok_typed()?;
         if let Some(data) = delta.data {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),
@@ -40,35 +40,12 @@ where
     Ok(response.unwrap_or_else(T::empty))
 }
 
-/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
-/// errors. Existing callers that expose string errors can continue to use
-/// [`aggregate_stream`].
+/// Backwards-compatible name for callers that adopted typed aggregation before
+/// it became the default.
 pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
     S: Stream<Item = Annotated<T>>,
 {
-    let mut stream = std::pin::pin!(stream);
-    let mut response: Option<T> = None;
-
-    while let Some(delta) = stream.next().await {
-        if delta.is_error() {
-            return Err(delta.error.unwrap_or_else(|| {
-                DynamoError::msg(
-                    delta
-                        .comment
-                        .map(|comments| comments.join(", "))
-                        .unwrap_or_else(|| "unknown error".to_string()),
-                )
-            }));
-        }
-        if let Some(data) = delta.data {
-            match response.as_mut() {
-                Some(existing) => existing.merge(data),
-                None => response = Some(data),
-            }
-        }
-    }
-
-    Ok(response.unwrap_or_else(T::empty))
+    aggregate_stream(stream).await
 }

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvVideosResponse;
 
@@ -22,7 +23,7 @@ impl NvVideosResponse {
     /// Aggregates an annotated stream of video responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvVideosResponse>>,
-    ) -> Result<NvVideosResponse, String> {
+    ) -> Result<NvVideosResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/tensor.rs
+++ b/lib/llm/src/protocols/tensor.rs
@@ -4,7 +4,7 @@
 use crate::protocols::Annotated;
 use anyhow::Result;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use validator::Validate;
@@ -264,55 +264,21 @@ impl AnnotationsProvider for NvCreateTensorRequest {
     }
 }
 
-pub struct DeltaAggregator {
-    response: Option<NvCreateTensorResponse>,
-    error: Option<String>,
-}
-
 impl NvCreateTensorResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateTensorResponse>>,
     ) -> Result<NvCreateTensorResponse> {
-        let aggregator = stream
-            .fold(
-                DeltaAggregator {
-                    response: None,
-                    error: None,
-                },
-                |mut aggregator, delta| async move {
-                    let delta = match delta.ok() {
-                        Ok(delta) => delta,
-                        Err(error) => {
-                            if aggregator.error.is_none() {
-                                aggregator.error = Some(error);
-                            }
-                            return aggregator;
-                        }
-                    };
-                    match delta.data {
-                        Some(resp) => {
-                            if aggregator.response.is_none() {
-                                aggregator.response = Some(resp);
-                            } else if aggregator.error.is_none() {
-                                aggregator.error =
-                                    Some("Multiple responses in non-streaming mode".to_string());
-                            }
-                        }
-                        None => {
-                            // Ignore metadata-only deltas in non-streaming mode.
-                        }
-                    }
-                    aggregator
-                },
-            )
-            .await;
-        if let Some(error) = aggregator.error {
-            Err(anyhow::anyhow!(error))
-        } else if let Some(response) = aggregator.response {
-            Ok(response)
-        } else {
-            Err(anyhow::anyhow!("No response received"))
+        pin_mut!(stream);
+        let mut response = None;
+        while let Some(delta) = stream.next().await {
+            let Some(next) = delta.into_data().map_err(anyhow::Error::new)? else {
+                continue;
+            };
+            if response.replace(next).is_some() {
+                anyhow::bail!("Multiple responses in non-streaming mode");
+            }
         }
+        response.ok_or_else(|| anyhow::anyhow!("No response received"))
     }
 }
 

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -19,7 +19,10 @@ use serde::Serialize;
 use serde_json::Value;
 
 use super::ports::bind_random_port;
-use super::scripted_chat_engine::{Script, ScriptGate, ScriptedChatEngine};
+use super::scripted_chat_engine::{
+    AnnotatedScript, CompletionScript, Script, ScriptGate, ScriptedChatEngine,
+    ScriptedCompletionEngine,
+};
 
 pub const MODEL: &str = "harness-model";
 
@@ -36,6 +39,7 @@ pub struct HarnessService {
     pub base_url: String,
     pub client: reqwest::Client,
     pub engine: Arc<ScriptedChatEngine>,
+    pub completion_engine: Arc<ScriptedCompletionEngine>,
     cancel: CancellationToken,
     join: Option<tokio::task::JoinHandle<Result<()>>>,
 }
@@ -43,15 +47,40 @@ pub struct HarnessService {
 impl HarnessService {
     pub async fn start(scripts: impl IntoIterator<Item = Script>) -> Self {
         let engine = Arc::new(ScriptedChatEngine::new(scripts));
-        Self::start_with_engine(engine).await
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
+    pub async fn start_with_completion_scripts(
+        scripts: impl IntoIterator<Item = CompletionScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new([]));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new(scripts));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
+    pub async fn start_with_scripts(
+        chat_scripts: impl IntoIterator<Item = AnnotatedScript>,
+        completion_scripts: impl IntoIterator<Item = CompletionScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new_annotated(chat_scripts));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new(completion_scripts));
+        Self::start_with_engines(engine, completion_engine).await
     }
 
     pub async fn start_with_gated_tail(script: Script, split_at: usize) -> (Self, ScriptGate) {
         let (engine, gate) = ScriptedChatEngine::with_gated_tail(script, split_at);
-        (Self::start_with_engine(Arc::new(engine)).await, gate)
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        (
+            Self::start_with_engines(Arc::new(engine), completion_engine).await,
+            gate,
+        )
     }
 
-    async fn start_with_engine(engine: Arc<ScriptedChatEngine>) -> Self {
+    async fn start_with_engines(
+        engine: Arc<ScriptedChatEngine>,
+        completion_engine: Arc<ScriptedCompletionEngine>,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .no_proxy()
             .build()
@@ -61,7 +90,7 @@ impl HarnessService {
             .port(port)
             .host("127.0.0.1")
             .enable_chat_endpoints(true)
-            .enable_cmpl_endpoints(false)
+            .enable_cmpl_endpoints(true)
             .enable_responses_endpoints(true)
             .enable_anthropic_endpoints(true)
             .build()
@@ -72,6 +101,10 @@ impl HarnessService {
             .model_manager()
             .add_chat_completions_model(MODEL, card.mdcsum(), engine.clone())
             .expect("failed to register scripted harness model");
+        service
+            .model_manager()
+            .add_completions_model(MODEL, card.mdcsum(), completion_engine.clone())
+            .expect("failed to register scripted harness completion model");
 
         let cancel = CancellationToken::new();
         let join = service.spawn_with_listener(cancel.clone(), listener).await;
@@ -82,6 +115,7 @@ impl HarnessService {
             base_url,
             client,
             engine,
+            completion_engine,
             cancel,
             join: Some(join),
         }

--- a/lib/llm/tests/common/http_harness.rs
+++ b/lib/llm/tests/common/http_harness.rs
@@ -68,6 +68,16 @@ impl HarnessService {
         Self::start_with_engines(engine, completion_engine).await
     }
 
+    pub async fn start_with_pending_annotated_scripts(
+        chat_scripts: impl IntoIterator<Item = AnnotatedScript>,
+    ) -> Self {
+        let engine = Arc::new(ScriptedChatEngine::new_pending_after_annotated(
+            chat_scripts,
+        ));
+        let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));
+        Self::start_with_engines(engine, completion_engine).await
+    }
+
     pub async fn start_with_gated_tail(script: Script, split_at: usize) -> (Self, ScriptGate) {
         let (engine, gate) = ScriptedChatEngine::with_gated_tail(script, split_at);
         let completion_engine = Arc::new(ScriptedCompletionEngine::new([]));

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -11,6 +11,7 @@ use dynamo_llm::protocols::{
     openai::chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
     },
+    openai::completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
 };
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
@@ -18,11 +19,13 @@ use dynamo_runtime::pipeline::{
 use tokio::sync::{Mutex, Semaphore};
 
 pub type Script = Vec<NvCreateChatCompletionStreamResponse>;
+pub type AnnotatedScript = Vec<Annotated<NvCreateChatCompletionStreamResponse>>;
+pub type CompletionScript = Vec<Annotated<NvCreateCompletionResponse>>;
 
 enum QueuedScript {
-    Immediate(Script),
+    Immediate(AnnotatedScript),
     Gated {
-        chunks: Script,
+        chunks: AnnotatedScript,
         split_at: usize,
         release: std::sync::Arc<Semaphore>,
     },
@@ -47,6 +50,22 @@ pub struct ScriptedChatEngine {
 impl ScriptedChatEngine {
     pub fn new(scripts: impl IntoIterator<Item = Script>) -> Self {
         Self {
+            scripts: Mutex::new(
+                scripts
+                    .into_iter()
+                    .map(|script| {
+                        QueuedScript::Immediate(
+                            script.into_iter().map(Annotated::from_data).collect(),
+                        )
+                    })
+                    .collect(),
+            ),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn new_annotated(scripts: impl IntoIterator<Item = AnnotatedScript>) -> Self {
+        Self {
             scripts: Mutex::new(scripts.into_iter().map(QueuedScript::Immediate).collect()),
             requests: Mutex::new(Vec::new()),
         }
@@ -61,7 +80,7 @@ impl ScriptedChatEngine {
         (
             Self {
                 scripts: Mutex::new(VecDeque::from([QueuedScript::Gated {
-                    chunks: script,
+                    chunks: script.into_iter().map(Annotated::from_data).collect(),
                     split_at,
                     release: release.clone(),
                 }])),
@@ -108,7 +127,7 @@ impl
             match script {
                 QueuedScript::Immediate(chunks) => {
                     for chunk in chunks {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
                 }
                 QueuedScript::Gated {
@@ -118,7 +137,7 @@ impl
                 } => {
                     let mut chunks = chunks.into_iter();
                     for chunk in chunks.by_ref().take(split_at) {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
                     let permit = release
                         .acquire()
@@ -126,11 +145,57 @@ impl
                         .expect("script gate semaphore was closed");
                     permit.forget();
                     for chunk in chunks {
-                        yield Annotated::from_data(chunk);
+                        yield chunk;
                     }
                 }
             }
         };
         Ok(ResponseStream::new(Box::pin(output), ctx))
+    }
+}
+
+/// Captures Completion requests and returns one annotated script per request.
+pub struct ScriptedCompletionEngine {
+    scripts: Mutex<VecDeque<CompletionScript>>,
+    requests: Mutex<Vec<NvCreateCompletionRequest>>,
+}
+
+impl ScriptedCompletionEngine {
+    pub fn new(scripts: impl IntoIterator<Item = CompletionScript>) -> Self {
+        Self {
+            scripts: Mutex::new(scripts.into_iter().collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub async fn take_requests(&self) -> Vec<NvCreateCompletionRequest> {
+        std::mem::take(&mut *self.requests.lock().await)
+    }
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateCompletionRequest>,
+        ManyOut<Annotated<NvCreateCompletionResponse>>,
+        Error,
+    > for ScriptedCompletionEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateCompletionRequest>,
+    ) -> Result<ManyOut<Annotated<NvCreateCompletionResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let ctx = context.context();
+        self.requests.lock().await.push(request);
+        let script =
+            self.scripts.lock().await.pop_front().ok_or_else(|| {
+                anyhow!("ScriptedCompletionEngine received an unexpected request")
+            })?;
+
+        Ok(ResponseStream::new(
+            Box::pin(futures::stream::iter(script)),
+            ctx,
+        ))
     }
 }

--- a/lib/llm/tests/common/scripted_chat_engine.rs
+++ b/lib/llm/tests/common/scripted_chat_engine.rs
@@ -24,6 +24,7 @@ pub type CompletionScript = Vec<Annotated<NvCreateCompletionResponse>>;
 
 enum QueuedScript {
     Immediate(AnnotatedScript),
+    PendingAfter(AnnotatedScript),
     Gated {
         chunks: AnnotatedScript,
         split_at: usize,
@@ -67,6 +68,18 @@ impl ScriptedChatEngine {
     pub fn new_annotated(scripts: impl IntoIterator<Item = AnnotatedScript>) -> Self {
         Self {
             scripts: Mutex::new(scripts.into_iter().map(QueuedScript::Immediate).collect()),
+            requests: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn new_pending_after_annotated(scripts: impl IntoIterator<Item = AnnotatedScript>) -> Self {
+        Self {
+            scripts: Mutex::new(
+                scripts
+                    .into_iter()
+                    .map(QueuedScript::PendingAfter)
+                    .collect(),
+            ),
             requests: Mutex::new(Vec::new()),
         }
     }
@@ -129,6 +142,12 @@ impl
                     for chunk in chunks {
                         yield chunk;
                     }
+                }
+                QueuedScript::PendingAfter(chunks) => {
+                    for chunk in chunks {
+                        yield chunk;
+                    }
+                    std::future::pending::<()>().await;
                 }
                 QueuedScript::Gated {
                     chunks,

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP regressions for validation failures shared by the frontend protocols.
+
+use dynamo_llm::protocols::{
+    Annotated,
+    openai::{
+        chat_completions::NvCreateChatCompletionStreamResponse,
+        completions::NvCreateCompletionResponse,
+    },
+};
+use dynamo_runtime::{
+    config::environment_names::llm::{
+        DYN_ENABLE_ANTHROPIC_API, DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+        DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS,
+    },
+    error::{BackendError, DynamoError, ErrorType},
+};
+use serde_json::{Value, json};
+use serial_test::serial;
+
+#[path = "common/http_harness.rs"]
+mod http_harness;
+#[path = "common/ports.rs"]
+mod ports;
+#[path = "common/scripted_chat_engine.rs"]
+mod scripted_chat_engine;
+
+use http_harness::{HarnessService, MODEL, load_agent_fixture, parse_json_sse};
+use scripted_chat_engine::{AnnotatedScript, CompletionScript};
+
+const BASE_ENV: [(&str, Option<&str>); 2] = [
+    (DYN_ENABLE_ANTHROPIC_API, Some("1")),
+    (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+];
+
+fn backend_error<T>(error_type: ErrorType, message: &str) -> Annotated<T> {
+    Annotated {
+        data: None,
+        id: None,
+        event: Some("error".to_string()),
+        comment: None,
+        error: Some(
+            DynamoError::builder()
+                .error_type(error_type)
+                .message(message)
+                .build(),
+        ),
+    }
+}
+
+async fn assert_openai_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["code"], 400);
+    assert!(
+        body["message"].as_str().is_some_and(|actual| actual
+            .to_ascii_lowercase()
+            .contains(&message.to_ascii_lowercase())),
+        "unexpected OpenAI error body: {body}"
+    );
+}
+
+async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: Value = response.json().await.unwrap();
+    assert_eq!(body["type"], "error");
+    assert_eq!(body["error"]["type"], "invalid_request_error");
+    assert!(
+        body["error"]["message"]
+            .as_str()
+            .is_some_and(|actual| actual.contains(message)),
+        "unexpected Anthropic error body: {body}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn completions_backend_validation_is_400_for_unary_and_streaming() {
+    let env = [
+        BASE_ENV[0],
+        BASE_ENV[1],
+        (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, Some("500")),
+    ];
+    temp_env::async_with_vars(env, async {
+        let max_tokens_message = "max_tokens must be less than 2147483647";
+        let logprobs_message = "Dynamo's SGLang backend does not currently support logprobs >= 1";
+        let scripts: Vec<CompletionScript> = [
+            max_tokens_message,
+            max_tokens_message,
+            logprobs_message,
+            logprobs_message,
+        ]
+        .into_iter()
+        .map(|message| {
+            vec![backend_error::<NvCreateCompletionResponse>(
+                ErrorType::Backend(BackendError::InvalidArgument),
+                message,
+            )]
+        })
+        .collect();
+        let svc = HarnessService::start_with_completion_scripts(scripts).await;
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "hello",
+                    "max_tokens": 2147483647_u32,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "max_tokens").await;
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/completions", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "prompt": "hello",
+                    "max_tokens": 16,
+                    "logprobs": 1,
+                    "stream": stream
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "logprobs").await;
+        }
+
+        let requests = svc.completion_engine.take_requests().await;
+        assert_eq!(requests.len(), 4);
+        assert_eq!(requests[0].inner.max_tokens, Some(2147483647));
+        assert_eq!(requests[1].inner.max_tokens, Some(2147483647));
+        assert_eq!(requests[2].inner.logprobs, Some(1));
+        assert_eq!(requests[3].inner.logprobs, Some(1));
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn protocol_adapter_validation_is_400_before_streaming_headers() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let valid_script = load_agent_fixture("text.sse").await.unwrap();
+        let svc = HarnessService::start([valid_script]).await;
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({"model": MODEL, "input": [], "stream": stream}))
+                .send()
+                .await
+                .unwrap();
+            assert_openai_400(response, "messages").await;
+        }
+        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
+            for stream in [false, true] {
+                let mut body = json!({"model": MODEL, "input": "ping", "stream": stream});
+                body.as_object_mut()
+                    .unwrap()
+                    .extend(field.as_object().unwrap().clone());
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/responses", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_openai_400(response, "must be").await;
+            }
+        }
+
+        for stream in [false, true] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": ["hello"]}]
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_anthropic_400(response, "content blocks must be objects").await;
+        }
+        for field in [json!({"temperature": 3.0}), json!({"top_p": 2.0})] {
+            for stream in [false, true] {
+                let mut body = json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "stream": stream,
+                    "messages": [{"role": "user", "content": "ping"}]
+                });
+                body.as_object_mut()
+                    .unwrap()
+                    .extend(field.as_object().unwrap().clone());
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/messages", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_anthropic_400(response, "must be").await;
+            }
+        }
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "stream": false,
+                "messages": [{
+                    "role": "user",
+                    "content": [
+                        {"type": "future_block_type", "value": 1},
+                        {"type": "text", "text": "ping"}
+                    ]
+                }]
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(svc.engine.take_requests().await.len(), 1);
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+fn partial_then_error(
+    partial: &NvCreateChatCompletionStreamResponse,
+    error_type: ErrorType,
+    message: &str,
+) -> AnnotatedScript {
+    vec![
+        Annotated::from_data(partial.clone()),
+        backend_error(error_type, message),
+    ]
+}
+
+#[tokio::test]
+#[serial]
+async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let scripts = vec![
+            partial_then_error(&partial, invalid, "invalid response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/worker.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late response input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/late.py",
+            ),
+            partial_then_error(&partial, invalid, "invalid late Anthropic input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/anthropic.py",
+            ),
+        ];
+        let svc = HarnessService::start_with_scripts(scripts, []).await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_openai_400(response, "invalid response input").await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": false}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            reqwest::StatusCode::INTERNAL_SERVER_ERROR
+        );
+        let body: Value = response.json().await.unwrap();
+        assert_eq!(body["message"], "Failed to fold responses stream");
+        assert!(!body.to_string().contains("/srv/worker.py"));
+
+        for (error_code, expected_message) in [
+            ("invalid_prompt", "invalid late response input"),
+            ("server_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/responses", svc.base_url))
+                .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let failed = events
+                .iter()
+                .find(|event| event.event == "response.failed")
+                .expect("missing response.failed event");
+            assert_eq!(failed.data["response"]["error"]["code"], error_code);
+            assert_eq!(
+                failed.data["response"]["error"]["message"],
+                expected_message
+            );
+        }
+
+        for (error_type, expected_message) in [
+            ("invalid_request_error", "invalid late Anthropic input"),
+            ("api_error", "Internal server error"),
+        ] {
+            let response = svc
+                .client
+                .post(format!("{}/v1/messages", svc.base_url))
+                .json(&json!({
+                    "model": MODEL,
+                    "max_tokens": 16,
+                    "messages": [{"role": "user", "content": "ping"}],
+                    "stream": true
+                }))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), reqwest::StatusCode::OK);
+            let events = parse_json_sse(&response.text().await.unwrap())
+                .await
+                .unwrap();
+            let error = events
+                .iter()
+                .find(|event| event.event == "error")
+                .expect("missing Anthropic error event");
+            assert_eq!(error.data["error"]["type"], error_type);
+            assert_eq!(error.data["error"]["message"], expected_message);
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -3,6 +3,8 @@
 
 //! HTTP regressions for validation failures shared by the frontend protocols.
 
+use std::time::Duration;
+
 use dynamo_llm::protocols::{
     Annotated,
     openai::{
@@ -30,9 +32,10 @@ mod scripted_chat_engine;
 use http_harness::{HarnessService, MODEL, load_agent_fixture, parse_json_sse};
 use scripted_chat_engine::{AnnotatedScript, CompletionScript};
 
-const BASE_ENV: [(&str, Option<&str>); 2] = [
+const BASE_ENV: [(&str, Option<&str>); 3] = [
     (DYN_ENABLE_ANTHROPIC_API, Some("1")),
     (DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS, Some("0")),
+    (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, None),
 ];
 
 fn backend_error<T>(error_type: ErrorType, message: &str) -> Annotated<T> {
@@ -78,12 +81,7 @@ async fn assert_anthropic_400(response: reqwest::Response, message: &str) {
 #[tokio::test]
 #[serial]
 async fn completions_backend_validation_is_400_for_unary_and_streaming() {
-    let env = [
-        BASE_ENV[0],
-        BASE_ENV[1],
-        (DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, Some("500")),
-    ];
-    temp_env::async_with_vars(env, async {
+    temp_env::async_with_vars(BASE_ENV, async {
         let max_tokens_message = "max_tokens must be less than 2147483647";
         let logprobs_message = "Dynamo's SGLang backend does not currently support logprobs >= 1";
         let scripts: Vec<CompletionScript> = [
@@ -278,8 +276,40 @@ async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
                 ErrorType::Backend(BackendError::Unknown),
                 "secret /srv/anthropic.py",
             ),
+            partial_then_error(&partial, invalid, "invalid late chat input"),
+            partial_then_error(
+                &partial,
+                ErrorType::Backend(BackendError::Unknown),
+                "secret /srv/chat.py",
+            ),
         ];
-        let svc = HarnessService::start_with_scripts(scripts, []).await;
+        let partial_completion: NvCreateCompletionResponse = serde_json::from_value(json!({
+            "id": "cmpl-partial",
+            "object": "text_completion",
+            "created": 0,
+            "model": MODEL,
+            "choices": [{
+                "text": "partial",
+                "index": 0,
+                "logprobs": null,
+                "finish_reason": null
+            }]
+        }))
+        .unwrap();
+        let completion_scripts = vec![
+            vec![
+                Annotated::from_data(partial_completion.clone()),
+                backend_error(invalid, "invalid late completion input"),
+            ],
+            vec![
+                Annotated::from_data(partial_completion),
+                backend_error(
+                    ErrorType::Backend(BackendError::Unknown),
+                    "secret /srv/completion.py",
+                ),
+            ],
+        ];
+        let svc = HarnessService::start_with_scripts(scripts, completion_scripts).await;
 
         let response = svc
             .client
@@ -358,6 +388,141 @@ async fn unary_and_late_stream_errors_keep_classification_and_envelopes() {
             assert_eq!(error.data["error"]["type"], error_type);
             assert_eq!(error.data["error"]["message"], expected_message);
         }
+
+        for (endpoint, client_message) in [
+            ("chat/completions", "invalid late chat input"),
+            ("completions", "invalid late completion input"),
+        ] {
+            for (code, error_type, expected_message) in [
+                (400, "invalid_request_error", client_message.to_string()),
+                (
+                    500,
+                    "internal_server_error",
+                    "Internal server error".to_string(),
+                ),
+            ] {
+                let body = if endpoint == "chat/completions" {
+                    json!({
+                        "model": MODEL,
+                        "messages": [{"role": "user", "content": "ping"}],
+                        "stream": true
+                    })
+                } else {
+                    json!({"model": MODEL, "prompt": "ping", "stream": true})
+                };
+                let response = svc
+                    .client
+                    .post(format!("{}/v1/{endpoint}", svc.base_url))
+                    .json(&body)
+                    .send()
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), reqwest::StatusCode::OK);
+                let events = parse_json_sse(&response.text().await.unwrap())
+                    .await
+                    .unwrap();
+                let error = events
+                    .iter()
+                    .find_map(|event| event.data.get("error"))
+                    .expect("missing OpenAI inline error event");
+                assert_eq!(error["code"], code);
+                assert_eq!(error["type"], error_type);
+                assert_eq!(error["message"], expected_message);
+            }
+        }
+
+        svc.shutdown().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+#[serial]
+async fn native_stream_errors_are_terminal_and_recorded_as_failures() {
+    temp_env::async_with_vars(BASE_ENV, async {
+        let partial = load_agent_fixture("text.sse").await.unwrap()[0].clone();
+        let invalid = ErrorType::Backend(BackendError::InvalidArgument);
+        let svc = HarnessService::start_with_pending_annotated_scripts([
+            partial_then_error(&partial, invalid, "terminal Responses validation"),
+            partial_then_error(&partial, invalid, "terminal Anthropic validation"),
+        ])
+        .await;
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/responses", svc.base_url))
+            .json(&json!({"model": MODEL, "input": "ping", "stream": true}))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Responses stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let failed = events
+            .iter()
+            .find(|event| event.event == "response.failed")
+            .expect("missing terminal response.failed event");
+        assert_eq!(
+            failed.data["response"]["error"]["message"],
+            "terminal Responses validation"
+        );
+
+        let response = svc
+            .client
+            .post(format!("{}/v1/messages", svc.base_url))
+            .json(&json!({
+                "model": MODEL,
+                "max_tokens": 16,
+                "messages": [{"role": "user", "content": "ping"}],
+                "stream": true
+            }))
+            .send()
+            .await
+            .unwrap();
+        let body = tokio::time::timeout(Duration::from_secs(1), response.text())
+            .await
+            .expect("Anthropic stream waited for backend EOF")
+            .unwrap();
+        let events = parse_json_sse(&body).await.unwrap();
+        let error = events
+            .iter()
+            .find(|event| event.event == "error")
+            .expect("missing terminal Anthropic error event");
+        assert_eq!(
+            error.data["error"]["message"],
+            "terminal Anthropic validation"
+        );
+
+        let metrics = svc
+            .client
+            .get(format!("{}/metrics", svc.base_url))
+            .send()
+            .await
+            .unwrap()
+            .text()
+            .await
+            .unwrap();
+        for endpoint in ["responses", "anthropic_messages"] {
+            let line = metrics
+                .lines()
+                .find(|line| {
+                    line.starts_with("dynamo_frontend_requests_total{")
+                        && line.contains(&format!("endpoint=\"{endpoint}\""))
+                        && line.contains("request_type=\"stream\"")
+                        && line.contains("status=\"error\"")
+                        && line.contains("error_type=\"validation\"")
+                })
+                .unwrap_or_else(|| panic!("missing validation failure metric for {endpoint}"));
+            assert!(line.ends_with(" 1"), "unexpected request metric: {line}");
+        }
+        assert!(
+            metrics.lines().any(|line| {
+                line == format!("dynamo_frontend_inflight_requests{{model=\"{MODEL}\"}} 0")
+            }),
+            "inflight gauge did not return to zero"
+        );
 
         svc.shutdown().await;
     })

--- a/lib/llm/tests/frontend_validation_http.rs
+++ b/lib/llm/tests/frontend_validation_http.rs
@@ -106,7 +106,7 @@ async fn completions_backend_validation_is_400_for_unary_and_streaming() {
                 .post(format!("{}/v1/completions", svc.base_url))
                 .json(&json!({
                     "model": MODEL,
-                    "prompt": "hello",
+                    "prompt": "test",
                     "max_tokens": 2147483647_u32,
                     "stream": stream
                 }))
@@ -155,7 +155,12 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
             let response = svc
                 .client
                 .post(format!("{}/v1/responses", svc.base_url))
-                .json(&json!({"model": MODEL, "input": [], "stream": stream}))
+                .json(&json!({
+                    "model": MODEL,
+                    "input": [],
+                    "max_tokens": 10,
+                    "stream": stream
+                }))
                 .send()
                 .await
                 .unwrap();
@@ -184,7 +189,7 @@ async fn protocol_adapter_validation_is_400_before_streaming_headers() {
                 .post(format!("{}/v1/messages", svc.base_url))
                 .json(&json!({
                     "model": MODEL,
-                    "max_tokens": 16,
+                    "max_tokens": 10,
                     "stream": stream,
                     "messages": [{"role": "user", "content": ["hello"]}]
                 }))

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -21,7 +21,6 @@ use dynamo_llm::{
     },
     model_card::ModelDeploymentCard,
 };
-use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::metrics::prometheus_names::{frontend_service, name_prefix};
 use dynamo_runtime::{
     CancellationToken,
@@ -1388,29 +1387,8 @@ async fn test_nvext_disabled_strips_request_and_response() {
 /// the peek-before-200 helper with chat_completions, so an `InvalidArgument`
 /// frame at t=0 must land as HTTP 400, not HTTP 200 + generic 500 SSE.
 ///
-/// The pre-commit peek is opt-in via `DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS`
-/// (default: unset → peek disabled). Enable it here so the assertion
-/// exercises the fix path. `#[serial]` prevents the env var from bleeding
-/// into other tests that may run in parallel.
 #[tokio::test]
-#[serial_test::serial]
 async fn test_streaming_responses_returns_4xx_on_backend_invalid_argument() {
-    // SAFETY: single-threaded via `#[serial]`; no other test reads or writes
-    // this env var concurrently.
-    unsafe {
-        std::env::set_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS, "500");
-    }
-    // Guard to unset on any exit path from this test.
-    struct EnvGuard;
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            unsafe {
-                std::env::remove_var(env_llm::DYN_HTTP_PRE_COMMIT_ERROR_PEEK_MS);
-            }
-        }
-    }
-    let _guard = EnvGuard;
-
     let (listener, port) = bind_random_port().await;
     let service = HttpService::builder()
         .port(port)

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -3,7 +3,7 @@
 
 use super::maybe_error::MaybeError;
 use crate::error::DynamoError;
-use anyhow::{Result, anyhow as error};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait AnnotationsProvider {
@@ -33,6 +33,19 @@ pub struct Annotated<R> {
 }
 
 impl<R> Annotated<R> {
+    fn cloned_error(&self) -> Option<DynamoError> {
+        self.is_error().then(|| {
+            self.error.clone().unwrap_or_else(|| {
+                DynamoError::msg(
+                    self.comment
+                        .as_ref()
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            })
+        })
+    }
+
     /// Create a new annotated stream from the given error string
     pub fn from_error(error: impl Into<String>) -> Self {
         Self {
@@ -74,37 +87,19 @@ impl<R> Annotated<R> {
     /// Convert to a [`Result<Self, String>`]
     /// If [`Self::event`] is "error", return an error message
     pub fn ok(self) -> Result<Self, String> {
-        if let Some(event) = &self.event
-            && event == "error"
-        {
-            // First check DynamoError, then fallback to comment
-            if let Some(ref err) = self.error {
-                return Err(err.to_string());
-            }
-            return Err(self
-                .comment
-                .unwrap_or(vec!["unknown error".to_string()])
-                .join(", "));
+        if let Some(error) = self.cloned_error() {
+            return Err(error.to_string());
         }
         Ok(self)
     }
 
-    /// Convert an error event into a structured [`DynamoError`].
-    ///
-    /// Unary response aggregators should use this instead of [`Self::ok`] so
-    /// the HTTP boundary can distinguish invalid client input from internal
-    /// failures without inspecting error strings.
-    pub fn ok_typed(self) -> Result<Self, DynamoError> {
-        if self.is_error() {
-            return Err(self.error.unwrap_or_else(|| {
-                DynamoError::msg(
-                    self.comment
-                        .unwrap_or_else(|| vec!["unknown error".to_string()])
-                        .join(", "),
-                )
-            }));
+    /// Consume the annotation and return its optional payload while preserving
+    /// structured errors.
+    pub fn into_data(self) -> Result<Option<R>, DynamoError> {
+        if let Some(error) = self.cloned_error() {
+            return Err(error);
         }
-        Ok(self)
+        Ok(self.data)
     }
 
     pub fn is_ok(&self) -> bool {
@@ -148,24 +143,7 @@ impl<R> Annotated<R> {
     }
 
     pub fn into_result(self) -> Result<Option<R>> {
-        match self.data {
-            Some(data) => Ok(Some(data)),
-            None => match self.event {
-                Some(event) if event == "error" => {
-                    // First check DynamoError, then fallback to comment
-                    if let Some(ref err) = self.error {
-                        Err(error!("{}", err))?
-                    } else {
-                        Err(error!(
-                            self.comment
-                                .unwrap_or(vec!["unknown error".to_string()])
-                                .join(", ")
-                        ))?
-                    }
-                }
-                _ => Ok(None),
-            },
-        }
+        self.into_data().map_err(anyhow::Error::new)
     }
 }
 
@@ -186,22 +164,7 @@ where
     }
 
     fn err(&self) -> Option<DynamoError> {
-        if self.is_error() {
-            // First check DynamoError field
-            if let Some(ref error) = self.error {
-                return Some(error.clone());
-            }
-
-            // Fallback to comment-based error
-            if let Some(comment) = &self.comment
-                && !comment.is_empty()
-            {
-                return Some(DynamoError::msg(comment.join("; ")));
-            }
-            Some(DynamoError::msg("unknown error"))
-        } else {
-            None
-        }
+        self.cloned_error()
     }
 }
 
@@ -273,7 +236,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ok_typed_preserves_error_type() {
+    fn test_into_data_preserves_error_type() {
         use crate::error::{BackendError, ErrorType};
 
         let error = DynamoError::builder()
@@ -282,7 +245,7 @@ mod tests {
             .build();
         let annotated = Annotated::<String>::from_err(error);
 
-        let error = annotated.ok_typed().unwrap_err();
+        let error = annotated.into_data().unwrap_err();
         assert_eq!(
             error.error_type(),
             ErrorType::Backend(BackendError::InvalidArgument)

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -89,6 +89,24 @@ impl<R> Annotated<R> {
         Ok(self)
     }
 
+    /// Convert an error event into a structured [`DynamoError`].
+    ///
+    /// Unary response aggregators should use this instead of [`Self::ok`] so
+    /// the HTTP boundary can distinguish invalid client input from internal
+    /// failures without inspecting error strings.
+    pub fn ok_typed(self) -> Result<Self, DynamoError> {
+        if self.is_error() {
+            return Err(self.error.unwrap_or_else(|| {
+                DynamoError::msg(
+                    self.comment
+                        .unwrap_or_else(|| vec!["unknown error".to_string()])
+                        .join(", "),
+                )
+            }));
+        }
+        Ok(self)
+    }
+
     pub fn is_ok(&self) -> bool {
         self.event.as_deref() != Some("error")
     }
@@ -252,6 +270,24 @@ mod tests {
         let result = annotated.ok();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("connection lost"));
+    }
+
+    #[test]
+    fn test_ok_typed_preserves_error_type() {
+        use crate::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid request")
+            .build();
+        let annotated = Annotated::<String>::from_err(error);
+
+        let error = annotated.ok_typed().unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid request");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve structured Dynamo errors through unary Annotated aggregation instead of flattening them into strings.
- Classify client validation, overload, availability, cancellation, and internal failures in one shared HTTP policy.
- Keep OpenAI, Responses, Anthropic, and Generate protocol-specific error envelopes.
- Apply shared Chat validation after Responses and Anthropic conversion.
- Handle streaming errors according to whether HTTP headers have already been committed.
- Classify a missing SGLang named tool as client validation and a missing DeepSeek-V4 integration as a server dependency failure.

## Root cause

Typed backend validation errors were often converted to strings during unary aggregation. The HTTP layer could then no longer distinguish invalid client input from internal runtime failures. Endpoint-specific first-frame checks covered some cases but failed when an error arrived after partial output or through a different aggregator.

## Addressed behavior

| Error class or scenario | Non-streaming: before → after | Streaming: before → after |
|---|---|---|
| InvalidArgument or Backend(InvalidArgument) during dispatch | Inconsistent 400/500 → consistent HTTP 400 with safe validation message | Inconsistent 400/500 → HTTP 400 if detected before headers |
| Typed validation error after normal output | Error type flattened, usually HTTP 500 → full aggregation preserves type and returns HTTP 400 | HTTP 200 already committed, often generic error → HTTP 200 with protocol-correct inline client error |
| Explicit backend/client 4xx status | Could be lost during aggregation → retained as a client 4xx | Before headers: preserved 4xx; after headers: HTTP 200 with inline client error |
| Completions max_tokens: 2147483647 | HTTP 500 → HTTP 400 | Generic 500 behavior → HTTP 400 if received before headers; otherwise inline client error |
| Completions unsupported logprobs | HTTP 500 → HTTP 400 | Generic 500 behavior → HTTP 400 before headers or inline client error after data |
| Responses input: [] | Could fail later as HTTP 500 → converted request is validated and returns HTTP 400 | HTTP 400 before the SSE response begins |
| Responses invalid temperature or top_p | Inconsistent validation → HTTP 400 | HTTP 400 before the SSE response begins |
| Anthropic scalar content such as content: ["hello"] | Generic conversion/internal failure → Anthropic invalid_request_error, HTTP 400 | HTTP 400 before the SSE response begins |
| Anthropic invalid temperature or top_p | Shared validation not consistently applied → HTTP 400 | HTTP 400 before the SSE response begins |
| SGLang named tool_choice absent from tools | Generic ValueError became HTTP 500 → PreprocessError becomes HTTP 400 | Immediate preprocessing error returns HTTP 400 before SSE headers |
| Existing PreprocessError cases | Explicitly converted to InvalidArgument, already HTTP 400 → unchanged | Already capable of returning 400 before headers → unchanged |
| Unknown/runtime error | Endpoint-specific handling or possible detail leakage → sanitized HTTP 500 | Before headers: sanitized HTTP 500; after SSE data: HTTP 200 with sanitized inline server error |
| ResourceExhausted or queue rejection | Scattered handling → centralized configured overload status, default 529 | Same status before headers; after data, HTTP 200 with inline overload/server event |
| Unavailable | Inconsistent handling → sanitized HTTP 503 | HTTP 503 before headers; after data, HTTP 200 with sanitized inline error |
| Cancelled | Centralized sanitized HTTP 499 | HTTP 499 if a response can still be sent before headers; after commitment or disconnect, stream terminates |
| Late Responses validation error | Unary aggregation often returned 500 | HTTP 200 with native response.failed, then stream termination |
| Late Anthropic validation error | Unary aggregation often returned 500 | HTTP 200 with native Anthropic error event, then stream termination |
| Late Chat/Completions validation error | Unary aggregation often returned 500 | HTTP 200 with OpenAI invalid_request_error, then stream termination |
| Late unknown error with backend remaining open | Unary returned sanitized 500 | Previously could wait for backend EOF → now emits an inline server error and terminates immediately |
| Error metrics after a late failure | Could be derived inconsistently → canonical error classification | Previously could be marked successful → now marked failed and inflight accounting is released |
| Missing DeepSeek-V4 SGLang integration | ValueError caught as Unknown, HTTP 500 → ImportError caught as Unknown, still sanitized HTTP 500 | Same HTTP behavior; error is discovered before output and remains a sanitized 500 |

## Deliberately unchanged or out of scope

| Error class or scenario | Non-streaming behavior | Streaming behavior |
|---|---|---|
| Error discovered after SSE headers | Not applicable | HTTP status cannot change; remains 200 with an inline error event |
| Generic preprocessing ValueError or TypeError caught by except Exception | Still becomes Unknown and returns 500 | Returns 500 if caught before headers; otherwise a sanitized inline server error |
| PreprocessError inheritance | Still inherits from Exception and is explicitly converted to InvalidArgument | Same explicit conversion; automatic ValueError mapping was not introduced |
| Unexpected tokenizer/chat-template ValueError | Remains sanitized 500 unless explicitly classified as PreprocessError | Same classification based on whether headers are committed |
| SGLang _generate_and_stream broad catch | Direct typed exceptions may still be collapsed to Unknown | May produce a generic inline server error rather than preserving the original category |
| SGLang routed annotated error flattened into an internal-error dictionary | May lose its original type and return 500 | May lose its original type and emit a generic server error |
| Backend returns Unknown for invalid client input | Remains sanitized HTTP 500; no message-based inference | HTTP 500 before headers or HTTP 200 with sanitized inline server error after data |
| CannotConnect or Disconnected | Remains a sanitized operational 5xx | Operational 5xx before headers or inline server error after commitment |
| ConnectionTimeout or ResponseTimeout | Remains 5xx | 5xx before headers or inline timeout/server error after commitment |
| EngineShutdown or StreamIncomplete | Remains sanitized HTTP 500 | HTTP 500 before headers or HTTP 200 with sanitized inline server error |
| Import/dependency/configuration failure | Remains sanitized HTTP 500 | HTTP 500 if detected before streaming begins |
| Internal tokenizer, parser, serialization, or postprocessing bug | Remains sanitized HTTP 500 | Sanitized 500 before headers or inline server error after data |
| Unsupported fields currently returning 501 | Existing behavior remains | Existing behavior remains |
| Model not found or unavailable | Existing 404/503 behavior remains | Same status if detected before headers |
| Malformed HTTP JSON/body | Existing framework-level 4xx behavior remains | Rejected before a stream is created |
| Hard-coded frontend max_tokens limit | None added | None added |
| Classification based on error-message strings | Not added | Not added |
| Validation parity across every backend | Depends on the backend emitting InvalidArgument | Same requirement; the frontend cannot recover a type discarded by the backend |

## Streaming status rule

| When the error is known | HTTP result |
|---|---|
| Before response headers | Return the classified 4xx or 5xx status |
| After SSE data commits HTTP 200 | Keep HTTP 200, emit the protocol-specific inline error, and terminate the stream |

## Validation

- cargo test -p dynamo-llm: 1,954 passed, 5 ignored
- Focused runtime typed-error tests: 7 passed
- Python TCP/etcd frontend validation test: passed
- SGLang processor unit suite: 200 passed
- Python binding build: passed
- Ruff, formatting, pre-commit hooks, and git diff --check: passed
- Three strict maintainability review rounds completed with no remaining findings

## Tracking

- [DYN-3787](https://linear.app/nvidia/issue/DYN-3787)
- [DYN-3788](https://linear.app/nvidia/issue/DYN-3788)
- [DYN-3789](https://linear.app/nvidia/issue/DYN-3789)
