### PR TITLE
fix: Add guided decoding json schema validation

### DIFF
--- a/components/src/dynamo/common/tests/test_guided_json.py
+++ b/components/src/dynamo/common/tests/test_guided_json.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.llm import HttpError
 
 pytestmark = [
@@ -43,8 +43,38 @@ pytestmark = [
     ],
 )
 def test_rejects_cyclic_root_ref_chains(schema):
-    with pytest.raises(HttpError, match=r"circular local \$ref chain") as error:
-        reject_cyclic_guided_json_ref_chain(schema)
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        pytest.param(
+            {
+                "$defs": {
+                    "A": {"allOf": [{"$ref": "#/$defs/A"}]},
+                },
+                "$ref": "#/$defs/A",
+            },
+            id="allof",
+        ),
+        pytest.param(
+            {
+                "type": "object",
+                "properties": {"value": {"$ref": "#/$defs/A"}},
+                "required": ["value"],
+                "$defs": {"A": {"$ref": "#/$defs/A"}},
+            },
+            id="required-property",
+        ),
+    ],
+)
+def test_rejects_nonprogressing_ref_cycles(schema):
+    with pytest.raises(HttpError, match=r"non-progressing local \$ref cycle") as error:
+        reject_nonprogressing_guided_json_ref_cycles(schema)
 
     assert error.value.code == 400
 
@@ -84,7 +114,7 @@ def test_rejects_cyclic_root_ref_chains(schema):
     ],
 )
 def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
-    reject_cyclic_guided_json_ref_chain(schema)
+    reject_nonprogressing_guided_json_ref_cycles(schema)
 
 
 @pytest.mark.parametrize(
@@ -96,4 +126,4 @@ def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
     ],
 )
 def test_leaves_unresolved_references_to_backend(schema):
-    reject_cyclic_guided_json_ref_chain(schema)
+    reject_nonprogressing_guided_json_ref_cycles(schema)

