### PR TITLE
fix: validation for pre-tokenized nvext.token_data

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -913,39 +913,32 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         request_input = self.input_param_manager.get_input_param(
             request, use_tokenizer=self.use_sglang_tokenizer
         )
-        if not isinstance(request_input, str):
-            self._validate_nvext_token_data(request, request_input)
+        self._validate_nvext_token_data(request, request_input)
 
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
 
     @staticmethod
-    def _resolve_max_input_token_id(engine: sgl.Engine) -> int:
-        """Resolve the largest token ID accepted by the model or tokenizer.
+    def _resolve_max_input_token_id(engine: sgl.Engine) -> Optional[int]:
+        """Resolve the largest token ID accepted by the model embedding table."""
+        tokenizer_manager = getattr(engine, "tokenizer_manager", None)
+        model_config = getattr(tokenizer_manager, "model_config", None)
+        model_vocab_size: object = getattr(model_config, "vocab_size", None)
 
-        Model and tokenizer vocabularies can differ. Matching vLLM's input
-        validation, accept the larger bound so model-only tokens and tokenizer
-        additions remain usable while truly out-of-vocabulary IDs are rejected.
-        """
-        tokenizer_manager = engine.tokenizer_manager
-        model_vocab_size = tokenizer_manager.model_config.hf_text_config.vocab_size
-        tokenizer = tokenizer_manager.tokenizer
-        tokenizer_max_token_id = -1
+        # Compatibility fallback for SGLang model configs that expose the
+        # Hugging Face text config but not the derived vocab_size attribute.
+        if model_vocab_size is None:
+            hf_text_config = getattr(model_config, "hf_text_config", None)
+            model_vocab_size = getattr(hf_text_config, "vocab_size", None)
 
