### PR TITLE
refactor(llm): preserve typed aggregation errors

### DIFF
--- a/lib/llm/src/protocols/openai/audios/aggregator.rs
+++ b/lib/llm/src/protocols/openai/audios/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvAudioSpeechResponse;
 
@@ -22,7 +23,7 @@ impl NvAudioSpeechResponse {
     /// Aggregates an annotated stream of audio responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvAudioSpeechResponse>>,
-    ) -> Result<NvAudioSpeechResponse, String> {
+    ) -> Result<NvAudioSpeechResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, TryStreamExt};
 use std::collections::{BTreeMap, HashMap};
 
 use dynamo_parsers::tool_calling::try_tool_call_parse_aggregate_finalize;
@@ -17,6 +17,7 @@ use crate::protocols::{
 
 use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::error::DynamoError;
 
 fn is_harmony_parser(parser: &str) -> bool {
     parser == "harmony"
@@ -42,8 +43,6 @@ pub struct DeltaAggregator {
     system_fingerprint: Option<String>,
     /// Map of incremental response choices, keyed by index.
     choices: HashMap<u32, DeltaChoice>,
-    /// Optional error message if an error occurs during aggregation.
-    error: Option<String>,
     /// Optional service tier information for the response.
     service_tier: Option<dynamo_protocols::types::ServiceTierResponse>,
     /// Aggregated nvext field from stream responses
@@ -199,7 +198,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             service_tier: None,
             nvext: None,
         }
@@ -213,25 +211,15 @@ impl DeltaAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation is successful.
-    /// * `Err(String)` if an error occurs during processing.
+    /// * `Err(DynamoError)` if an error occurs during processing.
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let mut aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                // Attempt to unwrap the delta, capturing any errors.
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     aggregator.id = delta.inner.id;
                     aggregator.model = delta.inner.model;
                     aggregator.created = delta.inner.created;
@@ -339,14 +327,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // Return early if an error was encountered.
-        if let Some(error) = aggregator.error {
-            return Err(error);
-        }
+            .await?;
 
         // #8640: finalize the per-index tool-call chunk accumulator into the
         // choice's `tool_calls` vector. Chunks missing id or name across the
@@ -523,11 +506,11 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 
     /// Converts an SSE stream into a [`NvCreateChatCompletionResponse`].
     ///
@@ -536,25 +519,25 @@ pub trait ChatCompletionAggregator {
     ///
     /// # Returns
     /// * `Ok(NvCreateChatCompletionResponse)` if aggregation succeeds.
-    /// * `Err(String)` if an error occurs.
+    /// * `Err(DynamoError)` if an error occurs.
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String>;
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError>;
 }
 
 impl ChatCompletionAggregator for NvCreateChatCompletionResponse {
     async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 
     async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateChatCompletionResponse, String> {
+    ) -> Result<NvCreateChatCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateChatCompletionStreamResponse>(stream);
         NvCreateChatCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -1825,5 +1808,42 @@ mod tests {
             "content key must be serialized as null when absent"
         );
         assert!(json.get("reasoning_content").is_some());
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let partial = create_test_delta(
+            0,
+            "partial",
+            Some(dynamo_protocols::types::Role::Assistant),
+            None,
+            None,
+            None,
+        );
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid sampling parameter")
+            .build();
+        let stream = stream::iter(vec![
+            partial,
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid sampling parameter");
     }
 }

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -6,7 +6,7 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
-    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
 use dynamo_runtime::{engine::DataStream, error::DynamoError};
@@ -48,7 +48,7 @@ impl NvCreateClassifyResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
     ) -> Result<NvCreateClassifyResponse, DynamoError> {
-        aggregate_typed_stream(stream).await
+        aggregate_stream(stream).await
     }
 }
 

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -3,8 +3,8 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
-use futures::{Stream, StreamExt};
+use dynamo_runtime::error::DynamoError;
+use futures::{Stream, StreamExt, TryStreamExt};
 
 use super::NvCreateCompletionResponse;
 use crate::protocols::{
@@ -23,7 +23,6 @@ pub struct DeltaAggregator {
     usage: Option<dynamo_protocols::types::CompletionUsage>,
     system_fingerprint: Option<String>,
     choices: HashMap<u32, DeltaChoice>,
-    error: Option<String>,
     nvext: Option<serde_json::Value>,
 }
 
@@ -49,7 +48,6 @@ impl DeltaAggregator {
             usage: None,
             system_fingerprint: None,
             choices: HashMap::new(),
-            error: None,
             nvext: None,
         }
     }
@@ -58,21 +56,12 @@ impl DeltaAggregator {
     pub async fn apply(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         tracing::debug!("Tool Call Parser: {:?}", parsing_options.tool_call_parser); // TODO: remove this once completion has tool call support
         let aggregator = stream
-            .fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
-                let delta = match delta.ok() {
-                    Ok(delta) => delta,
-                    Err(error) => {
-                        aggregator.error = Some(error);
-                        return aggregator;
-                    }
-                };
-
-                if aggregator.error.is_none()
-                    && let Some(delta) = delta.data
-                {
+            .map(Annotated::into_data)
+            .try_fold(DeltaAggregator::new(), |mut aggregator, delta| async move {
+                if let Some(delta) = delta {
                     // TODO(#14) - Aggregate Annotation
 
                     // these are cheap to move so we do it every time since we are consuming the delta
@@ -137,16 +126,9 @@ impl DeltaAggregator {
                         }
                     }
                 }
-                aggregator
+                Ok(aggregator)
             })
-            .await;
-
-        // If we have an error, return it
-        let aggregator = if let Some(error) = aggregator.error {
-            return Err(anyhow::anyhow!(error));
-        } else {
-            aggregator
-        };
+            .await?;
 
         // extra the aggregated deltas and sort by index
         let mut choices: Vec<_> = aggregator
@@ -193,7 +175,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateCompletionResponse>(stream);
         NvCreateCompletionResponse::from_annotated_stream(stream, parsing_options).await
     }
@@ -201,7 +183,7 @@ impl NvCreateCompletionResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateCompletionResponse>>,
         parsing_options: ParsingOptions,
-    ) -> Result<NvCreateCompletionResponse> {
+    ) -> Result<NvCreateCompletionResponse, DynamoError> {
         DeltaAggregator::apply(stream, parsing_options).await
     }
 }