--- a/components/src/dynamo/common/tests/test_guided_json.py
+++ b/components/src/dynamo/common/tests/test_guided_json.py
@@ -1,13 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for guided JSON schema validation."""
-
 import json
 
 import pytest
 
-from dynamo.common.utils.guided_json import validate_guided_json_schema
+from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
 from dynamo.llm import HttpError
 
 pytestmark = [
@@ -22,7 +20,6 @@ pytestmark = [
     [
         {"$ref": "#"},
         json.dumps({"$ref": "#"}),
-        {"$ref": "#", "type": "object"},
         {
             "$defs": {
                 "A": {"$ref": "#/$defs/B"},
@@ -32,18 +29,29 @@ pytestmark = [
         },
         {
             "$defs": {
-                "A": {"$ref": "#/$defs/B"},
-                "B": {"$ref": "#/$defs/C"},
-                "C": {"$ref": "#/$defs/A"},
+                "A": {"$id": "urn:example:A", "$ref": "#"},
             },
             "$ref": "#/$defs/A",
         },
         {
             "$defs": {
-                "A": {"allOf": [{"$ref": "#/$defs/A"}]},
+                "a/b": {"$ref": "#/$defs/c~0d"},
+                "c~d": {"$ref": "#/$defs/a~1b"},
             },
-            "$ref": "#/$defs/A",
+            "$ref": "#/$defs/a~1b",
         },
+    ],
+)
+def test_rejects_cyclic_root_ref_chains(schema):
+    with pytest.raises(HttpError, match=r"circular local \$ref chain") as error:
+        reject_cyclic_guided_json_ref_chain(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
         {
             "type": "string",
             "$defs": {
@@ -51,107 +59,41 @@ pytestmark = [
                 "B": {"$ref": "#/$defs/A"},
             },
         },
-    ],
-    ids=[
-        "root-self-reference",
-        "serialized-root-self-reference",
-        "root-self-reference-with-sibling",
-        "two-definition-cycle",
-        "three-definition-cycle",
-        "cycle-through-all-of",
-        "unused-definition-cycle",
-    ],
-)
-def test_rejects_unproductive_local_reference_cycles(schema):
-    with pytest.raises(
-        HttpError,
-        match="unproductive circular.*ref",
-    ) as error:
-        validate_guided_json_schema(schema)
-
-    assert error.value.code == 400
-
-
-@pytest.mark.parametrize(
-    "schema",
-    [
-        {
-            "type": "object",
-            "properties": {"city": {"type": "string"}},
-        },
-        {
-            "$defs": {"Name": {"type": "string"}},
-            "$ref": "#/$defs/Name",
-        },
         {
             "$defs": {
                 "Node": {
                     "type": "object",
                     "properties": {
-                        "value": {"type": "string"},
                         "next": {"$ref": "#/$defs/Node"},
                     },
                 }
             },
             "$ref": "#/$defs/Node",
         },
+        {"anyOf": [{"type": "string"}, {"$ref": "#"}]},
         {
             "$defs": {
-                "Node": {
-                    "anyOf": [
-                        {"type": "null"},
-                        {
-                            "type": "array",
-                            "items": {"$ref": "#/$defs/Node"},
-                        },
-                    ]
+                "A": {
+                    "$id": "urn:example:A",
+                    "$defs": {"B": {"type": "string"}},
+                    "$ref": "#/$defs/B",
                 }
             },
-            "$ref": "#/$defs/Node",
+            "$ref": "#/$defs/A",
         },
-        {
-            "$defs": {"a/b~c": {"type": "integer"}},
-            "$ref": "#/$defs/a~1b~0c",
-        },
-        {
-            "type": "object",
-            "properties": {"$ref": {"type": "string"}},
-        },
-    ],
-    ids=[
-        "ordinary-object",
-        "acyclic-definition",
-        "recursive-object-property",
-        "recursive-array-items",
-        "escaped-json-pointer",
-        "property-named-ref",
     ],
 )
-def test_accepts_productive_or_acyclic_schemas(schema):
-    validate_guided_json_schema(schema)
+def test_allows_schemas_outside_cyclic_root_ref_chains(schema):
+    reject_cyclic_guided_json_ref_chain(schema)
 
 
 @pytest.mark.parametrize(
     "schema",
     [
         {"$ref": "#/$defs/Missing"},
-        {"$defs": {"A": {"type": "string"}}, "$ref": "#/$defs/A~2B"},
-        {"$defs": {"A": 1}, "$ref": "#/$defs/A"},
+        {"$ref": "https://example.com/schema.json"},
         {"$ref": 123},
     ],
-    ids=[
-        "missing-target",
-        "invalid-pointer-escape",
-        "non-schema-target",
-        "non-string-ref",
-    ],
 )
-def test_rejects_malformed_local_references(schema):
-    with pytest.raises(HttpError) as error:
-        validate_guided_json_schema(schema)
-
-    assert error.value.code == 400
-
-
-def test_leaves_external_references_to_the_backend():
-    validate_guided_json_schema({"$ref": "https://example.com/schema.json"})
+def test_leaves_unresolved_references_to_backend(schema):
+    reject_cyclic_guided_json_ref_chain(schema)

--- a/components/src/dynamo/common/tests/test_guided_json.py
+++ b/components/src/dynamo/common/tests/test_guided_json.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for guided JSON schema validation."""
+
+import json
+
+import pytest
+
+from dynamo.common.utils.guided_json import validate_guided_json_schema
+from dynamo.llm import HttpError
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        json.dumps({"$ref": "#"}),
+        {"$ref": "#", "type": "object"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/C"},
+                "C": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+        {
+            "$defs": {
+                "A": {"allOf": [{"$ref": "#/$defs/A"}]},
+            },
+            "$ref": "#/$defs/A",
+        },
+        {
+            "type": "string",
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+        },
+    ],
+    ids=[
+        "root-self-reference",
+        "serialized-root-self-reference",
+        "root-self-reference-with-sibling",
+        "two-definition-cycle",
+        "three-definition-cycle",
+        "cycle-through-all-of",
+        "unused-definition-cycle",
+    ],
+)
+def test_rejects_unproductive_local_reference_cycles(schema):
+    with pytest.raises(
+        HttpError,
+        match="unproductive circular.*ref",
+    ) as error:
+        validate_guided_json_schema(schema)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+        },
+        {
+            "$defs": {"Name": {"type": "string"}},
+            "$ref": "#/$defs/Name",
+        },
+        {
+            "$defs": {
+                "Node": {
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string"},
+                        "next": {"$ref": "#/$defs/Node"},
+                    },
+                }
+            },
+            "$ref": "#/$defs/Node",
+        },
+        {
+            "$defs": {
+                "Node": {
+                    "anyOf": [
+                        {"type": "null"},
+                        {
+                            "type": "array",
+                            "items": {"$ref": "#/$defs/Node"},
+                        },
+                    ]
+                }
+            },
+            "$ref": "#/$defs/Node",
+        },
+        {
+            "$defs": {"a/b~c": {"type": "integer"}},
+            "$ref": "#/$defs/a~1b~0c",
+        },
+        {
+            "type": "object",
+            "properties": {"$ref": {"type": "string"}},
+        },
+    ],
+    ids=[
+        "ordinary-object",
+        "acyclic-definition",
+        "recursive-object-property",
+        "recursive-array-items",
+        "escaped-json-pointer",
+        "property-named-ref",
+    ],
+)
+def test_accepts_productive_or_acyclic_schemas(schema):
+    validate_guided_json_schema(schema)
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#/$defs/Missing"},
+        {"$defs": {"A": {"type": "string"}}, "$ref": "#/$defs/A~2B"},
+        {"$defs": {"A": 1}, "$ref": "#/$defs/A"},
+        {"$ref": 123},
+    ],
+    ids=[
+        "missing-target",
+        "invalid-pointer-escape",
+        "non-schema-target",
+        "non-string-ref",
+    ],
+)
+def test_rejects_malformed_local_references(schema):
+    with pytest.raises(HttpError) as error:
+        validate_guided_json_schema(schema)
+
+    assert error.value.code == 400
+
+
+def test_leaves_external_references_to_the_backend():
+    validate_guided_json_schema({"$ref": "https://example.com/schema.json"})