-        if tokenizer is not None:
-            tokenizer_max_token_id = getattr(tokenizer, "max_token_id", None)
-            if tokenizer_max_token_id is None:
-                get_vocab = getattr(tokenizer, "get_vocab", None)
-                if get_vocab is not None:
-                    tokenizer_max_token_id = max(
-                        get_vocab().values(),
-                        default=-1,
-                    )
-                else:
-                    tokenizer_max_token_id = tokenizer.vocab_size - 1
-
-        return max(model_vocab_size - 1, tokenizer_max_token_id)
+        if (
+            isinstance(model_vocab_size, bool)
+            or not isinstance(model_vocab_size, int)
+            or model_vocab_size <= 0
+        ):
+            return None
+        return model_vocab_size - 1
 
     def _validate_nvext_token_data(
         self,
@@ -962,15 +955,17 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
 
         if not isinstance(token_ids, list):
             raise HttpError(400, "nvext.token_data must resolve to a token ID list")
-        if not token_ids:
-            return
+        if self._max_input_token_id is None:
+            raise HttpError(400, "Unable to validate nvext.token_data for this model")
 
-        max_input_id = max(token_ids)
-        if (
-            self._max_input_token_id is not None
-            and max_input_id > self._max_input_token_id
-        ):
-            raise HttpError(400, f"Token id {max_input_id} is out of vocabulary")
+        for index, token_id in enumerate(token_ids):
+            if isinstance(token_id, bool) or not isinstance(token_id, int):
+                raise HttpError(
+                    400,
+                    f"nvext.token_data[{index}] must be an integer token ID",
+                )
+            if token_id < 0 or token_id > self._max_input_token_id:
+                raise HttpError(400, f"Token id {token_id} is out of vocabulary")
 
     @staticmethod
     def _get_guided_decoding_params(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -31,6 +31,7 @@ from dynamo.common.utils.endpoint_types import parse_endpoint_types
 from dynamo.common.utils.input_params import InputParamManager
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import (
+    HttpError,
     KvEventPublisher,
     ModelInput,
     ModelType,
@@ -568,8 +569,10 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         self.serving_mode = config.serving_mode
         self.use_sglang_tokenizer = config.dynamo_args.use_sglang_tokenizer
         self.enable_trace = getattr(config.server_args, "enable_trace", False)
+        self._max_input_token_id: Optional[int] = None
 
         if engine is not None:
+            self._max_input_token_id = self._resolve_max_input_token_id(engine)
             self.input_param_manager = InputParamManager(
                 self.engine.tokenizer_manager.tokenizer
                 if self.use_sglang_tokenizer
@@ -910,10 +913,64 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         request_input = self.input_param_manager.get_input_param(
             request, use_tokenizer=self.use_sglang_tokenizer
         )
+        if not isinstance(request_input, str):
+            self._validate_nvext_token_data(request, request_input)
 
         return {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
+
+    @staticmethod
+    def _resolve_max_input_token_id(engine: sgl.Engine) -> int:
+        """Resolve the largest token ID accepted by the model or tokenizer.
+
+        Model and tokenizer vocabularies can differ. Matching vLLM's input
+        validation, accept the larger bound so model-only tokens and tokenizer
+        additions remain usable while truly out-of-vocabulary IDs are rejected.
+        """
+        tokenizer_manager = engine.tokenizer_manager
+        model_vocab_size = tokenizer_manager.model_config.hf_text_config.vocab_size
+        tokenizer = tokenizer_manager.tokenizer
+        tokenizer_max_token_id = -1
+
+        if tokenizer is not None:
+            tokenizer_max_token_id = getattr(tokenizer, "max_token_id", None)
+            if tokenizer_max_token_id is None:
+                get_vocab = getattr(tokenizer, "get_vocab", None)
+                if get_vocab is not None:
+                    tokenizer_max_token_id = max(
+                        get_vocab().values(),
+                        default=-1,
+                    )
+                else:
+                    tokenizer_max_token_id = tokenizer.vocab_size - 1
+
+        return max(model_vocab_size - 1, tokenizer_max_token_id)
+
+    def _validate_nvext_token_data(
+        self,
+        request: Dict[str, Any],
+        token_ids: Any,
+    ) -> None:
+        """Reject out-of-vocabulary IDs supplied through ``nvext.token_data``."""
+        extra_args = request.get("extra_args")
+        if not isinstance(extra_args, dict):
+            return
+        nvext = extra_args.get("nvext")
+        if not isinstance(nvext, dict) or nvext.get("token_in") is not True:
+            return
+
+        if not isinstance(token_ids, list):
+            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
+        if not token_ids:
+            return
+
+        max_input_id = max(token_ids)
+        if (
+            self._max_input_token_id is not None
+            and max_input_id > self._max_input_token_id
+        ):
+            raise HttpError(400, f"Token id {max_input_id} is out of vocabulary")
 
     @staticmethod
     def _get_guided_decoding_params(

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -924,6 +924,14 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         """Resolve the largest token ID accepted by the model embedding table."""
         tokenizer_manager = getattr(engine, "tokenizer_manager", None)
         model_config = getattr(tokenizer_manager, "model_config", None)
+        return BaseWorkerHandler._resolve_max_input_token_id_from_model_config(
+            model_config
+        )
+
+    @staticmethod
+    def _resolve_max_input_token_id_from_model_config(
+        model_config: Any,
+    ) -> Optional[int]:
         model_vocab_size: object = getattr(model_config, "vocab_size", None)
 
         # Compatibility fallback for SGLang model configs that expose the
@@ -940,6 +948,57 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
             return None
         return model_vocab_size - 1
 
+    def _resolve_request_multimodal_token_ids(
+        self, request: Dict[str, Any]
+    ) -> frozenset[int]:
+        mm_data = request.get("multi_modal_data")
+        if not isinstance(mm_data, dict):
+            return frozenset()
+
+        tokenizer_manager = getattr(self.engine, "tokenizer_manager", None)
+        mm_processor = getattr(tokenizer_manager, "mm_processor", None)
+        mm_tokens = getattr(mm_processor, "mm_tokens", None)
+        token_ids = set()
+
+        if mm_tokens is not None:
+            for modality in ("image", "video", "audio"):
+                if not mm_data.get(f"{modality}_url"):
+                    continue
+                token_id = getattr(mm_tokens, f"{modality}_token_id", None)
+                if isinstance(token_id, int) and not isinstance(token_id, bool):
+                    token_ids.add(token_id)
+
+        # Some processors, including LLaVA's wrapper, expose only the image
+        # token on ModelConfig. LLaVA also represents video frames as images.
+        if mm_data.get("image_url") or mm_data.get("video_url"):
+            model_config = getattr(tokenizer_manager, "model_config", None)
+            image_token_id = getattr(model_config, "image_token_id", None)
+            if isinstance(image_token_id, int) and not isinstance(image_token_id, bool):
+                token_ids.add(image_token_id)
+
+        return frozenset(token_ids)
+
+    def _validate_token_ids(
+        self,
+        token_ids: Any,
+        allowed_oov_ids: frozenset[int] = frozenset(),
+    ) -> None:
+        if not isinstance(token_ids, list):
+            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
+
+        max_input_token_id = self._max_input_token_id
+        for index, token_id in enumerate(token_ids):
+            if isinstance(token_id, bool) or not isinstance(token_id, int):
+                raise HttpError(
+                    400,
+                    f"nvext.token_data[{index}] must be an integer token ID",
+                )
+            # Dynamo's Rust frontend uses u32 token IDs, so negatives are not expected.
+            if (
+                max_input_token_id is not None and token_id > max_input_token_id
+            ) and token_id not in allowed_oov_ids:
+                raise HttpError(400, f"Token id {token_id} is out of vocabulary")
+
     def _validate_nvext_token_data(
         self,
         request: Dict[str, Any],
@@ -953,19 +1012,10 @@ class BaseWorkerHandler(LoraMixin, BaseGenerativeHandler[RequestT, ResponseT]):
         if not isinstance(nvext, dict) or nvext.get("token_in") is not True:
             return
 
-        if not isinstance(token_ids, list):
-            raise HttpError(400, "nvext.token_data must resolve to a token ID list")
-        if self._max_input_token_id is None:
-            raise HttpError(400, "Unable to validate nvext.token_data for this model")
-
-        for index, token_id in enumerate(token_ids):
-            if isinstance(token_id, bool) or not isinstance(token_id, int):
-                raise HttpError(
-                    400,
-                    f"nvext.token_data[{index}] must be an integer token ID",
-                )
-            if token_id < 0 or token_id > self._max_input_token_id:
-                raise HttpError(400, f"Token id {token_id} is out of vocabulary")
+        self._validate_token_ids(
+            token_ids,
+            self._resolve_request_multimodal_token_ids(request),
+        )
 
     @staticmethod
     def _get_guided_decoding_params(

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -293,6 +293,9 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             dist_init_method="tcp://127.0.0.1:0",
             rank=0,
         )
+        self._max_input_token_id = self._resolve_max_input_token_id_from_model_config(
+            self.encoder.model_config
+        )
 
         # Let SGLang accept the NVDEC-backed decoder this handler builds, so it
         # keeps ownership of frame selection (see _install_load_video_passthrough).
@@ -951,6 +954,17 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         # Keep URL inputs on SGLang's existing loading path and materialize only
         # frontend-decoded images received through NIXL.
         image_items, video_urls = self._extract_media_inputs(raw_request)
+        preprocessed_request = PreprocessedRequest.model_validate(raw_request)
+        allowed_oov_ids = frozenset(
+            token_id
+            for media_inputs, token_id in (
+                (image_items, self.image_token_id),
+                (video_urls, self.video_token_id),
+            )
+            if media_inputs and token_id is not None
+        )
+        self._validate_token_ids(preprocessed_request.token_ids, allowed_oov_ids)
+
         (
             image_inputs,
             image_cache_keys,
@@ -977,7 +991,6 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
             MultiModalGroup(multimodal_input=MultiModalInput(video_url=url))
             for url in video_urls
         ]
-        preprocessed_request = PreprocessedRequest.model_validate(raw_request)
 
         # Build SglangMultimodalRequest from the pre-tokenized request
         request = SglangMultimodalRequest(

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -229,13 +229,13 @@ def _new_token_input_handler(maximum_input_token_id: int = 151935):
     return handler
 
 
-def test_resolve_max_input_token_id_uses_larger_model_vocabulary():
+def test_resolve_max_input_token_id_uses_model_vocabulary():
     tokenizer = SimpleNamespace(get_vocab=lambda: {"base": 0, "added": 151668})
     engine = SimpleNamespace(
         tokenizer_manager=SimpleNamespace(
             tokenizer=tokenizer,
             model_config=SimpleNamespace(
-                hf_text_config=SimpleNamespace(vocab_size=151936)
+                vocab_size=151936,
             ),
         )
     )
@@ -243,31 +243,31 @@ def test_resolve_max_input_token_id_uses_larger_model_vocabulary():
     assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
 
 
-def test_resolve_max_input_token_id_uses_larger_tokenizer_vocabulary():
+def test_resolve_max_input_token_id_rejects_tokenizer_only_vocabulary():
     tokenizer = SimpleNamespace(get_vocab=lambda: {"base": 0, "added": 151940})
     engine = SimpleNamespace(
         tokenizer_manager=SimpleNamespace(
             tokenizer=tokenizer,
             model_config=SimpleNamespace(
-                hf_text_config=SimpleNamespace(vocab_size=151936)
+                vocab_size=151936,
             ),
         )
     )
 
-    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151940
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
 
 
-def test_resolve_max_input_token_id_supports_tokenizer_vocab_size_fallback():
+def test_resolve_max_input_token_id_supports_hf_text_config_fallback():
     engine = SimpleNamespace(
         tokenizer_manager=SimpleNamespace(
-            tokenizer=SimpleNamespace(vocab_size=152000),
+            tokenizer=SimpleNamespace(),
             model_config=SimpleNamespace(
                 hf_text_config=SimpleNamespace(vocab_size=151936)
             ),
         )
     )
 
-    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151999
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
 
 
 def test_resolve_max_input_token_id_supports_missing_tokenizer():
@@ -275,12 +275,35 @@ def test_resolve_max_input_token_id_supports_missing_tokenizer():
         tokenizer_manager=SimpleNamespace(
             tokenizer=None,
             model_config=SimpleNamespace(
-                hf_text_config=SimpleNamespace(vocab_size=151936)
+                vocab_size=151936,
             ),
         )
     )
 
     assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
+
+
+def test_resolve_max_input_token_id_supports_missing_tokenizer_metadata():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=SimpleNamespace(),
+            model_config=SimpleNamespace(
+                vocab_size=151936,
+            ),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
+
+
+def test_resolve_max_input_token_id_supports_missing_model_metadata():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=SimpleNamespace(),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) is None
 
 
 def test_nvext_token_data_accepts_maximum_valid_token_id():
@@ -318,6 +341,53 @@ def test_nvext_token_data_accepts_empty_token_list():
     }
 
     assert handler._get_input_param(request) == {"input_ids": []}
+
+
+def test_nvext_token_data_rejects_marked_string_payload():
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": "not-token-ids",
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(
+        HttpError,
+        match=r"nvext\.token_data must resolve to a token ID list",
+    ) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
+
+
+def test_nvext_token_data_rejects_request_when_model_bound_is_unavailable():
+    handler = _new_token_input_handler()
+    handler._max_input_token_id = None
+    request = {
+        "token_ids": [1],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(
+        HttpError,
+        match=r"Unable to validate nvext\.token_data for this model",
+    ) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
+
+
+@pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
+def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": [invalid_token_id],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(HttpError) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
 
 
 def test_nvext_token_data_validation_skips_ordinary_token_input():

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from dynamo.common.metadata_upload import MetadataUploader
+from dynamo.llm import HttpError
 from dynamo.sglang.request_handlers.llm.decode_handler import (
     DecodeWorkerHandler,
     _extract_sglang_stop_reason,
@@ -217,6 +218,113 @@ def _new_decode_handler(*, use_sglang_tokenizer: bool = False, enable_rl: bool =
 
     handler._cancellation_monitor = no_cancellation_monitor
     return handler
+
+
+def _new_token_input_handler(maximum_input_token_id: int = 151935):
+    handler = _new_decode_handler()
+    handler._max_input_token_id = maximum_input_token_id
+    handler.input_param_manager = SimpleNamespace(
+        get_input_param=lambda request, use_tokenizer: request.get("token_ids")
+    )
+    return handler
+
+
+def test_resolve_max_input_token_id_uses_larger_model_vocabulary():
+    tokenizer = SimpleNamespace(get_vocab=lambda: {"base": 0, "added": 151668})
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=tokenizer,
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(vocab_size=151936)
+            ),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
+
+
+def test_resolve_max_input_token_id_uses_larger_tokenizer_vocabulary():
+    tokenizer = SimpleNamespace(get_vocab=lambda: {"base": 0, "added": 151940})
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=tokenizer,
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(vocab_size=151936)
+            ),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151940
+
+
+def test_resolve_max_input_token_id_supports_tokenizer_vocab_size_fallback():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=SimpleNamespace(vocab_size=152000),
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(vocab_size=151936)
+            ),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151999
+
+
+def test_resolve_max_input_token_id_supports_missing_tokenizer():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            tokenizer=None,
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(vocab_size=151936)
+            ),
+        )
+    )
+
+    assert DecodeWorkerHandler._resolve_max_input_token_id(engine) == 151935
+
+
+def test_nvext_token_data_accepts_maximum_valid_token_id():
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": [1, 151935],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1, 151935]}
+
+
+@pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
+def test_nvext_token_data_rejects_out_of_vocabulary_token_id(invalid_token_id):
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": [1, invalid_token_id],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(
+        HttpError,
+        match=rf"Token id {invalid_token_id} is out of vocabulary",
+    ) as error:
+        handler._get_input_param(request)
+
+    assert error.value.code == 400
+
+
+def test_nvext_token_data_accepts_empty_token_list():
+    handler = _new_token_input_handler()
+    request = {
+        "token_ids": [],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": []}
+
+
+def test_nvext_token_data_validation_skips_ordinary_token_input():
+    handler = _new_token_input_handler()
+    request = {"token_ids": [2**32 - 1]}
+
+    assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
 
 
 async def _stream(items):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -316,6 +316,39 @@ def test_nvext_token_data_accepts_maximum_valid_token_id():
     assert handler._get_input_param(request) == {"input_ids": [1, 151935]}
 
 
+def test_nvext_token_data_allows_only_llava_image_token_with_image():
+    handler = _new_token_input_handler(maximum_input_token_id=31999)
+    handler.engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            mm_processor=SimpleNamespace(),
+            model_config=SimpleNamespace(image_token_id=32000),
+        )
+    )
+    request = {
+        "token_ids": [1, 32000],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1, 32000]}
+
+    request["token_ids"].append(2**32 - 1)
+    with pytest.raises(HttpError, match="4294967295"):
+        handler._get_input_param(request)
+
+
+def test_nvext_token_data_handles_missing_multimodal_metadata():
+    handler = _new_token_input_handler()
+    handler.engine = SimpleNamespace(tokenizer_manager=SimpleNamespace())
+    request = {
+        "token_ids": [1],
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    assert handler._get_input_param(request) == {"input_ids": [1]}
+
+
 @pytest.mark.parametrize("invalid_token_id", [151936, 2**32 - 1])
 def test_nvext_token_data_rejects_out_of_vocabulary_token_id(invalid_token_id):
     handler = _new_token_input_handler()
@@ -359,24 +392,32 @@ def test_nvext_token_data_rejects_marked_string_payload():
     assert error.value.code == 400
 
 
-def test_nvext_token_data_rejects_request_when_model_bound_is_unavailable():
+def test_nvext_token_data_skips_validation_when_model_bound_is_unavailable():
     handler = _new_token_input_handler()
     handler._max_input_token_id = None
     request = {
-        "token_ids": [1],
+        "token_ids": [2**32 - 1],
         "extra_args": {"nvext": {"token_in": True}},
     }
 
-    with pytest.raises(
-        HttpError,
-        match=r"Unable to validate nvext\.token_data for this model",
-    ) as error:
+    assert handler._get_input_param(request) == {"input_ids": [2**32 - 1]}
+
+
+def test_nvext_token_data_without_model_bound_rejects_locally_invalid_token_id():
+    handler = _new_token_input_handler()
+    handler._max_input_token_id = None
+    request = {
+        "token_ids": [True],
+        "extra_args": {"nvext": {"token_in": True}},
+    }
+
+    with pytest.raises(HttpError) as error:
         handler._get_input_param(request)
 
     assert error.value.code == 400
 
 
-@pytest.mark.parametrize("invalid_token_id", [-1, True, 1.5, "1"])
+@pytest.mark.parametrize("invalid_token_id", [True, 1.5, "1"])
 def test_nvext_token_data_rejects_invalid_token_id(invalid_token_id):
     handler = _new_token_input_handler()
     request = {

--- a/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_frontend_decoding.py
@@ -19,6 +19,7 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
 from dynamo.common.multimodal import TransferRequest
+from dynamo.llm import HttpError
 from dynamo.sglang.backend_args import DynamoSGLangConfig
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
 from dynamo.sglang.request_handlers.multimodal.encode_worker_handler import (
@@ -151,6 +152,7 @@ async def test_encode_worker_caches_frontend_decoded_image(caplog):
     handler._embedding_cache = MultimodalEmbeddingCacheManager(1024 * 1024)
     handler.image_token_id = 42
     handler.video_token_id = None
+    handler._max_input_token_id = 41
 
     content_hash = "7a9bbcb11a898630"
     decoded_metadata = {
@@ -231,6 +233,27 @@ async def test_encode_worker_caches_frontend_decoded_image(caplog):
     assert pd_request["multimodal_inputs"][0]["image_grid_thw"] == [1, 2, 2]
     assert pd_request["multimodal_inputs"][0]["num_mm_tokens"] == 4
     assert "Decoded" not in json.dumps(pd_request)
+
+
+@pytest.mark.asyncio
+async def test_encode_worker_rejects_unknown_oov_token_before_loading_media():
+    handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+    handler.image_token_id = 32000
+    handler.video_token_id = None
+    handler._max_input_token_id = 31999
+    handler._prepare_image_inputs = AsyncMock()
+    raw_request = {
+        "token_ids": [1, 32000, 2**32 - 1],
+        "stop_conditions": {"max_tokens": 8},
+        "sampling_options": {"temperature": 0.0},
+        "multi_modal_data": {"image_url": [{"Url": "https://example.com/image.png"}]},
+    }
+
+    with pytest.raises(HttpError, match="4294967295"):
+        async for _ in handler.generate(raw_request, context=None):
+            pass
+
+    handler._prepare_image_inputs.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -315,6 +338,7 @@ async def test_encode_worker_releases_decoded_image_before_streaming():
     handler._embedding_cache = None
     handler.image_token_id = 42
     handler.video_token_id = None
+    handler._max_input_token_id = 41
 
     class _ImageLoader:
         image_ref = None

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_embedding_cache.py
@@ -56,6 +56,7 @@ def cache_handler() -> MultimodalEncodeWorkerHandler:
 
     handler.set_token_ids_for_test = _set_token_ids_for_test
     handler.set_token_ids_for_test(151655, 151656)
+    handler._max_input_token_id = 151654
     handler._missing_video_cache_key_config_warned = False
     handler._decoded_content_hash_warning_emitted = False
     handler._image_loader = None


### PR DESCRIPTION
## Overview:

Adds model-aware validation for pre-tokenized `nvext.token_data` requests sent to
SGLang. Token IDs outside the loaded model and tokenizer vocabulary are returned as a
clear client error before generation begins.

Fixes https://linear.app/nvidia/issue/DYN-3785

## Details:

- Resolves the maximum accepted input token ID once during SGLang worker
  initialization.
- Uses the larger of the model vocabulary and tokenizer vocabulary boundaries to
  support model-only tokens, tokenizer additions, and multimodal placeholder tokens.
- Supports tokenizers exposing `max_token_id`, `get_vocab()`, or `vocab_size`, and
  falls back to model metadata when no tokenizer is available.
- Uses the existing `nvext.token_in` marker to validate only requests originating from
  `nvext.token_data`, avoiding an additional scan for ordinary tokenized requests.
- Returns HTTP 400 when a supplied token ID is outside the accepted vocabulary.
- Adds focused unit coverage for model/tokenizer vocabulary differences, fallback
  metadata paths, valid boundaries, invalid boundaries, empty input, and request-path
  scoping.

Validation performed:

- Focused unit tests passed before the worktree split.
- `git diff --cached --check` passes for the isolated changes.
- A100 validation with `Qwen/Qwen3-0.6B` accepted ID `151935` and returned HTTP 400
  for IDs `151936` and `4294967295`; a follow-up request returned HTTP 200.
- A100 validation with `TinyLlama/TinyLlama-1.1B-Chat-v1.0` accepted ID `31999` and
  returned HTTP 400 for IDs `32000` and `4294967295`; a follow-up request returned
  HTTP 200.

## Where should the reviewer start?

Start with `components/src/dynamo/sglang/request_handlers/handler_base.py`, especially
`_resolve_max_input_token_id()` and `_validate_nvext_token_data()`. Then review
`components/src/dynamo/sglang/tests/test_sglang_decode_handler.py` for the vocabulary
boundary and request-scoping expectations.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia-deprecated.devinenterprise.com/review/ai-dynamo/dynamo/pull/12798" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for advanced token input data.
  - Invalid, malformed, non-string, or out-of-vocabulary token IDs now return clear HTTP 400 errors instead of being processed.
  - Token validation now consistently accounts for vocabulary limits from both the model and tokenizer.
  - Valid token lists, empty lists, and standard token input continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->