### PR TITLE
docs(llm): define N-1 compatibility policy [DYN-3846]

### DIFF
--- a/lib/kv-router/CLAUDE.md
+++ b/lib/kv-router/CLAUDE.md
@@ -4,6 +4,11 @@ KV-router contains hot-path routing, indexing, scheduling, and active-sequence
 state. Keep edits scoped and read the more specific `CLAUDE.md` in subdirectories
 when one exists.
 
+When router configuration is serialized inside a model deployment card, it is
+part of the N-1 worker/frontend wire contract described in
+[`lib/llm/CLAUDE.md`](../llm/CLAUDE.md). Keep compatibility handling narrow and
+give deprecated wire fields a versioned removal TODO.
+
 ## Dependencies
 
 - `validator` and `rand` carry a disproportionate transitive footprint for the

--- a/lib/llm/CLAUDE.md
+++ b/lib/llm/CLAUDE.md
@@ -1,10 +1,13 @@
-# Worker / Frontend Compatibility
+# N-1 Worker / Frontend Compatibility
 
-Dynamo is expected to support N-1 mixed-version operation between workers and
-frontends during rolling updates. Treat model deployment cards, discovery
-metadata, and worker/frontend wire formats owned by this crate as cross-process
-compatibility surfaces. Consider both directions: a previous-version worker
-with a current frontend and a current worker with a previous-version frontend.
+Assume N-1 mixed-version operation between workers and frontends during rolling
+updates: current-version components must interoperate with components from the
+immediately previous release. N-2 and older combinations are unsupported unless
+a narrower temporary exception is explicitly documented. Treat model deployment
+cards, discovery metadata, and worker/frontend wire formats owned by this crate
+as cross-process compatibility surfaces. Consider both directions: a
+previous-version worker with a current frontend and a current worker with a
+previous-version frontend.
 
 - Normal, default deployment paths should remain operable across the N-1
   boundary. Unconditional parsing or discovery failures on those paths are

--- a/lib/llm/CLAUDE.md
+++ b/lib/llm/CLAUDE.md
@@ -1,0 +1,39 @@
+# Worker / Frontend Compatibility
+
+Dynamo is expected to support N-1 mixed-version operation between workers and
+frontends during rolling updates. Treat model deployment cards, discovery
+metadata, and worker/frontend wire formats owned by this crate as cross-process
+compatibility surfaces. Consider both directions: a previous-version worker
+with a current frontend and a current worker with a previous-version frontend.
+
+- Normal, default deployment paths should remain operable across the N-1
+  boundary. Unconditional parsing or discovery failures on those paths are
+  generally compatibility bugs.
+- Prefer tolerant readers and conservative writers. Accept known legacy fields
+  when they are safe to interpret, and continue emitting required legacy fields
+  for the supported compatibility window.
+- Silent degradation may be acceptable when it is safe and bounded. It must not
+  erase an essential capability, violate an invariant, or produce misleading
+  state that makes an otherwise valid deployment unusable.
+- Conditional failures may be acceptable for explicitly enabled features whose
+  semantics cannot be represented safely by the other version. Prefer a
+  targeted unsupported-feature error over a generic deserialization failure.
+
+This expectation applies to cross-process worker/frontend wiring. It is not a
+general stability promise for in-process Rust APIs, which are internal unless
+explicitly documented otherwise.
+
+## Compatibility Shims
+
+Keep version-specific compatibility code narrow and temporary. Prefer a derived
+wire-only representation over restoring deprecated data as a second source of
+truth. Every shim must name its compatibility window and removal condition, for
+example:
+
+```rust
+// Compatibility with v1.3 workers during v1.4 rolling upgrades.
+// TODO(v1.5): Remove when v1.3 falls outside the N-1 compatibility window.
+```
+
+Remove the shim when the corresponding version leaves the supported window;
+do not carry compatibility branches forward indefinitely.

--- a/lib/llm/CLAUDE.md
+++ b/lib/llm/CLAUDE.md
@@ -25,9 +25,15 @@ explicitly documented otherwise.
 
 ## Compatibility Shims
 
-Keep version-specific compatibility code narrow and temporary. Prefer a derived
-wire-only representation over restoring deprecated data as a second source of
-truth. Every shim must name its compatibility window and removal condition, for
+Keep version-specific compatibility code narrow, close to the wire boundary,
+and temporary. Translate legacy input into canonical state immediately, and
+derive legacy output from canonical state. Do not plumb legacy fields through
+internal APIs, make core logic branch on them, or rely on their presence after
+deserialization. When both representations are present, the current
+representation is authoritative unless a specific compatibility rule says
+otherwise.
+
+Every shim must name its compatibility window and removal condition, for
 example:
 
 ```rust


### PR DESCRIPTION
## Summary

Define the worker/frontend compatibility assumption as N-1: current-version components must interoperate with components from the immediately previous release in either direction during rolling updates. N-2 and older combinations are unsupported unless a narrower temporary exception is explicitly documented.

Treat model deployment cards, discovery metadata, and worker/frontend wire formats as cross-process compatibility surfaces. Keep compatibility shims narrow, translate legacy data into canonical state at the wire boundary, and give each shim an explicit removal version. The KV-router guidance points to the same contract when router configuration is embedded in an MDC.

## Validation

- Commit-time hooks passed, including codespell, conflict checks, line-ending checks, and whitespace checks.
- `git diff --check` passed.