--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -1,52 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Validation for JSON schemas passed to constrained-decoding backends."""
+"""Targeted checks for JSON schemas passed to constrained-decoding backends."""
 
 import json
-from collections import deque
-from typing import Any, Iterator
+from typing import Any
 from urllib.parse import unquote
 
 from dynamo.llm import HttpError
-
-_NON_CONSUMING_ARRAY_KEYWORDS = ("allOf", "anyOf", "oneOf")
-_NON_CONSUMING_SINGLE_KEYWORDS = ("not", "if", "then", "else")
-_CONSUMING_ARRAY_KEYWORDS = ("prefixItems",)
-_CONSUMING_SINGLE_KEYWORDS = (
-    "additionalItems",
-    "additionalProperties",
-    "contains",
-    "contentSchema",
-    "items",
-    "propertyNames",
-    "unevaluatedItems",
-    "unevaluatedProperties",
-)
-_SCHEMA_MAP_KEYWORDS = (
-    "$defs",
-    "definitions",
-    "dependentSchemas",
-    "dependencies",
-    "patternProperties",
-    "properties",
-)
-_NON_CONSUMING_MAP_KEYWORDS = frozenset(("dependentSchemas", "dependencies"))
 
 
 def _schema_error(message: str) -> HttpError:
     return HttpError(400, f"Invalid guided_json schema: {message}")
 
 
-def _is_schema(value: Any) -> bool:
-    return isinstance(value, (dict, bool))
-
-
-def _escape_pointer_token(token: str) -> str:
-    return token.replace("~", "~0").replace("/", "~1")
-
-
-def _decode_pointer_token(token: str, ref: str) -> str:
+def _decode_pointer_token(token: str) -> str | None:
     decoded = []
     index = 0
     while index < len(token):
@@ -56,234 +24,77 @@ def _decode_pointer_token(token: str, ref: str) -> str:
             index += 1
             continue
         if index + 1 >= len(token) or token[index + 1] not in ("0", "1"):
-            raise _schema_error(f"invalid JSON pointer escape in $ref {ref!r}")
+            return None
         decoded.append("~" if token[index + 1] == "0" else "/")
         index += 2
     return "".join(decoded)
 
 
-def _resolve_local_ref(
-    root: Any,
-    ref: str,
-    anchors: dict[str, tuple[Any, str]],
-) -> tuple[Any, str] | None:
-    if not ref.startswith("#"):
-        # Preserve the backend's existing handling for external references.
-        return None
-
+def _resolve_local_pointer(
+    resource: dict[str, Any], ref: str
+) -> tuple[dict[str, Any], dict[str, Any]] | None:
     fragment = unquote(ref[1:])
     if not fragment:
-        return root, "#"
+        return resource, resource
     if not fragment.startswith("/"):
-        anchor = anchors.get(fragment)
-        if anchor is None:
-            # Leave unsupported local-anchor behavior to the grammar backend.
-            return None
-        return anchor
+        return None
 
-    target = root
-    canonical_path = "#"
+    target: Any = resource
+    target_resource = resource
     for encoded_token in fragment[1:].split("/"):
-        token = _decode_pointer_token(encoded_token, ref)
-        canonical_path += f"/{_escape_pointer_token(token)}"
+        token = _decode_pointer_token(encoded_token)
+        if token is None:
+            return None
         if isinstance(target, dict):
             if token not in target:
-                raise _schema_error(f"unresolvable local $ref {ref!r}")
+                return None
             target = target[token]
-        elif isinstance(target, list):
-            if not token.isdecimal():
-                raise _schema_error(f"unresolvable local $ref {ref!r}")
+        elif isinstance(target, list) and token.isdecimal():
             item_index = int(token)
             if item_index >= len(target):
-                raise _schema_error(f"unresolvable local $ref {ref!r}")
+                return None
             target = target[item_index]
         else:
-            raise _schema_error(f"unresolvable local $ref {ref!r}")
+            return None
 
-    return target, canonical_path
+        if isinstance(target, dict) and isinstance(target.get("$id"), str):
+            target_resource = target
 
-
-def _schema_children(
-    schema: dict[str, Any],
-    path: str,
-) -> Iterator[tuple[Any, str, bool]]:
-    for keyword in _NON_CONSUMING_ARRAY_KEYWORDS:
-        children = schema.get(keyword)
-        if isinstance(children, list):
-            for index, child in enumerate(children):
-                if _is_schema(child):
-                    yield child, f"{path}/{keyword}/{index}", True
-
-    for keyword in _NON_CONSUMING_SINGLE_KEYWORDS:
-        child = schema.get(keyword)
-        if _is_schema(child):
-            yield child, f"{path}/{keyword}", True
-
-    for keyword in _CONSUMING_ARRAY_KEYWORDS:
-        children = schema.get(keyword)
-        if isinstance(children, list):
-            for index, child in enumerate(children):
-                if _is_schema(child):
-                    yield child, f"{path}/{keyword}/{index}", False
-
-    for keyword in _CONSUMING_SINGLE_KEYWORDS:
-        child = schema.get(keyword)
-        if isinstance(child, list):
-            for index, item in enumerate(child):
-                if _is_schema(item):
-                    yield item, f"{path}/{keyword}/{index}", False
-        elif _is_schema(child):
-            yield child, f"{path}/{keyword}", False
-
-    for keyword in _SCHEMA_MAP_KEYWORDS:
-        children = schema.get(keyword)
-        if not isinstance(children, dict):
-            continue
-        non_consuming = keyword in _NON_CONSUMING_MAP_KEYWORDS
-        for name, child in children.items():
-            if _is_schema(child):
-                escaped_name = _escape_pointer_token(str(name))
-                yield child, f"{path}/{keyword}/{escaped_name}", non_consuming
+    if not isinstance(target, dict):
+        return None
+    return target, target_resource
 
 
-def _discover_schema_nodes(root: dict[str, Any]) -> dict[int, tuple[dict, str]]:
-    nodes: dict[int, tuple[dict, str]] = {}
-    pending = deque([(root, "#")])
+def reject_cyclic_guided_json_ref_chain(schema: Any) -> None:
+    """Reject root-reachable cycles made only of local ``$ref`` hops.
 
