### PR TITLE
fix(ci): extend SGLang GPU test timeout

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -781,6 +781,7 @@ jobs:
       run_cpu_only_tests: true
       cpu_only_test_markers: pre_merge and sglang and gpu_0
       gpu_test_markers: pre_merge and sglang and gpu_1
+      gpu_test_timeout_minutes: 45
       # Profiled tests run in the VRAM-aware GPU stage; unprofiled fall through to sequential.
       # Current single-GPU runners are 24 GiB, so this cap admits the profiled SGLang pool
       # while yielding one auto slot today. Larger runners will get more slots from the same markers.


### PR DESCRIPTION
## Summary

- Increase the SGLang single-GPU test stage timeout from the reusable workflow default of 30 minutes to 45 minutes.
- Keep the VRAM-aware scheduler and individual pytest timeouts unchanged.
- Preserve the outer timeout as protection against a genuinely stuck test stage.

## Background

Full CI for [PR #12746](https://github.com/ai-dynamo/dynamo/pull/12746) exposed how little headroom the current SGLang timeout has. In [the failed run](https://github.com/ai-dynamo/dynamo/actions/runs/31135800518), the parallel GPU step started at 00:56:52 UTC and was terminated at 01:26:52 UTC, exactly at its 30-minute limit. The runner reported `Executing the custom container implementation failed`; this was not a pytest assertion failure.

The last scheduled test, `tests/router/test_router_e2e_with_sglang.py::test_sglang_kv_router_basic[tcp]`, did not start until 01:25:22 UTC. Its own timeout was 270 seconds, but the outer step limit stopped the container after roughly 90 seconds. Individual test timeouts already begin when each subprocess starts, so queued time does not consume the test's own budget; the problem is that the workflow-level timeout includes collection, queueing, execution, and cleanup.

This is also close to occurring on successful runs. A recent successful SGLang parallel step took 29 minutes and 33 seconds, leaving only 27 seconds of headroom, while another completed in 13 minutes and 49 seconds. That variation makes a 30-minute stage limit brittle even when every test is healthy.

## Implementation

Set `gpu_test_timeout_minutes: 45` explicitly for the SGLang test job. This matches the existing vLLM single-GPU timeout and gives a queued test enough time to use its own timeout budget. The value remains an upper bound: successful jobs finish immediately and do not wait for the full 45 minutes.

This does not retry the GPU suite, ignore failures, or change any per-test timeout.

## Validation

- Parsed `.github/workflows/pr.yaml` with PyYAML.
- Ran `git diff --check`.
- Compared the failed SGLang parallel step with two recent successful runs to verify the timeout boundary and runtime variance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended the GPU test job timeout to 45 minutes, allowing longer-running test suites to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->