### PR TITLE
feat(kv-router): add cold pool routing

### DIFF
--- a/lib/kv-router/src/scheduling/cold_pool.rs
+++ b/lib/kv-router/src/scheduling/cold_pool.rs
@@ -1,0 +1,283 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Actor-local state for bounded soft-drain warm/cold routing.
+
+use std::collections::{HashMap, HashSet};
+use std::time::Duration;
+
+use tokio::time::Instant;
+
+use crate::protocols::{WorkerId, WorkerWithDpRank};
+
+const COLD_POOL_RECHECK_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(crate) fn periodic_recheck_interval(configured: Duration) -> Duration {
+    configured.min(COLD_POOL_RECHECK_INTERVAL)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ColdPoolConfig {
+    /// Raw requests below this length enter the Warm lane. Longer requests
+    /// enter the Cold lane only when their best effective prefill is also at
+    /// or above this threshold.
+    pub(crate) request_threshold: usize,
+    /// Requested number of Cold workers before topology clamping. The effective
+    /// pool is capped at one third of the registered workers, with at least one
+    /// Cold worker whenever the topology can also retain a Warm worker.
+    pub(crate) workers: usize,
+    /// Maximum time Cold waits for a member without active Warm work.
+    pub(crate) soft_drain_timeout: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ColdPoolLane {
+    Warm,
+    Cold,
+}
+
+pub(crate) struct ColdPoolState {
+    config: ColdPoolConfig,
+    cold_worker_ids: HashSet<WorkerId>,
+    pending_cold: usize,
+    active_cold_requests: HashMap<String, WorkerWithDpRank>,
+    active_cold_by_worker: HashMap<WorkerWithDpRank, usize>,
+}
+
+impl ColdPoolState {
+    pub(crate) fn new(config: ColdPoolConfig) -> Self {
+        Self {
+            config,
+            cold_worker_ids: HashSet::new(),
+            pending_cold: 0,
+            active_cold_requests: HashMap::new(),
+            active_cold_by_worker: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn classify(
+        &self,
+        raw_isl_tokens: usize,
+        best_effective_prefill_tokens: impl FnOnce() -> usize,
+    ) -> Option<ColdPoolLane> {
+        if raw_isl_tokens < self.config.request_threshold {
+            return Some(ColdPoolLane::Warm);
+        }
+        if best_effective_prefill_tokens() >= self.config.request_threshold {
+            return Some(ColdPoolLane::Cold);
+        }
+        None
+    }
+
+    pub(crate) fn soft_drain_expired(&self, enqueue_at: Instant, now: Instant) -> bool {
+        now.saturating_duration_since(enqueue_at) >= self.config.soft_drain_timeout
+    }
+
+    pub(crate) fn cold_worker_ids(&self) -> &HashSet<WorkerId> {
+        &self.cold_worker_ids
+    }
+
+    pub(crate) fn effective_worker_count(&self, worker_count: usize) -> usize {
+        if worker_count < 2 {
+            return 0;
+        }
+
+        let topology_cap = (worker_count / 3).max(1);
+        self.config.workers.clamp(1, topology_cap)
+    }
+
+    pub(crate) fn reconcile_membership(&mut self, worker_ids: impl IntoIterator<Item = WorkerId>) {
+        let mut worker_ids: Vec<_> = worker_ids.into_iter().collect();
+        worker_ids.sort_unstable();
+        worker_ids.dedup();
+        let effective = self.effective_worker_count(worker_ids.len());
+        worker_ids.sort_unstable_by(|left, right| {
+            rendezvous_score(*right)
+                .cmp(&rendezvous_score(*left))
+                .then_with(|| left.cmp(right))
+        });
+        let next: HashSet<_> = worker_ids.into_iter().take(effective).collect();
+        if next != self.cold_worker_ids {
+            self.cold_worker_ids = next;
+        }
+    }
+
+    pub(crate) fn on_queued(&mut self, lane: ColdPoolLane) {
+        if lane == ColdPoolLane::Cold {
+            self.pending_cold += 1;
+        }
+    }
+
+    pub(crate) fn on_dequeued(&mut self, lane: ColdPoolLane) {
+        if lane == ColdPoolLane::Cold {
+            debug_assert!(self.pending_cold > 0, "Cold Pool pending counter underflow");
+            self.pending_cold = self.pending_cold.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn on_dispatched(
+        &mut self,
+        request_id: String,
+        lane: ColdPoolLane,
+        worker: WorkerWithDpRank,
+    ) {
+        if lane != ColdPoolLane::Cold {
+            return;
+        }
+        self.active_cold_requests.insert(request_id, worker);
+        *self.active_cold_by_worker.entry(worker).or_default() += 1;
+    }
+
+    pub(crate) fn reconcile_active_cold(
+        &mut self,
+        mut is_active: impl FnMut(&String, WorkerWithDpRank) -> bool,
+    ) {
+        self.active_cold_requests
+            .retain(|request_id, worker| is_active(request_id, *worker));
+        self.active_cold_by_worker.clear();
+        for worker in self.active_cold_requests.values().copied() {
+            *self.active_cold_by_worker.entry(worker).or_default() += 1;
+        }
+    }
+
+    pub(crate) fn active_cold(&self, worker: WorkerWithDpRank) -> usize {
+        self.active_cold_by_worker
+            .get(&worker)
+            .copied()
+            .unwrap_or(0)
+    }
+
+    pub(crate) fn active_warm(&self, worker: WorkerWithDpRank, total_active: usize) -> usize {
+        total_active.saturating_sub(self.active_cold(worker))
+    }
+
+    pub(crate) fn warm_avoid_worker_ids(&self) -> HashSet<WorkerId> {
+        if self.pending_cold > 0 {
+            return self.cold_worker_ids.clone();
+        }
+        self.active_cold_by_worker
+            .iter()
+            .filter_map(|(worker, active)| (*active > 0).then_some(worker.worker_id))
+            .collect()
+    }
+}
+
+/// SplitMix64 gives every Worker ID a stable, well-distributed HRW score.
+fn rendezvous_score(worker_id: WorkerId) -> u64 {
+    let mut value = worker_id.wrapping_add(0x9e37_79b9_7f4a_7c15);
+    value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(workers: usize) -> ColdPoolConfig {
+        ColdPoolConfig {
+            request_threshold: 128_000,
+            workers,
+            soft_drain_timeout: Duration::from_secs(1),
+        }
+    }
+
+    #[test]
+    fn membership_is_stable_and_leaves_one_warm_worker() {
+        let mut state = ColdPoolState::new(config(10));
+        state.reconcile_membership([1, 2, 3, 4]);
+        assert_eq!(state.cold_worker_ids.len(), 1);
+
+        let first = state.cold_worker_ids.clone();
+        state.reconcile_membership([4, 3, 2, 1]);
+        assert_eq!(state.cold_worker_ids, first);
+
+        state.reconcile_membership([1]);
+        assert!(state.cold_worker_ids.is_empty());
+    }
+
+    #[test]
+    fn effective_worker_count_is_bounded_by_topology() {
+        let state = ColdPoolState::new(config(10));
+        let expected = [
+            (0, 0),
+            (1, 0),
+            (2, 1),
+            (3, 1),
+            (4, 1),
+            (5, 1),
+            (6, 2),
+            (8, 2),
+            (9, 3),
+        ];
+
+        for (worker_count, cold_count) in expected {
+            assert_eq!(state.effective_worker_count(worker_count), cold_count);
+        }
+
+        let configured_one = ColdPoolState::new(config(1));
+        assert_eq!(configured_one.effective_worker_count(9), 1);
+    }
+
+    #[test]
+    fn pressure_tracks_pending_and_active_cold() {
+        let mut state = ColdPoolState::new(config(1));
+        state.reconcile_membership([1, 2]);
+        let cold_worker = *state.cold_worker_ids.iter().next().unwrap();
+        let lane = state.classify(400_000, || 400_000).unwrap();
+
+        state.on_queued(lane);
+        assert_eq!(state.warm_avoid_worker_ids(), state.cold_worker_ids);
+        state.on_dequeued(lane);
+        state.on_dispatched(
+            "cold-1".to_string(),
+            lane,
+            WorkerWithDpRank::new(cold_worker, 0),
+        );
+        assert_eq!(state.warm_avoid_worker_ids(), state.cold_worker_ids);
+
+        state.reconcile_active_cold(|_, _| false);
+        assert!(state.warm_avoid_worker_ids().is_empty());
+    }
+
+    #[test]
+    fn classification_bypasses_cache_affine_long_contexts() {
+        let state = ColdPoolState::new(config(1));
+
+        assert_eq!(
+            state.classify(127_999, || panic!(
+                "Warm classification must not inspect cache"
+            )),
+            Some(ColdPoolLane::Warm)
+        );
+        assert_eq!(
+            state.classify(128_000, || 128_000),
+            Some(ColdPoolLane::Cold)
+        );
+        assert_eq!(
+            state.classify(400_000, || 128_000),
+            Some(ColdPoolLane::Cold)
+        );
+        assert_eq!(state.classify(400_000, || 127_999), None);
+    }
+
+    #[test]
+    fn soft_drain_timeout_is_bounded_by_enqueue_age() {
+        let state = ColdPoolState::new(config(1));
+        let enqueued = Instant::now();
+        assert!(!state.soft_drain_expired(enqueued, enqueued + Duration::from_millis(999)));
+        assert!(state.soft_drain_expired(enqueued, enqueued + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn bounded_drain_caps_the_existing_recheck_interval() {
+        assert_eq!(
+            periodic_recheck_interval(Duration::from_secs(60)),
+            Duration::from_millis(100)
+        );
+        assert_eq!(
+            periodic_recheck_interval(Duration::from_millis(50)),
+            Duration::from_millis(50)
+        );
+    }
+}

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -10,6 +10,7 @@ use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+use super::cold_pool::periodic_recheck_interval;
 use super::config::RouterQueuePolicy;
 use super::overlap::OverlapSignals;
 use super::overlap_refresh::{NoopOverlapScoresRefresh, OverlapScoresRefresh};
@@ -183,6 +184,11 @@ where
         worker_type: &'static str,
         monitor_worker_configs: bool,
     ) -> Result<Self, KvSchedulerError> {
+        let recheck_interval = if profile.cold_pool_config().is_some() {
+            periodic_recheck_interval(recheck_interval)
+        } else {
+            recheck_interval
+        };
         let queue = Arc::new(SchedulerQueue::new_with_policy_profile(
             Arc::clone(&slots),
             workers_with_configs.clone(),

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod cold_pool;
 pub mod config;
 mod filter;
 mod local;

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 use serde::Deserialize;
 use thiserror::Error;
 
+use super::cold_pool::ColdPoolConfig;
 use super::config::RouterQueuePolicy;
 
 const SYNTHETIC_POLICY_CLASS: &str = "default";
@@ -62,6 +63,7 @@ impl PolicyClassConfig {
 pub struct PolicyProfile {
     classes: Vec<PolicyClassConfig>,
     classifier: PolicyClassifier,
+    cold_pool: Option<ColdPoolConfig>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -125,6 +127,7 @@ impl PolicyProfile {
         Self {
             classes: vec![class],
             classifier: PolicyClassifier::SyntheticSingle { class_index: 0 },
+            cold_pool: None,
         }
     }
 
@@ -158,12 +161,23 @@ impl PolicyProfile {
     pub fn class(&self, index: usize) -> &PolicyClassConfig {
         &self.classes[index]
     }
+
+    pub(crate) fn cold_pool_config(&self) -> Option<&ColdPoolConfig> {
+        self.cold_pool.as_ref()
+    }
+
+    /// Removes prefill-only Cold Pool routing from a shared policy profile.
+    pub fn without_cold_pool(mut self) -> Self {
+        self.cold_pool = None;
+        self
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RouterPolicyConfig {
     root: Option<PolicyProfile>,
     models: HashMap<String, PolicyProfile>,
+    cold_pool: Option<ColdPoolConfig>,
 }
 
 impl RouterPolicyConfig {
@@ -200,17 +214,21 @@ impl RouterPolicyConfig {
     ) -> PolicyProfile {
         // Model profiles replace the root wholesale; the synthetic profile is
         // constructed only when neither configured profile applies.
-        model_name
+        let mut profile = model_name
             .and_then(|name| self.models.get(name))
             .or(self.root.as_ref())
             .cloned()
-            .unwrap_or_else(|| PolicyProfile::synthetic(fallback_threshold, fallback_policy))
+            .unwrap_or_else(|| PolicyProfile::synthetic(fallback_threshold, fallback_policy));
+        profile.cold_pool = self.cold_pool.clone();
+        profile
     }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawRouterPolicyConfig {
+    #[serde(default)]
+    cold_pool: Option<RawColdPoolConfig>,
     #[serde(default)]
     default_policy_family: Option<String>,
     #[serde(default)]
@@ -223,6 +241,7 @@ struct RawRouterPolicyConfig {
 
 impl RawRouterPolicyConfig {
     fn resolve(self) -> Result<RouterPolicyConfig, RouterPolicyConfigError> {
+        let cold_pool = self.cold_pool.map(RawColdPoolConfig::resolve).transpose()?;
         let root = match (
             self.default_policy_family,
             self.policy_classes,
@@ -264,7 +283,40 @@ impl RawRouterPolicyConfig {
             ));
         }
 
-        Ok(RouterPolicyConfig { root, models })
+        Ok(RouterPolicyConfig {
+            root,
+            models,
+            cold_pool,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawColdPoolConfig {
+    request_threshold: usize,
+    workers: usize,
+    soft_drain_timeout_ms: u64,
+}
+
+impl RawColdPoolConfig {
+    fn resolve(self) -> Result<ColdPoolConfig, RouterPolicyConfigError> {
+        if self.request_threshold == 0 {
+            return Err(RouterPolicyConfigError::Validation(
+                "cold_pool.request_threshold must be greater than zero".to_string(),
+            ));
+        }
+        if self.workers == 0 {
+            return Err(RouterPolicyConfigError::Validation(
+                "cold_pool.workers must be greater than zero".to_string(),
+            ));
+        }
+
+        Ok(ColdPoolConfig {
+            request_threshold: self.request_threshold,
+            workers: self.workers,
+            soft_drain_timeout: std::time::Duration::from_millis(self.soft_drain_timeout_ms),
+        })
     }
 }
 
@@ -415,6 +467,7 @@ fn resolve_profile(
                 .map(|class_index| class_index.expect("validated complete policy matrix"))
                 .collect(),
         }),
+        cold_pool: None,
     })
 }
 
@@ -904,5 +957,85 @@ policy_classes:
                 .all(|class| class.name != "custom_priority"),
             "model profiles must completely replace root classes"
         );
+    }
+
+    #[test]
+    fn cold_pool_config_is_attached_to_resolved_profiles() {
+        let config = RouterPolicyConfig::from_yaml(
+            r#"
+cold_pool:
+  request_threshold: 131072
+  workers: 2
+  soft_drain_timeout_ms: 1000
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: default
+    policy_family: default
+    cache_bucket: all
+    quantum: 1
+    prefill_busy_threshold: 65536
+"#,
+        )
+        .unwrap();
+
+        let profile = config.resolve_profile(None, None, RouterQueuePolicy::Fcfs);
+        let cold_pool = profile.cold_pool_config().unwrap();
+        assert_eq!(cold_pool.request_threshold, 131_072);
+        assert_eq!(cold_pool.workers, 2);
+        assert_eq!(
+            cold_pool.soft_drain_timeout,
+            std::time::Duration::from_secs(1)
+        );
+
+        let decode_profile = profile.without_cold_pool();
+        assert!(decode_profile.cold_pool_config().is_none());
+    }
+
+    #[test]
+    fn cold_pool_config_allows_zero_soft_drain_timeout() {
+        let config = RouterPolicyConfig::from_yaml(
+            r#"
+cold_pool:
+  request_threshold: 1
+  workers: 1
+  soft_drain_timeout_ms: 0
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: default
+    policy_family: default
+    cache_bucket: all
+    quantum: 1
+    prefill_busy_threshold: 1
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            config
+                .resolve_profile(None, None, RouterQueuePolicy::Fcfs)
+                .cold_pool_config()
+                .unwrap()
+                .soft_drain_timeout,
+            std::time::Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn cold_pool_config_rejects_zero_required_values() {
+        for cold_pool in [
+            "request_threshold: 0\n  workers: 1",
+            "request_threshold: 1\n  workers: 0",
+        ] {
+            let yaml = format!(
+                "cold_pool:\n  {cold_pool}\n  soft_drain_timeout_ms: 1\ndefault_policy_family: default\nuncached_isl_buckets:\n  - min_tokens: 0\n    bucket: all\npolicy_classes:\n  - name: default\n    policy_family: default\n    cache_bucket: all\n    quantum: 1\n    prefill_busy_threshold: 1\n"
+            );
+            assert!(RouterPolicyConfig::from_yaml(&yaml).is_err());
+        }
     }
 }

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -11,6 +11,7 @@ use crossbeam_queue::SegQueue;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
 
+use super::cold_pool::{ColdPoolLane, ColdPoolState};
 use super::config::RouterQueuePolicy;
 use super::filter::RoutingEligibility;
 use super::overlap::SelectedWorkerTierSnapshot;
@@ -56,6 +57,7 @@ struct QueuedRequest {
     request: SchedulingRequest,
     enqueue_at: Instant,
     block_hashes: Option<Vec<LocalBlockHash>>,
+    cold_pool_lane: Option<ColdPoolLane>,
 }
 
 struct SelectedWorkerForRequest {
@@ -217,7 +219,10 @@ struct SchedulerQueueActor<
     overlap_refresh_after: Option<Duration>,
     overloaded_worker_provider: Option<OverloadedWorkerProvider>,
     non_max_overlap_selection_observer: Arc<OnceLock<NonMaxOverlapSelectionObserver>>,
+    cold_pool_state: Option<ColdPoolState>,
 }
+
+mod cold_pool_integration;
 
 /// Queue that gates scheduling requests behind a capacity check.
 /// When all workers exceed `threshold_frac` utilisation the request is parked in `pending`.
@@ -316,10 +321,11 @@ impl<
         admission_channel_capacity: usize,
     ) -> Result<Self, KvSchedulerError> {
         let pending = PolicyQueue::new(profile.clone());
-        let queueing_enabled = profile
-            .classes()
-            .iter()
-            .any(PolicyClassConfig::queueing_enabled);
+        let queueing_enabled = profile.cold_pool_config().is_some()
+            || profile
+                .classes()
+                .iter()
+                .any(PolicyClassConfig::queueing_enabled);
         for class in profile.classes() {
             tracing::info!(
                 policy_class = class.name,
@@ -361,6 +367,7 @@ impl<
         let (admission_tx, admission_rx) = mpsc::channel(admission_channel_capacity);
         let cleanup = Arc::new(AdmissionCleanup::default());
         let non_max_overlap_selection_observer = Arc::new(OnceLock::new());
+        let cold_pool_state = profile.cold_pool_config().cloned().map(ColdPoolState::new);
         let actor = SchedulerQueueActor {
             pending,
             cleanup: Arc::clone(&cleanup),
@@ -379,6 +386,7 @@ impl<
             overlap_refresh_after,
             overloaded_worker_provider,
             non_max_overlap_selection_observer: Arc::clone(&non_max_overlap_selection_observer),
+            cold_pool_state,
         };
         tokio::spawn(actor.run(admission_rx));
         Ok(Self {
@@ -759,12 +767,28 @@ impl<
                 .resolve_class_index(request.policy_class.as_deref(), snapshot.uncached_tokens);
             (class_index, Some(snapshot))
         };
+        let cold_pool_lane = self.prepare_cold_pool_request(&request);
         let class = self.profile.class(class_index);
-        let should_queue = self.should_queue(class_index, class, || {
-            self.all_workers_prefill_busy(class, request.eligibility(), decay_now)
-        });
+        let should_queue = if self.cold_pool_state.is_some() {
+            let can_dispatch = self.cold_pool_request_is_dispatchable(
+                class,
+                &request,
+                cold_pool_lane,
+                decay_now,
+                decay_now,
+            );
+            let must_queue = cold_pool_lane == Some(ColdPoolLane::Cold) && !can_dispatch;
+            self.should_queue(class_index, class, must_queue, || !can_dispatch)
+        } else {
+            self.should_queue(class_index, class, false, || {
+                self.all_workers_prefill_busy(class, request.eligibility(), decay_now)
+            })
+        };
         if !should_queue {
-            return (false, self.admit_one(request, decay_now));
+            return (
+                false,
+                self.admit_one(request, cold_pool_lane, class_index, decay_now),
+            );
         }
 
         let snapshot = snapshot.unwrap_or_else(|| self.snapshot_for(&request));
@@ -779,6 +803,7 @@ impl<
             request,
             enqueue_at: decay_now,
             block_hashes,
+            cold_pool_lane,
         };
         let worker_count = self.workers_with_configs.borrow().len();
         if let Err((rejection, queued)) = self.pending.enqueue(
@@ -799,6 +824,7 @@ impl<
         self.pending_isl_tokens
             .fetch_add(snapshot.raw_isl_tokens, AtomicOrdering::Relaxed);
         self.add_class_counters(class_index, snapshot);
+        self.on_cold_pool_request_queued(cold_pool_lane);
         (false, true)
     }
 
@@ -806,11 +832,15 @@ impl<
         &self,
         class_index: usize,
         class: &PolicyClassConfig,
-        all_workers_busy: impl FnOnce() -> bool,
+        must_queue: bool,
+        policy_blocked: impl FnOnce() -> bool,
     ) -> bool {
-        // Preserve backlog anti-bypass and lazily avoid worker scans when an
-        // earlier condition already decides admission.
-        class.queueing_enabled() && (self.pending.has_backlog(class_index) || all_workers_busy())
+        // Mandatory policy waits (for example, Cold soft-drain) bypass the
+        // optional capacity gate. Otherwise preserve backlog anti-bypass and
+        // lazily avoid worker scans when an earlier condition decides admission.
+        must_queue
+            || (class.queueing_enabled()
+                && (self.pending.has_backlog(class_index) || policy_blocked()))
     }
 
     fn snapshot_for(&self, request: &SchedulingRequest) -> QueueSnapshot {
@@ -859,6 +889,7 @@ impl<
                     });
                 removed_ready_head |= class_head_removed;
                 for entry in removed {
+                    self.on_cold_pool_request_dequeued(entry.payload().cold_pool_lane);
                     self.subtract_pending_counters(class_index, entry.snapshot());
                 }
             }
@@ -867,16 +898,34 @@ impl<
     }
 
     fn has_dispatchable_ready_head(&self) -> bool {
-        let active_tokens = self.slots.active_tokens(Instant::now());
+        let now = Instant::now();
+        let active_tokens = self.slots.active_tokens(now);
         let configs = self.workers_with_configs.borrow();
-        self.pending.any_ready_head(|_, class, queued| {
-            !Self::all_workers_prefill_busy_with(
-                &active_tokens,
-                &configs,
-                class,
-                queued.request.eligibility(),
-            )
-        })
+        if self.cold_pool_state.is_some() {
+            let active_counts = self.slots.active_request_counts();
+            self.pending.any_ready_head(|_, class, queued| {
+                Self::cold_pool_request_is_dispatchable_with(
+                    self.cold_pool_state.as_ref(),
+                    class,
+                    &queued.request,
+                    queued.cold_pool_lane,
+                    Some(queued.enqueue_at),
+                    &active_tokens,
+                    &active_counts,
+                    &configs,
+                    now,
+                )
+            })
+        } else {
+            self.pending.any_ready_head(|_, class, queued| {
+                !Self::all_workers_prefill_busy_with(
+                    &active_tokens,
+                    &configs,
+                    class,
+                    queued.request.eligibility(),
+                )
+            })
+        }
     }
 
     fn subtract_pending_counters(&self, class_index: usize, snapshot: QueueSnapshot) {
@@ -887,6 +936,7 @@ impl<
     }
 
     async fn handle_update(&mut self, worker: Option<WorkerWithDpRank>) {
+        self.reconcile_cold_pool();
         if !self.pending.has_ready() {
             return;
         }
@@ -906,17 +956,34 @@ impl<
             let active_tokens = self.slots.active_tokens(decay_now);
             let popped = {
                 let configs = self.workers_with_configs.borrow();
-                self.pending.pop_next(|_, class, queued| {
-                    // TODO: This preserves head-of-line blocking within each policy
-                    // class. A blocked constrained head can stall later entries in
-                    // that class until a bounded non-HOL policy is introduced.
-                    !Self::all_workers_prefill_busy_with(
-                        &active_tokens,
-                        &configs,
-                        class,
-                        queued.request.eligibility(),
-                    )
-                })
+                if self.cold_pool_state.is_some() {
+                    let active_counts = self.slots.active_request_counts();
+                    self.pending.pop_next(|_, class, queued| {
+                        Self::cold_pool_request_is_dispatchable_with(
+                            self.cold_pool_state.as_ref(),
+                            class,
+                            &queued.request,
+                            queued.cold_pool_lane,
+                            Some(queued.enqueue_at),
+                            &active_tokens,
+                            &active_counts,
+                            &configs,
+                            decay_now,
+                        )
+                    })
+                } else {
+                    self.pending.pop_next(|_, class, queued| {
+                        // TODO: This preserves head-of-line blocking within each policy
+                        // class. A blocked constrained head can stall later entries in
+                        // that class until a bounded non-HOL policy is introduced.
+                        !Self::all_workers_prefill_busy_with(
+                            &active_tokens,
+                            &configs,
+                            class,
+                            queued.request.eligibility(),
+                        )
+                    })
+                }
             };
             let Some(mut popped) = popped else {
                 break;
@@ -965,17 +1032,21 @@ impl<
             let class = self.profile.class(class_index);
             let queued = popped.into_payload();
             let request = queued.request;
+            let cold_pool_lane = queued.cold_pool_lane;
             tracing::debug!(
                 policy_class = class.name,
                 "scheduling request from pending queue"
             );
-            self.admit_one(request, admit_now);
+            self.on_cold_pool_request_dequeued(cold_pool_lane);
+            self.admit_one(request, cold_pool_lane, class_index, admit_now);
         }
     }
 
     fn select_worker_for_request(
         &self,
         request: &mut SchedulingRequest,
+        cold_pool_lane: Option<ColdPoolLane>,
+        class_index: Option<usize>,
         decay_now: Instant,
     ) -> Result<SelectedWorkerForRequest, KvSchedulerError> {
         request.worker_loads = self
@@ -988,45 +1059,52 @@ impl<
                 .overloaded_worker_provider
                 .as_ref()
                 .and_then(|provider| provider());
-            let eligibility = request.eligibility_with_overloaded(overloaded_worker_ids.as_ref());
-            self.selector
-                .select_worker(&workers, request, eligibility, self.block_size)
-                .map(|selection| {
-                    let non_max_overlap_selection = if request.mode.is_tracked()
-                        && self.non_max_overlap_selection_observer.get().is_some()
-                    {
-                        non_max_overlap_selection(
-                            &workers,
-                            request,
-                            eligibility,
-                            selection.worker,
-                            selection.effective_overlap_blocks,
-                        )
-                    } else {
-                        None
-                    };
-                    let config = workers
-                        .get(&selection.worker.worker_id)
-                        .expect("selected worker config must exist");
-                    let selected_worker_tiers = request
-                        .overlap
-                        .selected_worker_tiers(selection.worker, config);
-                    let worker_load = request.worker_load_for(selection.worker);
-                    let selected_worker_load = AdvisoryWorkerLoad {
-                        active_prefill_tokens: worker_load.active_prefill_tokens,
-                        prefill_token_capacity: config
-                            .max_num_batched_tokens()
-                            .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS)
-                            as usize,
-                        total_kv_blocks: config.total_kv_blocks().map(|blocks| blocks as usize),
-                    };
-                    SelectedWorkerForRequest {
-                        selection,
-                        selected_worker_tiers,
-                        selected_worker_load,
-                        non_max_overlap_selection,
-                    }
-                })
+            self.select_worker_with_cold_pool(
+                request,
+                cold_pool_lane,
+                class_index.map(|index| self.profile.class(index)),
+                &workers,
+                overloaded_worker_ids.as_ref(),
+            )
+            .map(|selection| {
+                // The observer intentionally uses caller-level eligibility rather than the
+                // Cold Pool's narrowed candidate set. This preserves main's meaning: report
+                // locality sacrificed by any router policy, including pool isolation.
+                let non_max_overlap_selection = if request.mode.is_tracked()
+                    && self.non_max_overlap_selection_observer.get().is_some()
+                {
+                    non_max_overlap_selection(
+                        &workers,
+                        request,
+                        request.eligibility_with_overloaded(overloaded_worker_ids.as_ref()),
+                        selection.worker,
+                        selection.effective_overlap_blocks,
+                    )
+                } else {
+                    None
+                };
+                let config = workers
+                    .get(&selection.worker.worker_id)
+                    .expect("selected worker config must exist");
+                let selected_worker_tiers = request
+                    .overlap
+                    .selected_worker_tiers(selection.worker, config);
+                let worker_load = request.worker_load_for(selection.worker);
+                let selected_worker_load = AdvisoryWorkerLoad {
+                    active_prefill_tokens: worker_load.active_prefill_tokens,
+                    prefill_token_capacity: config
+                        .max_num_batched_tokens()
+                        .unwrap_or(DEFAULT_MAX_BATCHED_TOKENS)
+                        as usize,
+                    total_kv_blocks: config.total_kv_blocks().map(|blocks| blocks as usize),
+                };
+                SelectedWorkerForRequest {
+                    selection,
+                    selected_worker_tiers,
+                    selected_worker_load,
+                    non_max_overlap_selection,
+                }
+            })
         }
     }
 
@@ -1035,7 +1113,7 @@ impl<
         request: &mut SchedulingRequest,
         decay_now: Instant,
     ) -> Result<AdvisorySchedulingResponse, KvSchedulerError> {
-        let selected = self.select_worker_for_request(request, decay_now)?;
+        let selected = self.select_worker_for_request(request, None, None, decay_now)?;
 
         Ok(AdvisorySchedulingResponse {
             selected_worker_load: selected.selected_worker_load,
@@ -1051,8 +1129,19 @@ impl<
 
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
-    fn admit_one(&mut self, mut request: SchedulingRequest, decay_now: Instant) -> bool {
-        let selected = match self.select_worker_for_request(&mut request, decay_now) {
+    fn admit_one(
+        &mut self,
+        mut request: SchedulingRequest,
+        cold_pool_lane: Option<ColdPoolLane>,
+        class_index: usize,
+        decay_now: Instant,
+    ) -> bool {
+        let selected = match self.select_worker_for_request(
+            &mut request,
+            cold_pool_lane,
+            Some(class_index),
+            decay_now,
+        ) {
             Ok(s) => s,
             Err(e) => {
                 tracing::warn!("scheduling failed: {e}");
@@ -1101,6 +1190,7 @@ impl<
             sequence_request,
             response,
             non_max_overlap_selection,
+            cold_pool_lane,
         )
     }
 
@@ -1110,11 +1200,12 @@ impl<
     /// request lifetime and the caller must install its RAII cleanup owner. If
     /// delivery loses that race, roll back the booking here.
     fn book_and_respond(
-        &self,
+        &mut self,
         mut request: SchedulingRequest,
         sequence_request: SequenceRequest,
         response: SchedulingResponse,
         non_max_overlap_selection: Option<NonMaxOverlapSelection>,
+        cold_pool_lane: Option<ColdPoolLane>,
     ) -> bool {
         if request.response_is_closed() {
             tracing::debug!(
@@ -1133,8 +1224,13 @@ impl<
 
         if request.respond(Ok(response)) {
             if let Some(selection) = non_max_overlap_selection {
-                self.dispatch_non_max_overlap_selection(request_id, selection);
+                self.dispatch_non_max_overlap_selection(request_id.clone(), selection);
             }
+            let worker = self
+                .slots
+                .request_worker(&request_id)
+                .expect("new scheduler booking must retain its worker");
+            self.on_cold_pool_request_dispatched(request_id, cold_pool_lane, worker);
             return true;
         }
 
@@ -2022,6 +2118,510 @@ mod tests {
         queue.enqueue(abandoned).await;
 
         assert!(observed.lock().unwrap().is_empty());
+    }
+
+    fn cold_pool_profile(soft_drain_timeout_ms: u64) -> PolicyProfile {
+        policy_profile(&format!(
+            r#"
+cold_pool:
+  request_threshold: 131072
+  workers: 1
+  soft_drain_timeout_ms: {soft_drain_timeout_ms}
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: default
+    policy_family: default
+    cache_bucket: all
+    quantum: 1
+    prefill_busy_threshold: 9000000
+"#
+        ))
+    }
+
+    fn cold_pool_two_worker_fallback_profile() -> PolicyProfile {
+        policy_profile(
+            r#"
+cold_pool:
+  request_threshold: 131072
+  workers: 2
+  soft_drain_timeout_ms: 1000
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: default
+    policy_family: default
+    cache_bucket: all
+    quantum: 1
+    prefill_busy_threshold: 100000
+"#,
+        )
+    }
+
+    fn cold_pool_cache_affinity_profile() -> PolicyProfile {
+        policy_profile(
+            r#"
+cold_pool:
+  request_threshold: 131072
+  workers: 1
+  soft_drain_timeout_ms: 10000
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: cache_affine
+  - min_tokens: 131072
+    bucket: true_miss
+policy_classes:
+  - name: default_cache_affine
+    policy_family: default
+    cache_bucket: cache_affine
+    quantum: 1
+    prefill_busy_threshold: 9000000
+  - name: default_true_miss
+    policy_family: default
+    cache_bucket: true_miss
+    quantum: 1
+    prefill_busy_threshold: 9000000
+"#,
+        )
+    }
+
+    fn cold_pool_isolation_first_profile() -> PolicyProfile {
+        policy_profile(
+            r#"
+cold_pool:
+  request_threshold: 131072
+  workers: 1
+  soft_drain_timeout_ms: 10000
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: warm
+  - min_tokens: 131072
+    bucket: true_miss
+policy_classes:
+  - name: default_warm
+    policy_family: default
+    cache_bucket: warm
+    quantum: 1
+    prefill_busy_threshold: 1000
+  - name: default_true_miss
+    policy_family: default
+    cache_bucket: true_miss
+    quantum: 1
+    prefill_busy_threshold: 1000
+"#,
+        )
+    }
+
+    fn configured_cold_worker(profile: &PolicyProfile, worker_count: usize) -> WorkerId {
+        let mut state = ColdPoolState::new(profile.cold_pool_config().unwrap().clone());
+        state.reconcile_membership(0..worker_count as u64);
+        *state.cold_worker_ids().iter().next().unwrap()
+    }
+
+    fn configured_cold_workers(profile: &PolicyProfile, worker_count: usize) -> Vec<WorkerId> {
+        let mut state = ColdPoolState::new(profile.cold_pool_config().unwrap().clone());
+        state.reconcile_membership(0..worker_count as u64);
+        let mut workers: Vec<_> = state.cold_worker_ids().iter().copied().collect();
+        workers.sort_unstable();
+        workers
+    }
+
+    #[tokio::test]
+    async fn cold_pool_routes_cold_and_prefers_other_workers_for_warm() {
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (cold, cold_rx) = make_request("cold-active", 400_000);
+        queue.enqueue(cold).await;
+        let cold_response = cold_rx.await.unwrap().unwrap();
+        assert_eq!(cold_response.best_worker.worker_id, cold_worker);
+
+        let (warm, warm_rx) = make_request("warm-preferred", 1_000);
+        queue.enqueue(warm).await;
+        let warm_response = warm_rx.await.unwrap().unwrap();
+        assert_ne!(warm_response.best_worker.worker_id, cold_worker);
+
+        slots.free(&"cold-active".to_string(), decay_now()).unwrap();
+        slots
+            .free(&"warm-preferred".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cold_pool_queues_warm_when_isolation_preferred_workers_are_busy() {
+        let profile = cold_pool_isolation_first_profile();
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let non_cold_workers: Vec<_> = (0..4u64).filter(|worker| *worker != cold_worker).collect();
+        let cold_worker_rank = WorkerWithDpRank::new(cold_worker, 0);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut warm_on_cold, warm_on_cold_rx) = make_request("warm-on-cold", 1_000);
+        warm_on_cold.pinned_worker = Some(cold_worker_rank);
+        queue.enqueue(warm_on_cold).await;
+        assert_eq!(
+            warm_on_cold_rx.await.unwrap().unwrap().best_worker,
+            cold_worker_rank
+        );
+
+        let mut busy_request_ids = Vec::new();
+        for (index, worker_id) in non_cold_workers.iter().copied().enumerate() {
+            let request_id = format!("busy-warm-{index}");
+            let (mut busy_warm, busy_warm_rx) = make_request(&request_id, 2_000);
+            busy_warm.pinned_worker = Some(WorkerWithDpRank::new(worker_id, 0));
+            queue.enqueue(busy_warm).await;
+            assert_eq!(
+                busy_warm_rx.await.unwrap().unwrap().best_worker.worker_id,
+                worker_id
+            );
+            busy_request_ids.push(request_id);
+        }
+
+        let (cold, mut cold_rx) = make_request("waiting-cold", 400_000);
+        queue.enqueue(cold).await;
+        assert_eq!(queue.pending_count(), 1);
+        assert!(cold_rx.try_recv().is_err());
+
+        let (probe_warm, mut probe_warm_rx) = make_request("queued-warm", 1_000);
+        queue.enqueue(probe_warm).await;
+
+        assert_eq!(queue.pending_count(), 2);
+        assert!(probe_warm_rx.try_recv().is_err());
+
+        slots.free(&busy_request_ids[0], decay_now()).unwrap();
+        queue.update().await;
+
+        let probe_response = probe_warm_rx.try_recv().unwrap().unwrap();
+        assert_ne!(probe_response.best_worker.worker_id, cold_worker);
+        assert_eq!(queue.pending_count(), 1);
+        assert!(cold_rx.try_recv().is_err());
+
+        for request_id in busy_request_ids.iter().skip(1) {
+            slots.free(request_id, decay_now()).unwrap();
+        }
+        slots.free(&"queued-warm".to_string(), decay_now()).unwrap();
+        slots
+            .free(&"warm-on-cold".to_string(), decay_now())
+            .unwrap();
+        queue.update().await;
+
+        let cold_response = cold_rx.try_recv().unwrap().unwrap();
+        assert_eq!(cold_response.best_worker, cold_worker_rank);
+        slots
+            .free(&"waiting-cold".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cold_pool_bypasses_cached_long_context_to_non_cold_owner() {
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let cache_owner = (0..4u64).find(|worker| *worker != cold_worker).unwrap();
+        let cache_owner_rank = WorkerWithDpRank::new(cache_owner, 0);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut continuation, continuation_rx) = make_request("cached-long-context", 400_000);
+        continuation
+            .overlap
+            .effective_overlap_blocks
+            .insert(cache_owner_rank, 18_750.0);
+        continuation
+            .overlap
+            .effective_cached_tokens
+            .insert(cache_owner_rank, 300_000);
+        queue.enqueue(continuation).await;
+
+        let response = continuation_rx.await.unwrap().unwrap();
+        assert_eq!(response.best_worker, cache_owner_rank);
+        assert_eq!(response.cached_tokens, 300_000);
+        slots
+            .free(&"cached-long-context".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cache_affine_bypass_reuses_cold_owner_while_true_miss_waits() {
+        let profile = cold_pool_cache_affinity_profile();
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let cold_worker_rank = WorkerWithDpRank::new(cold_worker, 0);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut warm, warm_rx) = make_request("warm-on-cold-owner", 1_000);
+        warm.pinned_worker = Some(cold_worker_rank);
+        queue.enqueue(warm).await;
+        assert_eq!(
+            warm_rx.await.unwrap().unwrap().best_worker,
+            cold_worker_rank
+        );
+
+        let (true_miss, true_miss_rx) = make_request("waiting-true-miss", 400_000);
+        queue.enqueue(true_miss).await;
+        assert_eq!(queue.pending_count(), 1);
+
+        let (mut continuation, continuation_rx) = make_request("cached-on-cold-owner", 400_000);
+        continuation
+            .overlap
+            .effective_overlap_blocks
+            .insert(cold_worker_rank, 18_750.0);
+        continuation
+            .overlap
+            .effective_cached_tokens
+            .insert(cold_worker_rank, 300_000);
+        queue.enqueue(continuation).await;
+
+        let continuation_response = continuation_rx.await.unwrap().unwrap();
+        assert_eq!(continuation_response.best_worker, cold_worker_rank);
+        assert_eq!(continuation_response.cached_tokens, 300_000);
+        assert_eq!(queue.pending_count(), 1);
+
+        slots
+            .free(&"cached-on-cold-owner".to_string(), decay_now())
+            .unwrap();
+        slots
+            .free(&"warm-on-cold-owner".to_string(), decay_now())
+            .unwrap();
+        queue.update().await;
+
+        let true_miss_response = true_miss_rx.await.unwrap().unwrap();
+        assert_eq!(true_miss_response.best_worker, cold_worker_rank);
+        assert_eq!(queue.pending_count(), 0);
+        slots
+            .free(&"waiting-true-miss".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cold_pool_waits_in_policy_queue_until_active_warm_drains() {
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut warm, warm_rx) = make_request("warm-on-cold", 1_000);
+        warm.pinned_worker = Some(WorkerWithDpRank::new(cold_worker, 0));
+        queue.enqueue(warm).await;
+        assert_eq!(
+            warm_rx.await.unwrap().unwrap().best_worker.worker_id,
+            cold_worker
+        );
+
+        let (cold, cold_rx) = make_request("waiting-cold", 400_000);
+        queue.enqueue(cold).await;
+        assert_eq!(queue.pending_count(), 1);
+
+        slots
+            .free(&"warm-on-cold".to_string(), decay_now())
+            .unwrap();
+        queue.update().await;
+        let cold_response = cold_rx.await.unwrap().unwrap();
+        assert_eq!(cold_response.best_worker.worker_id, cold_worker);
+        assert_eq!(queue.pending_count(), 0);
+        slots
+            .free(&"waiting-cold".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cold_pool_zero_timeout_allows_bounded_fallback() {
+        let profile = cold_pool_profile(0);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut warm, warm_rx) = make_request("warm-overlap", 1_000);
+        warm.pinned_worker = Some(WorkerWithDpRank::new(cold_worker, 0));
+        queue.enqueue(warm).await;
+        warm_rx.await.unwrap().unwrap();
+
+        let (cold, cold_rx) = make_request("fallback-cold", 400_000);
+        queue.enqueue(cold).await;
+        let cold_response = cold_rx.await.unwrap().unwrap();
+        assert_eq!(cold_response.best_worker.worker_id, cold_worker);
+        assert_eq!(queue.pending_count(), 0);
+
+        slots
+            .free(&"warm-overlap".to_string(), decay_now())
+            .unwrap();
+        slots
+            .free(&"fallback-cold".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn cold_pool_falls_back_after_soft_drain_timeout() {
+        let profile = cold_pool_profile(1_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut warm, warm_rx) = make_request("warm-through-timeout", 1_000);
+        warm.pinned_worker = Some(WorkerWithDpRank::new(cold_worker, 0));
+        queue.enqueue(warm).await;
+        warm_rx.await.unwrap().unwrap();
+
+        let (cold, mut cold_rx) = make_request("bounded-cold", 400_000);
+        queue.enqueue(cold).await;
+        assert_eq!(queue.pending_count(), 1);
+
+        tokio::time::advance(Duration::from_millis(999)).await;
+        queue.update().await;
+        assert!(cold_rx.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        queue.update().await;
+        let response = cold_rx.try_recv().unwrap().unwrap();
+        assert_eq!(response.best_worker.worker_id, cold_worker);
+        assert_eq!(queue.pending_count(), 0);
+
+        for request_id in ["warm-through-timeout", "bounded-cold"] {
+            slots.free(&request_id.to_string(), decay_now()).unwrap();
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn cold_pool_timeout_skips_busy_preferred_during_fallback() {
+        let profile = cold_pool_two_worker_fallback_profile();
+        let cold_workers = configured_cold_workers(&profile, 6);
+        assert_eq!(cold_workers.len(), 2);
+        let busy_clean = WorkerWithDpRank::new(cold_workers[0], 0);
+        let ready_with_warm = WorkerWithDpRank::new(cold_workers[1], 0);
+        let (queue, slots) = make_queue_with_profile(6, 16, 1_000_000, profile);
+
+        let (mut active_cold, active_cold_rx) = make_request("active-cold", 400_000);
+        active_cold.pinned_worker = Some(busy_clean);
+        queue.enqueue(active_cold).await;
+        assert_eq!(
+            active_cold_rx.await.unwrap().unwrap().best_worker,
+            busy_clean
+        );
+
+        let (mut active_warm, active_warm_rx) = make_request("active-warm", 1_000);
+        active_warm.pinned_worker = Some(ready_with_warm);
+        queue.enqueue(active_warm).await;
+        assert_eq!(
+            active_warm_rx.await.unwrap().unwrap().best_worker,
+            ready_with_warm
+        );
+
+        let (fallback, mut fallback_rx) = make_request("timeout-fallback", 400_000);
+        queue.enqueue(fallback).await;
+        assert_eq!(queue.pending_count(), 1);
+        assert!(fallback_rx.try_recv().is_err());
+
+        tokio::time::advance(Duration::from_millis(1_000)).await;
+        queue.update().await;
+        assert_eq!(
+            fallback_rx.try_recv().unwrap().unwrap().best_worker,
+            ready_with_warm,
+            "the final selector must skip the busy preferred worker after timeout"
+        );
+        assert_eq!(queue.pending_count(), 0);
+
+        for request_id in ["active-cold", "active-warm", "timeout-fallback"] {
+            slots.free(&request_id.to_string(), decay_now()).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn cold_pool_bypasses_a_cold_request_pinned_to_a_non_member() {
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let pinned_worker = (0..4u64).find(|worker| *worker != cold_worker).unwrap();
+        let pinned_rank = WorkerWithDpRank::new(pinned_worker, 0);
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile);
+
+        let (mut request, response_rx) = make_request("pinned-non-member", 400_000);
+        request.pinned_worker = Some(pinned_rank);
+        queue.enqueue(request).await;
+
+        assert_eq!(response_rx.await.unwrap().unwrap().best_worker, pinned_rank);
+        assert_eq!(queue.pending_count(), 0);
+        slots
+            .free(&"pinned-non-member".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cold_pool_bypasses_incompatible_and_single_worker_topologies() {
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 4);
+        let non_cold_worker = (0..4u64).find(|worker| *worker != cold_worker).unwrap();
+        let (queue, slots) = make_queue_with_profile(4, 16, 1_000_000, profile.clone());
+
+        let (mut constrained, constrained_rx) = make_request("constrained-cold", 400_000);
+        constrained.allowed_worker_ids = Some(HashSet::from([non_cold_worker]));
+        queue.enqueue(constrained).await;
+        assert_eq!(
+            constrained_rx.await.unwrap().unwrap().best_worker.worker_id,
+            non_cold_worker
+        );
+        slots
+            .free(&"constrained-cold".to_string(), decay_now())
+            .unwrap();
+
+        let (single_queue, single_slots) = make_queue_with_profile(1, 16, 1_000_000, profile);
+        let (single, single_rx) = make_request("single-worker-cold", 400_000);
+        single_queue.enqueue(single).await;
+        assert_eq!(single_rx.await.unwrap().unwrap().best_worker.worker_id, 0);
+        single_slots
+            .free(&"single-worker-cold".to_string(), decay_now())
+            .unwrap();
+    }
+
+    #[test]
+    fn cold_pool_missing_fallback_uses_ordinary_busy_gate() {
+        type TestActor = SchedulerQueueActor<
+            NoopSequencePublisher,
+            SimpleWorkerConfig,
+            DefaultWorkerSelector,
+            NoopOverlapScoresRefresh,
+        >;
+
+        let profile = cold_pool_profile(10_000);
+        let cold_worker = configured_cold_worker(&profile, 2);
+        let non_cold_worker = (0..2u64).find(|worker| *worker != cold_worker).unwrap();
+        let mut state = ColdPoolState::new(profile.cold_pool_config().unwrap().clone());
+        state.reconcile_membership(0..2u64);
+        let class = profile.default_class();
+        let (request, _response_rx) = make_request("missing-cold-fallback", 400_000);
+        let now = decay_now();
+        let active_counts = HashMap::new();
+
+        let workers = HashMap::from([(
+            non_cold_worker,
+            SimpleWorkerConfig {
+                max_num_batched_tokens: Some(1_000_000),
+                ..Default::default()
+            },
+        )]);
+        let active_tokens = HashMap::from([(WorkerWithDpRank::new(non_cold_worker, 0), 9_000_001)]);
+        assert!(!TestActor::cold_pool_request_is_dispatchable_with(
+            Some(&state),
+            class,
+            &request,
+            Some(ColdPoolLane::Cold),
+            Some(now),
+            &active_tokens,
+            &active_counts,
+            &workers,
+            now,
+        ));
+
+        let no_workers = HashMap::new();
+        assert!(TestActor::cold_pool_request_is_dispatchable_with(
+            Some(&state),
+            class,
+            &request,
+            Some(ColdPoolLane::Cold),
+            Some(now),
+            &HashMap::new(),
+            &active_counts,
+            &no_workers,
+            now,
+        ));
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/scheduling/queue/cold_pool_integration.rs
+++ b/lib/kv-router/src/scheduling/queue/cold_pool_integration.rs
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Narrow Queue integration for bounded soft-drain routing.
+
+use std::collections::{HashMap, HashSet};
+
+use tokio::time::Instant;
+
+use super::SchedulerQueueActor;
+use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+use crate::scheduling::cold_pool::{ColdPoolLane, ColdPoolState};
+use crate::scheduling::filter::RoutingEligibility;
+use crate::scheduling::overlap_refresh::OverlapScoresRefresh;
+use crate::scheduling::policy_config::PolicyClassConfig;
+use crate::scheduling::selector::WorkerSelector;
+use crate::scheduling::types::{KvSchedulerError, SchedulingContext, SchedulingRequest};
+use crate::sequences::SequencePublisher;
+
+impl<
+    P: SequencePublisher + 'static,
+    C: WorkerConfigLike + Send + Sync + 'static,
+    Sel: WorkerSelector<C> + Send + 'static,
+    RF: OverlapScoresRefresh + Send + Sync + 'static,
+> SchedulerQueueActor<P, C, Sel, RF>
+{
+    pub(super) fn reconcile_cold_pool(&mut self) {
+        let Some(state) = self.cold_pool_state.as_mut() else {
+            return;
+        };
+        let workers = self.workers_with_configs.borrow();
+        state.reconcile_membership(workers.keys().copied());
+        state.reconcile_active_cold(|request_id, worker| {
+            self.slots.request_worker(request_id) == Some(worker)
+        });
+    }
+
+    pub(super) fn prepare_cold_pool_request(
+        &mut self,
+        request: &SchedulingRequest,
+    ) -> Option<ColdPoolLane> {
+        if !request.mode.is_tracked() {
+            return None;
+        }
+        self.reconcile_cold_pool();
+        let state = self.cold_pool_state.as_ref()?;
+        let workers = self.workers_with_configs.borrow();
+        let lane = state.classify(request.isl_tokens, || {
+            SchedulingContext::new(request, &workers).best_effective_prefill_tokens()
+        })?;
+        if lane == ColdPoolLane::Cold {
+            let candidates = cold_worker_ids(state, request, &workers);
+            if candidates.is_empty()
+                || !eligibility_for(request, Some(&candidates))
+                    .any_eligible_worker_rank(&workers, |_, _| true)
+            {
+                return None;
+            }
+        }
+        Some(lane)
+    }
+
+    pub(super) fn cold_pool_request_is_dispatchable(
+        &self,
+        class: &PolicyClassConfig,
+        request: &SchedulingRequest,
+        lane: Option<ColdPoolLane>,
+        enqueue_at: Instant,
+        now: Instant,
+    ) -> bool {
+        let active_tokens = self.slots.active_tokens(now);
+        let active_counts = self.slots.active_request_counts();
+        let workers = self.workers_with_configs.borrow();
+        Self::cold_pool_request_is_dispatchable_with(
+            self.cold_pool_state.as_ref(),
+            class,
+            request,
+            lane,
+            Some(enqueue_at),
+            &active_tokens,
+            &active_counts,
+            &workers,
+            now,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn cold_pool_request_is_dispatchable_with(
+        state: Option<&ColdPoolState>,
+        class: &PolicyClassConfig,
+        request: &SchedulingRequest,
+        lane: Option<ColdPoolLane>,
+        enqueue_at: Option<Instant>,
+        active_tokens: &HashMap<WorkerWithDpRank, usize>,
+        active_counts: &HashMap<WorkerWithDpRank, usize>,
+        workers: &HashMap<WorkerId, C>,
+        now: Instant,
+    ) -> bool {
+        let Some((state, lane)) = state.zip(lane) else {
+            return !Self::all_workers_prefill_busy_with(
+                active_tokens,
+                workers,
+                class,
+                request.eligibility(),
+            );
+        };
+
+        match lane {
+            ColdPoolLane::Warm => {
+                let preferred = warm_preferred_worker_ids(state, request, workers);
+                let eligibility = preferred.as_ref().map_or_else(
+                    || request.eligibility(),
+                    |ids| eligibility_for(request, Some(ids)),
+                );
+                !Self::all_workers_prefill_busy_with(active_tokens, workers, class, eligibility)
+            }
+            ColdPoolLane::Cold => {
+                let fallback = cold_worker_ids(state, request, workers);
+                if fallback.is_empty() {
+                    // Cold containment is no longer structurally possible.
+                    // Fall back to ordinary queue admission so busy workers
+                    // still queue while invalid eligibility reaches selector.
+                    return !Self::all_workers_prefill_busy_with(
+                        active_tokens,
+                        workers,
+                        class,
+                        request.eligibility(),
+                    );
+                }
+                let preferred =
+                    clean_cold_worker_ids(state, request, workers, active_counts, &fallback);
+                if !preferred.is_empty()
+                    && !Self::all_workers_prefill_busy_with(
+                        active_tokens,
+                        workers,
+                        class,
+                        eligibility_for(request, Some(&preferred)),
+                    )
+                {
+                    return true;
+                }
+
+                let expired = enqueue_at.is_none_or(|at| state.soft_drain_expired(at, now));
+                expired
+                    && !Self::all_workers_prefill_busy_with(
+                        active_tokens,
+                        workers,
+                        class,
+                        eligibility_for(request, Some(&fallback)),
+                    )
+            }
+        }
+    }
+
+    pub(super) fn select_worker_with_cold_pool(
+        &self,
+        request: &SchedulingRequest,
+        lane: Option<ColdPoolLane>,
+        class: Option<&PolicyClassConfig>,
+        workers: &HashMap<WorkerId, C>,
+        overloaded_worker_ids: Option<&HashSet<WorkerId>>,
+    ) -> Result<WorkerSelectionResult, KvSchedulerError> {
+        let Some((state, lane)) = self.cold_pool_state.as_ref().zip(lane) else {
+            return self.selector.select_worker(
+                workers,
+                request,
+                request.eligibility_with_overloaded(overloaded_worker_ids),
+                self.block_size,
+            );
+        };
+
+        let active_counts = self.slots.active_request_counts();
+        let (preferred, fallback) = match lane {
+            ColdPoolLane::Warm => (warm_preferred_worker_ids(state, request, workers), None),
+            ColdPoolLane::Cold => {
+                let fallback = cold_worker_ids(state, request, workers);
+                if fallback.is_empty() {
+                    return self.selector.select_worker(
+                        workers,
+                        request,
+                        request.eligibility_with_overloaded(overloaded_worker_ids),
+                        self.block_size,
+                    );
+                }
+                let preferred =
+                    clean_cold_worker_ids(state, request, workers, &active_counts, &fallback);
+                ((!preferred.is_empty()).then_some(preferred), Some(fallback))
+            }
+        };
+
+        let skip_preferred = lane == ColdPoolLane::Cold
+            && preferred.as_ref().is_some_and(|preferred| {
+                preferred_workers_prefill_busy(
+                    request,
+                    workers,
+                    class.expect("Cold Pool selection must have a resolved policy class"),
+                    preferred,
+                )
+            });
+        if !skip_preferred && let Some(preferred) = preferred.as_ref() {
+            match self.selector.select_worker(
+                workers,
+                request,
+                eligibility_for_with_overload(request, Some(preferred), overloaded_worker_ids),
+                self.block_size,
+            ) {
+                Ok(selection) => return Ok(selection),
+                Err(
+                    KvSchedulerError::NoEndpoints | KvSchedulerError::AllEligibleWorkersOverloaded,
+                ) => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        match fallback {
+            Some(mut fallback) => {
+                if skip_preferred && let Some(preferred) = preferred {
+                    fallback.retain(|worker| !preferred.contains(worker));
+                }
+                self.selector.select_worker(
+                    workers,
+                    request,
+                    eligibility_for_with_overload(request, Some(&fallback), overloaded_worker_ids),
+                    self.block_size,
+                )
+            }
+            None => self.selector.select_worker(
+                workers,
+                request,
+                request.eligibility_with_overloaded(overloaded_worker_ids),
+                self.block_size,
+            ),
+        }
+    }
+
+    pub(super) fn on_cold_pool_request_queued(&mut self, lane: Option<ColdPoolLane>) {
+        if let Some((state, lane)) = self.cold_pool_state.as_mut().zip(lane) {
+            state.on_queued(lane);
+        }
+    }
+
+    pub(super) fn on_cold_pool_request_dequeued(&mut self, lane: Option<ColdPoolLane>) {
+        if let Some((state, lane)) = self.cold_pool_state.as_mut().zip(lane) {
+            state.on_dequeued(lane);
+        }
+    }
+
+    pub(super) fn on_cold_pool_request_dispatched(
+        &mut self,
+        request_id: String,
+        lane: Option<ColdPoolLane>,
+        worker: WorkerWithDpRank,
+    ) {
+        if let Some((state, lane)) = self.cold_pool_state.as_mut().zip(lane) {
+            state.on_dispatched(request_id, lane, worker);
+        }
+    }
+}
+
+fn preferred_workers_prefill_busy<C: WorkerConfigLike>(
+    request: &SchedulingRequest,
+    workers: &HashMap<WorkerId, C>,
+    class: &PolicyClassConfig,
+    preferred: &HashSet<WorkerId>,
+) -> bool {
+    let eligibility = eligibility_for(request, Some(preferred));
+    let mut checked_any = false;
+    let has_available = eligibility.any_eligible_worker_rank(workers, |worker, config| {
+        checked_any = true;
+        let max_batched = config
+            .max_num_batched_tokens()
+            .unwrap_or(super::DEFAULT_MAX_BATCHED_TOKENS);
+        let active_tokens = request.worker_load_for(worker).active_prefill_tokens;
+        !class.worker_is_busy(active_tokens, max_batched)
+    });
+    checked_any && !has_available
+}
+
+fn warm_preferred_worker_ids<C: WorkerConfigLike>(
+    state: &ColdPoolState,
+    request: &SchedulingRequest,
+    workers: &HashMap<WorkerId, C>,
+) -> Option<HashSet<WorkerId>> {
+    let avoid = state.warm_avoid_worker_ids();
+    if avoid.is_empty() {
+        return None;
+    }
+    let preferred: HashSet<_> = workers
+        .keys()
+        .copied()
+        .filter(|worker_id| request.eligibility().caller_allows_worker_id(*worker_id))
+        .filter(|worker_id| !avoid.contains(worker_id))
+        .collect();
+    let has_structural_candidate =
+        eligibility_for(request, Some(&preferred)).any_eligible_worker_rank(workers, |_, _| true);
+    has_structural_candidate.then_some(preferred)
+}
+
+fn cold_worker_ids<C: WorkerConfigLike>(
+    state: &ColdPoolState,
+    request: &SchedulingRequest,
+    workers: &HashMap<WorkerId, C>,
+) -> HashSet<WorkerId> {
+    state
+        .cold_worker_ids()
+        .iter()
+        .copied()
+        .filter(|worker_id| workers.contains_key(worker_id))
+        .filter(|worker_id| request.eligibility().caller_allows_worker_id(*worker_id))
+        .collect()
+}
+
+fn clean_cold_worker_ids<C: WorkerConfigLike>(
+    state: &ColdPoolState,
+    request: &SchedulingRequest,
+    workers: &HashMap<WorkerId, C>,
+    active_counts: &HashMap<WorkerWithDpRank, usize>,
+    fallback: &HashSet<WorkerId>,
+) -> HashSet<WorkerId> {
+    let eligibility = eligibility_for(request, Some(fallback));
+    let mut clean = HashSet::new();
+    let mut has_active_warm = HashSet::new();
+    eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
+        clean.insert(worker.worker_id);
+        let total_active = active_counts.get(&worker).copied().unwrap_or(0);
+        if state.active_warm(worker, total_active) > 0 {
+            has_active_warm.insert(worker.worker_id);
+        }
+    });
+    clean.retain(|worker_id| !has_active_warm.contains(worker_id));
+    clean
+}
+
+fn eligibility_for<'a>(
+    request: &'a SchedulingRequest,
+    allowed_worker_ids: Option<&'a HashSet<WorkerId>>,
+) -> RoutingEligibility<'a> {
+    eligibility_for_with_overload(request, allowed_worker_ids, None)
+}
+
+fn eligibility_for_with_overload<'a>(
+    request: &'a SchedulingRequest,
+    allowed_worker_ids: Option<&'a HashSet<WorkerId>>,
+    overloaded_worker_ids: Option<&'a HashSet<WorkerId>>,
+) -> RoutingEligibility<'a> {
+    RoutingEligibility::new(
+        allowed_worker_ids,
+        overloaded_worker_ids,
+        request.pinned_worker,
+        &request.routing_constraints,
+    )
+}

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -123,6 +123,13 @@ impl KvEventSourceRequirement {
     }
 }
 
+fn worker_role_supports_cold_pool(worker_role: Option<WorkerType>) -> bool {
+    matches!(
+        worker_role,
+        None | Some(WorkerType::Prefill | WorkerType::Aggregated)
+    )
+}
+
 impl fmt::Display for KvEventSourceRequirement {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(self.as_str())
@@ -440,6 +447,7 @@ where
             Some(overloaded_worker_provider),
             model_name.as_deref(),
             metric_worker_type,
+            worker_role_supports_cold_pool(worker_role),
             cancellation_token.child_token(),
         )
         .await?;
@@ -1556,6 +1564,15 @@ mod tests {
             resolve_tracking_model_name(TrackingHashAlgorithm::PublicXxh3V1, Some("")).unwrap(),
             ""
         );
+    }
+
+    #[test]
+    fn cold_pool_is_enabled_only_for_prefill_capable_worker_roles() {
+        assert!(worker_role_supports_cold_pool(None));
+        assert!(worker_role_supports_cold_pool(Some(WorkerType::Prefill)));
+        assert!(worker_role_supports_cold_pool(Some(WorkerType::Aggregated)));
+        assert!(!worker_role_supports_cold_pool(Some(WorkerType::Decode)));
+        assert!(!worker_role_supports_cold_pool(Some(WorkerType::Encode)));
     }
 
     #[test]

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -63,6 +63,7 @@ where
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         model_name: Option<&str>,
         worker_type: &'static str,
+        cold_pool_enabled: bool,
         cancellation_token: CancellationToken,
     ) -> Result<Self, KvSchedulerError> {
         let initial_workers: HashMap<WorkerId, ModelRuntimeConfig> =
@@ -88,6 +89,13 @@ where
         let profile = kv_router_config
             .policy_profile(model_name)
             .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
+        // Cold Pool protects prefill capacity. A shared policy file must not alter the
+        // independent decode scheduler in a disaggregated deployment.
+        let profile = if cold_pool_enabled {
+            profile
+        } else {
+            profile.without_cold_pool()
+        };
         let queue_recheck_interval = kv_router_config.router_queue_recheck_interval();
         let metric_model = model_name.unwrap_or("unknown");
         let queue_metrics = profile
@@ -525,6 +533,7 @@ mod tests {
             None,
             Some("test-model"),
             "decode",
+            false,
             cancellation_token.clone(),
         )
         .await


### PR DESCRIPTION
## Overview:

This draft implements the opt-in Cold Pool proposed in #12803. It confines very long,
low-reuse cache-miss prefills within a small stable worker set, with the goal of protecting
ordinary-request latency while preserving aggregate cluster capacity.

The current version uses static Cold membership with bounded soft drain. It is opened as a draft
for implementation and architecture feedback and is not yet requesting formal review.

When `cold_pool` is not configured, the existing scheduling path and behavior are preserved.

### Motivation and preliminary results

The target scenario is a workload that the cluster can sustain overall, but where a small number
of very long cache-miss prefills spread interference across workers and disproportionately increase
ordinary-request TTFT, ITL, and E2E latency.

The prototype was evaluated with six H20 workers, SGLang `0.5.14`, and
DeepSeek-V4-Flash-Base near the measured capacity knee. Baseline and Candidate replayed identical
Kimi ToolAgent traces using the same dual-FCFS policy and worker configuration. Candidate only
enabled Cold Pool. Four mixed workloads were produced by injecting true cache-miss requests of
approximately 400K or 600K tokens into the same Natural trace.

| Metric | Observed Candidate change across injected-Cold workloads |
|---|---:|
| Warm TTFT mean | improved `31.5%-72.5%` |
| Warm ITL P99 | improved `34.5%-64.7%` |
| Warm E2E P99 | improved `16.4%-36.5%` |
| Aggregate input-token throughput | changed `+0.03%-+3.4%` |
| Cold TTFT mean | regressed `3.0%-17.4%` |
| Cold TTFT median | regressed `8.2%-25.9%` |
| Cold E2E mean | improved `4.4%-10.7%` in 3/4 workloads; regressed `21.0%` for 400K/20s |
| Cold E2E median | improved `6.4%-10.8%` in 3/4 workloads; regressed `32.6%` for 400K/20s |
| Cold E2E P99 | improved `2.0%-34.0%` |

Natural traffic remained broadly neutral.

Full workload construction, Warm and Cold percentile tables, and the intended latency trade-off
are documented in [#12803](https://github.com/ai-dynamo/dynamo/issues/12803).

## Details:

The feature is configured through the existing router-policy YAML:

```yaml
cold_pool:
  request_threshold: 262144
  workers: 2
  soft_drain_timeout_ms: 20000
```

- `request_threshold` classifies managed Cold requests using effective prefill after KV-cache
  overlap, rather than raw input length alone.
- `workers` requests the Cold Pool size. The effective size is capped at one third of the online
  topology, while retaining at least one non-Cold worker.
- `soft_drain_timeout_ms` bounds how long Cold waits for active Warm requests on Cold workers to
  finish naturally.

The implementation:

- selects stable Cold membership from the online topology using Rendezvous Hashing;
- preserves Warm access to the caller's full eligible worker set when there is no Cold pressure;
- prefers non-Cold workers for Warm requests under Cold pressure, with fallback to the original
  eligibility so Warm capacity is not permanently reduced;
- restricts managed Cold requests to the intersection of caller eligibility and Cold membership;
- prefers Cold workers with no active Warm requests, while bounding Cold starvation with the soft
  drain timeout;
- preserves existing selector scoring, `PolicyQueue` ordering, pinning, taints, overload filtering,
  and topology semantics; and
- removes the prefill-oriented Cold Pool policy from standalone decode schedulers.

An empty intersection between caller eligibility and Cold membership bypasses Cold containment; it
never expands the caller's original eligibility.

### Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router`
  - 850 passed, 2 ignored
- `cargo test -p dynamo-llm --no-default-features --lib kv_router -- --test-threads=1`
  - 240 passed, 2 ignored

## Where should the reviewer start?

1. `lib/kv-router/src/scheduling/cold_pool.rs`
   - Membership, request classification, accounting, and soft-drain policy.
2. `lib/kv-router/src/scheduling/queue/cold_pool_integration.rs`
   - Adapter between Cold Pool decisions and queue dispatch/worker selection.
3. `lib/kv-router/src/scheduling/queue.rs`
   - Cold Pool lifecycle integration points in the existing queue path.
4. `lib/kv-router/src/scheduling/policy_config.rs`
   - Configuration parsing and validation.
5. `lib/llm/src/kv_router.rs` and `lib/llm/src/kv_router/scheduler.rs`
   - Worker-role integration and exclusion from standalone decode routing.

The main feedback requested in this draft is whether static membership, Warm fallback, and bounded
soft drain are appropriate first-version semantics, and whether the queue integration boundary is
acceptable.

## Related Issues

- Relates to #12803