-    while pending:
-        value, path = pending.popleft()
-        if not isinstance(value, dict) or id(value) in nodes:
-            continue
-        nodes[id(value)] = (value, path)
-        for child, child_path, _ in _schema_children(value, path):
-            if isinstance(child, dict):
-                pending.append((child, child_path))
-
-    return nodes
-
-
-def _collect_anchors(
-    nodes: dict[int, tuple[dict, str]],
-) -> dict[str, tuple[Any, str]]:
-    anchors: dict[str, tuple[Any, str]] = {}
-    for schema, path in nodes.values():
-        anchor = schema.get("$anchor")
-        if not isinstance(anchor, str):
-            continue
-        if anchor in anchors:
-            raise _schema_error(f"duplicate local $anchor {anchor!r}")
-        anchors[anchor] = (schema, path)
-    return anchors
-
-
-def _find_non_consuming_cycle(
-    edges: dict[int, set[int]],
-    paths: dict[int, str],
-) -> list[str] | None:
-    state: dict[int, int] = {}
-
-    for start in edges:
-        if state.get(start, 0) != 0:
-            continue
-
-        state[start] = 1
-        active_nodes = [start]
-        active_indexes = {start: 0}
-        stack = [(start, iter(edges.get(start, ())))]
-
-        while stack:
-            node, neighbors = stack[-1]
-            try:
-                neighbor = next(neighbors)
-            except StopIteration:
-                state[node] = 2
-                active_indexes.pop(node)
-                active_nodes.pop()
-                stack.pop()
-                continue
-
-            neighbor_state = state.get(neighbor, 0)
-            if neighbor_state == 0:
-                state[neighbor] = 1
-                active_indexes[neighbor] = len(active_nodes)
-                active_nodes.append(neighbor)
-                stack.append((neighbor, iter(edges.get(neighbor, ()))))
-            elif neighbor_state == 1:
-                cycle_start = active_indexes[neighbor]
-                cycle = active_nodes[cycle_start:] + [neighbor]
-                return [paths[node_id] for node_id in cycle]
-
-    return None
-
-
-def validate_guided_json_schema(schema: Any) -> None:
-    """Reject local-reference cycles that make no structural progress.
-
-    Recursive object properties and array items are productive because they
-    descend into a child JSON value. Direct references and same-instance schema
-    combinators do not consume input, so a cycle containing only those edges can
-    put a constrained-decoding backend into an invalid state.
+    This intentionally does not interpret JSON Schema applicators. Productive
+    recursion and schemas outside this narrow failure mode remain backend-owned.
     """
     if isinstance(schema, str):
         try:
             schema = json.loads(schema)
         except json.JSONDecodeError:
-            # Preserve the backend's existing malformed-JSON error behavior.
             return
 
     if not isinstance(schema, dict):
         return
 
-    nodes = _discover_schema_nodes(schema)
-    anchors = _collect_anchors(nodes)
-    edges: dict[int, set[int]] = {node_id: set() for node_id in nodes}
-    paths = {node_id: path for node_id, (_, path) in nodes.items()}
-    pending = deque(nodes)
-    processed: set[int] = set()
+    resource = schema
+    node = schema
+    seen: set[int] = set()
 
-    while pending:
-        node_id = pending.popleft()
-        if node_id in processed:
-            continue
-        processed.add(node_id)
-        node, path = nodes[node_id]
+    while True:
+        node_id = id(node)
+        if node_id in seen:
+            raise _schema_error("circular local $ref chain detected")
+        seen.add(node_id)
 
-        for child, child_path, non_consuming in _schema_children(node, path):
-            if not isinstance(child, dict):
-                continue
-            child_id = id(child)
-            if child_id not in nodes:
-                nodes[child_id] = (child, child_path)
-                paths[child_id] = child_path
-                edges[child_id] = set()
-                pending.append(child_id)
-            if non_consuming:
-                edges[node_id].add(child_id)
-
-        if "$ref" not in node:
-            continue
-        ref = node["$ref"]
-        if not isinstance(ref, str):
-            raise _schema_error(f"$ref at {path} must be a string")
-        resolved = _resolve_local_ref(schema, ref, anchors)
+        ref = node.get("$ref")
+        if not isinstance(ref, str) or not ref.startswith("#"):
+            return
+        resolved = _resolve_local_pointer(resource, ref)
         if resolved is None:
-            continue
-        target, target_path = resolved
-        if not _is_schema(target):
-            raise _schema_error(f"local $ref {ref!r} does not target a schema")
-        if not isinstance(target, dict):
-            continue
+            return
 
-        target_id = id(target)
-        if target_id not in nodes:
-            nodes[target_id] = (target, target_path)
-            paths[target_id] = target_path
-            edges[target_id] = set()
-            pending.append(target_id)
-        edges[node_id].add(target_id)
-
-    cycle = _find_non_consuming_cycle(edges, paths)
-    if cycle is not None:
-        raise _schema_error(
-            "unproductive circular $ref detected: " + " -> ".join(cycle)
-        )
+        node, resource = resolved