@@ -462,5 +444,34 @@ mod tests {
             choice1.finish_reason,
             Some(dynamo_protocols::types::CompletionFinishReason::Stop)
         );
+    }
+
+    #[tokio::test]
+    async fn preserves_typed_error_after_partial_output() {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("unsupported logprobs")
+            .build();
+        let stream = stream::iter(vec![
+            create_test_delta(0, "partial", None, None),
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            },
+        ]);
+
+        let error = DeltaAggregator::apply(stream, ParsingOptions::default())
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "unsupported logprobs");
     }
 }

--- a/lib/llm/src/protocols/openai/embeddings/aggregator.rs
+++ b/lib/llm/src/protocols/openai/embeddings/aggregator.rs
@@ -9,7 +9,7 @@ use crate::protocols::{
     openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
-use dynamo_runtime::engine::DataStream;
+use dynamo_runtime::{engine::DataStream, error::DynamoError};
 use futures::Stream;
 
 impl StreamAggregable for NvCreateEmbeddingResponse {
@@ -28,7 +28,7 @@ impl NvCreateEmbeddingResponse {
     /// Converts an SSE stream into a [`NvCreateEmbeddingResponse`].
     pub async fn from_sse_stream(
         stream: DataStream<Result<Message, SseCodecError>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         let stream = convert_sse_stream::<NvCreateEmbeddingResponse>(stream);
         NvCreateEmbeddingResponse::from_annotated_stream(stream).await
     }
@@ -36,7 +36,7 @@ impl NvCreateEmbeddingResponse {
     /// Aggregates an annotated stream of embedding responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateEmbeddingResponse>>,
-    ) -> Result<NvCreateEmbeddingResponse, String> {
+    ) -> Result<NvCreateEmbeddingResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }
@@ -44,6 +44,7 @@ impl NvCreateEmbeddingResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_runtime::error::{BackendError, ErrorType};
     use futures::stream;
 
     fn create_test_embedding_response(
@@ -141,7 +142,40 @@ mod tests {
         let result = NvCreateEmbeddingResponse::from_annotated_stream(Box::pin(stream)).await;
 
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Test error"));
+        assert!(result.unwrap_err().to_string().contains("Test error"));
+    }
+
+    #[tokio::test]
+    async fn test_typed_error_after_data_is_preserved() {
+        let embedding = dynamo_protocols::types::Embedding {
+            index: 0,
+            object: "embedding".to_string(),
+            embedding: dynamo_protocols::types::EmbeddingVector::Float(vec![0.1]),
+        };
+        let response = create_test_embedding_response(vec![embedding], 1, 1);
+        let error = Annotated::<NvCreateEmbeddingResponse> {
+            data: None,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(
+                DynamoError::builder()
+                    .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                    .message("invalid embedding request")
+                    .build(),
+            ),
+        };
+
+        let result =
+            NvCreateEmbeddingResponse::from_annotated_stream(stream::iter(vec![response, error]))
+                .await;
+
+        let error = result.expect_err("typed error must win over partial data");
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid embedding request");
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -569,8 +569,7 @@ impl GenerateAggregator {
         let mut aggregator = GenerateAggregator::new(request_id);
         pin_mut!(stream);
         while let Some(delta) = stream.next().await {
-            let delta = delta.ok().map_err(anyhow::Error::msg)?;
-            if let Some(output) = delta.data {
+            if let Some(output) = delta.into_data().map_err(anyhow::Error::new)? {
                 aggregator.apply_output(output, options)?;
             }
         }

--- a/lib/llm/src/protocols/openai/images/aggregator.rs
+++ b/lib/llm/src/protocols/openai/images/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvImagesResponse;
 
@@ -22,7 +23,7 @@ impl NvImagesResponse {
     /// Aggregates an annotated stream of image responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvImagesResponse>>,
-    ) -> Result<NvImagesResponse, String> {
+    ) -> Result<NvImagesResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/openai/pooling/aggregator.rs
+++ b/lib/llm/src/protocols/openai/pooling/aggregator.rs
@@ -6,7 +6,7 @@ use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
     convert_sse_stream,
-    openai::stream_aggregator::{StreamAggregable, aggregate_typed_stream},
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
 };
 
 use dynamo_runtime::{engine::DataStream, error::DynamoError};
@@ -48,7 +48,7 @@ impl NvCreatePoolingResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreatePoolingResponse>>,
     ) -> Result<NvCreatePoolingResponse, DynamoError> {
-        aggregate_typed_stream(stream).await
+        aggregate_stream(stream).await
     }
 }
 

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -19,7 +19,7 @@ pub trait StreamAggregable: Sized {
 /// Aggregate a stream of [`Annotated<T>`] into a single `T`. The first error
 /// encountered short-circuits further merging and is returned; the remainder
 /// of the stream is dropped.
-pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, String>
+pub async fn aggregate_stream<T, S>(stream: S) -> Result<T, DynamoError>
 where
     T: StreamAggregable,
     S: Stream<Item = Annotated<T>>,
@@ -28,41 +28,7 @@ where
     let mut response: Option<T> = None;
 
     while let Some(delta) = stream.next().await {
-        let delta = delta.ok()?;
-        if let Some(data) = delta.data {
-            match response.as_mut() {
-                Some(existing) => existing.merge(data),
-                None => response = Some(data),
-            }
-        }
-    }
-
-    Ok(response.unwrap_or_else(T::empty))
-}
-
-/// Aggregate a stream of [`Annotated<T>`] while preserving structured backend
-/// errors. Existing callers that expose string errors can continue to use
-/// [`aggregate_stream`].
-pub async fn aggregate_typed_stream<T, S>(stream: S) -> Result<T, DynamoError>
-where
-    T: StreamAggregable,
-    S: Stream<Item = Annotated<T>>,
-{
-    let mut stream = std::pin::pin!(stream);
-    let mut response: Option<T> = None;
-
-    while let Some(delta) = stream.next().await {
-        if delta.is_error() {
-            return Err(delta.error.unwrap_or_else(|| {
-                DynamoError::msg(
-                    delta
-                        .comment
-                        .map(|comments| comments.join(", "))
-                        .unwrap_or_else(|| "unknown error".to_string()),
-                )
-            }));
-        }
-        if let Some(data) = delta.data {
+        if let Some(data) = delta.into_data()? {
             match response.as_mut() {
                 Some(existing) => existing.merge(data),
                 None => response = Some(data),

--- a/lib/llm/src/protocols/openai/videos/aggregator.rs
+++ b/lib/llm/src/protocols/openai/videos/aggregator.rs
@@ -5,6 +5,7 @@ use futures::Stream;
 
 use crate::protocols::openai::stream_aggregator::{StreamAggregable, aggregate_stream};
 use crate::types::Annotated;
+use dynamo_runtime::error::DynamoError;
 
 use super::NvVideosResponse;
 
@@ -22,7 +23,7 @@ impl NvVideosResponse {
     /// Aggregates an annotated stream of video responses into a final response.
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvVideosResponse>>,
-    ) -> Result<NvVideosResponse, String> {
+    ) -> Result<NvVideosResponse, DynamoError> {
         aggregate_stream(stream).await
     }
 }

--- a/lib/llm/src/protocols/tensor.rs
+++ b/lib/llm/src/protocols/tensor.rs
@@ -4,7 +4,7 @@
 use crate::protocols::Annotated;
 use anyhow::Result;
 use dynamo_runtime::protocols::annotated::AnnotationsProvider;
-use futures::{Stream, StreamExt};
+use futures::{Stream, StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use validator::Validate;
@@ -264,55 +264,21 @@ impl AnnotationsProvider for NvCreateTensorRequest {
     }
 }
 
-pub struct DeltaAggregator {
-    response: Option<NvCreateTensorResponse>,
-    error: Option<String>,
-}
-
 impl NvCreateTensorResponse {
     pub async fn from_annotated_stream(
         stream: impl Stream<Item = Annotated<NvCreateTensorResponse>>,
     ) -> Result<NvCreateTensorResponse> {
-        let aggregator = stream
-            .fold(
-                DeltaAggregator {
-                    response: None,
-                    error: None,
-                },
-                |mut aggregator, delta| async move {
-                    let delta = match delta.ok() {
-                        Ok(delta) => delta,
-                        Err(error) => {
-                            if aggregator.error.is_none() {
-                                aggregator.error = Some(error);
-                            }
-                            return aggregator;
-                        }
-                    };
-                    match delta.data {
-                        Some(resp) => {
-                            if aggregator.response.is_none() {
-                                aggregator.response = Some(resp);
-                            } else if aggregator.error.is_none() {
-                                aggregator.error =
-                                    Some("Multiple responses in non-streaming mode".to_string());
-                            }
-                        }
-                        None => {
-                            // Ignore metadata-only deltas in non-streaming mode.
-                        }
-                    }
-                    aggregator
-                },
-            )
-            .await;
-        if let Some(error) = aggregator.error {
-            Err(anyhow::anyhow!(error))
-        } else if let Some(response) = aggregator.response {
-            Ok(response)
-        } else {
-            Err(anyhow::anyhow!("No response received"))
+        pin_mut!(stream);
+        let mut response = None;
+        while let Some(delta) = stream.next().await {
+            let Some(next) = delta.into_data().map_err(anyhow::Error::new)? else {
+                continue;
+            };
+            if response.replace(next).is_some() {
+                anyhow::bail!("Multiple responses in non-streaming mode");
+            }
         }
+        response.ok_or_else(|| anyhow::anyhow!("No response received"))
     }
 }
 

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -39,6 +39,7 @@ impl<R> Annotated<R> {
                 DynamoError::msg(
                     self.comment
                         .as_ref()
+                        .filter(|comments| !comments.is_empty())
                         .map(|comments| comments.join(", "))
                         .unwrap_or_else(|| "unknown error".to_string()),
                 )
@@ -195,6 +196,27 @@ mod tests {
         assert!(annotated.is_err());
         let err = annotated.err().unwrap();
         assert!(err.to_string().contains("connection lost"));
+    }
+
+    #[test]
+    fn test_comment_only_error_fallback() {
+        for (comments, expected) in [
+            (vec![], "unknown error"),
+            (
+                vec!["first".to_string(), "second".to_string()],
+                "first, second",
+            ),
+        ] {
+            let annotated = Annotated::<String> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: Some(comments),
+                error: None,
+            };
+
+            assert_eq!(annotated.err().unwrap().message(), expected);
+        }
     }
 
     #[test]

--- a/lib/runtime/src/protocols/annotated.rs
+++ b/lib/runtime/src/protocols/annotated.rs
@@ -3,7 +3,7 @@
 
 use super::maybe_error::MaybeError;
 use crate::error::DynamoError;
-use anyhow::{Result, anyhow as error};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 pub trait AnnotationsProvider {
@@ -33,6 +33,19 @@ pub struct Annotated<R> {
 }
 
 impl<R> Annotated<R> {
+    fn cloned_error(&self) -> Option<DynamoError> {
+        self.is_error().then(|| {
+            self.error.clone().unwrap_or_else(|| {
+                DynamoError::msg(
+                    self.comment
+                        .as_ref()
+                        .map(|comments| comments.join(", "))
+                        .unwrap_or_else(|| "unknown error".to_string()),
+                )
+            })
+        })
+    }
+
     /// Create a new annotated stream from the given error string
     pub fn from_error(error: impl Into<String>) -> Self {
         Self {
@@ -74,19 +87,19 @@ impl<R> Annotated<R> {
     /// Convert to a [`Result<Self, String>`]
     /// If [`Self::event`] is "error", return an error message
     pub fn ok(self) -> Result<Self, String> {
-        if let Some(event) = &self.event
-            && event == "error"
-        {
-            // First check DynamoError, then fallback to comment
-            if let Some(ref err) = self.error {
-                return Err(err.to_string());
-            }
-            return Err(self
-                .comment
-                .unwrap_or(vec!["unknown error".to_string()])
-                .join(", "));
+        if let Some(error) = self.cloned_error() {
+            return Err(error.to_string());
         }
         Ok(self)
+    }
+
+    /// Consume the annotation and return its optional payload while preserving
+    /// structured errors.
+    pub fn into_data(self) -> Result<Option<R>, DynamoError> {
+        if let Some(error) = self.cloned_error() {
+            return Err(error);
+        }
+        Ok(self.data)
     }
 
     pub fn is_ok(&self) -> bool {
@@ -130,24 +143,7 @@ impl<R> Annotated<R> {
     }
 
     pub fn into_result(self) -> Result<Option<R>> {
-        match self.data {
-            Some(data) => Ok(Some(data)),
-            None => match self.event {
-                Some(event) if event == "error" => {
-                    // First check DynamoError, then fallback to comment
-                    if let Some(ref err) = self.error {
-                        Err(error!("{}", err))?
-                    } else {
-                        Err(error!(
-                            self.comment
-                                .unwrap_or(vec!["unknown error".to_string()])
-                                .join(", ")
-                        ))?
-                    }
-                }
-                _ => Ok(None),
-            },
-        }
+        self.into_data().map_err(anyhow::Error::new)
     }
 }
 
@@ -168,22 +164,7 @@ where
     }
 
     fn err(&self) -> Option<DynamoError> {
-        if self.is_error() {
-            // First check DynamoError field
-            if let Some(ref error) = self.error {
-                return Some(error.clone());
-            }
-
-            // Fallback to comment-based error
-            if let Some(comment) = &self.comment
-                && !comment.is_empty()
-            {
-                return Some(DynamoError::msg(comment.join("; ")));
-            }
-            Some(DynamoError::msg("unknown error"))
-        } else {
-            None
-        }
+        self.cloned_error()
     }
 }
 
@@ -252,6 +233,24 @@ mod tests {
         let result = annotated.ok();
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("connection lost"));
+    }
+
+    #[test]
+    fn test_into_data_preserves_error_type() {
+        use crate::error::{BackendError, ErrorType};
+
+        let error = DynamoError::builder()
+            .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+            .message("invalid request")
+            .build();
+        let annotated = Annotated::<String>::from_err(error);
+
+        let error = annotated.into_data().unwrap_err();
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+        assert_eq!(error.message(), "invalid request");
     }
 
     #[test]


### PR DESCRIPTION
## Stack

**1 of 4** — base: `main`

Next: [#12808](https://github.com/ai-dynamo/dynamo/pull/12808)

## Summary

- Preserve structured `DynamoError` values when consuming `Annotated<T>`.
- Return typed errors from every shared unary aggregation path instead of flattening them to strings.
- Stop aggregation immediately on a typed error, including when it arrives after partial output.

This layer intentionally does not change HTTP status policy.

## Root cause

Unary aggregators converted annotated backend errors to strings. Once the structured error type was discarded, the HTTP layer could not reliably distinguish invalid client input from runtime failures.

## Validation

- `cargo check -p dynamo-llm`: passed
- Runtime typed-error regression: 1 passed
- Chat/Completions partial-output typed-error regressions: 2 passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

## Tracking

- [DYN-3787](https://linear.app/nvidia/issue/DYN-3787)
- [DYN-3788](https://linear.app/nvidia/issue/DYN-3788)
- [DYN-3789](https://linear.app/nvidia/issue/DYN-3789)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling across streaming responses for chat, completions, embeddings, audio, images, videos, and tensor operations.
  - Structured backend errors are now preserved and returned accurately, including when failures occur after partial results.
  - Empty or invalid tensor streams now produce clearer errors, while metadata-only updates are handled safely.
  - Stream aggregation behavior is more consistent across classification and pooling requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->