### PR TITLE
perf(mocker): avoid per-token replay request lookups

### DIFF
--- a/lib/mocker/src/replay/collector.rs
+++ b/lib/mocker/src/replay/collector.rs
@@ -1163,7 +1163,7 @@ impl TraceCollector {
         }
         if let Some(token_completion_ms) = token_completion_ms {
             self.on_output_signals(
-                &pass.output_signals,
+                pass.output_signals.as_slice(),
                 token_completion_ms,
                 pass.accept_length_output_tokens > pass.accept_length_decode_forwards,
             );
@@ -1598,6 +1598,7 @@ fn std_dev(values: &[f64]) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::scheduler::EngineOutputs;
 
     fn build_distribution_stats_sorted(values: &[f64]) -> TraceDistributionStats {
         if values.is_empty() {
@@ -1760,7 +1761,7 @@ mod tests {
                     reused_input_tokens: 1,
                 },
             ],
-            output_signals: vec![
+            output_signals: EngineOutputs::untracked(vec![
                 OutputSignal {
                     uuid: first,
                     token_id: Some(10),
@@ -1789,7 +1790,7 @@ mod tests {
                     rejected: false,
                     handoff_delay_ms: None,
                 },
-            ],
+            ]),
             lifecycle_events: Vec::new(),
             mocker_metrics: crate::scheduler::vllm::MockerMetrics::default(),
             router_event_visibility: crate::scheduler::RouterEventVisibility::PassEnd,

--- a/lib/mocker/src/replay/offline/README.md
+++ b/lib/mocker/src/replay/offline/README.md
@@ -150,17 +150,20 @@ pub(in crate::replay::offline) struct SimulationEvent {
 }
 
 pub(in crate::replay::offline) enum SimulationEventKind {
-    WorkerCompletion { stage, worker_idx, completed_requests, output_signals, kv_events },
+    WorkerCompletion { /* private completion payload */ },
     WorkerCompletionBatch { payloads },
-    DecodeHandoff { uuid },
+    TransferComplete { handoff_id },
     WorkerReady { stage, worker_id },
+    // Non-exhaustive: other internal event variants are omitted.
 }
 ```
 
-- `WorkerCompletion` is emitted after a worker pass is executed and applied when the harness clock reaches `pass.end_ms`. It carries the `stage` (`Aggregated`, `Prefill`, or `Decode`), `worker_idx`, `completed_requests`, `output_signals`, and router-visible `kv_events`.
+- `WorkerCompletion` is emitted after a worker pass is executed and applied when the harness clock reaches `pass.end_ms`. Its private payload carries the stage, worker identity, completed-request count, tracked scheduler outputs, lifecycle events, router-visible KV events, progress flags, optional FPM snapshot, and accept-length counters.
 - `WorkerCompletionBatch` stores the ordered rank payloads for one positive-duration attention-DP epoch in a single heap event. Each payload is still applied independently in rank order.
-- `DecodeHandoff` is used by the disaggregated harness to move a request from prefill to decode at the same logical timestamp (see below).
-- `WorkerReady` marks the point at which a worker returns to the admission pool after a pass completes.
+- `TransferComplete` marks the modeled end of a disaggregated KV transfer.
+- `WorkerReady` marks completion of configured worker startup delay. Pass completion itself is represented by `WorkerCompletion` or `WorkerCompletionBatch`.
+
+Inside the scheduler/runtime boundary, `EngineOutputs` keeps public `OutputSignal` values in their original vector and stores aggregate replay's generational request keys in a private sidecar. Aggregate replay uses those keys for release-build request-ID validation and direct lifecycle-state access without hashing the UUID for every token. Disaggregated replay and ordinary live batches have no sidecar, so their original `Vec<OutputSignal>` moves unchanged into the existing processing or publication path.
 
 ## Router Integration
 

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -39,17 +39,102 @@ use super::{
     },
     state::AggRequestState,
 };
-use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs, OutputSignal};
+use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
 use crate::loadgen::{ReplayRequestPayload, WorkloadDriver};
 #[cfg(test)]
 use crate::replay::ReplayRouterMode;
 use crate::replay::{ReplayRequestPool, ReplayTerminalStatus, TraceCollector};
-use anyhow::bail;
+use anyhow::{anyhow, bail, ensure};
 use rustc_hash::FxHashMap;
+use slotmap::SlotMap;
 #[cfg(test)]
 use std::collections::HashMap;
 use std::collections::{BinaryHeap, VecDeque};
 use uuid::Uuid;
+
+use crate::scheduler::{EngineOutputs, EngineRequest, ReplayRequestKey};
+
+#[derive(Default)]
+struct AggRequests {
+    by_uuid: FxHashMap<Uuid, ReplayRequestKey>,
+    states: SlotMap<ReplayRequestKey, (Uuid, AggRequestState)>,
+}
+
+impl AggRequests {
+    fn contains_uuid(&self, uuid: Uuid) -> bool {
+        self.by_uuid.contains_key(&uuid)
+    }
+
+    fn insert(&mut self, uuid: Uuid, state: AggRequestState) -> ReplayRequestKey {
+        debug_assert!(!self.contains_uuid(uuid));
+        let key = self.states.insert((uuid, state));
+        self.by_uuid.insert(uuid, key);
+        key
+    }
+
+    fn get_mut_by_uuid(
+        &mut self,
+        uuid: Uuid,
+    ) -> anyhow::Result<(ReplayRequestKey, &mut AggRequestState)> {
+        let key =
+            self.by_uuid.get(&uuid).copied().ok_or_else(|| {
+                anyhow!("offline aggregate replay missing request state for {uuid}")
+            })?;
+        Ok((key, self.get_mut_by_key(key, uuid)?))
+    }
+
+    fn get_mut_by_key(
+        &mut self,
+        key: ReplayRequestKey,
+        uuid: Uuid,
+    ) -> anyhow::Result<&mut AggRequestState> {
+        let (stored_uuid, state) = self
+            .states
+            .get_mut(key)
+            .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
+        ensure!(
+            *stored_uuid == uuid,
+            "offline aggregate replay request state key does not match {uuid}"
+        );
+        Ok(state)
+    }
+
+    fn validate_key(&self, key: ReplayRequestKey, uuid: Uuid) -> anyhow::Result<()> {
+        self.get_by_key(key, uuid)?;
+        ensure!(
+            self.by_uuid.get(&uuid).copied() == Some(key),
+            "offline aggregate replay request state indexes disagree for {uuid}"
+        );
+        Ok(())
+    }
+
+    fn remove_validated(&mut self, key: ReplayRequestKey, uuid: Uuid) -> AggRequestState {
+        self.by_uuid
+            .remove(&uuid)
+            .expect("validated replay UUID must remain present");
+        self.states
+            .remove(key)
+            .expect("validated replay key must remain present")
+            .1
+    }
+
+    fn get_by_key(&self, key: ReplayRequestKey, uuid: Uuid) -> anyhow::Result<&AggRequestState> {
+        let (stored_uuid, state) = self
+            .states
+            .get(key)
+            .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
+        ensure!(
+            *stored_uuid == uuid,
+            "offline aggregate replay request state key does not match {uuid}"
+        );
+        Ok(state)
+    }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = (Uuid, &AggRequestState)> {
+        self.states.values().map(|(uuid, state)| (*uuid, state))
+    }
+}
 
 fn common_origin(mut origins: impl Iterator<Item = u64>) -> Option<u64> {
     let first = origins.next()?;
@@ -126,7 +211,7 @@ where
     next_event_seq: u64,
     next_scaling_tick_ordinal: u64,
     admission: AdmissionQueue<Metadata>,
-    requests: FxHashMap<Uuid, AggRequestState>,
+    requests: AggRequests,
     engine: EngineComponent<Observation>,
     collector: TraceCollector,
     events: BinaryHeap<SimulationEvent<Observation::Batch>>,
@@ -223,7 +308,7 @@ where
             next_event_seq: 0,
             next_scaling_tick_ordinal: 0,
             admission,
-            requests: FxHashMap::default(),
+            requests: AggRequests::default(),
             engine,
             collector,
             events: BinaryHeap::new(),
@@ -355,8 +440,12 @@ where
         request: DirectRequest,
         uuid: Uuid,
         worker_idx: usize,
+        replay_request_key: ReplayRequestKey,
     ) -> anyhow::Result<()> {
-        self.engine.dispatch(worker_idx, request)?;
+        self.engine.dispatch_engine(
+            worker_idx,
+            EngineRequest::for_replay(request, replay_request_key),
+        )?;
         self.record_dispatch(uuid, worker_idx);
         // Aggregated replay uses a single pool. Treat the assignment as the
         // decode_worker_idx so per-request records consistently carry the
@@ -400,14 +489,9 @@ where
                 dp_rank,
                 placement.reported_overlap_tokens,
             );
-            let request = self
-                .requests
-                .get_mut(&uuid)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("offline replay missing queued request state for {uuid}")
-                })?
-                .take_queued_request(uuid)?;
-            self.dispatch_to_worker(request, uuid, placement.scheduler_id)?;
+            let (replay_request_key, request) = self.requests.get_mut_by_uuid(uuid)?;
+            let request = request.take_queued_request(uuid)?;
+            self.dispatch_to_worker(request, uuid, placement.scheduler_id, replay_request_key)?;
         }
         Ok(())
     }
@@ -421,6 +505,9 @@ where
         session_id: Option<String>,
     ) -> anyhow::Result<Uuid> {
         let uuid = request.metadata().uuid.unwrap_or_else(Uuid::new_v4);
+        if self.requests.contains_uuid(uuid) {
+            bail!("offline replay request {uuid} is already active");
+        }
         let input_length = request.input_length();
         let output_length = request.metadata().max_output_tokens;
         request.metadata_mut().uuid = Some(uuid);
@@ -461,7 +548,7 @@ where
                     dp_rank,
                     placement.reported_overlap_tokens,
                 );
-                self.requests.insert(
+                let replay_request_key = self.requests.insert(
                     uuid,
                     AggRequestState::new_running(input_length, output_length),
                 );
@@ -469,6 +556,7 @@ where
                     request.into_direct_request(),
                     uuid,
                     placement.scheduler_id,
+                    replay_request_key,
                 )?;
             }
             PlacementDecision::Queued => {
@@ -563,11 +651,20 @@ where
     }
 
     /// Consume one output signal, updating router state, collector state, and completion counts.
-    fn process_output_signal(&mut self, signal: OutputSignal) -> anyhow::Result<()> {
-        if let Some(token_id) = signal.token_id {
-            CoreAdmissionSource::on_output_token(&mut self.admission, signal.uuid, token_id)?;
-        }
+    fn process_output_signal(
+        &mut self,
+        signal: crate::common::protocols::OutputSignal,
+        replay_request_key: ReplayRequestKey,
+    ) -> anyhow::Result<()> {
         if signal.completed {
+            // Validate the generational key before publishing any terminal
+            // side effects. Terminal signals are rare enough that the later
+            // removal can retain its own defensive validation.
+            self.requests
+                .validate_key(replay_request_key, signal.uuid)?;
+            if let Some(token_id) = signal.token_id {
+                CoreAdmissionSource::on_output_token(&mut self.admission, signal.uuid, token_id)?;
+            }
             let status = if signal.rejected {
                 ReplayTerminalStatus::Rejected
             } else {
@@ -582,9 +679,9 @@ where
                 self.stats.router_freed_count += 1;
             }
             self.record_router_pending();
-            let removed_state = self.requests.remove(&signal.uuid).ok_or_else(|| {
-                anyhow::anyhow!("offline replay missing request state for {}", signal.uuid)
-            })?;
+            let removed_state = self
+                .requests
+                .remove_validated(replay_request_key, signal.uuid);
             // Rejected requests never ran: keep them out of completed-request
             // shape and latency samples. Their offered demand was already
             // recorded at arrival, matching requests_started_total.
@@ -617,23 +714,24 @@ where
             return Ok(());
         }
 
-        let already_marked = self
-            .requests
-            .get(&signal.uuid)
-            .ok_or_else(|| {
-                anyhow::anyhow!("offline replay missing request state for {}", signal.uuid)
-            })?
-            .prefill_completed;
-        if already_marked {
+        let marks_prefill_completion = {
+            let state = self
+                .requests
+                .get_mut_by_key(replay_request_key, signal.uuid)?;
+            if state.prefill_completed {
+                false
+            } else {
+                state.prefill_completed = true;
+                true
+            }
+        };
+        if let Some(token_id) = signal.token_id {
+            CoreAdmissionSource::on_output_token(&mut self.admission, signal.uuid, token_id)?;
+        }
+        if !marks_prefill_completion {
             return Ok(());
         }
 
-        self.requests
-            .get_mut(&signal.uuid)
-            .ok_or_else(|| {
-                anyhow::anyhow!("offline replay missing request state for {}", signal.uuid)
-            })?
-            .prefill_completed = true;
         let placements = self.placement.prefill_completed(signal.uuid, self.now_ms)?;
         #[cfg(test)]
         if self.placement.is_router() {
@@ -663,9 +761,7 @@ where
     /// Apply one completed pass: free request slots, publish KV events, and handle outputs.
     fn process_completed_pass(
         &mut self,
-        _worker_idx: usize,
-        _completed_requests: usize,
-        output_signals: Vec<OutputSignal>,
+        output_signals: EngineOutputs,
         engine_events: Observation::Batch,
         accept_length_output_tokens: usize,
         accept_length_decode_forwards: usize,
@@ -673,8 +769,8 @@ where
         self.apply_engine_observations(engine_events, KvIngestBoundary::PassEnd)?;
         self.traffic
             .on_accept_length_sample(accept_length_output_tokens, accept_length_decode_forwards);
-        for signal in output_signals {
-            self.process_output_signal(signal)?;
+        for (signal, replay_request_key) in output_signals.into_tracked()? {
+            self.process_output_signal(signal, replay_request_key)?;
         }
         Ok(())
     }
@@ -715,8 +811,6 @@ where
             self.record_fpm(payload.worker_idx, fpm)?;
         }
         self.process_completed_pass(
-            payload.worker_idx,
-            payload.completed_requests,
             payload.output_signals,
             payload.engine_events,
             payload.accept_length_output_tokens,
@@ -1323,14 +1417,14 @@ where
             .requests
             .iter()
             .filter(|(_, state)| state.phase == AggRequestPhase::QueuedAtRouter)
-            .map(|(uuid, _)| *uuid)
+            .map(|(uuid, _)| uuid)
             .collect::<Vec<_>>();
         router_pending_request_ids.sort_unstable();
         let mut prefill_completed = self
             .requests
             .iter()
             .filter(|(_, state)| state.prefill_completed)
-            .map(|(uuid, _)| *uuid)
+            .map(|(uuid, _)| uuid)
             .collect::<Vec<_>>();
         prefill_completed.sort_unstable();
 
@@ -1355,13 +1449,103 @@ mod tests {
         run_trace_workload_multi_collect_with_stats, run_trace_workload_single_collect,
     };
     use super::*;
-    use crate::common::protocols::{EngineType, G1Backend, SglangArgs};
+    use crate::common::protocols::{EngineType, G1Backend, OutputSignal, SglangArgs};
     use crate::loadgen::{AgenticTrace, AgenticTurnTrace, SessionTrace, Trace, TurnTrace};
     use crate::replay::offline::extensions::kv_router::{ReplayKvRouterConfig, RouterQueuePolicy};
     use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
     use rstest::rstest;
     use std::cell::RefCell;
     use std::rc::Rc;
+
+    #[test]
+    fn aggregate_request_tracking_validates_keys_and_duplicates() {
+        let args = replay_args(false, false);
+        let mut runtime =
+            RoundRobinAggRuntime::new_round_robin(&args, VecDeque::new(), 1, ReplayMode::Trace)
+                .unwrap();
+        let stale_uuid = Uuid::from_u128(9);
+        let stale_key = runtime
+            .requests
+            .insert(stale_uuid, AggRequestState::new_running(4, 2));
+        runtime
+            .requests
+            .validate_key(stale_key, stale_uuid)
+            .unwrap();
+        runtime.requests.remove_validated(stale_key, stale_uuid);
+
+        let uuid = Uuid::from_u128(10);
+        let request = |tokens, max_output_tokens| DirectRequest {
+            tokens: vec![1; tokens],
+            max_output_tokens,
+            uuid: Some(uuid),
+            ..Default::default()
+        };
+        runtime
+            .assign_request(
+                ReplayRequestPayload::materialized(request(4, 2)),
+                0.0,
+                (),
+                None,
+            )
+            .unwrap();
+        let key = runtime.requests.by_uuid[&uuid];
+        assert_ne!(stale_key, key);
+
+        let collector_before = runtime.collector.snapshot(uuid).unwrap();
+        let in_flight_before = runtime.engine.in_flight();
+        assert!(
+            runtime
+                .assign_request(
+                    ReplayRequestPayload::materialized(request(9, 7)),
+                    10.0,
+                    (),
+                    None,
+                )
+                .is_err()
+        );
+        assert_eq!(runtime.collector.snapshot(uuid), Some(collector_before));
+        assert_eq!(runtime.engine.in_flight(), in_flight_before);
+
+        let signal = |uuid, token_id| OutputSignal {
+            uuid,
+            token_id,
+            completed: false,
+            rejected: false,
+            handoff_delay_ms: None,
+        };
+        assert!(
+            runtime
+                .process_output_signal(signal(uuid, Some(1)), stale_key)
+                .is_err()
+        );
+        assert!(
+            runtime
+                .process_output_signal(signal(Uuid::from_u128(11), Some(1)), key)
+                .is_err()
+        );
+
+        runtime
+            .process_output_signal(signal(uuid, None), key)
+            .unwrap();
+        assert!(
+            runtime
+                .requests
+                .get_by_key(key, uuid)
+                .unwrap()
+                .prefill_completed
+        );
+
+        runtime
+            .process_output_signal(signal(uuid, Some(1)), key)
+            .unwrap();
+        assert!(
+            runtime
+                .requests
+                .get_by_key(key, uuid)
+                .unwrap()
+                .prefill_completed
+        );
+    }
 
     struct CaptureOncePolicy {
         at_ms: f64,

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -39,7 +39,7 @@ use super::{
     },
     state::AggRequestState,
 };
-use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
+use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs, OutputSignal};
 use crate::loadgen::{ReplayRequestPayload, WorkloadDriver};
 #[cfg(test)]
 use crate::replay::ReplayRouterMode;
@@ -49,7 +49,7 @@ use rustc_hash::FxHashMap;
 use slotmap::SlotMap;
 #[cfg(test)]
 use std::collections::HashMap;
-use std::collections::{BinaryHeap, VecDeque};
+use std::collections::{BinaryHeap, VecDeque, hash_map::Entry};
 use uuid::Uuid;
 
 use crate::scheduler::{EngineOutputs, EngineRequest, ReplayRequestKey};
@@ -65,11 +65,17 @@ impl AggRequests {
         self.by_uuid.contains_key(&uuid)
     }
 
-    fn insert(&mut self, uuid: Uuid, state: AggRequestState) -> ReplayRequestKey {
-        debug_assert!(!self.contains_uuid(uuid));
-        let key = self.states.insert((uuid, state));
-        self.by_uuid.insert(uuid, key);
-        key
+    fn insert(&mut self, uuid: Uuid, state: AggRequestState) -> anyhow::Result<ReplayRequestKey> {
+        match self.by_uuid.entry(uuid) {
+            Entry::Occupied(_) => {
+                bail!("offline replay request {uuid} is already active")
+            }
+            Entry::Vacant(entry) => {
+                let key = self.states.insert((uuid, state));
+                entry.insert(key);
+                Ok(key)
+            }
+        }
     }
 
     fn get_mut_by_uuid(
@@ -92,42 +98,47 @@ impl AggRequests {
             .states
             .get_mut(key)
             .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
-        ensure!(
-            *stored_uuid == uuid,
-            "offline aggregate replay request state key does not match {uuid}"
-        );
+        Self::validate_stored_uuid(*stored_uuid, uuid)?;
         Ok(state)
     }
 
-    fn validate_key(&self, key: ReplayRequestKey, uuid: Uuid) -> anyhow::Result<()> {
-        self.get_by_key(key, uuid)?;
+    fn remove(&mut self, key: ReplayRequestKey, uuid: Uuid) -> anyhow::Result<AggRequestState> {
+        let Entry::Occupied(entry) = self.by_uuid.entry(uuid) else {
+            bail!("offline aggregate replay missing request state for {uuid}");
+        };
         ensure!(
-            self.by_uuid.get(&uuid).copied() == Some(key),
+            *entry.get() == key,
             "offline aggregate replay request state indexes disagree for {uuid}"
         );
-        Ok(())
-    }
-
-    fn remove_validated(&mut self, key: ReplayRequestKey, uuid: Uuid) -> AggRequestState {
-        self.by_uuid
-            .remove(&uuid)
-            .expect("validated replay UUID must remain present");
-        self.states
+        let (stored_uuid, _) = self
+            .states
+            .get(key)
+            .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
+        Self::validate_stored_uuid(*stored_uuid, uuid)?;
+        let (_, state) = self
+            .states
             .remove(key)
-            .expect("validated replay key must remain present")
-            .1
+            .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
+        entry.remove();
+        Ok(state)
     }
 
+    #[cfg(test)]
     fn get_by_key(&self, key: ReplayRequestKey, uuid: Uuid) -> anyhow::Result<&AggRequestState> {
         let (stored_uuid, state) = self
             .states
             .get(key)
             .ok_or_else(|| anyhow!("offline aggregate replay missing request state for {uuid}"))?;
+        Self::validate_stored_uuid(*stored_uuid, uuid)?;
+        Ok(state)
+    }
+
+    fn validate_stored_uuid(stored_uuid: Uuid, uuid: Uuid) -> anyhow::Result<()> {
         ensure!(
-            *stored_uuid == uuid,
+            stored_uuid == uuid,
             "offline aggregate replay request state key does not match {uuid}"
         );
-        Ok(state)
+        Ok(())
     }
 
     #[cfg(test)]
@@ -551,7 +562,7 @@ where
                 let replay_request_key = self.requests.insert(
                     uuid,
                     AggRequestState::new_running(input_length, output_length),
-                );
+                )?;
                 self.dispatch_to_worker(
                     request.into_direct_request(),
                     uuid,
@@ -563,7 +574,7 @@ where
                 self.collector
                     .on_route_queued(uuid, ReplayRequestPool::Agg, self.now_ms);
                 self.requests
-                    .insert(uuid, AggRequestState::new_queued(request));
+                    .insert(uuid, AggRequestState::new_queued(request))?;
             }
         }
         self.record_router_pending();
@@ -653,15 +664,11 @@ where
     /// Consume one output signal, updating router state, collector state, and completion counts.
     fn process_output_signal(
         &mut self,
-        signal: crate::common::protocols::OutputSignal,
+        signal: OutputSignal,
         replay_request_key: ReplayRequestKey,
     ) -> anyhow::Result<()> {
         if signal.completed {
-            // Validate the generational key before publishing any terminal
-            // side effects. Terminal signals are rare enough that the later
-            // removal can retain its own defensive validation.
-            self.requests
-                .validate_key(replay_request_key, signal.uuid)?;
+            let removed_state = self.requests.remove(replay_request_key, signal.uuid)?;
             if let Some(token_id) = signal.token_id {
                 CoreAdmissionSource::on_output_token(&mut self.admission, signal.uuid, token_id)?;
             }
@@ -679,9 +686,6 @@ where
                 self.stats.router_freed_count += 1;
             }
             self.record_router_pending();
-            let removed_state = self
-                .requests
-                .remove_validated(replay_request_key, signal.uuid);
             // Rejected requests never ran: keep them out of completed-request
             // shape and latency samples. Their offered demand was already
             // recorded at arrival, matching requests_started_total.
@@ -1449,7 +1453,7 @@ mod tests {
         run_trace_workload_multi_collect_with_stats, run_trace_workload_single_collect,
     };
     use super::*;
-    use crate::common::protocols::{EngineType, G1Backend, OutputSignal, SglangArgs};
+    use crate::common::protocols::{EngineType, G1Backend, SglangArgs};
     use crate::loadgen::{AgenticTrace, AgenticTurnTrace, SessionTrace, Trace, TurnTrace};
     use crate::replay::offline::extensions::kv_router::{ReplayKvRouterConfig, RouterQueuePolicy};
     use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
@@ -1466,12 +1470,9 @@ mod tests {
         let stale_uuid = Uuid::from_u128(9);
         let stale_key = runtime
             .requests
-            .insert(stale_uuid, AggRequestState::new_running(4, 2));
-        runtime
-            .requests
-            .validate_key(stale_key, stale_uuid)
+            .insert(stale_uuid, AggRequestState::new_running(4, 2))
             .unwrap();
-        runtime.requests.remove_validated(stale_key, stale_uuid);
+        runtime.requests.remove(stale_key, stale_uuid).unwrap();
 
         let uuid = Uuid::from_u128(10);
         let request = |tokens, max_output_tokens| DirectRequest {
@@ -1490,6 +1491,13 @@ mod tests {
             .unwrap();
         let key = runtime.requests.by_uuid[&uuid];
         assert_ne!(stale_key, key);
+        assert!(
+            runtime
+                .requests
+                .insert(uuid, AggRequestState::new_running(9, 7))
+                .is_err()
+        );
+        assert_eq!(runtime.requests.by_uuid[&uuid], key);
 
         let collector_before = runtime.collector.snapshot(uuid).unwrap();
         let in_flight_before = runtime.engine.in_flight();
@@ -1506,26 +1514,45 @@ mod tests {
         assert_eq!(runtime.collector.snapshot(uuid), Some(collector_before));
         assert_eq!(runtime.engine.in_flight(), in_flight_before);
 
-        let signal = |uuid, token_id| OutputSignal {
+        let signal = |uuid, token_id, completed| OutputSignal {
             uuid,
             token_id,
-            completed: false,
+            completed,
             rejected: false,
             handoff_delay_ms: None,
         };
+        let state_before = runtime.debug_snapshot();
+        let collector_before = runtime.collector.snapshot(uuid).unwrap();
         assert!(
             runtime
-                .process_output_signal(signal(uuid, Some(1)), stale_key)
+                .process_output_signal(signal(uuid, Some(1), true), stale_key)
+                .is_err()
+        );
+        assert_eq!(runtime.debug_snapshot(), state_before);
+        assert_eq!(
+            runtime.collector.snapshot(uuid),
+            Some(collector_before.clone())
+        );
+        assert!(
+            runtime
+                .process_output_signal(signal(Uuid::from_u128(11), Some(1), true), key,)
+                .is_err()
+        );
+        assert_eq!(runtime.debug_snapshot(), state_before);
+        assert_eq!(runtime.collector.snapshot(uuid), Some(collector_before));
+        assert!(
+            runtime
+                .process_output_signal(signal(uuid, Some(1), false), stale_key)
                 .is_err()
         );
         assert!(
             runtime
-                .process_output_signal(signal(Uuid::from_u128(11), Some(1)), key)
+                .process_output_signal(signal(Uuid::from_u128(11), Some(1), false), key)
                 .is_err()
         );
 
         runtime
-            .process_output_signal(signal(uuid, None), key)
+            .process_output_signal(signal(uuid, None, false), key)
             .unwrap();
         assert!(
             runtime
@@ -1536,7 +1563,7 @@ mod tests {
         );
 
         runtime
-            .process_output_signal(signal(uuid, Some(1)), key)
+            .process_output_signal(signal(uuid, Some(1), false), key)
             .unwrap();
         assert!(
             runtime

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -20,7 +20,9 @@ use super::{EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineO
 use crate::common::protocols::DirectRequest;
 use crate::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
-use crate::scheduler::{EnginePassResult, RouterEventVisibility, SchedulerCommand};
+use crate::scheduler::{
+    EngineOutputs, EnginePassResult, EngineRequest, RouterEventVisibility, SchedulerCommand,
+};
 
 fn fpm_has_scheduled_work(snapshot: &ForwardPassSnapshot) -> bool {
     snapshot.num_prefill_requests > 0 || snapshot.num_decode_requests > 0
@@ -561,7 +563,7 @@ where
     pub(in crate::replay::offline) fn dispatch_engine(
         &mut self,
         rank_id: usize,
-        request: crate::scheduler::EngineRequest,
+        request: EngineRequest,
     ) -> anyhow::Result<()> {
         self.update_worker(rank_id, |worker| worker.receive_engine_request(request))
             .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))??;
@@ -575,7 +577,7 @@ where
         rank_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        self.dispatch_engine(rank_id, crate::scheduler::EngineRequest::untracked(request))
+        self.dispatch_engine(rank_id, EngineRequest::untracked(request))
     }
 
     pub(in crate::replay::offline) fn apply_command(
@@ -801,7 +803,7 @@ where
                                     stage: self.stage,
                                     worker_idx: rank_id,
                                     completed_requests: 0,
-                                    output_signals: crate::scheduler::EngineOutputs::default(),
+                                    output_signals: EngineOutputs::default(),
                                     lifecycle_events: Vec::new(),
                                     engine_events: Observation::Batch::default(),
                                     progress: EngineProgress::default(),
@@ -1079,13 +1081,13 @@ mod tests {
         engine
             .dispatch_engine(
                 0,
-                crate::scheduler::EngineRequest::for_replay(timed_request(fast, 4), fast_key),
+                EngineRequest::for_replay(timed_request(fast, 4), fast_key),
             )
             .unwrap();
         engine
             .dispatch_engine(
                 1,
-                crate::scheduler::EngineRequest::for_replay(timed_request(slow, 8), slow_key),
+                EngineRequest::for_replay(timed_request(slow, 8), slow_key),
             )
             .unwrap();
         let mut collector = TraceCollector::default();
@@ -1507,6 +1509,7 @@ mod tests {
         assert!(
             final_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == uuid && signal.completed)
         );

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -16,7 +16,9 @@ use super::super::state::OfflineWorkerState;
 #[cfg(feature = "kvbm-offload")]
 use super::ObservedOffloadEffects;
 use super::{EngineEffects, EnginePassMode, ObservedCommandEffects, ReplayEngineObservation};
-use crate::common::protocols::{DirectRequest, ForwardPassSnapshot, MockEngineArgs};
+#[cfg(test)]
+use crate::common::protocols::DirectRequest;
+use crate::common::protocols::{ForwardPassSnapshot, MockEngineArgs};
 use crate::replay::TraceCollector;
 use crate::scheduler::{EnginePassResult, RouterEventVisibility, SchedulerCommand};
 
@@ -556,15 +558,24 @@ where
         ready
     }
 
+    pub(in crate::replay::offline) fn dispatch_engine(
+        &mut self,
+        rank_id: usize,
+        request: crate::scheduler::EngineRequest,
+    ) -> anyhow::Result<()> {
+        self.update_worker(rank_id, |worker| worker.receive_engine_request(request))
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))??;
+        self.refresh_rank(rank_id);
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(in crate::replay::offline) fn dispatch(
         &mut self,
         rank_id: usize,
         request: DirectRequest,
     ) -> anyhow::Result<()> {
-        self.update_worker(rank_id, |worker| worker.receive_request(request))
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown rank {rank_id}"))?;
-        self.refresh_rank(rank_id);
-        Ok(())
+        self.dispatch_engine(rank_id, crate::scheduler::EngineRequest::untracked(request))
     }
 
     pub(in crate::replay::offline) fn apply_command(
@@ -790,7 +801,7 @@ where
                                     stage: self.stage,
                                     worker_idx: rank_id,
                                     completed_requests: 0,
-                                    output_signals: Vec::new(),
+                                    output_signals: crate::scheduler::EngineOutputs::default(),
                                     lifecycle_events: Vec::new(),
                                     engine_events: Observation::Batch::default(),
                                     progress: EngineProgress::default(),
@@ -945,7 +956,10 @@ mod tests {
         DirectRequest, EngineType, MockEngineArgs, SglangArgs, WorkerType,
     };
     use crate::replay::offline::extensions::kv_events::RouterEventObservation;
-    use crate::scheduler::{SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent};
+    use crate::scheduler::{
+        ReplayRequestKey, SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent,
+    };
+    use slotmap::SlotMap;
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -1059,8 +1073,21 @@ mod tests {
         let mut engine = ranked_timing_engine(2);
         let fast = Uuid::from_u128(30);
         let slow = Uuid::from_u128(31);
-        engine.dispatch(0, timed_request(fast, 4)).unwrap();
-        engine.dispatch(1, timed_request(slow, 8)).unwrap();
+        let mut replay_keys = SlotMap::<ReplayRequestKey, ()>::with_key();
+        let fast_key = replay_keys.insert(());
+        let slow_key = replay_keys.insert(());
+        engine
+            .dispatch_engine(
+                0,
+                crate::scheduler::EngineRequest::for_replay(timed_request(fast, 4), fast_key),
+            )
+            .unwrap();
+        engine
+            .dispatch_engine(
+                1,
+                crate::scheduler::EngineRequest::for_replay(timed_request(slow, 8), slow_key),
+            )
+            .unwrap();
         let mut collector = TraceCollector::default();
         collector.on_arrival(fast, 0.0, 4, 1);
         collector.on_arrival(slow, 0.0, 8, 1);
@@ -1084,6 +1111,14 @@ mod tests {
         assert!(scheduled.payloads.iter().all(|payload| {
             (payload.fpm.as_ref().unwrap().wall_time_secs - 0.009).abs() < f64::EPSILON
         }));
+        assert_eq!(
+            scheduled.payloads[0].output_signals.replay_key_at(0),
+            Some(fast_key)
+        );
+        assert_eq!(
+            scheduled.payloads[1].output_signals.replay_key_at(0),
+            Some(slow_key)
+        );
         assert_eq!(collector.request_latencies(fast).unwrap().0, 9.0);
         assert_eq!(collector.request_latencies(slow).unwrap().0, 9.0);
     }

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -3,7 +3,7 @@
 
 use crate::common::protocols::MockEngineArgs;
 use crate::replay::TraceCollector;
-use crate::scheduler::{EngineCore, EnginePassResult, SglangCore, VllmCore};
+use crate::scheduler::{EngineCore, EnginePassResult, EngineRequest, SglangCore, VllmCore};
 
 fn record_pass(collector: &mut TraceCollector, pass: &EnginePassResult, now_ms: f64) {
     collector.on_scheduler_pass(pass, now_ms, Some(pass.token_completion_ms));
@@ -62,7 +62,9 @@ impl ReplayWorkerCore {
         &mut self,
         request: crate::common::protocols::DirectRequest,
     ) -> uuid::Uuid {
-        self.core.receive(request)
+        self.core
+            .receive_engine(EngineRequest::untracked(request))
+            .expect("ordinary request ID must be unique")
     }
 
     pub(crate) fn num_requests(&self) -> usize {
@@ -85,7 +87,7 @@ mod tests {
     use super::*;
     use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
     use crate::scheduler::vllm::MockerMetrics;
-    use crate::scheduler::{AdmissionEvent, RouterEventVisibility};
+    use crate::scheduler::{AdmissionEvent, EngineOutputs, RouterEventVisibility};
     use uuid::Uuid;
 
     #[test]
@@ -97,13 +99,13 @@ mod tests {
             end_ms: 20.0,
             token_completion_ms: 5.0,
             completed_requests: 1,
-            output_signals: vec![OutputSignal {
+            output_signals: EngineOutputs::untracked(vec![OutputSignal {
                 uuid,
                 token_id: Some(1),
                 completed: true,
                 rejected: false,
                 handoff_delay_ms: None,
-            }],
+            }]),
             admissions: vec![AdmissionEvent {
                 uuid,
                 reused_input_tokens: 0,

--- a/lib/mocker/src/replay/offline/components/worker_core.rs
+++ b/lib/mocker/src/replay/offline/components/worker_core.rs
@@ -3,7 +3,7 @@
 
 use crate::common::protocols::MockEngineArgs;
 use crate::replay::TraceCollector;
-use crate::scheduler::{EngineCore, EnginePassResult, EngineRequest, SglangCore, VllmCore};
+use crate::scheduler::{EngineCore, EnginePassResult, SglangCore, VllmCore};
 
 fn record_pass(collector: &mut TraceCollector, pass: &EnginePassResult, now_ms: f64) {
     collector.on_scheduler_pass(pass, now_ms, Some(pass.token_completion_ms));
@@ -62,9 +62,7 @@ impl ReplayWorkerCore {
         &mut self,
         request: crate::common::protocols::DirectRequest,
     ) -> uuid::Uuid {
-        self.core
-            .receive_engine(EngineRequest::untracked(request))
-            .expect("ordinary request ID must be unique")
+        self.core.receive(request)
     }
 
     pub(crate) fn num_requests(&self) -> usize {

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -53,7 +53,8 @@ use crate::replay::{
     OfflineDisaggReplayConfig, ReplayRequestPool, ReplayTerminalStatus, TraceCollector,
 };
 use crate::scheduler::{
-    AdmissionEvent, SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent,
+    AdmissionEvent, EngineOutputs, SchedulerCommand, SchedulerCommandResult,
+    SchedulerLifecycleEvent,
 };
 
 fn common_origin(mut origins: impl Iterator<Item = u64>) -> Option<u64> {
@@ -611,15 +612,14 @@ impl DisaggFlowState {
         collector: &mut TraceCollector,
     ) -> Result<Uuid> {
         let uuid = request.metadata().uuid.unwrap_or_else(Uuid::new_v4);
+        if self.requests.contains_key(&uuid) {
+            bail!("offline disagg replay request {uuid} is already active");
+        }
         let input_length = request.input_length();
         let output_length = request.metadata().max_output_tokens;
         request.metadata_mut().uuid = Some(uuid);
         request.metadata_mut().arrival_timestamp_ms = Some(arrival_time_ms);
 
-        collector.on_arrival(uuid, arrival_time_ms, input_length, output_length);
-        if self.requests.contains_key(&uuid) {
-            bail!("offline disagg replay request {uuid} is already active");
-        }
         let handoff_id = HandoffId::new();
         let mut state = DisaggRequestState::new(
             request,
@@ -637,6 +637,7 @@ impl DisaggFlowState {
             .checked_add(1)
             .expect("logical in-flight request count overflow");
         self.action_queues.enqueue_all(uuid, actions);
+        collector.on_arrival(uuid, arrival_time_ms, input_length, output_length);
         Ok(uuid)
     }
 
@@ -862,11 +863,13 @@ impl DisaggFlowState {
         }
 
         let handoff_id = self.state(uuid)?.handoff_id;
-        self.state_mut(uuid)?.mark_done();
-        let removed = self.requests_by_handoff.remove(&handoff_id);
-        if removed != Some(uuid) {
+        if self.requests_by_handoff.get(&handoff_id).copied() != Some(uuid) {
             bail!("offline disagg replay handoff index is inconsistent for {uuid}");
         }
+        self.state_mut(uuid)?.mark_done();
+        self.requests_by_handoff
+            .remove(&handoff_id)
+            .expect("validated disaggregated handoff index must remain present");
         Ok(())
     }
 }
@@ -1899,14 +1902,12 @@ where
     /// Apply the side effects of a finished prefill pass.
     fn process_prefill_pass(
         &mut self,
-        _worker_idx: usize,
-        _completed_requests: usize,
-        output_signals: Vec<OutputSignal>,
+        output_signals: EngineOutputs,
         lifecycle_events: Vec<SchedulerLifecycleEvent>,
         engine_events: Observation::Batch,
     ) -> Result<()> {
         self.apply_prefill_observations(engine_events, KvIngestBoundary::PassEnd)?;
-        for signal in output_signals {
+        for signal in output_signals.into_untracked()? {
             self.process_prefill_signal(signal)?;
         }
         self.process_lifecycle_events(lifecycle_events)?;
@@ -1916,7 +1917,7 @@ where
     /// Apply the side effects of a finished decode pass.
     fn process_decode_pass(
         &mut self,
-        output_signals: Vec<OutputSignal>,
+        output_signals: EngineOutputs,
         lifecycle_events: Vec<SchedulerLifecycleEvent>,
         engine_events: Observation::Batch,
         accept_length_output_tokens: usize,
@@ -1925,7 +1926,7 @@ where
         self.apply_decode_observations(engine_events, KvIngestBoundary::PassEnd)?;
         self.traffic
             .on_accept_length_sample(accept_length_output_tokens, accept_length_decode_forwards);
-        for signal in output_signals {
+        for signal in output_signals.into_untracked()? {
             self.process_decode_signal(signal)?;
         }
         self.process_lifecycle_events(lifecycle_events)?;
@@ -1966,8 +1967,6 @@ where
                         .insert(payload.worker_idx, fpm, self.now_ms);
                 }
                 self.process_prefill_pass(
-                    payload.worker_idx,
-                    payload.completed_requests,
                     payload.output_signals,
                     payload.lifecycle_events,
                     payload.engine_events,

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -292,6 +292,34 @@ fn request(
 }
 
 #[test]
+fn disagg_rejects_duplicate_request_before_recording_arrival() {
+    let mut flow = DisaggFlowState::new(HandoffOrder::SourceFirst, false);
+    let mut collector = TraceCollector::default();
+    let uuid = flow
+        .on_external_arrival(
+            ReplayRequestPayload::materialized(request(90_100, 8, 2, 0.0)),
+            0.0,
+            None,
+            None,
+            &mut collector,
+        )
+        .unwrap();
+
+    assert!(
+        flow.on_external_arrival(
+            ReplayRequestPayload::materialized(request(90_100, 16, 4, 1.0)),
+            1.0,
+            None,
+            None,
+            &mut collector,
+        )
+        .is_err()
+    );
+    assert_eq!(flow.logical_in_flight, 1);
+    assert_eq!(collector.snapshot(uuid).unwrap().input_length, 8);
+}
+
+#[test]
 fn scaling_tick_emits_idle_fpm_for_both_disagg_pools() {
     let mut config = disagg_config();
     config.num_prefill_workers = 1;

--- a/lib/mocker/src/replay/offline/events.rs
+++ b/lib/mocker/src/replay/offline/events.rs
@@ -5,8 +5,8 @@ use std::cmp::Ordering;
 
 use super::core::{EngineEventBatch, EngineProgress};
 use crate::common::handoff::HandoffId;
-use crate::common::protocols::{ForwardPassSnapshot, OutputSignal};
-use crate::scheduler::SchedulerLifecycleEvent;
+use crate::common::protocols::ForwardPassSnapshot;
+use crate::scheduler::{EngineOutputs, SchedulerLifecycleEvent};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::replay::offline) enum SimulationWorkerStage {
@@ -20,7 +20,7 @@ pub(in crate::replay::offline) struct WorkerCompletionPayload<Events: EngineEven
     pub(in crate::replay::offline) stage: SimulationWorkerStage,
     pub(in crate::replay::offline) worker_idx: usize,
     pub(in crate::replay::offline) completed_requests: usize,
-    pub(in crate::replay::offline) output_signals: Vec<OutputSignal>,
+    pub(in crate::replay::offline) output_signals: EngineOutputs,
     pub(in crate::replay::offline) lifecycle_events: Vec<SchedulerLifecycleEvent>,
     pub(in crate::replay::offline) engine_events: Events,
     pub(in crate::replay::offline) progress: EngineProgress,
@@ -35,7 +35,7 @@ pub(in crate::replay::offline) enum SimulationEventKind<Events: EngineEventBatch
         stage: SimulationWorkerStage,
         worker_idx: usize,
         completed_requests: usize,
-        output_signals: Vec<OutputSignal>,
+        output_signals: EngineOutputs,
         lifecycle_events: Vec<SchedulerLifecycleEvent>,
         engine_events: Events,
         made_progress: bool,

--- a/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_events/mod.rs
@@ -266,7 +266,7 @@ pub(in crate::replay) fn generate_trace_worker_artifacts_with_visibility(
             }));
 
         let output_timestamp_us = timestamp_us_from_ms(current_time_ms);
-        for signal in pass.output_signals {
+        for signal in pass.output_signals.into_untracked()? {
             if let Some(token_id) = signal.token_id {
                 driver.on_output_token(signal.uuid, token_id)?;
             }

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -305,8 +305,8 @@ mod tests {
             engine_events: (),
             progress: EngineProgress::default(),
             fpm: None,
-            accept_length_output_tokens: 0,
-            accept_length_decode_forwards: 0,
+            accept_length_output_tokens: worker_idx * 10 + completed_requests,
+            accept_length_decode_forwards: worker_idx * 10 + completed_requests + 1,
         }
     }
 
@@ -387,13 +387,22 @@ mod tests {
         assert_eq!(
             payloads
                 .iter()
-                .map(|payload| (payload.worker_idx, payload.completed_requests))
+                .map(|payload| (
+                    payload.worker_idx,
+                    payload.completed_requests,
+                    payload.accept_length_output_tokens,
+                    payload.accept_length_decode_forwards,
+                ))
                 .collect::<Vec<_>>(),
-            vec![(7, 1), (8, 2)]
+            vec![(7, 1, 71, 72), (8, 2, 82, 83)]
         );
         assert!(payloads.iter().all(|payload| {
             payload.output_signals.len() == payload.completed_requests
-                && payload.output_signals.iter().all(|signal| signal.completed)
+                && payload
+                    .output_signals
+                    .as_slice()
+                    .iter()
+                    .all(|signal| signal.completed)
         }));
         assert_eq!(
             pop_ready_worker_ready(&mut events, 10.0),

--- a/lib/mocker/src/replay/offline/runtime_utils.rs
+++ b/lib/mocker/src/replay/offline/runtime_utils.rs
@@ -270,6 +270,7 @@ pub(super) fn pop_ready_scaling_tick<Events: EngineEventBatch>(
 mod tests {
     use super::*;
     use crate::replay::offline::events::SimulationWorkerStage;
+    use crate::scheduler::EngineOutputs;
     use uuid::Uuid;
 
     fn direct_request(uuid: u128, arrival_timestamp_ms: Option<f64>) -> DirectRequest {
@@ -289,19 +290,23 @@ mod tests {
             stage: SimulationWorkerStage::Aggregated,
             worker_idx,
             completed_requests,
-            output_signals: vec![OutputSignal {
-                uuid: Uuid::from_u128(worker_idx as u128),
-                token_id: None,
-                completed: true,
-                rejected: false,
-                handoff_delay_ms: None,
-            }],
+            output_signals: EngineOutputs::untracked(
+                (0..completed_requests)
+                    .map(|offset| OutputSignal {
+                        uuid: Uuid::from_u128((worker_idx * 10 + offset) as u128),
+                        token_id: None,
+                        completed: true,
+                        rejected: false,
+                        handoff_delay_ms: None,
+                    })
+                    .collect(),
+            ),
             lifecycle_events: Vec::new(),
             engine_events: (),
             progress: EngineProgress::default(),
             fpm: None,
-            accept_length_output_tokens: 1,
-            accept_length_decode_forwards: 1,
+            accept_length_output_tokens: 0,
+            accept_length_decode_forwards: 0,
         }
     }
 
@@ -386,6 +391,10 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![(7, 1), (8, 2)]
         );
+        assert!(payloads.iter().all(|payload| {
+            payload.output_signals.len() == payload.completed_requests
+                && payload.output_signals.iter().all(|signal| signal.completed)
+        }));
         assert_eq!(
             pop_ready_worker_ready(&mut events, 10.0),
             Some((SimulationWorkerStage::Aggregated, 5))

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -236,7 +236,7 @@ impl SingleRuntime {
             || !pass.output_signals.is_empty()
             || !pass.kv_events.is_empty();
         if let AdmissionSource::Workload(driver) = &mut self.admission {
-            for signal in &pass.output_signals {
+            for signal in pass.output_signals.iter() {
                 if let Some(token_id) = signal.token_id {
                     driver
                         .on_output_token(signal.uuid, token_id)

--- a/lib/mocker/src/replay/offline/single.rs
+++ b/lib/mocker/src/replay/offline/single.rs
@@ -236,7 +236,7 @@ impl SingleRuntime {
             || !pass.output_signals.is_empty()
             || !pass.kv_events.is_empty();
         if let AdmissionSource::Workload(driver) = &mut self.admission {
-            for signal in pass.output_signals.iter() {
+            for signal in pass.output_signals.as_slice() {
                 if let Some(token_id) = signal.token_id {
                     driver
                         .on_output_token(signal.uuid, token_id)
@@ -259,12 +259,13 @@ impl SingleRuntime {
                 }
             }
         }
-        let completed_requests = pass
+        let completed_requests = pass.output_signals.completed_count();
+        for signal in pass
             .output_signals
+            .as_slice()
             .iter()
             .filter(|signal| signal.completed)
-            .count();
-        for signal in pass.output_signals.iter().filter(|signal| signal.completed) {
+        {
             let status = if signal.rejected {
                 ReplayTerminalStatus::Rejected
             } else {
@@ -367,7 +368,12 @@ mod tests {
     }
 
     fn record_manual_terminals(collector: &mut TraceCollector, pass: &EnginePassResult) {
-        for signal in pass.output_signals.iter().filter(|signal| signal.completed) {
+        for signal in pass
+            .output_signals
+            .as_slice()
+            .iter()
+            .filter(|signal| signal.completed)
+        {
             let status = if signal.rejected {
                 ReplayTerminalStatus::Rejected
             } else {

--- a/lib/mocker/src/replay/offline/state.rs
+++ b/lib/mocker/src/replay/offline/state.rs
@@ -10,7 +10,7 @@ use crate::common::protocols::DirectRequest;
 use crate::common::protocols::MockEngineArgs;
 use crate::loadgen::{ReplayRequestHashes, ReplayRequestPayload};
 use crate::scheduler::{
-    EngineCore, EnginePassResult, SchedulerCommand, SchedulerCommandEffects,
+    EngineCore, EnginePassResult, EngineRequest, SchedulerCommand, SchedulerCommandEffects,
     SchedulerCommandResult, SchedulerLifecycleEvent,
 };
 use uuid::Uuid;
@@ -324,13 +324,26 @@ impl OfflineWorkerState {
         self.in_flight
     }
 
-    pub(crate) fn receive_request(&mut self, mut request: DirectRequest) {
+    pub(crate) fn receive_engine_request(
+        &mut self,
+        mut request: EngineRequest,
+    ) -> anyhow::Result<()> {
         self.in_flight = self
             .in_flight
             .checked_add(1)
             .expect("offline worker in-flight request count overflow");
-        request.dp_rank = self.dp_rank;
-        self.core.receive(request);
+        request.set_dp_rank(self.dp_rank);
+        if let Err(error) = self.core.receive_engine(request) {
+            self.in_flight -= 1;
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn receive_request(&mut self, request: DirectRequest) {
+        self.receive_engine_request(EngineRequest::untracked(request))
+            .expect("ordinary request ID must be unique");
     }
 
     pub(crate) fn apply_command(

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -250,7 +250,7 @@ async fn run_live_scheduler<C: LiveBoundaryCore>(
                 &cancel_token,
                 deadline,
             )
-            .await
+            .await?
             {
                 break;
             }
@@ -319,21 +319,19 @@ impl PendingLivePass {
             || self.pass.mocker_metrics != *metrics_before
     }
 
-    pub(crate) fn suppress_request_outputs(&mut self, request_id: uuid::Uuid) {
+    pub(crate) fn suppress_request_outputs(
+        &mut self,
+        request_id: uuid::Uuid,
+    ) -> anyhow::Result<()> {
         self.pass
             .output_signals
-            .retain_untracked(|signal| signal.uuid != request_id)
-            .expect("live scheduler pass must not carry replay keys");
-        self.pass.completed_requests = self
-            .pass
-            .output_signals
-            .iter()
-            .filter(|signal| signal.completed)
-            .count();
+            .retain_untracked(|signal| signal.uuid != request_id)?;
+        self.pass.completed_requests = self.pass.output_signals.completed_count();
         let (output_tokens, decode_forwards) =
             crate::scheduler::accept_length_sample(self.pass.output_signals.as_slice());
         self.pass.accept_length_output_tokens = output_tokens;
         self.pass.accept_length_decode_forwards = decode_forwards;
+        Ok(())
     }
 }
 
@@ -416,12 +414,7 @@ impl LiveEffectsPublisher {
 
         #[cfg(debug_assertions)]
         {
-            let completed_signals = pending
-                .pass
-                .output_signals
-                .iter()
-                .filter(|signal| signal.completed)
-                .count();
+            let completed_signals = pending.pass.output_signals.completed_count();
             let accept_length =
                 crate::scheduler::accept_length_sample(pending.pass.output_signals.as_slice());
             debug_assert_eq!(pending.pass.completed_requests, completed_signals);
@@ -738,7 +731,7 @@ pub(crate) async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
     scheduler_start: &Instant,
     cancel_token: &CancellationToken,
     deadline: Instant,
-) -> bool {
+) -> anyhow::Result<bool> {
     let sleep = sleep_until_precise(deadline);
     tokio::pin!(sleep);
     let mut accept_commands = true;
@@ -748,11 +741,11 @@ pub(crate) async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
         tokio::pin!(internal_deadline);
         tokio::select! {
             biased;
-            _ = cancel_token.cancelled() => return false,
-            _ = &mut sleep => return true,
+            _ = cancel_token.cancelled() => return Ok(false),
+            _ = &mut sleep => return Ok(true),
             cancellation = cancellation_rx.recv() => {
                 let Some(cancellation) = cancellation else {
-                    return false;
+                    return Ok(false);
                 };
                 let request_id = cancellation.request_id;
                 let discard_pending_output = cancellation.discard_pending_output;
@@ -765,7 +758,7 @@ pub(crate) async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
                     )
                     .await;
                 if discard_pending_output || outcome != Some(SchedulerCommandResult::Noop) {
-                    pending.suppress_request_outputs(request_id);
+                    pending.suppress_request_outputs(request_id)?;
                 }
                 if outcome == Some(SchedulerCommandResult::Applied) && core.live_is_empty() {
                     // Cancellation updates occupancy immediately, but the
@@ -789,7 +782,7 @@ pub(crate) async fn wait_for_live_pass_boundary<C: LiveBoundaryCore>(
             }
             command = command_rx.recv(), if accept_commands => {
                 let Some(command) = command else {
-                    return false;
+                    return Ok(false);
                 };
                 if command_can_apply_during_pass(&command.command) {
                     publisher

--- a/lib/mocker/src/scheduler/live_boundary.rs
+++ b/lib/mocker/src/scheduler/live_boundary.rs
@@ -322,7 +322,8 @@ impl PendingLivePass {
     pub(crate) fn suppress_request_outputs(&mut self, request_id: uuid::Uuid) {
         self.pass
             .output_signals
-            .retain(|signal| signal.uuid != request_id);
+            .retain_untracked(|signal| signal.uuid != request_id)
+            .expect("live scheduler pass must not carry replay keys");
         self.pass.completed_requests = self
             .pass
             .output_signals
@@ -330,7 +331,7 @@ impl PendingLivePass {
             .filter(|signal| signal.completed)
             .count();
         let (output_tokens, decode_forwards) =
-            crate::scheduler::accept_length_sample(&self.pass.output_signals);
+            crate::scheduler::accept_length_sample(self.pass.output_signals.as_slice());
         self.pass.accept_length_output_tokens = output_tokens;
         self.pass.accept_length_decode_forwards = decode_forwards;
     }
@@ -422,7 +423,7 @@ impl LiveEffectsPublisher {
                 .filter(|signal| signal.completed)
                 .count();
             let accept_length =
-                crate::scheduler::accept_length_sample(&pending.pass.output_signals);
+                crate::scheduler::accept_length_sample(pending.pass.output_signals.as_slice());
             debug_assert_eq!(pending.pass.completed_requests, completed_signals);
             debug_assert_eq!(
                 (
@@ -432,7 +433,7 @@ impl LiveEffectsPublisher {
                 accept_length
             );
         }
-        self.publish_outputs(core, pending.pass.output_signals)
+        self.publish_outputs(core, pending.pass.output_signals.into_untracked()?)
             .await?;
         // Live completion/accept accounting is carried by the admission and
         // output channels; the scalar replay counters have no separate live

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::ForwardPassSnapshot;
-use crate::scheduler::SchedulerCommandResult;
+use crate::scheduler::{EngineOutputs, SchedulerCommandResult};
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -122,13 +122,13 @@ fn pass() -> EnginePassResult {
         end_ms: 1.0,
         token_completion_ms: 1.0,
         completed_requests: 1,
-        output_signals: vec![OutputSignal {
+        output_signals: EngineOutputs::untracked(vec![OutputSignal {
             uuid: request_id,
             token_id: Some(1),
             completed: true,
             rejected: false,
             handoff_delay_ms: None,
-        }],
+        }]),
         admissions: vec![AdmissionEvent {
             uuid: request_id,
             reused_input_tokens: 0,
@@ -252,7 +252,7 @@ async fn explicit_discard_suppresses_pending_output_after_noop_cancellation() {
 fn output_suppression_repairs_stale_accept_length_counters() {
     let mut pass = pass();
     let surviving = Uuid::from_u128(2);
-    pass.output_signals.extend([
+    for output in [
         OutputSignal {
             uuid: surviving,
             token_id: Some(2),
@@ -274,7 +274,9 @@ fn output_suppression_repairs_stale_accept_length_counters() {
             rejected: true,
             handoff_delay_ms: None,
         },
-    ]);
+    ] {
+        pass.output_signals.push(output, None).unwrap();
+    }
     pass.accept_length_output_tokens = 0;
     pass.accept_length_decode_forwards = 0;
     let mut pending = PendingLivePass {
@@ -288,6 +290,13 @@ fn output_suppression_repairs_stale_accept_length_counters() {
 
     assert_eq!(pending.pass.accept_length_output_tokens, 2);
     assert_eq!(pending.pass.accept_length_decode_forwards, 1);
+    assert!(
+        pending
+            .pass
+            .output_signals
+            .iter()
+            .all(|signal| signal.uuid == surviving)
+    );
 }
 
 #[tokio::test]

--- a/lib/mocker/src/scheduler/live_boundary/tests.rs
+++ b/lib/mocker/src/scheduler/live_boundary/tests.rs
@@ -4,7 +4,7 @@
 use super::*;
 use crate::common::handoff::HandoffId;
 use crate::common::protocols::ForwardPassSnapshot;
-use crate::scheduler::{EngineOutputs, SchedulerCommandResult};
+use crate::scheduler::{EngineOutputs, ReplayRequestKey, SchedulerCommandResult};
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData};
 use std::sync::{Arc, Mutex};
 use uuid::Uuid;
@@ -216,11 +216,11 @@ async fn cancel_pending_pass(
         let result = tokio::select! {
             reply = reply_rx => reply.unwrap().unwrap().result,
             boundary_result = &mut boundary => {
-                panic!("pass boundary completed before cancellation was acknowledged: {boundary_result}")
+                panic!("pass boundary completed before cancellation was acknowledged: {boundary_result:?}")
             }
         };
         cancel_token.cancel();
-        assert!(!boundary.await);
+        assert!(!boundary.await.unwrap());
         result
     };
     (result, pending)
@@ -275,7 +275,7 @@ fn output_suppression_repairs_stale_accept_length_counters() {
             handoff_delay_ms: None,
         },
     ] {
-        pass.output_signals.push(output, None).unwrap();
+        pass.output_signals.push(output, None);
     }
     pass.accept_length_output_tokens = 0;
     pass.accept_length_decode_forwards = 0;
@@ -286,7 +286,9 @@ fn output_suppression_repairs_stale_accept_length_counters() {
         pass_start_kv_published: false,
     };
 
-    pending.suppress_request_outputs(Uuid::from_u128(1));
+    pending
+        .suppress_request_outputs(Uuid::from_u128(1))
+        .unwrap();
 
     assert_eq!(pending.pass.accept_length_output_tokens, 2);
     assert_eq!(pending.pass.accept_length_decode_forwards, 1);
@@ -294,9 +296,38 @@ fn output_suppression_repairs_stale_accept_length_counters() {
         pending
             .pass
             .output_signals
+            .as_slice()
             .iter()
             .all(|signal| signal.uuid == surviving)
     );
+}
+
+#[test]
+fn tracked_outputs_fail_live_suppression_without_panicking() {
+    let mut pass = pass();
+    let signal = std::mem::take(&mut pass.output_signals)
+        .into_untracked()
+        .unwrap()
+        .pop()
+        .unwrap();
+    let mut keys = slotmap::SlotMap::<ReplayRequestKey, ()>::with_key();
+    let key = keys.insert(());
+    let mut outputs = EngineOutputs::with_capacity(1);
+    outputs.push(signal, Some(key));
+    pass.output_signals = outputs;
+    let mut pending = PendingLivePass {
+        pass,
+        kv_events: Vec::new(),
+        admissions_published: false,
+        pass_start_kv_published: false,
+    };
+
+    assert!(
+        pending
+            .suppress_request_outputs(Uuid::from_u128(1))
+            .is_err()
+    );
+    assert_eq!(pending.pass.output_signals.len(), 1);
 }
 
 #[tokio::test]
@@ -346,14 +377,14 @@ async fn cancellation_does_not_end_pass_with_unrelated_pending_output() {
     let result = tokio::select! {
         biased;
         boundary_result = &mut boundary => {
-            panic!("cancellation ended a pass with unrelated pending output: {boundary_result}")
+            panic!("cancellation ended a pass with unrelated pending output: {boundary_result:?}")
         }
         reply = reply_rx => reply.unwrap().unwrap().result,
     };
     assert_eq!(result, SchedulerCommandResult::Applied);
 
     cancel_token.cancel();
-    assert!(!boundary.await);
+    assert!(!boundary.await.unwrap());
 }
 
 #[tokio::test]

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use live_boundary::{
     LiveBoundaryCore, LivePassExecution, LiveSchedulerState, spawn_live_scheduler,
 };
 use rustc_hash::FxHashSet;
+use slotmap::new_key_type;
 pub(crate) use source_holds::{
     ActiveHandoffRequests, DestinationHolds, PendingDestinations, RemovedSource, SourceCompletion,
     SourceHolds,
@@ -27,6 +28,147 @@ pub use source_holds::{
 };
 use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
+
+new_key_type! {
+    /// Generational handle for offline-replay request state.
+    pub(crate) struct ReplayRequestKey;
+}
+
+/// Request metadata carried only across the private engine boundary.
+pub(crate) struct EngineRequest(DirectRequest, Option<ReplayRequestKey>);
+
+impl EngineRequest {
+    pub(crate) fn untracked(request: DirectRequest) -> Self {
+        Self(request, None)
+    }
+
+    pub(crate) fn for_replay(request: DirectRequest, replay_request_key: ReplayRequestKey) -> Self {
+        Self(request, Some(replay_request_key))
+    }
+
+    pub(crate) fn into_parts(self) -> (DirectRequest, Option<ReplayRequestKey>) {
+        (self.0, self.1)
+    }
+
+    pub(crate) fn set_dp_rank(&mut self, dp_rank: u32) {
+        self.0.dp_rank = dp_rank;
+    }
+}
+
+/// Engine outputs with an all-or-nothing replay-key sidecar.
+///
+/// Live, disaggregated replay, and ordinary execution retain a plain
+/// `Vec<OutputSignal>` that can be moved directly to its existing processing
+/// or publication path. Aggregate replay carries exactly one generational key
+/// per signal.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct EngineOutputs {
+    signals: Vec<OutputSignal>,
+    replay_request_keys: Option<Vec<ReplayRequestKey>>,
+}
+
+impl EngineOutputs {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            signals: Vec::with_capacity(capacity),
+            replay_request_keys: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn untracked(signals: Vec<OutputSignal>) -> Self {
+        Self {
+            signals,
+            replay_request_keys: None,
+        }
+    }
+
+    pub(crate) fn push(
+        &mut self,
+        signal: OutputSignal,
+        replay_request_key: Option<ReplayRequestKey>,
+    ) -> anyhow::Result<()> {
+        match (&mut self.replay_request_keys, replay_request_key) {
+            (Some(keys), Some(key)) => keys.push(key),
+            (None, Some(key)) if self.signals.is_empty() => {
+                let mut keys = Vec::with_capacity(self.signals.capacity());
+                keys.push(key);
+                self.replay_request_keys = Some(keys);
+            }
+            (None, None) => {}
+            _ => anyhow::bail!("engine pass mixed replay-tracked and ordinary outputs"),
+        }
+        self.signals.push(signal);
+        Ok(())
+    }
+
+    pub(crate) fn reserve(&mut self, additional: usize) {
+        self.signals.reserve(additional);
+        if let Some(keys) = &mut self.replay_request_keys {
+            keys.reserve(additional);
+        }
+    }
+
+    pub(crate) fn retain_untracked(
+        &mut self,
+        keep: impl FnMut(&OutputSignal) -> bool,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.replay_request_keys.is_none(),
+            "cannot suppress outputs from a replay-tracked pass"
+        );
+        self.signals.retain(keep);
+        Ok(())
+    }
+
+    pub(crate) fn into_untracked(self) -> anyhow::Result<Vec<OutputSignal>> {
+        anyhow::ensure!(
+            self.replay_request_keys.is_none(),
+            "replay-tracked outputs reached an ordinary publication boundary"
+        );
+        Ok(self.signals)
+    }
+
+    pub(crate) fn into_tracked(
+        self,
+    ) -> anyhow::Result<impl Iterator<Item = (OutputSignal, ReplayRequestKey)>> {
+        anyhow::ensure!(
+            self.replay_request_keys.is_some() || self.signals.is_empty(),
+            "ordinary outputs reached an aggregate replay completion boundary"
+        );
+        let keys = self.replay_request_keys.unwrap_or_default();
+        anyhow::ensure!(
+            self.signals.len() == keys.len(),
+            "aggregate replay output metadata is misaligned"
+        );
+        Ok(self.signals.into_iter().zip(keys))
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.signals.is_empty()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.signals.len()
+    }
+
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, OutputSignal> {
+        self.signals.iter()
+    }
+
+    pub(crate) fn as_slice(&self) -> &[OutputSignal] {
+        &self.signals
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replay_key_at(&self, index: usize) -> Option<ReplayRequestKey> {
+        self.replay_request_keys
+            .as_ref()
+            .and_then(|keys| keys.get(index))
+            .copied()
+    }
+}
 
 #[cfg(feature = "kvbm-offload")]
 pub(crate) struct OffloadTickEffects {
@@ -179,7 +321,7 @@ pub(crate) struct EnginePassResult {
     /// KVBM stall-advance) can extend `end_ms`.
     pub(crate) token_completion_ms: f64,
     pub(crate) completed_requests: usize,
-    pub(crate) output_signals: Vec<OutputSignal>,
+    pub(crate) output_signals: EngineOutputs,
     pub(crate) admissions: Vec<AdmissionEvent>,
     pub(crate) lifecycle_events: Vec<SchedulerLifecycleEvent>,
     pub(crate) mocker_metrics: MockerMetrics,
@@ -241,11 +383,17 @@ pub(crate) enum EngineCore {
 }
 
 impl EngineCore {
-    pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
+    pub(crate) fn receive_engine(&mut self, request: EngineRequest) -> anyhow::Result<Uuid> {
         match self {
-            Self::Vllm(core) => core.receive(request),
-            Self::Sglang(core) => core.receive(request),
+            Self::Vllm(core) => core.receive_engine(request),
+            Self::Sglang(core) => core.receive_engine(request),
         }
+    }
+
+    #[cfg(test)]
+    fn receive(&mut self, request: DirectRequest) -> Uuid {
+        self.receive_engine(EngineRequest::untracked(request))
+            .expect("ordinary request ID must be unique")
     }
 
     pub(crate) fn is_empty(&self) -> bool {
@@ -718,6 +866,65 @@ mod tests {
         ];
 
         assert_eq!(accept_length_sample(&signals), (2, 1));
+    }
+
+    #[test]
+    fn engine_outputs_keep_live_storage_and_validate_replay_sidecars() {
+        let uuid = Uuid::from_u128(7);
+        let signal = || OutputSignal {
+            uuid,
+            token_id: Some(1),
+            completed: false,
+            rejected: false,
+            handoff_delay_ms: None,
+        };
+
+        let mut live = EngineOutputs::with_capacity(1);
+        live.push(signal(), None).unwrap();
+        let live_ptr = live.as_slice().as_ptr();
+        let published = live.into_untracked().unwrap();
+        assert_eq!(published.as_ptr(), live_ptr);
+
+        let mut keys = slotmap::SlotMap::<ReplayRequestKey, ()>::with_key();
+        let key = keys.insert(());
+        let mut replay = EngineOutputs::with_capacity(1);
+        replay.push(signal(), Some(key)).unwrap();
+        assert!(replay.retain_untracked(|_| true).is_err());
+        assert_eq!(replay.into_tracked().unwrap().next().unwrap().1, key);
+
+        let mut mixed = EngineOutputs::with_capacity(2);
+        mixed.push(signal(), Some(key)).unwrap();
+        assert!(mixed.push(signal(), None).is_err());
+        assert!(EngineOutputs::default().into_tracked().is_ok());
+        let mut ordinary = EngineOutputs::with_capacity(1);
+        ordinary.push(signal(), None).unwrap();
+        assert!(ordinary.into_tracked().is_err());
+    }
+
+    #[test]
+    fn replay_submission_uses_complete_request_id_validation() {
+        for (case, engine_type) in [EngineType::Vllm, EngineType::Sglang]
+            .into_iter()
+            .enumerate()
+        {
+            let mut core = core(engine_type, WorkerType::Aggregated, 32);
+            let uuid = Uuid::from_u128(8_000 + case as u128);
+            let mut keys = slotmap::SlotMap::<ReplayRequestKey, ()>::with_key();
+            let key = keys.insert(());
+            core.receive_engine(EngineRequest::for_replay(
+                request(uuid, vec![1, 2, 3, 4]),
+                key,
+            ))
+            .unwrap();
+            assert!(
+                core.receive_engine(EngineRequest::for_replay(
+                    request(uuid, vec![5, 6, 7, 8]),
+                    key,
+                ))
+                .is_err(),
+                "{engine_type:?} accepted a duplicate replay request ID"
+            );
+        }
     }
 
     #[test]

--- a/lib/mocker/src/scheduler/mod.rs
+++ b/lib/mocker/src/scheduler/mod.rs
@@ -64,47 +64,59 @@ impl EngineRequest {
 #[derive(Debug, Clone, Default)]
 pub(crate) struct EngineOutputs {
     signals: Vec<OutputSignal>,
-    replay_request_keys: Option<Vec<ReplayRequestKey>>,
+    tracking: OutputTracking,
+}
+
+#[derive(Debug, Clone, Default)]
+enum OutputTracking {
+    #[default]
+    Empty,
+    Untracked,
+    Tracked(Vec<ReplayRequestKey>),
+    Mixed,
 }
 
 impl EngineOutputs {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         Self {
             signals: Vec::with_capacity(capacity),
-            replay_request_keys: None,
+            tracking: OutputTracking::Empty,
         }
     }
 
     #[cfg(test)]
     pub(crate) fn untracked(signals: Vec<OutputSignal>) -> Self {
-        Self {
-            signals,
-            replay_request_keys: None,
-        }
+        let tracking = if signals.is_empty() {
+            OutputTracking::Empty
+        } else {
+            OutputTracking::Untracked
+        };
+        Self { signals, tracking }
     }
 
     pub(crate) fn push(
         &mut self,
         signal: OutputSignal,
         replay_request_key: Option<ReplayRequestKey>,
-    ) -> anyhow::Result<()> {
-        match (&mut self.replay_request_keys, replay_request_key) {
-            (Some(keys), Some(key)) => keys.push(key),
-            (None, Some(key)) if self.signals.is_empty() => {
+    ) {
+        match (&mut self.tracking, replay_request_key) {
+            (OutputTracking::Empty, Some(key)) => {
                 let mut keys = Vec::with_capacity(self.signals.capacity());
                 keys.push(key);
-                self.replay_request_keys = Some(keys);
+                self.tracking = OutputTracking::Tracked(keys);
             }
-            (None, None) => {}
-            _ => anyhow::bail!("engine pass mixed replay-tracked and ordinary outputs"),
+            (OutputTracking::Empty, None) => self.tracking = OutputTracking::Untracked,
+            (OutputTracking::Tracked(keys), Some(key)) => keys.push(key),
+            (OutputTracking::Untracked, None) => {}
+            (OutputTracking::Mixed, _) => {}
+            _ => self.tracking = OutputTracking::Mixed,
         }
         self.signals.push(signal);
-        Ok(())
     }
 
     pub(crate) fn reserve(&mut self, additional: usize) {
         self.signals.reserve(additional);
-        if let Some(keys) = &mut self.replay_request_keys {
+        if let OutputTracking::Tracked(keys) = &mut self.tracking {
             keys.reserve(additional);
         }
     }
@@ -114,7 +126,10 @@ impl EngineOutputs {
         keep: impl FnMut(&OutputSignal) -> bool,
     ) -> anyhow::Result<()> {
         anyhow::ensure!(
-            self.replay_request_keys.is_none(),
+            matches!(
+                self.tracking,
+                OutputTracking::Empty | OutputTracking::Untracked
+            ),
             "cannot suppress outputs from a replay-tracked pass"
         );
         self.signals.retain(keep);
@@ -123,7 +138,10 @@ impl EngineOutputs {
 
     pub(crate) fn into_untracked(self) -> anyhow::Result<Vec<OutputSignal>> {
         anyhow::ensure!(
-            self.replay_request_keys.is_none(),
+            matches!(
+                self.tracking,
+                OutputTracking::Empty | OutputTracking::Untracked
+            ),
             "replay-tracked outputs reached an ordinary publication boundary"
         );
         Ok(self.signals)
@@ -132,11 +150,16 @@ impl EngineOutputs {
     pub(crate) fn into_tracked(
         self,
     ) -> anyhow::Result<impl Iterator<Item = (OutputSignal, ReplayRequestKey)>> {
-        anyhow::ensure!(
-            self.replay_request_keys.is_some() || self.signals.is_empty(),
-            "ordinary outputs reached an aggregate replay completion boundary"
-        );
-        let keys = self.replay_request_keys.unwrap_or_default();
+        let keys = match self.tracking {
+            OutputTracking::Empty => Vec::new(),
+            OutputTracking::Tracked(keys) => keys,
+            OutputTracking::Untracked => {
+                anyhow::bail!("ordinary outputs reached an aggregate replay completion boundary")
+            }
+            OutputTracking::Mixed => {
+                anyhow::bail!("engine pass mixed replay-tracked and ordinary outputs")
+            }
+        };
         anyhow::ensure!(
             self.signals.len() == keys.len(),
             "aggregate replay output metadata is misaligned"
@@ -145,16 +168,18 @@ impl EngineOutputs {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.signals.is_empty()
+        self.len() == 0
     }
 
-    #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
         self.signals.len()
     }
 
-    pub(crate) fn iter(&self) -> std::slice::Iter<'_, OutputSignal> {
-        self.signals.iter()
+    pub(crate) fn completed_count(&self) -> usize {
+        self.signals
+            .iter()
+            .filter(|signal| signal.completed)
+            .count()
     }
 
     pub(crate) fn as_slice(&self) -> &[OutputSignal] {
@@ -163,10 +188,10 @@ impl EngineOutputs {
 
     #[cfg(test)]
     pub(crate) fn replay_key_at(&self, index: usize) -> Option<ReplayRequestKey> {
-        self.replay_request_keys
-            .as_ref()
-            .and_then(|keys| keys.get(index))
-            .copied()
+        match &self.tracking {
+            OutputTracking::Tracked(keys) => keys.get(index).copied(),
+            _ => None,
+        }
     }
 }
 
@@ -390,8 +415,7 @@ impl EngineCore {
         }
     }
 
-    #[cfg(test)]
-    fn receive(&mut self, request: DirectRequest) -> Uuid {
+    pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
         self.receive_engine(EngineRequest::untracked(request))
             .expect("ordinary request ID must be unique")
     }
@@ -880,7 +904,7 @@ mod tests {
         };
 
         let mut live = EngineOutputs::with_capacity(1);
-        live.push(signal(), None).unwrap();
+        live.push(signal(), None);
         let live_ptr = live.as_slice().as_ptr();
         let published = live.into_untracked().unwrap();
         assert_eq!(published.as_ptr(), live_ptr);
@@ -888,16 +912,17 @@ mod tests {
         let mut keys = slotmap::SlotMap::<ReplayRequestKey, ()>::with_key();
         let key = keys.insert(());
         let mut replay = EngineOutputs::with_capacity(1);
-        replay.push(signal(), Some(key)).unwrap();
+        replay.push(signal(), Some(key));
         assert!(replay.retain_untracked(|_| true).is_err());
         assert_eq!(replay.into_tracked().unwrap().next().unwrap().1, key);
 
         let mut mixed = EngineOutputs::with_capacity(2);
-        mixed.push(signal(), Some(key)).unwrap();
-        assert!(mixed.push(signal(), None).is_err());
+        mixed.push(signal(), Some(key));
+        mixed.push(signal(), None);
+        assert!(mixed.into_tracked().is_err());
         assert!(EngineOutputs::default().into_tracked().is_ok());
         let mut ordinary = EngineOutputs::with_capacity(1);
-        ordinary.push(signal(), None).unwrap();
+        ordinary.push(signal(), None);
         assert!(ordinary.into_tracked().is_err());
     }
 

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -789,11 +789,7 @@ impl SglangCore {
         Ok(EnginePassResult {
             end_ms: decode.end_ms,
             token_completion_ms: decode.end_ms,
-            completed_requests: decode
-                .output_signals
-                .iter()
-                .filter(|signal| signal.completed)
-                .count(),
+            completed_requests: decode.output_signals.completed_count(),
             output_signals: decode.output_signals,
             admissions,
             lifecycle_events: std::mem::take(&mut self.lifecycle_events),

--- a/lib/mocker/src/scheduler/sglang/core.rs
+++ b/lib/mocker/src/scheduler/sglang/core.rs
@@ -28,10 +28,10 @@ use super::prefill::get_new_batch_prefill;
 use super::request::SglangRequest;
 use crate::scheduler::{
     ActiveHandoffRequests, AdmissionInvariant, AdmissionStage, CapturedRouterEventBuffer,
-    DestinationHolds, EnginePassResult, MockerMetrics, PendingDestinations, RemovedSource,
-    RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult,
-    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, build_fpm_snapshot,
-    capture_router_event_sink,
+    DestinationHolds, EnginePassResult, EngineRequest, MockerMetrics, PendingDestinations,
+    RemovedSource, ReplayRequestKey, RouterEventVisibility, SchedulerCommand,
+    SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion,
+    SourceHolds, build_fpm_snapshot, capture_router_event_sink,
 };
 
 pub(crate) struct SglangCore {
@@ -157,13 +157,16 @@ impl SglangCore {
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
-        match self
-            .apply_command(SchedulerCommand::Submit(request))
+        self.receive_engine(EngineRequest::untracked(request))
             .expect("ordinary request ID must be unique")
-        {
-            SchedulerCommandResult::Submitted(uuid) => uuid,
-            _ => unreachable!("submit command must return a request ID"),
-        }
+    }
+
+    pub(crate) fn receive_engine(&mut self, request: EngineRequest) -> anyhow::Result<Uuid> {
+        let (mut request, replay_request_key) = request.into_parts();
+        let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        request.uuid = Some(uuid);
+        self.validate_request_id(uuid)?;
+        self.submit_with_replay_key(request, replay_request_key)
     }
 
     pub(crate) fn apply_command(
@@ -184,7 +187,7 @@ impl SglangCore {
                 request.uuid = Some(uuid);
                 self.validate_request_id(uuid)?;
                 Ok(SchedulerCommandEffects::new(
-                    SchedulerCommandResult::Submitted(self.submit(request)?),
+                    SchedulerCommandResult::Submitted(self.submit_with_replay_key(request, None)?),
                 ))
             }
             SchedulerCommand::CancelRequest { request_id } => {
@@ -208,7 +211,7 @@ impl SglangCore {
                 self.validate_request_id(uuid)?;
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self
-                    .submit(request)
+                    .submit_with_replay_key(request, None)
                     .expect("prevalidated handoff request must submit");
                 Ok(SchedulerCommandEffects::new(
                     SchedulerCommandResult::Submitted(submitted),
@@ -245,7 +248,7 @@ impl SglangCore {
                 {
                     anyhow::bail!("destination handoff {handoff_id:?} is already active");
                 }
-                let request = self.build_request(request);
+                let request = self.build_request(request, None);
                 let prompt_footprint = request
                     .prompt_len()
                     .div_ceil(self.config.block_size)
@@ -367,8 +370,12 @@ impl SglangCore {
             || self.running.iter().any(|request| request.uuid == uuid)
     }
 
-    fn submit(&mut self, request: DirectRequest) -> anyhow::Result<Uuid> {
-        let request = self.build_request(request);
+    fn submit_with_replay_key(
+        &mut self,
+        request: DirectRequest,
+        replay_request_key: Option<ReplayRequestKey>,
+    ) -> anyhow::Result<Uuid> {
+        let request = self.build_request(request, replay_request_key);
         if self.request_is_active(request.uuid) {
             anyhow::bail!("request {} is already active", request.uuid);
         }
@@ -378,7 +385,11 @@ impl SglangCore {
         Ok(uuid)
     }
 
-    fn build_request(&self, request: DirectRequest) -> SglangRequest {
+    fn build_request(
+        &self,
+        request: DirectRequest,
+        replay_request_key: Option<ReplayRequestKey>,
+    ) -> SglangRequest {
         let max_output_tokens = request
             .output_token_ids
             .as_ref()
@@ -388,7 +399,12 @@ impl SglangCore {
             max_output_tokens,
             request.output_token_ids.is_some(),
         );
-        SglangRequest::new(request, self.config.block_size, output_storage_hint)
+        SglangRequest::new_with_replay_key(
+            request,
+            self.config.block_size,
+            output_storage_hint,
+            replay_request_key,
+        )
     }
 
     fn complete_source(&mut self, request: SglangRequest) {
@@ -767,7 +783,7 @@ impl SglangCore {
         #[cfg(debug_assertions)]
         debug_assert_eq!(
             (accept_length.output_tokens, accept_length.decode_forwards),
-            crate::scheduler::accept_length_sample(&decode.output_signals)
+            crate::scheduler::accept_length_sample(decode.output_signals.as_slice())
         );
         debug_assert_sglang_scheduler_state(&self.waiting, &self.running, self.config.block_size);
         Ok(EnginePassResult {

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -250,7 +250,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                 ),
             },
             req.replay_request_key,
-        )?;
+        );
     }
     let mut completed_requests = already_completed_indices
         .iter()
@@ -365,7 +365,7 @@ pub(super) fn simulate_decode_step_with_sampler(
                     ),
                 },
                 req.replay_request_key,
-            )?;
+            );
             emitted_tokens += 1;
 
             if is_complete {

--- a/lib/mocker/src/scheduler/sglang/decode.rs
+++ b/lib/mocker/src/scheduler/sglang/decode.rs
@@ -14,13 +14,13 @@ use crate::replay::offline::evidence::{
 
 use super::config::{SglangConfig, floor_to_block};
 use super::request::SglangRequest;
-use crate::scheduler::AcceptLengthSample;
+use crate::scheduler::{AcceptLengthSample, EngineOutputs};
 
 #[derive(Default)]
 pub(super) struct DecodeResult {
     pub(super) requests: Vec<SglangRequest>,
     pub(super) completed_requests: Vec<SglangRequest>,
-    pub(super) output_signals: Vec<OutputSignal>,
+    pub(super) output_signals: EngineOutputs,
     pub(super) accept_length: AcceptLengthSample,
     pub(super) retracted_any: bool,
     pub(super) end_ms: f64,
@@ -232,10 +232,10 @@ pub(super) fn simulate_decode_step_with_sampler(
         .enumerate()
         .filter_map(|(idx, req)| (req.remaining_output_tokens() == 0).then_some(idx))
         .collect::<Vec<_>>();
-    let mut output_signals = already_completed_indices
-        .iter()
-        .map(|&idx| {
-            let req = &running[idx];
+    let mut output_signals = EngineOutputs::with_capacity(already_completed_indices.len());
+    for &idx in &already_completed_indices {
+        let req = &running[idx];
+        output_signals.push(
             OutputSignal {
                 uuid: req.uuid,
                 token_id: None,
@@ -248,9 +248,10 @@ pub(super) fn simulate_decode_step_with_sampler(
                     config.kv_transfer_bandwidth,
                     config.kv_bytes_per_token,
                 ),
-            }
-        })
-        .collect::<Vec<_>>();
+            },
+            req.replay_request_key,
+        )?;
+    }
     let mut completed_requests = already_completed_indices
         .iter()
         .rev()
@@ -349,19 +350,22 @@ pub(super) fn simulate_decode_step_with_sampler(
             req.debug_assert_invariants(config.block_size);
 
             let is_complete = req.output_len() >= req.max_output_tokens;
-            output_signals.push(OutputSignal {
-                uuid: req.uuid,
-                token_id: Some(token_id),
-                completed: is_complete,
-                rejected: false,
-                handoff_delay_ms: compute_prefill_handoff_delay_ms(
-                    config.worker_type,
-                    is_complete,
-                    req.prompt_len(),
-                    config.kv_transfer_bandwidth,
-                    config.kv_bytes_per_token,
-                ),
-            });
+            output_signals.push(
+                OutputSignal {
+                    uuid: req.uuid,
+                    token_id: Some(token_id),
+                    completed: is_complete,
+                    rejected: false,
+                    handoff_delay_ms: compute_prefill_handoff_delay_ms(
+                        config.worker_type,
+                        is_complete,
+                        req.prompt_len(),
+                        config.kv_transfer_bandwidth,
+                        config.kv_bytes_per_token,
+                    ),
+                },
+                req.replay_request_key,
+            )?;
             emitted_tokens += 1;
 
             if is_complete {

--- a/lib/mocker/src/scheduler/sglang/request.rs
+++ b/lib/mocker/src/scheduler/sglang/request.rs
@@ -10,10 +10,12 @@ use uuid::Uuid;
 use crate::cache::radix_cache::KvPageId;
 use crate::common::protocols::DirectRequest;
 use crate::kv_manager::sglang_backend::RadixRequestLease;
+use crate::scheduler::ReplayRequestKey;
 
 #[derive(Debug)]
 pub(super) struct SglangRequest {
     pub(super) uuid: Uuid,
+    pub(super) replay_request_key: Option<ReplayRequestKey>,
     pub(super) sequence_tokens: Vec<u32>,
     pub(super) prompt_len: usize,
     pub(super) max_output_tokens: usize,
@@ -24,7 +26,12 @@ pub(super) struct SglangRequest {
 }
 
 impl SglangRequest {
-    pub(super) fn new(req: DirectRequest, block_size: usize, output_storage_hint: usize) -> Self {
+    pub(super) fn new_with_replay_key(
+        req: DirectRequest,
+        block_size: usize,
+        output_storage_hint: usize,
+        replay_request_key: Option<ReplayRequestKey>,
+    ) -> Self {
         let prompt_len = req.tokens.len();
         let max_output_tokens = req
             .output_token_ids
@@ -44,6 +51,7 @@ impl SglangRequest {
 
         Self {
             uuid: req.uuid.unwrap_or_else(Uuid::new_v4),
+            replay_request_key,
             sequence_tokens,
             prompt_len,
             max_output_tokens,

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -898,6 +898,7 @@ mod destination_lifecycle {
         assert!(
             blocker_terminal
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == blocker_uuid && signal.completed)
         );
@@ -923,6 +924,7 @@ mod destination_lifecycle {
         assert!(
             terminal
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == logical_uuid && signal.completed)
         );
@@ -1609,6 +1611,7 @@ mod core_behavior {
         let second = core.execute_pass(&mut collector, first.end_ms);
         let ordered = second
             .output_signals
+            .as_slice()
             .iter()
             .map(|signal| (signal.uuid, signal.completed))
             .collect::<Vec<_>>();
@@ -1638,6 +1641,7 @@ mod core_behavior {
         assert_eq!(
             third
                 .output_signals
+                .as_slice()
                 .iter()
                 .map(|signal| signal.uuid)
                 .collect::<Vec<_>>(),

--- a/lib/mocker/src/scheduler/sglang/tests.rs
+++ b/lib/mocker/src/scheduler/sglang/tests.rs
@@ -158,6 +158,7 @@ fn make_decoded_request(
     let alloc = kv_manager.allocate_for_request(&prompt_tokens).unwrap();
     let mut running = vec![SglangRequest {
         uuid: Uuid::new_v4(),
+        replay_request_key: None,
         sequence_tokens: prompt_tokens,
         prompt_len,
         max_output_tokens,
@@ -206,6 +207,7 @@ fn zero_output_completion_survives_decode_reservation_failure() {
     let mut running = vec![
         SglangRequest {
             uuid: zero_uuid,
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4],
             prompt_len: 4,
             max_output_tokens: 0,
@@ -216,6 +218,7 @@ fn zero_output_completion_survives_decode_reservation_failure() {
         },
         SglangRequest {
             uuid: normal_uuid,
+            replay_request_key: None,
             sequence_tokens: vec![5, 6, 7, 8],
             prompt_len: 4,
             max_output_tokens: 1,
@@ -266,6 +269,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_pages() {
     kv_manager.finish(&prompt, cached.lease);
     let mut waiting = VecDeque::from([SglangRequest {
         uuid: Uuid::from_u128(90_002),
+        replay_request_key: None,
         sequence_tokens: prompt.clone(),
         prompt_len: prompt.len(),
         max_output_tokens: 1,
@@ -289,6 +293,7 @@ fn fresh_prefill_tracks_cache_owned_prefix_pages() {
     let blocker_alloc = kv_manager.allocate_for_request(&blocker_tokens).unwrap();
     let blocker = SglangRequest {
         uuid: Uuid::from_u128(90_003),
+        replay_request_key: None,
         sequence_tokens: blocker_tokens,
         prompt_len: 3,
         max_output_tokens: 1,
@@ -392,9 +397,9 @@ mod source_holds {
         .unwrap();
 
         let first = execute(&mut core, 0.0);
-        assert!(!first.output_signals[0].completed);
+        assert!(!first.output_signals.as_slice()[0].completed);
         let terminal = execute(&mut core, first.end_ms);
-        assert!(terminal.output_signals[0].completed);
+        assert!(terminal.output_signals.as_slice()[0].completed);
         assert!(matches!(
             terminal.lifecycle_events.as_slice(),
             [SchedulerLifecycleEvent::SourceHeld {
@@ -459,7 +464,7 @@ mod source_holds {
 
         let first = execute(&mut core, 0.0);
         let terminal = execute(&mut core, first.end_ms);
-        assert!(terminal.output_signals[0].completed);
+        assert!(terminal.output_signals.as_slice()[0].completed);
         assert!(!core.source_is_held(second_id));
     }
 
@@ -471,7 +476,7 @@ mod source_holds {
         let first = execute(&mut core, 0.0);
         let terminal = execute(&mut core, first.end_ms);
 
-        assert!(terminal.output_signals[0].completed);
+        assert!(terminal.output_signals.as_slice()[0].completed);
         assert_eq!(occupied_tokens(&core), 8);
     }
 
@@ -1126,6 +1131,7 @@ mod scheduling {
         let mut waiting = VecDeque::from([
             SglangRequest {
                 uuid: no_match_uuid,
+                replay_request_key: None,
                 sequence_tokens: vec![9, 8, 7],
                 prompt_len: 3,
                 max_output_tokens: 1,
@@ -1136,6 +1142,7 @@ mod scheduling {
             },
             SglangRequest {
                 uuid: match_uuid,
+                replay_request_key: None,
                 sequence_tokens: vec![1, 2, 3, 4, 5, 6, 7],
                 prompt_len: 5,
                 max_output_tokens: 1,
@@ -1169,6 +1176,7 @@ mod scheduling {
         for _ in 0..33 {
             waiting.push_back(SglangRequest {
                 uuid: Uuid::new_v4(),
+                replay_request_key: None,
                 sequence_tokens: duplicate_prefix.clone(),
                 prompt_len: duplicate_prefix.len(),
                 max_output_tokens: 1,
@@ -1181,6 +1189,7 @@ mod scheduling {
         let unique_uuid = Uuid::new_v4();
         waiting.push_back(SglangRequest {
             uuid: unique_uuid,
+            replay_request_key: None,
             sequence_tokens: (100..132).collect(),
             prompt_len: 32,
             max_output_tokens: 1,
@@ -1222,6 +1231,8 @@ mod core_behavior {
             let pass = core.execute_pass(&mut collector, step as f64);
             emitted.extend(
                 pass.output_signals
+                    .into_untracked()
+                    .unwrap()
                     .into_iter()
                     .filter(|signal| signal.uuid == uuid)
                     .map(|signal| signal.token_id.expect("planned token should be present")),
@@ -1247,6 +1258,7 @@ mod core_behavior {
         let mut kv_manager = SglangKvManager::new(10000, 4, KvEventPublishers::default(), 0);
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1; 6],
             prompt_len: 6,
             max_output_tokens: 3,
@@ -1277,6 +1289,7 @@ mod core_behavior {
         let mut kv_manager = SglangKvManager::new(12, 4, KvEventPublishers::default(), 0);
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1; 16],
             prompt_len: 16,
             max_output_tokens: 2,
@@ -1310,6 +1323,7 @@ mod core_behavior {
         let mut waiting = VecDeque::from([
             SglangRequest {
                 uuid: first_uuid,
+                replay_request_key: None,
                 sequence_tokens: vec![1; 7],
                 prompt_len: 7,
                 max_output_tokens: 3,
@@ -1320,6 +1334,7 @@ mod core_behavior {
             },
             SglangRequest {
                 uuid: second_uuid,
+                replay_request_key: None,
                 sequence_tokens: vec![2; 8],
                 prompt_len: 8,
                 max_output_tokens: 3,
@@ -1354,6 +1369,7 @@ mod core_behavior {
         kv_manager.extend_cached_prefix(&[1, 2, 3, 4], &mut alloc.lease);
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4, 5, 6],
             prompt_len: 6,
             max_output_tokens: 4,
@@ -1398,6 +1414,7 @@ mod core_behavior {
         let base_alloc = base_kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut base_running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4],
             prompt_len: 4,
             max_output_tokens: 4,
@@ -1411,6 +1428,7 @@ mod core_behavior {
         let fast_alloc = fast_kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut fast_running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4],
             prompt_len: 4,
             max_output_tokens: 4,
@@ -1460,6 +1478,7 @@ mod core_behavior {
         let mut running = vec![
             SglangRequest {
                 uuid: Uuid::new_v4(),
+                replay_request_key: None,
                 sequence_tokens: vec![1, 2, 3, 4, 11, 12, 13, 14],
                 prompt_len: 4,
                 max_output_tokens: 10,
@@ -1470,6 +1489,7 @@ mod core_behavior {
             },
             SglangRequest {
                 uuid: Uuid::new_v4(),
+                replay_request_key: None,
                 sequence_tokens: vec![9, 8, 7, 6, 21],
                 prompt_len: 4,
                 max_output_tokens: 10,
@@ -1501,6 +1521,7 @@ mod core_behavior {
         let alloc = kv_manager.allocate_for_request(&[1, 2, 3, 4]).unwrap();
         let mut running = vec![SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4],
             prompt_len: 4,
             max_output_tokens: 4,
@@ -1803,6 +1824,7 @@ mod router_events {
         let prompt_tokens = vec![101, 202];
         let mut expected_request = SglangRequest {
             uuid,
+            replay_request_key: None,
             sequence_tokens: prompt_tokens.clone(),
             prompt_len: prompt_tokens.len(),
             max_output_tokens: 2,
@@ -1915,6 +1937,7 @@ mod router_events {
 
         let mut waiting = VecDeque::from([SglangRequest {
             uuid: Uuid::new_v4(),
+            replay_request_key: None,
             sequence_tokens: vec![1, 2, 3, 4, 5, 6, 7],
             prompt_len: 7,
             max_output_tokens: 3,
@@ -2148,6 +2171,7 @@ mod router_events {
         let pass = core.execute_pass(&mut collector, 0.0);
         let signal = pass
             .output_signals
+            .as_slice()
             .first()
             .expect("prefill pass should emit one completed signal");
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -33,10 +33,11 @@ use crate::scheduler::vllm::policy::{self, AdmissionDecision, PolicySequence};
 use crate::scheduler::vllm::request::RequestKvState;
 use crate::scheduler::{
     AcceptLengthSample, ActiveHandoffRequests, AdmissionEvent, AdmissionInvariant, AdmissionStage,
-    CapturedRouterEventBuffer, DestinationHolds, EnginePassResult, ForwardPassSnapshot,
-    MockerMetrics, PendingDestinations, RemovedSource, RouterEventVisibility, SchedulerCommand,
-    SchedulerCommandEffects, SchedulerCommandResult, SchedulerLifecycleEvent, SourceCompletion,
-    SourceHolds, build_fpm_snapshot, capture_router_event_sink,
+    CapturedRouterEventBuffer, DestinationHolds, EngineOutputs, EnginePassResult, EngineRequest,
+    ForwardPassSnapshot, MockerMetrics, PendingDestinations, RemovedSource, ReplayRequestKey,
+    RouterEventVisibility, SchedulerCommand, SchedulerCommandEffects, SchedulerCommandResult,
+    SchedulerLifecycleEvent, SourceCompletion, SourceHolds, build_fpm_snapshot,
+    capture_router_event_sink,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +49,7 @@ pub(crate) enum RequestStatus {
 }
 
 pub(crate) struct VllmRequestState {
+    pub(crate) replay_request_key: Option<ReplayRequestKey>,
     pub(crate) sequence: RequestKvState,
     pub(crate) status: RequestStatus,
     pub(crate) num_computed_tokens: usize,
@@ -557,13 +559,16 @@ impl VllmCore {
     }
 
     pub(crate) fn receive(&mut self, request: DirectRequest) -> Uuid {
-        match self
-            .apply_command(SchedulerCommand::Submit(request))
+        self.receive_engine(EngineRequest::untracked(request))
             .expect("ordinary request ID must be unique")
-        {
-            SchedulerCommandResult::Submitted(uuid) => uuid,
-            _ => unreachable!("submit command must return a request ID"),
-        }
+    }
+
+    pub(crate) fn receive_engine(&mut self, request: EngineRequest) -> anyhow::Result<Uuid> {
+        let (mut request, replay_request_key) = request.into_parts();
+        let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
+        request.uuid = Some(uuid);
+        self.validate_request_id(uuid)?;
+        self.submit_with_replay_key(request, replay_request_key)
     }
 
     #[cfg(test)]
@@ -601,7 +606,7 @@ impl VllmCore {
                 request.uuid = Some(uuid);
                 self.validate_request_id(uuid)?;
                 Ok(SchedulerCommandEffects::new(
-                    SchedulerCommandResult::Submitted(self.submit(request)?),
+                    SchedulerCommandResult::Submitted(self.submit_with_replay_key(request, None)?),
                 ))
             }
             SchedulerCommand::CancelRequest { request_id } => {
@@ -626,7 +631,7 @@ impl VllmCore {
                 self.validate_request_id(uuid)?;
                 self.source_holds.register(uuid, handoff_id)?;
                 let submitted = self
-                    .submit(request)
+                    .submit_with_replay_key(request, None)
                     .expect("prevalidated handoff request must submit");
                 Ok(SchedulerCommandEffects::new(
                     SchedulerCommandResult::Submitted(submitted),
@@ -666,7 +671,11 @@ impl VllmCore {
                 {
                     anyhow::bail!("destination handoff {handoff_id:?} is already active");
                 }
-                let request = self.make_request_state(request, RequestStatus::WaitingForRemoteKv);
+                let request = self.make_request_state_with_replay_key(
+                    request,
+                    RequestStatus::WaitingForRemoteKv,
+                    None,
+                );
                 if request.sequence.current_known_blocks() > self.args.num_gpu_blocks {
                     anyhow::bail!("destination prompt exceeds the KV pool capacity");
                 }
@@ -858,13 +867,21 @@ impl VllmCore {
         max_output_tokens.min(kv_remaining).min(model_remaining)
     }
 
-    fn submit(&mut self, mut request: DirectRequest) -> anyhow::Result<Uuid> {
+    fn submit_with_replay_key(
+        &mut self,
+        mut request: DirectRequest,
+        replay_request_key: Option<ReplayRequestKey>,
+    ) -> anyhow::Result<Uuid> {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         request.uuid = Some(uuid);
         if self.state.requests.contains_key(&uuid) {
             anyhow::bail!("request {uuid} is already active");
         }
-        let request = self.make_request_state(request, RequestStatus::Waiting);
+        let request = self.make_request_state_with_replay_key(
+            request,
+            RequestStatus::Waiting,
+            replay_request_key,
+        );
         self.state.insert_waiting(uuid, request);
         if let Some(request) = self.state.requests.get(&uuid) {
             request.debug_assert_progress(uuid);
@@ -872,10 +889,11 @@ impl VllmCore {
         Ok(uuid)
     }
 
-    fn make_request_state(
+    fn make_request_state_with_replay_key(
         &self,
         request: DirectRequest,
         status: RequestStatus,
+        replay_request_key: Option<ReplayRequestKey>,
     ) -> VllmRequestState {
         let uuid = request.uuid.unwrap_or_else(Uuid::new_v4);
         let prompt_len = request.tokens.len();
@@ -934,6 +952,7 @@ impl VllmCore {
             )
         };
         VllmRequestState {
+            replay_request_key,
             sequence,
             status,
             num_computed_tokens: 0,
@@ -1483,7 +1502,7 @@ impl VllmCore {
         let max_num_running = self.args.max_num_seqs.unwrap_or(usize::MAX);
         let scheduling_policy = self.args.scheduling_policy();
         let admission = AdmissionInvariant::new(self.pending_destinations.has_pending());
-        let mut rejected_uuids: Vec<Uuid> = Vec::new();
+        let mut rejected_requests: Vec<(Uuid, Option<ReplayRequestKey>)> = Vec::new();
         while !preempted_any && self.state.running.len() < max_num_running {
             let prefer_materialized = matches!(
                 admission.stage_for(false),
@@ -1565,7 +1584,12 @@ impl VllmCore {
                         num_gpu_blocks = self.args.num_gpu_blocks,
                         "rejecting request that exceeds a worker admission limit"
                     );
-                    rejected_uuids.push(uuid);
+                    let replay_request_key = self
+                        .state
+                        .requests
+                        .get(&uuid)
+                        .and_then(|request| request.replay_request_key);
+                    rejected_requests.push((uuid, replay_request_key));
                     self.drop_request(uuid);
                     continue;
                 }
@@ -1614,19 +1638,22 @@ impl VllmCore {
         let (decode_time, mut output_signals, accept_length) = self.emit_ready_tokens()?;
         // Emit the terminal signals for the requests the gate rejected above
         // (see the gate comment for why this can't be done inline).
-        for uuid in rejected_uuids {
-            output_signals.push(OutputSignal {
-                uuid,
-                token_id: None,
-                completed: true,
-                rejected: true,
-                handoff_delay_ms: None,
-            });
+        for (uuid, replay_request_key) in rejected_requests {
+            output_signals.push(
+                OutputSignal {
+                    uuid,
+                    token_id: None,
+                    completed: true,
+                    rejected: true,
+                    handoff_delay_ms: None,
+                },
+                replay_request_key,
+            )?;
         }
         #[cfg(debug_assertions)]
         debug_assert_eq!(
             (accept_length.output_tokens, accept_length.decode_forwards),
-            crate::scheduler::accept_length_sample(&output_signals)
+            crate::scheduler::accept_length_sample(output_signals.as_slice())
         );
         let token_completion_ms = decode_start_ms + decode_time.as_secs_f64() * 1000.0;
         #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
@@ -2175,7 +2202,7 @@ impl VllmCore {
     #[cfg_attr(feature = "profile", inline(never))]
     fn emit_ready_tokens(
         &mut self,
-    ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
+    ) -> anyhow::Result<(Duration, EngineOutputs, AcceptLengthSample)> {
         let mut ready = Vec::with_capacity(self.state.running.len());
         let mut already_complete = Vec::new();
         let mut total_length = 0usize;
@@ -2196,7 +2223,12 @@ impl VllmCore {
                 );
                 let effects = split_terminal_effects(request.sequence.terminal_signals());
                 debug_assert!(effects.immediate.is_empty());
-                already_complete.push((uuid, handoff_delay_ms, effects.cleanup));
+                already_complete.push((
+                    uuid,
+                    request.replay_request_key,
+                    handoff_delay_ms,
+                    effects.cleanup,
+                ));
                 continue;
             }
             ready.push(uuid);
@@ -2205,16 +2237,19 @@ impl VllmCore {
 
         // Requests already terminal after prefill must release their running slots
         // without manufacturing an output token.
-        let mut output_signals = Vec::with_capacity(already_complete.len() + ready.len());
-        for (uuid, handoff_delay_ms, cleanup) in already_complete {
+        let mut output_signals = EngineOutputs::with_capacity(already_complete.len() + ready.len());
+        for (uuid, replay_request_key, handoff_delay_ms, cleanup) in already_complete {
             self.complete_source(uuid, cleanup);
-            output_signals.push(OutputSignal {
-                uuid,
-                token_id: None,
-                completed: true,
-                rejected: false,
-                handoff_delay_ms,
-            });
+            output_signals.push(
+                OutputSignal {
+                    uuid,
+                    token_id: None,
+                    completed: true,
+                    rejected: false,
+                    handoff_delay_ms,
+                },
+                replay_request_key,
+            )?;
         }
 
         if ready.is_empty() {
@@ -2229,14 +2264,11 @@ impl VllmCore {
         }
 
         if self.speculative_sampler.is_some() {
-            if output_signals.is_empty() {
-                return self.emit_speculative_ready_tokens(ready);
+            if !output_signals.is_empty() {
+                self.state.compact_running();
             }
-
-            self.state.compact_running();
-            let (decode_time, mut speculative_signals, accept_length) =
-                self.emit_speculative_ready_tokens(ready)?;
-            output_signals.append(&mut speculative_signals);
+            let (decode_time, accept_length) =
+                self.emit_speculative_ready_tokens(ready, &mut output_signals)?;
             return Ok((decode_time, output_signals, accept_length));
         }
 
@@ -2343,16 +2375,20 @@ impl VllmCore {
                 continue;
             }
 
-            let handoff_delay_ms = self.state.requests.get(&uuid).and_then(|request| {
-                request.debug_assert_progress(uuid);
-                compute_prefill_handoff_delay_ms(
-                    self.args.worker_type,
-                    completed,
-                    request.sequence.num_input_tokens(),
-                    self.args.kv_transfer_bandwidth,
-                    self.args.kv_bytes_per_token,
-                )
-            });
+            let request = self
+                .state
+                .requests
+                .get(&uuid)
+                .ok_or_else(|| anyhow::anyhow!("vLLM missing request state for {uuid}"))?;
+            request.debug_assert_progress(uuid);
+            let replay_request_key = request.replay_request_key;
+            let handoff_delay_ms = compute_prefill_handoff_delay_ms(
+                self.args.worker_type,
+                completed,
+                request.sequence.num_input_tokens(),
+                self.args.kv_transfer_bandwidth,
+                self.args.kv_bytes_per_token,
+            );
             let output_signal = OutputSignal {
                 uuid,
                 token_id: emitted_token_id,
@@ -2364,7 +2400,7 @@ impl VllmCore {
                 self.complete_source(uuid, deferred_deref);
                 running_changed = true;
             }
-            output_signals.push(output_signal);
+            output_signals.push(output_signal, replay_request_key)?;
             accept_length.record_forward(1);
         }
 
@@ -2384,7 +2420,8 @@ impl VllmCore {
     fn emit_speculative_ready_tokens(
         &mut self,
         mut ready: Vec<Uuid>,
-    ) -> anyhow::Result<(Duration, Vec<OutputSignal>, AcceptLengthSample)> {
+        output_signals: &mut EngineOutputs,
+    ) -> anyhow::Result<(Duration, AcceptLengthSample)> {
         let max_burst = if self.args.worker_type == WorkerType::Prefill {
             1
         } else {
@@ -2395,7 +2432,7 @@ impl VllmCore {
         };
         for uuid in ready.iter().copied() {
             if self.refresh_request_offload_dependency(uuid).is_some() {
-                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
+                return Ok((Duration::ZERO, AcceptLengthSample::default()));
             }
         }
         let mut running_changed = false;
@@ -2434,7 +2471,7 @@ impl VllmCore {
                             .expect("speculative dependency request must remain active");
                         request.offload_dependency = dependency;
                     }
-                    return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
+                    return Ok((Duration::ZERO, AcceptLengthSample::default()));
                 }
                 G1Acquire::RetryNow { .. } => {
                     panic!("speculative reservation must consume bounded RetryNow internally")
@@ -2446,7 +2483,7 @@ impl VllmCore {
                 if running_changed {
                     self.state.compact_running();
                 }
-                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
+                return Ok((Duration::ZERO, AcceptLengthSample::default()));
             };
             running_changed = true;
             self.finish_preemption(preempted);
@@ -2464,7 +2501,7 @@ impl VllmCore {
             }
             if ready.is_empty() {
                 self.state.compact_running();
-                return Ok((Duration::ZERO, Vec::new(), AcceptLengthSample::default()));
+                return Ok((Duration::ZERO, AcceptLengthSample::default()));
             }
         };
 
@@ -2510,15 +2547,14 @@ impl VllmCore {
                     } else {
                         sampler.sample_output_tokens(remaining)
                     };
-                    (*uuid, burst)
+                    (*uuid, burst, request.replay_request_key)
                 })
                 .collect::<Vec<_>>()
         };
 
-        let mut output_signals =
-            Vec::with_capacity(sampled_bursts.iter().map(|(_, burst)| *burst).sum());
+        output_signals.reserve(sampled_bursts.iter().map(|(_, burst, _)| *burst).sum());
         let mut accept_length = AcceptLengthSample::default();
-        for (uuid, burst) in sampled_bursts {
+        for (uuid, burst, replay_request_key) in sampled_bursts {
             let mut emitted_tokens = 0usize;
             let mut completed = false;
             let mut deferred_deref = Vec::new();
@@ -2589,19 +2625,22 @@ impl VllmCore {
                     }
                     request.sequence.num_input_tokens()
                 };
-                output_signals.push(OutputSignal {
-                    uuid,
-                    token_id: Some(token_id),
-                    completed: is_complete,
-                    rejected: false,
-                    handoff_delay_ms: compute_prefill_handoff_delay_ms(
-                        self.args.worker_type,
-                        is_complete,
-                        prompt_tokens,
-                        self.args.kv_transfer_bandwidth,
-                        self.args.kv_bytes_per_token,
-                    ),
-                });
+                output_signals.push(
+                    OutputSignal {
+                        uuid,
+                        token_id: Some(token_id),
+                        completed: is_complete,
+                        rejected: false,
+                        handoff_delay_ms: compute_prefill_handoff_delay_ms(
+                            self.args.worker_type,
+                            is_complete,
+                            prompt_tokens,
+                            self.args.kv_transfer_bandwidth,
+                            self.args.kv_bytes_per_token,
+                        ),
+                    },
+                    replay_request_key,
+                )?;
                 emitted_tokens += 1;
                 if is_complete {
                     completed = true;
@@ -2636,7 +2675,7 @@ impl VllmCore {
         if running_changed {
             self.state.compact_running();
         }
-        Ok((decode_time, output_signals, accept_length))
+        Ok((decode_time, accept_length))
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1588,7 +1588,8 @@ impl VllmCore {
                         .state
                         .requests
                         .get(&uuid)
-                        .and_then(|request| request.replay_request_key);
+                        .expect("rejected waiting request must remain active")
+                        .replay_request_key;
                     rejected_requests.push((uuid, replay_request_key));
                     self.drop_request(uuid);
                     continue;
@@ -1648,7 +1649,7 @@ impl VllmCore {
                     handoff_delay_ms: None,
                 },
                 replay_request_key,
-            )?;
+            );
         }
         #[cfg(debug_assertions)]
         debug_assert_eq!(
@@ -2249,7 +2250,7 @@ impl VllmCore {
                     handoff_delay_ms,
                 },
                 replay_request_key,
-            )?;
+            );
         }
 
         if ready.is_empty() {
@@ -2400,7 +2401,7 @@ impl VllmCore {
                 self.complete_source(uuid, deferred_deref);
                 running_changed = true;
             }
-            output_signals.push(output_signal, replay_request_key)?;
+            output_signals.push(output_signal, replay_request_key);
             accept_length.record_forward(1);
         }
 
@@ -2640,7 +2641,7 @@ impl VllmCore {
                         ),
                     },
                     replay_request_key,
-                )?;
+                );
                 emitted_tokens += 1;
                 if is_complete {
                     completed = true;

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -651,7 +651,7 @@ mod vllm {
         let mut collector = crate::replay::TraceCollector::default();
         let pass = core.execute_pass(&mut collector, 0.0);
         for (uuid, expected_token) in [(first, 4), (second, 104)] {
-            assert!(pass.output_signals.iter().any(|signal| {
+            assert!(pass.output_signals.as_slice().iter().any(|signal| {
                 signal.uuid == uuid
                     && signal.token_id == Some(expected_token)
                     && !signal.completed
@@ -668,7 +668,7 @@ mod vllm {
 
         let next_pass = core.execute_pass(&mut collector, pass.end_ms);
         for (uuid, expected_token) in [(first, 5), (second, 105)] {
-            assert!(next_pass.output_signals.iter().any(|signal| {
+            assert!(next_pass.output_signals.as_slice().iter().any(|signal| {
                 signal.uuid == uuid
                     && signal.token_id == Some(expected_token)
                     && !signal.completed
@@ -713,7 +713,7 @@ mod vllm {
         });
         let seed_pass = core.execute_pass(&mut collector, 0.0);
         assert!(
-            seed_pass.output_signals.iter().any(|signal| {
+            seed_pass.output_signals.as_slice().iter().any(|signal| {
                 signal.uuid == seed
                     && signal.token_id == Some(8)
                     && signal.completed
@@ -740,6 +740,7 @@ mod vllm {
         assert!(
             unrelated_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == unrelated && signal.completed)
         );
@@ -804,6 +805,7 @@ mod vllm {
 
         assert!(
             pass.output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == uuid && signal.completed && signal.rejected)
         );
@@ -878,6 +880,7 @@ mod vllm {
         assert_eq!(pass.output_signals.len(), 3);
         assert!(
             pass.output_signals
+                .as_slice()
                 .iter()
                 .take(2)
                 .all(|signal| !signal.completed)
@@ -1094,11 +1097,7 @@ mod trtllm {
             // the core over-admit.
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms.max(now_ms + 1.0);
-            completed += pass
-                .output_signals
-                .iter()
-                .filter(|signal| signal.completed)
-                .count();
+            completed += pass.output_signals.completed_count();
             max_preemptions = max_preemptions.max(pass.mocker_metrics.vllm_preemptions_total);
         }
 
@@ -1188,11 +1187,7 @@ mod trtllm {
             }
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms.max(now_ms + 1.0);
-            completed += pass
-                .output_signals
-                .iter()
-                .filter(|signal| signal.completed)
-                .count();
+            completed += pass.output_signals.completed_count();
         }
         completed
     }
@@ -1333,6 +1328,7 @@ mod trtllm {
             now_ms = pass.end_ms.max(now_ms + 1.0);
             if pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == valid && signal.completed)
             {
@@ -1377,7 +1373,7 @@ mod trtllm {
             }
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms.max(now_ms + 1.0);
-            for signal in pass.output_signals.iter() {
+            for signal in pass.output_signals.as_slice() {
                 if signal.uuid == oversized && signal.completed && signal.rejected {
                     oversized_rejected = true;
                 }
@@ -1438,6 +1434,7 @@ mod trtllm {
         );
         assert!(
             pass.output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == reuser && signal.completed && signal.rejected),
             "reuser's 10-block footprint can never fit the 8-block pool (reused prefix is still \

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -838,7 +838,7 @@ mod vllm {
         let pass = core.execute_pass(&mut collector, 0.0);
 
         assert_eq!(pass.output_signals.len(), 1);
-        let terminal = &pass.output_signals[0];
+        let terminal = &pass.output_signals.as_slice()[0];
         assert_eq!(terminal.uuid, uuid);
         assert!(terminal.token_id.is_some());
         assert!(terminal.completed);
@@ -882,7 +882,7 @@ mod vllm {
                 .take(2)
                 .all(|signal| !signal.completed)
         );
-        let terminal = pass.output_signals.last().unwrap();
+        let terminal = pass.output_signals.as_slice().last().unwrap();
         assert!(terminal.completed);
         assert!(!terminal.rejected);
         assert!(!core.state().requests.contains_key(&uuid));
@@ -1377,7 +1377,7 @@ mod trtllm {
             }
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms.max(now_ms + 1.0);
-            for signal in &pass.output_signals {
+            for signal in pass.output_signals.iter() {
                 if signal.uuid == oversized && signal.completed && signal.rejected {
                     oversized_rejected = true;
                 }

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -21,7 +21,8 @@ use crate::kv_manager::G1Acquire;
 use crate::scheduler::SchedulerHandle;
 use crate::scheduler::test_utils::{RouterIndexerHarness, removed_event_count, stored_hashes};
 use crate::scheduler::{
-    RouterEventVisibility, SchedulerCommand, SchedulerCommandResult, SchedulerLifecycleEvent,
+    EngineRequest, ReplayRequestKey, RouterEventVisibility, SchedulerCommand,
+    SchedulerCommandResult, SchedulerLifecycleEvent,
 };
 
 use super::core::{RequestStatus, VllmCore, VllmRequestState};
@@ -368,6 +369,7 @@ fn speculative_batch_drains_zero_output_before_emitting_tokens() {
     assert_eq!(pass.completed_requests, 2);
     assert_eq!(
         pass.output_signals
+            .as_slice()
             .iter()
             .filter(|signal| signal.uuid == zero_uuid && signal.token_id.is_none())
             .count(),
@@ -375,6 +377,7 @@ fn speculative_batch_drains_zero_output_before_emitting_tokens() {
     );
     assert_eq!(
         pass.output_signals
+            .as_slice()
             .iter()
             .filter(|signal| signal.uuid == normal_uuid && signal.token_id.is_some())
             .count(),
@@ -853,6 +856,7 @@ mod destination_lifecycle {
             now_ms = pass.end_ms;
             if pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == blocker_uuid && signal.completed)
             {
@@ -929,6 +933,7 @@ mod destination_lifecycle {
         assert!(
             blocker_terminal
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == activation_blocker_uuid && signal.completed)
         );
@@ -957,6 +962,7 @@ mod destination_lifecycle {
         assert!(
             terminal
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == logical_uuid && signal.completed)
         );
@@ -1247,7 +1253,12 @@ mod core_behavior {
         core.execute_pass(&mut collector, 0.0);
         let pass = core.execute_pass(&mut collector, 1.0);
 
-        assert!(pass.output_signals.iter().any(|signal| signal.uuid == r1));
+        assert!(
+            pass.output_signals
+                .as_slice()
+                .iter()
+                .any(|signal| signal.uuid == r1)
+        );
         assert_eq!(
             core.state.requests.get(&r2).unwrap().num_computed_tokens,
             0,
@@ -1499,6 +1510,7 @@ mod core_behavior {
         assert!(
             pass1
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == holder && signal.completed)
         );
@@ -1538,25 +1550,40 @@ mod core_behavior {
         let mut core = VllmCore::new(args);
         let oversized = Uuid::from_u128(1);
         let follower = Uuid::from_u128(2);
+        let mut replay_keys = slotmap::SlotMap::<ReplayRequestKey, ()>::with_key();
+        let mut oversized_key = None;
         for (uuid, range) in [(oversized, 0u32..20u32), (follower, 100u32..104u32)] {
-            core.receive(DirectRequest {
-                tokens: range.collect(),
-                max_output_tokens: 1,
-                output_token_ids: None,
-                uuid: Some(uuid),
-                dp_rank: 0,
-                arrival_timestamp_ms: None,
-                ..Default::default()
-            });
+            let key = replay_keys.insert(());
+            if uuid == oversized {
+                oversized_key = Some(key);
+            }
+            core.receive_engine(EngineRequest::for_replay(
+                DirectRequest {
+                    tokens: range.collect(),
+                    max_output_tokens: 1,
+                    output_token_ids: None,
+                    uuid: Some(uuid),
+                    dp_rank: 0,
+                    arrival_timestamp_ms: None,
+                    ..Default::default()
+                },
+                key,
+            ))
+            .unwrap();
         }
 
         let mut collector = crate::replay::TraceCollector::default();
         let pass = core.execute_pass(&mut collector, 0.0);
 
-        assert!(
-            pass.output_signals
-                .iter()
-                .any(|signal| { signal.uuid == oversized && signal.completed && signal.rejected })
+        let oversized_index = pass
+            .output_signals
+            .as_slice()
+            .iter()
+            .position(|signal| signal.uuid == oversized && signal.completed && signal.rejected)
+            .unwrap();
+        assert_eq!(
+            pass.output_signals.replay_key_at(oversized_index),
+            oversized_key
         );
         assert!(
             pass.admissions
@@ -1704,6 +1731,7 @@ mod core_behavior {
         let pass = core.execute_pass(&mut collector, first.end_ms);
         let ordered = pass
             .output_signals
+            .as_slice()
             .iter()
             .map(|signal| (signal.uuid, signal.completed))
             .collect::<Vec<_>>();
@@ -3245,6 +3273,7 @@ mod offload {
         assert!(
             sampled_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == blocked),
             "sampling must not acquire the dangling token's new block"
@@ -3259,6 +3288,7 @@ mod offload {
         assert!(
             blocked_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .all(|signal| signal.uuid != blocked),
             "the sampled token must wait before computation when its block cannot be acquired"
@@ -3266,6 +3296,7 @@ mod offload {
         assert!(
             blocked_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == unrelated),
             "the unrelated running request should continue"
@@ -3291,6 +3322,7 @@ mod offload {
         assert!(
             resumed
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == blocked),
             "decode must resume after its exact offload dependency terminates"
@@ -3355,6 +3387,7 @@ mod offload {
         assert_eq!(
             resumed
                 .output_signals
+                .as_slice()
                 .iter()
                 .filter(|signal| signal.uuid == blocked)
                 .count(),
@@ -3363,6 +3396,7 @@ mod offload {
         assert_eq!(
             resumed
                 .output_signals
+                .as_slice()
                 .iter()
                 .filter(|signal| signal.uuid == unrelated)
                 .count(),
@@ -3449,6 +3483,7 @@ mod offload {
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms;
             pass.output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == cached_uuid && signal.completed)
         });
@@ -3468,6 +3503,7 @@ mod offload {
         assert!(
             blocker_pass
                 .output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == blocker_uuid && !signal.completed)
         );
@@ -4419,6 +4455,7 @@ mod offload {
             let pass = core.execute_pass(&mut collector, now_ms);
             now_ms = pass.end_ms;
             pass.output_signals
+                .as_slice()
                 .iter()
                 .any(|signal| signal.uuid == cached_uuid && signal.completed)
         });

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -429,7 +429,7 @@ mod source_holds {
         .unwrap();
 
         let first = execute(&mut core, 0.0);
-        assert!(!first.output_signals[0].completed);
+        assert!(!first.output_signals.as_slice()[0].completed);
         let active_before_terminal = core.kv_manager.num_active_blocks();
         assert!(active_before_terminal > 0);
         let expected_held_blocks = core.state.requests[&request_id]
@@ -438,7 +438,7 @@ mod source_holds {
             .div_ceil(core.args.block_size);
 
         let terminal = execute(&mut core, first.end_ms);
-        assert!(terminal.output_signals[0].completed);
+        assert!(terminal.output_signals.as_slice()[0].completed);
         assert!(matches!(
             terminal.lifecycle_events.as_slice(),
             [SchedulerLifecycleEvent::SourceHeld {
@@ -502,7 +502,7 @@ mod source_holds {
 
         let first = execute(&mut core, 0.0);
         let terminal = execute(&mut core, first.end_ms);
-        assert!(terminal.output_signals[0].completed);
+        assert!(terminal.output_signals.as_slice()[0].completed);
         assert!(!core.source_is_held(second_id));
         assert_eq!(core.kv_manager.num_active_blocks(), 0);
     }
@@ -1130,6 +1130,8 @@ mod core_behavior {
             let pass = core.execute_pass(&mut collector, step as f64);
             emitted.extend(
                 pass.output_signals
+                    .into_untracked()
+                    .unwrap()
                     .into_iter()
                     .filter(|signal| signal.uuid == uuid)
                     .map(|signal| signal.token_id.expect("planned token should be present")),
@@ -1344,6 +1346,7 @@ mod core_behavior {
         let pass = core.execute_pass(&mut collector, 0.0);
         let signal = pass
             .output_signals
+            .as_slice()
             .first()
             .expect("prefill pass should emit one completed signal");
 
@@ -1369,8 +1372,8 @@ mod core_behavior {
         let pass = core.execute_pass(&mut collector, 0.0);
 
         assert_eq!(pass.output_signals.len(), 1);
-        assert_eq!(pass.output_signals[0].uuid, uuid);
-        assert!(!pass.output_signals[0].completed);
+        assert_eq!(pass.output_signals.as_slice()[0].uuid, uuid);
+        assert!(!pass.output_signals.as_slice()[0].completed);
         assert_eq!(
             core.state
                 .requests
@@ -1615,6 +1618,7 @@ mod core_behavior {
         core.state.requests.insert(
             uuid,
             VllmRequestState {
+                replay_request_key: None,
                 sequence: RequestKvState::kvbm(sequence),
                 status: RequestStatus::Running,
                 num_computed_tokens: 9,
@@ -3142,6 +3146,7 @@ mod offload {
         core.state.requests.insert(
             uuid,
             VllmRequestState {
+                replay_request_key: None,
                 sequence: RequestKvState::kvbm(sequence),
                 status: RequestStatus::Running,
                 num_computed_tokens,


### PR DESCRIPTION
## Overview

This PR removes the per-token UUID hash-map lookup from aggregate offline replay while keeping live and disaggregated output publication on their existing untracked path. The radix-tree optimization previously included here has moved to an independent PR.

## Summary

- Carry one private optional `ReplayRequestKey` through the existing engine request path and preserve complete backend request-ID validation.
- Store aggregate replay state in a generational `SlotMap`; retain the UUID index only for routing, admission, duplicate detection, and validated terminal removal.
- Keep `EngineOutputs` small: the original `Vec<OutputSignal>` plus private `Empty`, `Untracked`, `Tracked`, and `Mixed` bookkeeping. Appends are infallible; release builds reject mixed tracking, missing keys, stale/reused keys, UUID mismatches, and tracked outputs at live/disaggregated publication boundaries.
- Derive the first nonterminal prefill transition from runtime-owned state, including tokenless nonterminal signals. A first-and-terminal request still skips `prefill_completed`.
- Move the original output vector directly through live and disaggregated publication with no wrapper conversion or replacement allocation.
- Reject duplicate active UUIDs before observable side effects in aggregate and disaggregated replay.
- Preserve output order, speculative bursts, live suppression, attention-DP payloads, one-token completion behavior, and public replay/event formats.

The final diff is 1,025 additions and 311 deletions across 22 files. The follow-up review fix is 303 additions and 176 deletions; it replaces fallible post-mutation output appends and split validation/removal paths instead of adding another tracking abstraction. The obsolete marker-index machinery, wrapper traits, tracked-retain path, and every KV-router change remain gone.

## Details

Each aggregate output carries its request's private generational key in a sidecar aligned with the original signal vector. Nonterminal processing validates the slot and its UUID directly in O(1), without hashing the reverse UUID index. Terminal processing validates both indexes and removes the request before collector, placement, admission, or routing callbacks; index corruption is returned as an error without partially mutating either index.

Live and disaggregated paths never create replay keys. Their publication boundaries call `into_untracked()`, which rejects unexpected metadata and returns the owned `Vec<OutputSignal>` directly. vLLM also fails immediately if request state disappears while generating outputs.

No public API, configuration, event format, scheduling policy, or simulation behavior changes.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/mod.rs` for `EngineRequest` and the compact `EngineOutputs` sidecar.
- `lib/mocker/src/replay/offline/agg.rs` for aggregate `SlotMap` state and output validation.
- `lib/mocker/src/scheduler/vllm/core.rs` and `lib/mocker/src/scheduler/sglang/core.rs` for backend key propagation and request-ID checks.

## Related Issues

None.

## Validation

### Source validation

- `cargo test -p dynamo-mocker replay::offline` — 192 passed
- `cargo test -p dynamo-mocker` — 721 passed
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` — 194 passed; the exact base reproduces the same two existing failures:
  - `busy_worker_advances_offload_without_destination_admission`
  - `aggregated_canonical_evidence_covers_real_kvbm_lifecycle`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --features aic-forward-pass`
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Focused coverage includes duplicate insertion and bidirectional index integrity, completed stale/reused/UUID-mismatched keys before callbacks, mixed-boundary rejection after infallible appends, propagated live-suppression errors, vLLM rejection metadata, nonzero completion-batch counters, zero-copy untracked publication, tokenless nonterminal output, first-and-terminal completion, speculative output, attention-DP propagation, and both scheduler backends.

### Canonical correctness parity

The full correctness-parity protocol passed between exact base `038c642b56a01b0afddd8c194565526faae35d26` and final head `88cefb8f710248b09fd8a10e6c827e3e6665e397`. The preserved two-process base half and a freshly run two-process final-head half cover 16 reports across aggregate/disaggregated SGLang and native-vLLM KVBM. Every report completed 5,000 requests, each final pair was byte-identical, and every final canonical report was byte-identical to its preserved base counterpart.

| Row | Canonical SHA-256 | Pressure coverage |
| --- | --- | --- |
| SGLang aggregate | `84d13ec294115d63621805ceaa37e38c4069c38028ceac0b023f0c7b1a7d8a11` | KV overlap and immediate/queued placement |
| SGLang disaggregated | `ed7f2268248c118ed6b9aba7bd47f8c0d7476d4be968bda07097fab23a5a86a6` | 5,000 handoffs; 12 bounded retractions |
| vLLM KVBM aggregate | `079e11aeb65a19d0cb2dcf516e517ae88c8e4733170a2cb413d6281fcd3469c5` | 2 preemptions; nonzero G1/G2 activity |
| vLLM KVBM disaggregated | `f9e3924ad429da3ddeed49919092343f49c8c5e1426e89ddd8b7a8cb1f113cf0` | 5,000 handoffs; 1 preemption; nonzero G1/G2 activity |

### Astra vLLM point comparison

Ordinary release builds used AIConfigurator `0fa09bb7b5`, 12 aggregate vLLM workers pinned to CPU 0, B200 TP4/attention-DP1 and MoE TP1/EP4, 64-token pages, 4,096-token batching/chunking, prefix caching, KV routing/events, and the 187,906-request 2x Astra trace (`b7b2e3dccb90...`). There were no warm-ups. Preflight was 99.67–100% idle on CPU 0.

| Revision | Wall | Processed tok/s | vs. base | vs. pre-fix |
| --- | ---: | ---: | ---: | ---: |
| Base `038c642b56` | 60.149 s | 42.907 M | — | — |
| Pre-fix `de5f5c86c9` | 57.595 s | 44.810 M | +4.43% | — |
| Final `88cefb8f71` | 57.376 s | 44.981 M | **+4.83%** | +0.38% |

All three reports completed 187,906 requests with 2,401,594,588 input tokens, 179,237,676 output tokens, and 2,580,832,264 processed tokens. These are CPU-0 point comparisons, not a statistical-significance claim; routing-induced cache reuse varied from 41.829% to 42.162%.

The final extension SHA-256 is `9b1d5dcb623f8f1eb44377ac6193c409c5f8d880f9ddf024bb019a7726e008bb` (ELF build ID `aadd75e6ff872a1bf15dff7db33588c5af252e65`); the preserved base extension SHA-256 is `a0f9ab62861164069308f6388fb9e8b3c2ba2e269bf0b4c167e56712bb36b6ca`.

### Structural hot-path confirmation

- Aggregate nonterminal outputs validate `ReplayRequestKey` directly in the `SlotMap`; the UUID index is not consulted per token.
- Live and disaggregated boundaries consume the owned signal vector through `into_untracked()` and reject any sidecar, so no conversion allocation is introduced.
- The prior profile's removed per-token UUID hashing remains absent; this rewrite removes wrapper/marker scaffolding without restoring that call path.