--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -1,0 +1,289 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validation for JSON schemas passed to constrained-decoding backends."""
+
+import json
+from collections import deque
+from typing import Any, Iterator
+from urllib.parse import unquote
+
+from dynamo.llm import HttpError
+
+_NON_CONSUMING_ARRAY_KEYWORDS = ("allOf", "anyOf", "oneOf")
+_NON_CONSUMING_SINGLE_KEYWORDS = ("not", "if", "then", "else")
+_CONSUMING_ARRAY_KEYWORDS = ("prefixItems",)
+_CONSUMING_SINGLE_KEYWORDS = (
+    "additionalItems",
+    "additionalProperties",
+    "contains",
+    "contentSchema",
+    "items",
+    "propertyNames",
+    "unevaluatedItems",
+    "unevaluatedProperties",
+)
+_SCHEMA_MAP_KEYWORDS = (
+    "$defs",
+    "definitions",
+    "dependentSchemas",
+    "dependencies",
+    "patternProperties",
+    "properties",
+)
+_NON_CONSUMING_MAP_KEYWORDS = frozenset(("dependentSchemas", "dependencies"))
+
+
+def _schema_error(message: str) -> HttpError:
+    return HttpError(400, f"Invalid guided_json schema: {message}")
+
+
+def _is_schema(value: Any) -> bool:
+    return isinstance(value, (dict, bool))
+
+
+def _escape_pointer_token(token: str) -> str:
+    return token.replace("~", "~0").replace("/", "~1")
+
+
+def _decode_pointer_token(token: str, ref: str) -> str:
+    decoded = []
+    index = 0
+    while index < len(token):
+        char = token[index]
+        if char != "~":
+            decoded.append(char)
+            index += 1
+            continue
+        if index + 1 >= len(token) or token[index + 1] not in ("0", "1"):
+            raise _schema_error(f"invalid JSON pointer escape in $ref {ref!r}")
+        decoded.append("~" if token[index + 1] == "0" else "/")
+        index += 2
+    return "".join(decoded)
+
+
+def _resolve_local_ref(
+    root: Any,
+    ref: str,
+    anchors: dict[str, tuple[Any, str]],
+) -> tuple[Any, str] | None:
+    if not ref.startswith("#"):
+        # Preserve the backend's existing handling for external references.
+        return None
+
+    fragment = unquote(ref[1:])
+    if not fragment:
+        return root, "#"
+    if not fragment.startswith("/"):
+        anchor = anchors.get(fragment)
+        if anchor is None:
+            # Leave unsupported local-anchor behavior to the grammar backend.
+            return None
+        return anchor
+
+    target = root
+    canonical_path = "#"
+    for encoded_token in fragment[1:].split("/"):
+        token = _decode_pointer_token(encoded_token, ref)
+        canonical_path += f"/{_escape_pointer_token(token)}"
+        if isinstance(target, dict):
+            if token not in target:
+                raise _schema_error(f"unresolvable local $ref {ref!r}")
+            target = target[token]
+        elif isinstance(target, list):
+            if not token.isdecimal():
+                raise _schema_error(f"unresolvable local $ref {ref!r}")
+            item_index = int(token)
+            if item_index >= len(target):
+                raise _schema_error(f"unresolvable local $ref {ref!r}")
+            target = target[item_index]
+        else:
+            raise _schema_error(f"unresolvable local $ref {ref!r}")
+
+    return target, canonical_path
+
+
+def _schema_children(
+    schema: dict[str, Any],
+    path: str,
+) -> Iterator[tuple[Any, str, bool]]:
+    for keyword in _NON_CONSUMING_ARRAY_KEYWORDS:
+        children = schema.get(keyword)
+        if isinstance(children, list):
+            for index, child in enumerate(children):
+                if _is_schema(child):
+                    yield child, f"{path}/{keyword}/{index}", True
+
+    for keyword in _NON_CONSUMING_SINGLE_KEYWORDS:
+        child = schema.get(keyword)
+        if _is_schema(child):
+            yield child, f"{path}/{keyword}", True
+
+    for keyword in _CONSUMING_ARRAY_KEYWORDS:
+        children = schema.get(keyword)
+        if isinstance(children, list):
+            for index, child in enumerate(children):
+                if _is_schema(child):
+                    yield child, f"{path}/{keyword}/{index}", False
+
+    for keyword in _CONSUMING_SINGLE_KEYWORDS:
+        child = schema.get(keyword)
+        if isinstance(child, list):
+            for index, item in enumerate(child):
+                if _is_schema(item):
+                    yield item, f"{path}/{keyword}/{index}", False
+        elif _is_schema(child):
+            yield child, f"{path}/{keyword}", False
+
+    for keyword in _SCHEMA_MAP_KEYWORDS:
+        children = schema.get(keyword)
+        if not isinstance(children, dict):
+            continue
+        non_consuming = keyword in _NON_CONSUMING_MAP_KEYWORDS
+        for name, child in children.items():
+            if _is_schema(child):
+                escaped_name = _escape_pointer_token(str(name))
+                yield child, f"{path}/{keyword}/{escaped_name}", non_consuming
+
+
+def _discover_schema_nodes(root: dict[str, Any]) -> dict[int, tuple[dict, str]]:
+    nodes: dict[int, tuple[dict, str]] = {}
+    pending = deque([(root, "#")])
+
+    while pending:
+        value, path = pending.popleft()
+        if not isinstance(value, dict) or id(value) in nodes:
+            continue
+        nodes[id(value)] = (value, path)
+        for child, child_path, _ in _schema_children(value, path):
+            if isinstance(child, dict):
+                pending.append((child, child_path))
+
+    return nodes
+
+
+def _collect_anchors(
+    nodes: dict[int, tuple[dict, str]],
+) -> dict[str, tuple[Any, str]]:
+    anchors: dict[str, tuple[Any, str]] = {}
+    for schema, path in nodes.values():
+        anchor = schema.get("$anchor")
+        if not isinstance(anchor, str):
+            continue
+        if anchor in anchors:
+            raise _schema_error(f"duplicate local $anchor {anchor!r}")
+        anchors[anchor] = (schema, path)
+    return anchors
+
+
+def _find_non_consuming_cycle(
+    edges: dict[int, set[int]],
+    paths: dict[int, str],
+) -> list[str] | None:
+    state: dict[int, int] = {}
+
+    for start in edges:
+        if state.get(start, 0) != 0:
+            continue
+
+        state[start] = 1
+        active_nodes = [start]
+        active_indexes = {start: 0}
+        stack = [(start, iter(edges.get(start, ())))]
+
+        while stack:
+            node, neighbors = stack[-1]
+            try:
+                neighbor = next(neighbors)
+            except StopIteration:
+                state[node] = 2
+                active_indexes.pop(node)
+                active_nodes.pop()
+                stack.pop()
+                continue
+
+            neighbor_state = state.get(neighbor, 0)
+            if neighbor_state == 0:
+                state[neighbor] = 1
+                active_indexes[neighbor] = len(active_nodes)
+                active_nodes.append(neighbor)
+                stack.append((neighbor, iter(edges.get(neighbor, ()))))
+            elif neighbor_state == 1:
+                cycle_start = active_indexes[neighbor]
+                cycle = active_nodes[cycle_start:] + [neighbor]
+                return [paths[node_id] for node_id in cycle]
+
+    return None
+
+
+def validate_guided_json_schema(schema: Any) -> None:
+    """Reject local-reference cycles that make no structural progress.
+
+    Recursive object properties and array items are productive because they
+    descend into a child JSON value. Direct references and same-instance schema
+    combinators do not consume input, so a cycle containing only those edges can
+    put a constrained-decoding backend into an invalid state.
+    """
+    if isinstance(schema, str):
+        try:
+            schema = json.loads(schema)
+        except json.JSONDecodeError:
+            # Preserve the backend's existing malformed-JSON error behavior.
+            return
+
+    if not isinstance(schema, dict):
+        return
+
+    nodes = _discover_schema_nodes(schema)
+    anchors = _collect_anchors(nodes)
+    edges: dict[int, set[int]] = {node_id: set() for node_id in nodes}
+    paths = {node_id: path for node_id, (_, path) in nodes.items()}
+    pending = deque(nodes)
+    processed: set[int] = set()
+
+    while pending:
+        node_id = pending.popleft()
+        if node_id in processed:
+            continue
+        processed.add(node_id)
+        node, path = nodes[node_id]
+
+        for child, child_path, non_consuming in _schema_children(node, path):
+            if not isinstance(child, dict):
+                continue
+            child_id = id(child)
+            if child_id not in nodes:
+                nodes[child_id] = (child, child_path)
+                paths[child_id] = child_path
+                edges[child_id] = set()
+                pending.append(child_id)
+            if non_consuming:
+                edges[node_id].add(child_id)
+
+        if "$ref" not in node:
+            continue
+        ref = node["$ref"]
+        if not isinstance(ref, str):
+            raise _schema_error(f"$ref at {path} must be a string")
+        resolved = _resolve_local_ref(schema, ref, anchors)
+        if resolved is None:
+            continue
+        target, target_path = resolved
+        if not _is_schema(target):
+            raise _schema_error(f"local $ref {ref!r} does not target a schema")
+        if not isinstance(target, dict):
+            continue
+
+        target_id = id(target)
+        if target_id not in nodes:
+            nodes[target_id] = (target, target_path)
+            paths[target_id] = target_path
+            edges[target_id] = set()
+            pending.append(target_id)
+        edges[node_id].add(target_id)
+
+    cycle = _find_non_consuming_cycle(edges, paths)
+    if cycle is not None:
+        raise _schema_error(
+            "unproductive circular $ref detected: " + " -> ".join(cycle)
+        )

--- a/components/src/dynamo/common/utils/guided_json.py
+++ b/components/src/dynamo/common/utils/guided_json.py
@@ -4,6 +4,8 @@
 """Targeted checks for JSON schemas passed to constrained-decoding backends."""
 
 import json
+from collections import deque
+from collections.abc import Iterator
 from typing import Any
 from urllib.parse import unquote
 
@@ -65,11 +67,71 @@ def _resolve_local_pointer(
     return target, target_resource
 
 
-def reject_cyclic_guided_json_ref_chain(schema: Any) -> None:
-    """Reject root-reachable cycles made only of local ``$ref`` hops.
+def _child_resource(child: dict[str, Any], resource: dict[str, Any]) -> dict[str, Any]:
+    return child if isinstance(child.get("$id"), str) else resource
 
-    This intentionally does not interpret JSON Schema applicators. Productive
-    recursion and schemas outside this narrow failure mode remain backend-owned.
+
+def _iter_progressing_children(node: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for keyword in (
+        "properties",
+        "patternProperties",
+        "dependentSchemas",
+        "dependencies",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            for child in children.values():
+                if isinstance(child, dict):
+                    yield child
+
+    for keyword in (
+        "additionalProperties",
+        "unevaluatedProperties",
+        "propertyNames",
+        "items",
+        "additionalItems",
+        "prefixItems",
+        "contains",
+        "unevaluatedItems",
+        "contentSchema",
+    ):
+        children = node.get(keyword)
+        if isinstance(children, dict):
+            yield children
+        elif isinstance(children, list):
+            for child in children:
+                if isinstance(child, dict):
+                    yield child
+
+
+def _has_cycle(
+    edges: dict[tuple[int, int], set[tuple[int, int]]],
+) -> bool:
+    in_degree = {node: 0 for node in edges}
+    for targets in edges.values():
+        for target in targets:
+            in_degree.setdefault(target, 0)
+            in_degree[target] += 1
+
+    ready = deque(node for node, degree in in_degree.items() if degree == 0)
+    visited = 0
+    while ready:
+        node = ready.popleft()
+        visited += 1
+        for target in edges.get(node, ()):
+            in_degree[target] -= 1
+            if in_degree[target] == 0:
+                ready.append(target)
+
+    return visited != len(in_degree)
+
+
+def reject_nonprogressing_guided_json_ref_cycles(schema: Any) -> None:
+    """Reject reachable local ``$ref`` cycles that cannot consume JSON.
+
+    ``allOf`` preserves the current JSON instance, while object properties and
+    array items cross a progress boundary. Choice applicators and schemas outside
+    this narrow failure mode remain backend-owned.
     """
     if isinstance(schema, str):
         try:
@@ -80,21 +142,40 @@ def reject_cyclic_guided_json_ref_chain(schema: Any) -> None:
     if not isinstance(schema, dict):
         return
 
-    resource = schema
-    node = schema
-    seen: set[int] = set()
+    pending = [(schema, schema)]
+    processed: set[tuple[int, int]] = set()
+    edges: dict[tuple[int, int], set[tuple[int, int]]] = {}
 
-    while True:
-        node_id = id(node)
-        if node_id in seen:
-            raise _schema_error("circular local $ref chain detected")
-        seen.add(node_id)
+    while pending:
+        node, resource = pending.pop()
+        node_key = (id(node), id(resource))
+        if node_key in processed:
+            continue
+        processed.add(node_key)
+        targets: set[tuple[int, int]] | None = None
 
         ref = node.get("$ref")
-        if not isinstance(ref, str) or not ref.startswith("#"):
-            return
-        resolved = _resolve_local_pointer(resource, ref)
-        if resolved is None:
-            return
+        if isinstance(ref, str) and ref.startswith("#"):
+            resolved = _resolve_local_pointer(resource, ref)
+            if resolved is not None:
+                target, target_resource = resolved
+                targets = edges.setdefault(node_key, set())
+                targets.add((id(target), id(target_resource)))
+                pending.append((target, target_resource))
 
-        node, resource = resolved
+        all_of = node.get("allOf")
+        if isinstance(all_of, list):
+            for child in all_of:
+                if not isinstance(child, dict):
+                    continue
+                child_resource = _child_resource(child, resource)
+                if targets is None:
+                    targets = edges.setdefault(node_key, set())
+                targets.add((id(child), id(child_resource)))
+                pending.append((child, child_resource))
+
+        for child in _iter_progressing_children(node):
+            pending.append((child, _child_resource(child, resource)))
+
+    if _has_cycle(edges):
+        raise _schema_error("non-progressing local $ref cycle detected")

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -28,6 +28,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
+from dynamo.common.utils.guided_json import validate_guided_json_schema
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
@@ -923,6 +924,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
+                validate_guided_json_schema(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -28,7 +28,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
@@ -924,7 +924,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
-                reject_cyclic_guided_json_ref_chain(json_schema)
+                reject_nonprogressing_guided_json_ref_cycles(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -28,7 +28,7 @@ from dynamo._core import Context
 from dynamo.common.constants import DisaggregationMode
 from dynamo.common.lora.manager import get_lora_manager
 from dynamo.common.utils.endpoint_types import parse_endpoint_types
-from dynamo.common.utils.guided_json import validate_guided_json_schema
+from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
@@ -924,7 +924,7 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
-                validate_guided_json_schema(json_schema)
+                reject_cyclic_guided_json_ref_chain(json_schema)
                 return {"json_schema": json.dumps(json_schema)}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from dynamo.common.metadata_upload import MetadataUploader
+from dynamo.llm import HttpError
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_sglang_stop_reason,
@@ -295,6 +296,33 @@ def test_build_sampling_params_maps_guided_decoding_to_json_schema():
     assert sampling_params["json_schema"] == (
         '{"type": "object", "properties": {"city": {"type": "string"}}}'
     )
+
+
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+    ],
+)
+def test_build_sampling_params_rejects_guided_json_reference_cycles(schema):
+    handler = _new_decode_handler(use_sglang_tokenizer=False)
+
+    with pytest.raises(HttpError) as error:
+        handler._build_sampling_params(
+            {
+                "sampling_options": {"guided_decoding": {"json": schema}},
+                "stop_conditions": {"max_tokens": 8},
+            }
+        )
+
+    assert error.value.code == 400
 
 
 def test_build_sampling_params_passes_n_for_sglang_tokenizer_requests():

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -64,6 +64,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
+from dynamo.common.utils.guided_json import validate_guided_json_schema
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
@@ -717,8 +718,11 @@ def build_sampling_params(
             sampling_options.update(passthrough_sampling_options)
     guided_decoding = sampling_options.get("guided_decoding")
     if guided_decoding is not None and isinstance(guided_decoding, dict):
+        json_schema = guided_decoding.get("json")
+        if json_schema is not None:
+            validate_guided_json_schema(json_schema)
         sampling_params.structured_outputs = StructuredOutputsParams(
-            json=guided_decoding.get("json"),
+            json=json_schema,
             regex=guided_decoding.get("regex"),
             choice=guided_decoding.get("choice"),
             grammar=guided_decoding.get("grammar"),
@@ -3362,14 +3366,15 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # the per-request deferred guard so engine_client.abort() never fires in
         # the unsafe pre-first-token window, and the admin abort_request route can
         # reach this request via self._deferred_aborts.
-        async with _deferred_abort_guard(
-            self.engine_client,
-            request_id,
-            is_decode_only,
-            self._deferred_aborts,
-            self._shutdown_on_engine_dead,
-        ) as abort_guard, self._abort_monitor(
-            context, request_id, abort_guard=abort_guard
+        async with (
+            _deferred_abort_guard(
+                self.engine_client,
+                request_id,
+                is_decode_only,
+                self._deferred_aborts,
+                self._shutdown_on_engine_dead,
+            ) as abort_guard,
+            self._abort_monitor(context, request_id, abort_guard=abort_guard),
         ):
             try:
                 gen = self.engine_client.generate(

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -64,7 +64,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
-from dynamo.common.utils.guided_json import validate_guided_json_schema
+from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
@@ -720,7 +720,7 @@ def build_sampling_params(
     if guided_decoding is not None and isinstance(guided_decoding, dict):
         json_schema = guided_decoding.get("json")
         if json_schema is not None:
-            validate_guided_json_schema(json_schema)
+            reject_cyclic_guided_json_ref_chain(json_schema)
         sampling_params.structured_outputs = StructuredOutputsParams(
             json=json_schema,
             regex=guided_decoding.get("regex"),

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -64,7 +64,7 @@ from dynamo.common.rl import (
 )
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.common.utils.engine_response import normalize_finish_reason
-from dynamo.common.utils.guided_json import reject_cyclic_guided_json_ref_chain
+from dynamo.common.utils.guided_json import reject_nonprogressing_guided_json_ref_cycles
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.common.utils.time_section import time_and_log_code_section
@@ -720,7 +720,7 @@ def build_sampling_params(
     if guided_decoding is not None and isinstance(guided_decoding, dict):
         json_schema = guided_decoding.get("json")
         if json_schema is not None:
-            reject_cyclic_guided_json_ref_chain(json_schema)
+            reject_nonprogressing_guided_json_ref_cycles(json_schema)
         sampling_params.structured_outputs = StructuredOutputsParams(
             json=json_schema,
             regex=guided_decoding.get("regex"),

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1204,6 +1204,66 @@ def test_build_sampling_params_maps_guided_decoding(constraint_name, constraint_
         assert getattr(sp.structured_outputs, field) == expected
 
 
+@pytest.mark.parametrize(
+    "schema",
+    [
+        {"$ref": "#"},
+        json.dumps({"$ref": "#"}),
+        {
+            "$defs": {
+                "A": {"$ref": "#/$defs/B"},
+                "B": {"$ref": "#/$defs/A"},
+            },
+            "$ref": "#/$defs/A",
+        },
+    ],
+)
+def test_build_sampling_params_rejects_guided_json_reference_cycles(schema):
+    from dynamo.llm import HttpError
+    from dynamo.vllm.handlers import build_sampling_params
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"guided_decoding": {"json": schema}},
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    with pytest.raises(HttpError) as error:
+        build_sampling_params(request, default_sampling_params={})
+
+    assert error.value.code == 400
+
+
+def test_build_sampling_params_accepts_productive_recursive_guided_json():
+    from dynamo.vllm.handlers import build_sampling_params
+
+    schema = {
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "children": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/Node"},
+                    }
+                },
+            }
+        },
+        "$ref": "#/$defs/Node",
+    }
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {"guided_decoding": {"json": schema}},
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    sampling_params = build_sampling_params(request, default_sampling_params={})
+
+    assert sampling_params.structured_outputs.json == schema
+
+
 def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     from dynamo.vllm.handlers import build_sampling_params
 


### PR DESCRIPTION
## Overview:

Adds shared guided JSON schema validation for SGLang and vLLM. Schemas containing
unsupported local reference cycles now return a clear client error before backend
grammar processing, while productive recursive schemas remain supported.

Fixes DYN-3784
Fixes DYN-3786

## Details:

- Introduces a backend-neutral guided JSON validator under `dynamo.common.utils`.
- Accepts schemas supplied as Python objects or JSON strings.
- Resolves local JSON Pointer references and anchors without recursive traversal.
- Distinguishes same-instance schema application from child-instance traversal so
  recursive object and array definitions continue to work.
- Applies the validation consistently in the SGLang and vLLM request handlers.
- Adds unit coverage for direct references, multi-definition cycles, nested schema
  keywords, escaped JSON Pointer segments, anchors, valid recursive schemas, and
  backend request handling.

Validation performed:

- Focused common and SGLang tests: 29 passed.
- Focused vLLM tests: 9 passed.
- Pre-commit checks passed for the changed files.
- Live backend checks confirmed consistent client errors for unsupported schemas and
  successful follow-up requests.

## Where should the reviewer start?

Start with `components/src/dynamo/common/utils/guided_json.py`, which contains the
reference graph construction and cycle classification. Then review the SGLang and
vLLM call sites in `request_handlers/handler_base.py` and `handlers.py`, followed by
`components/src/dynamo/common/tests/test_guided_json.py` for the expected compatibility
boundary.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12795" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for guided JSON schemas, including local references, anchors, malformed references, and non-productive cycles.
  * Valid schemas with productive recursion or external references continue to be supported.
  * Invalid schemas are rejected with an HTTP 400 error before request processing.

* **Tests**
  * Added coverage across SGLang and vLLM integrations for valid and invalid guided JSON schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->